### PR TITLE
chromium,chromedriver: 139.0.7258.66 -> 139.0.7258.127

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "139.0.7258.66",
+    "version": "139.0.7258.127",
     "chromedriver": {
-      "version": "139.0.7258.67",
-      "hash_darwin": "sha256-kWrlkFZ1X0n7h5GtnfZnKbT1zylVuaSCDMJA549LoEY=",
-      "hash_darwin_aarch64": "sha256-HWgR2CWj5/N2zPIIHXBnA1DoYe0+KAmScopNfMcYlzc="
+      "version": "139.0.7258.128",
+      "hash_darwin": "sha256-QHYwd9B47p3/Y3z/TYaUpNbCBenUrI7yXVsMUwtnifg=",
+      "hash_darwin_aarch64": "sha256-rwMRpEW+sQ6u/Y0rJWGw7UICfjZO8WQddOfzpqwcsnY="
     },
     "deps": {
       "depot_tools": {
@@ -20,8 +20,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "a62d329947691f76c376a873eae39f56381103c8",
-        "hash": "sha256-RWqOw0Kogz2GwbICet7NdcGnZMrkkE4bu70jU+tbYFQ=",
+        "rev": "5dc2cf9cf870d324cd9fba708f26d2572cc6d4d8",
+        "hash": "sha256-YcOVErOKKruc3kPuXhmeibo3KL+Rrny1FEwF769+aEU=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -96,8 +96,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "0145c376fadde16390298681252785f98ae90185",
-        "hash": "sha256-8ztvupTvp5v8lTq3eo/viR9X85qm+bw8299jxr6XslE="
+        "rev": "5f3636345f1d8afd495e2fcc474fd81e91c4866b",
+        "hash": "sha256-fx+QD0T85Js9jPQx2aghJU8UOL6WbR0bOkGY2i87A3w="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -401,8 +401,8 @@
       },
       "src/third_party/libaom/source/libaom": {
         "url": "https://aomedia.googlesource.com/aom.git",
-        "rev": "0ddc6630b3723b14b164752d46c27752f078ddd3",
-        "hash": "sha256-cs1+5vBEFPqzi1vbxiSgujrLIoaXZROZaRJq2gRdUrE="
+        "rev": "90c632fc6c01cd8637186c783ca8012bab3c3260",
+        "hash": "sha256-e+rUkNOakv6WQrgx1ozoJTynk/GZy1zdsnYX4oz+6ks="
       },
       "src/third_party/crabbyavif/src": {
         "url": "https://chromium.googlesource.com/external/github.com/webmproject/CrabbyAvif.git",
@@ -631,8 +631,8 @@
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "cbc694239b06ecf694676aba22d5263dbc23ee5e",
-        "hash": "sha256-5vIwNP9RbtUVtgKKDiZd6NVkR2Ed3DUqZWESTUM+fIs="
+        "rev": "2d6f1aa4be9c33b013c322b2bc9cd99a682243b6",
+        "hash": "sha256-VysJkpCRRYNdCStnXvo6wyMCv1gLHecMwefKiwypARc="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",
@@ -796,8 +796,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "b07b4e9376489c7f7c0ff2af5eceb4261b3bb784",
-        "hash": "sha256-MnrieVgkvlkWKZ0O790gDSCrgF9c+XEk/XLHQDzMqVY="
+        "rev": "505ec917b67c535519bebec58c62a34f145dd49f",
+        "hash": "sha256-fsf8j2Spe++vSnuO8763eWWmMhYqcyybpILb7OkkXq4="
       }
     }
   },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2025/08/stable-channel-update-for-desktop_12.html

This update includes 6 security fixes.

CVEs:
CVE-2025-8879 CVE-2025-8880 CVE-2025-8901 CVE-2025-8881 CVE-2025-8882

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
