### PR TITLE
yffi: init at 0.24.0

### DIFF
--- a/pkgs/by-name/yf/yffi/package.nix
+++ b/pkgs/by-name/yf/yffi/package.nix
@@ -1,0 +1,50 @@
+{
+  fetchFromGitHub,
+  lib,
+  rust-cbindgen,
+  rustPlatform,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "yffi";
+  version = "0.24.0";
+
+  src = fetchFromGitHub {
+    owner = "y-crdt";
+    repo = "y-crdt";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RFdLEsKQxt8BGqbf5FFM7mZD64glW7bTKRJaAQOe+vo=";
+  };
+
+  cargoHash = "sha256-RL9lBc7lSmc6jOavE5lZupmaNGZgQhJBedNhjfHVajg=";
+
+  buildAndTestSubdir = "yffi";
+
+  nativeBuildInputs = [
+    rust-cbindgen
+  ];
+
+  postBuild = ''
+    cbindgen --config yffi/cbindgen.toml --crate yffi --output libyrs.h --lang C
+  '';
+
+  postCheck = ''
+    $CXX -o yrs-ffi-tests -I . tests-ffi/main.cpp target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/libyrs.a
+    ./yrs-ffi-tests
+  '';
+
+  postInstall = ''
+    install -Dm644 libyrs.h $out/include/libyrs.h
+  '';
+
+  meta = {
+    description = "C foreign function interface for Yrs";
+    homepage = "https://github.com/y-crdt/y-crdt/tree/main/yffi";
+    downloadPage = "https://github.com/y-crdt/y-crdt/tags";
+    changelog = "https://github.com/y-crdt/y-crdt/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    teams = with lib.teams; [ ngi ];
+    platforms = with lib.platforms; linux;
+  };
+})


### PR DESCRIPTION
See also https://github.com/ngi-nix/projects/issues/17.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
