### PR TITLE
linux-pam: fix platform checks for audit/logind

### DIFF
--- a/pkgs/by-name/li/linux-pam/package.nix
+++ b/pkgs/by-name/li/linux-pam/package.nix
@@ -114,5 +114,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Pluggable Authentication Modules, a flexible mechanism for authenticating user";
     platforms = lib.platforms.linux;
     license = lib.licenses.bsd3;
+    badPlatforms = [ lib.systems.inspect.platformPatterns.isStatic ];
   };
 })

--- a/pkgs/by-name/li/linux-pam/package.nix
+++ b/pkgs/by-name/li/linux-pam/package.nix
@@ -20,6 +20,8 @@
   findXMLCatalogs,
   docbook_xsl_ns,
   nix-update-script,
+  withLogind ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
+  withAudit ? lib.meta.availableOn stdenv.hostPlatform audit,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -66,8 +68,10 @@ stdenv.mkDerivation (finalAttrs: {
     db4
     libxcrypt
   ]
-  ++ lib.optionals stdenv.buildPlatform.isLinux [
+  ++ lib.optionals withAudit [
     audit
+  ]
+  ++ lib.optionals withLogind [
     systemdLibs
   ];
 
@@ -75,8 +79,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonAutoFeatures = "auto";
   mesonFlags = [
-    (lib.mesonEnable "logind" stdenv.buildPlatform.isLinux)
-    (lib.mesonEnable "audit" stdenv.buildPlatform.isLinux)
+    (lib.mesonEnable "logind" withLogind)
+    (lib.mesonEnable "audit" withAudit)
     (lib.mesonEnable "pam_lastlog" (!stdenv.hostPlatform.isMusl)) # TODO: switch to pam_lastlog2, pam_lastlog is deprecated and broken on musl
     (lib.mesonEnable "pam_unix" true)
     # (lib.mesonBool "pam-debug" true) # warning: slower execution due to debug makes VM tests fail!

--- a/pkgs/by-name/sh/shadow/package.nix
+++ b/pkgs/by-name/sh/shadow/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libxcrypt
   ]
-  ++ lib.optional (pam != null && stdenv.hostPlatform.isLinux) pam
+  ++ lib.optional (pam != null && (lib.meta.availableOn stdenv.hostPlatform pam)) pam
   ++ lib.optional withLibbsd libbsd
   ++ lib.optional withTcb tcb;
 

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -17,7 +17,7 @@
   cryptsetup,
   ncursesSupport ? true,
   ncurses,
-  pamSupport ? true,
+  pamSupport ? lib.meta.availableOn stdenv.hostPlatform pam,
   pam,
   systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
   systemd,
@@ -28,8 +28,8 @@
   installShellFiles,
   writeSupport ? stdenv.hostPlatform.isLinux,
   shadowSupport ? stdenv.hostPlatform.isLinux,
-  # Doesn't build on Darwin, also doesn't really make sense on Darwin
-  withLastlog ? !stdenv.hostPlatform.isDarwin,
+  # Doesn't build on Darwin, only makes sense on systems which have pam
+  withLastlog ? !stdenv.hostPlatform.isDarwin && lib.meta.availableOn stdenv.hostPlatform pam,
   gitUpdater,
   nixosTests,
 }:


### PR DESCRIPTION
doesn't fix static build of pam, but fixes broken availability check.

pam on static doesn't make sense: not much pluggability if there is no `dlopen`. So, ideally, it should be conditional on non-static host platform.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
