### PR TITLE
labymod-launcher 2.1.10 to 2.1.12

### DIFF
--- a/pkgs/by-name/la/labymod-launcher/package.nix
+++ b/pkgs/by-name/la/labymod-launcher/package.nix
@@ -6,12 +6,12 @@
 
 let
   pname = "labymod-launcher";
-  version = "2.1.10";
+  version = "2.1.12";
 
   src = fetchurl {
     name = "labymod-launcher";
     url = "https://releases.r2.labymod.net/launcher/linux/x64/LabyMod%20Launcher-${version}.AppImage";
-    hash = "sha256-yRzk1bish/KBe15rnnbaft3358zSv7WaejdvXAdpEC4=";
+    hash = "sha256-n0ipNxtmVSG/Do5UcFpWhGH+4SO3ZljsUXPW4hYzkZU=";
   };
 
   appimageContents = appimageTools.extract { inherit pname version src; };


### PR DESCRIPTION
Updated labymod-launcher to latest version 2.1.12. 
Patch notes include:
- Fixed player renderer within textures library
- Fixed blocking port 25565 in some cases
- Improved news un/read state

I have built the package and verified basic binary functionality.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.