### PR TITLE
fabric-servers: init at 1.14-1.21.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25752,6 +25752,19 @@
     githubId = 1391883;
     name = "Tom Hall";
   };
+  threadexio = {
+    email = "pzarganitis@gmail.com";
+    matrix = "@threadexio:matrix.org";
+    github = "threadexio";
+    githubId = 59455514;
+    name = "Panagiotis Zarganitis";
+
+    keys = [
+      {
+        fingerprint = "D475 1508 457E 4172 6D4A  4F24 7FAD 5F3A 3702 647C";
+      }
+    ];
+  };
   three = {
     email = "eric@ericroberts.dev";
     github = "three";

--- a/pkgs/games/fabric-servers/default.nix
+++ b/pkgs/games/fabric-servers/default.nix
@@ -5,9 +5,7 @@
 let
   escapeVersion = lib.replaceString "." "_";
 
-  versions = lib.sort
-    (a: b: lib.versionOlder a.version b.version)
-    (lib.importJSON ./versions.json);
+  versions = lib.sort (a: b: lib.versionOlder a.version b.version) (lib.importJSON ./versions.json);
 
   latest = lib.last versions;
 

--- a/pkgs/games/fabric-servers/default.nix
+++ b/pkgs/games/fabric-servers/default.nix
@@ -3,10 +3,9 @@
   lib,
 }:
 let
-  older = a: b: lib.versionOlder a.version b.version;
-  escapeVersion = builtins.replaceStrings [ "." ] [ "_" ];
+  escapeVersion = builtins.replaceString "." "_";
 
-  versions = builtins.sort older (lib.importJSON ./versions.json);
+  versions = builtins.sort (a: b: lib.versionOlder a.version b.version) (lib.importJSON ./versions.json);
   latest = lib.last versions;
 
   versions' = lib.listToAttrs (

--- a/pkgs/games/fabric-servers/default.nix
+++ b/pkgs/games/fabric-servers/default.nix
@@ -3,9 +3,12 @@
   lib,
 }:
 let
-  escapeVersion = builtins.replaceString "." "_";
+  escapeVersion = lib.replaceString "." "_";
 
-  versions = builtins.sort (a: b: lib.versionOlder a.version b.version) (lib.importJSON ./versions.json);
+  versions = lib.sort
+    (a: b: lib.versionOlder a.version b.version)
+    (lib.importJSON ./versions.json);
+
   latest = lib.last versions;
 
   versions' = lib.listToAttrs (

--- a/pkgs/games/fabric-servers/default.nix
+++ b/pkgs/games/fabric-servers/default.nix
@@ -1,0 +1,23 @@
+{
+  callPackage,
+  lib,
+}:
+let
+  older = a: b: lib.versionOlder a.version b.version;
+  escapeVersion = builtins.replaceStrings [ "." ] [ "_" ];
+
+  versions = builtins.sort older (lib.importJSON ./versions.json);
+  latest = lib.last versions;
+
+  versions' = lib.listToAttrs (
+    map (x: lib.nameValuePair "fabric-${escapeVersion x.version}" x) versions
+  );
+
+  packages = lib.mapAttrs (_: callPackage ./derivation.nix) versions';
+in
+lib.recurseIntoAttrs (
+  packages
+  // {
+    fabric = packages."fabric-${escapeVersion latest.version}";
+  }
+)

