### PR TITLE
libtas: 1.4.5 -> 1.4.6 + several fixes

### DIFF
--- a/pkgs/by-name/li/libtas/package.nix
+++ b/pkgs/by-name/li/libtas/package.nix
@@ -14,6 +14,10 @@
   file,
   binutils,
   makeDesktopItem,
+
+  # Forces libTAS to run in X11.
+  # Enabled by default because libTAS does not support Wayland.
+  withForceX11 ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -73,6 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
           ffmpeg.lib
         ]
       } \
+      ${lib.optionalString withForceX11 "--set QT_QPA_PLATFORM xcb"} \
       --set-default LIBTAS_SO_PATH $out/lib/libtas.so
   '';
 

--- a/pkgs/by-name/li/libtas/package.nix
+++ b/pkgs/by-name/li/libtas/package.nix
@@ -7,7 +7,7 @@
   SDL2,
   alsa-lib,
   ffmpeg,
-  lua5_3,
+  lua5_4,
   qt5,
   file,
   binutils,
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libtas";
-  version = "1.4.5";
+  version = "1.4.6";
 
   src = fetchFromGitHub {
     owner = "clementgallet";
     repo = "libTAS";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-n4iaJG9k+/TFfGMDCYL83Z6paxpm/gY3thP9T84GeQU=";
+    hash = "sha256-/hyKJ8HGLN7hT+9If/lcp0C7GnhJMRpc7EKDgA1kQcI=";
   };
 
   nativeBuildInputs = [
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     SDL2
     alsa-lib
     ffmpeg
-    lua5_3
+    lua5_4
     qt5.qtbase
   ];
 

--- a/pkgs/by-name/li/libtas/package.nix
+++ b/pkgs/by-name/li/libtas/package.nix
@@ -70,6 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
       --suffix LD_LIBRARY_PATH : ${
         lib.makeLibraryPath [
           xorg.libXi
+          ffmpeg.lib
         ]
       } \
       --set-default LIBTAS_SO_PATH $out/lib/libtas.so

--- a/pkgs/by-name/li/libtas/package.nix
+++ b/pkgs/by-name/li/libtas/package.nix
@@ -10,6 +10,7 @@
   ffmpeg,
   lua5_4,
   qt5,
+  xorg,
   file,
   binutils,
   makeDesktopItem,
@@ -64,6 +65,11 @@ stdenv.mkDerivation (finalAttrs: {
           file
           binutils
           ffmpeg
+        ]
+      } \
+      --suffix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          xorg.libXi
         ]
       } \
       --set-default LIBTAS_SO_PATH $out/lib/libtas.so

--- a/pkgs/by-name/li/libtas/package.nix
+++ b/pkgs/by-name/li/libtas/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchurl,
   autoreconfHook,
   pkg-config,
   SDL2,
@@ -24,6 +25,13 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-/hyKJ8HGLN7hT+9If/lcp0C7GnhJMRpc7EKDgA1kQcI=";
   };
+  patches = [
+    # Fixes `undefined symbol: SDL_Log` errors
+    (fetchurl {
+      url = "https://github.com/clementgallet/libTAS/commit/779ff0fb0f3accfc62949680d85ecf96b28d18ef.patch";
+      hash = "sha256-xAaTWIXt8FkMu6GE5mBWtLypROFZ1aEqmBTtG+6rTWk=";
+    })
+  ];
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
Supersedes / Resolves #325049

Bumps libtas to [v1.4.6](<https://github.com/clementgallet/libTAS/releases/tag/v1.4.6>) ([changelog](<https://github.com/clementgallet/libTAS/blob/v1.4.6/CHANGELOG.md#146---2024-07-05>)) with fixes to issues I've encountered throughout upgrading this package & using the package for developing a TAS for Deltarune.

CC: @skyrina

## Things done

- 510a921fa4cad23baf4b8e6174ffaf3013e70806 Bump libTAS to 1.4.6
- 510a921fa4cad23baf4b8e6174ffaf3013e70806 Bump Lua dependency to 5.4 [as suggested here](<https://github.com/NixOS/nixpkgs/pull/325049#pullrequestreview-2161844705>) as well as in the [README](<https://github.com/clementgallet/libTAS/tree/v1.4.6?tab=readme-ov-file#install>) of libtas.
- f76a7e7ed5287b152e6ee77bc4ab020c7cbfb28d Fix `undefined symbol: SDL_Log` errors by applying the patch of [this upstream commit](<https://github.com/clementgallet/libTAS/commit/779ff0fb0f3accfc62949680d85ecf96b28d18ef>) which is not part of a stable release yet.
- 6664ef393b5b513d03a157179127df06784e4f2f Allows libTAS to run on X11 again (fixes `Could not import symbol XIGetSelectedEvents` errors)
- 4c90a4483206cc09d5ea11eb44448689e9c9ab0f Fixes audio capture when encoding movies. Previously, videos would be silent because libTAS could not find `libswresample4`.
- e300b37aecd531173307a09787c33f416142fd56 Add (enabled by default) override option to force libTAS to run in X11. libTAS fails to capture game inputs under Wayland & upstream states X11 is supported only.

If desired, some parts of the PR can be dropped or be split up into separate PRs. 

## Checklist

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
