### PR TITLE
nixos/pam: enable lastlog2 import service if any pam service uses lastlog

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -2311,11 +2311,14 @@ in
 
     environment.etc = lib.mapAttrs' makePAMService enabledServices;
 
-    systemd = lib.optionalAttrs config.security.pam.services.login.updateWtmp {
-      tmpfiles.packages = [ pkgs.util-linux.lastlog ]; # /lib/tmpfiles.d/lastlog2-tmpfiles.conf
-      services.lastlog2-import.enable = true;
-      packages = [ pkgs.util-linux.lastlog ]; # lib/systemd/system/lastlog2-import.service
-    };
+    systemd =
+      lib.optionalAttrs
+        (lib.any (service: service.updateWtmp) (lib.attrValues config.security.pam.services))
+        {
+          tmpfiles.packages = [ pkgs.util-linux.lastlog ]; # /lib/tmpfiles.d/lastlog2-tmpfiles.conf
+          services.lastlog2-import.enable = true;
+          packages = [ pkgs.util-linux.lastlog ]; # lib/systemd/system/lastlog2-import.service
+        };
 
     security.pam.services = {
       other.text = ''

--- a/nixos/tests/pam/pam-lastlog.nix
+++ b/nixos/tests/pam/pam-lastlog.nix
@@ -13,9 +13,18 @@
     };
 
   testScript = ''
-    machine.wait_for_unit("multi-user.target")
-    machine.succeed("run0 --pty true") # perform full login
-    print(machine.succeed("lastlog2 --active --user root"))
-    machine.succeed("stat /var/lib/lastlog/lastlog2.db")
+    with subtest("Test legacy lastlog import"):
+      # create old lastlog file to test import
+      # empty = nothing will actually be imported, but the service will run
+      machine.succeed("touch /var/log/lastlog")
+      machine.wait_for_unit("lastlog2-import.service")
+      machine.succeed("journalctl -b --grep 'Starting Import lastlog data into lastlog2 database'")
+      machine.succeed("stat /var/log/lastlog.migrated")
+
+    with subtest("Test lastlog entries are created by logins"):
+      machine.wait_for_unit("multi-user.target")
+      machine.succeed("run0 --pty true") # perform full login
+      print(machine.succeed("lastlog2 --active --user root"))
+      machine.succeed("stat /var/lib/lastlog/lastlog2.db")
   '';
 }


### PR DESCRIPTION
As described in https://github.com/util-linux/util-linux/pull/2508#issue-1911140109, `lastlog2-import.service` is used for compatibility to import old `lastlog` databases. It is possible someone used `updateWtmp` on some PAM service while disabling it on `login`, which would currently make the import of the old database fail.

Fixes https://github.com/NixOS/nixpkgs/pull/429203#discussion_r2265312365

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
