### PR TITLE
catgirl: replace libressl with libretls

### DIFF
--- a/pkgs/by-name/ca/catgirl/package.nix
+++ b/pkgs/by-name/ca/catgirl/package.nix
@@ -39,12 +39,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
     homepage = "https://git.causal.agency/catgirl/about/";
-    license = licenses.gpl3Plus;
     description = "TLS-only terminal IRC client";
-    platforms = platforms.unix;
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.unix;
     mainProgram = "catgirl";
-    maintainers = with maintainers; [ xfnw ];
+    maintainers = with lib.maintainers; [ xfnw ];
   };
 })

--- a/pkgs/by-name/ca/catgirl/package.nix
+++ b/pkgs/by-name/ca/catgirl/package.nix
@@ -8,12 +8,12 @@
   stdenv,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "catgirl";
   version = "2.2a";
 
   src = fetchurl {
-    url = "https://git.causal.agency/catgirl/snapshot/${pname}-${version}.tar.gz";
+    url = "https://git.causal.agency/catgirl/snapshot/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     hash = "sha256-xtdgqu4TTgUlht73qRA1Q/coH95lMfvLQQhkcHlCl8I=";
   };
 
@@ -47,4 +47,4 @@ stdenv.mkDerivation rec {
     mainProgram = "catgirl";
     maintainers = with maintainers; [ xfnw ];
   };
-}
+})

--- a/pkgs/by-name/ca/catgirl/package.nix
+++ b/pkgs/by-name/ca/catgirl/package.nix
@@ -2,7 +2,8 @@
   ctags,
   fetchurl,
   lib,
-  libressl,
+  libretls,
+  openssl,
   ncurses,
   pkg-config,
   stdenv,
@@ -19,12 +20,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   # catgirl's configure script uses pkg-config --variable exec_prefix openssl
   # to discover the install location of the openssl(1) utility. exec_prefix
-  # is the "out" output of libressl in our case (where the libraries are
+  # is the "out" output of openssl in our case (where the libraries are
   # installed), so we need to fix this up.
   postConfigure = ''
-    substituteInPlace config.mk --replace \
+    substituteInPlace config.mk --replace-fail \
       "$($PKG_CONFIG --variable exec_prefix openssl)" \
-      "${lib.getBin libressl}"
+      "${lib.getBin openssl}"
   '';
 
   nativeBuildInputs = [
@@ -32,7 +33,8 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
   buildInputs = [
-    libressl
+    libretls
+    openssl
     ncurses
   ];
   strictDeps = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
replaces libressl with the libretls wrapper around openssl, since catgirl cannot find the system ca store when using latest libressl:
```    
catgirl: tls_connect: failed to open CA file 'etc/ssl/cert.pem': No such file or directory
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
