### PR TITLE
stdenv: cleanup after bump of minver

### DIFF
--- a/pkgs/build-support/testers/expect-failure.sh
+++ b/pkgs/build-support/testers/expect-failure.sh
@@ -41,7 +41,7 @@ echo "testBuildFailure: Original builder produced exit code: $r"
 #
 # NOTE: This MUST be done after the original builder has finished!
 #       Otherwise we could pollute its environment.
-if [ -e "${NIX_ATTRS_SH_FILE:-}" ]; then . "$NIX_ATTRS_SH_FILE"; elif [ -f .attrs.sh ]; then . .attrs.sh; fi
+if [ -e "${NIX_ATTRS_SH_FILE:-}" ]; then . "$NIX_ATTRS_SH_FILE"; fi
 
 # Variables injected by replaceVars
 #

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -847,7 +847,7 @@ let
               "-c"
               ''
                 out="${placeholder "out"}"
-                if [ -e "$NIX_ATTRS_SH_FILE" ]; then . "$NIX_ATTRS_SH_FILE"; elif [ -f .attrs.sh ]; then . .attrs.sh; fi
+                if [ -e "$NIX_ATTRS_SH_FILE" ]; then . "$NIX_ATTRS_SH_FILE"; fi
                 declare -p > $out
                 for var in $passAsFile; do
                     pathVar="''${var}Path"

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -25,7 +25,7 @@ if [[ ${NIX_DEBUG:-0} -ge 6 ]]; then
     set -x
 fi
 
-if [ -f .attrs.sh ] || [[ -n "${NIX_ATTRS_JSON_FILE:-}" ]]; then
+if [[ -n "${NIX_ATTRS_JSON_FILE:-}" ]]; then
     __structuredAttrs=1
     echo "structuredAttrs is enabled"
 
@@ -33,16 +33,6 @@ if [ -f .attrs.sh ] || [[ -n "${NIX_ATTRS_JSON_FILE:-}" ]]; then
         # ex: out=/nix/store/...
         export "$outputName=${outputs[$outputName]}"
     done
-
-    # $NIX_ATTRS_JSON_FILE pointed to the wrong location in sandbox
-    # https://github.com/NixOS/nix/issues/6736; please keep around until the
-    # fix reaches *every patch version* that's >= lib/minver.nix
-    if ! [[ -e "${NIX_ATTRS_JSON_FILE:-}" ]]; then
-        export NIX_ATTRS_JSON_FILE="$NIX_BUILD_TOP/.attrs.json"
-    fi
-    if ! [[ -e "${NIX_ATTRS_SH_FILE:-}" ]]; then
-        export NIX_ATTRS_SH_FILE="$NIX_BUILD_TOP/.attrs.sh"
-    fi
 else
     __structuredAttrs=
     : "${outputs:=out}"

--- a/pkgs/stdenv/generic/source-stdenv.sh
+++ b/pkgs/stdenv/generic/source-stdenv.sh
@@ -1,3 +1,3 @@
-if [ -e "$NIX_ATTRS_SH_FILE" ]; then . "$NIX_ATTRS_SH_FILE"; elif [ -f .attrs.sh ]; then . .attrs.sh; fi
+if [ -e "$NIX_ATTRS_SH_FILE" ]; then . "$NIX_ATTRS_SH_FILE"; fi
 source "$stdenv/setup"
 source "$1"


### PR DESCRIPTION
In #428076, we raised `lib/minver.nix` to 2.18. This allows some cleanup around `stdenv`'s `structuredAttrs` handling.

More discussion about the `attrs.sh` change in https://github.com/NixOS/nixpkgs/pull/357053.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
