### PR TITLE
mtkclient: init at 2.0.1-unstable-2025-09-26

### DIFF
--- a/pkgs/by-name/mt/mtkclient/package.nix
+++ b/pkgs/by-name/mt/mtkclient/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "mtkclient";
+  version = "2.0.1-unstable-2025-09-26";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bkerler";
+    repo = "mtkclient";
+    rev = "399b3a1c25e73ddf4951f12efd20f7254ee04a39";
+    hash = "sha256-XNPYeVhp5P+zQdumS9IzlUd5+WebL56qcgs10WS2/LY=";
+  };
+
+  build-system = [ python3Packages.hatchling ];
+
+  dependencies = with python3Packages; [
+    colorama
+    fusepy
+    pycryptodome
+    pycryptodomex
+    pyserial
+    pyside6
+    pyusb
+    shiboken6
+  ];
+
+  pythonImportsCheck = [ "mtkclient" ];
+
+  # Note: No need to install mtkclient udev rules, 50-android.rules is covered by
+  #       systemd 258 or newer and 51-edl.rules only applies to Qualcomm (i.e. not MTK).
+
+  meta = {
+    description = "MTK reverse engineering and flash tool";
+    homepage = "https://github.com/bkerler/mtkclient";
+    mainProgram = "mtk";
+    license = lib.licenses.gpl3;
+    sourceProvenance = with lib.sourceTypes; [
+      # loaders, preloaders and exploit payloads
+      binaryFirmware
+      # everything else
+      fromSource
+    ];
+    maintainers = [ lib.maintainers.timschumi ];
+  };
+}


### PR DESCRIPTION
[mtkclient](https://github.com/bkerler/mtkclient) is a low-level tool to interface with Mediatek-based devices while in brom or preloader mode.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
