### PR TITLE
pdf2htmlex: init at 0.18.8.rc1

### DIFF
--- a/pkgs/by-name/pd/pdf2htmlex/0001-fix-apple-sdk-iconv.patch
+++ b/pkgs/by-name/pd/pdf2htmlex/0001-fix-apple-sdk-iconv.patch
@@ -1,0 +1,16 @@
+diff --git a/pdf2htmlEX/CMakeLists.txt b/pdf2htmlEX/CMakeLists.txt
+index b5cb520..dad760e 100644
+--- a/pdf2htmlEX/CMakeLists.txt
++++ b/pdf2htmlEX/CMakeLists.txt
+@@ -227,6 +227,11 @@ set(PDF2HTMLEX_SRC ${PDF2HTMLEX_SRC}
+ add_executable(pdf2htmlEX ${PDF2HTMLEX_SRC})
+ target_link_libraries(pdf2htmlEX ${PDF2HTMLEX_LIBS})
+ 
++if(APPLE)
++  target_link_libraries(pdf2htmlEX PRIVATE iconv)
++  target_link_libraries(pdf2htmlEX PRIVATE "-framework CoreServices" "-framework CoreFoundation")
++endif()
++
+ add_custom_target(pdf2htmlEX_resources ALL DEPENDS
+     ${CMAKE_SOURCE_DIR}/share/base.min.css
+     ${CMAKE_SOURCE_DIR}/share/fancy.min.css

--- a/pkgs/by-name/pd/pdf2htmlex/0002-include-glib.patch
+++ b/pkgs/by-name/pd/pdf2htmlex/0002-include-glib.patch
@@ -1,0 +1,16 @@
+diff --git a/pdf2htmlEX/CMakeLists.txt b/pdf2htmlEX/CMakeLists.txt
+index dad760e..767992e 100644
+--- a/pdf2htmlEX/CMakeLists.txt
++++ b/pdf2htmlEX/CMakeLists.txt
+@@ -232,6 +232,11 @@ if(APPLE)
+   target_link_libraries(pdf2htmlEX PRIVATE "-framework CoreServices" "-framework CoreFoundation")
+ endif()
+ 
++pkg_check_modules(GLIB REQUIRED glib-2.0 gio-2.0 gobject-2.0)
++target_include_directories(pdf2htmlEX PRIVATE ${GLIB_INCLUDE_DIRS})
++link_directories(${GLIB_LIBRARY_DIRS})
++target_link_libraries(pdf2htmlEX PRIVATE ${GLIB_LIBRARIES})
++
+ add_custom_target(pdf2htmlEX_resources ALL DEPENDS
+     ${CMAKE_SOURCE_DIR}/share/base.min.css
+     ${CMAKE_SOURCE_DIR}/share/fancy.min.css

--- a/pkgs/by-name/pd/pdf2htmlex/fontforge.nix
+++ b/pkgs/by-name/pd/pdf2htmlex/fontforge.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  pkg-config,
+  freetype,
+  glib,
+  libjpeg,
+  libpng,
+  libxml2,
+  uthash,
+  zeromq,
+  zlib,
+  fontforge,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fontforge";
+  # Follow https://github.com/pdf2htmlEX/pdf2htmlEX/blob/v0.18.8.rc1/buildScripts/versionEnvs
+  version = "20200314";
+
+  src = fetchFromGitHub {
+    owner = "fontforge";
+    repo = "fontforge";
+    tag = finalAttrs.version;
+    hash = "sha256-QygbZVJLel+QKTdJSO2hIzA1JgcUDsOOF67O35t4uxw=";
+  };
+
+  patches = [
+    # Unreleased fix for https://github.com/fontforge/fontforge/issues/4229
+    # which is required to fix an uninterposated `${CMAKE_INSTALL_PREFIX}/lib`, see
+    # see https://github.com/nh2/static-haskell-nix/pull/98#issuecomment-665395399
+    # TODO: Remove https://github.com/fontforge/fontforge/pull/4232 is in a release.
+    (fetchpatch {
+      name = "fontforge-cmake-set-rpath-to-the-configure-time-CMAKE_INSTALL_PREFIX";
+      url = "https://github.com/fontforge/fontforge/commit/297ee9b5d6db5970ca17ebe5305189e79a1520a1.patch";
+      hash = "sha256-E8/SsYytYLE4pmDpQBULjCILu2FWYEhW/H8DyC+6DpM=";
+    })
+  ];
+
+  # https://github.com/fontforge/fontforge/issues/5251
+  postPatch = ''
+    rm -fv po/{fr,it}.po
+    substituteInPlace po/LINGUAS \
+      --replace-fail "fr" "" \
+      --replace-fail "it" ""
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    freetype
+    glib
+    libjpeg
+    libpng
+    libxml2
+    uthash
+    zeromq
+    zlib
+  ];
+
+  # Follow https://github.com/pdf2htmlEX/pdf2htmlEX/blob/v0.18.8.rc1/buildScripts/buildFontforge
+  cmakeFlags = with lib; [
+    (cmakeBool "BUILD_SHARED_LIBS" false)
+    (cmakeBool "ENABLE_GUI" false)
+    (cmakeBool "ENABLE_X11" false)
+    (cmakeBool "ENABLE_NATIVE_SCRIPTING" true)
+    (cmakeBool "ENABLE_PYTHON_SCRIPTING" false)
+    (cmakeBool "ENABLE_PYTHON_EXTENSION" false)
+    (cmakeBool "ENABLE_LIBSPIRO" false)
+    (cmakeBool "ENABLE_LIBUNINAMESLIST" false)
+    (cmakeBool "ENABLE_LIBGIF" false)
+    (cmakeBool "ENABLE_LIBJPEG" true)
+    (cmakeBool "ENABLE_LIBPNG" true)
+    (cmakeBool "ENABLE_LIBREADLINE" false)
+    (cmakeBool "ENABLE_LIBTIFF" false)
+    (cmakeBool "ENABLE_WOFF2" false)
+    (cmakeBool "ENABLE_DOCS" false)
+    (cmakeBool "ENABLE_CODE_COVERAGE" false)
+    (cmakeBool "ENABLE_DEBUG_RAW_POINTS" false)
+    (cmakeBool "ENABLE_FONTFORGE_EXTRAS" false)
+    (cmakeBool "ENABLE_MAINTAINER_TOOLS" false)
+    (cmakeBool "ENABLE_TILE_PATH" false)
+    (cmakeBool "ENABLE_WRITE_PFM" false)
+    (cmakeFeature "ENABLE_SANITIZER" "none")
+    (cmakeFeature "ENABLE_FREETYPE_DEBUGGER" "")
+    (cmakeBool "SPHINX_USE_VENV" false)
+    (cmakeFeature "REAL_TYPE" "double")
+    (cmakeFeature "THEME" "tango")
+  ];
+
+  postInstall = ''
+    install -Dvm644 -t $out/lib/ ./lib/libfontforge.a
+    install -Dvm644 -t $out/include/ ./inc/*.h
+  '';
+
+  meta = fontforge.meta // {
+    maintainers = with lib.maintainers; [
+      Cryolitia
+    ];
+  };
+})

--- a/pkgs/by-name/pd/pdf2htmlex/package.nix
+++ b/pkgs/by-name/pd/pdf2htmlex/package.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  stdenv,
+  callPackage,
+  fetchFromGitLab,
+  fetchgit,
+  cmake,
+  jdk17,
+  pkg-config,
+  cairo,
+  expat,
+  fontconfig,
+  freetype,
+  glib,
+  libjpeg,
+  libpng,
+  libxml2,
+  xorg,
+}:
+let
+  poppler = callPackage ./poppler.nix { };
+  poppler-data = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "poppler";
+    repo = "poppler-data";
+    tag = "POPPLER_DATA_0_4_9";
+    hash = "sha256-sNvIgxXXLuTe7JWs67Z+fv4r4smLPKpDu83fvRYoasQ=";
+  };
+  fontforge = callPackage ./fontforge.nix { };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pdf2htmlex";
+  version = "0.18.8.rc1";
+
+  src = fetchgit {
+    url = "https://github.com/pdf2htmlEX/pdf2htmlex.git";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-ylLDLheRUy1hAxVneF1HQwDnGTWko0SE3G1M9SFCr9w=";
+  };
+
+  patches = [
+    ./0001-fix-apple-sdk-iconv.patch
+    ./0002-include-glib.patch
+  ];
+
+  # The pdf2htmlEX needs lots of private headers from poppler and fontforge,
+  # it also needs the static libraries.
+  postUnpack = ''
+    pushd pdf2htmlex
+
+    install -Dvm644 -t ./poppler/build/poppler/glib ${poppler}/include/poppler/glib/*.h
+    install -Dvm644 -t ./poppler/poppler/ ${poppler}/include/poppler/*.h
+    install -Dvm644 -t ./poppler/poppler/ ${poppler.src}/poppler/*.h
+    install -Dvm644 -t ./poppler/fofi/ ${poppler.src}/fofi/*.h
+    install -Dvm644 -t ./poppler/goo/ ${poppler.src}/goo/*.h
+    install -Dvm644 -t ./poppler/splash/ ${poppler.src}/splash/*.h
+    install -Dvm644 -t ./poppler/build/ ${poppler}/lib/libpoppler.a
+    install -Dvm644 -t ./poppler/build/glib/ ${poppler}/lib/libpoppler-glib.a
+
+    cp -rv ${poppler-data} poppler-data
+
+    install -Dvm644 -t ./fontforge/inc/ ${fontforge}/include/*.h
+    install -Dvm644 -t ./fontforge/inc/ ${fontforge.src}/inc/*.h
+    install -Dvm644 -t ./fontforge/fontforge/ ${fontforge.src}/fontforge/*.h
+    install -Dvm644 -t ./fontforge/build/lib/ ${fontforge}/lib/libfontforge.a
+
+    popd
+  '';
+
+  preConfigure = ''
+    cd pdf2htmlEX
+  '';
+
+  buildInputs = [
+    cairo
+    expat
+    fontconfig
+    freetype
+    glib
+    libjpeg
+    libpng
+    libxml2
+    xorg.libXdmcp
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    jdk17
+    pkg-config
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_INSTALL_RPATH" (lib.makeLibraryPath [ freetype ]))
+  ];
+
+  meta = {
+    description = "Convert PDF to HTML";
+    homepage = "https://github.com/pdf2htmlEX/pdf2htmlEX";
+    license = lib.licenses.gpl3Plus;
+    platforms = with lib.platforms; (linux ++ darwin);
+    maintainers = with lib.maintainers; [ Cryolitia ];
+    mainProgram = "pdf2htmlEX";
+  };
+})

--- a/pkgs/by-name/pd/pdf2htmlex/poppler-private.patch
+++ b/pkgs/by-name/pd/pdf2htmlex/poppler-private.patch
@@ -1,0 +1,12 @@
+From: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=pdf2htmlex
+--- a/glib/poppler-private.h	2020-05-28 05:23:59.000000000 +0800
++++ b/glib/poppler-private.h	2022-06-07 21:57:01.848597082 +0800
+@@ -154,7 +154,7 @@
+ GType                                                                                 \
+ type_name##_get_type (void)                                                           \
+ {                                                                                     \
+-        static volatile gsize g_define_type_id__volatile = 0;                         \
++        static gsize g_define_type_id__volatile = 0;                         \
+ 	if (g_once_init_enter (&g_define_type_id__volatile)) {                        \
+ 	        GType g_define_type_id =                                              \
+ 		    g_boxed_type_register_static (g_intern_static_string (#TypeName), \

--- a/pkgs/by-name/pd/pdf2htmlex/poppler.nix
+++ b/pkgs/by-name/pd/pdf2htmlex/poppler.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  poppler,
+  cmake,
+  pkg-config,
+  cairo,
+  curl,
+  fontconfig,
+  freetype,
+  lcms,
+  libjpeg,
+  openjpeg,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "poppler-${finalAttrs.version}-static";
+  # Follow https://github.com/pdf2htmlEX/pdf2htmlEX/blob/v0.18.8.rc1/buildScripts/versionEnvs#L11
+  version = "0.89.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "poppler";
+    repo = "poppler";
+    tag = "poppler-${finalAttrs.version}";
+    hash = "sha256-I6hapmimQSueU+mcaH/RBtWENPqNeM9cMSZ139Q4j70=";
+  };
+
+  patches = [
+    ./poppler-private.patch
+  ];
+
+  buildInputs = [
+    cairo
+    curl
+    fontconfig
+    freetype
+    lcms
+    libjpeg
+    openjpeg
+    zlib
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  # Follow https://github.com/pdf2htmlEX/pdf2htmlEX/blob/v0.18.8.rc1/buildScripts/buildPoppler
+  cmakeFlags = with lib; [
+    (cmakeBool "ENABLE_UNSTABLE_API_ABI_HEADERS" false)
+    (cmakeBool "ENABLE_SPLASH" true)
+    (cmakeBool "ENABLE_UTILS" false)
+    (cmakeBool "ENABLE_CPP" false)
+    (cmakeBool "ENABLE_GLIB" true)
+    (cmakeBool "ENABLE_GOBJECT_INTROSPECTION" false)
+    (cmakeBool "ENABLE_GTK_DOC" false)
+    (cmakeBool "ENABLE_QT5" false)
+    (cmakeFeature "ENABLE_LIBOPENJPEG" "none")
+    (cmakeFeature "ENABLE_CMS" "none")
+    (cmakeFeature "ENABLE_DCTDECODER" "libjpeg")
+    (cmakeBool "ENABLE_LIBCURL" false)
+    (cmakeBool "ENABLE_ZLIB" true)
+    (cmakeBool "ENABLE_ZLIB_UNCOMPRESS" false)
+    (cmakeBool "USE_FLOAT" false)
+    (cmakeBool "BUILD_SHARED_LIBS" false)
+    (cmakeBool "RUN_GPERF_IF_PRESENT" false)
+    (cmakeBool "EXTRA_WARN" false)
+    (cmakeBool "WITH_JPEG" true)
+    (cmakeBool "WITH_PNG" true)
+    (cmakeBool "WITH_TIFF" false)
+    (cmakeBool "WITH_NSS3" false)
+    (cmakeBool "WITH_Cairo" true)
+  ];
+
+  postInstall = ''
+    cp -rv poppler/* $out/include/poppler/
+  '';
+
+  meta = poppler.meta // {
+    maintainers = with lib.maintainers; [
+      Cryolitia
+    ];
+  };
+})


### PR DESCRIPTION
Convert PDF to HTML without losing text or format. 

https://github.com/pdf2htmlEX/pdf2htmlEX

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
