### PR TITLE
micropython: 1.25.0 -> 1.26.0

### DIFF
--- a/pkgs/by-name/mi/micropython/package.nix
+++ b/pkgs/by-name/mi/micropython/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchpatch,
   pkg-config,
   python3,
   libffi,
@@ -10,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "micropython";
-  version = "1.25.0";
+  version = "1.26.0";
 
   src = fetchFromGitHub {
     owner = "micropython";
     repo = "micropython";
     tag = "v${version}";
-    hash = "sha256-yH5omiYs07ZKECI+DAnpYq4T+r2O/RuGdtN+dhYxePc=";
+    hash = "sha256-T0yaTXRQFEdx6lap+S68I2RRA2kQnjbKGz+YB6okJkY=";
     fetchSubmodules = true;
 
     # remove unused libraries from rp2 port's SDK. we leave this and the other
@@ -29,6 +30,20 @@ stdenv.mkDerivation rec {
       rm -rf $out/lib/pico-sdk/lib/{tinyusb,lwip,btstack}
     '';
   };
+
+  patches = [
+    # Fixes Mbed TLS submodule build with GCC 14.
+    #
+    # See:
+    # * <https://github.com/openwrt/openwrt/pull/15479>
+    # * <https://github.com/Mbed-TLS/mbedtls/issues/9003>
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/openwrt/openwrt/52b6c9247997e51a97f13bb9e94749bc34e2d52e/package/libs/mbedtls/patches/100-fix-gcc14-build.patch";
+      stripLen = 1;
+      extraPrefix = "lib/mbedtls/";
+      hash = "sha256-Sllp/iWWEhykMJ3HALw5KzR4ta22120Jcl51JZCkZE0=";
+    })
+  ];
 
   nativeBuildInputs = [
     pkg-config
@@ -53,9 +68,9 @@ stdenv.mkDerivation rec {
 
   skippedTests =
     " -e select_poll_fd"
-    + lib.optionalString (
-      stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64
-    ) " -e ffi_callback -e float_parse -e float_parse_doubleproc"
+    +
+      lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)
+        " -e ffi_callback -e float_parse -e float_parse_doubleproc -e 'thread/stress_*' -e select_poll_eintr"
     + lib.optionalString (
       stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64
     ) " -e float_parse";


### PR DESCRIPTION
Needs additional patch to build on `aarch64-linux` on GCC 14 due to a submodule containing a problematic version of Mbed TLS. Modeled after nixpkgs 9ff0e609fe7a6bd61e9f289b3f5c0bed3f55e751.

Also disables additional flaky tests on `aarch64-darwin` (upstream has disabled some as well).

Supersedes #432335 .

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
