### PR TITLE
remarkable-mouse: 7.1.1 -> unstable-2024-02-23

### DIFF
--- a/pkgs/applications/misc/remarkable/remarkable-mouse/default.nix
+++ b/pkgs/applications/misc/remarkable/remarkable-mouse/default.nix
@@ -1,22 +1,28 @@
 {
   lib,
   buildPythonApplication,
-  fetchPypi,
+  fetchFromGitHub,
   libevdev,
   paramiko,
   pynput,
+  setuptools,
   screeninfo,
+  tkinter,
 }:
 
-buildPythonApplication rec {
+buildPythonApplication {
   pname = "remarkable-mouse";
-  version = "7.1.1";
-  format = "setuptools";
+  version = "unstable-2024-02-23";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-82P9tE3jiUlKBGZCiWDoL+9VJ06Bc+If+aMfcEEU90U=";
+  src = fetchFromGitHub {
+    owner = "Evidlo";
+    repo = "remarkable_mouse";
+    rev = "05142ef37a8b3f9e350156a14c2dec6844ed0ea8";
+    hash = "sha256-0X/7SIfSnlEL98fxJBAYrHAkRmdtymqA7xBmVoa5VIw=";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [
     screeninfo

--- a/pkgs/applications/misc/remarkable/remarkable-mouse/default.nix
+++ b/pkgs/applications/misc/remarkable/remarkable-mouse/default.nix
@@ -23,6 +23,7 @@ buildPythonApplication rec {
     paramiko
     pynput
     libevdev
+    tkinter
   ];
 
   # no tests


### PR DESCRIPTION
Updates the `remarkable-mouse` to a more recent version, while also adding a missing dependency (for the `--region` feature to work).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
