### PR TITLE
nixos/systemd/{homed,userdbd}: add module options, SSH integration support

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -550,6 +550,11 @@ in
           (mkAfter [ "[success=merge] systemd" ]) # need merge so that NSS won't stop at file-based groups
         ]
       );
+      shadow = (
+        mkMerge [
+          (mkAfter [ "systemd" ])
+        ]
+      );
     };
 
     environment.systemPackages = [ cfg.package ];

--- a/nixos/modules/system/boot/systemd/homed.nix
+++ b/nixos/modules/system/boot/systemd/homed.nix
@@ -1,46 +1,92 @@
 {
   config,
   lib,
-  pkgs,
+  utils,
   ...
 }:
 
 let
   cfg = config.services.homed;
 in
+
 {
-  options.services.homed.enable = lib.mkEnableOption ''
-    systemd home area/user account manager
-  '';
+  options.services.homed = {
+    enable = lib.mkEnableOption "systemd home area/user account manager";
+
+    promptOnFirstBoot =
+      lib.mkEnableOption ''
+        interactively prompting for user creation on first boot
+      ''
+      // {
+        default = true;
+      };
+
+    settings.Home = lib.mkOption {
+      default = { };
+      type = lib.types.submodule {
+        freeformType = lib.types.attrsOf utils.systemdUtils.unitOptions.unitOption;
+      };
+      example = {
+        DefaultStorage = "luks";
+        DefaultFileSystemType = "btrfs";
+      };
+      description = ''
+        Options for systemd-homed. See {manpage}`homed.conf(5)` man page for
+        available options.
+      '';
+    };
+  };
 
   config = lib.mkIf cfg.enable {
     assertions = [
       {
         assertion = config.services.nscd.enable;
-        message = "systemd-homed requires the use of systemd nss module. services.nscd.enable must be set to true,";
+        message = ''
+          systemd-homed requires the use of the systemd nss module.
+          services.nscd.enable must be set to true.
+        '';
       }
     ];
 
     systemd.additionalUpstreamSystemUnits = [
       "systemd-homed.service"
       "systemd-homed-activate.service"
+      "systemd-homed-firstboot.service"
     ];
 
-    # This is mentioned in homed's [Install] section.
-    #
-    # While homed appears to work without it, it's probably better
-    # to follow upstream recommendations.
-    services.userdbd.enable = lib.mkDefault true;
+    # homed exposes SSH public keys and other user metadata using userdb
+    services.userdbd = {
+      enable = true;
+      enableSSHSupport = lib.mkDefault config.services.openssh.enable;
+    };
+
+    # Enable creation and mounting of LUKS home areas with all filesystems
+    # supported by systemd-homed.
+    boot.supportedFilesystems = [
+      "btrfs"
+      "ext4"
+      "xfs"
+    ];
+
+    environment.etc."systemd/homed.conf".text = ''
+      [Home]
+      ${utils.systemdUtils.lib.attrsToSection cfg.settings.Home}
+    '';
 
     systemd.services = {
       systemd-homed = {
-        # These packages are required to manage encrypted volumes
+        # These packages are required to manage home areas with LUKS storage
         path = config.system.fsPackages;
         aliases = [ "dbus-org.freedesktop.home1.service" ];
         wantedBy = [ "multi-user.target" ];
       };
 
       systemd-homed-activate = {
+        wantedBy = [ "systemd-homed.service" ];
+      };
+
+      systemd-homed-firstboot = {
+        enable = cfg.promptOnFirstBoot;
         wantedBy = [ "systemd-homed.service" ];
       };
     };

--- a/nixos/modules/system/boot/systemd/userdbd.nix
+++ b/nixos/modules/system/boot/systemd/userdbd.nix
@@ -4,15 +4,45 @@ let
   cfg = config.services.userdbd;
 in
 {
-  options.services.userdbd.enable = lib.mkEnableOption ''
-    the systemd JSON user/group record lookup service
-  '';
+  options.services.userdbd = {
+    enable = lib.mkEnableOption ''
+      the systemd JSON user/group record lookup service
+    '';
+
+    enableSSHSupport = lib.mkEnableOption ''
+      exposing OpenSSH public keys defined in userdb. Be aware that this
+      enables modifying public keys at runtime, either by users managed by
+      {option}`services.homed`, or globally via drop-in files
+    '';
+  };
+
   config = lib.mkIf cfg.enable {
+    assertions = lib.singleton {
+      assertion = cfg.enableSSHSupport -> config.security.enableWrappers;
+      message = "OpenSSH userdb integration requires security wrappers.";
+    };
+
     systemd.additionalUpstreamSystemUnits = [
       "systemd-userdbd.socket"
       "systemd-userdbd.service"
     ];
 
     systemd.sockets.systemd-userdbd.wantedBy = [ "sockets.target" ];
+
+    # OpenSSH requires AuthorizedKeysCommand to be owned only by root.
+    # Referencing `userdbctl` directly from the Nix store won't work, as
+    # `/nix/store` is owned by the `nixbld` group.
+    security.wrappers = lib.mkIf cfg.enableSSHSupport {
+      userdbctl = {
+        owner = "root";
+        group = "root";
+        source = lib.getExe' config.systemd.package "userdbctl";
+      };
+    };
+
+    services.openssh = lib.mkIf cfg.enableSSHSupport {
+      authorizedKeysCommand = "/run/wrappers/bin/userdbctl ssh-authorized-keys %u";
+      authorizedKeysCommandUser = "root";
+    };
   };
 }

--- a/nixos/modules/system/boot/systemd/userdbd.nix
+++ b/nixos/modules/system/boot/systemd/userdbd.nix
@@ -2,6 +2,12 @@
 
 let
   cfg = config.services.userdbd;
+
+  # List of system users that will be incorrectly treated as regular/normal
+  # users by userdb.
+  highSystemUsers = lib.filter (
+    user: user.enable && user.isSystemUser && (lib.defaultTo 0 user.uid) >= 1000 && user.uid != 65534
+  ) (lib.attrValues config.users.users);
 in
 {
   options.services.userdbd = {
@@ -14,6 +20,14 @@ in
       enables modifying public keys at runtime, either by users managed by
       {option}`services.homed`, or globally via drop-in files
     '';
+
+    silenceHighSystemUsers = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      example = true;
+      description = "Silence warning about system users with high UIDs.";
+      visible = false;
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -21,6 +35,28 @@ in
       assertion = cfg.enableSSHSupport -> config.security.enableWrappers;
       message = "OpenSSH userdb integration requires security wrappers.";
     };
+
+    warnings = lib.optional (lib.length highSystemUsers > 0 && !cfg.silenceHighSystemUsers) ''
+      The following system users have UIDs higher than 1000:
+
+      ${lib.concatLines (lib.map (user: user.name) highSystemUsers)}
+
+      These users will be recognized by systemd-userdb as "regular" users, not
+      "system" users. This will affect programs that query regular users, such
+      as systemd-homed, which will not run the first boot user creation flow,
+      as regular users already exist.
+
+      To fix this issue, please remove or redefine these system users to have
+      UIDs below 1000. For Nix build users, it's possible to adjust the base
+      build user ID using the `ids.uids.nixbld` option, however care must be
+      taken to avoid collisions with UIDs of other services. Alternatively, you
+      may enable the `auto-allocate-uids` experimental feature and option in
+      the Nix configuration to avoid creating these users, however please note
+      that this option is experimental and subject to change.
+
+      Alternatively, to acknowledge and silence this warning, set
+      `services.userdbd.silenceHighSystemUsers` to true.
+    '';
 
     systemd.additionalUpstreamSystemUnits = [
       "systemd-userdbd.socket"

--- a/nixos/tests/systemd-homed.nix
+++ b/nixos/tests/systemd-homed.nix
@@ -1,101 +1,132 @@
-{ pkgs, lib, ... }:
 let
-  password = "foobarfoo";
-  newPass = "barfoobar";
+  username = "test-homed-user";
+  initialPassword = "foobarfoo";
+  newPassword = "barfoobar";
 in
+
 {
   name = "systemd-homed";
-  nodes.machine =
-    { config, pkgs, ... }:
-    {
-      services.homed.enable = true;
 
-      users.users.test-normal-user = {
-        extraGroups = [ "wheel" ];
-        isNormalUser = true;
-        initialPassword = password;
+  nodes = {
+    machine =
+      { ... }:
+      {
+        services = {
+          homed.enable = true;
+          openssh.enable = true;
+        };
+
+        # Prevent nixbld users from showing up as regular users, required for
+        # first boot prompt
+        nix.settings = {
+          experimental-features = [ "auto-allocate-uids" ];
+          auto-allocate-uids = true;
+        };
       };
-    };
+
+    sshClient =
+      { pkgs, ... }:
+      {
+        services = {
+          homed.enable = true;
+          userdbd.silenceHighSystemUsers = true;
+        };
+
+        # Regular user, should prevent first boot prompt
+        users.users.test-normal-user = {
+          extraGroups = [ "wheel" ];
+          isNormalUser = true;
+          inherit initialPassword;
+        };
+      };
+  };
+
   testScript = ''
-    def switchTTY(number):
-      machine.send_key(f"alt-f{number}")
-      machine.wait_until_succeeds(f"[ $(fgconsole) = {number} ]")
-      machine.wait_for_unit(f"getty@tty{number}.service")
-      machine.wait_until_succeeds(f"pgrep -f 'agetty.*tty{number}'")
+    start_all()
 
-    machine.wait_for_unit("multi-user.target")
-
-    # Smoke test to make sure the pam changes didn't break regular users.
-    machine.wait_until_succeeds("pgrep -f 'agetty.*tty1'")
-    with subtest("login as regular user"):
-      switchTTY(2)
-      machine.wait_until_tty_matches("2", "login: ")
-      machine.send_chars("test-normal-user\n")
-      machine.wait_until_tty_matches("2", "login: test-normal-user")
-      machine.wait_until_tty_matches("2", "Password: ")
-      machine.send_chars("${password}\n")
-      machine.wait_until_succeeds("pgrep -u test-normal-user bash")
-      machine.send_chars("whoami > /tmp/1\n")
-      machine.wait_for_file("/tmp/1")
-      assert "test-normal-user" in machine.succeed("cat /tmp/1")
-
-    with subtest("create homed encrypted user"):
-      # TODO: Figure out how to pass password manually.
-      #
-      # This environment variable is used for homed internal testing
-      # and is not documented.
-      machine.succeed("NEWPASSWORD=${password} homectl create --shell=/run/current-system/sw/bin/bash --storage=luks -G wheel test-homed-user")
+    with subtest("create systemd-homed user on first boot prompt"):
+      machine.wait_for_unit("systemd-homed.service")
+      machine.wait_until_tty_matches("1", "-- Press any key to proceed --")
+      machine.send_chars(" ")
+      machine.wait_until_tty_matches("1", "Please enter user name")
+      machine.send_chars("${username}\n")
+      machine.wait_until_tty_matches("1", "Please enter an auxiliary group")
+      machine.send_chars("wheel\n")
+      machine.wait_until_tty_matches("1", "Please enter an auxiliary group")
+      machine.send_chars("\n")
+      machine.wait_until_tty_matches("1", "Please enter the shell to use")
+      machine.send_chars("/bin/sh\n")
+      machine.wait_until_tty_matches("1", "Please enter new password")
+      machine.send_chars("${initialPassword}\n")
+      machine.wait_until_tty_matches("1", "(repeat)")
+      machine.send_chars("${initialPassword}\n")
 
     with subtest("login as homed user"):
-      switchTTY(3)
-      machine.wait_until_tty_matches("3", "login: ")
-      machine.send_chars("test-homed-user\n")
-      machine.wait_until_tty_matches("3", "login: test-homed-user")
-      machine.wait_until_tty_matches("3", "Password: ")
-      machine.send_chars("${password}\n")
-      machine.wait_until_succeeds("pgrep -t tty3 -u test-homed-user bash")
+      machine.wait_until_tty_matches("1", "login: ")
+      machine.send_chars("${username}\n")
+      machine.wait_until_tty_matches("1", "Password: ")
+      machine.send_chars("${initialPassword}\n")
+      machine.wait_until_succeeds("pgrep -u ${username} -t tty1 sh")
       machine.send_chars("whoami > /tmp/2\n")
       machine.wait_for_file("/tmp/2")
-      assert "test-homed-user" in machine.succeed("cat /tmp/2")
+      assert "${username}" in machine.succeed("cat /tmp/2")
+
+    # Smoke test to make sure the pam changes didn't break regular users.
+    # Since homed is also enabled in the sshClient, it also tests the first
+    # boot prompt did not occur.
+    with subtest("login as regular user"):
+      sshClient.wait_until_tty_matches("1", "login: ")
+      sshClient.send_chars("test-normal-user\n")
+      sshClient.wait_until_tty_matches("1", "Password: ")
+      sshClient.send_chars("${initialPassword}\n")
+      sshClient.wait_until_succeeds("pgrep -u test-normal-user bash")
+      sshClient.send_chars("whoami > /tmp/1\n")
+      sshClient.wait_for_file("/tmp/1")
+      assert "test-normal-user" in sshClient.succeed("cat /tmp/1")
+
+    with subtest("add homed ssh authorized key"):
+      sshClient.send_chars('ssh-keygen -t ed25519 -f /tmp/id_ed25519 -N ""\n')
+      sshClient.wait_for_file("/tmp/id_ed25519.pub")
+      public_key = sshClient.succeed('cat /tmp/id_ed25519.pub')
+      public_key = public_key.strip()
+      machine.succeed(f"homectl update ${username} --offline --ssh-authorized-keys '{public_key}'")
+      machine.succeed("userdbctl ssh-authorized-keys ${username} | grep ed25519")
 
     with subtest("change homed user password"):
-      switchTTY(4)
-      machine.wait_until_tty_matches("4", "login: ")
-      machine.send_chars("test-homed-user\n")
-      machine.wait_until_tty_matches("4", "login: test-homed-user")
-      machine.wait_until_tty_matches("4", "Password: ")
-      machine.send_chars("${password}\n")
-      machine.wait_until_succeeds("pgrep -t tty4 -u test-homed-user bash")
-      machine.send_chars("passwd\n")
+      machine.send_chars("passwd; echo $? > /tmp/3\n")
       # homed does it in a weird order, it asks for new passes, then it asks
       # for the old one.
-      machine.sleep(2)
-      machine.send_chars("${newPass}\n")
-      machine.sleep(2)
-      machine.send_chars("${newPass}\n")
+      machine.wait_until_tty_matches("1", "New password: ")
+      machine.send_chars("${newPassword}\n")
+      machine.wait_until_tty_matches("1", "Retype new password: ")
+      machine.send_chars("${newPassword}\n")
+      #machine.wait_until_tty_matches("1", "Password: ")
       machine.sleep(4)
-      machine.send_chars("${password}\n")
-      machine.wait_until_fails("pgrep -t tty4 passwd")
+      machine.send_chars("${initialPassword}\n")
+      machine.wait_for_file("/tmp/3")
+      assert "0\n" == machine.succeed("cat /tmp/3")
 
-      @polling_condition
-      def not_logged_in_tty5():
-        machine.fail("pgrep -t tty5 bash")
-
-      switchTTY(5)
-      with not_logged_in_tty5: # type: ignore[union-attr]
-        machine.wait_until_tty_matches("5", "login: ")
-        machine.send_chars("test-homed-user\n")
-        machine.wait_until_tty_matches("5", "login: test-homed-user")
-        machine.wait_until_tty_matches("5", "Password: ")
-        machine.send_chars("${password}\n")
-        machine.wait_until_tty_matches("5", "Password incorrect or not sufficient for authentication of user test-homed-user.")
-        machine.wait_until_tty_matches("5", "Sorry, try again: ")
-      machine.send_chars("${newPass}\n")
-      machine.send_chars("whoami > /tmp/4\n")
+    with subtest("escalate to root from homed user"):
+      # Also tests the user is in wheel.
+      machine.send_chars("sudo id | tee /tmp/4\n")
+      machine.wait_until_tty_matches("1", "password for ${username}")
+      machine.send_chars("${newPassword}\n")
       machine.wait_for_file("/tmp/4")
-      assert "test-homed-user" in machine.succeed("cat /tmp/4")
+      machine.wait_until_succeeds("grep uid=0 /tmp/4")
 
-    with subtest("homed user should be in wheel according to NSS"):
-      machine.succeed("userdbctl group wheel -s io.systemd.NameServiceSwitch | grep test-homed-user")
+    with subtest("log out and deactivate homed user's home area"):
+      machine.send_chars("exit\n")
+      machine.wait_until_succeeds("homectl inspect ${username} | grep 'State: inactive'")
+
+    with subtest("ssh as homed user"):
+      sshClient.send_chars("ssh -o StrictHostKeyChecking=no -i /tmp/id_ed25519 ${username}@machine\n")
+      sshClient.wait_until_tty_matches("1", "Please enter password for user")
+      sshClient.send_chars("${newPassword}\n")
+      machine.wait_until_succeeds("pgrep -u ${username} sh")
+      sshClient.send_chars("whoami > /tmp/5\n")
+      machine.wait_for_file("/tmp/5")
+      assert "${username}" in machine.succeed("cat /tmp/5")
+      sshClient.send_chars("exit\n") # ssh
+      sshClient.send_chars("exit\n") # sh
   '';
 }


### PR DESCRIPTION
Improves support for systemd-homed by adding SSH integration support and a few basic module options.

It includes 5 commits:

- One to add systemd NSS module to the shadow database:
  - This is part of integrating homed and userdb with NSS and is documented in `nss-systemd(8)` as being needed for a correct setup.
- One to add OpenSSH integration to userdb:
  - OpenSSH calls `userdbctl ssh-authorized-keys <username>` to retrieve keys from userdb when no other keys are found (see Integration with SSH section in `userdbctl(1)`)
  - A wrapper is needed because the executable needs to be owned by root/root, and OpenSSH throws an error when using it directly from the Nix store, complaining about `/nix/store` permissions
  - A warning is added as a reminder that this causes SSH keys to be modifiable at runtime, whether through systemd-homed users modifying their own key, or for any user by creating a drop-in file at `/run/userdb/<username>.user-privileged` with something like `{"privileged": "sshAuthorizedKeys": ["ssh-ed25519 AAAAC3..."]}`
- One to add configuration and OpenSSH integration to homed:
  - The initial module options allow setting options in `homed.conf(5)`, which is only two options: default storage type and filesystem for LUKS
  - I enabled Btrfs, ext4, and XFS to allow mounting and manipulating home areas with all filesystems supported by systemd. Since users can define the filesystem using `homectl create --fs-type` anyway, it made more sense to me to allow all 3 filesystems by default than to have the command fail with errors.
  - The SSH integration is enabled by default if homed and OpenSSH are enabled. Note that after authentication, when the home area is not active, the user will still be required to enter their password (if they didn't authenticate with one). This works even with OpenSSH password authentication disabled.
  - Also I added support for `systemd-homed-firstboot` which should prompt for creation of a homed user on first boot, if no other non-system account (homed or not) exists. This requires no users with UID >= 1000 to exist during the system's first boot.
- One to add a warning when `userdb` is active and system users with UIDs above 1000 exist:
  - This is to inform users that these users will be mistakenly treated as "regular" disposition instead of "system" disposition, and that it will completely break the `systemd-homed-firstboot` service (it will simply exit saying that a regular user already exists).
- One to update the `systemd-homed` tests with the new functionality.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
