### PR TITLE
workflows/eval: fix compare job not running

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -57,7 +57,7 @@ jobs:
   eval:
     runs-on: ubuntu-24.04-arm
     needs: versions
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && !failure() }}
     strategy:
       fail-fast: false
       matrix:
@@ -197,7 +197,7 @@ jobs:
   compare:
     runs-on: ubuntu-24.04-arm
     needs: [eval]
-    if: needs.eval.outputs.targetRunId
+    if: needs.eval.outputs.targetRunId && !cancelled() && !failure()
     permissions:
       statuses: write
     timeout-minutes: 5


### PR DESCRIPTION
The conclusion of the `versions` job propagates from through `eval` to `compare`, which meant the `compare` job was skipped. No rebuild labels, no reviewer requests.

Also, we don't want to run eval when `versions` runs, but fails.

This regressed in #427724. Fixes https://github.com/NixOS/nixpkgs/pull/427724#issuecomment-3178350124.

## Things done

- [x] Tested in my fork.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
