### PR TITLE
python3Packages.typed-argparse: init at 0.3.1-unstable-2025-05-09

### DIFF
--- a/pkgs/development/python-modules/typed-argparse/default.nix
+++ b/pkgs/development/python-modules/typed-argparse/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  typing-extensions,
+  pytestCheckHook,
+  pytest-cov-stub,
+}:
+buildPythonPackage {
+  pname = "typed-argparse";
+  version = "0.3.1-unstable-2025-05-09";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "typed-argparse";
+    repo = "typed-argparse";
+    rev = "989887701c5b4e8c835fac60d6124a9efa557e6f";
+    hash = "sha256-RgOHIjODBacZdUMCrazZxhQerHtZrNO0BBXPkWPN47o=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ typing-extensions ];
+
+  pythonImportsCheck = [ "typed_argparse" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
+
+  meta = {
+    description = "Type-safe Python argument parsing";
+    homepage = "https://typed-argparse.github.io/typed-argparse/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.me-and ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18534,6 +18534,8 @@ self: super: with self; {
     inherit (pkgs) file zlib;
   };
 
+  typed-argparse = callPackage ../development/python-modules/typed-argparse { };
+
   typed-settings = callPackage ../development/python-modules/typed-settings { };
 
   typedmonarchmoney = callPackage ../development/python-modules/typedmonarchmoney { };


### PR DESCRIPTION
https://pypi.org/project/typed-argparse/

Python argument parsing with type checking

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
