### PR TITLE
fex: update to qt6, make qt optional

### DIFF
--- a/pkgs/by-name/fe/fex-headless/package.nix
+++ b/pkgs/by-name/fe/fex-headless/package.nix
@@ -1,0 +1,7 @@
+{
+  fex,
+}:
+
+fex.override {
+  withQt = false;
+}

--- a/pkgs/by-name/fe/fex/package.nix
+++ b/pkgs/by-name/fe/fex/package.nix
@@ -101,7 +101,6 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     owner = "FEX-Emu";
     repo = "FEX";
     tag = "FEX-${finalAttrs.version}";
-
     hash = "sha256-Dq87cx7tv+HJvpy57L8dcApE+3E8VEyyTYKhDyoUfVU=";
 
     leaveDotGit = true;
@@ -117,8 +116,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
         External/jemalloc_glibc \
         External/robin-map \
         External/vixl \
-        Source/Common/cpp-optparse \
-        External/Catch2
+        Source/Common/cpp-optparse
 
       find . -name .git -print0 | xargs -0 rm -rf
 
@@ -165,7 +163,6 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     llvmPackages.bintools
-
     (python3.withPackages (
       pythonPackages: with pythonPackages; [
         setuptools
@@ -174,8 +171,6 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     ))
   ]
   ++ lib.optional withQt qt6.wrapQtAppsHook;
-
-  nativeCheckInputs = [ nasm ];
 
   buildInputs = [
     xxHash
@@ -196,8 +191,6 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeFeature "USE_LINKER" "lld")
-    (lib.cmakeBool "ENABLE_LTO" true)
-    (lib.cmakeBool "ENABLE_ASSERTIONS" false)
     (lib.cmakeFeature "OVERRIDE_VERSION" finalAttrs.version)
     (lib.cmakeBool "BUILD_TESTS" finalAttrs.finalPackage.doCheck)
     (lib.cmakeBool "BUILD_THUNKS" true)
@@ -211,6 +204,9 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
 
   # Unsupported on non-4K page size kernels (e.g. Apple Silicon)
   doCheck = true;
+
+  nativeCheckInputs = [ nasm ];
+  checkInputs = [ catch2 ];
 
   # List not exhaustive, e.g. because they depend on an x86 compiler or some
   # other difficult-to-build test binaries.


### PR DESCRIPTION
Closes #376837

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
