### PR TITLE
Fix double xprofile sourcing

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -96,6 +96,8 @@
 
 - The `services.polipo` module has been removed as `polipo` is unmaintained and archived upstream.
 
+- The default xsession script provided by `services.x11.display-managers` has been changed to avoid running `~/.xprofile` twice. The `_DID_SYSTEMD_CAT` variable is now no longer available to xsession scripts.
+
 - The non-LTS Forgejo package (`forgejo`) has been updated to 12.0.0. This release contains breaking changes, see the [release blog post](https://forgejo.org/2025-07-release-v12-0/)
   for all the details and how to ensure smooth upgrades.
 

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -436,6 +436,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
   the kernel ring buffer (dmesg) to rotate quickly and potentially discard more
   relevant diagnostic information.
 
+- The default xsession script provided by `services.x11.display-managers` has been changed to avoid running `~/.xprofile` twice. The `_DID_SYSTEMD_CAT` variable is now no longer available to xsession scripts.
+
 - The `services.calibre-web` systemd service has been hardened with additional sandboxing restrictions.
 
 - `services.kanidm` options for server, client and unix were moved under dedicated namespaces.

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -63,6 +63,31 @@ let
   xsessionWrapper = pkgs.writeScript "xsession-wrapper" ''
     #! ${pkgs.bash}/bin/bash
 
+    ${optionalString config.services.displayManager.logToJournal ''
+      # Pass logging to systemd's journal.
+      # Must come first, as this re-executes the whole script and we shouldn't
+      # be re-executing most of the remaining commands in here.
+      if [ -z "$_DID_SYSTEMD_CAT" ]; then
+        export _DID_SYSTEMD_CAT=1
+        exec ${config.systemd.package}/bin/systemd-cat -t xsession "$0" "$@"
+      fi
+      unset _DID_SYSTEMD_CAT
+    ''}
+
+    ${optionalString
+      (config.services.displayManager.logToJournal && config.services.displayManager.logToFile)
+      ''
+        exec > >(tee ~/.xsession-errors) 2>&1
+      ''
+    }
+
+    ${optionalString
+      (!config.services.displayManager.logToJournal && config.services.displayManager.logToFile)
+      ''
+        exec > ~/.xsession-errors 2>&1
+      ''
+    }
+
     # Shared environment setup for graphical sessions.
 
     . /etc/profile
@@ -76,17 +101,6 @@ let
     if test -f ~/.xprofile; then
         source ~/.xprofile
     fi
-
-    ${optionalString config.services.displayManager.logToJournal ''
-      if [ -z "$_DID_SYSTEMD_CAT" ]; then
-        export _DID_SYSTEMD_CAT=1
-        exec ${config.systemd.package}/bin/systemd-cat -t xsession "$0" "$@"
-      fi
-    ''}
-
-    ${optionalString config.services.displayManager.logToFile ''
-      exec &> >(tee ~/.xsession-errors)
-    ''}
 
     # Load X defaults. This should probably be safe on wayland too.
     ${pkgs.xrdb}/bin/xrdb -merge ${xresourcesXft}
@@ -116,8 +130,6 @@ let
     # Work around KDE errors when a user first logs in and
     # .local/share doesn't exist yet.
     mkdir -p "''${XDG_DATA_HOME:-$HOME/.local/share}"
-
-    unset _DID_SYSTEMD_CAT
 
     ${cfg.displayManager.sessionCommands}
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -431,6 +431,7 @@ in
     imports = [ ./discourse.nix ];
     _module.args.package = pkgs.discourseAllPlugins;
   };
+  display-managers = runTest ./display-managers.nix;
   dnscrypt-proxy2 = runTestOn [ "x86_64-linux" ] ./dnscrypt-proxy2.nix;
   dnsdist = import ./dnsdist.nix { inherit pkgs runTest; };
   doas = runTest ./doas.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -463,6 +463,7 @@ in
     imports = [ ./discourse.nix ];
     _module.args.package = pkgs.discourseAllPlugins;
   };
+  display-managers = runTest ./display-managers.nix;
   dnscrypt-proxy = runTestOn [ "x86_64-linux" ] ./dnscrypt-proxy.nix;
   dnsdist = import ./dnsdist.nix { inherit pkgs runTest; };
   doas = runTest ./doas.nix;

--- a/nixos/tests/display-managers.nix
+++ b/nixos/tests/display-managers.nix
@@ -1,0 +1,67 @@
+{ pkgs, ... }:
+{
+  name = "display-managers";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ ];
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [
+        ./common/user-account.nix
+      ];
+
+      services = {
+        xserver = {
+          enable = true;
+          windowManager.icewm.enable = true;
+          displayManager.lightdm.enable = true;
+        };
+        displayManager = {
+          enable = true;
+          autoLogin.user = "alice";
+          defaultSession = "none+icewm";
+        };
+      };
+
+      systemd.services."give-alice-an-xprofile" = {
+        description = "Write out Alice's .xprofile before x11 starts";
+        wantedBy = [ "graphical.target" ];
+        before = [ "display-manager.service" ];
+        serviceConfig = {
+          User = "alice";
+          Type = "oneshot";
+        };
+        script = ''
+          printf "%s\n" "echo xprofile has been executed once | ${pkgs.systemd}/bin/systemd-cat -p crit" > ~alice/.xprofile
+        '';
+      };
+    };
+
+  testScript =
+    { nodes, ... }:
+    let
+      user = nodes.machine.users.users.alice;
+    in
+    ''
+      start_all()
+      machine.wait_for_x()
+
+      machine.wait_for_file("${user.home}/.Xauthority")
+      machine.succeed("xauth merge ${user.home}/.Xauthority")
+
+      machine.wait_for_window("^IceWM ")
+
+      # Look for our xprofile sentinel message in the logs
+      our_sentinel = "xprofile has been executed once"
+      log_contents = machine.succeed(f"journalctl --no-pager --boot --grep='{our_sentinel}'").strip()
+
+      # Do we have multiple lines in here?
+      num_lines = sum(1 for line in log_contents.split("\n")
+                      if our_sentinel in line)
+
+      assert num_lines != 0, "xprofile doesn't appear to have run"  # should result in command above failing anyway, but can't hurt to check
+      assert num_lines == 1, "xprofile appears to have run multiple times"
+    '';
+}


### PR DESCRIPTION
Tweaked the xsession wrapper script so that it doesn't launch the xprofile twice.

Addresses #119513 (in which I [investigated](https://github.com/NixOS/nixpkgs/issues/119513#issuecomment-2846037310) the issue), and #188545.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

##### Reviewed points

- [ ] changes are backward compatible
- [ ] removed options are declared with `mkRemovedOptionModule`
- [x] changes that are not backward compatible are documented in release notes
- [x] module tests succeed on ARCHITECTURE
- [ ] options types are appropriate
- [ ] options description is set
- [ ] options example is provided
- [ ] documentation affected by the changes is updated

##### Possible improvements

##### Comments

Not sure if I need to mark myself as test maintainer? I would rather not for now if that's allowed.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
