### PR TITLE
esptool: 4.9.0 -> 5.0.2

### DIFF
--- a/pkgs/by-name/es/esptool/package.nix
+++ b/pkgs/by-name/es/esptool/package.nix
@@ -7,14 +7,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "esptool";
-  version = "4.9.0";
+  version = "5.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "espressif";
     repo = "esptool";
     tag = "v${version}";
-    hash = "sha256-iIFjInqiqjeqiDYL7BU3vT99pCVnu8OhU7u9uKwe/SI=";
+    hash = "sha256-oRvtEBp88tmgjjIuoQS5ySm4I0aD/Zs8VLRUZo0sh/I=";
   };
 
   postPatch = ''
@@ -29,14 +29,14 @@ python3Packages.buildPythonApplication rec {
   ];
 
   dependencies = with python3Packages; [
-    argcomplete
     bitstring
+    click
     cryptography
-    ecdsa
     intelhex
     pyserial
-    reedsolo
     pyyaml
+    reedsolo
+    rich-click
   ];
 
   optional-dependencies = with python3Packages; {
@@ -48,39 +48,39 @@ python3Packages.buildPythonApplication rec {
     [
       pyelftools
       pytestCheckHook
+      requests
       softhsm
     ]
     ++ lib.flatten (lib.attrValues optional-dependencies);
 
-  # tests mentioned in `.github/workflows/test_esptool.yml`
-  checkPhase = ''
-    runHook preCheck
+  preCheck = ''
+    export PATH="$out/bin:$PATH"
+  '';
 
+  pytestFlags = [
+    "-m"
+    "host_test"
+  ];
+
+  postCheck = ''
     export SOFTHSM2_CONF=$(mktemp)
     echo "directories.tokendir = $(mktemp -d)" > "$SOFTHSM2_CONF"
     ./ci/setup_softhsm2.sh
 
-    pytest test/test_imagegen.py
-    pytest test/test_espsecure.py
     pytest test/test_espsecure_hsm.py
-    pytest test/test_merge_bin.py
-    pytest test/test_image_info.py
-    pytest test/test_modules.py
-
-    runHook postCheck
   '';
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/espressif/esptool/blob/${src.tag}/CHANGELOG.md";
     description = "ESP8266 and ESP32 serial bootloader utility";
     homepage = "https://github.com/espressif/esptool";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
       dezgeg
       dotlambda
     ];
     teams = [ lib.teams.lumiguide ];
-    platforms = with platforms; linux ++ darwin;
-    mainProgram = "esptool.py";
+    platforms = with lib.platforms; linux ++ darwin;
+    mainProgram = "esptool";
   };
 }


### PR DESCRIPTION
Diff: https://github.com/espressif/esptool/compare/refs/tags/v4.9.0...refs/tags/v5.0.2

Changelog: https://github.com/espressif/esptool/blob/v5.0.2/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
