### PR TITLE
tayga: 0.9.2 -> 0.9.5

### DIFF
--- a/nixos/modules/services/networking/tayga.nix
+++ b/nixos/modules/services/networking/tayga.nix
@@ -171,13 +171,16 @@ in
       };
     };
 
+    environment.etc."tayga.conf".source = configFile;
+
     systemd.services.tayga = {
       description = "Stateless NAT64 implementation";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
 
+      reloadTriggers = [ configFile ];
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/tayga -d --nodetach --config ${configFile}";
+        ExecStart = "${cfg.package}/bin/tayga -d --nodetach --config /etc/tayga.conf";
         ExecReload = "${pkgs.coreutils}/bin/kill -SIGHUP $MAINPID";
         Restart = "always";
 

--- a/nixos/modules/services/networking/tayga.nix
+++ b/nixos/modules/services/networking/tayga.nix
@@ -23,6 +23,10 @@ let
     data-dir ${cfg.dataDir}
 
     ${concatStringsSep "\n" (mapAttrsToList (ipv4: ipv6: "map " + ipv4 + " " + ipv6) cfg.mappings)}
+
+    ${optionalString ((builtins.length cfg.log) > 0) ''
+      log ${concatStringsSep " " cfg.log}
+    ''}
   '';
 
   addrOpts =
@@ -130,6 +134,15 @@ in
             "192.168.5.43" = "2001:db8:1:4444::2";
             "192.168.255.2" = "2001:db8:1:569::143";
           }
+        '';
+      };
+
+      log = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "Packet errors to log (drop, reject, icmp, self)";
+        example = literalExpression ''
+          [ "drop" "reject" "icmp" "self" ]
         '';
       };
     };

--- a/nixos/modules/services/networking/tayga.nix
+++ b/nixos/modules/services/networking/tayga.nix
@@ -27,6 +27,8 @@ let
     ${optionalString ((builtins.length cfg.log) > 0) ''
       log ${concatStringsSep " " cfg.log}
     ''}
+
+    wkpf-strict ${if cfg.wkpfStrict then "yes" else "no"}
   '';
 
   addrOpts =
@@ -144,6 +146,12 @@ in
         example = literalExpression ''
           [ "drop" "reject" "icmp" "self" ]
         '';
+      };
+
+      wkpfStrict = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Enable restrictions on the use of the well-known prefix (64:ff9b::/96) - prevents translation of non-global IPv4 ranges when using the well-known prefix. Must be enabled for RFC 6052 compatibility.";
       };
     };
   };

--- a/nixos/tests/tayga.nix
+++ b/nixos/tests/tayga.nix
@@ -87,6 +87,7 @@
       ];
 
       networking = {
+        hostName = "router-systemd";
         useDHCP = false;
         useNetworkd = true;
         firewall.enable = false;
@@ -152,6 +153,7 @@
       ];
 
       networking = {
+        hostName = "router-nixos";
         useDHCP = false;
         firewall.enable = false;
         interfaces.eth1 = lib.mkForce {

--- a/nixos/tests/tayga.nix
+++ b/nixos/tests/tayga.nix
@@ -63,6 +63,7 @@
         };
       };
       programs.mtr.enable = true;
+      environment.systemPackages = [ pkgs.tcpdump ];
     };
 
     # The router is configured with static IPv4 addresses towards the server
@@ -139,6 +140,7 @@
           "192.0.2.42" = "2001:db8::2";
         };
       };
+      environment.systemPackages = [ pkgs.tcpdump ];
     };
 
     router_nixos = {
@@ -204,6 +206,7 @@
           "192.0.2.42" = "2001:db8::2";
         };
       };
+      environment.systemPackages = [ pkgs.tcpdump ];
     };
 
     # The client is configured with static IPv6 addresses. It has also a static
@@ -235,6 +238,7 @@
         };
       };
       programs.mtr.enable = true;
