### PR TITLE
sillytavern: change to global installation

### DIFF
--- a/pkgs/by-name/si/sillytavern/package.nix
+++ b/pkgs/by-name/si/sillytavern/package.nix
@@ -1,7 +1,5 @@
 {
-  makeBinaryWrapper,
   buildNpmPackage,
-  nodejs,
   fetchFromGitHub,
   lib,
 }:
@@ -17,19 +15,12 @@ buildNpmPackage (finalAttrs: {
   };
   npmDepsHash = "sha256-hayhsEZN857V6bsWPXupLeqxcOr1sgKs0uWN2pSQD+k=";
 
-  nativeBuildInputs = [ makeBinaryWrapper ];
-
   dontNpmBuild = true;
-  installPhase = ''
-    runHook preInstall
 
-    mkdir -p $out/{bin,opt}
-    cp -r . $out/opt/sillytavern
-    makeWrapper ${lib.getExe nodejs} $out/bin/sillytavern \
-      --add-flags $out/opt/sillytavern/server.js \
-      --set-default NODE_ENV production
-
-    runHook postInstall
+  # These dirs are not installed automatically.
+  # And if they were not in place, the app would try to create them at runtime, which is of course impossible to achieve.
+  postInstall = ''
+    mkdir $out/lib/node_modules/sillytavern/{backups,public/scripts/extensions/third-party}
   '';
 
   meta = {
@@ -37,6 +28,9 @@ buildNpmPackage (finalAttrs: {
     longDescription = ''
       SillyTavern is a user interface you can install on your computer (and Android phones) that allows you to interact with
       text generation AIs and chat/roleplay with characters you or the community create.
+
+      This package makes a global installation, instead of a standalone installation according to the official tutorial.
+      See [the official documentation](https://docs.sillytavern.app/installation/#global--standalone-mode) for the context.
     '';
     downloadPage = "https://github.com/SillyTavern/SillyTavern/releases";
     homepage = "https://docs.sillytavern.app/";


### PR DESCRIPTION
See SillyTavern/SillyTavern#4289 and [the official documentation](https://docs.sillytavern.app/installation/#global--standalone-mode).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
