### PR TITLE
ocamlPackages.ppxlib: 0.33.0 → 0.36.0

### DIFF
--- a/pkgs/development/compilers/reason/default.nix
+++ b/pkgs/development/compilers/reason/default.nix
@@ -14,15 +14,30 @@
   dune-build-info,
 }:
 
+let
+  param =
+    if lib.versionAtLeast ppxlib.version "0.36" then
+      {
+        version = "3.16.0";
+        hash = "sha256-R7DkOn00jiqFBlirS+xaT7u5/U/z7IocGBZRFVjFNk4=";
+      }
+    else
+      {
+        version = "3.15.0";
+
+        hash = "sha256-7D0gJfQ5Hw0riNIFPmJ6haoa3dnFEyDp5yxpDgX7ZqY=";
+      };
+in
+
 buildDunePackage rec {
   pname = "reason";
-  version = "3.15.0";
+  inherit (param) version;
 
   minimalOCamlVersion = "4.11";
 
   src = fetchurl {
     url = "https://github.com/reasonml/reason/releases/download/${version}/reason-${version}.tbz";
-    hash = "sha256-7D0gJfQ5Hw0riNIFPmJ6haoa3dnFEyDp5yxpDgX7ZqY=";
+    inherit (param) hash;
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/ocaml-modules/bisect_ppx/default.nix
+++ b/pkgs/development/ocaml-modules/bisect_ppx/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch,
   buildDunePackage,
   cmdliner,
   ppxlib,
@@ -16,6 +17,12 @@ buildDunePackage rec {
     rev = version;
     hash = "sha256-3qXobZLPivFDtls/3WNqDuAgWgO+tslJV47kjQPoi6o=";
   };
+
+  # Ensure compatibility with ppxlib 0.36
+  patches = lib.optional (lib.versionAtLeast ppxlib.version "0.36") (fetchpatch {
+    url = "https://github.com/aantron/bisect_ppx/commit/f35fdf4bdcb82c308d70f7c9c313a77777f54bdf.patch";
+    hash = "sha256-hQMDU6zrHDV9JszGAj2p4bd9zlqqjc1TLU+cfMEgz9c=";
+  });
 
   minimalOCamlVersion = "4.11";
 

--- a/pkgs/development/ocaml-modules/bistro/default.nix
+++ b/pkgs/development/ocaml-modules/bistro/default.nix
@@ -13,6 +13,7 @@
   rresult,
   sexplib,
   tyxml,
+  ppxlib,
 }:
 
 buildDunePackage rec {
@@ -47,5 +48,6 @@ buildDunePackage rec {
     description = "Build and execute typed scientific workflows";
     maintainers = [ lib.maintainers.vbgl ];
     license = lib.licenses.gpl2;
+    meta.broken = lib.versionAtLeast ppxlib.version "0.36";
   };
 }

--- a/pkgs/development/ocaml-modules/bitstring/ppx.nix
+++ b/pkgs/development/ocaml-modules/bitstring/ppx.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildDunePackage,
+  fetchpatch,
   ocaml,
   bitstring,
   ppxlib,
@@ -15,7 +16,10 @@ else
     pname = "ppx_bitstring";
     inherit (bitstring) version src;
 
-    duneVersion = "3";
+    patches = lib.optional (lib.versionAtLeast ppxlib.version "0.36") (fetchpatch {
+      url = "https://github.com/xguerin/bitstring/commit/b42d4924cbb5ec5fd5309e6807852b63f456f35d.patch";
+      hash = "sha256-wtpSnGOzIUTmB3LhyHGopecy7F/5SYFOwaR6eReV+6g=";
+    });
 
     buildInputs = [
       bitstring

--- a/pkgs/development/ocaml-modules/config/default.nix
+++ b/pkgs/development/ocaml-modules/config/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildDunePackage,
   fetchurl,
+  fetchpatch,
   ppxlib,
   spices,
 }:
@@ -14,6 +15,12 @@ buildDunePackage rec {
     url = "https://github.com/ocaml-sys/config.ml/releases/download/${version}/config-${version}.tbz";
     hash = "sha256-bcRCfLX2ro8vnQTJiX2aYGJC+eD26vkPynMYg817YFM=";
   };
+
+  # Compatibility with ppxlib 0.36
+  patches = lib.optional (lib.versionAtLeast ppxlib.version "0.36") (fetchpatch {
+    url = "https://github.com/ocaml-sys/config.ml/commit/89222d8088cc3c530eb0094d7ff8ec8a67da07d1.patch";
+    hash = "sha256-/jNsUXoUrfza5BCpEo7XtEjKwQX3ofEq99v0+UBh7ss=";
+  });
 
   propagatedBuildInputs = [
     ppxlib

--- a/pkgs/development/ocaml-modules/dream-html/default.nix
+++ b/pkgs/development/ocaml-modules/dream-html/default.nix
@@ -23,5 +23,6 @@ buildDunePackage {
     description = "Write HTML directly in your OCaml source files with editor support";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.naora ];
+    broken = lib.versionAtLeast ppxlib.version "0.36";
   };
 }

