### PR TITLE
warp-terminal: 0.2025.08.06.08.12.stable_01 -> 0.2025.08.06.08.12.stable_02

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-s4SHM2pU1CZPJZFiWE5VDeSEprLsSYChFazNGOpz+oo=",
-    "version": "0.2025.08.06.08.12.stable_01"
+    "hash": "sha256-wO3xE8cSSMaYVc6eoswDcR3acBzWwB/BHbins8ciM4Y=",
+    "version": "0.2025.08.06.08.12.stable_02"
   },
   "linux_x86_64": {
-    "hash": "sha256-u0TH9u1o+g3GngEMg6r78fSZH778kGcKe5tB/lpExZE=",
-    "version": "0.2025.08.06.08.12.stable_01"
+    "hash": "sha256-/Nhy0fyslK8h5zzhwlDJT+6nhNmdBowj/jGOTCunX4w=",
+    "version": "0.2025.08.06.08.12.stable_02"
   },
   "linux_aarch64": {
-    "hash": "sha256-smg2QiXRlADGBKxl9Wlq2yWsCCi3JwjxhwR13yG70mA=",
-    "version": "0.2025.08.06.08.12.stable_01"
+    "hash": "sha256-Jqm2aUg11nrIZUofcLDYZ7BQtaSPx7KrrM91i0bc+ig=",
+    "version": "0.2025.08.06.08.12.stable_02"
   }
 }


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
