### PR TITLE
protobuf-language-server: init at 0.1.1-unstable-2025-05-21

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18908,6 +18908,12 @@
     githubId = 20295134;
     name = "Oliver Ni";
   };
+  olk = {
+    name = "Oleksandr Knyshuk";
+    email = "olk@disr.it";
+    github = "k1gen";
+    githubId = 62500387;
+  };
   ollieB = {
     github = "oliverbunting";
     githubId = 1237862;

--- a/pkgs/by-name/pr/protobuf-language-server/package.nix
+++ b/pkgs/by-name/pr/protobuf-language-server/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "protobuf-language-server";
+  version = "0.1.1-unstable-2025-05-21";
+
+  src = fetchFromGitHub {
+    owner = "lasorda";
+    repo = "protobuf-language-server";
+    rev = "ecab27467944346fb4227f90161d3ec823346646";
+    hash = "sha256-hN91/yBcybF/4syItD1B03/qlR4cICYJQ3NNjIDBOrs=";
+  };
+
+  vendorHash = "sha256-4nTpKBe7ekJsfQf+P6edT/9Vp2SBYbKz1ITawD3bhkI=";
+
+  # Exclude the example binary from being built
+  excludedPackages = [ "./go-lsp/example" ];
+
+  postPatch = ''
+    # Fix the generate function in methods_gen_test.go to include proper imports
+    substituteInPlace go-lsp/lsp/methods_gen_test.go \
+      --replace-fail 'pkg := "// code gen by methods_gen_test.go, do not edit!\npackage lsp\n"' \
+      'pkg := "// code gen by methods_gen_test.go, do not edit!\npackage lsp\n\nimport (\n\t\"context\"\n\n\t\"github.com/lasorda/protobuf-language-server/go-lsp/jsonrpc\"\n\t\"github.com/lasorda/protobuf-language-server/go-lsp/lsp/defines\"\n)\n"'
+  '';
+
+  meta = {
+    description = "Language server implementation for Google Protocol Buffers";
+    homepage = "https://github.com/lasorda/protobuf-language-server";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ olk ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
This adds an LSP implementation for Google Protocol Buffers: https://github.com/lasorda/protobuf-language-server

I have tested the package in Zed editor: with the `proto` extension, after running `nix profile install -f . protobuf-language-server` - the LSP works.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