--- a/pkgs/games/fabric-servers/derivation.nix
+++ b/pkgs/games/fabric-servers/derivation.nix
@@ -1,0 +1,59 @@
+{
+  stdenvNoCC,
+  fetchurl,
+  makeWrapper,
+  lib,
+
+  jre,
+  udev,
+
+  version,
+  url,
+  hash,
+}:
+
+stdenvNoCC.mkDerivation (final: {
+  pname = "fabric-server";
+  inherit version;
+
+  src = fetchurl {
+    pname = "fabric-jar";
+    inherit (final) version;
+
+    inherit url hash;
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 $src $out/lib/fabric/server.jar
+
+    makeWrapper ${lib.getExe jre} "$out/bin/minecraft-server" \
+      --append-flags "-jar $out/lib/fabric/server.jar nogui" \
+      ${lib.optionalString stdenvNoCC.hostPlatform.isLinux "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ udev ]}"}
+
+    runHook postInstall
+  '';
+
+  preferLocalBuild = true;
+
+  passthru = {
+    updateScript = ./update.py;
+  };
+
+  meta = {
+    description = "Modular, lightweight mod loader for Minecraft";
+    homepage = "https://fabricmc.net";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    license = lib.licenses.asl20;
+    inherit (jre.meta) platforms;
+    maintainers = with lib.maintainers; [
+      threadexio
+    ];
+    mainProgram = "minecraft-server";
+  };
+})

--- a/pkgs/games/fabric-servers/update.py
+++ b/pkgs/games/fabric-servers/update.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python3 -p 'python3.withPackages (p: [p.requests])'
+
+from pathlib import Path
+from typing import *
+import requests
+import hashlib
+import base64
+import json
+
+URL = "https://meta.fabricmc.net"
+
+HEADERS = {
+    "User-Agent": "nixpkgs/update.py",
+    "Accept": "application/json"
+}
+
+def b64e(x) -> str:
+    return base64.b64encode(x).decode("ascii")
+
+def get(url: str, /, headers={}, **kwargs) -> Any:
+    r = requests.get(url, headers=HEADERS | headers, **kwargs)
+    r.raise_for_status()
+    return r.json()
+
+def hashurl(url: str, /, headers={}, **kwargs) -> str:
+    STREAM_BLOCK_SIZE = 4096
+
+    r = requests.get(url, stream=True, headers=HEADERS | headers, **kwargs)
+    r.raise_for_status()
+
+    hash = hashlib.sha256()
+    for x in r.iter_content(STREAM_BLOCK_SIZE):
+        hash.update(x)
+
+    digest = hash.digest()
+
+    return f"sha256-{b64e(digest)}"
+
+def generate() -> List[Dict]:
+    gameVersions = get(f"{URL}/v2/versions/game")
+    gameVersions = filter(lambda x: x["stable"], gameVersions)
+    gameVersions = map(lambda x: x["version"], gameVersions)
+
+    loaderVersions = get(f"{URL}/v2/versions/loader")
+    loaderVersions = filter(lambda x: x["stable"], loaderVersions)
+    loaderVersions = map(lambda x: x["version"], loaderVersions)
+
+    # Always use the latest loader.
+    loaderVersion = next(loaderVersions)
+
+    installerVersions = get(f"{URL}/v2/versions/installer")
+    installerVersions = filter(lambda x: x["stable"], installerVersions)
+    installerVersions = map(lambda x: x["version"], installerVersions)
+
+    # Always use the latest installer.
+    installerVersion = next(installerVersions)
+
+    def version(gameVersion) -> Dict:
+        print(gameVersion)
+        url = f"{URL}/v2/versions/loader/{gameVersion}/{loaderVersion}/{installerVersion}/server/jar"
+
+        return {
+            "version": gameVersion,
+            "url": url,
+            "hash": hashurl(url)
+        }
+
+    versions = map(version, gameVersions)
+    return list(versions)
+
+if __name__ == "__main__":
+    with open(Path(__file__).parent / "versions.json", "w") as f:
+        json.dump(generate(), f, indent=2)
+        f.write("\n")

--- a/pkgs/games/fabric-servers/versions.json
+++ b/pkgs/games/fabric-servers/versions.json
@@ -1,0 +1,202 @@
+[
+  {
+    "version": "1.21.8",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.21.8/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-gPZubbZF6/qx+nDxeCguKkGyAsnzSKC860lnwN0sdSI="
+  },
+  {
+    "version": "1.21.7",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.21.7/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-cRUWJaLb6n4oQ9hymZrunxW7DvZC0rtMvoAbFo5TntE="
+  },
+  {
+    "version": "1.21.6",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.21.6/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-vZv9Rb710CZNpq6qeWne5TwQnj2cyUS3pOns/qO/F5w="
+  },
+  {
+    "version": "1.21.5",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.21.5/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-YzND6Pwi1ikIybi4iX99SYF9+ScJ6cyyauWcy+CHhvQ="
+  },
+  {
+    "version": "1.21.4",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.21.4/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-rdgGZYcv4WilffrjI6xq7hHohdnNl/rumuBabx9lsBA="
+  },
+  {
+    "version": "1.21.3",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.21.3/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-uqbovmtGNdyxBXVhCD36x/AjqgxQNIAwrwAS+t0aCWs="
+  },
+  {
+    "version": "1.21.2",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.21.2/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-z1JgJP+Q8kjtMccUulWjek2K6VH4JZ+O0W7EBIunEqA="
+  },
+  {
+    "version": "1.21.1",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.21.1/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-8+qAIjSLXtz/AQI8THugssuwMyMx5j9SS+jrORzBaRw="
+  },
+  {
+    "version": "1.21",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.21/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-LKiWn+UJiHHRmiWwMS1ryzHGZj261F4aVhL2BJmiw/Q="
+  },
+  {
+    "version": "1.20.6",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.20.6/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-2X0yr1KNrkTvZ2xZcr/UvksQa3tCn6GgGsyJxl9LWME="
+  },
+  {
+    "version": "1.20.5",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.20.5/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-uZndEmP8mywzyXADaw+05RSoSQhcQT4RAdd7tQaIO+o="
+  },
+  {
+    "version": "1.20.4",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.20.4/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-a953nLBecHYsoocERHNxr6eV/8e7VpwIiQ/MzNdqlKo="
+  },
+  {
+    "version": "1.20.3",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.20.3/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-7Ea7FgzGJzjoe7LmKqY92ByGBqM7cI1J95Ou6PE0S7A="
+  },
+  {
+    "version": "1.20.2",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.20.2/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-0OA16Uf3hwF7g0PzHIwj+7tNTel579tgJgzVVSwRfqM="
+  },
+  {
+    "version": "1.20.1",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.20.1/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-NkKrvv2pYS3zmRvrg+QKVySnzsxeEya0vRzaiIvco5o="
+  },
+  {
+    "version": "1.20",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.20/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-CPqr8/IcjsffaQ1lNsMWAXznKkc3PyNqmOTF15S4zdA="
+  },
+  {
+    "version": "1.19.4",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.19.4/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-rHQU3YLoX17kFUqUE3PxtzC79X/htz3G9uYglpRAqp8="
+  },
+  {
+    "version": "1.19.3",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.19.3/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-IimkCaaMUPZElc0V7TT4ySrEzlLJ3ZxYwgOeXRIHrW4="
+  },
+  {
+    "version": "1.19.2",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.19.2/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-4V0pbQtPoVG09lxHPjugPtNITMhQDKR/FHtvANAuZe0="
+  },
+  {
+    "version": "1.19.1",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.19.1/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-yj/S5+mtMl5oszHcn0yO6V9TWuAQWkd7HbTRkDXNBXI="
+  },
+  {
+    "version": "1.19",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.19/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-kvPgZ9iY1u/RxUqB0fEalIB7N73NpyvzQ1HM1GfCZOc="
+  },
+  {
+    "version": "1.18.2",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.18.2/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-css3QD98t7ZAlCqIQIuhANotv8I2DMeex8nDKdDj1+E="
+  },
+  {
+    "version": "1.18.1",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.18.1/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-lgO40oIC1sYWP6H0ygeGWDeIPhfvJ7oWrvjv9NzzmxQ="
+  },
+  {
+    "version": "1.18",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.18/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-10AhozBcLtHUdrw7Z2nAbBpANB/WB4/2yW/3CExoAfU="
+  },
+  {
+    "version": "1.17.1",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.17.1/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-2jXPqC/gXhU32DXHDrkc5vCr87uiepWisuPILoPYQ/8="
+  },
+  {
+    "version": "1.17",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.17/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-vTRkd27FQ7350BO8APkArblgmexg9baOmpsFiI+T998="
+  },
+  {
+    "version": "1.16.5",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.16.5/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-JKbR8Do1GJGI5lL86EWYj1EZGJ+cN7UBk9H4B7kK2nM="
+  },
+  {
+    "version": "1.16.4",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.16.4/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-A9wL6O+8+ZJ3/Rf2V4quFS3uSX5m99r51bsPHJihlT4="
+  },
+  {
+    "version": "1.16.3",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.16.3/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-FktdZ6V7YeGbNSWNyffkbxpvzjKa9kaKwJEiorU51Yo="
+  },
+  {
+    "version": "1.16.2",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.16.2/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-mQ8x3NmIUBtjPEopqLDq7+O3hAOBYsEfY6zmzlKoY7s="
+  },
+  {
+    "version": "1.16.1",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.16.1/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-ND9opie0CQBF40c68RefVo8MfPplPkaoDNMzBd/YPHY="
+  },
+  {
+    "version": "1.16",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.16/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-dmyWDMY98QeOAl4uLf8hyIPjFZ0tbHA/xEzw8Tn3J6s="
+  },
+  {
+    "version": "1.15.2",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.15.2/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-hZsk2QXsGqe1Bj+rgW2GvHQWjVGHdRECFMWdP+f1/uM="
+  },
+  {
+    "version": "1.15.1",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.15.1/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-UbQIN/lW5tj/vYaD4Cfp1rW7FbvSrpAiWLDETYLQytU="
+  },
+  {
+    "version": "1.15",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.15/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-VxEbFbbd4+KMplSxJqlqY2HxLBS8S3Q7DGAFyKlCfTE="
+  },
+  {
+    "version": "1.14.4",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.14.4/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-3XcfiP42/6c30azOAYdMOPTCH+T1ez7HQydDFGXvOMw="
+  },
+  {
+    "version": "1.14.3",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.14.3/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-o3XFcUqaQfOoYFZU3QiyEoJVpPa6cSfgbsYkBvjYbVc="
+  },
+  {
+    "version": "1.14.2",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.14.2/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-vGhsq7IJb5D5Qx1pU3j/0Bn6hP6FEwry1KkO3RKf9MQ="
+  },
+  {
+    "version": "1.14.1",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.14.1/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-cVJt35ydfx/kMsgZ2JmKc93kG+OneUhrmhS3Et+YkR4="
+  },
+  {
+    "version": "1.14",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.14/0.17.2/1.1.0/server/jar",
+    "hash": "sha256-YR5/pPiQxm62u6xF5HE6u/xTKj7cImASn13rB6XRd4k="
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14101,6 +14101,8 @@ with pkgs;
   minecraftServers = import ../games/minecraft-servers { inherit callPackage lib javaPackages; };
   minecraft-server = minecraftServers.vanilla; # backwards compatibility
 
+  fabricServers = import ../games/fabric-servers { inherit callPackage lib; };
+
   luanti-client = luanti.override { buildServer = false; };
   luanti-server = luanti.override { buildClient = false; };
 


### PR DESCRIPTION
Added packages for the fabric mod loader for Minecraft.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
