### PR TITLE
python3Packages.openai: 1.99.1 -> 1.99.9

### DIFF
--- a/pkgs/development/python-modules/openai/default.nix
+++ b/pkgs/development/python-modules/openai/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonAtLeast,
 
   # build-system
   hatchling,
@@ -18,10 +17,9 @@
   tqdm,
   typing-extensions,
 
-  # `httpx_aiohttp` not currently in `nixpkgs`
   # optional-dependencies (aiohttp)
-  # aiohttp,
-  # httpx_aiohttp,
+  aiohttp,
+  httpx-aiohttp,
 
   # optional-dependencies (datalib)
   numpy,
@@ -45,20 +43,22 @@
   respx,
 
   # optional-dependencies toggle
+  withAiohttp ? true,
+  withDatalib ? false,
   withRealtime ? true,
   withVoiceHelpers ? true,
 }:
 
 buildPythonPackage rec {
   pname = "openai";
-  version = "1.99.1";
+  version = "1.99.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "openai";
     repo = "openai-python";
     tag = "v${version}";
-    hash = "sha256-TFzLfCT71BSbKg7LSqpFAsutKYAeQ6ALy7AE4ldeHr8=";
+    hash = "sha256-gE74uUQTj2kL9kwsRdu4IW69BGRmEOCRjDRiZCN8TEA=";
   };
 
   postPatch = ''substituteInPlace pyproject.toml --replace-fail "hatchling==1.26.3" "hatchling"'';
@@ -78,15 +78,16 @@ buildPythonPackage rec {
     tqdm
     typing-extensions
   ]
+  ++ lib.optionals withAiohttp optional-dependencies.aiohttp
+  ++ lib.optionals withDatalib optional-dependencies.datalib
   ++ lib.optionals withRealtime optional-dependencies.realtime
   ++ lib.optionals withVoiceHelpers optional-dependencies.voice-helpers;
 
   optional-dependencies = {
-    # `httpx_aiohttp` not currently in `nixpkgs`
-    # aiohttp = [
-    #   aiohttp
-    #   httpx_aiohttp
-    # ];
+    aiohttp = [
+      aiohttp
+      httpx-aiohttp
+    ];
     datalib = [
       numpy
       pandas
@@ -114,23 +115,12 @@ buildPythonPackage rec {
     respx
   ];
 
-  pytestFlags = [
-    "-Wignore::DeprecationWarning"
-  ];
-
-  disabledTests = [
-    # Tests make network requests
-    "test_copy_build_request"
-    "test_basic_attribute_access_works"
-  ]
-  ++ lib.optionals (pythonAtLeast "3.13") [
-    # RuntimeWarning: coroutine method 'aclose' of 'AsyncStream._iter_events' was never awaited
-    "test_multi_byte_character_multiple_chunks"
-  ];
-
   disabledTestPaths = [
     # Test makes network requests
     "tests/api_resources"
+    # E   TypeError: Unexpected type for 'content', <class 'inline_snapshot._external.external'>
+    # This seems to be due to `inline-snapshot` being disabled when `pytest-xdist` is used.
+    "tests/lib/chat/test_completions_streaming.py"
   ];
 
   meta = {


### PR DESCRIPTION
- Update to latest version.
- Disabled some test that seem to fail due to `inline-snapshot` being incompatible with running tests using `pytest-xdist`.
- Cleaned up other disabled tests that no longer seem to be failing.
- Added support for `aiohttp` to enable support for better concurrency performance.

Diff: https://github.com/openai/openai-python/compare/v1.99.1...v1.99.9
Changelog: https://github.com/openai/openai-python/blob/v1.99.9/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
