### PR TITLE
vital: add desktop entry, set license to unfree

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14673,6 +14673,12 @@
     githubId = 542154;
     name = "Lorenz Leutgeb";
   };
+  lortane = {
+    email = "lortane@pm.me";
+    github = "lortane";
+    githubId = 61233304;
+    name = "Lorenzo Ortiz";
+  };
   loskutov = {
     email = "ignat.loskutov@gmail.com";
     github = "loskutov";

--- a/pkgs/by-name/vi/vital/package.nix
+++ b/pkgs/by-name/vi/vital/package.nix
@@ -2,8 +2,11 @@
   lib,
   stdenv,
   fetchzip,
+  fetchurl,
   autoPatchelfHook,
   makeBinaryWrapper,
+  copyDesktopItems,
+  makeDesktopItem,
 
   alsa-lib,
   libjack2,
@@ -14,6 +17,12 @@
   zenity,
 }:
 
+let
+  iconPng = fetchurl {
+    url = "https://vital.audio/images/vital_full_no_background.png";
+    sha256 = "sha256-Qvt1v+9DVfrTFSZvi/zRf8iXZsej6Sq7KZhOjOYKpvo=";
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "vital";
   version = "1.5.5";
@@ -28,6 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     autoPatchelfHook
     makeBinaryWrapper
+    copyDesktopItems
   ];
 
   buildInputs = [
@@ -65,19 +75,38 @@ stdenv.mkDerivation (finalAttrs: {
         ]
       }"
 
+    ln -s $out/bin/Vital $out/bin/vital
+
+    install -D ${iconPng} $out/share/icons/hicolor/256x256/apps/vital.png
+
     runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      exec = finalAttrs.meta.mainProgram;
+      name = "vital";
+      icon = "vital";
+      comment = finalAttrs.meta.description;
+      desktopName = "Vital";
+      categories = [
+        "AudioVideo"
+        "Audio"
+        "Music"
+      ];
+    })
+  ];
 
   meta = with lib; {
     description = "Spectral warping wavetable synth";
     homepage = "https://vital.audio/";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    license = with licenses; [
-      unfree
-      gpl3Plus
-    ];
+    license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ PowerUser64 ];
+    maintainers = with maintainers; [
+      PowerUser64
+      lortane
+    ];
     mainProgram = "Vital";
   };
 })


### PR DESCRIPTION
- Install .desktop via copyDesktopItems with Categories=AudioVideo;Audio;Music;.
- Install 256x256 icon.
- Set meta.license = unfree (per upstream EULA: https://vital.audio/eula/).
- Add maintainer lortane.
- Built locally on x86_64-linux; nixpkgs-review -p vital passed.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Ran `nixpkgs-review` on this PR → 1 package built (`vital`), no regressions.
  - [x] Manual run of binary (`Vital 1.5.5` works).
  - [x] `.desktop` file passes `desktop-file-validate`.
  - [x] Icon installed in `$out/share/icons/hicolor/256x256/apps/vital.png`.
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
