### PR TITLE
level-zero: Fix NixOS GPU driver lookup 

### DIFF
--- a/pkgs/by-name/le/level-zero/package.nix
+++ b/pkgs/by-name/le/level-zero/package.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation rec {
     addDriverRunpath $out/lib/libze_loader.so
   '';
 
+  setupHook = ./setup-hook.sh;
+
   passthru = {
     tests = {
       inherit intel-compute-runtime openvino;

--- a/pkgs/by-name/le/level-zero/setup-hook.sh
+++ b/pkgs/by-name/le/level-zero/setup-hook.sh
@@ -1,0 +1,7 @@
+if [ -d /run/opengl-driver/lib ]; then
+  export LD_LIBRARY_PATH="/run/opengl-driver/lib${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH:-}"
+fi
+
+if [ -d /run/opengl-driver-32/lib ]; then
+  export LD_LIBRARY_PATH="/run/opengl-driver-32/lib${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH:-}"
+fi


### PR DESCRIPTION
## Things done

This update will fix a MAJOR issue in utilizing Intel GPUs for NixOS. It took us few weeks to arrive to this beautiful 12 LOC fix for every `nix develop` and removes the need for declaring this lookup explicitly in `devShell`s and `mkDerivation`s considering `setup-hooks` gets executed on every `nix develop` when `flake.nix` has `level-zero` in `buildInputs`: https://github.com/intel/llvm/issues/19751

Also, potential upcoming `oneAPIPackages.llvm` (just like `rocmPackages.llvm`) compiler could provide this behavior to all binaries & development environments without needing any changes to a projects `flake.nix`, since `intel/llvm` compilation requires this `level-zero` nixpkgs as a dependency.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
