### PR TITLE
nixos/open-webui: add backwards compatability migration

### DIFF
--- a/nixos/modules/services/misc/open-webui.nix
+++ b/nixos/modules/services/misc/open-webui.nix
@@ -97,6 +97,23 @@ in
       }
       // cfg.environment;
 
+      # backwards compatability migration
+      preStart = ''
+        if [ -d "${cfg.stateDir}/data" ] && [ -n "$(ls -A "${cfg.stateDir}/data" 2>/dev/null)" ]; then
+          exit 0
+        fi
+
+        mkdir -p "${cfg.stateDir}/data"
+
+        [ -f "${cfg.stateDir}/webui.db" ] && mv "${cfg.stateDir}/webui.db" "${cfg.stateDir}/data/"
+
+        for dir in cache uploads vector_db; do
+          [ -d "${cfg.stateDir}/$dir" ] && mv "${cfg.stateDir}/$dir" "${cfg.stateDir}/data/"
+        done
+
+        exit 0
+      '';
+
       serviceConfig = {
         ExecStart = "${lib.getExe cfg.package} serve --host \"${cfg.host}\" --port ${toString cfg.port}";
         EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;


### PR DESCRIPTION
The change in https://github.com/NixOS/nixpkgs/pull/431395 introduced a brand new location for the database. A seamless migration is not included and Users are left to figure it out on their own. Leaving them with an empty & unconfigured `open-webui` service after upgrading their nixpkgs input.

This PR attempts to fix that and let a `preStart` script handle the migration. (suggested in https://github.com/NixOS/nixpkgs/issues/430433#issuecomment-3167713548)

I imagine this script will be removed as soon as it's no longer needed and everyone has migrated. 👍

I've tested this by moving my databases from `/var/lib/open-webui/data` back to `/var/lib/open-webui/` and then removed the data folder. It has worked successfully.

I've also tested this, when a User has already figured out to move their data to the new location. The first check handle's that.

Please let me know if this is not how Nixpkgs handles migrations or if I missed anything! I only love to learn more!

fixes https://github.com/NixOS/nixpkgs/issues/430433

P.S. this is my second commit to nixpkgs!
Happy to contribute. :smile: 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
