### PR TITLE
arduino-cli: 1.2.2 -> 1.3.1, use writableTmpDirAsHomeHook

### DIFF
--- a/pkgs/by-name/ar/arduino-cli/package.nix
+++ b/pkgs/by-name/ar/arduino-cli/package.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   buildFHSEnv,
   installShellFiles,
+  writableTmpDirAsHomeHook,
   go-task,
 }:
 
@@ -21,7 +22,10 @@ let
       hash = "sha256-xRo38yyGW2k37JS2rZzbqR1fEUCQQJ1bm45brgtQ4bk=";
     };
 
-    nativeBuildInputs = [ installShellFiles ];
+    nativeBuildInputs = [
+      installShellFiles
+      writableTmpDirAsHomeHook
+    ];
 
     nativeCheckInputs = [ go-task ];
 
@@ -64,12 +68,10 @@ let
     ++ lib.optionals stdenv.hostPlatform.isLinux [ "-extldflags '-static'" ];
 
     postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-      export HOME="$(mktemp -d)"
       installShellCompletion --cmd arduino-cli \
         --bash <($out/bin/arduino-cli completion bash) \
         --zsh <($out/bin/arduino-cli completion zsh) \
         --fish <($out/bin/arduino-cli completion fish)
-      unset HOME
     '';
 
     meta = {

--- a/pkgs/by-name/ar/arduino-cli/package.nix
+++ b/pkgs/by-name/ar/arduino-cli/package.nix
@@ -12,13 +12,13 @@ let
 
   pkg = buildGoModule rec {
     pname = "arduino-cli";
-    version = "1.2.2";
+    version = "1.3.0";
 
     src = fetchFromGitHub {
       owner = "arduino";
       repo = "arduino-cli";
       tag = "v${version}";
-      hash = "sha256-zP0N9QfyaKCFP413S2rlrWwqVdfhdcxAgcxsAO/mfpE=";
+      hash = "sha256-xRo38yyGW2k37JS2rZzbqR1fEUCQQJ1bm45brgtQ4bk=";
     };
 
     nativeBuildInputs = [ installShellFiles ];
@@ -27,7 +27,7 @@ let
 
     subPackages = [ "." ];
 
-    vendorHash = "sha256-BOB9K5N4ELLWdSHCNdFYCypbEyoZz2dOz9wouwP7AHw=";
+    vendorHash = "sha256-q7ojdO+Yy2o3slltVCzU/UB5/VgQfXBm/FOcWBR+vbk=";
 
     postPatch =
       let

--- a/pkgs/by-name/ar/arduino-cli/package.nix
+++ b/pkgs/by-name/ar/arduino-cli/package.nix
@@ -13,13 +13,13 @@ let
 
   pkg = buildGoModule rec {
     pname = "arduino-cli";
-    version = "1.3.0";
+    version = "1.3.1";
 
     src = fetchFromGitHub {
       owner = "arduino";
       repo = "arduino-cli";
       tag = "v${version}";
-      hash = "sha256-xRo38yyGW2k37JS2rZzbqR1fEUCQQJ1bm45brgtQ4bk=";
+      hash = "sha256-vUa/Mgztyu5jKVIIhp+Cg79n+ulN94mlfVpxecRb6PA=";
     };
 
     nativeBuildInputs = [
@@ -31,7 +31,7 @@ let
 
     subPackages = [ "." ];
 
-    vendorHash = "sha256-q7ojdO+Yy2o3slltVCzU/UB5/VgQfXBm/FOcWBR+vbk=";
+    vendorHash = "sha256-msv+ZG6uabTtPDVcRksRd8UTSpoztMKw3YGxvhJr26w=";
 
     postPatch =
       let


### PR DESCRIPTION
https://github.com/arduino/arduino-cli/releases/tag/v1.3.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
