### PR TITLE
jump: add shell completion for bash, zsh, fish

### DIFF
--- a/pkgs/by-name/ju/jump/package.nix
+++ b/pkgs/by-name/ju/jump/package.nix
@@ -3,8 +3,9 @@
   fetchFromGitHub,
   lib,
   installShellFiles,
+  stdenv,
+  writableTmpDirAsHomeHook,
 }:
-
 buildGoModule rec {
   pname = "jump";
   version = "0.51.0";
@@ -18,7 +19,10 @@ buildGoModule rec {
 
   vendorHash = "sha256-nMUqZWdq//q/DNthvpKiYLq8f95O0QoItyX5w4vHzSA=";
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+    writableTmpDirAsHomeHook
+  ];
 
   ldflags = [
     "-s"
@@ -27,6 +31,12 @@ buildGoModule rec {
 
   postInstall = ''
     installManPage man/j.1 man/jump.1
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd jump \
+       --bash <($out/bin/jump shell bash) \
+       --fish <($out/bin/jump shell fish) \
+       --zsh <($out/bin/jump shell zsh)
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Install the shell completions provided by `jump shell $shellname`. This is an important step in the setup guide: https://github.com/gsamokovarov/jump?tab=readme-ov-file#integration

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable: AFAICT, no applicable tests
  - [ ] ~[NixOS tests] in [nixos/tests]: AFAICT, no applicable tests~
  - [ ] ~[Package tests] at `passthru.tests`.~
  - [ ] ~ Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs: as far as I can tell

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
