### PR TITLE
treewide: remove prusnak from maintainers for packages i don't use

### DIFF
--- a/pkgs/by-name/fa/faraday/package.nix
+++ b/pkgs/by-name/fa/faraday/package.nix
@@ -37,9 +37,6 @@ buildGoModule rec {
     description = "LND Channel Management Tools";
     homepage = "https://github.com/lightninglabs/faraday";
     license = licenses.mit;
-    maintainers = with maintainers; [
-      proofofkeags
-      prusnak
-    ];
+    maintainers = with maintainers; [ proofofkeags ];
   };
 }

--- a/pkgs/by-name/li/libsurvive/package.nix
+++ b/pkgs/by-name/li/libsurvive/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     description = "Open Source Lighthouse Tracking System";
     homepage = "https://github.com/cntools/libsurvive";
     license = licenses.mit;
-    maintainers = with maintainers; [ prusnak ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/li/lightning-loop/package.nix
+++ b/pkgs/by-name/li/lightning-loop/package.nix
@@ -31,9 +31,6 @@ buildGoModule rec {
     description = "Lightning Loop Client";
     homepage = "https://github.com/lightninglabs/loop";
     license = licenses.mit;
-    maintainers = with maintainers; [
-      proofofkeags
-      prusnak
-    ];
+    maintainers = with maintainers; [ proofofkeags ];
   };
 }

--- a/pkgs/by-name/li/lightning-pool/package.nix
+++ b/pkgs/by-name/li/lightning-pool/package.nix
@@ -31,9 +31,6 @@ buildGoModule rec {
     description = "Lightning Pool Client";
     homepage = "https://github.com/lightninglabs/pool";
     license = licenses.mit;
-    maintainers = with maintainers; [
-      proofofkeags
-      prusnak
-    ];
+    maintainers = with maintainers; [ proofofkeags ];
   };
 }

--- a/pkgs/by-name/mo/monado/package.nix
+++ b/pkgs/by-name/mo/monado/package.nix
@@ -168,10 +168,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Open source XR runtime";
     homepage = "https://monado.freedesktop.org/";
     license = lib.licenses.boost;
-    maintainers = with lib.maintainers; [
-      Scrumplex
-      prusnak
-    ];
+    maintainers = with lib.maintainers; [ Scrumplex ];
     platforms = lib.platforms.linux;
     mainProgram = "monado-cli";
   };

--- a/pkgs/development/compilers/ghc/8.10.7-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.7-binary.nix
@@ -540,9 +540,7 @@ stdenv.mkDerivation {
     # long as the evaluator runs on a platform that supports
     # `pkgsMusl`.
     platforms = builtins.attrNames ghcBinDists.${distSetName};
-    maintainers = with lib.maintainers; [
-      prusnak
-    ];
+    maintainers = with lib.maintainers; [ ];
     teams = [ lib.teams.haskell ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/domain-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/domain-exporter.nix
@@ -29,7 +29,6 @@ buildGoModule rec {
     license = licenses.mit;
     maintainers = with maintainers; [
       mmilata
-      prusnak
       peterhoeg
       caarlos0
     ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
