### PR TITLE
bibletime: 3.0.3 -> 3.1.1

### DIFF
--- a/pkgs/by-name/bi/bibletime/package.nix
+++ b/pkgs/by-name/bi/bibletime/package.nix
@@ -6,15 +6,17 @@
   docbook_xml_dtd_45,
   docbook_xsl_ns,
   fetchFromGitHub,
+  gettext,
+  libxslt,
   perlPackages,
   pkg-config,
-  qt5,
+  qt6,
   stdenv,
   sword,
 }:
 
 let
-  inherit (qt5)
+  inherit (qt6)
     qtbase
     qtsvg
     qttools
@@ -23,18 +25,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "bibletime";
-  version = "3.0.3";
+  version = "3.1.1";
 
   src = fetchFromGitHub {
     owner = "bibletime";
     repo = "bibletime";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-4O8F5/EyoJFJBEWOAs9lzN3TKuu/CEdKfPaOF8gNqps=";
+    hash = "sha256-kYQjkwfWsEijJ/umOylnfvHgv4u16xr3pkr3ALN4O8c=";
   };
 
   nativeBuildInputs = [
     cmake
     docbook_xml_dtd_45
+    gettext
+    libxslt
     pkg-config
     wrapQtAppsHook
     perlPackages.Po4a


### PR DESCRIPTION
Update bibletime to 3.1.1, update to Qt6, fix dependency issues.

Tested the GUI and it works.

Changelog: https://github.com/bibletime/bibletime/releases

Closes #431665

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
