### PR TITLE
Revert "workflows/eval: disable swap"

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,6 +23,7 @@ jobs:
     name: Backport Pull Request
     if: vars.NIXPKGS_CI_APP_ID && github.event.pull_request.merged == true && (github.event.action != 'labeled' || startsWith(github.event.label.name, 'backport'))
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 3
     steps:
       # Use a GitHub App to create the PR so that CI gets triggered
       # The App is scoped to Repository > Contents and Pull Requests: write for Nixpkgs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
             desc: shell
     name: '${{ matrix.system }}: ${{ matrix.desc }}'
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,6 +38,7 @@ jobs:
     permissions:
       pull-requests: write
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/codeowners-v2.yml
+++ b/.github/workflows/codeowners-v2.yml
@@ -49,6 +49,7 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -106,6 +107,7 @@ jobs:
   request:
     name: Request
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
     steps:
       - uses: cachix/install-nix-action@f0fe604f8a612776892427721526b4c7cfb23aba # v31
 

--- a/.github/workflows/dismissed-review.yml
+++ b/.github/workflows/dismissed-review.yml
@@ -25,6 +25,7 @@ jobs:
   minimize:
     name: Minimize as resolved
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 2
     steps:
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:

--- a/.github/workflows/edited.yml
+++ b/.github/workflows/edited.yml
@@ -31,6 +31,7 @@ jobs:
     name: Trigger jobs
     runs-on: ubuntu-24.04
     if: github.event.changes.base.ref.from && github.event.changes.base.ref.from != github.event.pull_request.base.ref
+    timeout-minutes: 2
     steps:
       # Use a GitHub App to create the PR so that CI gets triggered
       # The App is scoped to Repository > Contents and Pull Requests: write for Nixpkgs

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -32,11 +32,16 @@ jobs:
     outputs:
       targetRunId: ${{ steps.targetRunId.outputs.targetRunId }}
     steps:
-      # We'd rather fail than run slow eval on swap.
-      # Failing allows us to adjust the chunkSize to remain fast.
-      - name: Disable swap
+      # This is not supposed to be used and just acts as a fallback.
+      # Without swap, when Eval runs OOM, it will fail badly with a
+      # job that is sometimes not interruptible anymore.
+      # If Eval starts swapping, decrease chunkSize to keep it fast.
+      - name: Enable swap
         run: |
-          sudo swapoff -a
+          sudo fallocate -l 10G /swap
+          sudo chmod 600 /swap
+          sudo mkswap /swap
+          sudo swapon /swap
 
       - name: Check out the PR at the test merge commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -31,6 +31,7 @@ jobs:
     name: ${{ matrix.system }}
     outputs:
       targetRunId: ${{ steps.targetRunId.outputs.targetRunId }}
+    timeout-minutes: 15
     steps:
       # This is not supposed to be used and just acts as a fallback.
       # Without swap, when Eval runs OOM, it will fail badly with a
@@ -155,6 +156,7 @@ jobs:
     if: needs.eval.outputs.targetRunId
     permissions:
       statuses: write
+    timeout-minutes: 5
     steps:
       - name: Download output paths and eval stats for all systems
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -237,6 +239,7 @@ jobs:
   misc:
     if: ${{ github.event_name != 'push' }}
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,7 @@ defaults:
 jobs:
   treefmt:
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -51,6 +52,7 @@ jobs:
 
   parse:
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -72,7 +74,6 @@ jobs:
 
   nixpkgs-vet:
     runs-on: ubuntu-24.04-arm
-    # This should take 1 minute at most, but let's be generous. The default of 6 hours is definitely too long.
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/periodic-merge.yml
+++ b/.github/workflows/periodic-merge.yml
@@ -19,6 +19,7 @@ defaults:
 jobs:
   merge:
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
     steps:
       # Use a GitHub App to create the PR so that CI gets triggered
       # The App is scoped to Repository > Contents and Pull Requests: write for Nixpkgs

--- a/.github/workflows/reviewers.yml
+++ b/.github/workflows/reviewers.yml
@@ -27,6 +27,7 @@ defaults:
 jobs:
   request:
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
     steps:
       - name: Check out the PR at the base commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
This reverts commit https://github.com/NixOS/nixpkgs/commit/f2648b263b69aecca529c14fd5441503850a7c0d.

While the idea to never use swap was fine, in practice this meant that when nix ran OOM, some other process was killed instead. This lead to the job not being possible to be cancelled anymore and thus needing to timeout, before subsequent jobs could be scheduled. This can take up to 6 hours for GitHub Actions by default.

Re-enabling the swap file to catch this case more gracefully. It's still the goal to never actually *use* the swap file during Eval and just a safeguard.

Keeping the changed `chunkSize` and not reverting it - this makes it slightly less likely to hit the swap file when running with Lix.

Also setting sensible timeouts for all jobs to make sure that *if* we ever hit that again, these PRs are not blocked for 6 hours...

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
