### PR TITLE
hiera-eyaml: 3.0.0 -> 4.3.0

### DIFF
--- a/pkgs/by-name/hi/hiera-eyaml/Gemfile.lock
+++ b/pkgs/by-name/hi/hiera-eyaml/Gemfile.lock
@@ -1,11 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    hiera-eyaml (3.0.0)
-      highline (~> 1.6.19)
-      optimist
-    highline (1.6.21)
-    optimist (3.0.0)
+    hiera-eyaml (4.3.0)
+      highline (>= 2.1, < 4)
+      optimist (~> 3.1)
+    highline (3.1.2)
+      reline
+    io-console (0.8.1)
+    optimist (3.2.1)
+    reline (0.6.2)
+      io-console (~> 0.5)
 
 PLATFORMS
   ruby
@@ -14,4 +18,4 @@ DEPENDENCIES
   hiera-eyaml
 
 BUNDLED WITH
-   2.1.4
+   2.6.9

--- a/pkgs/by-name/hi/hiera-eyaml/gemset.nix
+++ b/pkgs/by-name/hi/hiera-eyaml/gemset.nix
@@ -8,27 +8,51 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "049rxnwyivqgyjl0sjg7cb2q44ic0wsml288caspd1ps8v31gl18";
+      sha256 = "02mb113yjzwb6jkckybzsiq803c688r9xpv4w1nxbckhkpma5sqr";
       type = "gem";
     };
-    version = "3.0.0";
+    version = "4.3.0";
   };
   highline = {
+    dependencies = [ "reline" ];
+    groups = [ "default" ];
+    platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "06bml1fjsnrhd956wqq5k3w8cyd09rv1vixdpa3zzkl6xs72jdn1";
+      sha256 = "0jmvyhjp2v3iq47la7w6psrxbprnbnmzz0hxxski3vzn356x7jv7";
       type = "gem";
     };
-    version = "1.6.21";
+    version = "3.1.2";
+  };
+  io-console = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1jszj95hazqqpnrjjzr326nn1j32xmsc9xvd97mbcrrgdc54858y";
+      type = "gem";
+    };
+    version = "0.8.1";
   };
   optimist = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "05jxrp3nbn5iilc1k7ir90mfnwc5abc9h78s5rpm3qafwqxvcj4j";
+      sha256 = "0kp3f8g7g7cbw5vfkmpdv71pphhpcxk3lpc892mj9apkd7ys1y4c";
       type = "gem";
     };
-    version = "3.0.0";
+    version = "3.2.1";
+  };
+  reline = {
+    dependencies = [ "io-console" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0ii8l0q5zkang3lxqlsamzfz5ja7jc8ln905isfdawl802k2db8x";
+      type = "gem";
+    };
+    version = "0.6.2";
   };
 }

--- a/pkgs/by-name/hi/hiera-eyaml/package.nix
+++ b/pkgs/by-name/hi/hiera-eyaml/package.nix
@@ -14,7 +14,7 @@ bundlerEnv {
 
   meta = with lib; {
     description = "Per-value asymmetric encryption of sensitive data for Hiera";
-    homepage = "https://github.com/TomPoulton/hiera-eyaml";
+    homepage = "https://github.com/voxpupuli/hiera-eyaml";
     license = licenses.mit;
     maintainers = with maintainers; [
       benley


### PR DESCRIPTION
Change upstream's URL, otherwise the tooling does not detect new versions


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


```
$  result/bin/eyaml  version
Source locally installed gems is ignoring #<Bundler::StubSpecification name=rbs version=3.4.0 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=racc version=1.7.3 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=debug version=1.9.2 platform=ruby> because it is missing extensions
/nix/store/3z51pkls0v09y35qhclmwaqzq97rhxvn-ruby3.3-hiera-eyaml-4.3.0/lib/ruby/gems/3.3.0/gems/hiera-eyaml-4.3.0/lib/hiera/backend/eyaml/CLI.rb:7: warning: base64 was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add base64 to your Gemfile or gemspec to silence this warning.
[hiera-eyaml-core] hiera-eyaml (core): 4.3.0
```

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
