### PR TITLE
kcc: 8.0.4 -> 9.0.0

### DIFF
--- a/pkgs/by-name/kc/kcc/package.nix
+++ b/pkgs/by-name/kc/kcc/package.nix
@@ -46,13 +46,12 @@ python3.pkgs.buildPythonApplication rec {
   # Note: python scripts wouldn't get wrapped anyway, but let's be explicit about it
   dontWrapQtApps = true;
 
-  makeWrapperArgs =
-    [
-      "\${qtWrapperArgs[@]}"
-    ]
-    ++ lib.optionals archiveSupport [
-      ''--prefix PATH : ${lib.makeBinPath [ p7zip ]}''
-    ];
+  makeWrapperArgs = [
+    "\${qtWrapperArgs[@]}"
+  ]
+  ++ lib.optionals archiveSupport [
+    ''--prefix PATH : ${lib.makeBinPath [ p7zip ]}''
+  ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgram = "${placeholder "out"}/bin/kcc-c2e";

--- a/pkgs/by-name/kc/kcc/package.nix
+++ b/pkgs/by-name/kc/kcc/package.nix
@@ -13,14 +13,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "kcc";
-  version = "8.0.4";
+  version = "9.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ciromattia";
     repo = "kcc";
     tag = "v${version}";
-    hash = "sha256-8rnuSGlfwH5AVp8GQn3RTtiTYFdTNp7Wqq+ATibpkNA=";
+    hash = "sha256-J4nuVY5eOmHziteLvoBf/+CAY0X/7wBbRtPoIgdd5MA=";
   };
 
   nativeBuildInputs = [ qt6.wrapQtAppsHook ];
@@ -31,6 +31,7 @@ python3.pkgs.buildPythonApplication rec {
 
   dependencies = with python3.pkgs; [
     packaging # undeclared dependency
+    pymupdf
     pyside6
     pillow
     psutil


### PR DESCRIPTION
Supersedes #429072

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
