### PR TITLE
home-assistant: 2025.8.0 -> 2025.8.1

### DIFF
--- a/pkgs/development/python-modules/airos/default.nix
+++ b/pkgs/development/python-modules/airos/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "airos";
-  version = "0.2.4";
+  version = "0.2.7";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "CoMPaTech";
     repo = "python-airos";
     tag = "v${version}";
-    hash = "sha256-zY0XPucCXiJDo9C4GiDqs/lxQDTphs/mBXBqSYPvkoI=";
+    hash = "sha256-c/YVjNEy1nI6ClYk8BgLai+zRCwiblTFSJ5Rxx3UaeU=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/hass-nabucasa/default.nix
+++ b/pkgs/development/python-modules/hass-nabucasa/default.nix
@@ -26,7 +26,7 @@
 
 buildPythonPackage rec {
   pname = "hass-nabucasa";
-  version = "0.111.1";
+  version = "0.111.2";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     owner = "nabucasa";
     repo = "hass-nabucasa";
     tag = version;
-    hash = "sha256-WmsLn/pHI3KJSmX5U20eNUEs0Q1upuwkkzcHIYPNYjY=";
+    hash = "sha256-64DdjyzeeYI9u8hYP7CwZvLhCcCzztti2DshvtYcxNQ=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/knx-frontend/default.nix
+++ b/pkgs/development/python-modules/knx-frontend/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "knx-frontend";
-  version = "2025.8.6.52906";
+  version = "2025.8.9.63154";
   pyproject = true;
 
   # TODO: source build, uses yarn.lock
   src = fetchPypi {
     pname = "knx_frontend";
     inherit version;
-    hash = "sha256-Wmiwj5PL68VH1j5xDhZJyAHBakoG+0SKzCJCcCntT18=";
+    hash = "sha256-Sphetc0ox0Oh70vNdkHorX0jpvC8bckm1TBKk2QSGPo=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/zha-quirks/default.nix
+++ b/pkgs/development/python-modules/zha-quirks/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "zha-quirks";
-  version = "0.0.142";
+  version = "0.0.143";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "zigpy";
     repo = "zha-device-handlers";
     tag = version;
-    hash = "sha256-D1FIkyVSa4j6p4PHkjCAU08zpZjjXPGWoL5lKlWUHuU=";
+    hash = "sha256-txU1KJzQitSR7Y+/18dLo82K0SkPrJ4iQRBX9C4hgGU=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/zha/default.nix
+++ b/pkgs/development/python-modules/zha/default.nix
@@ -27,7 +27,7 @@
 
 buildPythonPackage rec {
   pname = "zha";
-  version = "0.0.66";
+  version = "0.0.68";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     owner = "zigpy";
     repo = "zha";
     tag = version;
-    hash = "sha256-74rJ2bdscbGkaLuHMQr8sNxL1wNN72UrlpH4zIkSprY=";
+    hash = "sha256-NgUUzNfC1XngU5RBfbKpt/o8hu7XRXOUaDUb7OjSJJc=";
   };
 
   postPatch = ''

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2025.8.0";
+  version = "2025.8.1";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -330,7 +330,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2025.8.0";
+  hassVersion = "2025.8.1";
 
 in
 python.pkgs.buildPythonApplication rec {
@@ -351,13 +351,13 @@ python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-o8NZ06GorRmICeu8GQzomkCuE2aALnodT5UuiJ4EOEc=";
+    hash = "sha256-o1j1ejSMa6T18nNxrmvNcOSWAMbi8b11wgHKO+w5gHA=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-U06ttXEWe46h8O2wurYyaCN78EdSCvOs10VbnyOQdsM=";
+    hash = "sha256-6LyI3t/+wKIVIcVwCny9AIYEaONiwc4GFmbwqjv/9r8=";
   };
 
   build-system = with python.pkgs; [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -269,6 +269,17 @@ let
         doCheck = false;
       });
 
+      python-roborock = super.python-roborock.overridePythonAttrs rec {
+        version = "2.18.2";
+
+        src = fetchFromGitHub {
+          owner = "Python-roborock";
+          repo = "python-roborock";
+          tag = "v${version}";
+          hash = "sha256-7xcw1jNCDapHjH1YVB5NW7jxMyb8Raf8HuTnWf2vdFo=";
+        };
+      };
+
       python-telegram-bot = super.python-telegram-bot.overridePythonAttrs (oldAttrs: rec {
         version = "21.5";
 

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -8,7 +8,7 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20250806.0";
+  version = "20250811.0";
   format = "wheel";
 
   src = fetchPypi {
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    hash = "sha256-krx62/hxF9MAFOQygZGAgcwbTuYKXTPcRpfmrHfKzEQ=";
+    hash = "sha256-x//iMjNup4bf3PpvISYkHxOXKH20J2s+6oWQ22gS4BI=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.269";
+  version = "0.13.270";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     rev = "refs/tags/${version}";
-    hash = "sha256-5GKUfFxAs3plr5C9F6BQ5J+DU8J77lgyAQrj6xmuSHo=";
+    hash = "sha256-SDeQuzBZ1Fd97qotyWL6oB2CTB+qfplMN6yOaJguRmI=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2025.8.0";
+  version = "2025.8.1";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-YPWAeAqR6s2jMdN85S+7PZdr6epuCqPfzr7DdmpqsiE=";
+    hash = "sha256-EmZ79AmJpfdsI/VHasRC8OzUEsX0nv8zZfEEum1jneI=";
   };
 
   build-system = [

--- a/pkgs/servers/home-assistant/update-component-packages.py
+++ b/pkgs/servers/home-assistant/update-component-packages.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i python3 -p "python3.withPackages (ps: with ps; [ packaging rich ])" -p pyright ruff isort
+#! nix-shell -i python3 -p "python3.withPackages (ps: with ps; [ packaging rich ])" -p pyright ruff isort nixfmt
 #
 # This script downloads Home Assistant's source tarball.
 # Inside the homeassistant/components directory, each integration has an associated manifest.json,


### PR DESCRIPTION
    https://github.com/home-assistant/core/releases/tag/2025.8.1
    https://github.com/zigpy/zha/releases/tag/0.0.68
    https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.143
    https://github.com/XKNX/knx-frontend/releases/tag/2025.8.9.63154
    https://github.com/NabuCasa/hass-nabucasa/releases/tag/0.111.2
    https://github.com/CoMPaTech/python-airos/releases/tag/v0.2.7

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
