### PR TITLE
python3Packages.spectral-cube: 0.6.6 -> 0.6.6-unstable-2025-06-11

### DIFF
--- a/pkgs/development/python-modules/spectral-cube/default.nix
+++ b/pkgs/development/python-modules/spectral-cube/default.nix
@@ -25,15 +25,20 @@
 
 buildPythonPackage rec {
   pname = "spectral-cube";
-  version = "0.6.6";
+  version = "0.6.6-unstable-2025-06-11";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "radio-astro-tools";
     repo = "spectral-cube";
-    tag = "v${version}";
-    hash = "sha256-fBjbovBXqUfX8rG8gEM3BY5p0BLfa4n1PMbPpPJPDgQ=";
+    # tag = "v${version}";
+    # Unreleased PR with several build and test fixes: https://github.com/radio-astro-tools/spectral-cube/pull/951
+    rev = "f95ba1ca1823758d340ce0bfd3181ae3bc041b93";
+    hash = "sha256-LUWdxA7gfZI2MDpKuk+DiEJtXyWeS8co+3tZt97Uh3w=";
   };
+
+  # remove after update to 0.6.7
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = "0.6.6";
 
   build-system = [ setuptools-scm ];
 
@@ -60,104 +65,7 @@ buildPythonPackage rec {
     cd build/lib
   '';
 
-  pytestFlags = [
-    # FutureWarning: Can't acquire a memory view of a Dask array. This will raise in the future
-    # https://github.com/radio-astro-tools/spectral-cube/issues/943
-    "-Wignore::FutureWarning"
-  ];
-
-  disabledTests = [
-    # AttributeError: 'DaskSpectralCube' object has no attribute 'dtype'
-    "test_key_access_valid"
-
-    # For some reason, those tests are failing with "FutureWarning: Can't acquire a memory view of a Dask array."
-    # without being caught by the `-W ignore::FutureWarning` flag above.
-    "test_1d_slice_reductions"
-    "test_1d_slice_round"
-    "test_1d_slices"
-    "test_1dcomparison_mask_1d_index"
-    "test_1dmask_indexing"
-    "test_2dcomparison_mask_1d_index"
-    "test_3d_beams_roundtrip"
-    "test_4d_beams_roundtrip"
-    "test_LDO_arithmetic"
-    "test_add"
-    "test_apply_everywhere"
-    "test_apply_everywhere_plusminus"
-    "test_apply_function_parallel_shape"
-    "test_attributes"
-    "test_basic_arrayness"
-    "test_basic_unit_conversion"
-    "test_basic_unit_conversion_beams"
-    "test_beam_jpix_checks_array"
-    "test_beam_jtok"
-    "test_beam_jtok_2D"
-    "test_beam_jtok_array"
-    "test_beam_proj_meta"
-    "test_beams_convolution"
-    "test_beams_convolution_equal"
-    "test_casa_read_basic"
-    "test_convolution"
-    "test_convolve_to_equal"
-    "test_convolve_to_jybeam_multibeams"
-    "test_convolve_to_jybeam_onebeam"
-    "test_convolve_to_with_bad_beams"
-    "test_cube_add"
-    "test_cube_stacking"
-    "test_cube_with_swapped_axes"
-    "test_div"
-    "test_filled"
-    "test_getitem"
-    "test_getitem_vrsc"
-    "test_how_withfluxunit"
-    "test_initialization_from_units"
-    "test_mask_none"
-    "test_mosaic_cube"
-    "test_mul"
-    "test_mul_cubes"
-    "test_multibeams_unit_conversions_general_1D"
-    "test_numpy_ma_tools"
-    "test_oned_slic"
-    "test_oned_slice_beams"
-    "test_padding_direction"
-    "test_pow"
-    "test_preserves_header_meta_values"
-    "test_proj_meta"
-    "test_regression_719"
-    "test_repr_1d"
-    "test_slice_wcs"
-    "test_slicing"
-    "test_spatial_smooth_g2d"
-    "test_spatial_smooth_maxfilter"
-    "test_spatial_smooth_median"
-    "test_spatial_smooth_t2d"
-    "test_spatial_world"
-    "test_spectral_interpolate"
-    "test_spectral_interpolate_reversed"
-    "test_spectral_interpolate_varying_chunksize"
-    "test_spectral_interpolate_with_fillvalue"
-    "test_spectral_interpolate_with_mask"
-    "test_spectral_slice_preserve_units"
-    "test_spectral_smooth"
-    "test_spectral_units"
-    "test_stacking"
-    "test_stacking_badvels"
-    "test_stacking_noisy"
-    "test_stacking_reversed_specaxis"
-    "test_stacking_woffset"
-    "test_stacking_wpadding"
-    "test_subtract"
-    "test_subtract_cubes"
-    "test_unit_conversions_general"
-    "test_unit_conversions_general_1D"
-    "test_unit_conversions_general_2D"
-    "test_varyres_mask"
-    "test_varyres_spectra"
-    "test_varyres_unitconversion_roundtrip"
-    "test_with_flux_unit"
-    "test_with_spectral_unit"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
     # Flaky: AssertionError: assert diffvals.max()*u.B <= 1*u.MB
     "test_reproject_3D_memory"
   ];


### PR DESCRIPTION
Bump spectral-cube to an unreleased revision mainly to include https://github.com/radio-astro-tools/spectral-cube/pull/951, which fixes several issues with build and tests. Thanks to this, all 1520 enabled tests are passing on linux-x86_64.

Closes #419536

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
