### PR TITLE
lasuite-docs: fix mail notifications

### DIFF
--- a/pkgs/by-name/la/lasuite-docs/mjml-mail-dir.patch
+++ b/pkgs/by-name/la/lasuite-docs/mjml-mail-dir.patch
@@ -1,0 +1,26 @@
+diff --git a/src/mail/bin/html-to-plain-text b/src/mail/bin/html-to-plain-text
+index ced0c13d..bcdef288 100755
+--- a/src/mail/bin/html-to-plain-text
++++ b/src/mail/bin/html-to-plain-text
+@@ -1,7 +1,7 @@
+ #!/usr/bin/env bash
+ set -eo pipefail
+ # Run html-to-text to convert all html files to text files
+-DIR_MAILS="../backend/core/templates/mail/"
++DIR_MAILS="${DIR_MAILS:-../backend/core/templates/mail}/"
+ 
+ if [ ! -d "${DIR_MAILS}" ]; then
+   mkdir -p "${DIR_MAILS}";
+diff --git a/src/mail/bin/mjml-to-html b/src/mail/bin/mjml-to-html
+index fb5710b0..15e2fc7d 100755
+--- a/src/mail/bin/mjml-to-html
++++ b/src/mail/bin/mjml-to-html
+@@ -1,7 +1,7 @@
+ #!/usr/bin/env bash
+ 
+ # Run mjml command to convert all mjml templates to html files
+-DIR_MAILS="../backend/core/templates/mail/html/"
++DIR_MAILS="${DIR_MAILS:-../backend/core/templates/mail}/html/"
+ 
+ if [ ! -d "${DIR_MAILS}" ]; then
+   mkdir -p "${DIR_MAILS}";

--- a/pkgs/by-name/la/lasuite-docs/package.nix
+++ b/pkgs/by-name/la/lasuite-docs/package.nix
@@ -1,9 +1,14 @@
 {
+  stdenv,
   lib,
   python3,
   fetchFromGitHub,
   nixosTests,
   fetchPypi,
+  fetchYarnDeps,
+  nodejs,
+  yarnBuildHook,
+  yarnConfigHook,
 }:
 let
   python = python3.override {
@@ -20,19 +25,45 @@ let
       };
     };
   };
-in
 
-python.pkgs.buildPythonApplication rec {
-  pname = "lasuite-docs";
   version = "3.4.2";
-  pyproject = true;
-
   src = fetchFromGitHub {
     owner = "suitenumerique";
     repo = "docs";
     tag = "v${version}";
     hash = "sha256-uo49y+tJXdc8gfFIHSIEk0DEowMsHWA64IxlHpFHUTU=";
   };
+
+  mail-templates = stdenv.mkDerivation {
+    name = "lasuite-docs-${version}-mjml";
+    inherit src;
+
+    sourceRoot = "source/src/mail";
+
+    patches = [ ./mjml-mail-dir.patch ];
+    patchFlags = [ "-p3" ];
+
+    env.DIR_MAILS = "${placeholder "out"}";
+
+    offlineCache = fetchYarnDeps {
+      yarnLock = "${src}/src/mail/yarn.lock";
+      hash = "sha256-oyLs7Df+KGzqCW8uF/7uzcL6ecMx8kHMzpuHSSywwfw=";
+    };
+
+    nativeBuildInputs = [
+      nodejs
+      yarnConfigHook
+      yarnBuildHook
+    ];
+
+    dontInstall = true;
+  };
+in
+
+python.pkgs.buildPythonApplication rec {
+  pname = "lasuite-docs";
+  pyproject = true;
+  inherit version src;
 
   sourceRoot = "source/src/backend";
 
@@ -108,6 +139,9 @@ python.pkgs.buildPythonApplication rec {
         --prefix PYTHONPATH : "${pythonPath}:$out/${python.sitePackages}"
       makeWrapper ${lib.getExe python.pkgs.gunicorn} $out/bin/gunicorn \
         --prefix PYTHONPATH : "${pythonPath}:$out/${python.sitePackages}"
+
+      mkdir -p $out/${python.sitePackages}/core/templates
+      ln -sv ${mail-templates}/ $out/${python.sitePackages}/core/templates/mail
     '';
 
   passthru.tests = {


### PR DESCRIPTION
The build-process doesn't install the mjml-based mail templates which results in the following log-lines when trying to invite somebody by email to collaborate on a document:

    Aug 11 08:25:08 lasuite gunicorn[345]:   File "/nix/store/4h2z6psmq0nizy39psyf2lil0cqiwl42-python3.13-django-5.2.4/lib/python3.13/site-packages/django/template/loader.py", line 19, in get_template
    Aug 11 08:25:08 lasuite gunicorn[345]:     raise TemplateDoesNotExist(template_name, chain=chain)
    Aug 11 08:25:08 lasuite gunicorn[345]: django.template.exceptions.TemplateDoesNotExist: mail/html/template.html


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
