### PR TITLE
jdenticon-cli: init at 3.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9302,6 +9302,12 @@
     githubId = 471835;
     name = "Giorgio Gallo";
   };
+  gipphe = {
+    email = "gipphe@gmail.com";
+    github = "Gipphe";
+    githubId = 2266817;
+    name = "Victor Nascimento Bakke";
+  };
   GirardR1006 = {
     email = "julien.girard2@cea.fr";
     github = "GirardR1006";

--- a/pkgs/by-name/jd/jdenticon-cli/package.nix
+++ b/pkgs/by-name/jd/jdenticon-cli/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nodejs,
+  makeWrapper,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "jdenticon-cli";
+  version = "3.3.0";
+  src = fetchFromGitHub {
+    owner = "dmester";
+    repo = "jdenticon";
+    tag = finalAttrs.version;
+    hash = "sha256-uOPNsfEreC7F+Y0WWmudZSPnGxqarna0JPOwQyK6LiQ=";
+  };
+  npmDepsHash = "sha256-LXwvb088oHmA57EryfYtKi0L/9sB+yyUr/K/qGA1W9k=";
+
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D bin/jdenticon.js "$out/lib/jdenticon/bin/jdenticon.js"
+    install -D dist/jdenticon-node.js "$out/lib/jdenticon/dist/jdenticon-node.js"
+    install -d "$out/lib/jdenticon/node_modules"
+    cp -r node_modules/canvas-renderer  "$out/lib/jdenticon/node_modules"
+    makeWrapper "${lib.getExe nodejs}" "$out/bin/jdenticon" \
+      --add-flags "$out/lib/jdenticon/bin/jdenticon.js"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/dmester/jdenticon/releases/tag/${finalAttrs.version}";
+    description = "JavaScript library for generating highly recognizable identicons using HTML5 canvas or SVG.";
+    homepage = "https://jdenticon.com/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.gipphe ];
+    mainProgram = "jdenticon";
+  };
+})


### PR DESCRIPTION
NodeJS wrapper for using [jdenticon](https://www.npmjs.com/package/jdenticon) from the CLI.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
