### PR TITLE
scalafmt: add automated update script

### DIFF
--- a/pkgs/by-name/sc/scalafmt/package.nix
+++ b/pkgs/by-name/sc/scalafmt/package.nix
@@ -47,6 +47,8 @@ stdenv.mkDerivation {
     $out/bin/${baseName} --version | grep -q "${version}"
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
     description = "Opinionated code formatter for Scala";
     homepage = "http://scalameta.org/scalafmt";

--- a/pkgs/by-name/sc/scalafmt/update.sh
+++ b/pkgs/by-name/sc/scalafmt/update.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl jq gnused nix
+
+set -euo pipefail
+
+latest_version=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
+    https://api.github.com/repos/scalameta/scalafmt/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+
+current_version=$(nix-instantiate --eval -A scalafmt.version | jq -r)
+
+if [[ "$current_version" == "$latest_version" ]]; then
+    echo "Already up to date, nothing to do."
+    exit 0
+fi
+
+echo "Updating scalafmt: $current_version -> $latest_version"
+
+package_dir="$(dirname "${BASH_SOURCE[0]}")"
+package_nix="$package_dir/package.nix"
+
+sed -i "s|version = \"$current_version\"|version = \"$latest_version\"|" "$package_nix"
+
+build_output=$(nix-build -A scalafmt 2>&1) || true
+
+if echo "$build_output" | grep -q "hash mismatch"; then
+    new_deps_hash=$(echo "$build_output" | grep "got:" | sed -n 's/.*got:[[:space:]]*\(sha256-[A-Za-z0-9+/=]*\).*/\1/p' | head -1)
+    if [[ -n "$new_deps_hash" ]]; then
+        sed -i "s|outputHash = \"sha256-[A-Za-z0-9+/=]*\"|outputHash = \"$new_deps_hash\"|" "$package_nix"
+    else
+        echo "Could not extract new hash from build output, build output:"
+        echo "$build_output"
+        exit 1
+    fi
+else
+    echo "Unexpected: Build succeeded without hash mismatch, build output:"
+    echo "$build_output"
+    exit 1
+fi


### PR DESCRIPTION
Add an update script for scalafmt

Did not yet update scalafmt to 3.9.9 on purpose, hopefully r-ryantm will do it using this script 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
