### PR TITLE
python3Packages.sipsimple: Fix build on aarch64

### DIFF
--- a/pkgs/development/python-modules/sipsimple/pjsip-0001-NEON.patch
+++ b/pkgs/development/python-modules/sipsimple/pjsip-0001-NEON.patch
@@ -1,0 +1,133 @@
+From c18466834e4f845dfc9383c6944a72f31a78fafc Mon Sep 17 00:00:00 2001
+From: Andrey <loukhnov@lotes-tm.ru>
+Date: Thu, 14 Nov 2024 05:51:54 +0300
+Subject: [PATCH 1/3] Correct cpu features detection during cross-compiation
+ (#4151)
+
+---
+ aconfigure    | 48 +++++++++++++++++++++++++++++++++++++++++++++---
+ aconfigure.ac | 35 ++++++++++++++++++++++++++++++++---
+ 2 files changed, 77 insertions(+), 6 deletions(-)
+
+diff --git a/aconfigure b/aconfigure
+index 57716969d..eac120472 100755
+--- a/aconfigure
++++ b/aconfigure
+@@ -8997,6 +8997,36 @@ $as_echo "Checking if libyuv is disabled...no" >&6; }
+ fi
+ 
+ 
++SAVED_CFLAGS="$CFLAGS"
++case $target_cpu in
++	arm*)
++        CFLAGS="-mfpu=neon $CFLAGS"
++	;;
++	aarch64*)
++        CFLAGS="-march=armv8-a+simd $CFLAGS"
++	;;
++esac
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++int
++main (void)
++{
++
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"
++then :
++  ax_cv_support_neon_ext=yes
++else $as_nop
++  ax_cv_support_neon_ext=no
++
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++CFLAGS="$SAVED_CFLAGS"
++
+ 
+ 
+ 
+@@ -9064,9 +9094,21 @@ $as_echo "Checking if libwebrtc is disabled...no" >&6; }
+ 			;;
+ 		     *win32* | *w32* | *darwin* | *linux*)
+                          case $target in
+-                             armv7l*gnueabihf)
+-                                 ac_webrtc_instset=neon
+-                                 ac_webrtc_cflags="-DWEBRTC_ARCH_ARMV7 -mfloat-abi=hard -mfpu=neon"
++                             arm*gnueabihf)
++                                 if test "x$ax_cv_support_neon_ext" = "xyes"; then
++                                     ac_webrtc_instset=neon
++                                     ac_webrtc_cflags="-DWEBRTC_ARCH_ARMV7 -mfloat-abi=hard -mfpu=neon"
++                                 else
++                                     ac_webrtc_instset=generic
++                                 fi
++                                 ;;
++                             aarch64*)
++                                 if test "x$ax_cv_support_neon_ext" = "xyes"; then
++                                     ac_webrtc_instset=neon
++                                     ac_webrtc_cflags="-DWEBRTC_ARCH_ARM64"
++                                 else
++                                     ac_webrtc_instset=generic
++                                 fi
+                                  ;;
+                              arm-apple-darwin*)
+                                  ac_webrtc_instset=neon
+diff --git a/aconfigure.ac b/aconfigure.ac
+index 48ff9f18e..fc472c7de 100644
+--- a/aconfigure.ac
++++ b/aconfigure.ac
+@@ -2057,6 +2057,23 @@ AC_ARG_ENABLE(libyuv,
+ 	      AC_MSG_RESULT([Checking if libyuv is disabled...no]))
+ 
+ 
++dnl proper neon detector
++SAVED_CFLAGS="$CFLAGS"
++case $target_cpu in
++	arm*)
++        CFLAGS="-mfpu=neon $CFLAGS"
++	;;
++	aarch64*)
++        CFLAGS="-march=armv8-a+simd $CFLAGS"
++	;;
++esac
++AC_COMPILE_IFELSE(
++    [AC_LANG_PROGRAM()],
++    [ax_cv_support_neon_ext=yes],
++    [ax_cv_support_neon_ext=no]
++)
++CFLAGS="$SAVED_CFLAGS"
++
+ dnl # Include webrtc
+ AC_SUBST(ac_no_webrtc)
+ AC_SUBST(ac_webrtc_instset)
+@@ -2121,9 +2138,21 @@ AC_ARG_ENABLE(libwebrtc,
+ 			;;
+ 		     *win32* | *w32* | *darwin* | *linux*)
+                          case $target in
+-                             armv7l*gnueabihf)
+-                                 ac_webrtc_instset=neon
+-                                 ac_webrtc_cflags="-DWEBRTC_ARCH_ARMV7 -mfloat-abi=hard -mfpu=neon"
++                             arm*gnueabihf)
++                                 if test "x$ax_cv_support_neon_ext" = "xyes"; then
++                                     ac_webrtc_instset=neon
++                                     ac_webrtc_cflags="-DWEBRTC_ARCH_ARMV7 -mfloat-abi=hard -mfpu=neon"
++                                 else
++                                     ac_webrtc_instset=generic
++                                 fi
++                                 ;;
++                             aarch64*)
++                                 if test "x$ax_cv_support_neon_ext" = "xyes"; then
++                                     ac_webrtc_instset=neon
++                                     ac_webrtc_cflags="-DWEBRTC_ARCH_ARM64"
++                                 else
++                                     ac_webrtc_instset=generic
++                                 fi
+                                  ;;
+                              *)
+                                  ac_webrtc_instset=sse2
+-- 
+2.50.1
+

