### PR TITLE
nixos/release-notes: move some things from the nixpkgs changelog to here

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -34,8 +34,6 @@
 
 - `conftest` since `0.60.0` has moved to use rego `v1` as default. To continue using `v0` use `--rego-version v0`. For more information about upgrading to Rego v1 syntax, see the [upstream docs](https://www.openpolicyagent.org/docs/latest/v0-upgrade/).
 
-- `stalwart-mail` since `0.13.0` "introduces a significant redesign of the MTA’s delivery and queueing subsystem". See [the upgrading announcement for the `0.13.0` release](https://github.com/stalwartlabs/stalwart/blob/89b561b5ca1c5a11f2a768b4a2cfef0f473b7a01/UPGRADING.md#upgrading-from-v012x-and-v011x-to-v013x).
-
 - Greetd and its original greeters (`tuigreet`, `gtkgreet`, `qtgreet`, `regreet`, `wlgreet`) were moved from `greetd` namespace to top level (`greetd.tuigreet` -> `tuigreet`, `greetd.greetd` -> `greetd`, etc). The original attrs are available for compatibility as passthrus of `greetd`, but will emit a warning. They will be removed in future releases.
 
 - The `archipelago-minecraft` package was removed, as upstream no longer provides support for the Minecraft APWorld.
@@ -63,12 +61,6 @@
 - `podofo` has been updated from `0.9.8` to `1.0.0`. These releases are by nature very incompatable due to major api changes. The legacy versions can be found under `podofo_0_10` and `podofo_0_9`.
   Changelog: https://github.com/podofo/podofo/blob/1.0.0/CHANGELOG.md, API-Migration-Guide: https://github.com/podofo/podofo/blob/1.0.0/API-MIGRATION.md.
 
-- NetBox was updated to `>= 4.3.0`. Have a look at the breaking changes
-  of the [4.3 release](https://github.com/netbox-community/netbox/releases/tag/v4.2.0),
-  make the required changes to your database, if needed, then upgrade by setting `services.netbox.package = pkgs.netbox_4_3;` in your configuration.
-
-- `privatebin` has been updated to `2.0.0`. This release changes configuration defaults including switching the template and removing legacy features. See the [v2.0.0 changelog entry](https://github.com/PrivateBin/PrivateBin/releases/tag/2.0.0) for details on how to upgrade.
-
 - `go-mockery` has been updated to v3. For migration instructions see the [upstream documentation](https://vektra.github.io/mockery/latest/v3/). If v2 is still required `go-mockery_v2` has been added but will be removed on or before 2029-12-31 in-line with it's [upstream support lifecycle](https://vektra.github.io/mockery/
 
 - [private-gpt](https://github.com/zylon-ai/private-gpt) service has been removed by lack of maintenance upstream.
@@ -81,20 +73,11 @@
 
 - The systemd initrd will now respect `x-systemd.wants` and `x-systemd.requires` for reliably unlocking multi-disk bcachefs volumes.
 
-- [`homebox` 0.20.0](https://github.com/sysadminsmedia/homebox/releases/tag/v0.20.0) changed how assets are stored and hashed. It is recommended to back up your database before this update.
-
 - New hardening flags, `strictflexarrays1` and `strictflexarrays3` were made available, corresponding to the gcc/clang options `-fstrict-flex-arrays=1` and `-fstrict-flex-arrays=3` respectively.
-
-- `gramps` has been updated to 6.0.0
-  Upstream recommends [backing up your Family Trees](https://gramps-project.org/wiki/index.php/Gramps_6.0_Wiki_Manual_-_Manage_Family_Trees#Backing_up_a_Family_Tree) before upgrading.
 
 - `meta.mainProgram`: Changing this `meta` entry can lead to a package rebuild due to being used to determine the `NIX_MAIN_PROGRAM` environment variable.
 
-- `searx` was updated to use `envsubst` instead of `sed` for parsing secrets from environment variables.
-  If your previous configuration included a secret reference like `server.secret_key = "@SEARX_SECRET_KEY@"`, you must migrate to the new envsubst syntax: `server.secret_key = "$SEARX_SECRET_KEY"`.
-
 - `versionCheckHook`: Packages that previously relied solely on `pname` to locate the program used to version check, but have a differing `meta.mainProgram` entry, might now fail.
-
 
 - The debug outputs produced by `separateDebugInfo = true;` now contain symlinks mapping build-ids to the original source and ELF file.
   Specifically, if `$out/bin/ninja` has build-id `483bd7f7229bdb06462222e1e353e4f37e15c293`, then

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -107,6 +107,9 @@
 
 - The `dovecot` systemd service was renamed from `dovecot2` to `dovecot`. The former is now just an alias. Update any overrides on the systemd unit to the new name.
 
+- `searx` was updated to use `envsubst` instead of `sed` for parsing secrets from environment variables.
+  If your previous configuration included a secret reference like `server.secret_key = "@SEARX_SECRET_KEY@"`, you must migrate to the new envsubst syntax: `server.secret_key = "$SEARX_SECRET_KEY"`.
+
 - `Prosody` has been updated to major release 13 which removed some obsoleted modules and brought a couple of major and breaking changes:
   - The `http_files` module is now disabled by default because it now requires `http_files_dir` to be configured.
   - The `vcard_muc` module has been removed and got replaced by the inbuilt `muc_vcard` module.
@@ -115,11 +118,18 @@
   - The `mime_types_file` setting is now set to `"${pkgs.mailcap}/etc/mime.types"` to prevent errors.
   For a complete list of changes, please see [their announcement](https://blog.prosody.im/prosody-13.0.0-released/).
 
+- [`homebox` 0.20.0](https://github.com/sysadminsmedia/homebox/releases/tag/v0.20.0) changed how assets are stored and hashed. It is recommended to back up your database before this update.
+
+- `gramps` has been updated to 6.0.0
+  Upstream recommends [backing up your Family Trees](https://gramps-project.org/wiki/index.php/Gramps_6.0_Wiki_Manual_-_Manage_Family_Trees#Backing_up_a_Family_Tree) before upgrading.
+
 - The `yeahwm` package and `services.xserver.windowManager.yeahwm` module were removed due to the package being broken and unmaintained upstream.
 
 - The `services.postgresql` module now sets up a systemd unit `postgresql.target`. Depending on `postgresql.target` guarantees that postgres is in read-write mode and initial/ensure scripts were executed. Depending on `postgresql.service` only guarantees a read-only connection.
 
 - The `services.siproxd` module has been removed as `siproxd` is unmaintained and broken with libosip 5.x.
+
+- `stalwart-mail` since `0.13.0` "introduces a significant redesign of the MTA’s delivery and queueing subsystem". See [the upgrading announcement for the `0.13.0` release](https://github.com/stalwartlabs/stalwart/blob/89b561b5ca1c5a11f2a768b4a2cfef0f473b7a01/UPGRADING.md#upgrading-from-v012x-and-v011x-to-v013x).
 
 - `netbox-manage` script created by the `netbox` module no longer uses `sudo -u netbox` internally. It can be run as root and will change it's user to `netbox` using `runuser`
 
@@ -127,6 +137,12 @@
 
 - `gitversion` was updated to 6.3.0, which includes a number of breaking changes, old configurations may need updating or they will cause the tool to fail to run.
   See the [6.0.0 release notes for GitVersion](https://github.com/GitTools/GitVersion/releases/tag/6.0.0) for details on the breaking changes, [the documentation on the configuration format](https://gitversion.net/docs/reference/configuration) for the new configuration specification, and [the documentation on version variables](https://gitversion.net/docs/reference/variables) for what is now supported.
+
+- NetBox was updated to `>= 4.3.0`. Have a look at the breaking changes
+  of the [4.3 release](https://github.com/netbox-community/netbox/releases/tag/v4.2.0),
+  make the required changes to your database, if needed, then upgrade by setting `services.netbox.package = pkgs.netbox_4_3;` in your configuration.
+
+- `privatebin` has been updated to `2.0.0`. This release changes configuration defaults including switching the template and removing legacy features. See the [v2.0.0 changelog entry](https://github.com/PrivateBin/PrivateBin/releases/tag/2.0.0) for details on how to upgrade.
 
 - `renovate` was updated to v41. See the upstream release notes for [v40](https://github.com/renovatebot/renovate/releases/tag/40.0.0) and [v41](https://github.com/renovatebot/renovate/releases/tag/41.0.0) for breaking changes.
 


### PR DESCRIPTION
see https://github.com/NixOS/nixpkgs/commit/ca88da9ce3d77ad5ae654f884361c01623c0d09e

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