--- a/pkgs/development/ocaml-modules/elpi/default.nix
+++ b/pkgs/development/ocaml-modules/elpi/default.nix
@@ -11,9 +11,7 @@
   re,
   perl,
   ncurses,
-  ppxlib,
   ppx_deriving,
-  ppxlib_0_15,
   ppx_deriving_0_15,
   coqPackages,
   version ?
@@ -88,12 +86,10 @@ buildDunePackage {
   ++ (
     if lib.versionAtLeast version "1.13" || version == "dev" then
       [
-        ppxlib
         ppx_deriving
       ]
     else
       [
-        ppxlib_0_15
         ppx_deriving_0_15
       ]
   );

--- a/pkgs/development/ocaml-modules/gen_js_api/default.nix
+++ b/pkgs/development/ocaml-modules/gen_js_api/default.nix
@@ -30,7 +30,7 @@ buildDunePackage rec {
     js_of_ocaml-compiler
     nodejs
   ];
-  doCheck = lib.versionAtLeast ocaml.version "4.13";
+  doCheck = lib.versionAtLeast ocaml.version "4.13" && !(lib.versionAtLeast ppxlib.version "0.36");
 
   meta = {
     homepage = "https://github.com/LexiFi/gen_js_api";

--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -133,6 +133,7 @@ with self;
       js_of_ocaml
       uri-sexp
     ];
+    meta.broken = lib.versionAtLeast ppxlib.version "0.36";
   };
 
   async_kernel = janePackage {
@@ -297,18 +298,31 @@ with self;
     ];
   };
 
-  base_quickcheck = janePackage {
-    pname = "base_quickcheck";
-    hash = "sha256-jDxO+/9Qnntt6ZNX1xvaWvoJ0JpnPqeq8X8nsYpeqsY=";
-    meta.description = "Randomized testing framework, designed for compatibility with Base";
-    propagatedBuildInputs = [
-      ppx_base
-      ppx_fields_conv
-      ppx_let
-      ppx_sexp_value
-      splittable_random
-    ];
-  };
+  base_quickcheck = janePackage (
+    {
+      pname = "base_quickcheck";
+      meta.description = "Randomized testing framework, designed for compatibility with Base";
+      propagatedBuildInputs = [
+        ppx_base
+        ppx_fields_conv
+        ppx_let
+        ppx_sexp_value
+        splittable_random
+      ];
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.1";
+          hash = "sha256-0s40sGu2FvaUjvC5JSvHlRhbyQV1bVPrVTTWdHtTQ+k=";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-jDxO+/9Qnntt6ZNX1xvaWvoJ0JpnPqeq8X8nsYpeqsY=";
+        }
+    )
+  );
 
   bidirectional_map = janePackage {
     pname = "bidirectional_map";
@@ -818,6 +832,7 @@ with self;
       js_of_ocaml-ppx
     ];
     patches = [ ./js_of_ocaml_patches.patch ];
+    meta.broken = lib.versionAtLeast ppxlib.version "0.36";
   };
 
   jsonaf = janePackage {
@@ -1083,23 +1098,49 @@ with self;
     ];
   };
 
-  ppx_bench = janePackage {
-    pname = "ppx_bench";
-    hash = "sha256-y4nL/wwjJUL2Fa7Ne0f7SR5flCjT1ra9M1uBHOUZWCg=";
-    meta.description = "Syntax extension for writing in-line benchmarks in ocaml code";
-    propagatedBuildInputs = [ ppx_inline_test ];
-  };
+  ppx_bench = janePackage (
+    {
+      pname = "ppx_bench";
+      meta.description = "Syntax extension for writing in-line benchmarks in ocaml code";
+      propagatedBuildInputs = [ ppx_inline_test ];
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.1";
+          hash = "sha256-nHqZSyJ5mZ86SGu9WtoVNfYTnd5kslyI8Zm/LJ7b/Fo=";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-y4nL/wwjJUL2Fa7Ne0f7SR5flCjT1ra9M1uBHOUZWCg=";
+        }
+    )
+  );
 
-  ppx_bin_prot = janePackage {
-    pname = "ppx_bin_prot";
-    hash = "sha256-nQps/+Csx3+6H6KBzIm/dLCGWJ9fcRD7JxB4P2lky0o=";
-    meta.description = "Generation of bin_prot readers and writers from types";
-    propagatedBuildInputs = [
-      bin_prot
-      ppx_here
-    ];
-    doCheck = false; # circular dependency with ppx_jane
-  };
+  ppx_bin_prot = janePackage (
+    {
+      pname = "ppx_bin_prot";
+      meta.description = "Generation of bin_prot readers and writers from types";
+      propagatedBuildInputs = [
+        bin_prot
+        ppx_here
+      ];
+      doCheck = false; # circular dependency with ppx_jane
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.1";
+          hash = "sha256-9TNtRwieITJMZs+7RT7tOf1GwVlxuGeKZktVon9B7g4=";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-nQps/+Csx3+6H6KBzIm/dLCGWJ9fcRD7JxB4P2lky0o=";
+        }
+    )
+  );
 
   ppx_cold = janePackage {
     pname = "ppx_cold";
@@ -1186,20 +1227,34 @@ with self;
       ppx_jane
       ppxlib
     ];
