### PR TITLE
python313Packages.dramatiq: disable failing test, python313Packages.prometheus-flask-exporter: 0.22.4 -> 0.23.2

### DIFF
--- a/pkgs/development/python-modules/dramatiq/default.nix
+++ b/pkgs/development/python-modules/dramatiq/default.nix
@@ -89,6 +89,9 @@ buildPythonPackage rec {
     "test_rabbitmq_process_100k_messages_with_cli"
     "test_rabbitmq_process_10k_fib_with_cli"
     "test_rabbitmq_process_1k_latency_with_cli"
+    # AssertionError
+    "test_cli_scrubs_stale_pid_files"
+    "test_message_contains_requeue_time_after_retry"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Takes too long for darwin ofborg

--- a/pkgs/development/python-modules/flask-dramatiq/default.nix
+++ b/pkgs/development/python-modules/flask-dramatiq/default.nix
@@ -1,27 +1,25 @@
 {
   lib,
   buildPythonPackage,
-  pythonOlder,
-  fetchFromGitLab,
-  poetry-core,
   dramatiq,
-  flask,
-  requests,
-  pytestCheckHook,
-  pytest-cov-stub,
+  fetchFromGitLab,
   flask-migrate,
+  flask,
   periodiq,
+  poetry-core,
   postgresql,
   postgresqlTestHook,
   psycopg2,
+  pytest-cov-stub,
+  pytest-mock,
+  pytestCheckHook,
+  requests,
 }:
 
 buildPythonPackage {
   pname = "flask-dramatiq";
   version = "0.6.0";
-  format = "pyproject";
-
-  disabled = pythonOlder "3.6";
+  pyproject = true;
 
   src = fetchFromGitLab {
     owner = "bersace";
@@ -38,20 +36,21 @@ buildPythonPackage {
     patchShebangs --build ./example.py
   '';
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ poetry-core ];
 
-  propagatedBuildInputs = [ dramatiq ];
+  dependencies = [ dramatiq ];
 
   nativeCheckInputs = [
-    pytestCheckHook
-    pytest-cov-stub
     flask
-    requests
     flask-migrate
     periodiq
     postgresql
     postgresqlTestHook
     psycopg2
+    pytest-cov-stub
+    pytest-mock
+    pytestCheckHook
+    requests
   ]
   ++ dramatiq.optional-dependencies.rabbitmq;
 
@@ -62,22 +61,12 @@ buildPythonPackage {
     python3 ./example.py db upgrade
   '';
 
-  pytestFlags = [
-    "-x"
-  ];
-
-  disabledTestPaths = [
-    "tests/func/"
-    "tests/unit"
-  ];
-
-  pythonImportsCheck = [ "flask_dramatiq" ];
-
-  # Does HTTP requests to localhost
   disabledTests = [
     "test_fast"
     "test_other"
   ];
+
+  pythonImportsCheck = [ "flask_dramatiq" ];
 
   meta = with lib; {
     description = "Adds Dramatiq support to your Flask application";

--- a/pkgs/development/python-modules/prometheus-flask-exporter/default.nix
+++ b/pkgs/development/python-modules/prometheus-flask-exporter/default.nix
@@ -5,27 +5,36 @@
   flask,
   prometheus-client,
   pytestCheckHook,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "prometheus-flask-exporter";
-  version = "0.22.4";
-  format = "setuptools";
+  version = "0.23.2";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rycus86";
     repo = "prometheus_flask_exporter";
-    rev = version;
-    hash = "sha256-GAQ80J7at8Apqu+DUMN3+rLi/lrNv5Y7w/DKpUN2iu8=";
+    tag = version;
+    hash = "sha256-fWCIthtBiPJwn/Mbbwdv2+1cr9nlpUsPE2mDkaSsfpM=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     flask
     prometheus-client
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
+
   enabledTestPaths = [ "tests/" ];
+
+  disabledTests = [
+    # AssertionError
+    "test_group_by_lambda_is_not_supported"
+  ];
 
   meta = with lib; {
     description = "Prometheus exporter for Flask applications";


### PR DESCRIPTION
https://hydra.nixos.org/build/303670326

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
