### PR TITLE
linux_hardened: only provide latest LTS and latest stable version

### DIFF
--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -34,7 +34,7 @@ in
       ];
     };
 
-    boot.kernelPackages = mkDefault pkgs.linuxPackages_hardened;
+    boot.kernelPackages = mkDefault pkgs.linuxKernel.packages.linux_hardened;
 
     nix.settings.allowed-users = mkDefault [ "@users" ];
 

--- a/nixos/tests/kernel-generic.nix
+++ b/nixos/tests/kernel-generic.nix
@@ -35,14 +35,8 @@ let
     ) args);
   kernels = pkgs.linuxKernel.vanillaPackages // {
     inherit (pkgs.linuxKernel.packages)
-      linux_5_4_hardened
-      linux_5_10_hardened
-      linux_5_15_hardened
-      linux_6_1_hardened
-      linux_6_6_hardened
       linux_6_12_hardened
-      linux_6_13_hardened
-      linux_6_14_hardened
+      linux_6_15_hardened
       linux_rt_5_4
       linux_rt_5_10
       linux_rt_5_15

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -72,6 +72,7 @@ let
       extraMeta ? { },
       extraPassthru ? { },
 
+      isLTS ? false,
       isZen ? false,
       isLibre ? false,
       isHardened ? false,
@@ -332,6 +333,7 @@ let
               commonStructuredConfig
               structuredExtraConfig
               extraMakeFlags
+              isLTS
               isZen
               isHardened
               isLibre

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -2,11 +2,11 @@
     "6.12": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-v6.12.34-hardened1.patch",
-            "sha256": "1aw8r52gbxp53sgl4pwv51axw0kmgh3ib6gfvw81dlyaajmlbm6b",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.12.34-hardened1/linux-hardened-v6.12.34-hardened1.patch"
+            "name": "linux-hardened-v6.12.41-hardened1.patch",
+            "sha256": "1a0gc03nr0aiy2zadg6hfy718nlb2k8p5h5ymvwsdl6kblxi9f47",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.12.41-hardened1/linux-hardened-v6.12.41-hardened1.patch"
         },
-        "sha256": "0kf2f3r96npzs01kdq3q2ag7zg8l3avfyqwv5qbs9v373wwgxwx7",
-        "version": "6.12.34"
+        "sha256": "09qfpxyxi3z8cd64r2r5mxvh54a5sx8p5mk4d50y4ga2k6pa66bb",
+        "version": "6.12.41"
     }
 }

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -8,5 +8,15 @@
         },
         "sha256": "09qfpxyxi3z8cd64r2r5mxvh54a5sx8p5mk4d50y4ga2k6pa66bb",
         "version": "6.12.41"
+    },
+    "6.15": {
+        "patch": {
+            "extra": "-hardened1",
+            "name": "linux-hardened-v6.15.9-hardened1.patch",
+            "sha256": "132h0cgv8kzrlz7jprqvwcnragc2v793a759bhg0q6w3ninmncjc",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.15.9-hardened1/linux-hardened-v6.15.9-hardened1.patch"
+        },
+        "sha256": "0zcma8ycdwwzd4yci9752acsv85wh27lahclh5x2yc4jakw3lkz9",
+        "version": "6.15.9"
     }
 }

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -28,15 +28,5 @@
         },
         "sha256": "06rvydmc2yfspidnsay5hin3i8p4fxy3bvzwnry7gjf9dl5cs71z",
         "version": "6.14.11"
