### PR TITLE
github-to-sops: init at 2.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26198,6 +26198,13 @@
     githubId = 3742502;
     name = "Oscar Molnar";
   };
+  typedrat = {
+    name = "Alexis Williams";
+    email = "alexis@typedr.at";
+    github = "typedrat";
+    githubId = 1057789;
+    matrix = "@typedrat:thisratis.gay";
+  };
   typetetris = {
     email = "ericwolf42@mail.com";
     github = "typetetris";

--- a/pkgs/by-name/gi/github-to-sops/package.nix
+++ b/pkgs/by-name/gi/github-to-sops/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchpatch2,
+  python3Packages,
+  sops,
+  versionCheckHook,
+  nix-update-script,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "github-to-sops";
+  version = "2.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tarasglek";
+    repo = "github-to-sops";
+    tag = "v${version}";
+    hash = "sha256-HwJay5GaEWhXBsRijSgxX+FMKX7wIwssDVoekPKJ67M=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = [
+    sops
+  ];
+
+  patches = [
+    (fetchpatch2 {
+      name = "use-compliant-license-schema.patch";
+      url = "https://github.com/tarasglek/github-to-sops/commit/798c864f1537f668fbaf7802651ec8beb998a7af.patch?full_index=1";
+      hash = "sha256-udBO5dN8RCclXpkTj/gU6zcUcaoM+G9jPEw4dCZ+oT4=";
+    })
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool for managing infrastructure secrets in git repositories using SOPS and GitHub SSH keys";
+    homepage = "https://github.com/tarasglek/github-to-sops";
+    license = lib.licenses.mit;
+    mainProgram = "github-to-sops";
+    maintainers = with lib.maintainers; [ typedrat ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds the package [`github-to-sops`](https://github.com/tarasglek/github-to-sops/tree/v2.0.0), a script that automates using GitHub's account SSH keys to manage access to SOPS secrets.

Also adds `typedrat` as a maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
