### PR TITLE
mcap-cli: 0.0.46 -> 0.0.54

### DIFF
--- a/pkgs/by-name/mc/mcap-cli/package.nix
+++ b/pkgs/by-name/mc/mcap-cli/package.nix
@@ -8,7 +8,7 @@
   nix-update-script,
 }:
 let
-  version = "0.0.46";
+  version = "0.0.54";
 in
 buildGoModule {
 
@@ -20,10 +20,10 @@ buildGoModule {
     repo = "mcap";
     owner = "foxglove";
     rev = "releases/mcap-cli/v${version}";
-    hash = "sha256-UdR5A2ZtCcnQIjPxlwcntZb78CXzJBvRy73GJUqvjuM=";
+    hash = "sha256-b1Ngj8k2ZkI47lTwbLWTojtoMWQ54eJ8QN5Qd5ot9n4=";
   };
 
-  vendorHash = "sha256-ofJYarmnOHONu2lZ76GvSua0ViP1gr6968xAuQ/VRNk=";
+  vendorHash = "sha256-twuXJXiGhjTqlEZ3xD8G9CruSLxFC33PMs2GZadl1Ow=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -31,7 +31,20 @@ buildGoModule {
 
   modRoot = "go/cli/mcap";
 
-  env.GOWORK = "off";
+  tags = [
+    "sqlite_omit_load_extension"
+  ]
+  ++ lib.optionals stdenv.isLinux [
+    "netgo"
+    "osusergo"
+  ];
+
+  ldflags = [ "-X github.com/foxglove/mcap/go/cli/mcap/cmd.Version=${version}" ];
+
+  env = {
+    CGO_ENABLED = "1";
+    GOWORK = "off";
+  };
 
   # copy the local versions of the workspace modules
   postConfigure = ''
@@ -43,7 +56,7 @@ buildGoModule {
   checkFlags = [
     # requires git-lfs and network
     # https://github.com/foxglove/mcap/issues/895
-    "-skip=TestCat|TestInfo"
+    "-skip=TestCat|TestInfo|TestRequiresDuplicatedSchemasForIndexedMessages|TestPassesIndexedMessagesWithRepeatedSchemas|TestSortFile"
   ];
 
   postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (


### PR DESCRIPTION
Updating MCAP CLI to v0.0.54. Some bugfixes in the more recent releases.

Most recent changelog: https://github.com/foxglove/mcap/releases/tag/releases%2Fmcap-cli%2Fv0.0.54

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
