### PR TITLE
bash-git-prompt: init at 2.7.1-unstable-23-04-2025

### DIFF
--- a/pkgs/by-name/ba/bash-git-prompt/package.nix
+++ b/pkgs/by-name/ba/bash-git-prompt/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  python3,
+}:
+
+stdenv.mkDerivation {
+  pname = "bash-git-prompt";
+  version = "2.7.1-unstable-2025-04-23";
+
+  src = fetchFromGitHub {
+    owner = "magicmonty";
+    repo = "bash-git-prompt";
+    rev = "e733ada3e93fd9fdb6e9d1890e38e6e523522da7";
+    hash = "sha256-FWeYzISY4+cS2xg6skfcpTXgbkBs41E/EzEb3JNdFoQ=";
+  };
+
+  buildInputs = [ python3 ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+
+    # Copy all shell scripts
+    cp *.sh $out/
+
+    # Copy fish script
+    cp *.fish $out/
+
+    # Copy themes directory
+    cp -r themes $out/
+
+    # Copy documentation
+    cp README.md $out/
+    cp LICENSE.txt $out/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Informative, fancy bash prompt for Git users";
+    homepage = "https://github.com/magicmonty/bash-git-prompt";
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.parrot7483 ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
This PR adds [bash-git-prompt](https://github.com/magicmonty/bash-git-prompt). A bash prompt that displays information about the current git repository. Similar to [zsh-git-prompt](https://github.com/NixOS/nixpkgs/blob/nixos-25.05/pkgs/by-name/zs/zsh-git-prompt/package.nix#L45). Since the last release was in 2017 but the package being well maintained, I added latest HEAD of master. 

One can then use it like this in either home-manager or NixOS bash configuration: 

    
```bash
source "${pkgs.bash-git-prompt}/gitprompt.sh"
```


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
