### PR TITLE
pulse-visualizer: init at 1.2.2

### DIFF
--- a/pkgs/by-name/pu/pulse-visualizer/package.nix
+++ b/pkgs/by-name/pu/pulse-visualizer/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  pkg-config,
+  sdl3,
+  libpulseaudio,
+  pipewire,
+  fftwFloat,
+  freetype,
+  glew,
+  libGL,
+  yaml-cpp,
+  libebur128,
+  clang,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pulse-visualizer";
+  version = "1.2.2";
+
+  src = fetchFromGitHub {
+    owner = "Audio-Solutions";
+    repo = "pulse-visualizer";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OnZDNNDmN+OgsfzyPOtlpy8alt62WA6BNhNPJTtrHsU=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    clang
+  ];
+
+  buildInputs = [
+    sdl3
+    libpulseaudio
+    pipewire
+    fftwFloat
+    freetype
+    glew
+    libGL
+    yaml-cpp
+    libebur128
+  ];
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail " -march=native" "" \
+      --replace-fail " -mtune=native" "" \
+      --replace-fail "-Wl,-s" "" \
+      --replace-fail " -s" "" \
+      --replace-fail 'set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "Installation prefix" FORCE)' ""
+  '';
+
+  cmakeFlags = [
+    "-G Ninja"
+    "-DCMAKE_CXX_COMPILER=clang++"
+    "-DCMAKE_C_COMPILER=clang"
+    "-DCMAKE_BUILD_TYPE=Release"
+  ];
+
+  meta = {
+    description = "Real-time audio visualizer inspired by MiniMeters";
+    homepage = "https://github.com/Audio-Solutions/pulse-visualizer";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ miyu ];
+    platforms = lib.platforms.x86_64;
+    badPlatforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
