### PR TITLE
nixos/kanidm: add support for kanidm unixd config v2

### DIFF
--- a/nixos/modules/services/security/kanidm.nix
+++ b/nixos/modules/services/security/kanidm.nix
@@ -368,7 +368,7 @@ in
         freeformType = settingsFormat.type;
 
         options = {
-          pam_allowed_login_groups = mkOption {
+          kanidm.pam_allowed_login_groups = mkOption {
             description = "Kanidm groups that are allowed to login using PAM.";
             example = "my_pam_group";
             type = types.listOf types.str;
@@ -673,6 +673,10 @@ in
 
   config = mkIf (cfg.enableClient || cfg.enableServer || cfg.enablePam) {
     warnings = lib.optionals (cfg.package.eolMessage != "") [ cfg.package.eolMessage ];
+    services.kanidm = {
+      unixSettings.version = "2";
+      serverSettings.version = "2";
+    };
 
     assertions =
       let
@@ -710,6 +714,14 @@ in
           };
       in
       [
+        {
+          assertion = cfg.enablePam -> !(cfg.unixSettings ? pam_allowed_login_groups);
+          message = ''
+            <option>services.kanidm.unixSettings.pam_allowed_login_groups</option> has been renamed
+            to <option>services.kanidm.unixSettings.kanidm.pam_allowed_login_groups</option>.
+            Please change your usage.
+          '';
+        }
         {
           assertion =
             !cfg.enableServer

--- a/nixos/modules/services/security/kanidm.nix
+++ b/nixos/modules/services/security/kanidm.nix
@@ -29,6 +29,7 @@ let
     mkIf
     mkMerge
     mkOption
+    mkOrder
     mkPackageOption
     optional
     optionals
@@ -1052,8 +1053,9 @@ in
 
     system.nssModules = mkIf cfg.enablePam [ cfg.package ];
 
-    system.nssDatabases.group = optional cfg.enablePam "kanidm";
-    system.nssDatabases.passwd = optional cfg.enablePam "kanidm";
+    # Needs to be before "files" which is `mkBefore`
+    system.nssDatabases.group = mkOrder 490 (optional cfg.enablePam "kanidm");
+    system.nssDatabases.passwd = mkOrder 490 (optional cfg.enablePam "kanidm");
 
     users.groups = mkMerge [
       (mkIf cfg.enableServer { kanidm = { }; })

--- a/nixos/tests/kanidm.nix
+++ b/nixos/tests/kanidm.nix
@@ -66,7 +66,7 @@ in
         };
         enablePam = true;
         unixSettings = {
-          pam_allowed_login_groups = [ "shell" ];
+          kanidm.pam_allowed_login_groups = [ "shell" ];
         };
       };
 


### PR DESCRIPTION
Update kanidm module to support newest config versions for both server config and unixd config.

closes: #391080

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
