### PR TITLE
feyngame: init at 3.0.0

### DIFF
--- a/pkgs/by-name/fe/feyngame/package.nix
+++ b/pkgs/by-name/fe/feyngame/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitLab,
+  jdk,
+  jre,
+  desktop-file-utils,
+  git,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "feyngame";
+  version = "3.0.0";
+
+  src = fetchFromGitLab {
+    owner = "feyngame";
+    repo = "FeynGame";
+    tag = finalAttrs.version;
+    leaveDotGit = true; # the build script uses git log to find last commit date
+    hash = "sha256-PhdspIr0Lnuv4e8bjMEAXnVDK1YVlrI5XI+rP9qXNQ0=";
+  };
+
+  postPatch = ''
+    patchShebangs buildfile
+    substituteInPlace buildfile \
+      --replace-fail '$Prefix/bin/feyngame %U' 'feyngame %U' \
+      --replace-fail '$Prefix/share/pixmaps/fglogo.png' 'fglogo'
+  '';
+
+  # The build script includes both building and installing steps.
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    OSTYPE=${if stdenvNoCC.hostPlatform.isDarwin then "darwin" else "linux-gnu"} ./buildfile -i "$out"
+
+    runHook postInstall
+  '';
+
+  nativeBuildInputs = [
+    git
+    jdk
+    desktop-file-utils
+  ];
+  buildInputs = [ jre ];
+  strictDeps = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Java-based graphical tool for drawing Feynman diagrams";
+    homepage = "https://gitlab.com/feyngame/FeynGame";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+    platforms = jre.meta.platforms;
+    mainProgram = "feyngame";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[FeynGame](https://gitlab.com/feyngame/FeynGame) is a Java-based graphical tool for drawing Feynman diagrams.

Saving a figure as a `.fg` file does not seem to work properly. One has to first `touch` a file with the same filename and then overwrite it. This looks like a [JDK bug](https://bugs.java.com/bugdatabase/view_bug?bug_id=4300582) which is supposed to have been fixed long ago. Maybe someone can take a look.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
