### PR TITLE
sway-audio-idle-inhibit: 0.1.2 -> 0.2.0

### DIFF
--- a/pkgs/by-name/sw/sway-audio-idle-inhibit/package.nix
+++ b/pkgs/by-name/sw/sway-audio-idle-inhibit/package.nix
@@ -6,32 +6,28 @@
   ninja,
   pkg-config,
   libpulseaudio,
-  wayland,
-  wayland-protocols,
-  wayland-scanner,
+  systemd,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "sway-audio-idle-inhibit";
-  version = "0.1.2";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "ErikReider";
     repo = "SwayAudioIdleInhibit";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-6bdIkNosp/mzH5SiyK6Mox/z8kuFk5RLMmcFZ2VIi0g=";
+    hash = "sha256-AIK/2CPXWie72quzCcofZMQ7OVsggNm2Cq9PBJXKyhw=";
   };
 
   nativeBuildInputs = [
     meson
     ninja
     pkg-config
-    wayland-scanner
   ];
 
   buildInputs = [
     libpulseaudio
-    wayland
-    wayland-protocols
+    systemd
   ];
 
   meta = with lib; {


### PR DESCRIPTION
  - Uses systemd/elogind Inhibit instead of wayland protocol
  - Remove wayland dependencies, add systemd dependency
  - Fixes issues with hidden surfaces not preventing idle

  See upstream release notes:
  https://github.com/ErikReider/SwayAudioIdleInhibit/releases/tag/v0.2.0

  ## Things done

  - Built on platform:
    - [x] x86_64-linux
    - [ ] aarch64-linux
    - [ ] x86_64-darwin
    - [ ] aarch64-darwin
  - Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].
    - [ ] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core"
  functionality.
  - [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in
  `./result/bin/`.
  - Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
  - NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and
  other READMEs.