### PR TITLE
maintainers: fix out-of-date github accounts

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4186,12 +4186,6 @@
     github = "carlthome";
     githubId = 1595907;
   };
-  carpinchomug = {
-    email = "aki.suda@protonmail.com";
-    github = "carpinchomug";
-    githubId = 101536256;
-    name = "Akiyoshi Suda";
-  };
   cartr = {
     email = "carter.sande@duodecima.technology";
     github = "cartr";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23000,7 +23000,7 @@
   seylerius = {
     name = "Sable Seyler";
     email = "sable@seyleri.us";
-    github = "seylerius";
+    github = "sableseyler";
     githubId = 1145981;
     keys = [ { fingerprint = "7246 B6E1 ABB9 9A48 4395  FD11 DC26 B921 A9E9 DBDE"; } ];
   };

--- a/pkgs/by-name/li/libctl/package.nix
+++ b/pkgs/by-name/li/libctl/package.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation rec {
     mainProgram = "gen-ctl-io";
     homepage = "https://github.com/NanoComp/libctl";
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ carpinchomug ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
This isn't a full check-and-fix of outdated information, but a quick fix for issues highlighted by @zowoq in https://github.com/orgs/nix-community/discussions/1908#discussioncomment-13972992. These two maintainers are used in home-manager, but have out-of-date github info:

> * `carpinchomug` -> [api.github.com/user/101536256](https://api.github.com/user/101536256) -> account deleted
> * `seylerius` -> [api.github.com/user/1145981](https://api.github.com/user/1145981) -> `sableseyler`

---

**maintainers: remove carpinchomug**

No longer has a GitHub account: https://api.github.com/user/101536256 is 404

Has not committed since initially adding themselves as a maintainer, which was done as part of adding libctl:

- 2022-03-17 b792b179ae7e5e75d8396db51a3a2df989b444df
- 2022-03-17 9cdf795143a2ca42e32f42801e09f5f738660fed

libctl therefore has no listed maintainers.

In home-manager, they also added one module: https://github.com/nix-community/home-manager/pull/3353 (opened 2022-10-25, merged 2024-03-10)

In https://github.com/nix-community/home-manager/pull/7660 usage of `lib.maintainers.carpinchomug` was dropped by @khaneliman.

---

**maintainers: update seylerius's github**

As per https://api.github.com/user/1145981

cc @sableseyler

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
