### PR TITLE
prometheus-collectd-exporter: add support for missing flags

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/collectd.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/collectd.nix
@@ -29,6 +29,12 @@ in
         description = "File mapping user names to pre-shared keys (passwords).";
       };
 
+      typesdbFile = mkOption {
+        default = null;
+        type = types.nullOr types.path;
+        description = "Collectd types.db file for datasource names mapping.";
+      };
+
       port = mkOption {
         type = types.port;
         default = 25826;
@@ -84,9 +90,17 @@ in
   };
   serviceOpts =
     let
+      authFileArgs = optionalString (cfg.collectdBinary.authFile != null) ''
+        --collectd.auth-file ${escapeShellArg cfg.collectdBinary.authFile} \
+      '';
+      typesdbFileArgs = optionalString (cfg.collectdBinary.typesdbFile != null) ''
+        --collectd.typesdb-file ${escapeShellArg cfg.collectdBinary.typesdbFile} \
+      '';
       collectSettingsArgs = optionalString (cfg.collectdBinary.enable) ''
         --collectd.listen-address ${cfg.collectdBinary.listenAddress}:${toString cfg.collectdBinary.port} \
         --collectd.security-level ${cfg.collectdBinary.securityLevel} \
+        ${authFileArgs} \
+        ${typesdbFileArgs}
       '';
     in
     {


### PR DESCRIPTION
* Fix support for `--collectd.auth-file`, if option (`collectdBinary.authFile`) is present add flag to cmdline.
* Add support for `--collectd.typesdb-file`, if option (`collectdBinary.typesdbFile`) is present add flag to cmdline.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
