### PR TITLE
[Backport release-25.05] ananicy-rules-cachyos: 0-unstable-2025-03-19 -> 0-unstable-2025-08-06

### DIFF
--- a/pkgs/by-name/an/ananicy-rules-cachyos/package.nix
+++ b/pkgs/by-name/an/ananicy-rules-cachyos/package.nix
@@ -7,13 +7,13 @@
 
 stdenvNoCC.mkDerivation {
   pname = "ananicy-rules-cachyos";
-  version = "0-unstable-2025-03-19";
+  version = "0-unstable-2025-07-06";
 
   src = fetchFromGitHub {
     owner = "CachyOS";
     repo = "ananicy-rules";
-    rev = "99693d533a238c19915057f9cd5e541e6dbf57d9";
-    hash = "sha256-dTGfOw2Cj4q3AiQswcyl9bWUw1qInyqap43r4j+qS1Y=";
+    rev = "339bee6f2de3de8e866c23b210baf6cabf153549";
+    hash = "sha256-D/+/7NdfV8kHwYm5mJ6b7Vl3QCUdK2+NbZSefWTZt5k=";
   };
 
   dontConfigure = true;

--- a/pkgs/by-name/an/ananicy-rules-cachyos/package.nix
+++ b/pkgs/by-name/an/ananicy-rules-cachyos/package.nix
@@ -7,13 +7,13 @@
 
 stdenvNoCC.mkDerivation {
   pname = "ananicy-rules-cachyos";
-  version = "0-unstable-2025-07-06";
+  version = "0-unstable-2025-08-06";
 
   src = fetchFromGitHub {
     owner = "CachyOS";
     repo = "ananicy-rules";
-    rev = "339bee6f2de3de8e866c23b210baf6cabf153549";
-    hash = "sha256-D/+/7NdfV8kHwYm5mJ6b7Vl3QCUdK2+NbZSefWTZt5k=";
+    rev = "80576999c92af3eb88ea2008d4a18d29393ed579";
+    hash = "sha256-SdxOgm7purRxIU16RFuSgUzKIgi+7gJ2hJuCDVCjd54=";
   };
 
   dontConfigure = true;


### PR DESCRIPTION
Manual backport of #424635 #431608 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.