### PR TITLE
Fix rustc target custom JSON madness

### DIFF
--- a/pkgs/build-support/rust/hooks/cargo-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-build-hook.sh
@@ -19,7 +19,7 @@ cargoBuildHook() {
 
     local flagsArray=(
         "-j" "$NIX_BUILD_CORES"
-        "--target" "@rustcTarget@"
+        "--target" "@rustcTargetSpec@"
         "--offline"
     )
 

--- a/pkgs/build-support/rust/hooks/cargo-check-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-check-hook.sh
@@ -29,7 +29,7 @@ cargoCheckHook() {
     fi
 
     flagsArray+=(
-        "--target" "@rustcTarget@"
+        "--target" "@rustcTargetSpec@"
         "--offline"
     )
 

--- a/pkgs/build-support/rust/hooks/cargo-nextest-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-nextest-hook.sh
@@ -10,7 +10,7 @@ cargoNextestHook() {
     fi
 
     local flagsArray=(
-        "--target" "@rustcTarget@"
+        "--target" "@rustcTargetSpec@"
         "--offline"
     )
 

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -20,7 +20,7 @@
   cargoBuildHook = makeSetupHook {
     name = "cargo-build-hook.sh";
     substitutions = {
-      inherit (stdenv.targetPlatform.rust) rustcTarget;
+      inherit (stdenv.targetPlatform.rust) rustcTargetSpec;
       inherit (rust.envVars) setEnv;
 
     };
@@ -35,7 +35,7 @@
   cargoCheckHook = makeSetupHook {
     name = "cargo-check-hook.sh";
     substitutions = {
-      inherit (stdenv.targetPlatform.rust) rustcTarget;
+      inherit (stdenv.targetPlatform.rust) rustcTargetSpec;
       inherit (rust.envVars) setEnv;
     };
     passthru.tests = {
@@ -63,7 +63,7 @@
     name = "cargo-nextest-hook.sh";
     propagatedBuildInputs = [ cargo-nextest ];
     substitutions = {
-      inherit (stdenv.targetPlatform.rust) rustcTarget;
+      inherit (stdenv.targetPlatform.rust) rustcTargetSpec;
     };
     passthru.tests = {
       test = tests.rust-hooks.cargoNextestHook;
@@ -121,7 +121,7 @@
       pkgsHostTarget.rustc
     ];
     substitutions = {
-      inherit (stdenv.targetPlatform.rust) rustcTarget;
+      inherit (stdenv.targetPlatform.rust) rustcTargetSpec;
       inherit (rust.envVars) setEnv;
 
     };

--- a/pkgs/build-support/rust/hooks/maturin-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/maturin-build-hook.sh
@@ -20,7 +20,7 @@ maturinBuildHook() {
     local flagsArray=(
         "--jobs=$NIX_BUILD_CORES"
         "--offline"
-        "--target" "@rustcTarget@"
+        "--target" "@rustcTargetSpec@"
         "--manylinux" "off"
         "--strip"
         "--release"

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -111,9 +111,9 @@ stdenv.mkDerivation (finalAttrs: {
         stdenv: "${prefixForStdenv stdenv}${if (stdenv.cc.isClang or false) then "clang" else "cc"}";
       cxxPrefixForStdenv =
         stdenv: "${prefixForStdenv stdenv}${if (stdenv.cc.isClang or false) then "clang++" else "c++"}";
-      setBuild = "--set=target.\"${stdenv.buildPlatform.rust.rustcTarget}\"";
-      setHost = "--set=target.\"${stdenv.hostPlatform.rust.rustcTarget}\"";
-      setTarget = "--set=target.\"${stdenv.targetPlatform.rust.rustcTarget}\"";
+      setBuild = "--set=target.\"${stdenv.buildPlatform.rust.rustcTargetSpec}\"";
+      setHost = "--set=target.\"${stdenv.hostPlatform.rust.rustcTargetSpec}\"";
+      setTarget = "--set=target.\"${stdenv.targetPlatform.rust.rustcTargetSpec}\"";
       ccForBuild = ccPrefixForStdenv pkgsBuildBuild.targetPackages.stdenv;
       cxxForBuild = cxxPrefixForStdenv pkgsBuildBuild.targetPackages.stdenv;
       ccForHost = ccPrefixForStdenv pkgsBuildHost.targetPackages.stdenv;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Two places where we currently use `rustcTarget`, but it should be `rustcTargetSpec`.

Some hacks was still needed (https://github.com/NixOS/nixpkgs/pull/433135#issuecomment-3182579192), but any further fixes should, fingers crossed, be confined to platforms that actually need a custom `rustcTargetSpec`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux (Tried compiling `bonk` native, cross to riscv64, and cross to custom mips3 target (see: https://github.com/NixOS/nixpkgs/pull/433135#issuecomment-3182579192))
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
