### PR TITLE
kylin-virtual-keyboard: init at 4.20.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6421,6 +6421,12 @@
     github = "DimitarNestorov";
     githubId = 8790386;
   };
+  dingdang66686 = {
+    name = "Straying";
+    email = "strayingfar@outlook.com";
+    github = "dingdang66686";
+    githubId = 42102822;
+  };
   diniamo = {
     name = "diniamo";
     email = "diniamo53@gmail.com";

--- a/pkgs/by-name/ky/kylin-virtual-keyboard/package.nix
+++ b/pkgs/by-name/ky/kylin-virtual-keyboard/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  fcitx5,
+  libsForQt5,
+  gsettings-qt,
+  glib,
+  pkg-config,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "kylin-virtual-keyboard";
+  version = "4.20.1.0";
+
+  src = fetchFromGitHub {
+    owner = "openkylin";
+    repo = "kylin-virtual-keyboard";
+    rev = "upstream/${version}";
+    sha256 = "sha256-YM5FLJcgjhx7Ks1bgC26Ee4oDF8C6dK8yTtXSnD84aA=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    libsForQt5.wrapQtAppsHook
+    libsForQt5.qtgraphicaleffects
+    glib
+  ];
+
+  buildInputs = [
+    libsForQt5.qtbase
+    libsForQt5.qtdeclarative
+    libsForQt5.qtquickcontrols2
+    libsForQt5.qtsvg
+    fcitx5
+    libsForQt5.fcitx5-qt
+    libsForQt5.kwindowsystem
+    gsettings-qt
+  ];
+
+  patchPhase = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "/etc/xdg/autostart" "${placeholder "out"}/etc/xdg/autostart"
+
+    substituteInPlace data/kylin-virtual-keyboard-xwayland \
+      --replace-fail "/usr" "${placeholder "out"}"
+
+    substituteInPlace data/kylin-virtual-keyboard.desktop \
+      --replace-fail "/usr" "${placeholder "out"}"
+
+    substituteInPlace data/org.fcitx.Fcitx5.VirtualKeyboard.service \
+      --replace-fail "/usr" "${placeholder "out"}"
+  '';
+
+  postInstall = ''
+    glib-compile-schemas $out/share/glib-2.0/schemas
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/$pname \
+      --prefix XDG_DATA_DIRS : "$out/share/gsettings-schemas/$pname-$version"
+  '';
+
+  meta = with lib; {
+    description = "Kylin Virtual Keyboard - a modern on-screen keyboard for Linux";
+    homepage = "https://gitee.com/openkylin/kylin-virtual-keyboard";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ dingdang66686 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/by-name/ky/kylin-virtual-keyboard/package.nix
+++ b/pkgs/by-name/ky/kylin-virtual-keyboard/package.nix
@@ -28,21 +28,25 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
-    libsForQt5.wrapQtAppsHook
-    libsForQt5.qtgraphicaleffects
     glib
-  ];
+  ]
+  ++ (with libsForQt5; [
+    wrapQtAppsHook
+    qtgraphicaleffects
+  ]);
 
   buildInputs = [
-    libsForQt5.qtbase
-    libsForQt5.qtdeclarative
-    libsForQt5.qtquickcontrols2
-    libsForQt5.qtsvg
     fcitx5
-    libsForQt5.fcitx5-qt
-    libsForQt5.kwindowsystem
     gsettings-qt
-  ];
+  ]
+  ++ (with libsForQt5; [
+    qtbase
+    qtdeclarative
+    qtquickcontrols2
+    qtsvg
+    fcitx5-qt
+    kwindowsystem
+  ]);
 
   patchPhase = ''
     substituteInPlace CMakeLists.txt \

--- a/pkgs/by-name/ky/kylin-virtual-keyboard/package.nix
+++ b/pkgs/by-name/ky/kylin-virtual-keyboard/package.nix
@@ -3,23 +3,27 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  fcitx5,
-  libsForQt5,
-  gsettings-qt,
-  glib,
   pkg-config,
+  libsForQt5,
+  glib,
+  fcitx5,
+  gsettings-qt,
+  bashNonInteractive,
+  nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "kylin-virtual-keyboard";
   version = "4.20.1.0";
 
   src = fetchFromGitHub {
     owner = "openkylin";
     repo = "kylin-virtual-keyboard";
-    rev = "upstream/${version}";
-    sha256 = "sha256-YM5FLJcgjhx7Ks1bgC26Ee4oDF8C6dK8yTtXSnD84aA=";
+    tag = "upstream/${finalAttrs.version}";
+    hash = "sha256-YM5FLJcgjhx7Ks1bgC26Ee4oDF8C6dK8yTtXSnD84aA=";
   };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     cmake
@@ -44,18 +48,15 @@ stdenv.mkDerivation rec {
     substituteInPlace CMakeLists.txt \
       --replace-fail "/etc/xdg/autostart" "${placeholder "out"}/etc/xdg/autostart"
 
-    substituteInPlace data/kylin-virtual-keyboard-xwayland \
-      --replace-fail "/usr" "${placeholder "out"}"
-
-    substituteInPlace data/kylin-virtual-keyboard.desktop \
-      --replace-fail "/usr" "${placeholder "out"}"
-
-    substituteInPlace data/org.fcitx.Fcitx5.VirtualKeyboard.service \
-      --replace-fail "/usr" "${placeholder "out"}"
+    substituteInPlace \
+      data/{kylin-virtual-keyboard-xwayland,kylin-virtual-keyboard.desktop,org.fcitx.Fcitx5.VirtualKeyboard.service} \
+        --replace-fail "/usr" "${placeholder "out"}"
   '';
 
   postInstall = ''
     glib-compile-schemas $out/share/glib-2.0/schemas
+    substituteInPlace $out/bin/kylin-virtual-keyboard-xwayland \
+      --replace-fail "#!/bin/bash" "#!${lib.getExe bashNonInteractive}"
   '';
 
   postFixup = ''
@@ -63,11 +64,13 @@ stdenv.mkDerivation rec {
       --prefix XDG_DATA_DIRS : "$out/share/gsettings-schemas/$pname-$version"
   '';
 
-  meta = with lib; {
-    description = "Kylin Virtual Keyboard - a modern on-screen keyboard for Linux";
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Modern on-screen keyboard for Linux";
     homepage = "https://gitee.com/openkylin/kylin-virtual-keyboard";
-    license = licenses.lgpl3;
-    maintainers = with maintainers; [ dingdang66686 ];
-    platforms = platforms.linux;
+    license = lib.licenses.lgpl3;
+    maintainers = with lib.maintainers; [ dingdang66686 ];
+    platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
Add Kylin Virtual Keyboard, a modern on-screen keyboard developed by OpenKylin.

Features:
- Qt5-based virtual keyboard with Wayland/X11 support
- Fcitx5 integration via D-Bus service
- Patched install paths for Nix store compatibility

Maintainer: @dingdang66686
License: LGPL-3.0
Homepage: https://gitee.com/openkylin/kylin-virtual-keyboard


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
