### PR TITLE
erlang-language-platform:  update script with OTP version support

### DIFF
--- a/pkgs/by-name/er/erlang-language-platform/hashes.json
+++ b/pkgs/by-name/er/erlang-language-platform/hashes.json
@@ -1,0 +1,14 @@
+{
+  "elp-linux-aarch64-unknown-linux-gnu-otp-26.2": "sha256-xKl19cLz3Pm39QS8+9fOCGJHpxl4NoPYHIwTqKDq4Jc=",
+  "elp-linux-aarch64-unknown-linux-gnu-otp-27.3": "sha256-GNoV6Ihtro3ecl4cncyQKQez/5CBqj1E3JV1JK8l2V8=",
+  "elp-linux-aarch64-unknown-linux-gnu-otp-28": "sha256-DW00mSXJWIBfwsV9juMKaiFwNkezT1Ro+5zMaCwFRzE=",
+  "elp-linux-x86_64-unknown-linux-gnu-otp-26.2": "sha256-fQvlzwS7crDsqmSjsUlFXbqKnCKldOYuiQDmGojqJb8=",
+  "elp-linux-x86_64-unknown-linux-gnu-otp-27.3": "sha256-4pZtSVCDIiJ7k83go7WjJq4wxWbc9nG4hJoAgXDMOZM=",
+  "elp-linux-x86_64-unknown-linux-gnu-otp-28": "sha256-3hY+5TDBobRjKgfptvgHmdtuWm8UE7KoWFhsR2qmQhc=",
+  "elp-macos-aarch64-apple-darwin-otp-26.2": "sha256-38N+0msiPMv9eFTSzWdEqmczDp49JvTlu3kDedmC+Lw=",
+  "elp-macos-aarch64-apple-darwin-otp-27.3": "sha256-2uZyvyVwQULz+3HtvkIGvjO5Dm7qAAIbHE/VUcqcXkQ=",
+  "elp-macos-aarch64-apple-darwin-otp-28": "sha256-BosctdlXWTxkVyLX8awlJtyHAtfoVxFlvs7qrSlPTZc=",
+  "elp-macos-x86_64-apple-darwin-otp-26.2": "sha256-p0xotdrflT2CANJi4OaevJZT4nhFRAfdzrhQ/7M8ykA=",
+  "elp-macos-x86_64-apple-darwin-otp-27.3": "sha256-qTvsGRCVqqoSWK/t7MysE1wlD0PwtUQQ1N1Zols+Egk=",
+  "elp-macos-x86_64-apple-darwin-otp-28": "sha256-DSB8AXWM1KByuzg5HY2lh2x4zmeeR2nyiERR3Iovpns="
+}

--- a/pkgs/by-name/er/erlang-language-platform/package.nix
+++ b/pkgs/by-name/er/erlang-language-platform/package.nix
@@ -3,29 +3,41 @@
   lib,
   fetchurl,
   autoPatchelfHook,
+  erlang,
 }:
 let
+  # erlang-language-platform supports multiple OTP versions.
+  # here we search the release names from hashes.json to check support for our OTP.
+  # ELP releases only list the major and minor version so we do a prefix check.
   arch = if stdenv.hostPlatform.isAarch64 then "aarch64" else "x86_64";
-  release =
+  platform =
     if stdenv.hostPlatform.isDarwin then
-      "macos-${arch}-apple-darwin"
+      "elp-macos-${arch}-apple-darwin"
     else
-      "linux-${arch}-unknown-linux-gnu";
+      "elp-linux-${arch}-unknown-linux-gnu";
+  otp_version = "otp-${lib.versions.major erlang.version}";
+  release_major = "${platform}-${otp_version}";
 
-  hashes = {
-    linux-aarch64-unknown-linux-gnu = "sha256-i6XsOK8csrJ/9TDzltA7mGjdutLZONFiYGV5tqSCy8o=";
-    linux-x86_64-unknown-linux-gnu = "sha256-XK3DPWIdPDoIL10EATa8p1bnlpZaOzOdU0LnuKbj++E=";
-    macos-aarch64-apple-darwin = "sha256-8e5duQYDVFyZejMjuZPuWhg1on3CBku9eBuilG5p1BY=";
-    macos-x86_64-apple-darwin = "sha256-dnouUBUUAkMr1h+IJWYamxmk8IC7JdeIUS9/YI0GzOU=";
-  };
+  hashes = builtins.fromJSON (builtins.readFile ./hashes.json);
+
+  release_name =
+    let
+      hash_names = builtins.attrNames hashes;
+      found_name = lib.lists.findFirst (name: lib.strings.hasPrefix release_major name) false hash_names;
+    in
+    if found_name != false then
+      found_name
+    else
+      throw "erlang-language-platform does not support OTP major/minor version ${otp_version}";
+
 in
 stdenv.mkDerivation rec {
   pname = "erlang-language-platform";
   version = "2025-04-02";
 
   src = fetchurl {
-    url = "https://github.com/WhatsApp/erlang-language-platform/releases/download/${version}/elp-${release}-otp-26.2.tar.gz";
-    hash = hashes.${release};
+    url = "https://github.com/WhatsApp/erlang-language-platform/releases/download/${version}/${release_name}.tar.gz";
+    hash = hashes.${release_name};
   };
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isElf [ autoPatchelfHook ];
@@ -39,6 +51,8 @@ stdenv.mkDerivation rec {
     install -m755 -D elp $out/bin/elp
     runHook postInstall
   '';
+
+  passthru.updateScript = ./update.sh;
 
   meta = {
     description = "IDE-first library for the semantic analysis of Erlang code, including LSP server, linting and refactoring tools";

--- a/pkgs/by-name/er/erlang-language-platform/package.nix
+++ b/pkgs/by-name/er/erlang-language-platform/package.nix
@@ -33,7 +33,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "erlang-language-platform";
-  version = "2025-04-02";
+  version = "2025-07-21";
 
   src = fetchurl {
     url = "https://github.com/WhatsApp/erlang-language-platform/releases/download/${version}/${release_name}.tar.gz";

--- a/pkgs/by-name/er/erlang-language-platform/update.sh
+++ b/pkgs/by-name/er/erlang-language-platform/update.sh
@@ -1,0 +1,24 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p curl jq common-updater-scripts
+# shellcheck shell=bash
+
+set -euo pipefail
+
+curl_github() {
+    curl -L ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} "$@"
+}
+
+release_json=$(curl_github https://api.github.com/repos/WhatsApp/erlang-language-platform/releases/latest)
+version=$(echo "$release_json" | jq -r '.tag_name')
+releases=$(echo "$release_json" | jq -r '.assets[] | select(.browser_download_url | test(".tar.gz$")) | .name + ":" + .browser_download_url')
+
+update-source-version erlang-language-platform "$version" --file=./pkgs/by-name/er/erlang-language-platform/package.nix
+
+for release in $releases; do
+  IFS=: read -r name url <<< "$release"
+  hash_name=$(echo "$name" | sed 's/.tar.gz$//')
+  hash_prefetched=$(nix-prefetch-url --type sha256 "$url")
+  hash_sri=$(nix hash to-sri --type sha256 "$hash_prefetched")
+  echo "$hash_name" "$hash_sri"
+done |
+  jq -sR 'rtrimstr("\n") | split("\n") | map(split(" ") | {(.[0]): .[1]}) | add' > hashes.json


### PR DESCRIPTION
This PR updates the erlang-language-platform package to:
* introduce an update script which fetches the latest release tarball hashes to hashes.json
* updates package.nix to use those hashes
* uses the OTP package's version to select the release to build

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
