### PR TITLE
emacsPackages.eaf-browser: init at 0-unstable-2025-06-14

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -15,6 +15,10 @@ lib.packagesFromDirectoryRecursive {
     inherit (pkgs) codeium;
   };
 
+  eaf-browser = callPackage ./manual-packages/eaf-browser {
+    inherit (pkgs) aria2;
+  };
+
   elpaca = callPackage ./manual-packages/elpaca { inherit (pkgs) git; };
 
   emacs-application-framework = callPackage ./manual-packages/emacs-application-framework {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-browser/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-browser/default.nix
@@ -1,0 +1,71 @@
+{
+  # Basic
+  lib,
+  melpaBuild,
+  fetchFromGitHub,
+  # Dependencies
+  aria2,
+  # Java Script dependency
+  nodejs,
+  fetchNpmDeps,
+  npmHooks,
+  # Updater
+  nix-update-script,
+}:
+
+melpaBuild (finalAttrs: {
+
+  pname = "eaf-browser";
+  version = "0-unstable-2025-06-14";
+
+  src = fetchFromGitHub {
+    owner = "emacs-eaf";
+    repo = "eaf-browser";
+    rev = "120967319132f361a2b27f89ee54d1984aa23eaf";
+    hash = "sha256-DsPrctB1bSGBPQLI2LsnSUtqnzWpZRrWrVZM8lS9fms=";
+  };
+
+  env.npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-npm-deps";
+    inherit (finalAttrs) src;
+    hash = "sha256-UfQL7rN47nI1FyhgBlzH4QtyVCn0wGV3Rv5Y+aidRNE=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    npmHooks.npmConfigHook
+  ];
+
+  files = ''
+    ("*.el"
+     "*.py"
+     "easylist.txt"
+     "aria2-ng")
+  '';
+
+  postInstall = ''
+    LISPDIR=$out/share/emacs/site-lisp/elpa/${finalAttrs.ename}-${finalAttrs.melpaVersion}
+    cp -r node_modules $LISPDIR/
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+    eafPythonDeps =
+      ps: with ps; [
+        pysocks
+      ];
+    eafOtherDeps = [
+      aria2
+    ];
+  };
+
+  meta = {
+    description = "Modern browser in Emacs";
+    homepage = "https://github.com/emacs-eaf/eaf-browser";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      thattemperature
+    ];
+  };
+
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This EAF application is a bit more complex since it has npm/nodejs dependencies.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
