### PR TITLE
nixos/libvirtd: allow changing firewall backend

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -168,6 +168,7 @@
 - `services.gitea` supports sending notifications with sendmail again. To do this, activate the parameter `services.gitea.mailerUseSendmail` and configure SMTP server.
 
 - `libvirt` now supports using `nftables` backend.
+  - The `virtualisation.libvirtd.firewallBackend` option can be used to configure the firewall backend used by libvirtd.
 
 - `systemd.extraConfig` and `boot.initrd.systemd.extraConfig` was converted to RFC42-style `systemd.settings.Manager` and `boot.initrd.systemd.settings.Manager` respectively.
   - `systemd.watchdog.runtimeTime` was renamed to `systemd.settings.Manager.RuntimeWatchdogSec`


### PR DESCRIPTION
Alternative to #432083.
Fixes https://github.com/NixOS/nixpkgs/pull/424422#issuecomment-3157300461.

Allows changing the firewall backend used by libvirtd.
Introduces a new option `virtualisation.libvirtd.firewallBackend`, which can take as values `iptables` or `nftables`.

Since #424422, the libvirt daemon started using the nftables backend on all systems, including the ones with `networking.nftables.enable = false`. This caused a loss of connectivity for libvirt guests, as the firewall backend used was no longer the same.

To maintain the previous networking behavior, this PR introduces a change that tells libvirtd what backend to use, and it defaults to `iptables` or `nftables` depending on the value of `networking.nftables.enable`.

> [!NOTE]
> With `networking.nftables.enable = true`, all guests still have no networking, but that's because of differing firewall implementations for `iptables` vs `nftables`. To have networking in the guests when using `nftables`, `networking.firewall.trustedInterfaces` needs to be set (e.g. `[ "virbr0" ]`).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
