### PR TITLE
networking/firewall-nftables: add extraInputRulesEarly to enable drop rules

### DIFF
--- a/nixos/modules/services/networking/firewall-nftables.nix
+++ b/nixos/modules/services/networking/firewall-nftables.nix
@@ -35,6 +35,20 @@ in
         '';
       };
 
+      extraInputRulesEarly = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        example = "ip saddr { 192.0.2.0/24, 2001:db8::/32 } counter drop";
+        description = ''
+          Additional nftables rules to be added at the beginning of
+          input-allow chain. This precedes all the rules produced by
+          `networking.firewall.allowed{TCP,UDP}Port{s,Ranges}` so you can use it
+          to drop packets which would be allowed by those options.
+
+          This option only works with the nftables based firewall.
+        '';
+      };
+
       extraForwardRules = lib.mkOption {
         type = lib.types.lines;
         default = "";
@@ -147,6 +161,8 @@ in
       }
 
       chain input-allow {
+
+        ${cfg.extraInputRulesEarly}
 
         ${lib.concatStrings (
           lib.mapAttrsToList (


### PR DESCRIPTION
hi, i'm not sure what the contribution flow is for core nixos module changes like this, CONTRIBUTING.md seems to be concerned primarily with package changes. i'm not sure if this deserves release note mention as it's a pure addition? should there be a test for this change?

this change introduces option `networking.firewall.extraInputRulesEarly` for the NFT based firewall configuration. the purpose of this option is to allow adding extra `drop` rules into the input chain while using the existing `networking.firewall.allowed{TCP,UDP}Port{,Range}s`. this is necessary because the `accept` rules generated by allowedPorts are terminal and rules added via the existing `networking.firewall.extraInputRules` cannot affect packet matching them as they appear after those accept rules.

personally i'm using the option to ban IP ranges which engage in inconsiderate scraping. i've been using this patch for about 10 months and think it's useful enough addition to nixos to be worth making a PR for.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
