### PR TITLE
lib/systems: Add IEEE longdouble format

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -348,6 +348,8 @@ let
 
         darwinArch = parse.darwinArch final.parsed.cpu;
 
+        IEEE_format = parse.IEEE_format final.parsed.cpu;
+
         darwinPlatform =
           if final.isMacOS then
             "macos"

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -926,6 +926,36 @@ rec {
 
   darwinArch = cpu: if cpu.name == "aarch64" then "arm64" else cpu.name;
 
+  IEEE_format =
+    cpu:
+    builtins.getAttr cpu.name {
+      "aarch64" = "binary64";
+      "armv5tel" = "binary64";
+      "armv6l" = "binary64";
+      "armv7a" = "binary64";
+      "armv7l" = "binary64";
+      "arm" = "binary64";
+      "arm64" = "binary128";
+      "avr" = "binary32";
+      "i686" = "x87_extended";
+      "loongarch64" = "binary64"; # not well documented; usually binary64
+      "m68k" = "binary64"; # classic m68k is big-endian
+      "microblaze" = "binary64";
+      "microblazeel" = "binary64";
+      "wasm32" = "binary64";
+      "mips" = "binary64";
+      "mips64" = "binary64";
+      "mips64el" = "binary64";
+      "mipsel" = "binary64";
+      "powerpc64" = "binary64"; # on modern Linux (POWER9+)
+      "powerpc64le" = "binary64"; # recent distros switched to IEEE quad
+      "riscv32" = "binary64";
+      "riscv64" = "binary64"; # if quad ext enabled; otherwise double
+      "s390" = "binary64";
+      "s390x" = "binary64";
+      "x86_64" = "x87_extended";
+    };
+
   doubleFromSystem =
     {
       cpu,

--- a/pkgs/development/python-modules/numpy/2.nix
+++ b/pkgs/development/python-modules/numpy/2.nix
@@ -35,9 +35,17 @@
 assert (!blas.isILP64) && (!lapack.isILP64);
 
 let
+  longDoubleName =
+    {
+      "binary64" = "DOUBLE";
+      "binary128" = "QUAD";
+      "x87_extended" = "EXTENDED";
+    }
+    .${stdenv.hostPlatform.IEEE_format};
+  endianness = if stdenv.hostPlatform.isLittleEndian then "LE" else "BE";
   cfg = writeTextFile {
     name = "site.cfg";
-    text = lib.generators.toINI { } {
+    text = lib.generators.toINI { } ({
       ${blas.implementation} = {
         include_dirs = "${lib.getDev blas}/include:${lib.getDev lapack}/include";
         library_dirs = "${blas}/lib:${lapack}/lib";
@@ -54,7 +62,11 @@ let
         library_dirs = "${blas}/lib";
         runtime_library_dirs = "${blas}/lib";
       };
-    };
+    } // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+      properties = {
+        longdouble_format = "IEEE_${longDoubleName}_${endianness}";
+      };
+    });
   };
 in
 buildPythonPackage rec {


### PR DESCRIPTION
## Things done

- **lib/systems: Add IEEE longdouble format**
- **python3Packages.numpy: fix cross compilation**
- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
