### PR TITLE
workflows: checkout pinned nixpkgs explicitly

### DIFF
--- a/.github/actions/get-merge-commit/action.yml
+++ b/.github/actions/get-merge-commit/action.yml
@@ -9,6 +9,9 @@ inputs:
   merged-as-untrusted:
     description: "Whether to checkout the merge commit in the ./untrusted folder."
     type: boolean
+  pinnedFrom:
+    description: "Whether to checkout the pinned nixpkgs for CI and from where (trusted, untrusted)."
+    type: string
   targetSha:
     description: "The target commit SHA, previously collected."
     type: string
@@ -93,3 +96,26 @@ runs:
       with:
         ref: ${{ inputs.targetSha || steps.commits.outputs.targetSha }}
         path: trusted
+
+    - if: inputs.pinnedFrom
+      id: pinned
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      env:
+        PINNED_FROM: ${{ inputs.pinnedFrom }}
+      with:
+        script: |
+          const path = require('node:path')
+          const pinned = require(path.resolve(path.join(process.env.PINNED_FROM, 'ci', 'pinned.json')))
+          core.setOutput('pinnedSha', pinned.pins.nixpkgs.revision)
+
+    - if: steps.pinned.outputs.pinnedSha
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        ref: ${{ steps.pinned.outputs.pinnedSha }}
+        path: pinned
+        sparse-checkout: |
+          lib
+          maintainers
+          nixos/lib
+          pkgs
+

--- a/.github/actions/get-merge-commit/action.yml
+++ b/.github/actions/get-merge-commit/action.yml
@@ -86,13 +86,13 @@ runs:
       # Would be great to do the checkouts in git worktrees of the existing spare checkout instead,
       # but Nix is broken with them:
       # https://github.com/NixOS/nix/issues/6073
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         ref: ${{ inputs.mergedSha || steps.commits.outputs.mergedSha }}
         path: untrusted
 
     - if: inputs.target-as-trusted && (inputs.targetSha || steps.commits.outputs.targetSha)
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         ref: ${{ inputs.targetSha || steps.commits.outputs.targetSha }}
         path: trusted

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,7 @@ jobs:
 
       - uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31
         with:
+          # Sandbox is disabled on MacOS by default.
           extra_nix_config: sandbox = true
 
       - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           mergedSha: ${{ inputs.mergedSha }}
           merged-as-untrusted: true
+          pinnedFrom: untrusted
 
       - uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31
         with:
@@ -67,29 +68,29 @@ jobs:
 
       - name: Build shell
         if: contains(matrix.builds, 'shell')
-        run: nix-build untrusted/ci -A shell
+        run: nix-build untrusted/ci --arg nixpkgs ./pinned -A shell
 
       - name: Build NixOS manual
         if: |
           contains(matrix.builds, 'manual-nixos') && !cancelled() &&
           contains(fromJSON(inputs.baseBranch).type, 'primary')
-        run: nix-build untrusted/ci -A manual-nixos --argstr system ${{ matrix.system }} --out-link nixos-manual
+        run: nix-build untrusted/ci --arg nixpkgs ./pinned -A manual-nixos --argstr system ${{ matrix.system }} --out-link nixos-manual
 
       - name: Build Nixpkgs manual
         if: contains(matrix.builds, 'manual-nixpkgs') && !cancelled()
-        run: nix-build untrusted/ci -A manual-nixpkgs -A manual-nixpkgs-tests
+        run: nix-build untrusted/ci --arg nixpkgs ./pinned -A manual-nixpkgs -A manual-nixpkgs-tests
 
       - name: Build Nixpkgs manual tests
         if: contains(matrix.builds, 'manual-nixpkgs-tests') && !cancelled()
-        run: nix-build untrusted/ci -A manual-nixpkgs-tests
+        run: nix-build untrusted/ci --arg nixpkgs ./pinned -A manual-nixpkgs-tests
 
       - name: Build lib tests
         if: contains(matrix.builds, 'lib-tests') && !cancelled()
