### PR TITLE
nixos/dnscrypt-proxy: rename from dnscrypt-proxy2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -186,7 +186,9 @@
 
 - `services.dependency-track` removed its configuration of the JVM heap size. This lets the JVM choose its maximum heap size automatically, which should work much better in practice for most users. For deployments on systems with little RAM, it may now be necessary to manually configure a maximum heap size using  {option}`services.dependency-track.javaArgs`.
 
-- `services.dnscrypt-proxy2` gains a `package` option to specify dnscrypt-proxy package to use.
+- `services.dnscrypt-proxy2` was renamed to `services.dnscrypt-proxy` to match the package name. The systemd service is now also `dnscrypt-proxy`, but the old name is still provided as an alias for backwards compatibility.
+
+- `services.dnscrypt-proxy` gains a `package` option to specify dnscrypt-proxy package to use.
 
 - `services.nextcloud.configureRedis` now defaults to `true` in accordance with upstream recommendations to have caching for file locking. See the [upstream doc](https://docs.nextcloud.com/server/31/admin_manual/configuration_files/files_locking_transactional.html) for further details.
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1123,7 +1123,7 @@
   ./services/networking/deconz.nix
   ./services/networking/dhcpcd.nix
   ./services/networking/dnscache.nix
-  ./services/networking/dnscrypt-proxy2.nix
+  ./services/networking/dnscrypt-proxy.nix
   ./services/networking/dnsdist.nix
   ./services/networking/dnsmasq.nix
   ./services/networking/dnsproxy.nix

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -131,7 +131,6 @@ in
       "services"
       "deepin"
     ] "the Deepin desktop environment has been removed from nixpkgs due to lack of maintenance.")
