### PR TITLE
ruri: 3.8 -> 3.9.1

### DIFF
--- a/pkgs/by-name/ru/ruri/fix-install.patch
+++ b/pkgs/by-name/ru/ruri/fix-install.patch
@@ -1,0 +1,61 @@
+From b6939000d33fd5c727b93c5d1c535d5aa1e8b758 Mon Sep 17 00:00:00 2001
+From: dabao1955 <dabao1955@163.com>
+Date: Sun, 17 Aug 2025 11:35:47 +0800
+Subject: [PATCH] chore(cmake): Drop BUILD_LIB option
+
+It looks like nolonger uses it
+---
+ CMakeLists.txt | 32 ++++++++++++--------------------
+ 1 file changed, 12 insertions(+), 20 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 41a4da8..3d491c2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -144,7 +144,6 @@ option(ENABLE_STATIC "Enable static linking" OFF)
+ option(DISABLE_LIBCAP "Disable cap library linking" OFF)
+ option(DISABLE_LIBSECCOMP "Disable seccomp library linking" OFF)
+ option(DISABLE_RURIENV "Disable env in ruri" OFF)
+-option(BUILD_LIB "Build with lib" OFF)
+ option(STRIP_DEBUGINFO "Strip debuginfo from ruri binary" ON)
+ 
+ # For Debug build
+@@ -197,26 +196,19 @@ add_definitions(-D_FILE_OFFSET_BITS=64)
+ 
+ file(GLOB SOURCES ${CMAKE_SOURCE_DIR}/src/*.c ${CMAKE_SOURCE_DIR}/src/easteregg/*.c)
+ 
+-if (BUILD_LIB)
+-    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+-    add_library(ruri SHARED ${SOURCES})
+-    install (TARGETS ruri DESTINATION /usr/lib/)
+-else ()
+ # add the executable
+-    set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
+-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIE")
+-    add_executable(ruri ${SOURCES})
+-    if(STRIP_DEBUGINFO)
+-        add_custom_command(
+-            TARGET ruri
+-            POST_BUILD
+-            COMMAND strip ruri
+-            VERBATIM
+-        )
+-    endif()
+-    install (TARGETS ruri DESTINATION /usr/bin/)
+-endif()
++set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
++set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIE")
++add_executable(ruri ${SOURCES})
++if(STRIP_DEBUGINFO)
++    add_custom_command(
++        TARGET ruri
++        POST_BUILD
++        COMMAND strip ruri
++        VERBATIM
++    )
++endif()
++install (TARGETS ruri DESTINATION /usr/bin/)
+ 
+ add_custom_target(
+     tidy

--- a/pkgs/by-name/ru/ruri/package.nix
+++ b/pkgs/by-name/ru/ruri/package.nix
@@ -4,30 +4,33 @@
   fetchFromGitHub,
   libcap,
   libseccomp,
+  cmake,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ruri";
-  version = "3.8";
+  version = "3.9.1";
 
   src = fetchFromGitHub {
-    owner = "Moe-hacker";
+    owner = "RuriOSS";
     repo = "ruri";
     rev = "v${finalAttrs.version}";
     fetchSubmodules = false;
-    sha256 = "sha256-gf+WJPGeLbMntBk8ryTSsV9L4J3N4Goh9eWBIBj5FA4=";
+    sha256 = "sha256-stM4hSLdSqmYUZ/XBD3Y1GylrrGRISlcy8LN07HREpQ=";
   };
+
+  patches = [
+    # See https://github.com/NixOS/nixpkgs/pull/433118#issuecomment-3194094492
+    # cmake installed a wrong path
+    ./fix-install.patch
+  ];
 
   buildInputs = [
     libcap
     libseccomp
   ];
 
-  installPhase = ''
-    runHook preInstall
-    install -Dm755 ruri $out/bin/ruri
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ cmake ];
 
   meta = {
     description = "Self-contained Linux container implementation";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
