### PR TITLE
workflows/pr: block merging PRs when jobs have been cancelled

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -160,7 +160,7 @@ jobs:
     # Do NOT change the name of this job, otherwise the rule will not catch it anymore.
     # This would prevent all PRs from merging.
     name: no PR failures
-    if: ${{ failure() }}
+    if: ${{ cancelled() || failure() }}
     runs-on: ubuntu-24.04-arm
     steps:
       - run: exit 1


### PR DESCRIPTION
This currently happens, for still unknown reasons, for the "check cherry picks" job. The job gets cancelled by GHA mid-way. This should be the same as an error, because an important check didn't run: Merging should be blocked and auto-merge should not succeed.

This only fixes the symptoms of https://github.com/NixOS/nixpkgs/pull/433053#issuecomment-3178775495, will look into the actual cause next.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
