### PR TITLE
home-assistant-custom-components.luxer_one: init at 0-unstable-2023-03-27

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/luxer_one/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/luxer_one/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildHomeAssistantComponent,
+  ruff,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "tjhorner";
+  domain = "luxer";
+  version = "0-unstable-2023-03-27";
+
+  src = fetchFromGitHub {
+    owner = "tjhorner";
+    repo = "home-assistant-luxer-one";
+    rev = "f6a810034ab76e6a8635de755c4a1750e86b1674";
+    hash = "sha256-WmsL0NLe2ICqNGbEQ4vg1EzcZgIGi++G9aDyKjnmJMs=";
+  };
+
+  meta = {
+    description = "Home Assistant integration for Luxer One";
+    homepage = "https://github.com/tjhorner/home-assistant-luxer-one";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.haylin ];
+  };
+}


### PR DESCRIPTION
## Things done
Used locally vender'd in my nix repo for my server, finally getting around to upstreaming it. Never done a home-assistant component PR before might be missing something.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
