### PR TITLE
protopedal: init at 2.5

### DIFF
--- a/pkgs/by-name/pr/protopedal/package.nix
+++ b/pkgs/by-name/pr/protopedal/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  runCommand,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "protopedal";
+  version = "2.5";
+
+  src = fetchFromGitLab {
+    owner = "openirseny";
+    repo = "protopedal";
+    tag = "release-${finalAttrs.version}";
+    hash = "sha256-3I7tpvqEE6IcWkKlRyCTF6J3+okyHwjC9ddylcU6PlE=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -D protopedal -t $out/bin/
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.help = runCommand {
+      name = "${finalAttrs.finalPackage}-help-test";
+      nativeBuildInputs = [ finalAttrs.finalPackage ];
+      script = ''
+        protopedal --help
+        touch $out
+      '';
+    };
+  };
+
+  meta = {
+    description = "Compatibility tool for sim racing pedals and force feedback steering wheels";
+    longDescription = ''
+      Helps with wheel and pedal detection by creating virtual devices
+      with extended capabilities. Facilitates merging devices, range
+      adjustments, custom curves, button to axis and axis to button
+      mappings.
+    '';
+    license = lib.licenses.eupl12;
+    homepage = "https://gitlab.com/openirseny/protopedal";
+    platforms = lib.platforms.all;
+    badPlatforms = lib.platforms.darwin;
+    maintainers = [ lib.maintainers.rake5k ];
+    mainProgram = "protopedal";
+  };
+})


### PR DESCRIPTION
New package for https://gitlab.com/openirseny/protopedal, a compatibility tool for sim racing pedals and force feedback steering wheels.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
