### PR TITLE
linux: remove mentions of extraStructuredConfig & throw error

### DIFF
--- a/doc/packages/linux.section.md
+++ b/doc/packages/linux.section.md
@@ -25,7 +25,7 @@ pkgs.linux_latest.override {
   ignoreConfigErrors = true;
   autoModules = false;
   kernelPreferBuiltin = true;
-  extraStructuredConfig = with lib.kernel; {
+  structuredExtraConfig = with lib.kernel; {
     DEBUG_KERNEL = yes;
     FRAME_POINTER = yes;
     KGDB = yes;

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -102,7 +102,7 @@ in
           {
             name = "foo";
             patch = ./foo.patch;
-            extraStructuredConfig.FOO = lib.kernel.yes;
+            structuredExtraConfig.FOO = lib.kernel.yes;
             features.foo = true;
           }
           {
@@ -127,7 +127,7 @@ in
                                         # (required, but can be null if only config changes
                                         # are needed)
 
-          extraStructuredConfig = {     # attrset of extra configuration parameters without the CONFIG_ prefix
+          structuredExtraConfig = {     # attrset of extra configuration parameters without the CONFIG_ prefix
             FOO = lib.kernel.yes;       # (optional)
           };                            # values should generally be lib.kernel.yes,
                                         # lib.kernel.no or lib.kernel.module
@@ -138,7 +138,7 @@ in
 
           extraConfig = "FOO y";        # extra configuration options in string form without the CONFIG_ prefix
                                         # (optional, multiple lines allowed to specify multiple options)
-                                        # (deprecated, use extraStructuredConfig instead)
+                                        # (deprecated, use structuredExtraConfig instead)
         }
         ```
 

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -141,10 +141,17 @@ let
         {
           structuredExtraConfig ? { },
           ...
-        }:
-        {
-          settings = structuredExtraConfig;
-        }
+        }@args:
+        if args ? extraStructuredConfig then
+          throw ''
+            Passing `extraStructuredConfig` to the Linux kernel (e.g.
+            via `boot.kernelPatches` in NixOS) is not supported anymore. Use
+            `structuredExtraConfig` instead.
+          ''
+        else
+          {
+            settings = structuredExtraConfig;
+          }
       ) kernelPatches;
 
       # appends kernel patches extraConfig


### PR DESCRIPTION
PR #431115 changed extraStructuredConfig to structuredExtraConfig to follow the deprecation warning about `extraConfig`. However, `extraStructuredConfig` was mentioned in several places in the docs that weren't addressed. Also, using this would silently fail since the code in question would still accept the old key.

This patch updates the docs accordingly and throws an error if the code-path is reached and `extraStructuredConfig` is being used.

cc @Arcterus 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