+    meta.broken = lib.versionAtLeast ppxlib.version "0.36";
   };
 
-  ppx_diff = janePackage {
-    pname = "ppx_diff";
-    hash = "sha256-MAn+vcU6vLR8g16Wq1sORyLcLgWxLsazMQY1syY6HsA=";
-    meta.description = "Generation of diffs and update functions for ocaml types";
-    propagatedBuildInputs = [
-      base
-      gel
-      ppx_compare
-      ppx_enumerate
-      ppx_jane
-    ];
-  };
+  ppx_diff = janePackage (
+    {
+      pname = "ppx_diff";
+      meta.description = "Generation of diffs and update functions for ocaml types";
+      propagatedBuildInputs = [
+        base
+        gel
+        ppx_compare
+        ppx_enumerate
+        ppx_jane
+      ];
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.1";
+          hash = "sha256-eWzlEIPjNcxhz2Q5+y7fv9mJDJzauOpJ993CXoy8nh4=";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-MAn+vcU6vLR8g16Wq1sORyLcLgWxLsazMQY1syY6HsA=";
+        }
+    )
+  );
 
   ppx_disable_unused_warnings = janePackage {
     pname = "ppx_disable_unused_warnings";
@@ -1230,18 +1285,30 @@ with self;
     ];
   };
 
-  ppx_expect = janePackage {
-    pname = "ppx_expect";
-    version = "0.17.2";
-    hash = "sha256-na9n/+shkiHIIUQ2ZitybQ6NNsSS9gWFNAFxij+JNVo=";
-    meta.description = "Cram like framework for OCaml";
-    propagatedBuildInputs = [
-      ppx_here
-      ppx_inline_test
-      re
-    ];
-    doCheck = false; # test build rules broken
-  };
+  ppx_expect = janePackage (
+    {
+      pname = "ppx_expect";
+      meta.description = "Cram like framework for OCaml";
+      propagatedBuildInputs = [
+        ppx_here
+        ppx_inline_test
+        re
+      ];
+      doCheck = false; # test build rules broken
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.3";
+          hash = "sha256-eYZ3p3FYjHd15pj79TKyHSHNKRSWj80iHJFxBZN40s4=";
+        }
+      else
+        {
+          version = "0.17.2";
+          hash = "sha256-na9n/+shkiHIIUQ2ZitybQ6NNsSS9gWFNAFxij+JNVo=";
+        }
+    )
+  );
 
   ppx_fields_conv = janePackage {
     pname = "ppx_fields_conv";
@@ -1260,16 +1327,29 @@ with self;
     propagatedBuildInputs = [ ppxlib ];
   };
 
-  ppx_globalize = janePackage {
-    pname = "ppx_globalize";
-    hash = "sha256-LKV5zfaf6AXn3NzOhN2ka8NtjItPTIsfmoJVBw5bYi8=";
-    meta.description = "PPX rewriter that generates functions to copy local values to the global heap";
-    propagatedBuildInputs = [
-      base
-      ppxlib
-      ppxlib_jane
-    ];
-  };
+  ppx_globalize = janePackage (
+    {
+      pname = "ppx_globalize";
+      meta.description = "PPX rewriter that generates functions to copy local values to the global heap";
+      propagatedBuildInputs = [
+        base
+        ppxlib
+        ppxlib_jane
+      ];
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.2";
+          hash = "sha256-5pHqyv94DXpSG69TEATcnJwFh5YurxVCM5ZPtrlbXSo=";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-LKV5zfaf6AXn3NzOhN2ka8NtjItPTIsfmoJVBw5bYi8=";
+        }
+    )
+  );
 
   ppx_hash = janePackage {
     pname = "ppx_hash";
@@ -1296,16 +1376,29 @@ with self;
     propagatedBuildInputs = [ ppxlib ];
   };
 
-  ppx_inline_test = janePackage {
-    pname = "ppx_inline_test";
-    hash = "sha256-pNdrmAlT3MUbuPUcMmCRcUIXv4fZ/o/IofJmnUKf8Cs=";
-    meta.description = "Syntax extension for writing in-line tests in ocaml code";
-    propagatedBuildInputs = [
-      ppxlib
-      time_now
-    ];
-    doCheck = false; # test build rules broken
-  };
+  ppx_inline_test = janePackage (
+    {
+      pname = "ppx_inline_test";
+      meta.description = "Syntax extension for writing in-line tests in ocaml code";
+      propagatedBuildInputs = [
+        ppxlib
+        time_now
+      ];
+      doCheck = false; # test build rules broken
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.1";
+          hash = "sha256-wNDDdNUeWTW87HRKbRSuOXaCPQnDWx7/RXuCDISc9Pg=";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-pNdrmAlT3MUbuPUcMmCRcUIXv4fZ/o/IofJmnUKf8Cs=";
+        }
+    )
+  );
 
   ppx_jane = janePackage {
     pname = "ppx_jane";
@@ -1342,6 +1435,7 @@ with self;
       ppx_jane
       ppxlib
     ];
