### PR TITLE
patchelf: 0.15.0 -> 0.15.2

### DIFF
--- a/pkgs/development/tools/misc/patchelf/default.nix
+++ b/pkgs/development/tools/misc/patchelf/default.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation rec {
   pname = "patchelf";
-  version = "0.15.0";
+  version = "0.15.2";
 
   src = fetchurl {
     url = "https://github.com/NixOS/${pname}/releases/download/${version}/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-9ANtPuTY4ijewb7/8PbkbYpA6eVw4AaOOdd+YuLIvcI=";
+    sha256 = "sha256-F3RfVkFZyOIo/EEtplogSLhGxLa0Igt3y/IkFuAvLXw=";
   };
 
   strictDeps = true;
@@ -25,11 +25,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   # fails 8 out of 24 tests, problems when loading libc.so.6
-  doCheck =
-    stdenv.name == "stdenv-linux"
-    # test scripts require unprefixed bintools binaries
-    # https://github.com/NixOS/patchelf/issues/417
-    && stdenv.cc.targetPrefix == "";
+  doCheck = stdenv.name == "stdenv-linux";
 
   meta = with lib; {
     homepage = "https://github.com/NixOS/patchelf";


### PR DESCRIPTION
See the 0.15.1 and 0.15.2 changelogs: https://github.com/NixOS/patchelf/releases

I've carefully backported *just* some quality of life improvements (C++ warning fixes, shellcheck fixes, build system and CI infra). No behavior should be changed, except for the simplest bugfixes (e.g. close file before throwing exception). Therefore, this should be safe to bump in in Nixpkgs right away.

CC @mic92 @alyssais 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
