### PR TITLE
grpc-health-probe: Init grpc-health-probe at 0.4.39

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22822,6 +22822,12 @@
     name = "Otto Sabart";
     keys = [ { fingerprint = "0AF6 4C3B 1F12 14B3 8C8C  5786 1FA2 DBE6 7438 7CC3"; } ];
   };
+  sebimarkgraf = {
+    email = "sebastian-markgraf@t-online.de";
+    github = "sebimarkgraf";
+    githubId = 24530526;
+    name = "Sebastian Mossburger";
+  };
   sebrut = {
     email = "kontakt@sebastian-rutofski.de";
     github = "sebrut";

--- a/pkgs/by-name/gr/grpc-health-probe/package.nix
+++ b/pkgs/by-name/gr/grpc-health-probe/package.nix
@@ -1,0 +1,25 @@
+{
+  fetchFromGitHub,
+  buildGoModule,
+  lib,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "grpc-health-probe";
+  version = "0.4.39";
+  src = fetchFromGitHub {
+    owner = "grpc-ecosystem";
+    repo = "grpc-health-probe";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ZMU3ajBm9b/SzwQZlDKqyU4pGjnoPSD9zdk5gvxuWw8=";
+  };
+  vendorHash = "sha256-c2RZ7ov/hMBI7QD1HnTLAmPWUdqOKt0Zo74QU9OdXBU=";
+
+  meta = {
+    description = "Command-line tool to perform health-checks for gRPC applications";
+    homepage = "https://github.com/grpc-ecosystem/grpc-health-probe";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ sebimarkgraf ];
+  };
+})


### PR DESCRIPTION
## New package addition: grpc-health-probe
This adds [grpc-health-probe](https://github.com/grpc-ecosystem/grpc-health-probe) a simple Go cli with a considerable number of stars to check GRPC compliant health checks in non-k8s setups, e.g. in docker or bare-metal.

Adds `sebimarkgraf` as maintainer with `github` and `githubId` fields as this is my first contributed package.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