+    meta.broken = lib.versionAtLeast ppxlib.version "0.36";
   };
 
   ppx_js_style = janePackage {
@@ -1352,17 +1446,31 @@ with self;
       octavius
       ppxlib
     ];
+    meta.broken = lib.versionAtLeast ppxlib.version "0.36";
   };
 
-  ppx_let = janePackage {
-    pname = "ppx_let";
-    hash = "sha256-JkNQgbPHVDH659m4Xy9ipcZ/iqGtj5q1qQn1P+O7TUY=";
-    meta.description = "Monadic let-bindings";
-    propagatedBuildInputs = [
-      ppxlib
-      ppx_here
-    ];
-  };
+  ppx_let = janePackage (
+    {
+      pname = "ppx_let";
+      meta.description = "Monadic let-bindings";
+      propagatedBuildInputs = [
+        ppxlib
+        ppx_here
+      ];
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.1";
+          hash = "sha256-41C60UcMpERZs2eAPprg63uPnmjj33n7cd5s5IFZBGE=";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-JkNQgbPHVDH659m4Xy9ipcZ/iqGtj5q1qQn1P+O7TUY=";
+        }
+    )
+  );
 
   ppx_log = janePackage {
     pname = "ppx_log";
@@ -1393,12 +1501,25 @@ with self;
     propagatedBuildInputs = [ time_now ];
   };
 
-  ppx_optcomp = janePackage {
-    pname = "ppx_optcomp";
-    hash = "sha256-H9oTzhJx9IGRkcwY2YEvcvNgeJ8ETNO95qKcjTXJBwk=";
-    meta.description = "Optional compilation for OCaml";
-    propagatedBuildInputs = [ ppxlib ];
-  };
+  ppx_optcomp = janePackage (
+    {
+      pname = "ppx_optcomp";
+      meta.description = "Optional compilation for OCaml";
+      propagatedBuildInputs = [ ppxlib ];
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.1";
+          hash = "sha256-mi9YM0WGkc4sI1GF2YGTFwmPdF+4s5Ou2l7i07ys9nw=";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-H9oTzhJx9IGRkcwY2YEvcvNgeJ8ETNO95qKcjTXJBwk=";
+        }
+    )
+  );
 
   ppx_optional = janePackage {
     pname = "ppx_optional";
@@ -1415,6 +1536,7 @@ with self;
     hash = "sha256-IVDvFU9ERB2YFJOgP/glYcO4KhEH5VdQ7wCCfreboqA=";
     meta.description = "PPX for writing fast incremental bind nodes in a pattern match";
     propagatedBuildInputs = [ ppx_let ];
+    meta.broken = lib.versionAtLeast ppxlib.version "0.36";
   };
 
   ppx_pipebang = janePackage {
@@ -1454,19 +1576,33 @@ with self;
       ppx_sexp_conv
       ppx_sexp_message
     ];
+    meta.broken = lib.versionAtLeast ppxlib.version "0.36";
   };
 
-  ppx_sexp_conv = janePackage {
-    pname = "ppx_sexp_conv";
-    hash = "sha256-hUi0I50SODK1MpL86xy8eM8yn8f4q1Hv4LP9zFnnr70=";
-    meta.description = "[@@deriving] plugin to generate S-expression conversion functions";
-    propagatedBuildInputs = [
-      ppxlib
-      ppxlib_jane
-      sexplib0
-      base
-    ];
-  };
+  ppx_sexp_conv = janePackage (
+    {
+      pname = "ppx_sexp_conv";
+      meta.description = "[@@deriving] plugin to generate S-expression conversion functions";
+      propagatedBuildInputs = [
+        ppxlib
+        ppxlib_jane
+        sexplib0
+        base
+      ];
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.1";
+          hash = "sha256-yQJluA/NSzCAID/ydBgRuc1sFHyjbXare9vxen6f1iw=";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-hUi0I50SODK1MpL86xy8eM8yn8f4q1Hv4LP9zFnnr70=";
+        }
+    )
+  );
 
   ppx_sexp_message = janePackage {
     pname = "ppx_sexp_message";
@@ -1488,12 +1624,25 @@ with self;
     ];
   };
 
-  ppx_stable = janePackage {
-    pname = "ppx_stable";
-    hash = "sha256-N5oPjjQcLgiO9liX8Z0vg0IbQXaGZ4BqOgwvuIKSKaA=";
-    meta.description = "Stable types conversions generator";
-    propagatedBuildInputs = [ ppxlib ];
-  };
+  ppx_stable = janePackage (
+    {
+      pname = "ppx_stable";
+      meta.description = "Stable types conversions generator";
+      propagatedBuildInputs = [ ppxlib ];
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.1";
+          hash = "sha256-iVAgRVSOdLzajuUT8Yz+YMiMeChIx5DT8lBf104QMuE=";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-N5oPjjQcLgiO9liX8Z0vg0IbQXaGZ4BqOgwvuIKSKaA=";
+        }
+    )
+  );
 
   ppx_stable_witness = janePackage {
     pname = "ppx_stable_witness";
@@ -1527,15 +1676,28 @@ with self;
     ];
   };
 
