### PR TITLE
[25.05] ci/default: adjustments for removal of Nix 2.3

### DIFF
--- a/ci/default.nix
+++ b/ci/default.nix
@@ -128,8 +128,7 @@ rec {
   parse = pkgs.lib.recurseIntoAttrs {
     latest = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.latest; };
     lix = pkgs.callPackage ./parse.nix { nix = pkgs.lix; };
-    # TODO: Raise nixVersions.minimum to 2.24 and flip back to it.
-    minimum = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.nix_2_24; };
+    nix_2_24 = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.nix_2_24; };
   };
   shell = import ../shell.nix { inherit nixpkgs system; };
   tarball = import ../pkgs/top-level/make-tarball.nix {

--- a/ci/default.nix
+++ b/ci/default.nix
@@ -17,13 +17,7 @@ let
     else
       nixpkgs;
 
-  pkgs = import nixpkgs' {
-    inherit system;
-    config = {
-      permittedInsecurePackages = [ "nix-2.3.18" ];
-    };
-    overlays = [ ];
-  };
+  pkgs = import nixpkgs' { inherit system; };
 
   fmt =
     let

--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -16,7 +16,7 @@
   pkgsBB ? pkgs.pkgsBuildBuild,
   nix ? pkgs-nixVersions.stable,
   nixVersions ? [
-    pkgs-nixVersions.minimum
+    pkgs-nixVersions.nix_2_24
     nix
     pkgs-nixVersions.latest
   ],


### PR DESCRIPTION
*Very* partial backport of #428076 - only the changes to `ci/default.nix` as discussed in https://github.com/NixOS/nixpkgs/pull/428076#discussion_r2269277771.