### PR TITLE
nixos/config/sysfs: run treefmt

### DIFF
--- a/nixos/modules/config/sysfs.nix
+++ b/nixos/modules/config/sysfs.nix
@@ -191,27 +191,26 @@ in
 
   config = lib.mkIf (cfg != { }) {
     systemd = {
-      paths =
-        {
-          "nixos-sysfs@" = {
-            description = "/%I attribute watcher";
-            pathConfig.PathExistsGlob = "/%I";
-            unitConfig.DefaultDependencies = false;
-          };
-        }
-        // listToAttrs (
-          mapAttrsToListRecursive (
-            p: v:
-            if v == null then
-              [ ]
-            else
-              nameValuePair "nixos-sysfs@${escapeSystemdPath (mkPath p)}" {
-                overrideStrategy = "asDropin";
-                wantedBy = [ "sysinit.target" ];
-                before = [ "sysinit.target" ];
-              }
-          ) cfg
-        );
+      paths = {
+        "nixos-sysfs@" = {
+          description = "/%I attribute watcher";
+          pathConfig.PathExistsGlob = "/%I";
+          unitConfig.DefaultDependencies = false;
+        };
+      }
+      // listToAttrs (
+        mapAttrsToListRecursive (
+          p: v:
+          if v == null then
+            [ ]
+          else
+            nameValuePair "nixos-sysfs@${escapeSystemdPath (mkPath p)}" {
+              overrideStrategy = "asDropin";
+              wantedBy = [ "sysinit.target" ];
+              before = [ "sysinit.target" ];
+            }
+        ) cfg
+      );
 
       services."nixos-sysfs@" = {
         description = "/%I attribute setter";


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/pull/391329#issuecomment-3173524150

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