+      environment.systemPackages = [ pkgs.tcpdump ];
     };
   };
 

--- a/nixos/tests/tayga.nix
+++ b/nixos/tests/tayga.nix
@@ -31,11 +31,10 @@
   };
 
   nodes = {
-    # The server is configured with static IPv4 addresses. RFC 6052 Section 3.1
-    # disallows the mapping of non-global IPv4 addresses like RFC 1918 into the
-    # Well-Known Prefix 64:ff9b::/96. TAYGA also does not allow the mapping of
-    # documentation space (RFC 5737). To circumvent this, 100.64.0.2/24 from
-    # RFC 6589 (Carrier Grade NAT) is used here.
+    # The server is configured with static IPv4 addresses. We have to disable the
+    # well-known prefix restrictions (as required by RFC 6052 Section 3.1) because
+    # we're using private space (TAYGA also considers documentation space non-global,
+    # unfortunately).
     # To reach the IPv4 address pool of the NAT64 gateway, there is a static
     # route configured. In normal cases, where the router would also source NAT
     # the pool addresses to one IPv4 addresses, this would not be needed.
@@ -145,6 +144,7 @@
           "icmp"
           "self"
         ];
+        wkpfStrict = false;
       };
       environment.systemPackages = [ pkgs.tcpdump ];
     };
@@ -217,6 +217,7 @@
           "icmp"
           "self"
         ];
+        wkpfStrict = false;
       };
       environment.systemPackages = [ pkgs.tcpdump ];
     };

--- a/nixos/tests/tayga.nix
+++ b/nixos/tests/tayga.nix
@@ -139,6 +139,12 @@
         mappings = {
           "192.0.2.42" = "2001:db8::2";
         };
+        log = [
+          "drop"
+          "reject"
+          "icmp"
+          "self"
+        ];
       };
       environment.systemPackages = [ pkgs.tcpdump ];
     };
@@ -205,6 +211,12 @@
         mappings = {
           "192.0.2.42" = "2001:db8::2";
         };
+        log = [
+          "drop"
+          "reject"
+          "icmp"
+          "self"
+        ];
       };
       environment.systemPackages = [ pkgs.tcpdump ];
     };

--- a/pkgs/by-name/ta/tayga/package.nix
+++ b/pkgs/by-name/ta/tayga/package.nix
@@ -1,23 +1,32 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "0.9.2";
+  version = "0.9.5";
   pname = "tayga";
 
-  src = fetchurl {
-    url = "http://www.litech.org/tayga/tayga-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-Kx95J6nS3P+Qla/zwnGSSwUsz9L6ypWIsndDGkTwAJw=";
+  src = fetchFromGitHub {
+    owner = "apalrd";
+    repo = "tayga";
+    tag = finalAttrs.version;
+    hash = "sha256-xOm4fetFq2UGuhOojrT8WOcX78c6MLTMVbDv+O62x2E=";
   };
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-Wno-address-of-packed-member"
-    "-Wno-implicit-function-declaration"
-  ];
+  preBuild = ''
+    echo "#define TAYGA_VERSION \"${finalAttrs.version}\"" > version.h
+  '';
+
+  installPhase = ''
+    install -Dm755 tayga $out/bin/tayga
+    install -D tayga.conf.5 $out/share/man/man5/tayga.conf.5
+    install -D tayga.8 $out/share/man/man8/tayga.8
+    cp -R docs $out/share/
+    cp tayga.conf.example $out/share/docs/
+  '';
 
   passthru.tests.tayga = nixosTests.tayga;
 
@@ -30,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
       It is intended to provide production-quality NAT64 service
       for networks where dedicated NAT64 hardware would be overkill.
     '';
-    homepage = "http://www.litech.org/tayga";
+    homepage = "https://github.com/apalrd/tayga";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ _0x4A6F ];
     platforms = platforms.linux;


### PR DESCRIPTION
Upstream has changed to there, and it's actively maintained.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
