### PR TITLE
[Backport release-25.05] dotenv-cli: 8.0.0 -> 10.0.0

### DIFF
--- a/pkgs/by-name/do/dotenv-cli/package.nix
+++ b/pkgs/by-name/do/dotenv-cli/package.nix
@@ -10,18 +10,18 @@
 }:
 stdenv.mkDerivation rec {
   pname = "dotenv-cli";
-  version = "8.0.0";
+  version = "9.0.0";
 
   src = fetchFromGitHub {
     owner = "entropitor";
     repo = "dotenv-cli";
     rev = "v${version}";
-    hash = "sha256-cqJGw6z0m1ImFEmG2jfcYjaKVhrGyM4hbOAHC7xNAFY=";
+    hash = "sha256-mpVObsilwVCq1V2Z11uqK1T7VgwpfTYng2vqrTqJZE4=";
   };
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = "${src}/yarn.lock";
-    hash = "sha256-/w9MZ+hNEwB41VwPSYEY6V0uWmZ4Tsev3h2fa/REm2E=";
+    hash = "sha256-ak6QD9Z0tE0XgFVt3QkjZxk2kelUFPX9bEF855RiY2w=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/do/dotenv-cli/package.nix
+++ b/pkgs/by-name/do/dotenv-cli/package.nix
@@ -10,18 +10,18 @@
 }:
 stdenv.mkDerivation rec {
   pname = "dotenv-cli";
-  version = "9.0.0";
+  version = "10.0.0";
 
   src = fetchFromGitHub {
     owner = "entropitor";
     repo = "dotenv-cli";
     rev = "v${version}";
-    hash = "sha256-mpVObsilwVCq1V2Z11uqK1T7VgwpfTYng2vqrTqJZE4=";
+    hash = "sha256-prSGIEHf6wRqOFVsn3Ws25yG7Ga2YEbiU/IMP3QeLXU=";
   };
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = "${src}/yarn.lock";
-    hash = "sha256-ak6QD9Z0tE0XgFVt3QkjZxk2kelUFPX9bEF855RiY2w=";
+    hash = "sha256-rbG1oM1mEZSB/eYp87YMi6v9ves5YR7u7rkQRlziz7I=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Manual backport of #429421 #431776 to `release-25.05`.

Acceptable for backport because [there are not actually any breaking changes](https://github.com/NixOS/nixpkgs/pull/431776#issuecomment-3171850477).

- [X] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
