### PR TITLE
python313Packages.django-stubs-ext: 5.2.0 -> 5.2.2, python313Packages.django-stubs: 5.2.0 -> 5.2.2, python313Packages.djangorestframework-stubs: 3.16.0 -> 3.16.1

### DIFF
--- a/pkgs/development/python-modules/django-stubs-ext/default.nix
+++ b/pkgs/development/python-modules/django-stubs-ext/default.nix
@@ -7,13 +7,13 @@
   pytestCheckHook,
   pythonOlder,
   redis,
-  setuptools,
+  hatchling,
   typing-extensions,
 }:
 
 buildPythonPackage rec {
   pname = "django-stubs-ext";
-  version = "5.2.0";
+  version = "5.2.2";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -21,10 +21,10 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "django_stubs_ext";
     inherit version;
-    hash = "sha256-AMSuMHtTj1ZDr3YakUw/jk4/JfTnxtcJjxkGwNjyqsk=";
+    hash = "sha256-2dFRuRn+JDh2D1vZOPA+HLCMhNBlH55ZF/ExOQfkJoM=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ hatchling ];
 
   dependencies = [
     django
@@ -36,7 +36,8 @@ buildPythonPackage rec {
     oracle = [ oracledb ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  # Tests are not shipped with PyPI
+  doCheck = false;
 
   pythonImportsCheck = [ "django_stubs_ext" ];
 

--- a/pkgs/development/python-modules/django-stubs/default.nix
+++ b/pkgs/development/python-modules/django-stubs/default.nix
@@ -1,38 +1,38 @@
 {
   lib,
   buildPythonPackage,
-  django,
   django-stubs-ext,
-  fetchPypi,
+  django,
+  fetchFromGitHub,
+  hatchling,
   mypy,
+  oracledb,
   pytestCheckHook,
+  pytest-mypy-plugins,
   pythonOlder,
-  setuptools,
+  redis,
   tomli,
   types-pytz,
   types-pyyaml,
+  types-redis,
   typing-extensions,
 }:
 
 buildPythonPackage rec {
   pname = "django-stubs";
-  version = "5.2.0";
+  version = "5.2.2";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.10";
 
-  src = fetchPypi {
-    pname = "django_stubs";
-    inherit version;
-    hash = "sha256-B+JcLTy/9b5UAif/N3GcyJ8hXfqqpesDinWwG7+7JyI=";
+  src = fetchFromGitHub {
+    owner = "typeddjango";
+    repo = "django-stubs";
+    tag = version;
+    hash = "sha256-kF5g0/rkMQxYTfSrTqzZ6BuqGlE42K/AVhc1/ARc+/c=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "setuptools<79.0.0" setuptools
-  '';
-
-  build-system = [ setuptools ];
+  build-system = [ hatchling ];
 
   dependencies = [
     django
@@ -45,14 +45,30 @@ buildPythonPackage rec {
 
   optional-dependencies = {
     compatible-mypy = [ mypy ];
+    oracle = [ oracledb ];
+    redis = [
+      redis
+      types-redis
+    ];
   };
 
   nativeCheckInputs = [
+    pytest-mypy-plugins
     pytestCheckHook
   ]
   ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "django-stubs" ];
+
+  disabledTests = [
+    # AttributeError: module 'django.contrib.auth.forms' has no attribute
+    "test_find_classes_inheriting_from_generic"
+  ];
+
+  disabledTestPaths = [
+    # Skip type checking
+    "tests/typecheck/"
+  ];
 
   meta = with lib; {
     description = "PEP-484 stubs for Django";

--- a/pkgs/development/python-modules/djangorestframework-stubs/default.nix
+++ b/pkgs/development/python-modules/djangorestframework-stubs/default.nix
@@ -19,21 +19,26 @@
 
 buildPythonPackage rec {
   pname = "djangorestframework-stubs";
-  version = "3.16.0";
+  version = "3.16.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.9";
+  disabled = pythonOlder "3.10";
 
   src = fetchFromGitHub {
     owner = "typeddjango";
     repo = "djangorestframework-stubs";
     tag = version;
-    hash = "sha256-q/9tCMT79TMHIQ4KH8tiunaTt7L6IItwNYBFlbNxBcE=";
+    hash = "sha256-TTv6v7G3LODrUDSYSNNa4+dujih7QElmvK3mMQg9EuQ=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "<79.0.0" ""
+  '';
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     django-stubs
     requests
     types-pyyaml
@@ -54,7 +59,7 @@ buildPythonPackage rec {
   ]
   ++ lib.flatten (builtins.attrValues optional-dependencies);
 
-  # Upstream recommends mypy > 1.7 which we don't have yet, thus all testsare failing with 3.14.5 and below
+  # Upstream recommends mypy > 1.7 which we don't have yet, thus all tests are failing with 3.14.5 and below
   doCheck = false;
 
   pythonImportsCheck = [ "rest_framework-stubs" ];


### PR DESCRIPTION
https://hydra.nixos.org/build/303631166

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
