### PR TITLE
multimidicast: init at 1.4

### DIFF
--- a/pkgs/by-name/mu/multimidicast/package.nix
+++ b/pkgs/by-name/mu/multimidicast/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  alsa-lib,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  name = "multimidicast";
+  version = "1.4";
+
+  src = fetchzip {
+    url = "https://llg.cubic.org/tools/multimidicast/multimidicast-${finalAttrs.version}.tar.gz";
+    hash = "sha256-fuZKl9C5kr4bodVz+QsYbSTmWmsWNTiFU2eeYR9hw6Y=";
+  };
+
+  strictDeps = true;
+
+  buildInputs = [ alsa-lib ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm 755 multimidicast -t $out/bin
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Sends and receives MIDI from Alsa sequencers over your network";
+    homepage = "https://llg.cubic.org/tools/multimidicast";
+    license = lib.licenses.free;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ mrtnvgr ];
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
