### PR TITLE
nixos/ax25/axports: ax25 kernel module check

### DIFF
--- a/nixos/modules/services/networking/ax25/axports.nix
+++ b/nixos/modules/services/networking/ax25/axports.nix
@@ -115,6 +115,10 @@ in
 
   config = mkIf (enabledAxports != { }) {
 
+    system.requiredKernelConfig = [
+      (config.lib.kernelConfig.isEnabled "ax25")
+    ];
+
     environment.etc."ax25/axports" = {
       text = concatStringsSep "\n" (
         mapAttrsToList (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`services.ax25.axports` requires the ax25 kernel module be enabled:

```
boot.kernelModules = [ "ax25" ];
```

Running the current ax25 test without the module enabled results in the expected error:

```
$ nix run .#nixosTests.ax25.driver
...
node3 # [   13.120608] systemd[1]: Started Name Service Cache Daemon (nsncd).
node3 # [   13.128914] systemd[1]: Reached target Host and Network Name Lookups.
node3 # [   13.137518] systemd[1]: Reached target User and Group Name Lookups.
node3 # [   13.150580] nsncd[579]: Aug 10 18:36:05.738 INFO started, config: Config { ignored_request_types: {}, worker_count: 8, handoff_timeout: 10s }, path: "/var/run/nscd/socket"
node3 # [   13.167837] systemd[1]: Starting User Login Management...
node2: output:
!!! Traceback (most recent call last):
!!!   File "<string>", line 14, in <module>
!!!     wait_for_machine(node2)
!!!   File "<string>", line 2, in wait_for_machine
!!!     m.succeed("lsmod | grep ax25")
!!!
!!! RequestedAssertionFailed: command `lsmod | grep ax25` failed (exit code 1)
cleanup
kill machine (pid 2469)
qemu-system-x86_64: terminating on signal 15 from pid 2459 (/nix/store/9yh9ak97gn659bk4d3n411fx6c0ng7s2-python3-3.13.5/bin/python3.13)
kill machine (pid 2509)
qemu-system-x86_64: terminating on signal 15 from pid 2459 (/nix/store/9yh9ak97gn659bk4d3n411fx6c0ng7s2-python3-3.13.5/bin/python3.13)
kill machine (pid 2534)
qemu-system-x86_64: terminating on signal 15 from pid 2459 (/nix/store/9yh9ak97gn659bk4d3n411fx6c0ng7s2-python3-3.13.5/bin/python3.13)
kill vlan (pid 2467)
(finished: cleanup, in 0.02 seconds)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