-  ppx_tydi = janePackage {
-    pname = "ppx_tydi";
-    hash = "sha256-PM89fP6Rb6M99HgEzQ7LfpW1W5adw6J/E1LFQJtdd0U=";
-    meta.description = "Let expressions, inferring pattern type from expression";
-    propagatedBuildInputs = [
-      base
-      ppxlib
-    ];
-  };
+  ppx_tydi = janePackage (
+    {
+      pname = "ppx_tydi";
+      meta.description = "Let expressions, inferring pattern type from expression";
+      propagatedBuildInputs = [
+        base
+        ppxlib
+      ];
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.1";
+          hash = "sha256-dkZwu4Ujj7GKb4qo76f/ef5dvGrYSkk9B3y+Rg72CAM=";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-PM89fP6Rb6M99HgEzQ7LfpW1W5adw6J/E1LFQJtdd0U=";
+        }
+    )
+  );
 
   ppx_typed_fields = janePackage {
     pname = "ppx_typed_fields";
@@ -1546,27 +1708,54 @@ with self;
       ppx_jane
       ppxlib
     ];
+    meta.broken = lib.versionAtLeast ppxlib.version "0.36";
   };
 
-  ppx_typerep_conv = janePackage {
-    pname = "ppx_typerep_conv";
-    hash = "sha256-V9yOSy3cj5/bz9PvpO3J+aeFu1G+qGQ8AR3gSczUZbY=";
-    meta.description = "Generation of runtime types from type declarations";
-    propagatedBuildInputs = [
-      ppxlib
-      typerep
-    ];
-  };
+  ppx_typerep_conv = janePackage (
+    {
+      pname = "ppx_typerep_conv";
+      meta.description = "Generation of runtime types from type declarations";
+      propagatedBuildInputs = [
+        ppxlib
+        typerep
+      ];
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.1";
+          hash = "sha256-rxqL2v5vqjc7MgKUSkJEyIhm9GO5YqvxEYSM/uXdeBc=";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-V9yOSy3cj5/bz9PvpO3J+aeFu1G+qGQ8AR3gSczUZbY=";
+        }
+    )
+  );
 
-  ppx_variants_conv = janePackage {
-    pname = "ppx_variants_conv";
-    hash = "sha256-Av2F699LzVCpwcdji6qG0jt5DVxCnIY4eBLaPK1JC10=";
-    meta.description = "Generation of accessor and iteration functions for ocaml variant types";
-    propagatedBuildInputs = [
-      variantslib
-      ppxlib
-    ];
-  };
+  ppx_variants_conv = janePackage (
+    {
+      pname = "ppx_variants_conv";
+      meta.description = "Generation of accessor and iteration functions for ocaml variant types";
+      propagatedBuildInputs = [
+        variantslib
+        ppxlib
+      ];
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.1";
+          hash = "sha256-4v9sXtu7rDM+W3phPloizeMczRbBhku5dsCG4NqhdfU=";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-Av2F699LzVCpwcdji6qG0jt5DVxCnIY4eBLaPK1JC10=";
+        }
+    )
+  );
 
   ppxlib_jane = janePackage (
     {
@@ -1575,7 +1764,12 @@ with self;
       propagatedBuildInputs = [ ppxlib ];
     }
     // (
-      if lib.versionAtLeast ocaml.version "5.3" then
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.4";
+          hash = "sha256-cqF7aT0ubutRxsSTD5aHnHx4zvlPDkTzdBqONU6EgO0=";
+        }
+      else if lib.versionAtLeast ocaml.version "5.3" then
         {
           version = "0.17.2";
           hash = "sha256-AQJSdKtF6p/aG5Lx8VHVEOsisH8ep+iiml6DtW+Hdik=";
@@ -1847,6 +2041,7 @@ with self;
       ppx_jane
       ppxlib
     ];
+    meta.broken = lib.versionAtLeast ppxlib.version "0.36";
   };
 
   textutils = janePackage {

--- a/pkgs/development/ocaml-modules/landmarks-ppx/default.nix
+++ b/pkgs/development/ocaml-modules/landmarks-ppx/default.nix
@@ -23,5 +23,6 @@ buildDunePackage {
       Automatically or semi-automatically instrument your code using
       landmarks library.
     '';
+    broken = lib.versionAtLeast ppxlib.version "0.36";
   };
 }

--- a/pkgs/development/ocaml-modules/lun/ppx.nix
+++ b/pkgs/development/ocaml-modules/lun/ppx.nix
@@ -22,5 +22,6 @@ buildDunePackage {
   meta = lun.meta // {
     description = "Optics with lun package and PPX";
     license = lib.licenses.mit;
+    broken = lib.versionAtLeast ppxlib.version "0.36";
   };
 }

