### PR TITLE
qogir-cursors-recolored: init at 0-unstable-2023-10-03

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17344,6 +17344,12 @@
     githubId = 96225281;
     name = "Mustafa Çalışkan";
   };
+  mushrowan = {
+    email = "roarch@proton.me";
+    name = "rowan amber-jones";
+    github = "mushrowan";
+    githubId = 69822445;
+  };
   musjj = {
     name = "musjj";
     github = "musjj";

--- a/pkgs/by-name/qo/qogir-cursors-recolored/package.nix
+++ b/pkgs/by-name/qo/qogir-cursors-recolored/package.nix
@@ -1,0 +1,142 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  themeVariants ? [ ],
+  catppuccinColorVariants ? [ ],
+  draculaColorVariants ? [ ],
+  gruvboxColorVariants ? [ ],
+  originalColorVariants ? [ ],
+}:
+
+let
+  pname = "qogir-cursors-recolored";
+  version = "0-unstable-2023-10-03";
+
+  availableThemeVariants = [
+    "Catppuccin"
+    "Dracula"
+    "Gruvbox"
+    "Original"
+  ];
+
+  availableColorVariants = {
+    Catppuccin = [
+      "Blue"
+      "Flamingo"
+      "Green"
+      "Macchiato"
+      "Maroon"
+      "Mauve"
+      "Peach"
+      "Pink"
+      "Red"
+      "Rosewater"
+      "Sapphire"
+      "Sky"
+      "Yellow"
+    ];
+    Dracula = [
+      "Cyan"
+      "Green"
+      "Orange"
+      "Pink"
+      "Purple"
+      "Red"
+      "Teddy"
+      "Yellow"
+    ];
+    Gruvbox = [
+      "Aqua"
+      "Black"
+      "Blue"
+      "Gray"
+      "Green"
+      "Mojas84"
+      "Orange"
+      "Purple"
+      "White"
+    ];
+    Original = [
+      "Blue"
+      "Purple"
+      "Joris"
+      "Joris2"
+      "Joris3"
+      "Joris4"
+    ];
+  };
+in
+
+lib.checkListOfEnum "${pname}: theme variants" availableThemeVariants themeVariants
+  lib.checkListOfEnum
+  "${pname}: catppuccin color variants"
+  availableColorVariants.Catppuccin
+  catppuccinColorVariants
+  lib.checkListOfEnum
+  "${pname}: dracula color variants"
+  availableColorVariants.Dracula
+  draculaColorVariants
+  lib.checkListOfEnum
+  "${pname}: gruvbox color variants"
+  availableColorVariants.Gruvbox
+  gruvboxColorVariants
+  lib.checkListOfEnum
+  "${pname}: original color variants"
+  availableColorVariants.Original
+  originalColorVariants
+
+  stdenvNoCC.mkDerivation
+  {
+    inherit pname version;
+
+    src = fetchFromGitHub {
+      owner = "TeddyBearKilla";
+      repo = "Qogir-Cursors-Recolored";
+      rev = "0d2c6be805cb5b8744faa6d046c5b50e90e71a06";
+      hash = "sha256-MomchdS1H5EmjhNUp0khaPxXE5CYoP8WlGgYEhXU21A=";
+    };
+
+    installPhase =
+      let
+        dist = {
+          Catppuccin = "cat";
+          Dracula = "dracula";
+          Gruvbox = "gruvbox";
+        };
+        withAlternate = xs: xs': if xs != [ ] then xs else xs';
+        themeVariants' = withAlternate themeVariants availableThemeVariants;
+        colorVariants = {
+          Catppuccin = withAlternate catppuccinColorVariants availableColorVariants.Catppuccin;
+          Dracula = withAlternate draculaColorVariants availableColorVariants.Dracula;
+          Gruvbox = withAlternate gruvboxColorVariants availableColorVariants.Gruvbox;
+          Original = withAlternate originalColorVariants availableColorVariants.Original;
+        };
+      in
+      ''
+        runHook preInstall
+
+        mkdir -p $out/share/icons
+
+        ${lib.concatMapStringsSep "\n" (
+          theme:
+          lib.concatMapStringsSep "\n" (color: ''
+            ln -s \
+              "$src/colors/${theme}/${color}/dist-${
+                lib.optionalString (theme != "Original") (dist.${theme} + "-")
+              }${lib.toLower color}" \
+              "$out/share/icons/Qogir-Recolored-${theme}-${color}"
+          '') colorVariants.${theme}
+        ) themeVariants'}
+
+        runHook postInstall
+      '';
+
+    meta = {
+      description = "Recoloring of the Qogir Cursors x-cursor theme";
+      homepage = "https://github.com/TeddyBearKilla/Qogir-Cursors-Recolored";
+      maintainers = with lib.maintainers; [ mushrowan ];
+      platforms = lib.platforms.all;
+      license = lib.licenses.gpl3Plus;
+    };
+  }


### PR DESCRIPTION
# Description of changes
qogir-cursors-recolored: init at 2023-10-03
https://github.com/TeddyBearKilla/Qogir-Cursors-Recolored
I basically copied https://github.com/NixOS/nixpkgs/pull/284617 with a couple of tweaks related to capitalisation to make it work.

My first PR so please let me know if I've messed up :)

Basically a copy of the PR I made before @ https://github.com/NixOS/nixpkgs/pull/432246. I managed to mess something up so badly that it autoclosed my PR and wouldn't let me open. Hopefully won't break it again :(

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