--- a/pkgs/development/python-modules/sipsimple/pjsip-0002-RISC-V.patch
+++ b/pkgs/development/python-modules/sipsimple/pjsip-0002-RISC-V.patch
@@ -1,0 +1,96 @@
+From da5a961150fc20e48fb83ec3a279266600f47472 Mon Sep 17 00:00:00 2001
+From: Guoguo <16666742+imguoguo@users.noreply.github.com>
+Date: Tue, 12 Aug 2025 16:08:22 +0200
+Subject: [PATCH 2/3] Fix build failure on RISC-V architecture (#4173)
+
+---
+ aconfigure                               | 3 +++
+ aconfigure.ac                            | 3 +++
+ config.guess                             | 3 +++
+ config.sub                               | 2 ++
+ third_party/webrtc/src/webrtc/typedefs.h | 7 +++++++
+ 5 files changed, 18 insertions(+)
+
+diff --git a/aconfigure b/aconfigure
+index eac120472..09cd7b901 100755
+--- a/aconfigure
++++ b/aconfigure
+@@ -9114,6 +9114,9 @@ $as_echo "Checking if libwebrtc is disabled...no" >&6; }
+                                  ac_webrtc_instset=neon
+                                  ac_webrtc_cflags="-DWEBRTC_ARCH_ARM64"
+                                  ;;
++                             riscv*)
++                                 ac_webrtc_instset=generic
++                                 ;;
+                              *)
+                                  ac_webrtc_instset=sse2
+                                  ;;
+diff --git a/aconfigure.ac b/aconfigure.ac
+index fc472c7de..81be8ed7b 100644
+--- a/aconfigure.ac
++++ b/aconfigure.ac
+@@ -2154,6 +2154,9 @@ AC_ARG_ENABLE(libwebrtc,
+                                      ac_webrtc_instset=generic
+                                  fi
+                                  ;;
++                             riscv*)
++                                 ac_webrtc_instset=generic
++                                 ;;
+                              *)
+                                  ac_webrtc_instset=sse2
+                                  ;;
+diff --git a/config.guess b/config.guess
+index aa04f04bd..b6f948fdc 100755
+--- a/config.guess
++++ b/config.guess
+@@ -979,6 +979,9 @@ EOF
+     ppc:Linux:*:*)
+ 	echo powerpc-unknown-linux-gnu
+ 	exit ;;
++    riscv32:Linux:*:* | riscv32be:Linux:*:* | riscv64:Linux:*:* | riscv64be:Linux:*:*)
++	echo ${UNAME_MACHINE}-unknown-linux-gnu
++	exit ;;
+     s390:Linux:*:* | s390x:Linux:*:*)
+ 	echo ${UNAME_MACHINE}-ibm-linux
+ 	exit ;;
+diff --git a/config.sub b/config.sub
+index a92e84680..3117281cb 100755
+--- a/config.sub
++++ b/config.sub
+@@ -304,6 +304,7 @@ case $basic_machine in
+ 	| pdp10 | pdp11 | pj | pjl \
+ 	| powerpc | powerpc64 | powerpc64le | powerpcle \
+ 	| pyramid \
++	| riscv | riscv32 | riscv32be | riscv64 | riscv64be \
+ 	| rl78 | rx \
+ 	| score \
+ 	| sh | sh[1234] | sh[24]a | sh[24]aeb | sh[23]e | sh[34]eb | sheb | shbe | shle | sh[1234]le | sh3ele \
+@@ -419,6 +420,7 @@ case $basic_machine in
+ 	| pdp10-* | pdp11-* | pj-* | pjl-* | pn-* | power-* \
+ 	| powerpc-* | powerpc64-* | powerpc64le-* | powerpcle-* \
+ 	| pyramid-* \
++	| riscv-* | riscv32-* | riscv32be-* | riscv64-* | riscv64be-* \
+ 	| rl78-* | romp-* | rs6000-* | rx-* \
+ 	| sh-* | sh[1234]-* | sh[24]a-* | sh[24]aeb-* | sh[23]e-* | sh[34]eb-* | sheb-* | shbe-* \
+ 	| shle-* | sh[1234]le-* | sh3ele-* | sh64-* | sh64le-* \
+diff --git a/third_party/webrtc/src/webrtc/typedefs.h b/third_party/webrtc/src/webrtc/typedefs.h
+index 3034c7e74..d8d9813fe 100644
+--- a/third_party/webrtc/src/webrtc/typedefs.h
++++ b/third_party/webrtc/src/webrtc/typedefs.h
+@@ -47,6 +47,13 @@
+ #elif defined(__pnacl__)
+ #define WEBRTC_ARCH_32_BITS
+ #define WEBRTC_ARCH_LITTLE_ENDIAN
++#elif defined(__riscv) || defined(__riscv__)
++#define WEBRTC_ARCH_LITTLE_ENDIAN
++#if __riscv_xlen == 64
++#define WEBRTC_ARCH_64_BITS
++#else
++#define WEBRTC_ARCH_32_BITS
++#endif
+ #else
+ #error Please add support for your architecture in typedefs.h
+ #endif
+-- 
+2.50.1
+

