### PR TITLE
python3Packages.types-openpyxl: init at 3.1.5.20250809

### DIFF
--- a/pkgs/development/python-modules/types-openpyxl/default.nix
+++ b/pkgs/development/python-modules/types-openpyxl/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "types-openpyxl";
+  version = "3.1.5.20250809";
+
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "types_openpyxl";
+    inherit (finalAttrs) version;
+    hash = "sha256-SVNvoYo6i1Z7bSZx0zAdjCQOwvG895UQ9LrZ+skjLL0=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "openpyxl-stubs" ];
+
+  meta = {
+    description = "Typing stubs for openpyxl";
+    homepage = "https://github.com/python/typeshed";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.me-and ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19929,6 +19929,8 @@ self: super: with self; {
 
   types-mysqlclient = callPackage ../development/python-modules/types-mysqlclient { };
 
+  types-openpyxl = callPackage ../development/python-modules/types-openpyxl { };
+
   types-pillow = callPackage ../development/python-modules/types-pillow { };
 
   types-protobuf = callPackage ../development/python-modules/types-protobuf { };


### PR DESCRIPTION
Add type stubs for the openpyxl Python module, which is already available in Nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
