### PR TITLE
opencascade-occt: add optional vtk dependency

### DIFF
--- a/pkgs/by-name/op/opencascade-occt/package.nix
+++ b/pkgs/by-name/op/opencascade-occt/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = [ "-fpermissive" ];
   cmakeFlags = [
-    "-DUSE_RAPIDJSON=ON"
+    (lib.cmakeBool "USE_RAPIDJSON" true)
     # Enable exception handling for release builds.
     (lib.cmakeBool "BUILD_RELEASE_DISABLE_EXCEPTIONS" false)
   ]

--- a/pkgs/by-name/op/opencascade-occt/package.nix
+++ b/pkgs/by-name/op/opencascade-occt/package.nix
@@ -13,8 +13,12 @@
   libXext,
   libXmu,
   libXi,
-}:
+  vtk,
+  withVtk ? false,
 
+  # used in passthru.tests
+  opencascade-occt,
+}:
 stdenv.mkDerivation rec {
   pname = "opencascade-occt";
   version = "7.8.1";
@@ -33,6 +37,10 @@ stdenv.mkDerivation rec {
       url = "https://github.com/Open-Cascade-SAS/OCCT/commit/7236e83dcc1e7284e66dc61e612154617ef715d6.diff";
       hash = "sha256-NoC2mE3DG78Y0c9UWonx1vmXoU4g5XxFUT3eVXqLU60=";
     })
+
+    # patch does not apply against 7.9+, it was submitted upstream for future
+    # inclusion: https://github.com/Open-Cascade-SAS/OCCT/pull/683
+    ./vtk-draw-conditional-glx.patch
   ];
 
   nativeBuildInputs = [
@@ -49,10 +57,23 @@ stdenv.mkDerivation rec {
     libXmu
     libXi
     rapidjson
-  ];
+  ]
+  ++ lib.optional withVtk vtk;
 
   NIX_CFLAGS_COMPILE = [ "-fpermissive" ];
-  cmakeFlags = [ "-DUSE_RAPIDJSON=ON" ];
+  cmakeFlags = [
+    "-DUSE_RAPIDJSON=ON"
+  ]
+  ++ lib.optionals withVtk [
+    (lib.cmakeBool "USE_VTK" true)
+    (lib.cmakeFeature "3RDPARTY_VTK_INCLUDE_DIR" "${lib.getDev vtk}/include/vtk")
+  ];
+
+  passthru = {
+    tests = {
+      withVtk = opencascade-occt.override ({ withVtk = true; });
+    };
+  };
 
   meta = with lib; {
     description = "Open CASCADE Technology, libraries for 3D modeling and numerical simulation";
@@ -63,5 +84,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ amiloradovsky ];
     platforms = platforms.all;
   };
-
 }

--- a/pkgs/by-name/op/opencascade-occt/package.nix
+++ b/pkgs/by-name/op/opencascade-occt/package.nix
@@ -63,6 +63,8 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = [ "-fpermissive" ];
   cmakeFlags = [
     "-DUSE_RAPIDJSON=ON"
+    # Enable exception handling for release builds.
+    (lib.cmakeBool "BUILD_RELEASE_DISABLE_EXCEPTIONS" false)
   ]
   ++ lib.optionals withVtk [
     (lib.cmakeBool "USE_VTK" true)

--- a/pkgs/by-name/op/opencascade-occt/vtk-draw-conditional-glx.patch
+++ b/pkgs/by-name/op/opencascade-occt/vtk-draw-conditional-glx.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 86905287dc..19214e8f2d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -623,5 +623,9 @@ if (USE_VTK)
+   add_definitions (-DHAVE_VTK)
+   set (OCCT_VTK_USED_TARGETS "" CACHE INTERNAL "" FORCE)
+   OCCT_INCLUDE_CMAKE_FILE ("adm/cmake/vtk")
++  if (DEFINED VTK_USE_X AND NOT VTK_USE_X)
++      message (STATUS "Info: TKIVtkDraw toolkits excluded due to VTK has no glx support")
++      list (REMOVE_ITEM BUILD_TOOLKITS TKIVtkDraw)
++  endif()
+ else()
+   OCCT_CHECK_AND_UNSET_GROUP ("3RDPARTY_VTK")


### PR DESCRIPTION
build123d (#433247) requires `opencascade-occt` built with `vtk`. These changes add an attribute for that dependency (`withVtk`). Additionally, I enabled C++ exceptions, as they are disabled by default for release builds and `opencascade-occt`'s dependents in nixpkgs seem to require them.

CC @qbisi 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
