### PR TITLE
nixos/zigbee2mqtt: Update homeassistant setting

### DIFF
--- a/nixos/modules/services/home-automation/zigbee2mqtt.nix
+++ b/nixos/modules/services/home-automation/zigbee2mqtt.nix
@@ -41,7 +41,7 @@ in
       default = { };
       example = lib.literalExpression ''
         {
-          homeassistant = config.services.home-assistant.enable;
+          homeassistant.enabled = config.services.home-assistant.enable;
           permit_join = true;
           serial = {
             port = "/dev/ttyACM1";
@@ -60,7 +60,7 @@ in
 
     # preset config values
     services.zigbee2mqtt.settings = {
-      homeassistant = lib.mkDefault config.services.home-assistant.enable;
+      homeassistant.enabled = lib.mkDefault config.services.home-assistant.enable;
       permit_join = lib.mkDefault false;
       mqtt = {
         base_topic = lib.mkDefault "zigbee2mqtt";


### PR DESCRIPTION
This is now no longer a top-level boolean:

* https://www.zigbee2mqtt.io/guide/configuration/homeassistant.html
* https://github.com/Koenkk/zigbee2mqtt.io/commit/ae8965a0589789449cd9478adced39a2fb69760c#diff-aa9667dbf49ded55b85667093efbf5f706f30496292182850e7f94bb2e1e0774


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
