### PR TITLE
prism-model-checker: 4.8.1 -> 4.9

### DIFF
--- a/pkgs/by-name/pr/prism-model-checker/package.nix
+++ b/pkgs/by-name/pr/prism-model-checker/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  #  stdenv,
-  gcc13Stdenv,
+  stdenv,
+  gccStdenv,
   coreutils,
   fetchFromGitHub,
   openjdk,
@@ -13,22 +13,17 @@
 }:
 
 let
-  # The current version of prism does not build with gcc > 13
-  # it should be fixed in the upcoming version of prism.
-  # at that point revert stdenv' to :
-  #
-  # stdenv' = if stdenv.hostPlatform.isDarwin then gccStdenv else stdenv;
-  stdenv' = gcc13Stdenv;
+  stdenv' = if stdenv.hostPlatform.isDarwin then gccStdenv else stdenv;
 in
 stdenv'.mkDerivation (finalAttrs: {
   pname = "prism-model-checker";
-  version = "4.8.1";
+  version = "4.9";
 
   src = fetchFromGitHub {
     owner = "prismmodelchecker";
     repo = "prism";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-igFRIjPfx0BFpQjaW/vgMEnH2HLC06aL3IMHh+ELB6U=";
+    hash = "sha256-eoyMGrXta49j2h/bStPuzrF6OZd/l2aQBngPbTZEvAo=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Update Version.
There is also an automatically generated pr #432802, however this does not remove the dependency on gcc version 13.
The previous version of prism did not compile on gcc14, but since this problem no longer exists we should use the current version of gcc.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
