### PR TITLE
treewide: drop usage of nixfmt-rfc-style alias

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -2121,7 +2121,7 @@ The following rules are desired to be respected:
 * `pythonImportsCheck` is set. This is still a good smoke test even if `pytestCheckHook` is set.
 * `meta.platforms` takes the default value in many cases.
   It does not need to be set explicitly unless the package requires a specific platform.
-* The file is formatted with `nixfmt-rfc-style`.
+* The file is formatted with `nixfmt`.
 * Commit names of Python libraries must reflect that they are Python
   libraries (e.g. `python313Packages.numpy: 1.11 -> 1.12` rather than `numpy: 1.11 -> 1.12`).
 * The current default version of python should be included

--- a/pkgs/applications/editors/vscode/extensions/README.md
+++ b/pkgs/applications/editors/vscode/extensions/README.md
@@ -7,7 +7,7 @@
 
 * When adding a new extension, place its definition in a `default.nix` file in a directory with the extension's ID (e.g. `publisher.extension-name/default.nix`) and refer to it in `./default.nix`, e.g. `publisher.extension-name = callPackage ./publisher.extension-name { };`.
 
-* Currently `nixfmt-rfc-style` formatter is being used to format the VSCode extensions.
+* Currently `nixfmt` formatter is being used to format the VSCode extensions.
 
 * Respect `alphabetical order` whenever adding extensions. On disorder, please, kindly open a PR re-establishing the order.
 

--- a/pkgs/by-name/gr/gren/update.sh
+++ b/pkgs/by-name/gr/gren/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p cabal2nix curl jq nix-update nixfmt-rfc-style
+#!nix-shell -i bash -p cabal2nix curl jq nix-update nixfmt
 
 set -euo pipefail
 

--- a/pkgs/by-name/ni/nixfmt-tree/package.nix
+++ b/pkgs/by-name/ni/nixfmt-tree/package.nix
@@ -95,7 +95,7 @@ treefmtWithConfig.overrideAttrs {
       You can achieve similar results by manually configuring `treefmt`:
       ```nix
       pkgs.treefmt.withConfig {
-        runtimeInputs = [ pkgs.nixfmt-rfc-style ];
+        runtimeInputs = [ pkgs.nixfmt ];
 
         settings = {
           # Log level for files treefmt won't format

--- a/pkgs/os-specific/linux/kernel/update-xanmod.sh
+++ b/pkgs/os-specific/linux/kernel/update-xanmod.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p bash nix-prefetch curl jq gawk gnused nixfmt-rfc-style
+#!nix-shell -i bash -p bash nix-prefetch curl jq gawk gnused nixfmt
 
 set -euo pipefail
 

--- a/pkgs/servers/x11/xorg/update.py
+++ b/pkgs/servers/x11/xorg/update.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell --pure --keep NIX_PATH -i python3 -p nix git nixfmt-rfc-style "python3.withPackages (ps: [ ps. packaging ps.beautifulsoup4 ps.requests ])"
+#!nix-shell --pure --keep NIX_PATH -i python3 -p nix git nixfmt "python3.withPackages (ps: [ ps. packaging ps.beautifulsoup4 ps.requests ])"
 
 # Usage: Run ./update.py from the directory containing tarballs.list. The script checks for the
 # latest versions of all packages, updates the expressions if any update is found, and commits


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
