### PR TITLE
python3Packages.pyoppleio-legacy: init at 1.0.8

### DIFF
--- a/pkgs/development/python-modules/pyoppleio-legacy/default.nix
+++ b/pkgs/development/python-modules/pyoppleio-legacy/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  crc16,
+  fetchFromGitHub,
+  setuptools,
+}:
+
+buildPythonPackage {
+  pname = "pyoppleio-legacy";
+  version = "1.0.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tinysnake";
+    repo = "python-oppleio-legacy";
+    rev = "90c57f778554fcf3a00e42757d0e92caebcfd149";
+    hash = "sha256-ccvMn/jQSkW11uMwG3P+i53NiDj+MNZgJYEkouQ1tvU=";
+  };
+
+  build-system = [ setuptools ];
+
+  # Package has a runtime dependency on 'pycrc16' but we provide 'crc16'
+  # They provide the same crc16 module
+  pythonRemoveDeps = [ "pycrc16" ];
+
+  dependencies = [ crc16 ];
+
+  # Package has no tests
+  doCheck = false;
+
+  meta = {
+    description = "Python library for interfacing with Opple WiFi lights (legacy firmware support)";
+    homepage = "https://github.com/tinysnake/python-oppleio-legacy";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -4250,7 +4250,8 @@
       ];
     "opple" =
       ps: with ps; [
-      ]; # missing inputs: pyoppleio-legacy
+        pyoppleio-legacy
+      ];
     "oralb" =
       ps: with ps; [
         aioesphomeapi

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13470,6 +13470,8 @@ self: super: with self; {
 
   pyoppleio = callPackage ../development/python-modules/pyoppleio { };
 
+  pyoppleio-legacy = callPackage ../development/python-modules/pyoppleio-legacy { };
+
   pyorc = callPackage ../development/python-modules/pyorc { };
 
   pyorthanc = callPackage ../development/python-modules/pyorthanc { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://pypi.org/project/pyoppleio-legacy/
- https://github.com/tinysnake/python-oppleio-legacy
- https://www.home-assistant.io/integrations/opple/

The dependency on `crc16` is a bit of an odd one. `pyoppelio-legacy` declares a dependency on [`pycrc16`][1], but that appears to just be a patch version bump, from 0.1.1 to 0.1.2, of [`crc16`][2]. Both point to [Google code as the source archive][3]. But there is no longer any code there, and the only tangible difference in the code is replacing `int` with `Py_size_t`.

I've tried to replace the dependency on `pycrc16` with `crc16`.

EDIT: This seems related? https://github.com/home-assistant/core/issues/75268

[1]: https://pypi.org/project/pycrc16/
[2]: https://pypi.org/project/crc16/
[3]: http://code.google.com/p/pycrc16

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
