### PR TITLE
remmina: move wayland to linux to fix darwin build

### DIFF
--- a/pkgs/by-name/re/remmina/package.nix
+++ b/pkgs/by-name/re/remmina/package.nix
@@ -96,12 +96,12 @@ stdenv.mkDerivation (finalAttrs: {
     libsodium
     harfbuzz
     python3
-    wayland
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     fuse3
     libappindicator-gtk3
     libdbusmenu-gtk3
+    wayland
   ]
   ++ lib.optionals withLibsecret [ libsecret ]
   ++ lib.optionals withKf5Wallet [ libsForQt5.kwallet ]


### PR DESCRIPTION
`wayland` [fails to build on mac](https://hydra.nixos.org/build/303744066) and remmina works fine without it on darwin

This could and should be fixed, too, but `wayland` doesn't seem to be useful for remmina on darwin anyway. 

@bbigras @melsigl @ryantm 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
