### PR TITLE
[staging-next] python3Packages.home-assistant-chip-wheels: fix building with newer gn

### DIFF
--- a/pkgs/development/python-modules/home-assistant-chip-wheels/default.nix
+++ b/pkgs/development/python-modules/home-assistant-chip-wheels/default.nix
@@ -12,6 +12,7 @@
   cryptography,
   diskcache,
   fetchFromGitHub,
+  fetchpatch,
   glib,
   gn,
   googleapis-common-protos,
@@ -126,6 +127,19 @@ stdenv.mkDerivation rec {
     openssl
     glib
     libnl
+  ];
+
+  patches = [
+    (fetchpatch {
+      # Fix building with newer gn version
+      name = "pw_protobuf_compiler-Create-a-new-includes.txt-for-each-toolchain.patch";
+      # https://pigweed-review.googlesource.com/c/pigweed/pigweed/+/300272
+      url = "https://pigweed.googlesource.com/pigweed/pigweed/+/b66729b90fcb9df2ee4818f6d4fff59385cdbc80^!?format=TEXT";
+      decode = "base64 -d";
+      stripLen = 1;
+      extraPrefix = "connectedhomeip/third_party/pigweed/repo/";
+      hash = "sha256-6ss3j8j69w7EMio9mFP/EL2oPqQ2sLh67eWsJjHdDa8=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
This fixes the following error caused by https://gn-review.googlesource.com/c/gn/+/18820 and the gn bump in b59bfde89d116c180cc20962fdecbf40d92f8ce7 (#419337) by backporting https://pigweed-review.googlesource.com/c/pigweed/pigweed/+/300272

~~~
Running phase: configurePhase
gn flags: chip_project_config_include_dirs=\[\"//..\"\] chip_crypto=\"openssl\" [...]
  generated_file("$target_name._includes") {
  ^-----------------------------------------
Two or more targets generate the same output:
  protocol_buffer/gen/third_party/pigweed/repo/pw_chrono/protos.proto_library/includes.txt

This is can often be fixed by changing one of the target names, or by setting an output_name on one of them.

Collisions:
  //third_party/pigweed/repo/pw_chrono:protos._includes(//build/toolchain/custom:custom)
~~~

#432489

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
