### PR TITLE
collectl: init at 4.3.1

### DIFF
--- a/pkgs/by-name/co/collectl/linux.nix
+++ b/pkgs/by-name/co/collectl/linux.nix
@@ -1,0 +1,127 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  perl,
+  gzip,
+  coreutils,
+  gnugrep,
+  inetutils,
+  openssh,
+
+  pname,
+  version,
+  meta,
+  passthru,
+}:
+
+stdenv.mkDerivation rec {
+  inherit
+    pname
+    version
+    meta
+    passthru
+    ;
+
+  src = fetchurl {
+    url = "https://sourceforge.net/projects/collectl/files/collectl-${version}.src.tar.gz/download";
+    name = "collectl-${version}.src.tar.gz";
+    sha256 = "2187264d974b36a653c8a4b028ac6eeab23e1885f8b2563a33f06358f39889f1";
+  };
+
+  nativeBuildInputs = [ gzip ];
+
+  buildInputs = [ perl ];
+
+  propagatedBuildInputs = [
+    coreutils # provides hostname, cat, and other utilities
+    gnugrep # provides grep
+    inetutils # provides ping
+    openssh # provides ssh
+  ];
+
+  # No build phase needed - these are Perl scripts
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # Define directory variables following INSTALL script style
+    BINDIR=$out/bin
+    DOCDIR=$out/share/doc/collectl
+    SHRDIR=$out/share/collectl
+    MANDIR=$out/share/man/man1
+    ETCDIR=$out/etc
+    LOGDIR=$out/var/log/collectl
+
+    # Create directory structure
+    mkdir -p $BINDIR
+    mkdir -p $DOCDIR
+    mkdir -p $SHRDIR
+    mkdir -p $MANDIR
+    mkdir -p $ETCDIR
+    mkdir -p $SHRDIR/util
+    mkdir -p $LOGDIR
+
+    # Install main executables
+    cp collectl colmux $BINDIR
+
+    # Install configuration
+    cp collectl.conf $ETCDIR
+
+    # Install documentation
+    cp docs/* $DOCDIR
+    cp GPL ARTISTIC COPYING RELEASE-collectl $DOCDIR
+
+    # Install Perl modules and utilities
+    cp UNINSTALL $SHRDIR
+    cp formatit.ph lexpr.ph gexpr.ph misc.ph $SHRDIR
+    cp hello.ph graphite.ph envrules.std statsd.ph $SHRDIR
+    cp vmstat.ph vnet.ph vmsum.ph $SHRDIR
+    cp client.pl $SHRDIR/util
+
+    # Install and compress man pages
+    cp man1/* $MANDIR
+    gzip -f $MANDIR/collectl*
+
+    # Set permissions
+    chmod 755 $BINDIR/collectl $BINDIR/colmux
+    chmod 444 $ETCDIR/collectl.conf
+    chmod 444 $SHRDIR/*.ph
+    chmod 755 $SHRDIR/util/*
+
+    runHook postInstall
+  '';
+
+  # Patch hardcoded paths to system utilities
+  postFixup = ''
+    # Patch hardcoded paths in collectl
+    substituteInPlace $out/bin/collectl \
+      --replace-fail "'/bin/cat'" "'${coreutils}/bin/cat'" \
+      --replace-fail "'/bin/grep'" "'${gnugrep}/bin/grep'" \
+      --replace-fail '`/bin/hostname`' '`${inetutils}/bin/hostname`' \
+      --replace-fail '`hostname`' '`${inetutils}/bin/hostname`' \
+      --replace-fail '$configFile="$BinDir/$ConfigFile;$etcDir/$ConfigFile";' '$configFile="$BinDir/../etc/$ConfigFile;$etcDir/$ConfigFile";'
+
+    # Patch hardcoded paths in colmux
+    substituteInPlace $out/bin/colmux \
+      --replace-fail "'/bin/ping'" "'${inetutils}/bin/ping'" \
+      --replace-fail "'/bin/grep'" "'${gnugrep}/bin/grep'" \
+      --replace-fail '`hostname`' '`${inetutils}/bin/hostname`' \
+      --replace-fail '/usr/bin/ssh' '${openssh}/bin/ssh'
+
+    # Patch hardcoded paths in formatit.ph
+    substituteInPlace $out/share/collectl/formatit.ph \
+      --replace-fail '`hostname`' '`${inetutils}/bin/hostname`'
+
+    # Patch hardcoded paths in graphite.ph
+    substituteInPlace $out/share/collectl/graphite.ph \
+      --replace-fail '`hostname`' '`${inetutils}/bin/hostname`' \
+      --replace-fail '`hostname -f`' '`${inetutils}/bin/hostname -f`'
+
+    # Patch hardcoded paths in vmsum.ph
+    substituteInPlace $out/share/collectl/vmsum.ph \
+      --replace-fail '`hostname`' '`${inetutils}/bin/hostname`'
+  '';
+
+}

--- a/pkgs/by-name/co/collectl/package.nix
+++ b/pkgs/by-name/co/collectl/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  callPackage,
+}:
+
+let
+  pname = "collectl";
+  version = "4.3.1";
+
+  meta = with lib; {
+    description = "Performance monitoring tool for Linux systems";
+    longDescription = ''
+      Collectl is a light-weight performance monitoring tool capable of reporting
+      interactively as well as logging to disk. It reports statistics on cpu, disk,
+      infiniband, lustre, memory, network, nfs, process, quadrics, slabs and more
+      in easy to read format.
+    '';
+    homepage = "https://collectl.sourceforge.net/";
+    downloadPage = "https://sourceforge.net/projects/collectl/files/";
+    license = with licenses; [
+      artistic1
+      gpl1Plus
+    ];
+    maintainers = with maintainers; [ loberman ];
+    platforms = platforms.linux;
+    mainProgram = "collectl";
+  };
+
+  passthru = {
+    updateScript = ./update.sh;
+  };
+
+in
+callPackage ./linux.nix {
+  inherit
+    pname
+    version
+    meta
+    passthru
+    ;
+}

--- a/pkgs/by-name/co/collectl/update.sh
+++ b/pkgs/by-name/co/collectl/update.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq gnused
+
+set -euo pipefail
+
+ROOT="$(dirname "$(readlink -f "$0")")"
+if [[ ! "$(basename $ROOT)" == "collectl" || ! -f "$ROOT/package.nix" ]]; then
+  echo "error: Not in the collectl folder" >&2
+  exit 1
+fi
+
+PACKAGE_NIX="$ROOT/package.nix"
+LINUX_NIX="$ROOT/linux.nix"
+
+# Get latest version from SourceForge RSS feed
+COLLECTL_LATEST_VER="$(curl -s "https://sourceforge.net/projects/collectl/rss?path=/" | grep -oP 'collectl-\K[0-9]+\.[0-9]+\.[0-9]+(?=\.src\.tar\.gz)' | sort -V | tail -n1)"
+COLLECTL_CURRENT_VER="$(grep -oP 'version = "\K[^"]+' "$PACKAGE_NIX")"
+
+if [[ "$COLLECTL_LATEST_VER" == "" ]]; then
+  echo "error: could not fetch collectl latest version from SourceForge RSS" >&2
+  exit 1
+fi
+
+if [[ "$COLLECTL_LATEST_VER" == "$COLLECTL_CURRENT_VER" ]]; then
+  echo "collectl is up-to-date"
+  exit 0
+fi
+
+get_hash() {
+  # $1: URL
+  nix-hash --to-sri --type sha256 "$(nix-prefetch-url --type sha256 "$1")"
+}
+
+replace_hash_in_file() {
+  # $1: file
+  # $2: new hash
+  sed -i "s#sha256 = \".*\"#sha256 = \"$2\"#g" "$1"
+}
+
+replace_version_in_file() {
+  # $1: file
+  # $2: new version
+  sed -i "s#version = \".*\";#version = \"$2\";#g" "$1"
+}
+
+COLLECTL_HASH="$(get_hash "https://sourceforge.net/projects/collectl/files/collectl-${COLLECTL_LATEST_VER}.src.tar.gz/download")"
+
+replace_hash_in_file "$LINUX_NIX" "$COLLECTL_HASH"
+replace_version_in_file "$PACKAGE_NIX" "$COLLECTL_LATEST_VER"
+
+echo "Updated collectl from $COLLECTL_CURRENT_VER to $COLLECTL_LATEST_VER"


### PR DESCRIPTION
Add [collectl](https://collectl.sourceforge.net/) performance monitoring tool for Linux systems. Collectl is a light-weight performance monitoring tool capable of reporting interactively as well as logging to disk on cpu, disk, infiniband, lustre, memory, network, nfs, process, quadrics, slabs and more.

- Structured as by-name package following nixpkgs conventions
- Added update script for automated version bumps via SourceForge RSS
- Includes proper path patching for system utilities


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
