### PR TITLE
fetchtorrent: add flatten argument for rqbit

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -43,6 +43,8 @@
 
 - `tooling-language-server` has been renamed to `deputy` (both the package and binary), following the rename of the upstream project.
 
+- `fetchtorrent`, when using the "rqbit" backend, erroneously started fetching files into a subdirectory in Nixpkgs 24.11.  The original behaviour &ndash; which matches the behaviour using the "transmission" backend &ndash; has now been restored.  Users reliant on the erroneous behaviour can temporarily maintain it by adding `flatten = false` to the `fetchtorrent` arguments; Nix will produce an evaluation warning for anyone using `backend = "rqbit"` without `flatten = true`.
+
 - `webfontkitgenerator` has been renamed to `webfont-bundler`, following the rename of the upstream project.
   The binary name remains `webfontkitgenerator`.
   The `webfontkitgenerator` package is an alias to `webfont-bundler`.

--- a/pkgs/build-support/fetchtorrent/default.nix
+++ b/pkgs/build-support/fetchtorrent/default.nix
@@ -18,11 +18,7 @@ in
       "bittorrent"
     else
       "bittorrent-" + builtins.head (builtins.match urlRegexp url),
-  config ?
-    if (backend == "transmission") then
-      { }
-    else
-      throw "json config for configuring fetchFromBitorrent only works with the transmission backend",
+  config ? { },
   hash,
   backend ? "transmission",
   recursiveHash ? true,
@@ -44,6 +40,9 @@ let
   '';
   jsonConfig = (formats.json { }).generate "jsonConfig" config;
 in
+assert lib.assertMsg (config != { } -> backend == "transmission") ''
+  json config for configuring fetchtorrent only works with the transmission backend
+'';
 runCommand name
   {
     inherit meta;

--- a/pkgs/build-support/fetchtorrent/tests.nix
+++ b/pkgs/build-support/fetchtorrent/tests.nix
@@ -18,41 +18,74 @@ let
   };
 
   # Via https://webtorrent.io/free-torrents
-  httpUrl = "https://webtorrent.io/torrents/sintel.torrent";
-  magnetUrl = "magnet:?xt=urn:btih:08ada5a7a6183aae1e09d831df6748d566095a10&dn=Sintel&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fsintel.torrent";
+  http.url = "https://webtorrent.io/torrents/sintel.torrent";
+  magnet.url = "magnet:?xt=urn:btih:08ada5a7a6183aae1e09d831df6748d566095a10&dn=Sintel&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fsintel.torrent";
 
-  # All routes to download the torrent should produce the same output and
-  # therefore have the same FOD hash.
-  hash = "sha256-EzbmBiTEWOlFUNaV5R4eDeD9EBbp6d93rfby88ACg0s=";
+  flattened.hash = "sha256-EzbmBiTEWOlFUNaV5R4eDeD9EBbp6d93rfby88ACg0s=";
+  unflattened.hash = "sha256-lVrlo1AwmFcxwsIsY976VYqb3hAprFH1xWYdmlTuw0U=";
 in
-
-{
-  http-link = testers.invalidateFetcherByDrvHash fetchtorrent {
-    inherit hash;
-    url = httpUrl;
-    backend = "transmission";
+# Seems almost but not quite worth using lib.mapCartesianProduct...
+builtins.mapAttrs (n: v: testers.invalidateFetcherByDrvHash fetchtorrent v) {
+  http-link = {
+    inherit (http) url;
+    inherit (flattened) hash;
     inherit (sintel) meta;
   };
-  magnet-link = testers.invalidateFetcherByDrvHash fetchtorrent {
-    inherit hash;
-    url = magnetUrl;
+  http-link-transmission = {
+    inherit (http) url;
     backend = "transmission";
+    inherit (flattened) hash;
     inherit (sintel) meta;
   };
-  http-link-rqbit = testers.invalidateFetcherByDrvHash fetchtorrent {
-    inherit hash;
-    url = httpUrl;
-    backend = "rqbit";
-    meta = sintel.meta // {
-      broken = true;
-    };
+  magnet-link = {
+    inherit (magnet) url;
+    inherit (flattened) hash;
+    inherit (sintel) meta;
   };
-  magnet-link-rqbit = testers.invalidateFetcherByDrvHash fetchtorrent {
-    inherit hash;
-    url = magnetUrl;
+  magnet-link-transmission = {
+    inherit (magnet) url;
+    backend = "transmission";
+    inherit (flattened) hash;
+    inherit (sintel) meta;
+  };
+  http-link-rqbit = {
+    inherit (http) url;
     backend = "rqbit";
-    meta = sintel.meta // {
-      broken = true;
-    };
+    inherit (flattened) hash;
+    inherit (sintel) meta;
+  };
+  magnet-link-rqbit = {
+    inherit (magnet) url;
+    backend = "rqbit";
+    inherit (flattened) hash;
+    inherit (sintel) meta;
+  };
+  http-link-rqbit-flattened = {
+    inherit (http) url;
+    backend = "rqbit";
+    flatten = true;
+    inherit (flattened) hash;
+    inherit (sintel) meta;
+  };
+  magnet-link-rqbit-flattened = {
+    inherit (magnet) url;
+    backend = "rqbit";
+    flatten = true;
+    inherit (flattened) hash;
+    inherit (sintel) meta;
+  };
+  http-link-rqbit-unflattened = {
+    inherit (http) url;
+    backend = "rqbit";
+    flatten = false;
+    inherit (unflattened) hash;
+    inherit (sintel) meta;
+  };
+  magnet-link-rqbit-unflattened = {
+    inherit (magnet) url;
+    backend = "rqbit";
+    flatten = false;
+    inherit (unflattened) hash;
+    inherit (sintel) meta;
   };
 }


### PR DESCRIPTION
Currently, the output from fetchtorrent will be different depending on whether the default "transmission" backend or the "rqbit" backend is used, because "rqbit" changed its behaviour in v6.0.0 to create subdirectories.

Restore the old behaviour for the rqbit backend of flattening the directory structure, but add a "flatten" argument to allow users to explicitly request the behaviour without this change.

Because fetchtorrent produces fixed-output derivations, it's possible that people won't notice the changes in behaviour here, so add a warning that the behaviour might be unexpected (in either direction!) if the flatten argument isn't specified for the rqbit backend, and -- to avoid needing to support it indefinitely -- a warning that `flatten = false` will be deprecated in future.

Update the fetchtorrent tests to check all the relevant combinations, and to mark all tests as now working.

Update the release notes to advertise this breaking change.

Fixes #432001.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc