### PR TITLE
nixos/zcfan: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -88,6 +88,8 @@
 
 - [paisa](https://github.com/ananthakumaran/paisa), a personal finance tracker and dashboard. Available as [services.paisa](#opt-services.paisa.enable).
 
+- [zcfan](https://github.com/cdown/zcfan), a zero-configuration fan daemon for ThinkPads. Available as [services.zcfan](#opt-services.zcfan.enable).
+
 ## Backward Incompatibilities {#sec-release-25.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -695,6 +695,7 @@
   ./services/hardware/usbmuxd.nix
   ./services/hardware/usbrelayd.nix
   ./services/hardware/vdr.nix
+  ./services/hardware/zcfan.nix
   ./services/home-automation/ebusd.nix
   ./services/home-automation/esphome.nix
   ./services/home-automation/evcc.nix

--- a/nixos/modules/services/hardware/zcfan.nix
+++ b/nixos/modules/services/hardware/zcfan.nix
@@ -1,0 +1,59 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.zcfan;
+in
+{
+  options = {
+    services.zcfan = {
+      enable = lib.mkEnableOption "zero-configuration fan daemon for ThinkPads (zcfan)";
+
+      settings = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        description = ''
+          Optional lines added verbatim to the configuration file.
+          Before changing this, read the {manpage}`zcfan(1)`
+          and project's readme at
+          https://github.com/cdown/zcfan/tree/master?tab=readme-ov-file#usage
+        '';
+      };
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !config.services.thinkfan.enable;
+        message = ''
+          You have set services.zcfan.enable = true;
+          which conflicts with services.thinkfan.enable = true;
+        '';
+      }
+    ];
+
+    environment.systemPackages = [ pkgs.zcfan ];
+    systemd.packages = [ pkgs.zcfan ];
+
+    environment.etc."zcfan.conf".text = cfg.settings;
+
+    systemd.services = {
+      zcfan = {
+        serviceConfig = {
+          Restart = "on-failure";
+          RestartSec = "30s";
+        };
+        restartTriggers = [ config.environment.etc."zcfan.conf".text ];
+        # must be added manually, see issue #81138
+        wantedBy = [ "default.target" ];
+      };
+    };
+
+    boot.extraModprobeConfig = "options thinkpad_acpi fan_control=1";
+  };
+
+  meta.maintainers = with lib.maintainers; [ surfaceflinger ];
+}


### PR DESCRIPTION
Added a NixOS module for [zcfan](https://github.com/cdown/zcfan)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
