### PR TITLE
audiofile: add many CVE patches

### DIFF
--- a/pkgs/by-name/au/audiofile/package.nix
+++ b/pkgs/by-name/au/audiofile/package.nix
@@ -16,7 +16,7 @@ let
     }:
     fetchpatch {
       inherit sha256 name;
-      url = "https://salsa.debian.org/multimedia-team/audiofile/raw/debian/0.3.6-4/debian/patches/${debname}";
+      url = "https://salsa.debian.org/multimedia-team/audiofile/raw/debian/0.3.6-7/debian/patches/${debname}";
     };
 
 in
@@ -96,6 +96,31 @@ stdenv.mkDerivation rec {
       name = "CVE-2017-6833.patch";
       debname = "10_Check-for-division-by-zero-in-BlockCodec-runPull.patch";
       sha256 = "1rlislkjawq98bbcf1dgl741zd508wwsg85r37ca7pfdf6wgl6z7";
+    })
+    (fetchDebianPatch {
+      name = "CVE-2018-13440.patch";
+      debname = "11_CVE-2018-13440.patch";
+      sha256 = "sha256-qDfjiBJ4QXgn8588Ra1X0ViH0jBjtFS/+2zEGIUIhuo=";
+    })
+    (fetchDebianPatch {
+      name = "CVE-2018-17095.patch";
+      debname = "12_CVE-2018-17095.patch";
+      sha256 = "sha256-FC89EFZuRLcj5x4wZVqUlitEMTRPSZk+qzQpIoVk9xY=";
+    })
+    (fetchDebianPatch {
+      name = "CVE-2022-24599.patch";
+      debname = "0013-Fix-CVE-2022-24599.patch";
+      sha256 = "sha256-DHJQ4B6cvKfSlXy66ZC5RNaCMDaygj8dWLZZhJnhw1E=";
+    })
+    (fetchDebianPatch {
+      name = "1_CVE-2019-13147.patch";
+      debname = "0014-Partial-fix-of-CVE-2019-13147.patch";
+      sha256 = "sha256-clb/XiIZbmttPr2dT9AZsbQ97W6lwifEwMO4l2ZEh0k=";
+    })
+    (fetchDebianPatch {
+      name = "2_CVE-2019-13147.patch";
+      debname = "0015-Partial-fix-of-CVE-2019-13147.patch";
+      sha256 = "sha256-JOZIw962ae7ynnjJXGO29i8tuU5Dhk67DmB0o5/vSf4=";
     })
   ];
 


### PR DESCRIPTION
Patch the following CVEs using debian patches.

* CVE-2018-13440
* CVE-2018-17095
* CVE-2022-24599
* CVE-2019-13147

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
