### PR TITLE
mprisence: init at 1.2.4

### DIFF
--- a/pkgs/by-name/mp/mprisence/package.nix
+++ b/pkgs/by-name/mp/mprisence/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  dbus,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "mprisence";
+  version = "1.2.4";
+
+  src = fetchFromGitHub {
+    owner = "lazykern";
+    repo = "mprisence";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eUUUHjR6wnbaPb1QD9luEVvu5qSAxG5c4TuMjnzRV40=";
+  };
+
+  cargoHash = "sha256-BnzDMvwqQ56VFc7AuzsfyZ002qcmRaAOMfipynZ1/Mc=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    dbus
+    openssl
+  ];
+
+  meta = with lib; {
+    description = "Highly customizable Discord Rich Presence for MPRIS media players on Linux";
+    homepage = "https://github.com/lazykern/mprisence";
+    license = licenses.mit;
+    maintainers = with maintainers; [ toasteruwu ];
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    mainProgram = "mprisence";
+  };
+})


### PR DESCRIPTION
[lazykern/mprisence](https://github.com/lazykern/mprisence?rgh-link-date=2024-02-16T18%3A24%3A51Z)

Supersedes #289349 (Since this PR has been stale for a long while and is also outdated)
Closes #286464

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
