### PR TITLE
haskell.compiler.ghcHEAD: 9.15.20250805 -> 9.15.20250811

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -67,16 +67,16 @@
   enableShared ? with stdenv.targetPlatform; !isWindows && !useiOSPrebuilt && !isStatic && !isGhcjs,
 
   # Whether to build terminfo.
-  # FIXME(@sternenseemann): This actually doesn't influence what hadrian does,
-  # just what buildInputs etc. looks like. It would be best if we could actually
-  # tell it what to do like it was possible with make.
   enableTerminfo ?
     !(
       stdenv.targetPlatform.isWindows
       || stdenv.targetPlatform.isGhcjs
-      # terminfo can't be built for cross
-      || (stdenv.buildPlatform != stdenv.hostPlatform)
-      || (stdenv.hostPlatform != stdenv.targetPlatform)
+      # Before <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13932>,
+      # we couldn't force hadrian to build terminfo for cross.
+      || (
+        lib.versionOlder version "9.15.20250808"
+        && (stdenv.buildPlatform != stdenv.hostPlatform || stdenv.hostPlatform != stdenv.targetPlatform)
+      )
     ),
 
   # Libdw.c only supports x86_64, i686 and s390x as of 2022-08-04

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -1,5 +1,5 @@
 import ./common-hadrian.nix {
-  version = "9.15.20250805";
-  rev = "c2a78cea95d2d6cdd26a1c42556aad1f368ee4bd";
-  sha256 = "1pan87xyi9572rbispsvsxvajsxxzg36i35m09mk6spc5qr7a3dy";
+  version = "9.15.20250811";
+  rev = "c8d76a2994b8620c54adc2069f4728135d6b5059";
+  sha256 = "001rf9z5a1v2xpm9qjzz2p966m5bxmqcnykq0xgb3qf40vi9rnh4";
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.16.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.16.x.nix
@@ -47,12 +47,7 @@ self: super: {
   stm = null;
   system-cxx-std-lib = null;
   template-haskell = null;
-  # GHC only builds terminfo if it is a native compiler
-  terminfo =
-    if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform then
-      null
-    else
-      haskellLib.doDistribute self.terminfo_0_4_1_7;
+  terminfo = null;
   text = null;
   time = null;
   transformers = null;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (native and cross to aarch64-linux)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
