### PR TITLE
workflows/pr: fix condition for no-pr-failures job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -160,7 +160,11 @@ jobs:
     # Do NOT change the name of this job, otherwise the rule will not catch it anymore.
     # This would prevent all PRs from merging.
     name: no PR failures
-    if: ${{ cancelled() || failure() }}
+    # A single job is "cancelled" when it hits its timeout. This is not the same
+    # as "skipped", which happens when the `if` condition doesn't apply.
+    # The "cancelled()" function only checks the whole workflow, but not individual
+    # jobs.
+    if: ${{ failure() || contains(needs.*.result, 'cancelled') }}
     runs-on: ubuntu-24.04-arm
     steps:
       - run: exit 1


### PR DESCRIPTION
The `cancelled()` condition seems to only apply when *the whole workflow* was cancelled. This is not the case when a single job is cancelled due to timeout.

We can replicate this by checking each `needs.result` manually.

Fixes https://github.com/NixOS/nixpkgs/pull/433060#issuecomment-3179197442. This time tested in my fork in all 3 conditions.

## Things done

- [x] Tested with all jobs succeeding (some skipped).
- [x] Tested with one job failing.
- [x] Tested with one job cancelled.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
