### PR TITLE
ocamlPackages.lwd: 0.3 → 0.4

### DIFF
--- a/pkgs/by-name/do/docfd/nottui-unix.patch
+++ b/pkgs/by-name/do/docfd/nottui-unix.patch
@@ -1,0 +1,25 @@
+diff --git a/bin/dune b/bin/dune
+index e0ddc1f..a4e8523 100644
+--- a/bin/dune
++++ b/bin/dune
+@@ -47,6 +47,7 @@
+             notty
+             notty.unix
+             nottui
++            nottui-unix
+             lwd
+             oseq
+             eio
+diff --git a/bin/ui_base.ml b/bin/ui_base.ml
+index f56ee8d..8d8ed70 100644
+--- a/bin/ui_base.ml
++++ b/bin/ui_base.ml
+@@ -587,7 +587,7 @@ let ui_loop ~quit ~term root =
+       if term_width <> prev_term_width || term_height <> prev_term_height then (
+         Lwd.set Vars.term_width_height (term_width, term_height)
+       );
+-      Nottui.Ui_loop.step
++      Nottui_unix.step
+         ~process_event:true
+         ~timeout:0.05
+         ~renderer

--- a/pkgs/by-name/do/docfd/package.nix
+++ b/pkgs/by-name/do/docfd/package.nix
@@ -25,6 +25,9 @@ ocamlPackages.buildDunePackage rec {
     hash = "sha256-uRC2QBn4gAfS9u85YaNH2Mm2C0reP8FnDHbyloY+OC8=";
   };
 
+  # Compatibility with nottui ≥ 0.4
+  patches = [ ./nottui-unix.patch ];
+
   nativeBuildInputs = [
     python3
     dune_3
@@ -40,6 +43,7 @@ ocamlPackages.buildDunePackage rec {
     eio_main
     lwd
     nottui
+    nottui-unix
     notty
     ocaml_sqlite3
     ocolor

--- a/pkgs/development/ocaml-modules/lwd/default.nix
+++ b/pkgs/development/ocaml-modules/lwd/default.nix
@@ -7,14 +7,13 @@
 
 buildDunePackage rec {
   pname = "lwd";
-  version = "0.3";
+  version = "0.4";
 
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/let-def/lwd/releases/download/v${version}/lwd-${version}.tbz";
-    sha256 = "sha256-H/vyW2tn2OBuWwcmPs8NcINXgFe93MSxRd8dzeoXARI=";
+    hash = "sha256-nnFltlBWfPOerF4HuVNGzXcZxRSdsM+abeD5ZdQ+x8U=";
   };
 
   propagatedBuildInputs = [ seq ];

--- a/pkgs/development/ocaml-modules/lwd/nottui-pretty.nix
+++ b/pkgs/development/ocaml-modules/lwd/nottui-pretty.nix
@@ -10,9 +10,6 @@ buildDunePackage {
 
   inherit (lwd) version src;
 
-  minimalOCamlVersion = "4.08";
-  duneVersion = "3";
-
   propagatedBuildInputs = [ nottui ];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/lwd/nottui-unix.nix
+++ b/pkgs/development/ocaml-modules/lwd/nottui-unix.nix
@@ -2,24 +2,25 @@
   lib,
   buildDunePackage,
   lwd,
-  lwt,
   nottui,
+  notty,
 }:
 
 buildDunePackage {
-  pname = "nottui-lwt";
+  pname = "nottui-unix";
 
   inherit (lwd) version src;
 
   propagatedBuildInputs = [
-    lwt
+    lwd
     nottui
+    notty
   ];
 
   meta = with lib; {
-    description = "Run Nottui UIs in Lwt";
+    description = "UI toolkit for the UNIX terminal built on top of Notty and Lwd";
     license = licenses.mit;
-    maintainers = [ maintainers.alizter ];
+    maintainers = [ maintainers.vbgl ];
     homepage = "https://github.com/let-def/lwd";
   };
 }

--- a/pkgs/development/ocaml-modules/lwd/nottui.nix
+++ b/pkgs/development/ocaml-modules/lwd/nottui.nix
@@ -10,9 +10,6 @@ buildDunePackage {
 
   inherit (lwd) version src;
 
-  minimalOCamlVersion = "4.08";
-  duneVersion = "3";
-
   propagatedBuildInputs = [
     lwd
     notty

--- a/pkgs/development/ocaml-modules/lwd/tyxml-lwd.nix
+++ b/pkgs/development/ocaml-modules/lwd/tyxml-lwd.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  fetchpatch,
   buildDunePackage,
   js_of_ocaml,
   js_of_ocaml-ppx,
@@ -12,14 +11,6 @@ buildDunePackage {
   pname = "tyxml-lwd";
 
   inherit (lwd) version src;
-
-  # Compatibility with latest Tyxml (4.6.x)
-  patches = fetchpatch {
-    url = "https://github.com/let-def/lwd/commit/7f3364ec593b5ccf0d0294b97bcd1e28e4164691.patch";
-    hash = "sha256-W1HjExZxDKRwsrB9ZTkvHTMKO0K5iZl+FrNqPs6BPGU=";
-  };
-
-  minimalOCamlVersion = "4.08";
 
   buildInputs = [ js_of_ocaml-ppx ];
   propagatedBuildInputs = [

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1349,6 +1349,8 @@ let
 
         nottui-pretty = callPackage ../development/ocaml-modules/lwd/nottui-pretty.nix { };
 
+        nottui-unix = callPackage ../development/ocaml-modules/lwd/nottui-unix.nix { };
+
         notty = callPackage ../development/ocaml-modules/notty { };
 
         npy = callPackage ../development/ocaml-modules/npy {


### PR DESCRIPTION
ocamlPackages.nottui-unix: init at 0.4


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
