### PR TITLE
wlx-overlay-s: make openvr support optional, disable on aarch64-linux

### DIFF
--- a/pkgs/by-name/wl/wlx-overlay-s/package.nix
+++ b/pkgs/by-name/wl/wlx-overlay-s/package.nix
@@ -22,6 +22,8 @@
   testers,
   wayland,
   wlx-overlay-s,
+  # openvr support is broken on aarch64-linux
+  withOpenVr ? !stdenv.hostPlatform.isAarch64,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -36,6 +38,17 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoHash = "sha256-em5sWSty2/pZp2jTwBnLUIBgPOcoMpwELwj984XYf+k=";
+
+  # explicitly only add openvr if withOpenVr is set to true.
+  buildNoDefaultFeatures = true;
+  buildFeatures = [
+    "openxr"
+    "osc"
+    "x11"
+    "wayland"
+    "wayvr"
+  ]
+  ++ lib.optional withOpenVr "openvr";
 
   nativeBuildInputs = [
     makeWrapper
@@ -52,11 +65,11 @@ rustPlatform.buildRustPackage rec {
     libXext
     libXrandr
     libxkbcommon
-    openvr
     openxr-loader
     pipewire
     wayland
-  ];
+  ]
+  ++ lib.optional withOpenVr openvr;
 
   env.SHADERC_LIB_DIR = "${lib.getLib shaderc}/lib";
 
@@ -79,7 +92,7 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ Scrumplex ];
     platforms = lib.platforms.linux;
-    broken = stdenv.hostPlatform.isAarch64;
+    broken = stdenv.hostPlatform.isAarch64 && withOpenVr;
     mainProgram = "wlx-overlay-s";
   };
 }


### PR DESCRIPTION
wlx-overlay-s uses
https://github.com/galister/ovr_overlay_oyasumi/pull/2, which pulls in a version of ovr_overlay_sys with a build.rs file that doesn't build on aarch64-linux.

https://github.com/galister/ovr_overlay_oyasumi is a fork of https://github.com/Raphiiko/ovr_overlay_oyasumi, which is a fork of https://github.com/TheButlah/ovr_overlay, with the latter not updated in two years.

Luckily openvr is kinda discouraged, and openxr is the new kid on the block, and openvr support can be feature-flagged out.

So let's do this, by adding a withOpenVr option to the derivation, that defaults to false on aarch64-linux, unbreaking it there.

We still keep openvr support for x86_64-linux enabled, to not regress experience for people already using openvr on x86_64-linux.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
