### PR TITLE
nixos-rebuild-ng: remove conditionals for Nix < 2.18

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/README.md
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/README.md
@@ -89,9 +89,8 @@ not possible to fix, please open an issue and we can discuss a solution.
   your password wrong, it will fail during activation (this can be improved
   though)
 - When `--build-host` and `--target-host` are used together, we will use `nix
-  copy` (or 2 `nix-copy-closure` if you're using Nix <2.18) instead of SSH'ing
-  to build host and using `nix-copy-closure --to target-host`. The reason for
-  this is documented in PR
+  copy` instead of SSH'ing to build host and using
+  `nix-copy-closure --to target-host`. The reason for this is documented in PR
   [#364698](https://github.com/NixOS/nixpkgs/pull/364698). If you do need the
   previous behavior, you can simulate it using `ssh build-host --
   nixos-rebuild-ng switch --target-host target-host`. If that is not the case,
@@ -119,7 +118,7 @@ not possible to fix, please open an issue and we can discuss a solution.
   and there was a need to bootstrap a new version of Nix before evaluating the
   configuration (otherwise the new Nixpkgs version may have code that is only
   compatible with a newer version of Nix). Nixpkgs now has a policy to be
-  compatible with Nix 2.3, and even if this is bumped as long we don't do
+  compatible with Nix 2.18, and even if this is bumped as long we don't do
   drastic minimum version changes this should not be an issue. Also, the daemon
   itself always run with the previous version since even we can replace Nix in
   `PATH` (so Nix client), but we can't replace the daemon without switching to

--- a/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
@@ -251,10 +251,10 @@ It must be one of the following:
 
 *--use-substitutes*
 	When set, nixos-rebuild will add *--use-substitutes* to each invocation
-	of _nix-copy-closure_/_nix copy_. This will only affect the behavior of
-	nixos-rebuild if *--target-host* or *--build-host* is also set. This is
-	useful when the target-host connection to cache.nixos.org is faster than
-	the connection between hosts.
+	of _nix copy_. This will only affect the behavior of nixos-rebuild if
+	*--target-host* or *--build-host* is also set. This is useful when the
+	target-host connection to cache.nixos.org is faster than the connection
+	between hosts.
 
 *--sudo*
 	When set, *nixos-rebuild* prefixes activation commands with sudo.

--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -15,13 +15,6 @@
   # Very long tmp dirs lead to "too long for Unix domain socket"
   # SSH ControlPath errors. Especially macOS sets long TMPDIR paths.
   withTmpdir ? if stdenv.hostPlatform.isDarwin then "/tmp" else null,
-  # This version is kind of arbitrary, we use some features that were
-  # implemented in newer versions of Nix, but not necessary 2.18.
-  # However, Lix is a fork of Nix 2.18, so this looks like a good version
-  # to cut specific functionality.
-  # ATTN: This currently doesn't disambiguate between Nix and Lix, so using this
-  # in a conditional needs careful checking against both Nix implementations.
-  withNix218 ? lib.versionAtLeast nix.version "2.18",
   # passthru.tests
   nixosTests,
   nixVersions,
@@ -62,7 +55,6 @@ python3Packages.buildPythonApplication rec {
   postPatch = ''
     substituteInPlace nixos_rebuild/constants.py \
       --subst-var-by executable ${executable} \
-      --subst-var-by withNix218 ${lib.boolToString withNix218} \
       --subst-var-by withReexec ${lib.boolToString withReexec} \
       --subst-var-by withShellFiles ${lib.boolToString withShellFiles}
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -6,7 +6,7 @@ from subprocess import CalledProcessError, run
 from typing import Final, assert_never
 
 from . import nix, services
-from .constants import EXECUTABLE, WITH_NIX_2_18, WITH_REEXEC, WITH_SHELL_FILES
+from .constants import EXECUTABLE, WITH_REEXEC, WITH_SHELL_FILES
 from .models import Action, BuildAttr, Flake, Profile
 from .process import Remote
 from .utils import LogFormatter
@@ -269,9 +269,6 @@ def parse_args(
 
 def execute(argv: list[str]) -> None:
     args, args_groups = parse_args(argv)
-
-    if not WITH_NIX_2_18:
-        logger.warning("you're using Nix <2.18, some features will not work correctly")
 
     common_flags = vars(args_groups["common_flags"])
     common_build_flags = common_flags | vars(args_groups["common_build_flags"])

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/constants.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/constants.py
@@ -6,6 +6,5 @@ from typing import Final
 EXECUTABLE: Final[str] = "@executable@"
 # Use either `== "true"` if the default (e.g.: `python -m nixos_rebuild`) is
 # `False` or `!= "false"` if the default is `True`
-WITH_NIX_2_18: Final[bool] = "@withNix218@" != "false"
 WITH_REEXEC: Final[bool] = "@withReexec@" == "true"
 WITH_SHELL_FILES: Final[bool] = "@withShellFiles@" == "true"

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -13,7 +13,6 @@ from textwrap import dedent
 from typing import Final, Literal
 
 from . import tmpdir
-from .constants import WITH_NIX_2_18
 from .models import (
     Action,
     BuildAttr,
@@ -228,18 +227,7 @@ def copy_closure(
         case (Remote(_) as host, None) | (None, Remote(_) as host):
             nix_copy_closure(host, to=bool(to_host))
         case (Remote(_), Remote(_)):
-            if WITH_NIX_2_18:
-                # With newer Nix, use `nix copy` instead of `nix-copy-closure`
-                # since it supports `--to` and `--from` at the same time
-                # TODO: once we drop Nix 2.3 from nixpkgs, remove support for
-                # `nix-copy-closure`
-                nix_copy(to_host, from_host)
-            else:
-                # With older Nix, we need to copy from to local and local to
-                # host. This means it is slower and need additional disk space
-                # in local
-                nix_copy_closure(from_host, to=False)
-                nix_copy_closure(to_host, to=True)
+            nix_copy(to_host, from_host)
 
 
 def edit() -> None:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -10,7 +10,6 @@ from unittest.mock import ANY, Mock, call, patch
 import pytest
 
 import nixos_rebuild as nr
-from nixos_rebuild.constants import WITH_NIX_2_18
 
 from .helpers import get_qualified_name
 
@@ -450,10 +449,6 @@ def test_execute_nix_switch_flake(mock_run: Mock, tmp_path: Path) -> None:
 @patch("subprocess.run", autospec=True)
 @patch("uuid.uuid4", autospec=True)
 @patch(get_qualified_name(nr.services.cleanup_ssh), autospec=True)
-@pytest.mark.skipif(
-    not WITH_NIX_2_18,
-    reason="Tests internal logic based on the assumption that Nix >= 2.18",
-)
 def test_execute_nix_switch_build_target_host(
     mock_cleanup_ssh: Mock,
     mock_uuid4: Mock,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -254,7 +254,6 @@ def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
         )
 
     monkeypatch.setenv("NIX_SSHOPTS", "--ssh build-target-opt")
-    monkeypatch.setattr(n, "WITH_NIX_2_18", True)
     extra_env = {
         "NIX_SSHOPTS": " ".join([*p.SSH_DEFAULT_OPTS, "--ssh build-target-opt"])
     }
@@ -274,22 +273,6 @@ def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
                 closure,
             ],
             extra_env=extra_env,
-        )
-
-    monkeypatch.setattr(n, "WITH_NIX_2_18", False)
-    with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
-        n.copy_closure(closure, target_host, build_host)
-        mock_run.assert_has_calls(
-            [
-                call(
-                    ["nix-copy-closure", "--from", "user@build.host", closure],
-                    extra_env=extra_env,
-                ),
-                call(
-                    ["nix-copy-closure", "--to", "user@target.host", closure],
-                    extra_env=extra_env,
-                ),
-            ]
         )
 
 


### PR DESCRIPTION
We have [recently](https://github.com/NixOS/nixpkgs/pull/428076) raised Nixpkgs' minver to 2.18, thus a lot of conditionals are not required anymore.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [Package tests] at `passthru.tests`.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
