### PR TITLE
starpls: 0.1.21 -> 0.1.22-unstable-2025-12-30

### DIFF
--- a/pkgs/by-name/st/starpls/package.nix
+++ b/pkgs/by-name/st/starpls/package.nix
@@ -7,17 +7,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "starpls";
-  version = "0.1.21";
+  version = "0.1.22-unstable-2025-12-30";
 
   src = fetchFromGitHub {
     owner = "withered-magic";
     repo = "starpls";
-    # https://github.com/withered-magic/starpls/commit/96ef5d0548748745756c421960e0ebb5cfbef963
-    rev = "96ef5d0548748745756c421960e0ebb5cfbef963";
-    hash = "sha256-PymdSITGeSxKwcLnsJPKc73E8VDS8SSRBRRNQSKvnbU=";
+    rev = "db21acd3cb24893315dd601484c7d40689589e9a";
+    hash = "sha256-t9kdpBKyGM61CKhtfO5urVVzyKpL0bX0pZuf0djDdCw=";
   };
 
-  cargoHash = "sha256-yovv8ox7TtSOxGW+YKYr/ED4cq7P7T7vSqoXBFhFGb4=";
+  cargoHash = "sha256-5xYfQRm7U7sEQiJEfjaLznoXUxHsxnLmIEA/OxTkjFg=";
 
   nativeBuildInputs = [
     protobuf
@@ -31,7 +30,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     tests.version = testers.testVersion {
       package = finalAttrs.finalPackage;
       command = "starpls version";
-      version = "v${finalAttrs.version}";
+      version = "v${
+        lib.strings.substring 0 (builtins.stringLength finalAttrs.version - 6) finalAttrs.version
+      }";
     };
   };
 


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