-    },
-    "6.6": {
-        "patch": {
-            "extra": "-hardened1",
-            "name": "linux-hardened-v6.6.94-hardened1.patch",
-            "sha256": "0i1dshmsr8v230qmbawda916420m6njwwmillcbr42hsagdjhd0i",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.6.94-hardened1/linux-hardened-v6.6.94-hardened1.patch"
-        },
-        "sha256": "0mncdsqbqrxii0hirnymi1kmg50jn9v0p26flimlf2xj4vm82fbi",
-        "version": "6.6.94"
     }
 }

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -1,14 +1,4 @@
 {
-    "5.15": {
-        "patch": {
-            "extra": "-hardened1",
-            "name": "linux-hardened-v5.15.185-hardened1.patch",
-            "sha256": "00m1p8cm1d76drdlafv4bdrq81xkh40jgg33kvkk3wqcbiikq3h7",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v5.15.185-hardened1/linux-hardened-v5.15.185-hardened1.patch"
-        },
-        "sha256": "1p0kjc09qqv361phscny1gqj38di9dpab9gxywljkwqhi5wyn0rx",
-        "version": "5.15.185"
-    },
     "6.1": {
         "patch": {
             "extra": "-hardened1",

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -1,14 +1,4 @@
 {
-    "5.10": {
-        "patch": {
-            "extra": "-hardened1",
-            "name": "linux-hardened-v5.10.238-hardened1.patch",
-            "sha256": "1y4srk40v0gzfnlqsbh6g9h5vcs8rp5g2b8jjch6xx7dji189myq",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v5.10.238-hardened1/linux-hardened-v5.10.238-hardened1.patch"
-        },
-        "sha256": "1dkblixa0as9h11m081dqq8vlz4dcjbzdz7phkz07p621na55j07",
-        "version": "5.10.238"
-    },
     "5.15": {
         "patch": {
             "extra": "-hardened1",

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -8,15 +8,5 @@
         },
         "sha256": "0kf2f3r96npzs01kdq3q2ag7zg8l3avfyqwv5qbs9v373wwgxwx7",
         "version": "6.12.34"
-    },
-    "6.14": {
-        "patch": {
-            "extra": "-hardened1",
-            "name": "linux-hardened-v6.14.11-hardened1.patch",
-            "sha256": "07f0d76rag6jcclxdl24w70545fb8jrqy98xcdmgxwjabclaa1lp",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.14.11-hardened1/linux-hardened-v6.14.11-hardened1.patch"
-        },
-        "sha256": "06rvydmc2yfspidnsay5hin3i8p4fxy3bvzwnry7gjf9dl5cs71z",
-        "version": "6.14.11"
     }
 }

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -9,16 +9,6 @@
         "sha256": "0kf2f3r96npzs01kdq3q2ag7zg8l3avfyqwv5qbs9v373wwgxwx7",
         "version": "6.12.34"
     },
-    "6.13": {
-        "patch": {
-            "extra": "-hardened1",
-            "name": "linux-hardened-v6.13.12-hardened1.patch",
-            "sha256": "0i9raq3qcc6pxvs9l6yn5b6k8kiywwlis33kkpd8byqhs57aqsic",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.13.12-hardened1/linux-hardened-v6.13.12-hardened1.patch"
-        },
-        "sha256": "0hhj49k3ksjcp0dg5yiahqzryjfdpr9c1a9ph6j9slzmkikbn7v1",
-        "version": "6.13.12"
-    },
     "6.14": {
         "patch": {
             "extra": "-hardened1",

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -1,14 +1,4 @@
 {
-    "6.1": {
-        "patch": {
-            "extra": "-hardened1",
-            "name": "linux-hardened-v6.1.141-hardened1.patch",
-            "sha256": "10wbx6sjzjh3krx15pb65xxl55xcpia54ws825s9619wx059dskl",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.1.141-hardened1/linux-hardened-v6.1.141-hardened1.patch"
-        },
-        "sha256": "05n1561cbzaw9vcxp86bqzvhqz5wv7dajpy7cq34bw7myvx4ag5w",
-        "version": "6.1.141"
-    },
     "6.12": {
         "patch": {
             "extra": "-hardened1",

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -19,16 +19,6 @@
         "sha256": "1p0kjc09qqv361phscny1gqj38di9dpab9gxywljkwqhi5wyn0rx",
         "version": "5.15.185"
     },
-    "5.4": {
-        "patch": {
-            "extra": "-hardened1",
-            "name": "linux-hardened-v5.4.294-hardened1.patch",
-            "sha256": "1q6ffxnpk8j2fwi3g8rpf1lc247m8xiqix2kichxvggkadmjyzg0",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v5.4.294-hardened1/linux-hardened-v5.4.294-hardened1.patch"
-        },
-        "sha256": "16bv0x4c9ssr66vrd6jnv2dw5na1y7hxfn4d67g0zaksh6xd0yf8",
-        "version": "5.4.294"
-    },
     "6.1": {
         "patch": {
             "extra": "-hardened1",

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -5,34 +5,42 @@
     },
     "6.1": {
         "version": "6.1.148",
-        "hash": "sha256:18c024bqqc3srzv2gva55p95yghjc6x3p3f54v3hziki4wx3v86r"
+        "hash": "sha256:18c024bqqc3srzv2gva55p95yghjc6x3p3f54v3hziki4wx3v86r",
+        "lts": false
     },
     "5.15": {
         "version": "5.15.189",
-        "hash": "sha256:1hshd26ahn6dbw6jnqi0v5afpk672w7p09mk7iri93i7hxdh5l73"
+        "hash": "sha256:1hshd26ahn6dbw6jnqi0v5afpk672w7p09mk7iri93i7hxdh5l73",
+        "lts": true
     },
     "5.10": {
         "version": "5.10.240",
-        "hash": "sha256:04sdcf4aqsqchii38anzmk9f9x65wv8q1x3m9dandmi6fabw724d"
+        "hash": "sha256:04sdcf4aqsqchii38anzmk9f9x65wv8q1x3m9dandmi6fabw724d",
+        "lts": true
     },
     "5.4": {
         "version": "5.4.296",
-        "hash": "sha256:0fm73yqzbzclh2achcj8arpg428d412k2wgmlfmyy6xzb1762qrx"
+        "hash": "sha256:0fm73yqzbzclh2achcj8arpg428d412k2wgmlfmyy6xzb1762qrx",
+        "lts": true
     },
     "6.6": {
         "version": "6.6.102",
-        "hash": "sha256:0p6yjifwyrqlppn40isgxb0b5vqmljggmnp7w75vlc2c6fvzxll0"
+        "hash": "sha256:0p6yjifwyrqlppn40isgxb0b5vqmljggmnp7w75vlc2c6fvzxll0",
+        "lts": true
     },
     "6.12": {
         "version": "6.12.43",
-        "hash": "sha256:1vmxywg11z946i806sg7rk7jr9px87spmwwbzjxpps2nsjybpjqg"
+        "hash": "sha256:1vmxywg11z946i806sg7rk7jr9px87spmwwbzjxpps2nsjybpjqg",
+        "lts": true
     },
     "6.15": {
         "version": "6.15.11",
-        "hash": "sha256:14sxwrvw9p4ybizb8ky1rgahc62q0aw5qkmzqp3cpnavqfgldaw9"
+        "hash": "sha256:14sxwrvw9p4ybizb8ky1rgahc62q0aw5qkmzqp3cpnavqfgldaw9",
+        "lts": false
     },
     "6.16": {
         "version": "6.16.3",
-        "hash": "sha256:118bg72mdrf75r36gki5zi18ynl2kcygrf24pwd58by1anh9nhw0"
+        "hash": "sha256:118bg72mdrf75r36gki5zi18ynl2kcygrf24pwd58by1anh9nhw0",
+        "lts": false
     }
 }

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -41,6 +41,8 @@ lib.overrideDerivation
       }
       // (args.features or { });
 
+      isLTS = true;
+
       extraMeta =
         if (rpiVersion < 3) then
           {

--- a/pkgs/os-specific/linux/kernel/linux-rt-5.10.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-5.10.nix
@@ -40,6 +40,7 @@ buildLinux (
       in
       [ rt-patch ] ++ kernelPatches;
 
+    isLTS = true;
     structuredExtraConfig =
       with lib.kernel;
       {

--- a/pkgs/os-specific/linux/kernel/linux-rt-5.15.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-5.15.nix
@@ -57,6 +57,8 @@ buildLinux (
       }
       // structuredExtraConfig;
 
+    isLTS = true;
+
     extraMeta = extraMeta // {
       inherit branch;
     };

--- a/pkgs/os-specific/linux/kernel/linux-rt-5.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-5.4.nix
@@ -50,6 +50,8 @@ buildLinux (
       }
       // structuredExtraConfig;
 
+    isLTS = true;
+
     extraMeta = extraMeta // {
       inherit branch;
     };

--- a/pkgs/os-specific/linux/kernel/linux-rt-6.1.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-6.1.nix
@@ -60,6 +60,8 @@ buildLinux (
     extraMeta = extraMeta // {
       inherit branch;
     };
+
+    isLTS = true;
   }
   // argsOverride
 )

--- a/pkgs/os-specific/linux/kernel/linux-rt-6.6.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-6.6.nix
@@ -60,6 +60,8 @@ buildLinux (
     extraMeta = extraMeta // {
       inherit branch;
     };
+
+    isLTS = true;
   }
   // argsOverride
 )

--- a/pkgs/os-specific/linux/kernel/mainline.nix
+++ b/pkgs/os-specific/linux/kernel/mainline.nix
@@ -32,6 +32,7 @@ let
     (builtins.removeAttrs args [ "branch" ])
     // {
       inherit src version;
+      isLTS = thisKernel.lts;
 
       modDirVersion = lib.versions.pad 3 version;
       extraMeta.branch = branch;

--- a/pkgs/os-specific/linux/kernel/update-mainline.py
+++ b/pkgs/os-specific/linux/kernel/update-mainline.py
@@ -152,6 +152,7 @@ def main():
         all_kernels[branch] = {
             "version": kernel.version,
             "hash": get_hash(kernel),
+            "lts": kernel.nature == KernelNature.LONGTERM,
         }
 
         with VERSIONS_FILE.open("w") as fd:

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -17,6 +17,7 @@ let
     lts = {
       version = "6.12.43";
       hash = "sha256-Jc3VKpUaIc1nBbbCZ/jAx/kteuQBQBO6TEPlaNq8Jrk=";
+      isLTS = true;
     };
     # ./update-xanmod.sh main
     main = {
@@ -30,6 +31,7 @@ let
       version,
       suffix ? "xanmod1",
       hash,
+      isLTS ? false,
     }:
     buildLinux (
       args
@@ -76,6 +78,7 @@ let
           ./update-xanmod.sh
           variant
         ];
+        inherit isLTS;
 
         extraMeta = {
           branch = lib.versions.majorMinor version;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1413,6 +1413,22 @@ mapAliases {
   '';
   linux_latest_hardened = linuxPackages_latest_hardened;
 
+  # Added 2025-08-10
+  linuxPackages_hardened = linuxKernel.packages.linux_hardened;
+  linux_hardened = linuxPackages_hardened.kernel;
+  linuxPackages_5_4_hardened = linuxKernel.packages.linux_5_4_hardened;
+  linux_5_4_hardened = linuxKernel.kernels.linux_5_4_hardened;
+  linuxPackages_5_10_hardened = linuxKernel.packages.linux_5_10_hardened;
+  linux_5_10_hardened = linuxKernel.kernels.linux_5_10_hardened;
+  linuxPackages_5_15_hardened = linuxKernel.packages.linux_5_15_hardened;
+  linux_5_15_hardened = linuxKernel.kernels.linux_5_15_hardened;
+  linuxPackages_6_1_hardened = linuxKernel.packages.linux_6_1_hardened;
+  linux_6_1_hardened = linuxKernel.kernels.linux_6_1_hardened;
+  linuxPackages_6_6_hardened = linuxKernel.packages.linux_6_6_hardened;
+  linux_6_6_hardened = linuxKernel.kernels.linux_6_6_hardened;
+  linuxPackages_6_12_hardened = linuxKernel.packages.linux_6_12_hardened;
+  linux_6_12_hardened = linuxKernel.kernels.linux_6_12_hardened;
+
   # Added 2023-11-18, modified 2024-01-09
   linuxPackages_testing_bcachefs = throw "'linuxPackages_testing_bcachefs' has been removed, please use 'linuxPackages_latest', any kernel version at least 6.7, or any other linux kernel with bcachefs support";
   linux_testing_bcachefs = throw "'linux_testing_bcachefs' has been removed, please use 'linux_latest', any kernel version at least 6.7, or any other linux kernel with bcachefs support";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10602,20 +10602,6 @@ with pkgs;
   linux-rt = linuxPackages-rt.kernel;
   linux-rt_latest = linuxPackages-rt_latest.kernel;
 
-  # hardened kernels
-  linuxPackages_hardened = linuxKernel.packages.linux_hardened;
-  linux_hardened = linuxPackages_hardened.kernel;
-  linuxPackages_5_10_hardened = linuxKernel.packages.linux_5_10_hardened;
-  linux_5_10_hardened = linuxKernel.kernels.linux_5_10_hardened;
-  linuxPackages_5_15_hardened = linuxKernel.packages.linux_5_15_hardened;
-  linux_5_15_hardened = linuxKernel.kernels.linux_5_15_hardened;
-  linuxPackages_6_1_hardened = linuxKernel.packages.linux_6_1_hardened;
-  linux_6_1_hardened = linuxKernel.kernels.linux_6_1_hardened;
-  linuxPackages_6_6_hardened = linuxKernel.packages.linux_6_6_hardened;
-  linux_6_6_hardened = linuxKernel.kernels.linux_6_6_hardened;
-  linuxPackages_6_12_hardened = linuxKernel.packages.linux_6_12_hardened;
-  linux_6_12_hardened = linuxKernel.kernels.linux_6_12_hardened;
-
   # GNU Linux-libre kernels
   linuxPackages-libre = linuxKernel.packages.linux_libre;
   linux-libre = linuxPackages-libre.kernel;

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -294,14 +294,10 @@ in
 
         linux_latest_libre = deblobKernel packageAliases.linux_latest.kernel;
 
-        linux_hardened = hardenedKernelFor packageAliases.linux_default.kernel { };
-
-        linux_5_10_hardened = hardenedKernelFor kernels.linux_5_10 { };
-        linux_5_15_hardened = hardenedKernelFor kernels.linux_5_15 { };
-        linux_6_1_hardened = hardenedKernelFor kernels.linux_6_1 { };
-        linux_6_6_hardened = hardenedKernelFor kernels.linux_6_6 { };
         linux_6_12_hardened = hardenedKernelFor kernels.linux_6_12 { };
+        linux_6_15_hardened = hardenedKernelFor kernels.linux_6_15 { };
 
+        linux_hardened = hardenedKernelFor packageAliases.linux_default.kernel { };
       }
       // lib.optionalAttrs config.allowAliases {
         linux_4_19 = throw "linux 4.19 was removed because it will reach its end of life within 24.11";
@@ -310,6 +306,11 @@ in
         linux_6_11 = throw "linux 6.11 was removed because it has reached its end of life upstream";
         linux_6_13 = throw "linux 6.13 was removed because it has reached its end of life upstream";
         linux_6_14 = throw "linux 6.14 was removed because it has reached its end of life upstream";
+
+        linux_5_10_hardened = throw "linux_hardened on nixpkgs only contains latest stable and latest LTS";
+        linux_5_15_hardened = throw "linux_hardened on nixpkgs only contains latest stable and latest LTS";
+        linux_6_1_hardened = throw "linux_hardened on nixpkgs only contains latest stable and latest LTS";
+        linux_6_6_hardened = throw "linux_hardened on nixpkgs only contains latest stable and latest LTS";
 
         linux_4_19_hardened = throw "linux 4.19 was removed because it will reach its end of life within 24.11";
         linux_5_4_hardened = throw "linux_5_4_hardened was removed because it was broken";
@@ -776,11 +777,8 @@ in
 
       linux_hardened = recurseIntoAttrs (packagesFor kernels.linux_hardened);
 
-      linux_5_10_hardened = recurseIntoAttrs (packagesFor kernels.linux_5_10_hardened);
-      linux_5_15_hardened = recurseIntoAttrs (packagesFor kernels.linux_5_15_hardened);
-      linux_6_1_hardened = recurseIntoAttrs (packagesFor kernels.linux_6_1_hardened);
-      linux_6_6_hardened = recurseIntoAttrs (packagesFor kernels.linux_6_6_hardened);
       linux_6_12_hardened = recurseIntoAttrs (packagesFor kernels.linux_6_12_hardened);
+      linux_6_15_hardened = recurseIntoAttrs (packagesFor kernels.linux_6_15_hardened);
 
       linux_zen = recurseIntoAttrs (packagesFor kernels.linux_zen);
       linux_lqx = recurseIntoAttrs (packagesFor kernels.linux_lqx);
@@ -794,6 +792,12 @@ in
       __recurseIntoDerivationForReleaseJobs = true;
     }
     // lib.optionalAttrs config.allowAliases {
+
+      linux_5_10_hardened = throw "linux_hardened on nixpkgs only contains latest stable and latest LTS";
+      linux_5_15_hardened = throw "linux_hardened on nixpkgs only contains latest stable and latest LTS";
+      linux_6_1_hardened = throw "linux_hardened on nixpkgs only contains latest stable and latest LTS";
+      linux_6_6_hardened = throw "linux_hardened on nixpkgs only contains latest stable and latest LTS";
+
       linux_4_19_hardened = throw "linux 4.19 was removed because it will reach its end of life within 24.11";
       linux_5_4_hardened = throw "linux_5_4_hardened was removed because it was broken";
       linux_6_9_hardened = throw "linux 6.9 was removed because it has reached its end of life upstream";

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -345,7 +345,12 @@ in
         inherit (kernel) stdenv; # in particular, use the same compiler by default
 
         # to help determine module compatibility
-        inherit (kernel) isZen isHardened isLibre;
+        inherit (kernel)
+          isLTS
+          isZen
+          isHardened
+          isLibre
+          ;
         inherit (kernel) kernelOlder kernelAtLeast;
         kernelModuleMakeFlags = self.kernel.commonMakeFlags ++ [
           "KBUILD_OUTPUT=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"


### PR DESCRIPTION
To actually obtain the metadata about what's an LTS, I rebased most of @Atemu's #361573.

We should really backport this part btw, otherwise automatic backports of kernel patch-releases will be broken for the rest of 25.05.

---

As proposed in #346018 (not closing the ticket, this affects other
variants as well).

The packaging for hardened is in a pretty sad state: it was lagging
several patch-releases behind and nobody seems to care. The update
script aged poorly: the automatic removal was flat-out broken, several
type annotations are plain wrong (`list[int] != packaging.Version`).

This patch is an attempt to reduce the scope for the maintainer team
drastically to provide _some_ maintenance again by only packaging latest
LTS and latest stable.

Also, remove the top-level attributes for this. I still don't see any
compelling reason to give hardly used flavours that special treatment.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
