### PR TITLE
nixos/netbird: fix desktop file name pattern

### DIFF
--- a/nixos/modules/services/networking/netbird.nix
+++ b/nixos/modules/services/networking/netbird.nix
@@ -310,7 +310,7 @@ in
                         mkdir -p "$out/share/applications"
                         substitute ${cfg.ui.package}/share/applications/netbird.desktop \
                             "$out/share/applications/${mkBin "netbird"}.desktop" \
-                          --replace-fail 'Name=NetBird' "Name=NetBird @ ${client.service.name}" \
+                          --replace-fail 'Name=Netbird' "Name=NetBird @ ${client.service.name}" \
                           --replace-fail '${lib.getExe cfg.ui.package}' "$out/bin/${mkBin "netbird-ui"}"
                       '')
                     ];


### PR DESCRIPTION
The desktop file substitution was looking for 'Name=NetBird' but the actual desktop file contains 'Name=Netbird' (with lowercase 'b').

This caused build failures with the error:
```
substituteStream() in derivation netbird-0.49.0-wrapper-netbird: 
ERROR: pattern Name=NetBird doesn't match anything
```

Fixes #432454

## Testing
- [x] Verified the actual desktop file contains `Name=Netbird`
- [x] Updated substitution pattern to match the correct case
- [x] Commit follows nixpkgs conventions