### PR TITLE
[Backport release-25.05] openxr-loader: 1.1.47 -> 1.1.50

### DIFF
--- a/pkgs/by-name/op/openxr-loader/package.nix
+++ b/pkgs/by-name/op/openxr-loader/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "openxr-loader";
-  version = "1.1.47";
+  version = "1.1.49";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "OpenXR-SDK-Source";
     tag = "release-${version}";
-    hash = "sha256-7VW99dtE7gz0Y9pKyAdyeKHL6zgk5KvA8jPfgG1O5sc=";
+    hash = "sha256-fQmS8oJZ7Oy/miKCtOQGSvZFDIEMFOcUyz2D6P8hNZY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/op/openxr-loader/package.nix
+++ b/pkgs/by-name/op/openxr-loader/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "openxr-loader";
-  version = "1.1.49";
+  version = "1.1.50";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "OpenXR-SDK-Source";
     tag = "release-${version}";
-    hash = "sha256-fQmS8oJZ7Oy/miKCtOQGSvZFDIEMFOcUyz2D6P8hNZY=";
+    hash = "sha256-/5zw9tj7F0cxhzyIRf8njoYB9moJFYLEjDeqe0OBr34=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Manual backport of #413775 #429453 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
 