### PR TITLE
nixos/i2pd: remove destination option from inTunnel configuration

### DIFF
--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -106,10 +106,6 @@ let
         description = "Number of ElGamal/AES tags to send.";
         default = 40;
       };
-      destination = mkOption {
-        type = types.str;
-        description = "Remote endpoint, I2P hostname or b32.i2p address.";
-      };
       keys = mkOption {
         type = types.str;
         default = name + "-keys.dat";
@@ -254,7 +250,6 @@ let
             (intOpt "port" tun.port)
             (strOpt "host" tun.address)
           ]
-          ++ (optionals (tun ? destination) (optionalNullString "destination" tun.destination))
           ++ (optionals (tun ? keys) (optionalNullString "keys" tun.keys))
           ++ (optionals (tun ? inPort) (optionalNullInt "inport" tun.inPort))
           ++ (optionals (tun ? accessList) (optionalEmptyList "accesslist" tun.accessList));
@@ -685,6 +680,10 @@ in
             { name, ... }:
             {
               options = {
+                destination = mkOption {
+                  type = types.str;
+                  description = "Remote endpoint, I2P hostname or b32.i2p address.";
+                };
                 destinationPort = mkOption {
                   type = with types; nullOr int;
                   default = null;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://i2pd.readthedocs.io/en/latest/user-guide/tunnels/#servergeneric-tunnels

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
