### PR TITLE
dotnet: fix problems with --runtime flags

### DIFF
--- a/pkgs/build-support/dotnet/build-dotnet-module/hook/dotnet-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hook/dotnet-hook.sh
@@ -384,6 +384,9 @@ dotnetInstallPhase() {
       local runtimeIdFlags=()
       if [[ $projectFile == *.csproj || -n ${dotnetSelfContainedBuild-} ]]; then
         runtimeIdFlags+=("--runtime" "$runtimeId")
+        # set RuntimeIdentifier because --runtime is broken:
+        # https://github.com/dotnet/sdk/issues/13983
+        runtimeIdFlags+=(-p:RuntimeIdentifier="$runtimeId")
       fi
 
       dotnet pack ${1+"$projectFile"} \

--- a/pkgs/build-support/dotnet/build-dotnet-module/hook/dotnet-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hook/dotnet-hook.sh
@@ -357,7 +357,7 @@ dotnetInstallPhase() {
     local -r projectFile="${1-}"
 
     for runtimeId in "${runtimeIds[@]}"; do
-      runtimeIdFlags=()
+      local runtimeIdFlags=()
       if [[ $projectFile == *.csproj || -n ${dotnetSelfContainedBuild-} ]]; then
         runtimeIdFlags+=("--runtime" "$runtimeId")
       fi
@@ -381,6 +381,11 @@ dotnetInstallPhase() {
     local -r projectFile="${1-}"
 
     for runtimeId in "${runtimeIds[@]}"; do
+      local runtimeIdFlags=()
+      if [[ $projectFile == *.csproj || -n ${dotnetSelfContainedBuild-} ]]; then
+        runtimeIdFlags+=("--runtime" "$runtimeId")
+      fi
+
       dotnet pack ${1+"$projectFile"} \
              -maxcpucount:"$maxCpuFlag" \
              -p:ContinuousIntegrationBuild=true \
@@ -390,7 +395,7 @@ dotnetInstallPhase() {
              --configuration "$dotnetBuildType" \
              --no-restore \
              --no-build \
-             --runtime "$runtimeId" \
+             "${runtimeIdFlags[@]}" \
              "${flags[@]}" \
              "${packFlags[@]}"
     done

--- a/pkgs/build-support/dotnet/build-dotnet-module/hook/dotnet-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hook/dotnet-hook.sh
@@ -1,5 +1,9 @@
 # shellcheck shell=bash
 
+_dotnetIsSolution() {
+  dotnet sln ${1:+"$1"} list 2>/dev/null
+}
+
 dotnetConfigurePhase() {
   echo "Executing dotnetConfigureHook"
 
@@ -108,9 +112,12 @@ dotnetBuildPhase() {
   dotnetBuild() {
     local -r projectFile="${1-}"
 
+    local useRuntime=
+    _dotnetIsSolution "$projectFile" || useRuntime=1
+
     for runtimeId in "${runtimeIds[@]}"; do
       local runtimeIdFlags=()
-      if [[ $projectFile == *.csproj || -n ${dotnetSelfContainedBuild-} ]]; then
+      if [[ -n $useRuntime ]]; then
         runtimeIdFlags+=("--runtime" "$runtimeId")
       fi
 
@@ -188,9 +195,12 @@ dotnetCheckPhase() {
 
   local projectFile runtimeId
   for projectFile in "${testProjectFiles[@]-${projectFiles[@]}}"; do
+    local useRuntime=
+    _dotnetIsSolution "$projectFile" || useRuntime=1
+
     for runtimeId in "${runtimeIds[@]}"; do
       local runtimeIdFlags=()
-      if [[ $projectFile == *.csproj ]]; then
+      if [[ -n $useRuntime ]]; then
         runtimeIdFlags=("--runtime" "$runtimeId")
       fi
 
@@ -356,9 +366,12 @@ dotnetInstallPhase() {
   dotnetPublish() {
     local -r projectFile="${1-}"
 
+    local useRuntime=
+    _dotnetIsSolution "$projectFile" || useRuntime=1
+
     for runtimeId in "${runtimeIds[@]}"; do
       local runtimeIdFlags=()
-      if [[ $projectFile == *.csproj || -n ${dotnetSelfContainedBuild-} ]]; then
+      if [[ -n $useRuntime ]]; then
         runtimeIdFlags+=("--runtime" "$runtimeId")
       fi
 
@@ -380,9 +393,12 @@ dotnetInstallPhase() {
   dotnetPack() {
     local -r projectFile="${1-}"
 
+    local useRuntime=
+    _dotnetIsSolution "$projectFile" || useRuntime=1
+
     for runtimeId in "${runtimeIds[@]}"; do
       local runtimeIdFlags=()
-      if [[ $projectFile == *.csproj || -n ${dotnetSelfContainedBuild-} ]]; then
+      if [[ -n $useRuntime ]]; then
         runtimeIdFlags+=("--runtime" "$runtimeId")
         # set RuntimeIdentifier because --runtime is broken:
         # https://github.com/dotnet/sdk/issues/13983


### PR DESCRIPTION
Cc: @NixOS/dotnet 

Fixes: #283430

This is a subtly breaking change as shown in ArchiSteamFarm.

Projects that use a directory in `projectFile` will now be correctly identify if they are building a solution and omit the runtime flags.  If the project changes `dotnetProjectFile` between phases (like ArchiSteamFarm) this can cause a mismatch in the build paths. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
