### PR TITLE
open-webui: 0.6.18 -> 0.6.22

### DIFF
--- a/pkgs/by-name/op/open-webui/package.nix
+++ b/pkgs/by-name/op/open-webui/package.nix
@@ -9,13 +9,13 @@
 }:
 let
   pname = "open-webui";
-  version = "0.6.18";
+  version = "0.6.22";
 
   src = fetchFromGitHub {
     owner = "open-webui";
     repo = "open-webui";
     tag = "v${version}";
-    hash = "sha256-1V9mOhO8jpr0HU0djLjKw6xDQMBmqie6Gte4xfg9PfQ=";
+    hash = "sha256-SX2uLmDZu1TW45A6F5mSXVtSqv5rbNKuVw8sWj8tEb4=";
   };
 
   frontend = buildNpmPackage rec {
@@ -32,7 +32,7 @@ let
       url = "https://github.com/pyodide/pyodide/releases/download/${pyodideVersion}/pyodide-${pyodideVersion}.tar.bz2";
     };
 
-    npmDepsHash = "sha256-bMqK9NvuTwqnhflGDfZTEkaFG8y34Qf94SgR0HMClrQ=";
+    npmDepsHash = "sha256-mMnDYMy1/7gW6XVaWVct9BuxDP78XX5u46lGBWjUvOQ=";
 
     # See https://github.com/open-webui/open-webui/issues/15880
     npmFlags = [
@@ -161,6 +161,7 @@ python3Packages.buildPythonApplication rec {
       opentelemetry-instrumentation-logging
       opentelemetry-instrumentation-httpx
       opentelemetry-instrumentation-aiohttp-client
+      oracledb
       pandas
       passlib
       peewee
@@ -172,6 +173,7 @@ python3Packages.buildPythonApplication rec {
       posthog
       psutil
       psycopg2-binary
+      pyarrow
       pycrdt
       pydub
       pyjwt

--- a/pkgs/by-name/op/open-webui/update.sh
+++ b/pkgs/by-name/op/open-webui/update.sh
@@ -11,12 +11,22 @@ update-source-version open-webui "${version:1}" --file="$path"
 
 # Fetch npm deps and pyodide
 tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
 curl -O --output-dir $tmpdir "https://raw.githubusercontent.com/open-webui/open-webui/refs/tags/${version}/package-lock.json"
 curl -O --output-dir $tmpdir "https://raw.githubusercontent.com/open-webui/open-webui/refs/tags/${version}/package.json"
 pushd $tmpdir
+
+# Prefetch the npm dependencies hash
 npm_hash=$(prefetch-npm-deps package-lock.json)
 sed -i 's#npmDepsHash = "[^"]*"#npmDepsHash = "'"$npm_hash"'"#' "$path"
+
+# Extract pyodide version
 pyodide_version=$(sed -rn 's/^.*pyodide.*\^([0-9.]*)\".*$/\1/p' package.json)
 popd
-update-source-version open-webui.frontend "${pyodide_version}" --file="$path" --version-key=pyodideVersion --source-key=pyodide
-rm -rf $tmpdir
+
+# Update the pyodide version if necessary
+current_pyodide_version=$(nix eval --raw -f . open-webui.frontend.pyodideVersion)
+if [ "$current_pyodide_version" < "$pyodide_version" ]; then
+  update-source-version open-webui.frontend "${pyodide_version}" --file="$path" --version-key=pyodideVersion --source-key=pyodide
+fi


### PR DESCRIPTION
Diff: https://github.com/open-webui/open-webui/compare/refs/tags/v0.6.18...refs/tags/v0.6.22

Changelog: https://github.com/open-webui/open-webui/blob/v0.6.22/CHANGELOG.md

Also fixed the update script so it could get the correct npmDepsHash.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