-    (mkRemovedOptionModule [ "services" "dnscrypt-proxy" ] "Use services.dnscrypt-proxy2 instead")
     (mkRemovedOptionModule [ "services" "dnscrypt-wrapper" ] ''
       The dnscrypt-wrapper module was removed since the project has been effectively unmaintained since 2018;
       moreover the NixOS module had to rely on an abandoned version of dnscrypt-proxy v1 for the rotation of keys.

--- a/nixos/modules/services/networking/dnscrypt-proxy.nix
+++ b/nixos/modules/services/networking/dnscrypt-proxy.nix
@@ -7,13 +7,17 @@
 
 let
 
-  cfg = config.services.dnscrypt-proxy2;
+  cfg = config.services.dnscrypt-proxy;
 
 in
 
 {
-  options.services.dnscrypt-proxy2 = {
-    enable = lib.mkEnableOption "dnscrypt-proxy2";
+  imports = [
+    (lib.mkRenamedOptionModule [ "services" "dnscrypt-proxy2" ] [ "services" "dnscrypt-proxy" ])
+  ];
+
+  options.services.dnscrypt-proxy = {
+    enable = lib.mkEnableOption "dnscrypt-proxy";
 
     package = lib.mkPackageOption pkgs "dnscrypt-proxy" { };
 
@@ -38,7 +42,7 @@ in
 
     upstreamDefaults = lib.mkOption {
       description = ''
-        Whether to base the config declared in {option}`services.dnscrypt-proxy2.settings` on the upstream example config (<https://github.com/DNSCrypt/dnscrypt-proxy/blob/master/dnscrypt-proxy/example-dnscrypt-proxy.toml>)
+        Whether to base the config declared in {option}`services.dnscrypt-proxy.settings` on the upstream example config (<https://github.com/DNSCrypt/dnscrypt-proxy/blob/master/dnscrypt-proxy/example-dnscrypt-proxy.toml>)
 
         Disable this if you want to declare your dnscrypt config from scratch.
       '';
@@ -49,7 +53,7 @@ in
     configFile = lib.mkOption {
       description = ''
         Path to TOML config file. See: <https://github.com/DNSCrypt/dnscrypt-proxy/blob/master/dnscrypt-proxy/example-dnscrypt-proxy.toml>
-        If this option is set, it will override any configuration done in options.services.dnscrypt-proxy2.settings.
+        If this option is set, it will override any configuration done in options.services.dnscrypt-proxy.settings.
       '';
       example = "/etc/dnscrypt-proxy/dnscrypt-proxy.toml";
       type = lib.types.path;
@@ -73,7 +77,7 @@ in
             }
             ${pkgs.buildPackages.remarshal}/bin/json2toml < config.json > $out
           '';
-      defaultText = lib.literalMD "TOML file generated from {option}`services.dnscrypt-proxy2.settings`";
+      defaultText = lib.literalMD "TOML file generated from {option}`services.dnscrypt-proxy.settings`";
     };
   };
 
@@ -81,7 +85,7 @@ in
 
     networking.nameservers = lib.mkDefault [ "127.0.0.1" ];
 
-    systemd.services.dnscrypt-proxy2 = {
+    systemd.services.dnscrypt-proxy = {
       description = "DNSCrypt-proxy client";
       wants = [
         "network-online.target"
@@ -93,6 +97,7 @@ in
       wantedBy = [
         "multi-user.target"
       ];
+      aliases = [ "dnscrypt-proxy2.service" ];
       serviceConfig = {
         AmbientCapabilities = "CAP_NET_BIND_SERVICE";
         CacheDirectory = "dnscrypt-proxy";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -438,7 +438,7 @@ in
     imports = [ ./discourse.nix ];
     _module.args.package = pkgs.discourseAllPlugins;
   };
-  dnscrypt-proxy2 = runTestOn [ "x86_64-linux" ] ./dnscrypt-proxy2.nix;
+  dnscrypt-proxy = runTestOn [ "x86_64-linux" ] ./dnscrypt-proxy.nix;
   dnsdist = import ./dnsdist.nix { inherit pkgs runTest; };
   doas = runTest ./doas.nix;
   docker = runTestOn [ "aarch64-linux" "x86_64-linux" ] ./docker.nix;

--- a/nixos/tests/dnscrypt-proxy.nix
+++ b/nixos/tests/dnscrypt-proxy.nix
@@ -3,7 +3,7 @@ let
   localProxyPort = 43;
 in
 {
-  name = "dnscrypt-proxy2";
+  name = "dnscrypt-proxy";
   meta.maintainers = with lib.maintainers; [ joachifm ];
 
   nodes = {
@@ -14,8 +14,8 @@ in
       {
         security.apparmor.enable = true;
 
-        services.dnscrypt-proxy2.enable = true;
-        services.dnscrypt-proxy2.settings = {
+        services.dnscrypt-proxy.enable = true;
+        services.dnscrypt-proxy.settings = {
           listen_addresses = [ "127.0.0.1:${toString localProxyPort}" ];
           sources.public-resolvers = {
             urls = [ "https://download.dnscrypt.info/resolvers-list/v2/public-resolvers.md" ];
@@ -32,7 +32,7 @@ in
 
   testScript = ''
     client.wait_for_unit("dnsmasq")
-    client.wait_for_unit("dnscrypt-proxy2")
+    client.wait_for_unit("dnscrypt-proxy")
     client.wait_until_succeeds("ss --numeric --udp --listening | grep -q ${toString localProxyPort}")
   '';
 }

--- a/nixos/tests/dnsdist.nix
+++ b/nixos/tests/dnsdist.nix
@@ -72,9 +72,9 @@ in
     ];
 
     nodes.client = {
-      services.dnscrypt-proxy2.enable = true;
-      services.dnscrypt-proxy2.upstreamDefaults = false;
-      services.dnscrypt-proxy2.settings = {
+      services.dnscrypt-proxy.enable = true;
+      services.dnscrypt-proxy.upstreamDefaults = false;
+      services.dnscrypt-proxy.settings = {
         server_names = [ "server" ];
         listen_addresses = [ "[::1]:53" ];
         cache = false;
@@ -92,7 +92,7 @@ in
           almost_expiration = server.succeed("date --date '14min'").strip()
 
       with subtest("The DNSCrypt client can connect to the server"):
-          client.wait_until_succeeds("journalctl -u dnscrypt-proxy2 --grep '\\[server\\] OK'")
+          client.wait_until_succeeds("journalctl -u dnscrypt-proxy --grep '\\[server\\] OK'")
 
       with subtest("DNS queries over UDP are working"):
           client.wait_for_open_port(53)

--- a/pkgs/by-name/dn/dnscrypt-proxy/package.nix
+++ b/pkgs/by-name/dn/dnscrypt-proxy/package.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
     hash = "sha256-IFfhcirUGbp/pKFN/5aEpuIuhSR3ZS4K7TatBtaX5zg=";
   };
 
-  passthru.tests = { inherit (nixosTests) dnscrypt-proxy2; };
+  passthru.tests = { inherit (nixosTests) dnscrypt-proxy; };
 
   meta = with lib; {
     description = "Tool that provides secure DNS resolution";

--- a/pkgs/by-name/dn/dnsmasq/package.nix
+++ b/pkgs/by-name/dn/dnsmasq/package.nix
@@ -103,7 +103,7 @@ stdenv.mkDerivation rec {
     prometheus-exporter = nixosTests.prometheus-exporters.dnsmasq;
 
     # these tests use dnsmasq incidentally
-    inherit (nixosTests) dnscrypt-proxy2;
+    inherit (nixosTests) dnscrypt-proxy;
     kubernetes-dns-single = nixosTests.kubernetes.dns-single-node;
     kubernetes-dns-multi = nixosTests.kubernetes.dns-multi-node;
   };


### PR DESCRIPTION
Renames the `dnscrypt-proxy2` module (back) to `dnscrypt-proxy`, to match the package, which was renamed in 2023.

The systemd service is also renamed to `dnscrypt-proxy`, but an alias to `dnscrypt-proxy2` is provided for backwards compatibility.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
