### PR TITLE
 [Backport release-25.05] python3Packages.django_5: 5.1 -> 5.2

### DIFF
--- a/pkgs/by-name/au/authentik/package.nix
+++ b/pkgs/by-name/au/authentik/package.nix
@@ -159,7 +159,8 @@ let
   python = python312.override {
     self = python;
     packageOverrides = final: prev: {
-      django = final.django_5;
+      # https://github.com/goauthentik/authentik/pull/14709
+      django = final.django_5_1;
 
       # Running authentik currently requires a custom version.
       # Look in `pyproject.toml` for changes to the rev in the `[tool.uv.sources]` section.

--- a/pkgs/by-name/au/authentik/package.nix
+++ b/pkgs/by-name/au/authentik/package.nix
@@ -159,19 +159,12 @@ let
   python = python312.override {
     self = python;
     packageOverrides = final: prev: {
-      django-tenants = prev.django-tenants.overrideAttrs {
-        version = "3.6.1-unstable-2024-01-11";
-        src = fetchFromGitHub {
-          owner = "rissson";
-          repo = "django-tenants";
-          rev = "a7f37c53f62f355a00142473ff1e3451bb794eca";
-          hash = "sha256-YBT0kcCfETXZe0j7/f1YipNIuRrcppRVh1ecFS3cvNo=";
-        };
-      };
-      # Use 3.14.0 until https://github.com/encode/django-rest-framework/issues/9358 is fixed.
-      # Otherwise applying blueprints/default/default-brand.yaml fails with:
-      #   authentik.flows.models.RelatedObjectDoesNotExist: FlowStageBinding has no target.
-      djangorestframework = prev.buildPythonPackage rec {
+      django = final.django_5;
+
+      # Running authentik currently requires a custom version.
+      # Look in `pyproject.toml` for changes to the rev in the `[tool.uv.sources]` section.
+      # See https://github.com/goauthentik/authentik/pull/14057 for latest version bump.
+      djangorestframework = prev.buildPythonPackage {
         pname = "djangorestframework";
         version = "3.14.0";
         format = "setuptools";

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -38,7 +38,7 @@ let
   python = python3.override {
     self = python;
     packageOverrides = final: prev: {
-      django = prev.django_5;
+      django = prev.django_5_1;
 
       # tesseract5 may be overwritten in the paperless module and we need to propagate that to make the closure reduction effective
       ocrmypdf = prev.ocrmypdf.override { tesseract = tesseract5; };

--- a/pkgs/by-name/pr/pretalx/package.nix
+++ b/pkgs/by-name/pr/pretalx/package.nix
@@ -12,7 +12,7 @@ let
   python = python3.override {
     self = python;
     packageOverrides = final: prev: {
-      django = prev.django_5;
+      django = prev.django_5_1;
 
       django-extensions = prev.django-extensions.overridePythonAttrs {
         # Compat issues with Django 5.1

--- a/pkgs/by-name/ta/tandoor-recipes/package.nix
+++ b/pkgs/by-name/ta/tandoor-recipes/package.nix
@@ -36,12 +36,12 @@ python.pkgs.buildPythonPackage {
     django-annoying
     django-cleanup
     django-crispy-forms
-    django-crispy-bootstrap4
     django-tables2
     djangorestframework
     drf-writable-nested
     django-oauth-toolkit
     bleach
+    crispy-bootstrap4
     gunicorn
     lxml
     markdown

--- a/pkgs/by-name/we/weblate/package.nix
+++ b/pkgs/by-name/we/weblate/package.nix
@@ -81,7 +81,7 @@ python.pkgs.buildPythonApplication rec {
       celery
       certifi
       charset-normalizer
-      django-crispy-bootstrap3
+      crispy-bootstrap3
       cryptography
       cssselect
       cython

--- a/pkgs/by-name/we/weblate/package.nix
+++ b/pkgs/by-name/we/weblate/package.nix
@@ -16,7 +16,8 @@
 let
   python = python3.override {
     packageOverrides = final: prev: {
-      django = prev.django_5;
+      # https://github.com/django-crispy-forms/crispy-bootstrap3/issues/12
+      django = prev.django_5_1;
       djangorestframework = prev.djangorestframework.overridePythonAttrs (old: {
         # https://github.com/encode/django-rest-framework/discussions/9342
         disabledTests = (old.disabledTests or [ ]) ++ [ "test_invalid_inputs" ];

--- a/pkgs/development/python-modules/crispy-bootstrap3/default.nix
+++ b/pkgs/development/python-modules/crispy-bootstrap3/default.nix
@@ -10,7 +10,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "django-crispy-bootstrap3";
+  pname = "crispy-bootstrap3";
   version = "2024.1";
   pyproject = true;
 

--- a/pkgs/development/python-modules/crispy-bootstrap4/default.nix
+++ b/pkgs/development/python-modules/crispy-bootstrap4/default.nix
@@ -10,7 +10,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "django-crispy-bootstrap4";
+  pname = "crispy-bootstrap4";
   version = "2024.10";
   pyproject = true;
 

--- a/pkgs/development/python-modules/crispy-bootstrap5/default.nix
+++ b/pkgs/development/python-modules/crispy-bootstrap5/default.nix
@@ -10,8 +10,8 @@
 }:
 
 buildPythonPackage rec {
-  pname = "django-crispy-bootstrap5";
-  version = "2025.4";
+  pname = "crispy-bootstrap5";
+  version = "2025.6";
   pyproject = true;
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/django-apscheduler/default.nix
+++ b/pkgs/development/python-modules/django-apscheduler/default.nix
@@ -5,7 +5,7 @@
   setuptools,
   wheel,
   # dependencies
-  django_5,
+  django,
   apscheduler,
   # tests
   pytestCheckHook,
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
-    django_5
+    django
     apscheduler
   ];
 

--- a/pkgs/development/python-modules/django-postgres-partition/default.nix
+++ b/pkgs/development/python-modules/django-postgres-partition/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  django,
+  psycopg,
+  python-dateutil,
+}:
+
+buildPythonPackage rec {
+  pname = "django-postgres-partition";
+  version = "0.1.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "django_postgres_partition";
+    hash = "sha256-KUrgnfUXWyRerW4dqtVZO9bu5jHYnHcVOIg97w695RU=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonRelaxDeps = [
+    "django"
+  ];
+
+  dependencies = [
+    django
+    psycopg
+    python-dateutil
+  ];
+
+  doCheck = false; # pypi version doesn't ship with tests
+
+  pythonImportsCheck = [ "psql_partition" ];
+
+  meta = {
+    description = "Partition support for django, based on django-postgres-extra";
+    homepage = "https://gitlab.com/burke-software/django-postgres-partition";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ defelo ];
+  };
+}

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -196,6 +196,7 @@ mapAliases ({
   django_compat = django-compat; # added 2023-07-25
   django-compat = throw "django-compat has been removed. It provided forward/backport compat for django 1.x, which is long end of life."; # added 2023-07-26
   django_contrib_comments = django-contrib-comments; # added 2023-07-25
+  django-crispy-bootstrap3 = crispy-bootstrap3; # added 2025-06-11
   django-crontab = throw "django-crontabe has been removed beacause it is unmaintained since 2018"; # added 2024-08-21
   django-discover-runner = throw "django-discover-runner was removed because it is no longer maintained."; # added 2022-11-21
   django_environ = django-environ; # added 2021-12-25

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -198,6 +198,7 @@ mapAliases ({
   django_contrib_comments = django-contrib-comments; # added 2023-07-25
   django-crispy-bootstrap3 = crispy-bootstrap3; # added 2025-06-11
   django-crispy-bootstrap4 = crispy-bootstrap4; # added 2025-06-11
+  django-crispy-bootstrap5 = crispy-bootstrap5; # added 2025-06-11
   django-crontab = throw "django-crontabe has been removed beacause it is unmaintained since 2018"; # added 2024-08-21
   django-discover-runner = throw "django-discover-runner was removed because it is no longer maintained."; # added 2022-11-21
   django_environ = django-environ; # added 2021-12-25

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -197,6 +197,7 @@ mapAliases ({
   django-compat = throw "django-compat has been removed. It provided forward/backport compat for django 1.x, which is long end of life."; # added 2023-07-26
   django_contrib_comments = django-contrib-comments; # added 2023-07-25
   django-crispy-bootstrap3 = crispy-bootstrap3; # added 2025-06-11
+  django-crispy-bootstrap4 = crispy-bootstrap4; # added 2025-06-11
   django-crontab = throw "django-crontabe has been removed beacause it is unmaintained since 2018"; # added 2024-08-21
   django-discover-runner = throw "django-discover-runner was removed because it is no longer maintained."; # added 2022-11-21
   django_environ = django-environ; # added 2021-12-25

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2953,6 +2953,8 @@ self: super: with self; {
 
   crispy-bootstrap4 = callPackage ../development/python-modules/crispy-bootstrap4 { };
 
+  crispy-bootstrap5 = callPackage ../development/python-modules/crispy-bootstrap5 { };
+
   crochet = callPackage ../development/python-modules/crochet { };
 
   crocoddyl = toPythonModule (
@@ -3706,8 +3708,6 @@ self: super: with self; {
   django-cors-headers = callPackage ../development/python-modules/django-cors-headers { };
 
   django-countries = callPackage ../development/python-modules/django-countries { };
-
-  django-crispy-bootstrap5 = callPackage ../development/python-modules/django-crispy-bootstrap5 { };
 
   django-crispy-forms = callPackage ../development/python-modules/django-crispy-forms { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2949,6 +2949,8 @@ self: super: with self; {
 
   credstash = callPackage ../development/python-modules/credstash { };
 
+  crispy-bootstrap3 = callPackage ../development/python-modules/crispy-bootstrap3 { };
+
   crochet = callPackage ../development/python-modules/crochet { };
 
   crocoddyl = toPythonModule (
@@ -3702,8 +3704,6 @@ self: super: with self; {
   django-cors-headers = callPackage ../development/python-modules/django-cors-headers { };
 
   django-countries = callPackage ../development/python-modules/django-countries { };
-
-  django-crispy-bootstrap3 = callPackage ../development/python-modules/django-crispy-bootstrap3 { };
 
   django-crispy-bootstrap4 = callPackage ../development/python-modules/django-crispy-bootstrap4 { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3962,8 +3962,11 @@ self: super: with self; {
 
   django_4 = callPackage ../development/python-modules/django/4.nix { };
 
-  # Pre-release
-  django_5 = callPackage ../development/python-modules/django/5.nix { };
+  django_5 = self.django_5_2;
+
+  django_5_1 = callPackage ../development/python-modules/django/5_1.nix { };
+
+  django_5_2 = callPackage ../development/python-modules/django/5_2.nix { };
 
   djangocms-admin-style = callPackage ../development/python-modules/djangocms-admin-style { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2951,6 +2951,8 @@ self: super: with self; {
 
   crispy-bootstrap3 = callPackage ../development/python-modules/crispy-bootstrap3 { };
 
+  crispy-bootstrap4 = callPackage ../development/python-modules/crispy-bootstrap4 { };
+
   crochet = callPackage ../development/python-modules/crochet { };
 
   crocoddyl = toPythonModule (
@@ -3704,8 +3706,6 @@ self: super: with self; {
   django-cors-headers = callPackage ../development/python-modules/django-cors-headers { };
 
   django-countries = callPackage ../development/python-modules/django-countries { };
-
-  django-crispy-bootstrap4 = callPackage ../development/python-modules/django-crispy-bootstrap4 { };
 
   django-crispy-bootstrap5 = callPackage ../development/python-modules/django-crispy-bootstrap5 { };
 


### PR DESCRIPTION
Backport attempt of https://github.com/NixOS/nixpkgs/pull/416022#top

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