--- a/pkgs/development/python-modules/sipsimple/pjsip-0003-LoongArch64.patch
+++ b/pkgs/development/python-modules/sipsimple/pjsip-0003-LoongArch64.patch
@@ -1,0 +1,56 @@
+From 837d5d183588bfd42fc581a415714972f758b83d Mon Sep 17 00:00:00 2001
+From: xiaoxiaoafeifei <zhailiangliang@loongson.cn>
+Date: Tue, 12 Aug 2025 16:11:35 +0200
+Subject: [PATCH 3/3] Add support for the LoongArch64 architecture (#4386)
+
+---
+ aconfigure                               | 3 +++
+ aconfigure.ac                            | 3 +++
+ third_party/webrtc/src/webrtc/typedefs.h | 3 +++
+ 3 files changed, 9 insertions(+)
+
+diff --git a/aconfigure b/aconfigure
+index 09cd7b901..d551e6338 100755
+--- a/aconfigure
++++ b/aconfigure
+@@ -9114,6 +9114,9 @@ $as_echo "Checking if libwebrtc is disabled...no" >&6; }
+                                  ac_webrtc_instset=neon
+                                  ac_webrtc_cflags="-DWEBRTC_ARCH_ARM64"
+                                  ;;
++                             loongarch*)
++                                 ac_webrtc_instset=generic
++                                 ;;
+                              riscv*)
+                                  ac_webrtc_instset=generic
+                                  ;;
+diff --git a/aconfigure.ac b/aconfigure.ac
+index 81be8ed7b..cb4552ab5 100644
+--- a/aconfigure.ac
++++ b/aconfigure.ac
+@@ -2154,6 +2154,9 @@ AC_ARG_ENABLE(libwebrtc,
+                                      ac_webrtc_instset=generic
+                                  fi
+                                  ;;
++                             loongarch*)
++                                 ac_webrtc_instset=generic
++                                 ;;
+                              riscv*)
+                                  ac_webrtc_instset=generic
+                                  ;;
+diff --git a/third_party/webrtc/src/webrtc/typedefs.h b/third_party/webrtc/src/webrtc/typedefs.h
+index d8d9813fe..2493f77cd 100644
+--- a/third_party/webrtc/src/webrtc/typedefs.h
++++ b/third_party/webrtc/src/webrtc/typedefs.h
+@@ -54,6 +54,9 @@
+ #else
+ #define WEBRTC_ARCH_32_BITS
+ #endif
++#elif defined(__loongarch64) || defined(__loongarch64__)
++#define WEBRTC_ARCH_LITTLE_ENDIAN
++#define WEBRTC_ARCH_64_BITS
+ #else
+ #error Please add support for your architecture in typedefs.h
+ #endif
+-- 
+2.50.1
+


### PR DESCRIPTION
And apply potential fixes for riscv and loongarch64 as well.

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `5de84cc5ee3c77a838d424aa7342cb3ec15132f4`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>blink-qt</li>
    <li>blink-qt.dist</li>
    <li>python312Packages.sipsimple</li>
    <li>python312Packages.sipsimple.dist</li>
    <li>python313Packages.sipsimple</li>
    <li>python313Packages.sipsimple.dist</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
