### PR TITLE
[staging-next] Pile of fixes for 2025-08-11

### DIFF
--- a/pkgs/by-name/pa/paperless-ngx/concurrent-log-handler.patch
+++ b/pkgs/by-name/pa/paperless-ngx/concurrent-log-handler.patch
@@ -1,0 +1,21 @@
+diff --git a/src/paperless/settings.py b/src/paperless/settings.py
+index 3b69b2fc2..8549b9396 100644
+--- a/src/paperless/settings.py
++++ b/src/paperless/settings.py
+@@ -11,7 +11,6 @@ from typing import Final
+ from urllib.parse import urlparse
+ 
+ from celery.schedules import crontab
+-from concurrent_log_handler.queue import setup_logging_queues
+ from django.utils.translation import gettext_lazy as _
+ from dotenv import load_dotenv
+ 
+@@ -803,8 +802,6 @@ USE_TZ = True
+ # Logging                                                                     #
+ ###############################################################################
+ 
+-setup_logging_queues()
+-
+ LOGGING_DIR.mkdir(parents=True, exist_ok=True)
+ 
+ LOGROTATE_MAX_SIZE = os.getenv("PAPERLESS_LOGROTATE_MAX_SIZE", 1024 * 1024)

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   fetchPypi,
+  fetchpatch,
   node-gyp,
   nodejs_20,
   nixosTests,
@@ -143,6 +144,13 @@ python.pkgs.buildPythonApplication rec {
   pyproject = true;
 
   inherit version src;
+
+  # Manual partial backport of https://github.com/paperless-ngx/paperless-ngx/commit/9889c59d3daa8f4ac8ec2400c00ddc36a7ca63c9
+  # Fixes build with latest concurrent-log-handler.
+  # FIXME: remove in next update
+  patches = [
+    ./concurrent-log-handler.patch
+  ];
 
   postPatch = ''
     # pytest-xdist with to many threads makes the tests flaky

--- a/pkgs/development/libraries/mbedtls/3.nix
+++ b/pkgs/development/libraries/mbedtls/3.nix
@@ -3,4 +3,16 @@
 callPackage ./generic.nix {
   version = "3.6.4";
   hash = "sha256-y5YqKtjW4IXyIZkoJvwCGC4scx0qdeV40rynHza4NUE=";
+
+  patches = [
+    # Fixes the build with GCC 14 on aarch64.
+    #
+    # See:
+    # * <https://github.com/openwrt/openwrt/pull/15479>
+    # * <https://github.com/Mbed-TLS/mbedtls/issues/9003>
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/openwrt/openwrt/52b6c9247997e51a97f13bb9e94749bc34e2d52e/package/libs/mbedtls/patches/100-fix-gcc14-build.patch";
+      hash = "sha256-20bxGoUHkrOEungN3SamYKNgj95pM8IjbisNRh68Wlw=";
+    })
+  ];
 }

--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildGoModule,
   fetchFromGitHub,
+  fetchpatch,
   removeReferencesTo,
   tzdata,
   wire,
@@ -55,6 +56,15 @@ buildGoModule rec {
     rev = "v${version}";
     hash = "sha256-yraCuPLe68ryCgFzOZPL1H/JYynEvxijjgxMmQvcPZE=";
   };
+
+  # Fix build
+  # FIXME: remove in next update
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/grafana/grafana/commit/21f305c6a0e242463f5219cc6944fb880ea809f0.patch";
+      hash = "sha256-sXooRlnKY5ax0+1CPhy4zxDQtDGspbSdOoHHciqLTD8=";
+    })
+  ];
 
   # borrowed from: https://github.com/NixOS/nixpkgs/blob/d70d9425f49f9aba3c49e2c389fe6d42bac8c5b0/pkgs/development/tools/analysis/snyk/default.nix#L20-L22
   env = {

--- a/pkgs/tools/networking/openvpn/dco.patch
+++ b/pkgs/tools/networking/openvpn/dco.patch
@@ -1,0 +1,25 @@
+diff --git a/src/openvpn/ovpn_dco_linux.h b/src/openvpn/ovpn_dco_linux.h
+index 73e19b5..46c2786 100644
+--- a/src/openvpn/ovpn_dco_linux.h
++++ b/src/openvpn/ovpn_dco_linux.h
+@@ -237,20 +237,4 @@ enum ovpn_netlink_packet_attrs {
+ 	OVPN_PACKET_ATTR_MAX = __OVPN_PACKET_ATTR_AFTER_LAST - 1,
+ };
+ 
+-enum ovpn_ifla_attrs {
+-	IFLA_OVPN_UNSPEC = 0,
+-	IFLA_OVPN_MODE,
+-
+-	__IFLA_OVPN_AFTER_LAST,
+-	IFLA_OVPN_MAX = __IFLA_OVPN_AFTER_LAST - 1,
+-};
+-
+-enum ovpn_mode {
+-	__OVPN_MODE_FIRST = 0,
+-	OVPN_MODE_P2P = __OVPN_MODE_FIRST,
+-	OVPN_MODE_MP,
+-
+-	__OVPN_MODE_AFTER_LAST,
+-};
+-
+ #endif /* _UAPI_LINUX_OVPN_DCO_H_ */

--- a/pkgs/tools/networking/openvpn/default.nix
+++ b/pkgs/tools/networking/openvpn/default.nix
@@ -30,6 +30,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-nramYYNS+ee3canTiuFjG17f7tbUAjPiQ+YC3fIZXno=";
   };
 
+  # Effectively a backport of https://github.com/OpenVPN/openvpn/commit/1d3c2b67a73a0aa011c13e62f876d24e49d41df0
+  # to fix build on linux-headers 6.16.
+  # FIXME: remove in next update
+  patches = [
+    ./dco.patch
+  ];
+
   nativeBuildInputs = [
     pkg-config
   ]


### PR DESCRIPTION
This gets at least most of my config building again.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
