### PR TITLE
Julia.withPackages improvements

### DIFF
--- a/pkgs/development/julia-modules/default.nix
+++ b/pkgs/development/julia-modules/default.nix
@@ -11,6 +11,7 @@
 
   # Artifacts dependencies
   fetchurl,
+  gcc,
   glibc,
   pkgs,
   stdenv,
@@ -79,7 +80,9 @@ let
     PythonCall = [ "PyCall" ];
   };
 
-  # Invoke Julia resolution logic to determine the full dependency closure
+  # Invoke Julia resolution logic to determine the full dependency closure. Also
+  # gather information on the Julia standard libraries, which we'll need to
+  # generate a Manifest.toml.
   packageOverridesRepoified = lib.mapAttrs util.repoifySimple packageOverrides;
   closureYaml = callPackage ./package-closure.nix {
     inherit
@@ -89,6 +92,9 @@ let
       packageImplications
       ;
     packageOverrides = packageOverridesRepoified;
+  };
+  stdlibInfos = callPackage ./stdlib-infos.nix {
+    inherit julia;
   };
 
   # Generate a Nix file consisting of a map from dependency UUID --> package info with fetchgit call:
@@ -181,6 +187,27 @@ let
           "${dependencyUuidToRepoYaml}" \
           "$out"
       '';
+  project =
+    runCommand "julia-project"
+      {
+        buildInputs = [
+          (python3.withPackages (
+            ps: with ps; [
+              toml
+              pyyaml
+            ]
+          ))
+          git
+        ];
+      }
+      ''
+        python ${./python}/project.py \
+          "${closureYaml}" \
+          "${stdlibInfos}" \
+          '${lib.generators.toJSON { } overridesOnly}' \
+          "${dependencyUuidToRepoYaml}" \
+          "$out"
+      '';
 
   # Next, deal with artifacts. Scan each artifacts file individually and generate a Nix file that
   # produces the desired Overrides.toml.
@@ -220,7 +247,7 @@ let
         ;
     }
     // lib.optionalAttrs (!stdenv.targetPlatform.isDarwin) {
-      inherit glibc;
+      inherit gcc glibc;
     }
   );
   overridesJson = writeTextFile {
@@ -235,8 +262,7 @@ let
           "$out"
       '';
 
-  # Build a Julia project and depot. The project contains Project.toml/Manifest.toml, while the
-  # depot contains package build products (including the precompiled libraries, if precompile=true)
+  # Build a Julia project and depot under $out/project and $out/depot respectively
   projectAndDepot = callPackage ./depot.nix {
     inherit
       closureYaml
@@ -247,12 +273,8 @@ let
       precompile
       ;
     julia = juliaWrapped;
+    inherit project;
     registry = minimalRegistry;
-    packageNames =
-      if makeTransitiveDependenciesImportable then
-        lib.mapAttrsToList (uuid: info: info.name) dependencyUuidToInfo
-      else
-        packageNames;
   };
 
 in
@@ -276,7 +298,9 @@ runCommand "julia-${julia.version}-env"
       inherit artifactsNix;
       inherit overridesJson;
       inherit overridesToml;
+      inherit project;
       inherit projectAndDepot;
+      inherit stdlibInfos;
     };
   }
   (

--- a/pkgs/development/julia-modules/depot.nix
+++ b/pkgs/development/julia-modules/depot.nix
@@ -14,7 +14,7 @@
   juliaCpuTarget,
   overridesToml,
   packageImplications,
-  packageNames,
+  project,
   precompile,
   registry,
 }:
@@ -44,7 +44,7 @@ runCommand "julia-depot"
       (python3.withPackages (ps: with ps; [ pyyaml ]))
     ]
     ++ extraLibs;