-        run: nix-build untrusted/ci -A lib-tests
+        run: nix-build untrusted/ci --arg nixpkgs ./pinned -A lib-tests
 
       - name: Build tarball
         if: contains(matrix.builds, 'tarball') && !cancelled()
-        run: nix-build untrusted/ci -A tarball
+        run: nix-build untrusted/ci --arg nixpkgs ./pinned -A tarball
 
       - name: Upload NixOS manual
         if: |

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -52,8 +52,6 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31
-        with:
-          extra_nix_config: sandbox = true
 
       - name: Evaluate the ${{ matrix.system }} output paths for all derivation attributes
         env:
@@ -173,8 +171,6 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31
-        with:
-          extra_nix_config: sandbox = true
 
       - name: Combine all output paths and eval stats
         run: |
@@ -251,8 +247,6 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31
-        with:
-          extra_nix_config: sandbox = true
 
       - name: Ensure flake outputs on all systems still evaluate
         run: nix flake check --all-systems --no-build ./untrusted

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -44,11 +44,15 @@ jobs:
           sudo mkswap /swap
           sudo swapon /swap
 
-      - name: Check out the PR at the test merge commit
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          ref: ${{ inputs.mergedSha }}
-          path: untrusted
+          sparse-checkout: .github/actions
+      - name: Check out the PR at the test merge commit
+        uses: ./.github/actions/get-merge-commit
+        with:
+          mergedSha: ${{ inputs.mergedSha }}
+          merged-as-untrusted: true
+          pinnedFrom: untrusted
 
       - name: Install Nix
         uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31
@@ -57,7 +61,7 @@ jobs:
         env:
           MATRIX_SYSTEM: ${{ matrix.system }}
         run: |
-          nix-build untrusted/ci -A eval.singleSystem \
+          nix-build untrusted/ci --arg nixpkgs ./pinned  -A eval.singleSystem \
             --argstr evalSystem "$MATRIX_SYSTEM" \
             --arg chunkSize 8000 \
             --out-link merged
@@ -135,7 +139,7 @@ jobs:
         env:
           MATRIX_SYSTEM: ${{ matrix.system }}
         run: |
-          nix-build untrusted/ci -A eval.diff \
+          nix-build untrusted/ci --arg nixpkgs ./pinned -A eval.diff \
             --arg beforeDir ./target \
             --arg afterDir "$(readlink ./merged)" \
             --argstr evalSystem "$MATRIX_SYSTEM" \
@@ -156,6 +160,16 @@ jobs:
       statuses: write
     timeout-minutes: 5
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          sparse-checkout: .github/actions
+      - name: Check out the PR at the target commit
+        uses: ./.github/actions/get-merge-commit
+        with:
+          targetSha: ${{ inputs.targetSha }}
+          target-as-trusted: true
+          pinnedFrom: trusted
+
       - name: Download output paths and eval stats for all systems
         uses: actions/download-artifact@de96f4613b77ec03b5cf633e7c350c32bd3c5660 # v4.1.8
         with:
@@ -163,18 +177,12 @@ jobs:
           path: diff
           merge-multiple: true
 
-      - name: Check out the PR at the target commit
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          ref: ${{ inputs.targetSha }}
-          path: trusted
-
       - name: Install Nix
         uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31
 
       - name: Combine all output paths and eval stats
         run: |
-          nix-build trusted/ci -A eval.combine \
+          nix-build trusted/ci --arg nixpkgs ./pinned -A eval.combine \
             --arg diffDir ./diff \
             --out-link combined
 
@@ -187,7 +195,7 @@ jobs:
             | jq --raw-input --slurp 'split("\n")[:-1]' > touched-files.json
 
           # Use the target branch to get accurate maintainer info
-          nix-build trusted/ci -A eval.compare \
+          nix-build trusted/ci --arg nixpkgs ./pinned -A eval.compare \
             --arg combinedDir "$(realpath ./combined)" \
             --arg touchedFilesJson ./touched-files.json \
             --argstr githubAuthorId "$AUTHOR_ID" \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,8 +31,6 @@ jobs:
           merged-as-untrusted: true
 
       - uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31
