### PR TITLE
LycheeSlicer: fix mainProgram, wayland and extraPkgs, add maintainer ZachDavies

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28146,6 +28146,12 @@
     githubId = 908716;
     name = "Zach Coyle";
   };
+  ZachDavies = {
+    name = "Zach Davies";
+    email = "zdmalta@proton.me";
+    github = "ZachDavies";
+    githubId = 131615861;
+  };
   Zaczero = {
     name = "Kamil Monicz";
     email = "kamil@monicz.dev";

--- a/pkgs/by-name/ly/LycheeSlicer/package.nix
+++ b/pkgs/by-name/ly/LycheeSlicer/package.nix
@@ -47,7 +47,10 @@ appimageTools.wrapType2 {
     description = "All-in-one 3D slicer for resin and FDM printers";
     homepage = "https://lychee.mango3d.io/";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ tarinaky ];
+    maintainers = with lib.maintainers; [ 
+      tarinaky
+      ZachDavies
+    ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "lychee";
   };

--- a/pkgs/by-name/ly/LycheeSlicer/package.nix
+++ b/pkgs/by-name/ly/LycheeSlicer/package.nix
@@ -4,6 +4,8 @@
   makeDesktopItem,
   lib,
   xorg,
+  wayland,
+  wayland-protocols,
 }:
 let
   pname = "LycheeSlicer";
@@ -41,13 +43,15 @@ appimageTools.wrapType2 {
 
   extraPkgs = _: [
     xorg.libxshmfence
+    wayland
+    wayland-protocols
   ];
 
   meta = {
     description = "All-in-one 3D slicer for resin and FDM printers";
     homepage = "https://lychee.mango3d.io/";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ 
+    maintainers = with lib.maintainers; [
       tarinaky
       ZachDavies
     ];

--- a/pkgs/by-name/ly/LycheeSlicer/package.nix
+++ b/pkgs/by-name/ly/LycheeSlicer/package.nix
@@ -18,7 +18,7 @@ let
     name = "Lychee Slicer";
     genericName = "Resin Slicer";
     comment = "All-in-one 3D slicer for Resin and Filament";
-    desktopName = "Lychee";
+    desktopName = "LycheeSlicer";
     noDisplay = false;
     exec = "lychee";
     terminal = false;
@@ -39,7 +39,7 @@ appimageTools.wrapType2 {
     install -Dm444 -t $out/share/applications ${desktopItem}/share/applications/*
   '';
 
-  extraLibraries = [
+  extraPkgs = _: [
     xorg.libxshmfence
   ];
 
@@ -52,6 +52,6 @@ appimageTools.wrapType2 {
       ZachDavies
     ];
     platforms = [ "x86_64-linux" ];
-    mainProgram = "lychee";
+    mainProgram = "LycheeSlicer";
   };
 }


### PR DESCRIPTION
## Things done

Fixed Current release by added extraPkgs to appimage wrapper and added wayland dependencies (tested on niri wayland)
added self as maintainer
fixed minor naming issue in mainProgram,exec and desktopName

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
