### PR TITLE
python313Packages.mne: 1.9.0-unstable-2025-05-01 -> 1.10.0

### DIFF
--- a/pkgs/development/python-modules/mne/default.nix
+++ b/pkgs/development/python-modules/mne/default.nix
@@ -6,9 +6,12 @@
   hatch-vcs,
   numpy,
   scipy,
+  flaky,
+  pandas,
   pytestCheckHook,
   pytest-cov-stub,
   pytest-timeout,
+  writableTmpDirAsHomeHook,
   matplotlib,
   decorator,
   jinja2,
@@ -25,21 +28,17 @@
 
 buildPythonPackage rec {
   pname = "mne";
-  # https://github.com/mne-tools/mne-python/pull/13049 is required to build, it does not apply if fetchpatch'ed
-  stableVersion = "1.9.0";
-  version = "1.9.0-unstable-2025-05-01";
+  version = "1.10.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.9";
+  disabled = pythonOlder "3.10";
 
   src = fetchFromGitHub {
     owner = "mne-tools";
     repo = "mne-python";
-    rev = "5df1721b488070e3b3928dface9dd0b8c39a3bef";
-    hash = "sha256-BCLejk0sVym+HRCfnTl5LTOGUMrQdxZbqhrCnIpzsvM=";
+    tag = "v${version}";
+    hash = "sha256-j0kPtw00gV50Nuh/b4+Jq6P7pQVRgr4/xMTwRSyzJcU=";
   };
-
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = stableVersion;
 
   postPatch = ''
     substituteInPlace doc/conf.py \
@@ -72,14 +71,16 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    flaky
+    pandas
     pytestCheckHook
     pytest-cov-stub
     pytest-timeout
+    writableTmpDirAsHomeHook
   ]
   ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   preCheck = ''
-    export HOME=$(mktemp -d)
     export MNE_SKIP_TESTING_DATASET_TESTS=true
     export MNE_SKIP_NETWORK_TESTS=1
   '';
@@ -95,7 +96,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlag = [
-    # removes 700k lines form pytest log, remove this when scipy is at v1.17.0
+    # removes 700k lines from pytest log, remove this when scipy is at v1.17.0
     "--disable-warnings"
   ];
 
@@ -107,13 +108,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "mne" ];
 
-  meta = with lib; {
+  meta = {
     description = "Magnetoencephelography and electroencephalography in Python";
     mainProgram = "mne";
     homepage = "https://mne.tools";
-    changelog = "https://mne.tools/stable/changes/${stableVersion}.html";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [
+    changelog = "https://mne.tools/stable/changes/${version}.html";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
       bcdarwin
       mbalatsko
     ];


### PR DESCRIPTION
Routine update ([changelog (vs 1.9.0)](https://github.com/mne-tools/mne-python/compare/v1.9.0...v1.10.0))

@mbalatsko 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
