### PR TITLE
python3Packages.thingspeak: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/thingspeak/default.nix
+++ b/pkgs/development/python-modules/thingspeak/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildPythonPackage,
+  docopt,
+  fetchFromGitHub,
+  poetry-core,
+  pytest-vcr,
+  pytestCheckHook,
+  requests,
+  setuptools,
+  vcrpy,
+}:
+
+buildPythonPackage rec {
+  pname = "thingspeak";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mchwalisz";
+    repo = "thingspeak";
+    tag = "v${version}";
+    hash = "sha256-9YvudzksWp130hkG8WxiX9WHegAVH2TT1vwMbLJ13qE=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "poetry.masonry.api" "poetry.core.masonry.api" \
+      --replace-fail 'requires = ["poetry>=0.12"]' 'requires = ["poetry-core"]'
+  '';
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    docopt
+    requests
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    pytest-vcr
+    pytestCheckHook
+    vcrpy
+  ];
+
+  disabledTests = [
+    # VCR cassette conflicts with different API keys
+    "test_get_with_key"
+  ];
+
+  pythonImportsCheck = [
+    "thingspeak"
+  ];
+
+  meta = {
+    description = "Client library for the thingspeak.com API";
+    homepage = "https://github.com/mchwalisz/thingspeak";
+    changelog = "https://github.com/mchwalisz/thingspeak/releases/tag/v${version}";
+    license = lib.licenses.lgpl3Only;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -5979,7 +5979,8 @@
       ];
     "thingspeak" =
       ps: with ps; [
-      ]; # missing inputs: thingspeak
+        thingspeak
+      ];
     "thinkingcleaner" =
       ps: with ps; [
       ]; # missing inputs: pythinkingcleaner

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17981,6 +17981,8 @@ self: super: with self; {
 
   thinc = callPackage ../development/python-modules/thinc { };
 
+  thingspeak = callPackage ../development/python-modules/thingspeak { };
+
   thinqconnect = callPackage ../development/python-modules/thinqconnect { };
 
   thorlabspm100 = callPackage ../development/python-modules/thorlabspm100 { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://pypi.org/project/thingspeak/
- https://github.com/mchwalisz/thingspeak
- https://www.home-assistant.io/integrations/thingspeak/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
