### PR TITLE
nixos/sshd: Make sure network is fully configured before starting

### DIFF
--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -730,10 +730,13 @@ in
       services."sshd@" = {
         description = "SSH per-connection Daemon";
         after = [
-          "network.target"
+          "network-online.target"
           "sshd-keygen.service"
         ];
-        wants = [ "sshd-keygen.service" ];
+        wants = [
+          "network-online.target"
+          "sshd-keygen.service"
+        ];
         stopIfChanged = false;
         path = [ cfg.package ];
         environment.LD_LIBRARY_PATH = nssModulesPath;
@@ -755,10 +758,13 @@ in
         description = "SSH Daemon";
         wantedBy = [ "multi-user.target" ];
         after = [
-          "network.target"
+          "network-online.target"
           "sshd-keygen.service"
         ];
-        wants = [ "sshd-keygen.service" ];
+        wants = [
+          "network-online.target"
+          "sshd-keygen.service"
+        ];
         stopIfChanged = false;
         path = [ cfg.package ];
         environment.LD_LIBRARY_PATH = nssModulesPath;


### PR DESCRIPTION
When Systemd networkd is used and SSHd is configured to bind to specific
IP addresses, SSHd fails to start since it depends on network.target and
that has very little meaning during the start-up. That only ensures that
the network stack is set up but it doesn't have any requirements on the
configuration of the network interfaces. This issue doesn't occur when
`network.interfaces` is used for the network configuration, or when SSHd
is configured to bind to all addresses.

However, in order to ensure that the network interfaces are fully
configured before SSHd is started, let it depend on
network-online.target instead.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
