### PR TITLE
nix-eval-jobs: switch to nixComponents

### DIFF
--- a/pkgs/tools/package-management/nix-eval-jobs/default.nix
+++ b/pkgs/tools/package-management/nix-eval-jobs/default.nix
@@ -1,15 +1,14 @@
 {
   lib,
   boost,
-  cmake,
   fetchFromGitHub,
   meson,
   ninja,
   curl,
-  nix,
   nlohmann_json,
   pkg-config,
   stdenv,
+  nixComponents,
 }:
 stdenv.mkDerivation rec {
   pname = "nix-eval-jobs";
@@ -24,9 +23,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     boost
-    nix
     curl
     nlohmann_json
+    nixComponents.nix-store
+    nixComponents.nix-fetchers
+    nixComponents.nix-expr
+    nixComponents.nix-flake
+    nixComponents.nix-main
+    nixComponents.nix-cmd
   ];
 
   nativeBuildInputs = [
@@ -43,7 +47,11 @@ stdenv.mkDerivation rec {
   # Since this package is intimately tied to a specific Nix release, we
   # propagate the Nix used for building it to make it easier for users
   # downstream to reference it.
-  passthru = { inherit nix; };
+  passthru = {
+    inherit nixComponents;
+    # For nix-fast-build
+    nix = nixComponents.nix-cli;
+  };
 
   meta = {
     description = "Hydra's builtin hydra-eval-jobs as a standalone";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15766,7 +15766,7 @@ with pkgs;
     );
 
   nix-eval-jobs = callPackage ../tools/package-management/nix-eval-jobs {
-    nix = nixVersions.nix_2_30;
+    nixComponents = nixVersions.nixComponents_2_30;
   };
 
   nix-delegate = haskell.lib.compose.justStaticExecutables haskellPackages.nix-delegate;


### PR DESCRIPTION
this reduces nix-eval-jobs dependency closures to what it exactly uses


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
