### PR TITLE
tree-sitter-grammars.tree-sitter-slint: init tree-sitter-slint

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -95,6 +95,7 @@
   tree-sitter-scala = lib.importJSON ./tree-sitter-scala.json;
   tree-sitter-scheme = lib.importJSON ./tree-sitter-scheme.json;
   tree-sitter-scss = lib.importJSON ./tree-sitter-scss.json;
+  tree-sitter-slint = lib.importJSON ./tree-sitter-slint.json;
   tree-sitter-smithy = lib.importJSON ./tree-sitter-smithy.json;
   tree-sitter-solidity = lib.importJSON ./tree-sitter-solidity.json;
   tree-sitter-sparql = lib.importJSON ./tree-sitter-sparql.json;

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-slint.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-slint.json
@@ -1,0 +1,14 @@
+{
+  "url": "https://github.com/slint-ui/tree-sitter-slint",
+  "rev": "96bc969d20ff347030519184ea2467f4046a524d",
+  "date": "2025-07-13T19:36:58Z",
+  "path": "/nix/store/vns80yp0k4hpjrdxyasbijnj1q2v1rlf-tree-sitter-slint",
+  "sha256": "0q55q7rjf53jvhdxxr4qbnxwi5j1vxbda6g9pw18swn11nw72dn9",
+  "hash": "sha256-yTZxuA3Bco0Cv+kZ1VbfQZbIu12Y5N4b3HIUJ/PBpWA=",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "fetchTags": false,
+  "leaveDotGit": false,
+  "rootDir": ""
+}

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -492,6 +492,10 @@ let
       orga = "crystal-lang-tools";
       repo = "tree-sitter-crystal";
     };
+    "tree-sitter-slint" = {
+      orga = "slint-ui";
+      repo = "tree-sitter-slint";
+    };
   };
 
   pinnedGrammars = [


### PR DESCRIPTION
This is an out of band tree-sitter implementation for the Slint language. The repo is a copy of the directory within the Slint monorepo, and is only used for copying the slint tree-sitter server. Since it is outside the tree-sitter org, add it here as a third-party implementation.

See https://github.com/slint-ui/tree-sitter-slint (and the repo folder it mirrors from
https://github.com/slint-ui/slint/tree/master/editors/tree-sitter-slint) for the implementation.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
