### PR TITLE
rstfmt: add meta.mainProgram

### DIFF
--- a/pkgs/by-name/rs/rstfmt/package.nix
+++ b/pkgs/by-name/rs/rstfmt/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  python3,
   fetchFromGitHub,
+  python3,
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -16,11 +16,10 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-zvmKgNzfxyWYHoaD+q84I48r1Mpp4kU4oIGAwMSRRlA=";
   };
 
-  build-system = with python3.pkgs; [
-    setuptools
-  ];
+  build-system = with python3.pkgs; [ setuptools ];
 
   dependencies = with python3.pkgs; [
+    aiohttp
     black
     docutils
     sphinx
@@ -29,14 +28,12 @@ python3.pkgs.buildPythonApplication rec {
   # Project has no unittest just sample files
   doCheck = false;
 
-  pythonImportsCheck = [
-    "rstfmt"
-  ];
+  pythonImportsCheck = [ "rstfmt" ];
 
   meta = {
     description = "Formatter for reStructuredText";
     homepage = "https://github.com/dzhu/rstfmt";
-    changelog = "https://github.com/dzhu/rstfmt/releases/tag/v${version}";
+    changelog = "https://github.com/dzhu/rstfmt/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "rstfmt";

--- a/pkgs/by-name/rs/rstfmt/package.nix
+++ b/pkgs/by-name/rs/rstfmt/package.nix
@@ -39,5 +39,6 @@ python3.pkgs.buildPythonApplication rec {
     changelog = "https://github.com/dzhu/rstfmt/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "rstfmt";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Note that there are two programs in out:
- rstfmt
- rstfmtd

But `rstfmtd` fails with an error:

```
Traceback (most recent call last):
  File "/nix/store/1b5sg5a4inhjfxan4gbqalaqmrxbb99f-rstfmt-0.0.14/bin/.rstfmtd-wrapped", line 6, in <module>
    from rstfmt.server import main
  File "/nix/store/1b5sg5a4inhjfxan4gbqalaqmrxbb99f-rstfmt-0.0.14/lib/python3.13/site-packages/rstfmt/server.py", line 10, in <module>
    from aiohttp import web
ModuleNotFoundError: No module named 'aiohttp'
```

So if broken currently. And it seems like the correct program here is `rustfmt`.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
