### PR TITLE
python3Packages.uuid6: 2024.7.10 -> 2025.0.1

### DIFF
--- a/pkgs/development/python-modules/uuid6/default.nix
+++ b/pkgs/development/python-modules/uuid6/default.nix
@@ -1,37 +1,30 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   setuptools,
+  setuptools-scm,
   pytestCheckHook,
 }:
 buildPythonPackage rec {
   pname = "uuid6";
-  version = "2024.7.10";
+  version = "2025.0.1";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-LSnX9j9ZPKruoODQ3QrYEpycZjsp4ZvfiC6GS+3xj7A=";
+  src = fetchFromGitHub {
+    owner = "oittaa";
+    repo = "uuid6-python";
+    tag = version;
+    hash = "sha256-E8oBbD52zTDcpRCBsJXfSgpF7FPNSVB43uxvsA62XHU=";
   };
-
-  # https://github.com/oittaa/uuid6-python/blob/e647035428d984452b9906b75bb007198533dfb1/setup.py#L12-L19
-  env.GITHUB_REF = "refs/tags/${version}";
 
   build-system = [
     setuptools
+    setuptools-scm
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
-  ];
-
-  enabledTestPaths = [
-    "test/"
-  ];
-
-  disabledTestPaths = [
-    "test/test_uuid6.py"
   ];
 
   pythonImportsCheck = [
@@ -39,6 +32,7 @@ buildPythonPackage rec {
   ];
 
   meta = {
+    changelog = "https://github.com/oittaa/uuid6-python/releases/tag/${src.tag}";
     description = "New time-based UUID formats which are suited for use as a database key";
     homepage = "https://github.com/oittaa/uuid6-python";
     license = lib.licenses.mit;


### PR DESCRIPTION
Diff: https://github.com/oittaa/uuid6-python/compare/refs/tags/2024.7.10...refs/tags/2025.0.1

Changelog: https://github.com/oittaa/uuid6-python/releases/tag/2025.0.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
