### PR TITLE
nixos: allow more things to be disabled

### DIFF
--- a/nixos/modules/programs/fuse.nix
+++ b/nixos/modules/programs/fuse.nix
@@ -1,4 +1,9 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   cfg = config.programs.fuse;
@@ -7,6 +12,10 @@ in
   meta.maintainers = with lib.maintainers; [ ];
 
   options.programs.fuse = {
+    enable = lib.mkEnableOption "fuse" // {
+      default = true;
+    };
+
     mountMax = lib.mkOption {
       # In the C code it's an "int" (i.e. signed and at least 16 bit), but
       # negative numbers obviously make no sense:
@@ -27,10 +36,30 @@ in
     };
   };
 
-  config = {
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      pkgs.fuse
+      pkgs.fuse3
+    ];
+
+    security.wrappers =
+      let
+        mkSetuidRoot = source: {
+          setuid = true;
+          owner = "root";
+          group = "root";
+          inherit source;
+        };
+      in
+      {
+        fusermount = mkSetuidRoot "${lib.getBin pkgs.fuse}/bin/fusermount";
+        fusermount3 = mkSetuidRoot "${lib.getBin pkgs.fuse3}/bin/fusermount3";
+      };
+
     environment.etc."fuse.conf".text = ''
       ${lib.optionalString (!cfg.userAllowOther) "#"}user_allow_other
       mount_max = ${builtins.toString cfg.mountMax}
     '';
+
   };
 }

--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -335,6 +335,8 @@ in
       }
     );
 
+    environment.corePackages = [ cfg.package ];
+
     # SSH configuration. Slight duplication of the sshd_config
     # generation in the sshd service.
     environment.etc."ssh/ssh_config".text = ''

--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -266,8 +266,6 @@ in
       in
       {
         # These are mount related wrappers that require the +s permission.
-        fusermount = mkSetuidRoot "${lib.getBin pkgs.fuse}/bin/fusermount";
-        fusermount3 = mkSetuidRoot "${lib.getBin pkgs.fuse3}/bin/fusermount3";
         mount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/mount";
         umount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/umount";
       };

--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -317,7 +317,7 @@ in
       source ${config.system.build.earlyMountScript}
     '';
 
-    systemd.user = {
+    systemd.user = lib.mkIf config.system.activatable {
       services.nixos-activation = {
         description = "Run user-specific NixOS activation";
         script = config.system.userActivationScripts.script;

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -414,7 +414,9 @@ in
 
           ln -s ${initrdPath} $out/initrd
 
-          ln -s ${config.system.build.initialRamdiskSecretAppender}/bin/append-initrd-secrets $out
+          ${optionalString (config.boot.initrd.secrets != { }) ''
+            ln -s ${config.system.build.initialRamdiskSecretAppender}/bin/append-initrd-secrets $out
+          ''}
 
           ln -s ${config.hardware.firmware}/lib/firmware $out/firmware
         '';

--- a/nixos/modules/system/boot/kexec.nix
+++ b/nixos/modules/system/boot/kexec.nix
@@ -1,7 +1,22 @@
-{ pkgs, lib, ... }:
-
 {
-  config = lib.mkIf (lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.kexec-tools) {
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.boot.kexec;
+in
+{
+  options.boot.kexec = {
+    enable = lib.mkEnableOption "kexec" // {
+      default = lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.kexec-tools;
+      defaultText = lib.literalExpression ''lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.kexec-tools'';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
     environment.systemPackages = [ pkgs.kexec-tools ];
 
     systemd.services.prepare-kexec = {

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -461,13 +461,7 @@ in
     # Add the mount helpers to the system path so that `mount' can find them.
     system.fsPackages = [ pkgs.dosfstools ];
 
-    environment.systemPackages =
-      with pkgs;
-      [
-        fuse3
-        fuse
-      ]
-      ++ config.system.fsPackages;
+    environment.systemPackages = config.system.fsPackages;
 
     environment.etc.fstab.text =
       let

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1767,7 +1767,7 @@ in
       text = cfg.hostName + "\n";
     };
 
-    environment.systemPackages = [
+    environment.corePackages = [
       pkgs.host
       pkgs.hostname-debian
       pkgs.iproute2


### PR DESCRIPTION
Redo of https://github.com/NixOS/nixpkgs/pull/429695 

This was caused by merging issues due to weird priorities.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