-    inherit precompile registry;
+    inherit precompile project registry;
   }
   (
     ''
@@ -52,19 +52,21 @@ runCommand "julia-depot"
 
       echo "Building Julia depot and project with the following inputs"
       echo "Julia: ${julia}"
+      echo "Project: $project"
       echo "Registry: $registry"
       echo "Overrides ${overridesToml}"
 
       mkdir -p $out/project
       export JULIA_PROJECT="$out/project"
+      cp "$project/Manifest.toml" "$JULIA_PROJECT/Manifest.toml"
+      cp "$project/Project.toml" "$JULIA_PROJECT/Project.toml"
 
       mkdir -p $out/depot/artifacts
       export JULIA_DEPOT_PATH="$out/depot"
       cp ${overridesToml} $out/depot/artifacts/Overrides.toml
 
       # These can be useful to debug problems
-      # export JULIA_DEBUG=Pkg
-      # export JULIA_DEBUG=loading
+      # export JULIA_DEBUG=Pkg,loading
 
       ${setJuliaSslCaRootsPath}
 
@@ -104,26 +106,21 @@ runCommand "julia-depot"
 
         Pkg.Registry.add(Pkg.RegistrySpec(path="${registry}"))
 
-        input = ${lib.generators.toJSON { } packageNames} ::Vector{String}
+        # No need to Pkg.activate() since we set JULIA_PROJECT above
+        println("Running Pkg.instantiate()")
+        Pkg.instantiate()
 
-        if isfile("extra_package_names.txt")
-          append!(input, readlines("extra_package_names.txt"))
-        end
+        # Build is a separate step from instantiate.
+        # Needed for packages like Conda.jl to set themselves up.
+        println("Running Pkg.build()")
+        Pkg.build()
 
-        input = unique(input)
-
-        if !isempty(input)
-          println("Adding packages: " * join(input, " "))
-          Pkg.add(input; preserve=PRESERVE_NONE)
-          Pkg.instantiate()
-
-          if "precompile" in keys(ENV) && ENV["precompile"] != "0" && ENV["precompile"] != ""
-            if isdefined(Sys, :CPU_NAME)
-              println("Precompiling with CPU_NAME = " * Sys.CPU_NAME)
-            end
-
-            Pkg.precompile()
+        if "precompile" in keys(ENV) && ENV["precompile"] != "0" && ENV["precompile"] != ""
+          if isdefined(Sys, :CPU_NAME)
+            println("Precompiling with CPU_NAME = " * Sys.CPU_NAME)
           end
+
+          Pkg.precompile()
         end
 
         # Remove the registry to save space

--- a/pkgs/development/julia-modules/package-closure.nix
+++ b/pkgs/development/julia-modules/package-closure.nix
@@ -43,11 +43,20 @@ let
             println(io, "- name: " * spec.name)
             println(io, "  uuid: " * string(spec.uuid))
             println(io, "  version: " * string(spec.version))
+            println(io, "  tree_hash: " * string(spec.tree_hash))
             if endswith(spec.name, "_jll") && haskey(deps_map, spec.uuid)
                 println(io, "  depends_on: ")
                 for (dep_name, dep_uuid) in pairs(deps_map[spec.uuid])
                     println(io, "    \"$(dep_name)\": \"$(dep_uuid)\"")
                 end
+            end
+            println(io, "  deps: ")
+            for (dep_name, dep_uuid) in pairs(deps_map[spec.uuid])
+                println(io, "  - name: \"$(dep_name)\"")
+                println(io, "    uuid: \"$(dep_uuid)\"")
+            end
+            if spec.name in input
+                println(io, "  is_input: true")
             end
         end
     end

--- a/pkgs/development/julia-modules/python/project.py
+++ b/pkgs/development/julia-modules/python/project.py
@@ -1,0 +1,104 @@
+
+from collections import defaultdict
+import json
+import os
+from pathlib import Path
+import sys
+import toml
+import yaml
+
+
+desired_packages_path = Path(sys.argv[1])
+stdlib_infos_path = Path(sys.argv[2])
+package_overrides = json.loads(sys.argv[3])
+dependencies_path = Path(sys.argv[4])
+out_path = Path(sys.argv[5])
+
+with open(desired_packages_path, "r") as f:
+  desired_packages = yaml.safe_load(f) or []
+
+with open(stdlib_infos_path, "r") as f:
+  stdlib_infos = yaml.safe_load(f) or []
+
+with open(dependencies_path, "r") as f:
+  uuid_to_store_path = yaml.safe_load(f)
+
+result = {
+  "deps": defaultdict(list)
+}
+
+for pkg in desired_packages:
+  if pkg["uuid"] in package_overrides:
+    info = package_overrides[pkg["uuid"]]
+    result["deps"][info["name"]].append({
+      "uuid": pkg["uuid"],
+      "path": info["src"],
+    })
+    continue
+
+  path = uuid_to_store_path.get(pkg["uuid"], None)
+  isStdLib = False
+  if pkg["uuid"] in stdlib_infos["stdlibs"]:
+    path = stdlib_infos["stdlib_root"] + "/" + stdlib_infos["stdlibs"][pkg["uuid"]]["name"]
+    isStdLib = True
+
+  if path:
+    if (Path(path) / "Project.toml").exists():
+      project_toml = toml.load(Path(path) / "Project.toml")
+
+      deps = []
+      weak_deps = project_toml.get("weakdeps", {})
+      extensions = project_toml.get("extensions", {})
+
+      if "deps" in project_toml:
+        # Build up deps for the manifest, excluding weak deps
+        weak_deps_uuids = weak_deps.values()
+        for (dep_name, dep_uuid) in project_toml["deps"].items():
+          if not (dep_uuid in weak_deps_uuids):
+            deps.append(dep_name)
+    else:
+      # Not all projects have a Project.toml. In this case, use the deps we
+      # calculated from the package resolve step. This isn't perfect since it
+      # will fail to properly split out weak deps, but it's better than nothing.
+      print(f"""WARNING: package {pkg["name"]} didn't have a Project.toml in {path}""")
+      deps = [x["name"] for x in pkg.get("deps", [])]
+      weak_deps = {}
+      extensions = {}
+
+    tree_hash = pkg.get("tree_hash", "")
+
+    result["deps"][pkg["name"]].append({
+      "version": pkg["version"],
+      "uuid": pkg["uuid"],
+      "git-tree-sha1": (tree_hash if tree_hash != "nothing" else None) or None,
+      "deps": deps or None,
+      "weakdeps": weak_deps or None,
+      "extensions": extensions or None,
+
+      # We *don't* set "path" here, because then Julia will try to use the
+      # read-only Nix store path instead of cloning to the depot. This will
+      # cause packages like Conda.jl to fail during the Pkg.build() step.
+      #
+      # "path": None if isStdLib else path ,
+    })
+  else:
+    print("WARNING: adding a package that we didn't have a path for, and it doesn't seem to be a stdlib", pkg)
+    result["deps"][pkg["name"]].append({
+      "version": pkg["version"],
+      "uuid": pkg["uuid"],
+      "deps": [x["name"] for x in pkg["deps"]]
+    })
+
+os.makedirs(out_path)
+
+with open(out_path / "Manifest.toml", "w") as f:
+  f.write(f'julia_version = "{stdlib_infos["julia_version"]}"\n')
+  f.write('manifest_format = "2.0"\n\n')
+  toml.dump(result, f)
+
+with open(out_path / "Project.toml", "w") as f:
+  f.write('[deps]\n')
+
+  for pkg in desired_packages:
+    if pkg.get("is_input", False):
+      f.write(f'''{pkg["name"]} = "{pkg["uuid"]}"\n''')

--- a/pkgs/development/julia-modules/python/sources_nix.py
+++ b/pkgs/development/julia-modules/python/sources_nix.py
@@ -24,7 +24,7 @@ def ensure_version_valid(version):
   Ensure a version string is a valid Julia-parsable version.
   It doesn't really matter what it looks like as it's just used for overrides.
   """
-  return re.sub('[^0-9\.]','', version)
+  return re.sub('[^0-9.]','', version)
 
 with open(out_path, "w") as f:
   f.write("{fetchgit}:\n")
@@ -41,6 +41,9 @@ with open(out_path, "w") as f:
     treehash = "{treehash}";
   }};\n""")
     elif uuid in registry["packages"]:
