### PR TITLE
python3Packages: add matscipy (build failing)

### DIFF
--- a/pkgs/development/python-modules/matscipy/default.nix
+++ b/pkgs/development/python-modules/matscipy/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pythonOlder,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "matscipy";
+  version = "1.1.1";
+  pyproject = true;
+
+  build-system = [
+    meson
+    meson-python
+    ninja
+    cython
+    numpy
+  ];
+
+  src = fetchFromGitHub {
+    owner = "libAtoms";
+    repo = "matscipy";
+    tag = "v${version}";
+    hash = "sha256-mVN+9PTwEMD24KV3Eyp0Jq4vgA1Zs+jThdEbVcfs6pw=";
+  };
+
+  dependencies = with pkgs.python312Packages; [
+    numpy #>=1.16.0, <2.0.0
+    scipy #>+1.2.3
+    ase #>=3.23.0
+    packaging
+  ];
+
+  meta = {
+    description = "Generic Python Materials Science tools";
+    homepage = "https://github.com/libAtoms/matscipy";
+    changelog = "https://github.com/libAtoms/matscipy/releases/tag/v${version}";
+    license = with lib.licenses; [ lgpl21Only ];
+    maintainers = with lib.maintainers; [ sh4k0 ];
+  };
+}

--- a/pkgs/development/python-modules/matscipy/default.nix
+++ b/pkgs/development/python-modules/matscipy/default.nix
@@ -4,6 +4,14 @@
   buildPythonPackage,
   pythonOlder,
   setuptools,
+  meson,
+  meson-python,
+  ninja,
+  cython,
+  numpy,
+  scipy,
+  ase,
+  packaging,
 }:
 
 buildPythonPackage rec {
@@ -26,7 +34,7 @@ buildPythonPackage rec {
     hash = "sha256-mVN+9PTwEMD24KV3Eyp0Jq4vgA1Zs+jThdEbVcfs6pw=";
   };
 
-  dependencies = with pkgs.python312Packages; [
+  dependencies = [
     numpy #>=1.16.0, <2.0.0
     scipy #>+1.2.3
     ase #>=3.23.0

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8939,6 +8939,8 @@ self: super: with self; {
 
   matrix-nio = callPackage ../development/python-modules/matrix-nio { };
 
+  matscipy = callPackage ../development/python-modules/matscipy { };
+
   mattermostdriver = callPackage ../development/python-modules/mattermostdriver { };
 
   maubot = callPackage ../tools/networking/maubot { };


### PR DESCRIPTION
<!--
I would like to contribute this python library to nixpkgs. The build (meson) fails due to a build hook (`discover_version.py` in the root of the git repo) being unable to determine the package version. I am not sure on how to proceed, any help would be appreciated.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
