### PR TITLE
gemini-cli-bin: init at 0.3.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14551,6 +14551,12 @@
     githubId = 40217331;
     name = "LizeLive";
   };
+  ljxfstorm = {
+    name = "Likai Liu";
+    email = "ljxf.storm@live.cn";
+    github = "ljxfstorm";
+    githubId = 7077478;
+  };
   llakala = {
     email = "elevenaka11@gmail.com";
     github = "llakala";

--- a/pkgs/by-name/ge/gemini-cli-bin/package.nix
+++ b/pkgs/by-name/ge/gemini-cli-bin/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  nodejs,
+  gitUpdater,
+}:
+let
+  owner = "google-gemini";
+  repo = "gemini-cli";
+  asset = "gemini.js";
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "gemini-cli-bin";
+  version = "0.3.4";
+
+  src = fetchurl {
+    url = "https://github.com/${owner}/${repo}/releases/download/v${finalAttrs.version}/${asset}";
+    hash = "sha256-aVcizpbzV1hPsuMSGRxgMGXTyF+0yBqGk7EwPnKFDyQ=";
+  };
+
+  phases = [
+    "installPhase"
+    "fixupPhase"
+  ];
+
+  strictDeps = true;
+
+  buildInputs = [ nodejs ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D "$src" "$out/bin/gemini"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = [
+    ./update-asset.sh
+    "${owner}/${repo}"
+    "${asset}"
+  ];
+
+  meta = {
+    description = "AI agent that brings the power of Gemini directly into your terminal";
+    homepage = "https://github.com/google-gemini/gemini-cli";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ljxfstorm ];
+    mainProgram = "gemini";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+    priority = 10;
+  };
+})

--- a/pkgs/by-name/ge/gemini-cli-bin/update-asset.sh
+++ b/pkgs/by-name/ge/gemini-cli-bin/update-asset.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p gnugrep curl jq gnused
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+NIX_FILE="package.nix"
+RELEASE_ID="latest"
+
+GITHUB_REPO="$1"
+ASSET_NAME="$2"
+REV_PREFIX="${3:-v}"
+
+CURRENT_VER="$(grep -oP 'version = "\K[^"]+' "${NIX_FILE}")"
+CURRENT_HASH="$(grep -oP 'hash = "\K[^"]+' "${NIX_FILE}")"
+{
+    read -r LATEST_VER
+    read -r ASSET_DIGEST
+} < <(curl --fail -s ${GITHUB_TOKEN:+-u ":${GITHUB_TOKEN}"} "https://api.github.com/repos/${GITHUB_REPO}/releases/${RELEASE_ID}" | jq -r ".tag_name, (.assets[] | select(.name == \"${ASSET_NAME}\") | .digest)")
+
+LATEST_VER="${LATEST_VER#"${REV_PREFIX}"}"
+
+if [[ "${LATEST_VER}" == "${CURRENT_VER}" ]]; then
+    echo "Up to date."
+    exit 0
+fi
+
+LATEST_HASH="$(nix-hash --to-sri "${ASSET_DIGEST}")"
+
+sed -i "s#hash = \"${CURRENT_HASH}\";#hash = \"${LATEST_HASH}\";#g" "${NIX_FILE}"
+sed -i "s#version = \"${CURRENT_VER}\";#version = \"${LATEST_VER}\";#g" "${NIX_FILE}"
+
+echo "Successfully updated from ${CURRENT_VER} to version ${LATEST_VER}."


### PR DESCRIPTION
Add a "binary" variant of `gemini-cli` using the `gemini.js` release asset from upstream.
This provides a much smaller package size and makes updates easier, as we won't have to worry about upstream build changes or missing dependencies.

Known Issue:
Running the `gemini` command from this package will print a `DeprecationWarning` from Node.js, as shown below.
```console
(node:338601) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```
This is because the upstream `gemini.js` build still depends on Node.js's deprecated `punycode` module. The warning won't affect any functionality of `gemini-cli` and is expected to be suppressed after the Node.js v22.17.0 update.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