-        with:
-          extra_nix_config: sandbox = true
 
       - name: Check that files are formatted
         run: |
@@ -64,8 +62,6 @@ jobs:
           merged-as-untrusted: true
 
       - uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31
-        with:
-          extra_nix_config: sandbox = true
 
       - name: Parse all nix files
         run: |
@@ -88,8 +84,6 @@ jobs:
           target-as-trusted: true
 
       - uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31
-        with:
-          extra_nix_config: sandbox = true
 
       - name: Running nixpkgs-vet
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           mergedSha: ${{ inputs.mergedSha }}
           merged-as-untrusted: true
+          pinnedFrom: untrusted
 
       - uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31
 
@@ -37,7 +38,7 @@ jobs:
           # Note that it's fine to run this on untrusted code because:
           # - There's no secrets accessible here
           # - The build is sandboxed
-          if ! nix-build untrusted/ci -A fmt.check; then
+          if ! nix-build untrusted/ci --arg nixpkgs ./pinned -A fmt.check; then
             echo "Some files are not properly formatted"
             echo "Please format them by going to the Nixpkgs root directory and running one of:"
             echo "  nix-shell --run treefmt"
@@ -60,13 +61,14 @@ jobs:
         with:
           mergedSha: ${{ inputs.mergedSha }}
           merged-as-untrusted: true
+          pinnedFrom: untrusted
 
       - uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31
 
       - name: Parse all nix files
         run: |
           # Tests multiple versions at once, let's make sure all of them run, so keep-going.
-          nix-build untrusted/ci -A parse --keep-going
+          nix-build untrusted/ci --arg nixpkgs ./pinned -A parse --keep-going
 
   nixpkgs-vet:
     runs-on: ubuntu-24.04-arm
@@ -80,6 +82,7 @@ jobs:
         with:
           mergedSha: ${{ inputs.mergedSha }}
           merged-as-untrusted: true
+          pinnedFrom: untrusted
           targetSha: ${{ inputs.targetSha }}
           target-as-trusted: true
 
@@ -90,7 +93,7 @@ jobs:
           # Force terminal colors to be enabled. The library that `nixpkgs-vet` uses respects https://bixense.com/clicolors/
           CLICOLOR_FORCE: 1
         run: |
-          if nix-build untrusted/ci -A nixpkgs-vet --arg base "./trusted" --arg head "./untrusted"; then
+          if nix-build untrusted/ci --arg nixpkgs ./pinned -A nixpkgs-vet --arg base "./trusted" --arg head "./untrusted"; then
             exit 0
           else
             exitCode=$?

--- a/.github/workflows/reviewers.yml
+++ b/.github/workflows/reviewers.yml
@@ -37,8 +37,6 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31
-        with:
-          extra_nix_config: sandbox = true
 
       - name: Build the requestReviews derivation
         run: nix-build trusted/ci -A requestReviews

--- a/ci/default.nix
+++ b/ci/default.nix
@@ -121,8 +121,8 @@ rec {
   # CI jobs
   lib-tests = import ../lib/tests/release.nix { inherit pkgs; };
   manual-nixos = (import ../nixos/release.nix { }).manual.${system} or null;
-  manual-nixpkgs = (import ../doc { });
-  manual-nixpkgs-tests = (import ../doc { }).tests;
+  manual-nixpkgs = (import ../doc { inherit pkgs; });
+  manual-nixpkgs-tests = (import ../doc { inherit pkgs; }).tests;
   nixpkgs-vet = pkgs.callPackage ./nixpkgs-vet.nix { };
   parse = pkgs.lib.recurseIntoAttrs {
     latest = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.latest; };


### PR DESCRIPTION
This is slightly faster than downloading and extracting a tarball and additionally allows a sparse checkout. No need to download docs or nixos for our purpose.

The data is quite noisy, but suggests improvements from anywhere between 5-15 seconds for each job using the pinned nixpkgs.

## Things done

- [x] Tested in this PR.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
