### PR TITLE
python3Packages.pypillowfight: 0.3.0-unstable-2024-07-07 -> 0.3.1

### DIFF
--- a/pkgs/development/python-modules/pypillowfight/default.nix
+++ b/pkgs/development/python-modules/pypillowfight/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitLab,
   pillow,
@@ -8,7 +9,7 @@
 }:
 buildPythonPackage rec {
   pname = "pypillowfight";
-  version = "0.3.0-unstable-2024-07-07";
+  version = "0.3.1";
   pyproject = true;
 
   src = fetchFromGitLab {
@@ -16,12 +17,11 @@ buildPythonPackage rec {
     group = "World";
     owner = "OpenPaperwork";
     repo = "libpillowfight";
-    # Currently no tagged release past 0.3.0 and we need these patches to fix Python 3.12 compat
-    rev = "4d5f739b725530cd61e709071d31e9f707c64bd6";
-    hash = "sha256-o5FzUSDq0lwkXGXRMsS5NB/Mp4Ie833wkxKPziR23f4=";
+    tag = version;
+    hash = "sha256-ZH1Eg8GLe3LZ7elohQCYCToEvx8bGaRSrcsT+qSY9s4=";
   };
 
-  prePatch = ''
+  postPatch = ''
     echo '#define INTERNAL_PILLOWFIGHT_VERSION "${version}"' > src/pillowfight/_version.h
   '';
 
@@ -32,6 +32,9 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   meta = {
+    # Package has non-portable behavior that makes it not work on Darwin
+    # https://github.com/NixOS/nixpkgs/pull/433141#issuecomment-3180885173
+    broken = stdenv.hostPlatform.isDarwin;
     description = "Library containing various image processing algorithms";
     inherit (src.meta) homepage;
     license = lib.licenses.gpl3Plus;


### PR DESCRIPTION
Updates to the latest version of the package

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
