### PR TITLE
haskell.packages.ghc.910.ghc-lib{,-parser,-parser-ex}: 9.10.2.20250515 -> 9.12.2.20250421

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -76,10 +76,6 @@ in
   # Upgrade to accommodate new core library versions, where the authors have
   # already made the relevant changes.
   fourmolu = doDistribute self.fourmolu_0_16_0_0;
-  # https://github.com/digital-asset/ghc-lib/issues/600
-  ghc-lib = doDistribute self.ghc-lib_9_10_2_20250515;
-  ghc-lib-parser = doDistribute self.ghc-lib-parser_9_10_2_20250515;
-  ghc-lib-parser-ex = doDistribute self.ghc-lib-parser-ex_9_10_0_0;
   ormolu = doDistribute self.ormolu_0_7_7_0;
   stylish-haskell = doDistribute self.stylish-haskell_0_15_0_1;
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This fixes the build for `ghc-syntax-highlighter`, which fixes the build for `mmark-ext`.

Fixing build for mmark-ext/ghc-syntax-highlighter is here: https://hydra.nixos.org/build/304238156/nixlog/1

```
Running phase: setupCompilerEnvironmentPhase
Build with /nix/store/a6ch4glhsgzpn9i9cqzpdlmbli5ylff7-ghc-9.10.2.
Running phase: unpackPhase
unpacking source archive /nix/store/x18gxr14wxx0i3rx0saph5ynlacfl8ga-ghc-syntax-highlighter-0.0.13.0.tar.gz
source root is ghc-syntax-highlighter-0.0.13.0
setting SOURCE_DATE_EPOCH to timestamp 1000000000 of file "ghc-syntax-highlighter-0.0.13.0/tests/Spec.hs"
Running phase: patchPhase
Running phase: compileBuildDriverPhase
setupCompileFlags: -package-db=/build/tmp.mikNyFjyjn/setup-package.conf.d -threaded
[1 of 2] Compiling Main             ( /nix/store/4mdp8nhyfddh7bllbi7xszz7k9955n79-Setup.hs, /build/tmp.mikNyFjyjn/Main.o )
[2 of 2] Linking Setup
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
configureFlags: --verbose --prefix=/nix/store/qjp64hpi4mxns134nmwm6yscf3qxfnzx-ghc-syntax-highlighter-0.0.13.0 --libdir=$prefix/lib/$compiler/lib --libsubdir=$abi/$libname --datadir=/nix/store/a8mqz9rix24r00q84mdgas26417q674m-ghc-syntax-highlighter-0.0.13.0-data/share/ghc-9.10.2 --docdir=/nix/store/cqq7dyl3x4ajamyk9l4jv6c1b9qbr541-ghc-syntax-highlighter-0.0.13.0-doc/share/doc/ghc-syntax-highlighter-0.0.13.0 --with-gcc=gcc --package-db=/build/tmp.mikNyFjyjn/package.conf.d --ghc-option=-j16 --ghc-option=+RTS --ghc-option=-A64M --ghc-option=-RTS --enable-library-profiling --profiling-detail=exported-functions --disable-profiling --enable-shared --disable-coverage --enable-static --disable-executable-dynamic --enable-tests --disable-benchmarks --enable-library-vanilla --disable-library-for-ghci --enable-split-sections --enable-library-stripping --enable-executable-stripping --ghc-option=-haddock --extra-lib-dirs=/nix/store/4kark163478mlnx42k2gakrji1z43z9m-ncurses-6.5/lib --extra-lib-dirs=/nix/store/qfz8slc34jinyfkvmskaplijj8a79w25-libffi-3.5.1/lib --extra-lib-dirs=/nix/store/qg2k9xl5af62zzlynwfim5f3ajwai88v-elfutils-0.193/lib --extra-lib-dirs=/nix/store/f6yc9mbdp17kh3p70lhlix1w21jlj5kp-gmp-with-cxx-6.3.0/lib --extra-lib-dirs=/nix/store/sbhy9snfwl00agyy54jra3k6il6s1rxh-numactl-2.0.18/lib
Using Parsec parser
Configuring ghc-syntax-highlighter-0.0.13.0...
Error: [Cabal-8010]
Encountered missing or private dependencies:
    ghc-lib-parser >=9.12 && <9.13
CallStack (from HasCallStack):
  dieWithException, called at libraries/Cabal/Cabal/src/Distribution/Simple/Configure.hs:1457:11 in Cabal-3.12.1.0-8080:Distribution.Simple.Configure
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
