### PR TITLE
texlive: allow to add custom mirrors

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -42,6 +42,7 @@
   biber-ms,
   makeFontsConf,
   useFixedHashes ? true,
+  extraMirrors ? [ ],
   recurseIntoAttrs,
   nixfmt,
 }:
@@ -115,25 +116,28 @@ let
   # should be switching to the tlnet-final versions
   # (https://tug.org/historic/).
   mirrors =
-    if version.final then
-      [
-        # tlnet-final snapshot; used when texlive.tlpdb is frozen
-        # the TeX Live yearly freeze typically happens in mid-March
-        "http://ftp.math.utah.edu/pub/tex/historic/systems/texlive/${toString version.texliveYear}/tlnet-final"
-        "ftp://tug.org/texlive/historic/${toString version.texliveYear}/tlnet-final"
-      ]
-    else
-      [
-        # CTAN mirrors
-        "https://mirror.ctan.org/systems/texlive/tlnet"
-        # daily snapshots hosted by one of the texlive release managers;
-        # used for packages that in the meanwhile have been updated or removed from CTAN
-        # and for packages that have not reached yet the historic mirrors
-        # please note that this server is not meant for large scale deployment
-        # https://tug.org/pipermail/tex-live/2019-November/044456.html
-        # https://texlive.info/ MUST appear last (see tlpdbxz)
-        "https://texlive.info/tlnet-archive/${version.year}/${version.month}/${version.day}/tlnet"
-      ];
+    extraMirrors
+    ++ (
+      if version.final then
+        [
+          # tlnet-final snapshot; used when texlive.tlpdb is frozen
+          # the TeX Live yearly freeze typically happens in mid-March
+          "http://ftp.math.utah.edu/pub/tex/historic/systems/texlive/${toString version.texliveYear}/tlnet-final"
+          "ftp://tug.org/texlive/historic/${toString version.texliveYear}/tlnet-final"
+        ]
+      else
+        [
+          # CTAN mirrors
+          "https://mirror.ctan.org/systems/texlive/tlnet"
+          # daily snapshots hosted by one of the texlive release managers;
+          # used for packages that in the meanwhile have been updated or removed from CTAN
+          # and for packages that have not reached yet the historic mirrors
+          # please note that this server is not meant for large scale deployment
+          # https://tug.org/pipermail/tex-live/2019-November/044456.html
+          # https://texlive.info/ MUST appear last (see tlpdbxz)
+          "https://texlive.info/tlnet-archive/${version.year}/${version.month}/${version.day}/tlnet"
+        ]
+    );
 
   tlpdbxz = fetchurl {
     urls =


### PR DESCRIPTION
Add an `extraMirrors` argument to `texlive`, allowing to add multiple custom mirrors with a simple override (instead of patching).

This is useful in a firewalled environment, where a custom mirrors are necessary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
