### PR TITLE
lib/minfeatures: init from minver.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,13 +1,15 @@
 let
-  requiredVersion = import ./lib/minver.nix;
+  missingFeatures = map ({ description, ... }: description) (import ./lib/minfeatures.nix).missing;
 in
 
-if !builtins ? nixVersion || builtins.compareVersions requiredVersion builtins.nixVersion == 1 then
+if missingFeatures != [ ] then
 
   abort ''
 
-    This version of Nixpkgs requires Nix >= ${requiredVersion} but it is being
-    evaluated with Nix ${builtins.nixVersion or "(too old to know)"}, please upgrade:
+    This version of Nixpkgs requires an implementation of Nix with the following features:
+    - ${builtins.concatStringsSep "\n- " missingFeatures}
+
+    Your are evaluating with Nix ${builtins.nixVersion or "(too old to know)"}, please upgrade:
 
     - If you are running NixOS, `nixos-rebuild' can be used to upgrade your system.
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -19,7 +19,7 @@ This file evaluates to an attribute set containing two separate kinds of attribu
   Example: `lib.take` is an alias for `lib.lists.take`.
 
 Most files in this directory are definitions of sub-libraries, but there are a few others:
-- [`minver.nix`](minver.nix): A string of the minimum version of Nix that is required to evaluate Nixpkgs.
+- [`minfeatures.nix`](minfeatures.nix): A list of conditions for the used Nix version to match that are required to evaluate Nixpkgs.
 - [`tests`](tests): Tests, see [Running tests](#running-tests)
   - [`release.nix`](tests/release.nix): A derivation aggregating all tests
   - [`misc.nix`](tests/misc.nix): Evaluation unit tests for most sub-libraries

--- a/lib/minfeatures.nix
+++ b/lib/minfeatures.nix
@@ -1,0 +1,19 @@
+let
+  features = [
+    {
+      description = "the `nixVersion` builtin";
+      condition = builtins ? nixVersion;
+    }
+    {
+      description = "`builtins.nixVersion` reports at least 2.18";
+      condition = builtins ? nixVersion && builtins.compareVersions "2.18" builtins.nixVersion != 1;
+    }
+  ];
+
+  evaluated = builtins.partition ({ condition, ... }: condition) features;
+in
+{
+  all = features;
+  supported = evaluated.right;
+  missing = evaluated.wrong;
+}

--- a/lib/minver.nix
+++ b/lib/minver.nix
@@ -1,2 +1,0 @@
-# Expose the minimum required version for evaluating Nixpkgs
-"2.18"


### PR DESCRIPTION
The concept of having a "minimum supported Nix version" doesn't work anymore today, for the following reasons:
- With multiple forks / implementations of Nix available, their feature sets and versions will differ. We'd need *multiple* minimum versions, one for each implementation.
- Lix does not expose its real version. It only reports "2.18.3-lix", even though its real version is in the 2.90+ range.
- A minimum version has the expectation that it could be *raised* in the future. That's not possible with Lix, because Lix will always and forever report the above version.
- A minimum version has the expectation that *all* versions bigger than the minimum are supported. That was already quite a stretch when minver was 2.3 and none of the Nix versions between 2.4 and 2.23 were packed anymore. But it's impossible for us to test all these non-LTS versions anyway: We don't have Nix 2.18, 2.19, 2.20, 2.21, 2.22, 2.23, 2.25, 2.26 and 2.27 available in Nixpkgs at the time of this writing.
- ~~One example where we certainly didn't support all intermediate versions: From NixOS 24.11 on, we bumped minver to 2.3.17 to support zstd compressed binary artifacts. That doesn't mean that Nix 2.4, 2.5, ... etc. all support these, though. So we were essentially already breaking the minver promise for a long time.~~

With their policy around `builtins.nixVersion`, Lix forces our hand: We need to replace minver.nix with a "feature detection" mechanism.

This PR introduces the first two features:
- The availability of `builtins.nixVersion`: If this is not available, the version of Nix is so old, that we surely don't support it anymore.
- The value of `builtins.nixVersion` being greater or equal to 2.18.

Note, that this does **not** imply support for Nix 2.18. Instead, explicitly supported versions of Lix and Nix are only these that we actually test against.

If, eventually, we realize that the supported versions have advanced and Nixpkgs has adopted a feature only available in newer versions, we will have to add a feature check for this.

Put differently: The list of features in `minfeatures.nix` is not expected to be complete. It's a list of known-to-be-bad conditions that will cause problems when evaluating Nixpkgs. Their only purpose is to be able to show a helpful error message. Some other versions might also not be supported, but might fail with more subtle errors. That's just reality and has always been the case previously as well.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- [x] Tested it fails to evaluate with Nix 2.3.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