+      # The treehash is missing for stdlib packages. Don't bother downloading these.
+      if (not ("tree_hash" in pkg)) or pkg["tree_hash"] == "nothing": continue
+
       registry_info = registry["packages"][uuid]
       path = registry_info["path"]
       packageToml = toml.load(registry_path / path / "Package.toml")
@@ -65,7 +68,8 @@ with open(out_path, "w") as f:
     treehash = "{version_to_use["git-tree-sha1"]}";
   }};\n""")
     else:
-      # print("Warning: couldn't figure out what to do with pkg in sources_nix.py", pkg)
+      # This is probably a stdlib
+      # print("WARNING: couldn't figure out what to do with pkg in sources_nix.py", pkg)
       pass
 
   f.write("}")

--- a/pkgs/development/julia-modules/registry.nix
+++ b/pkgs/development/julia-modules/registry.nix
@@ -3,7 +3,7 @@
 fetchFromGitHub {
   owner = "CodeDownIO";
   repo = "General";
-  rev = "998c6da1553dc0776dfff314d2f1bd5af488ed71";
-  sha256 = "sha256-57RiIPTu9895mdk3oSfo7I3PYw7G0BfJG1u+mYkJeLk=";
-  # date = "2024-07-01T12:22:35+00:00";
+  rev = "4b19a1dc55d2877e85a5d0e98702b75872210e9d";
+  sha256 = "sha256-mVeBTpEQnW3fvJu1+4T8z+earMjEgtdy0tnZnAxz/pk=";
+  # date = "2025-08-12T05:20:40+00:00";
 }

--- a/pkgs/development/julia-modules/resolve_packages.jl
+++ b/pkgs/development/julia-modules/resolve_packages.jl
@@ -46,54 +46,6 @@ end
 foreach(pkg -> ctx.env.project.deps[pkg.name] = pkg.uuid, pkgs)
 
 # Save the original pkgs for later. We might need to augment it with the weak dependencies
-orig_pkgs = pkgs
+orig_pkgs = deepcopy(pkgs)
 
 pkgs, deps_map = _resolve(ctx.io, ctx.env, ctx.registries, pkgs, PRESERVE_NONE, ctx.julia_version)
-
-if VERSION >= VersionNumber("1.9")
-    while true
-        # Check for weak dependencies, which appear on the RHS of the deps_map but not in pkgs.
-        # Build up weak_name_to_uuid
-        uuid_to_name = Dict()
-        for pkg in pkgs
-            uuid_to_name[pkg.uuid] = pkg.name
-        end
-        weak_name_to_uuid = Dict()
-        for (uuid, deps) in pairs(deps_map)
-            for (dep_name, dep_uuid) in pairs(deps)
-                if !haskey(uuid_to_name, dep_uuid)
-                    weak_name_to_uuid[dep_name] = dep_uuid
-                end
-            end
-        end
-
-        if isempty(weak_name_to_uuid)
-            break
-        end
-
-        # We have nontrivial weak dependencies, so add each one to the initial pkgs and then re-run _resolve
-        println("Found weak dependencies: $(keys(weak_name_to_uuid))")
-
-        orig_uuids = Set([pkg.uuid for pkg in orig_pkgs])
-
-        for (name, uuid) in pairs(weak_name_to_uuid)
-            if uuid in orig_uuids
-                continue
-            end
-
-            pkg = PackageSpec(name, uuid)
-
-            push!(orig_uuids, uuid)
-            push!(orig_pkgs, pkg)
-            ctx.env.project.deps[name] = uuid
-            entry = Pkg.Types.manifest_info(ctx.env.manifest, uuid)
-            if VERSION >= VersionNumber("1.11")
-                orig_pkgs[length(orig_pkgs)] = update_package_add(ctx, pkg, entry, nothing, nothing, false)
-            else
-                orig_pkgs[length(orig_pkgs)] = update_package_add(ctx, pkg, entry, false)
-            end
-        end
-
-        global pkgs, deps_map = _resolve(ctx.io, ctx.env, ctx.registries, orig_pkgs, PRESERVE_NONE, ctx.julia_version)
-    end
-end

--- a/pkgs/development/julia-modules/stdlib-infos.nix
+++ b/pkgs/development/julia-modules/stdlib-infos.nix
@@ -1,0 +1,36 @@
+{
+  julia,
+  runCommand,
+}:
+
+let
+  juliaExpression = ''
+    using Pkg
+    open(ENV["out"], "w") do io
+        println(io, "stdlib_root: \"$(Sys.STDLIB)\"")
+
+        println(io, "julia_version: \"$(string(VERSION))\"")
+
+        stdlibs = Pkg.Types.stdlibs()
+        println(io, "stdlibs:")
+        for (uuid, (name, version)) in stdlibs
+            println(io, "  \"$(uuid)\": ")
+            println(io, "    name: $name")
+            println(io, "    version: $version")
+        end
+    end
+  '';
+in
+
+runCommand "julia-stdlib-infos.yml"
+  {
+    buildInputs = [
+      julia
+    ];
+  }
+  ''
+    # Prevent a warning where Julia tries to download package server info
+    export JULIA_PKG_SERVER=""
+
+    julia -e '${juliaExpression}';
+  ''

--- a/pkgs/development/julia-modules/util.nix
+++ b/pkgs/development/julia-modules/util.nix
@@ -1,5 +1,6 @@
 {
   gitMinimal,
+  lib,
   runCommand,
 }:
 
@@ -10,7 +11,10 @@
   # See https://github.com/NixOS/nixpkgs/pull/97467#issuecomment-689315186
   addPackagesToPython =
     python: packages:
-    if python ? "env" then
+    # TODO: this stopped working because "env" ended up being a key of the base
+    # derivation like "python3" as well. Is there a robust way to determine if
+    # this Python is already wrapped?
+    if python ? "env" && lib.isDerivation python.env then
       python.override (old: {
         extraLibs = old.extraLibs ++ packages;
       })


### PR DESCRIPTION
This PR resolves some longstanding issues with how `julia.withPackages` handles weak dependencies. Previously, we resolved all weak dependencies and installed them by default. This turned out to be a bad idea, because it is usually unnecessary and because in some cases, the full set of weak dependencies contains transitive dependency conflicts that keep a package from resolving! This started happening even with common packages like "Plots."

Instead, we adopt a new strategy. We resolve only the packages the user asked for, and then generate a `Manifest.toml` with all the desired versions fixed. Then, at the depot-building step, we no longer call `Pkg.add()` as we did in the past. Instead, we can just call `Pkg.instantiate()` with the given `Manifest.toml`, which avoids the need for a second resolve step (a potential source of failure in the past).

This design also moves us toward a world where a user can provide other inputs to `julia.withPackages`, such as a `Project.toml`/`Manifest.toml` combo or a set of package names with version constraints, which are features that have been requested in the past.

This PR also does a few other things:

* Bump the Julia General registry to the latest version
* Improve the test parallelism, add some logging and add a case.
* Fix the internal `addPackagesToPython`, which had gotten broken at some point.
* Some misc work to address unusual package compilation failures. For example, a lot of Julia artifacts seem to expect `libquadmath.so` to be available, so we add `gcc.cc.lib` to the artifact fixup stage by default.

With all these changes, we have a **100% success rate** for building and importing the top 1000 most popular Julia packages with both Julia 1.10 and 1.11. (Not counting a single package called `NNlibCUDA`, which fails even with normal Julia due to version constraints.)

CC @LEXUGE and @b-rodrigues 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