--- a/pkgs/development/ocaml-modules/lwt/ppx.nix
+++ b/pkgs/development/ocaml-modules/lwt/ppx.nix
@@ -1,5 +1,7 @@
 {
+  lib,
   fetchFromGitHub,
+  fetchpatch,
   buildDunePackage,
   lwt,
   ppxlib,
@@ -8,6 +10,11 @@
 buildDunePackage {
   pname = "lwt_ppx";
   inherit (lwt) version src;
+
+  patches = lib.optional (lib.versionAtLeast ppxlib.version "0.36") (fetchpatch {
+    url = "https://github.com/ocsigen/lwt/commit/96b7ac686208968503786bb6d101f4ee84c8d2e6.patch";
+    hash = "sha256-uxTwNVqV0O11WEKy66fphvGqW17FWDEzEylhVYNwNnY=";
+  });
 
   propagatedBuildInputs = [
     lwt

--- a/pkgs/development/ocaml-modules/ocsigen-ppx-rpc/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-ppx-rpc/default.nix
@@ -9,8 +9,6 @@ buildDunePackage rec {
   pname = "ocsigen-ppx-rpc";
   version = "1.0";
 
-  duneVersion = "3";
-
   src = fetchFromGitHub {
     owner = "ocsigen";
     repo = pname;
@@ -25,6 +23,7 @@ buildDunePackage rec {
     description = "Syntax for RPCs for Eliom and Ocsigen Start";
     license = lib.licenses.lgpl21Only;
     maintainers = [ lib.maintainers.vbgl ];
+    broken = lib.versionAtLeast ppxlib.version "0.36";
   };
 
 }

--- a/pkgs/development/ocaml-modules/ppx_deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving/default.nix
@@ -12,7 +12,9 @@
   ounit2,
   ocaml-migrate-parsetree,
   version ?
-    if lib.versionAtLeast ppxlib.version "0.32" then
+    if lib.versionAtLeast ppxlib.version "0.36" then
+      "6.1.0"
+    else if lib.versionAtLeast ppxlib.version "0.32" then
       "6.0.3"
     else if lib.versionAtLeast ppxlib.version "0.20" then
       "5.2.1"
@@ -25,6 +27,7 @@
 let
   hash =
     {
+      "6.1.0" = "sha256-dHpWiOpjD3elCw6QJUrG+KZr3Ul0suhzdjQUJ4B9S1Y=";
       "6.0.3" = "sha256-N0qpezLF4BwJqXgQpIv6IYwhO1tknkRSEBRVrBnJSm0=";
       "5.2.1" = "sha256:11h75dsbv3rs03pl67hdd3lbim7wjzh257ij9c75fcknbfr5ysz9";
       "5.1" = "sha256:1i64fd7qrfzbam5hfbl01r0sx4iihsahcwqj13smmrjlnwi3nkxh";

--- a/pkgs/development/ocaml-modules/ppx_deriving_cmdliner/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_cmdliner/default.nix
@@ -52,5 +52,6 @@ buildDunePackage rec {
     homepage = "https://github.com/hammerlab/ppx_deriving_cmdliner";
     license = licenses.asl20;
     maintainers = [ maintainers.romildo ];
+    broken = lib.versionAtLeast ppxlib.version "0.36";
   };
 }

--- a/pkgs/development/ocaml-modules/ppx_deriving_rpc/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_rpc/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildDunePackage,
+  fetchpatch,
   rpclib,
   alcotest,
   ppxlib,
@@ -14,7 +15,11 @@ buildDunePackage {
   inherit (rpclib) version src;
 
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
+
+  patches = lib.optional (lib.versionAtLeast ppxlib.version "0.36") (fetchpatch {
+    url = "https://github.com/mirage/ocaml-rpc/commit/678b7c0e59f6add174f2a732861be21c3e9583d0.patch";
+    hash = "sha256-6Vl4/C02NQ/nPn+h9I/eT86R7GLZ/C8nSqBs4Ywzhwc=";
+  });
 
   propagatedBuildInputs = [
     ppxlib

--- a/pkgs/development/ocaml-modules/ppx_deriving_yaml/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_yaml/default.nix
@@ -9,15 +9,29 @@
   yaml,
 }:
 
+let
+  param =
+    if lib.versionAtLeast ppxlib.version "0.36" then
+      {
+        version = "0.4.1";
+        hash = "sha256-3CvvMEOq/3I3WJ6X5EyopiaMjshZoEMPk2K4Lx0ldSo=";
+      }
+    else
+      {
+        version = "0.4.0";
+        hash = "sha256-MVwCFAZY9Ui1gOckfbbj882w2aloHCGmJhpL1BDUEAg=";
+      };
+in
+
 buildDunePackage rec {
   pname = "ppx_deriving_yaml";
-  version = "0.3.0";
+  inherit (param) version;
 
   minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/patricoferris/ppx_deriving_yaml/releases/download/v${version}/ppx_deriving_yaml-${version}.tbz";
-    hash = "sha256-HLY0ozmy6zY0KjXkwP3drTdz857PvLS/buN1nB+xf1s=";
+    inherit (param) hash;
   };
 
   propagatedBuildInputs = [
@@ -27,7 +41,10 @@ buildDunePackage rec {
   ];
 
   doCheck = true;
-  checkInputs = [ alcotest ];
+  checkInputs = [
+    alcotest
+    mdx
+  ];
   nativeCheckInputs = [ mdx.bin ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/ppx_deriving_yojson/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_yojson/default.nix
@@ -13,7 +13,13 @@
 
 let
   param =
-    if lib.versionAtLeast ppxlib.version "0.30" then
+    if lib.versionAtLeast ppxlib.version "0.36" then
+      {
+        version = "3.10.0";
+        sha256 = "sha256-Dy9egNpZdxsTPLo2mbpiFTMh5cYUXXOlOZLlQJuAK+E=";
+        checkInputs = [ ounit2 ];
+      }
+    else if lib.versionAtLeast ppxlib.version "0.30" then
       {
         version = "3.9.0";
         sha256 = "sha256-0d6YcBkeFoHXffCYjLIIvruw8B9ZB6NbUijhTv9uyN8=";

--- a/pkgs/development/ocaml-modules/ppxlib/default.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/default.nix
@@ -6,7 +6,10 @@
   version ?
     if lib.versionAtLeast ocaml.version "4.07" then
       if lib.versionAtLeast ocaml.version "4.08" then
-        if lib.versionAtLeast ocaml.version "4.11" then "0.33.0" else "0.24.0"
+        if lib.versionAtLeast ocaml.version "4.11" then
+          if lib.versionAtLeast ocaml.version "5.03" then "0.36.0" else "0.33.0"
+        else
+          "0.24.0"
       else
         "0.15.0"
     else
@@ -83,6 +86,10 @@ let
       "0.33.0" = {
         sha256 = "sha256-/6RO9VHyO3XiHb1pijAxBDE4Gq8UC5/kuBwucKLSxjo=";
         min_version = "4.07";
+      };
+      "0.36.0" = {
+        sha256 = "sha256-WrobzhTFMQhhQTARDIQ9AEv5O9LPOgd4/XCGuFOQpDQ=";
+        min_version = "4.08";
       };
     }
     ."${version}";

--- a/pkgs/development/ocaml-modules/qcheck/ppx_deriving_qcheck.nix
+++ b/pkgs/development/ocaml-modules/qcheck/ppx_deriving_qcheck.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   buildDunePackage,
   fetchFromGitHub,
   qcheck,
@@ -6,15 +7,30 @@
   ppx_deriving,
 }:
 
+let
+  param =
+    if lib.versionAtLeast ppxlib.version "0.36" then
+      {
+        version = "0.7";
+        tag = "v0.25";
+        hash = "sha256-Z89jJ21zm89wb9m5HthnbHdnE9iXLyaH9k8S+FAWkKQ=";
+      }
+    else
+      {
+        version = "0.6";
+        tag = "v0.24";
+        hash = "sha256-iuFlmSeUhumeWhqHlaNqDjReRf8c4e76hhT27DK3+/g=";
+      };
+in
+
 buildDunePackage {
   pname = "ppx_deriving_qcheck";
-  version = "0.6";
+  inherit (param) version;
 
   src = fetchFromGitHub {
     owner = "c-cube";
     repo = "qcheck";
-    tag = "v0.24";
-    hash = "sha256-iuFlmSeUhumeWhqHlaNqDjReRf8c4e76hhT27DK3+/g=";
+    inherit (param) tag hash;
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/reason-react/ppx.nix
+++ b/pkgs/development/ocaml-modules/reason-react/ppx.nix
@@ -23,5 +23,6 @@ buildDunePackage {
     homepage = "https://github.com/reasonml/reason-react";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.vog ];
+    broken = lib.versionAtLeast ppxlib.version "0.36";
   };
 }

--- a/pkgs/development/ocaml-modules/repr/ppx.nix
+++ b/pkgs/development/ocaml-modules/repr/ppx.nix
@@ -1,5 +1,7 @@
 {
+  lib,
   buildDunePackage,
+  fetchpatch,
   ppx_deriving,
   ppxlib,
   repr,
@@ -11,6 +13,11 @@ buildDunePackage {
   pname = "ppx_repr";
 
   inherit (repr) src version;
+
+  patches = lib.optional (lib.versionAtLeast ppxlib.version "0.36") (fetchpatch {
+    url = "https://github.com/mirage/repr/commit/9dcaeaa7e5f45998f76e1eab68f8fd18edc980cc.patch";
+    hash = "sha256-MKuZ4f8m/nNlgZpomGgqr80s5btynKcb1b4khpIIOY4=";
+  });
 
   propagatedBuildInputs = [
     ppx_deriving

--- a/pkgs/development/tools/ocaml/melange/default.nix
+++ b/pkgs/development/tools/ocaml/melange/default.nix
@@ -4,6 +4,7 @@
   cppo,
   dune-build-info,
   fetchurl,
+  fetchpatch,
   jq,
   lib,
   makeWrapper,
@@ -54,6 +55,14 @@ buildDunePackage {
     url = "https://github.com/melange-re/${pname}/releases/download/${version}/${pname}-${version}.tbz";
     inherit hash;
   };
+  patches = lib.optional (lib.versionAtLeast ppxlib.version "0.36") (fetchpatch {
+    url = "https://patch-diff.githubusercontent.com/raw/melange-re/melange/pull/1352.patch";
+    hash = "sha256-PMf66nB743nzW4/xblHjNZFv1BS8xC9maD+eCDDUWAY=";
+    excludes = [
+      "*.opam"
+      "*.template"
+    ];
+  });
   nativeBuildInputs = [
     cppo
     makeWrapper

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7149,7 +7149,13 @@ with pkgs;
     haskellPackages.callPackage ../tools/misc/fffuu { }
   );
 
-  flow = callPackage ../development/tools/analysis/flow { };
+  flow = callPackage ../development/tools/analysis/flow {
+    ocamlPackages = ocaml-ng.ocamlPackages.overrideScope (
+      self: super: {
+        ppxlib = super.ppxlib.override { version = "0.33.0"; };
+      }
+    );
+  };
 
   fswatch = callPackage ../development/tools/misc/fswatch { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -534,15 +534,17 @@ let
 
         elpi = callPackage ../development/ocaml-modules/elpi (
           let
-            ppxlib_0_15 =
-              if lib.versionAtLeast ppxlib.version "0.15" then
-                ppxlib.override { version = "0.15.0"; }
-              else
-                ppxlib;
+            ppx_deriving_ =
+              cap:
+              ppx_deriving.override {
+                ppxlib = ppxlib.override {
+                  version = if lib.versionAtLeast ppxlib.version cap then cap else ppxlib.version;
+                };
+              };
           in
           {
-            ppx_deriving_0_15 = ppx_deriving.override { ppxlib = ppxlib_0_15; };
-            inherit ppxlib_0_15;
+            ppx_deriving_0_15 = ppx_deriving_ "0.15";
+            ppx_deriving = ppx_deriving_ "0.33.0";
           }
         );
 
@@ -1689,7 +1691,9 @@ let
 
         ppx_deriving_rpc = callPackage ../development/ocaml-modules/ppx_deriving_rpc { };
 
-        ppx_deriving_yaml = callPackage ../development/ocaml-modules/ppx_deriving_yaml { };
+        ppx_deriving_yaml = callPackage ../development/ocaml-modules/ppx_deriving_yaml {
+          mdx = mdx.override { inherit logs; };
+        };
 
         ppx_deriving_yojson = callPackage ../development/ocaml-modules/ppx_deriving_yojson { };
 


### PR DESCRIPTION
ocamlPackages.base_quickcheck: 0.17.0 → 0.17.1
ocamlPackages.optcomp: 0.17.0 → 0.17.1
ocamlPackages.ppx_bench: 0.17.0 → 0.17.1
ocamlPackages.ppx_bin_prot: 0.17.0 → 0.17.1
ocamlPackages.ppx_deriving: 6.0.3 → 6.1.0
ocamlPackages.ppx_deriving_qcheck: 0.6 → 0.7
ocamlPackages.ppx_deriving_yaml: 0.3.0 → 0.4.1
ocamlPackages.ppx_deriving_yojson: 3.9.0 → 3.10.0
ocamlPackages.ppx_diff: 0.17.0 → 0.17.1
ocamlPackages.ppx_expect: 0.17.2 → 0.17.3
ocamlPackages.ppx_globalize: 0.17.0 → 0.17.2
ocamlPackages.ppx_inline_test: 0.17.0 → 0.17.1
ocamlPackages.ppx_let: 0.17.0 → 0.17.1
ocamlPackages.ppx_stable: 0.17.0 → 0.17.1
ocamlPackages.ppx_tydi: 0.17.0 → 0.17.1
ocamlPackages.ppx_typeprep_conv: 0.17.0 → 0.17.1
ocamlPackages.ppx_variants_conv: 0.17.0 → 0.17.1
ocamlPackages.sexp_conv: 0.17.0 → 0.17.1
ocamlPackages.sexp_message: 0.17.2 → 0.17.4
reason: 3.15.0 → 3.16.0

ocamlPackages.bisect_ppx: make compatible with ppxlib 0.36
ocamlPackages.config: make compatible with ppxlib 0.36
ocamlPackages.lwt_ppx: make compatible with ppxlib 0.36
ocamlPackages.melange: make compatible with ppxlib 0.36
ocamlPackages.ppx_bitstring: make compatible with ppxlib 0.36
ocamlPackages.ppx_repr: make compatible with ppxlib 0.36

ocamlPackages.bistro: mark as broken
ocamlPackages.dream-html: mark as broken
ocamlPackages.ocsigen-ppx-rpc: mark as broken
ocamlPackages.ppx_deriving_cmdliner: mark as broken
ocamlPackages.reason-react-ppx: mark as broken

## Things done

This PR breaks a few packages, but I think the trade-off is good. In particular, 0.36 is the only version of `ppxlib` known to work with the to-be-released-soon OCaml 5.4.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
