### PR TITLE
nfs-ganesha: Build with Ceph and DBus support

### DIFF
--- a/pkgs/by-name/nf/nfs-ganesha/allow-bypassing-dbus-pkg-config-test.patch
+++ b/pkgs/by-name/nf/nfs-ganesha/allow-bypassing-dbus-pkg-config-test.patch
@@ -1,0 +1,44 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 73276dff6..94027f5cb 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -974,21 +974,27 @@ endif(USE_EFENCE)
+
+ gopt_test(USE_DBUS)
+ if(USE_DBUS)
+-  find_package(PkgConfig)
+-  # pkg_check_modules doesn't fatal error on REQUIRED, so handle it ourselves
+-  pkg_check_modules(DBUS ${USE_DBUS_REQUIRED} dbus-1)
+-  if(NOT DBUS_FOUND)
+-    if(USE_DBUS_REQUIRED)
+-      message(FATAL_ERROR "Cannot find DBUS libs but requested on command line")
+-    else(USE_DBUS_REQUIRED)
+-      message(WARNING "Cannot find DBUS libs. Disabling DBUS support")
+-      set(USE_DBUS OFF)
+-    endif(USE_DBUS_REQUIRED)
+-  else(NOT DBUS_FOUND)
++  if(DBUS_NO_PKGCONFIG)
+     set(SYSTEM_LIBRARIES ${DBUS_LIBRARIES} ${SYSTEM_LIBRARIES})
+     LIST(APPEND CMAKE_LIBRARY_PATH ${DBUS_LIBRARY_DIRS})
+     link_directories (${DBUS_LIBRARY_DIRS})
+-  endif(NOT DBUS_FOUND)
++  else(DBUS_NO_PKGCONFIG)
++    find_package(PkgConfig)
++    # pkg_check_modules doesn't fatal error on REQUIRED, so handle it ourselves
++    pkg_check_modules(DBUS ${USE_DBUS_REQUIRED} dbus-1)
++    if(NOT DBUS_FOUND)
++      if(USE_DBUS_REQUIRED)
++        message(FATAL_ERROR "Cannot find DBUS libs but requested on command line")
++      else(USE_DBUS_REQUIRED)
++        message(WARNING "Cannot find DBUS libs. Disabling DBUS support")
++        set(USE_DBUS OFF)
++      endif(USE_DBUS_REQUIRED)
++    else(NOT DBUS_FOUND)
++      set(SYSTEM_LIBRARIES ${DBUS_LIBRARIES} ${SYSTEM_LIBRARIES})
++      LIST(APPEND CMAKE_LIBRARY_PATH ${DBUS_LIBRARY_DIRS})
++      link_directories (${DBUS_LIBRARY_DIRS})
++    endif(NOT DBUS_FOUND)
++  endif(DBUS_NO_PKGCONFIG)
+ endif(USE_DBUS)
+
+ if(USE_CB_SIMULATOR AND NOT USE_DBUS)

--- a/pkgs/by-name/nf/nfs-ganesha/package.nix
+++ b/pkgs/by-name/nf/nfs-ganesha/package.nix
@@ -59,8 +59,8 @@ stdenv.mkDerivation rec {
   ++ lib.optionals useDbus [
     "-DUSE_DBUS=ON"
     "-DDBUS_NO_PKGCONFIG=ON"
-    "-DDBUS_LIBRARY_DIRS=${dbus.lib}/lib"
-    "-DDBUS_INCLUDE_DIRS=${dbus.dev}/include/dbus-1.0\\;${dbus.lib}/lib/dbus-1.0/include"
+    "-DDBUS_LIBRARY_DIRS=${lib.getLib dbus}/lib"
+    "-DDBUS_INCLUDE_DIRS=${lib.getDev dbus}/include/dbus-1.0\\;${lib.getLib dbus}/lib/dbus-1.0/include"
     "-DDBUS_LIBRARIES=dbus-1"
   ];
 
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     flex
     sphinx
   ]
-  ++ lib.optional useDbus dbus.dev;
+  ++ lib.optional useDbus dbus;
 
   buildInputs = [
     acl


### PR DESCRIPTION
This enables using the Ceph FSAL to serve files from CephFS. Also enable DBus.

Testing was done against nixpkgs-25.05 using callPackage due to breakage on unstable, but I don't think it matters here.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
