### PR TITLE
capnproto: fix fibers on static builds

### DIFF
--- a/pkgs/by-name/ca/capnproto/fix-libucontext.patch
+++ b/pkgs/by-name/ca/capnproto/fix-libucontext.patch
@@ -1,0 +1,74 @@
+From f26dd335c8650a2f8ab7d6e4fb5dfc40ee6af618 Mon Sep 17 00:00:00 2001
+From: Jade Lovelace <software@lfcode.ca>
+Date: Sun, 10 Aug 2025 10:54:14 +0000
+Subject: [PATCH] fix: include libucontext in Requires.private in cmake builds
+
+This is required so that static musl actually links to libucontext
+correctly to get setcontext/etc for fibers.
+---
+ c++/CMakeLists.txt           | 4 ++++
+ c++/configure.ac             | 4 ++++
+ c++/pkgconfig/kj-async.pc.in | 1 +
+ 3 files changed, 9 insertions(+)
+
+diff --git a/c++/CMakeLists.txt b/c++/CMakeLists.txt
+index f335f12f7c..b2a24e40e0 100644
+--- a/c++/CMakeLists.txt
++++ b/c++/CMakeLists.txt
+@@ -96,6 +96,9 @@ set_property(CACHE WITH_FIBERS PROPERTY STRINGS AUTO ON OFF)
+ # CapnProtoConfig.cmake.in needs this variable.
+ set(_WITH_LIBUCONTEXT OFF)
+ 
++# Used by pkg-config files
++set(ASYNC_REQUIRES_PRIVATE "")
++
+ if (WITH_FIBERS OR WITH_FIBERS STREQUAL "AUTO")
+   set(_capnp_fibers_found OFF)
+   if (WIN32 OR CYGWIN)
+@@ -116,6 +119,7 @@ if (WITH_FIBERS OR WITH_FIBERS STREQUAL "AUTO")
+         if (libucontext_FOUND)
+           set(_WITH_LIBUCONTEXT ON)
+           set(_capnp_fibers_found ON)
++          set(ASYNC_REQUIRES_PRIVATE "${ASYNC_REQUIRES_PRIVATE} libucontext")
+         endif()
+       else()
+         set(_capnp_fibers_found OFF)
+diff --git a/c++/configure.ac b/c++/configure.ac
+index a2de7aac80..ce3c632e8c 100644
+--- a/c++/configure.ac
++++ b/c++/configure.ac
+@@ -216,6 +216,8 @@ AS_IF([test "$with_fibers" != no], [
+   ])
+ ])
+ 
++ASYNC_REQUIRES_PRIVATE=""
++
+ # Check for library support necessary for fibers.
+ AS_IF([test "$with_fibers" != no], [
+   case "${host_os}" in
+@@ -241,6 +243,7 @@ AS_IF([test "$with_fibers" != no], [
+         ])
+         AS_IF([test "$ucontext_supports_fibers" = yes], [
+           ASYNC_LIBS="$ASYNC_LIBS -lucontext"
++          ASYNC_REQUIRES_PRIVATE="$ASYNC_REQUIRES_PRIVATE libucontext"
+           with_fibers=yes
+         ], [
+           AS_IF([test "$with_fibers" = yes], [
+@@ -259,6 +262,7 @@ AS_IF([test "$with_fibers" = yes], [
+ ], [
+   CXXFLAGS="$CXXFLAGS -DKJ_USE_FIBERS=0"
+ ])
++AC_SUBST(ASYNC_REQUIRES_PRIVATE, $ASYNC_REQUIRES_PRIVATE)
+ 
+ # CapnProtoConfig.cmake.in needs these variables,
+ # we force them to NO because we don't need the CMake dependency for them,
+diff --git a/c++/pkgconfig/kj-async.pc.in b/c++/pkgconfig/kj-async.pc.in
+index 49d5ff6996..41aae28555 100644
+--- a/c++/pkgconfig/kj-async.pc.in
++++ b/c++/pkgconfig/kj-async.pc.in
+@@ -8,4 +8,5 @@ Description: Basic utility library called KJ (async part)
+ Version: @VERSION@
+ Libs: -L${libdir} -lkj-async @ASYNC_LIBS@ @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ @STDLIB_FLAG@
+ Requires: kj = @VERSION@
++Requires.private: @ASYNC_REQUIRES_PRIVATE@
+ Cflags: -I${includedir} @ASYNC_LIBS@ @PTHREAD_CFLAGS@ @STDLIB_FLAG@ @CAPNP_LITE_FLAG@

--- a/pkgs/by-name/ca/capnproto/package.nix
+++ b/pkgs/by-name/ca/capnproto/package.nix
@@ -1,11 +1,14 @@
 {
   binutils,
   lib,
+  libucontext,
+  pkg-config,
   clangStdenv,
   fetchFromGitHub,
   cmake,
   openssl,
   zlib,
+  nix-update-script,
 }:
 
 let
@@ -40,12 +43,22 @@ clangStdenv.mkDerivation rec {
     hash = "sha256-aDcn4bLZGq8915/NPPQsN5Jv8FRWd8cAspkG3078psc=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  patches = [
+    # https://github.com/capnproto/capnproto/pull/2377
+    ./fix-libucontext.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
   propagatedBuildInputs = [
     openssl
     zlib
   ]
-  ++ lib.optional (clangStdenv.cc.isClang && clangStdenv.hostPlatform.isStatic) empty-libgcc_eh;
+  ++ lib.optional (clangStdenv.cc.isClang && clangStdenv.hostPlatform.isStatic) empty-libgcc_eh
+  # musl doesn't ship getcontext/setcontext unlike basically every other libc
+  ++ lib.optional clangStdenv.hostPlatform.isMusl libucontext;
 
   # FIXME: separate the binaries from the stuff that user systems actually use
   # This runs into a terrible UX issue in Lix and I just don't want to debug it
@@ -55,6 +68,10 @@ clangStdenv.mkDerivation rec {
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" true)
+    # merely requires setcontext/getcontext (libc), lix expects fibers to
+    # be available, and we want to make sure that the build will fail if
+    # it breaks
+    (lib.cmakeBool "WITH_FIBERS" true)
     # Take optimization flags from CXXFLAGS rather than cmake injecting them
     (lib.cmakeFeature "CMAKE_BUILD_TYPE" "None")
   ];
@@ -65,6 +82,8 @@ clangStdenv.mkDerivation rec {
   };
 
   separateDebugInfo = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://capnproto.org/";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

built `pkgsStatic.capnproto`. depends on https://github.com/NixOS/nixpkgs/pull/432321

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
