### PR TITLE
sasl-xoauth2: init at 0.27

### DIFF
--- a/pkgs/by-name/sa/sasl-xoauth2/package.nix
+++ b/pkgs/by-name/sa/sasl-xoauth2/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  curl,
+  cyrus_sasl,
+  gitUpdater,
+  jsoncpp,
+  makeWrapper,
+  pandoc,
+  pkg-config,
+  python3,
+}:
+
+let
+  pythonEnv = python3.withPackages (
+    ps: with ps; [
+      argparse-manpage
+      msal
+    ]
+  );
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sasl-xoauth2";
+  version = "0.27";
+
+  src = fetchFromGitHub {
+    owner = "tarickb";
+    repo = "sasl-xoauth2";
+    tag = "release-${finalAttrs.version}";
+    hash = "sha256-GUdt39DNtYZl4qsnhnWufXOgu5Mg1+HCJap8IfFyldk=";
+  };
+
+  # Let sasl-xoauth2 find configuration files in /etc
+  postPatch = ''
+    substituteInPlace src/CMakeLists.txt scripts/sasl-xoauth2-tool.in \
+      --replace-fail "\''${CMAKE_INSTALL_FULL_SYSCONFDIR}" '/etc'
+
+    substituteInPlace scripts/sasl-xoauth2-tool.in \
+      --replace-fail '#!/usr/bin/python3' '#!${lib.getExe python3}'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    curl
+    makeWrapper
+    pandoc
+    pkg-config
+  ];
+
+  buildInputs = [
+    cyrus_sasl
+    jsoncpp
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/${finalAttrs.meta.mainProgram} \
+      --prefix PATH : "${pythonEnv}/bin" \
+      --set PYTHONPATH "$out/share/:${pythonEnv}/${python3.sitePackages}"
+  '';
+
+  passthru.updateScript = gitUpdater { rev-prefix = "release-"; };
+
+  meta = {
+    homepage = "https://github.com/tarickb/sasl-xoauth2";
+    changelog = "https://github.com/tarickb/sasl-xoauth2/blob/${finalAttrs.src.tag}/ChangeLog";
+    description = "SASL plugin for XOAUTH2";
+    platforms = lib.platforms.linux;
+    mainProgram = "sasl-xoauth2-tool";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ codgician ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adding [sasl-xoauth2](https://github.com/tarickb/sasl-xoauth2) as an alternative to fix #108480, which is much more actively maintained compared to what we have in nixpkgs.

The current xoauth2 plugin in nixpkgs [cyrus-sasl-xoauth2](https://github.com/moriyoshi/cyrus-sasl-xoauth2) hasn't been updated in years. Some packages that depend on it are not even including it by default due to its lack of maintenance, see: https://github.com/NixOS/nixpkgs/blob/29cf5a68873e29dda61efcf6fe508e5987e48984/pkgs/by-name/is/isync/package.nix#L13C1-L14C55

This has been tested on my NixOS setup with postfix, and it works with Office 365 + OAuth2. The key points are:

* Create /etc/sasl-xoauth2.conf for configuration (unfortunately this plugin does not offer ways to specify config path when using with postfix).
* Add `SASL_PATH` to `postfix.service` to make the plugin searchable
* Add `services.postfix.config.import_environment = "SASL_PATH";` to ensure above environment variable gets imported.
 

Anyone interested may take a look at https://github.com/codgician/serenitea-pot/blob/main/modules/nixos/services/postfix/default.nix for reference.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
