### PR TITLE
nixos/tailscale: Add option to disable upstream debug logging

### DIFF
--- a/nixos/modules/services/networking/tailscale.nix
+++ b/nixos/modules/services/networking/tailscale.nix
@@ -44,6 +44,12 @@ in
       description = "Whether to disable the Taildrop feature for sending files between nodes.";
     };
 
+    disableUpstreamLogging = mkOption {
+      default = false;
+      type = types.bool;
+      description = "Whether to disable Tailscaled from sending debug logging upstream.";
+    };
+
     package = lib.mkPackageOption pkgs "tailscale" { };
 
     openFirewall = mkOption {
@@ -154,6 +160,9 @@ in
       ])
       ++ (lib.optionals (cfg.disableTaildrop) [
         "TS_DISABLE_TAILDROP=true"
+      ])
+      ++ (lib.optionals (cfg.disableUpstreamLogging) [
+        "TS_NO_LOGS_NO_SUPPORT=true"
       ]);
       # Restart tailscaled with a single `systemctl restart` at the
       # end of activation, rather than a `stop` followed by a later


### PR DESCRIPTION
Tailscale by default sends logs upstream to a centralized logging service. We can disable this by adding an env var
https://tailscale.com/kb/1011/log-mesh-traffic?tab=linux#opting-out-of-client-logging. This is especially useful when you're using Headscale and don't want to sent any data to Tailscale Inc. (the company).

Logs before this change when I wasn't connected to the internet:
`
Aug 09 23:49:10 niato tailscaled[1552]: logtail: upload: log upload of 1412 bytes compressed failed: Post "https://log.tailscale.com/c/tailnode.log.tailscale.io/redactedID": failed to resolve "log.tailscale.com": no DNS fallback candidates remain for "log.tailscale.com"
`

after connecting to the internet:

`
Aug 09 23:51:08 niato tailscaled[1552]: logtail: upload succeeded after 3 failures and 50s
`

and after applying this patch and setting this option to true:

`
Aug 10 05:14:00 niato tailscaled[245889]: 2025/08/10 05:14:00 You have disabled logging. Tailscale will not be able to provide support.
`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
