### PR TITLE
ohsome-planet: init at 1.1.0

### DIFF
--- a/pkgs/by-name/oh/ohsome-planet/package.nix
+++ b/pkgs/by-name/oh/ohsome-planet/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  maven,
+  fetchFromGitHub,
+  jdk21,
+  makeWrapper,
+  nix-update-script,
+}:
+
+let
+  jdk = jdk21;
+in
+
+maven.buildMavenPackage rec {
+  pname = "ohsome-planet";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "GIScience";
+    repo = pname;
+    tag = "${version}";
+    sha256 = "sha256-DFrjYlCwS96wBBiB4Fm9ZfFhgbqSiCfCwCkYfeY105g=";
+  };
+
+  # FIXME: I didn't realize how to get the hash for maven
+  mvnHash = null;
+
+  # Skip tests during build to avoid test failures
+  mvnParameters = "-DskipTests";
+
+  passthru.updateScript = nix-update-script { };
+
+  mvnBuildTarget = "ohsome-planet-cli";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D ohsome-planet-cli/target/ohsome-planet.jar --target-directory=$out/lib
+
+    makeWrapper ${lib.getExe' jdk "java"} $out/bin/ohsome-planet \
+      --add-flags "-jar $out/lib/ohsome-planet.jar"
+  '';
+
+  meta = {
+    description = "Tool to transform OSM (history) PBF files into GeoParquet";
+    homepage = "https://github.com/GIScience/ohsome-planet";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ onnimonni ];
+  };
+}

--- a/pkgs/by-name/ze/zed-editor/package.nix
+++ b/pkgs/by-name/ze/zed-editor/package.nix
@@ -101,12 +101,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zed-editor";
   version = "0.198.6";
 
-  outputs = [
-    "out"
-  ]
-  ++ lib.optionals buildRemoteServer [
-    "remote_server"
-  ];
+  outputs =
+    [
+      "out"
+    ]
+    ++ lib.optionals buildRemoteServer [
+      "remote_server"
+    ];
 
   src = fetchFromGitHub {
     owner = "zed-industries";
@@ -140,53 +141,54 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-XIED6sQ7a5z2p1CZQ4A9TSTTNI5qpp9WSzVmiYdYG2o=";
 
-  nativeBuildInputs = [
-    cmake
-    copyDesktopItems
-    curl
-    perl
-    pkg-config
-    protobuf
-    rustPlatform.bindgenHook
-    cargo-about
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ makeBinaryWrapper ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [ cargo-bundle ];
+  nativeBuildInputs =
+    [
+      cmake
+      copyDesktopItems
+      curl
+      perl
+      pkg-config
+      protobuf
+      rustPlatform.bindgenHook
+      cargo-about
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ makeBinaryWrapper ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ cargo-bundle ];
 
   dontUseCmakeConfigure = true;
 
-  buildInputs = [
-    curl
-    fontconfig
-    freetype
-    libgit2
-    openssl
-    sqlite
-    zlib
-    zstd
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    alsa-lib
-    libxkbcommon
-    wayland
-    xorg.libxcb
-    # required by livekit:
-    libGL
-    libX11
-    libXext
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    apple-sdk_15
-    # ScreenCaptureKit, required by livekit, is only available on 12.3 and up:
-    # https://developer.apple.com/documentation/screencapturekit
-    (darwinMinVersionHook "12.3")
-  ];
+  buildInputs =
+    [
+      curl
+      fontconfig
+      freetype
+      libgit2
+      openssl
+      sqlite
+      zlib
+      zstd
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      alsa-lib
+      libxkbcommon
+      wayland
+      xorg.libxcb
+      # required by livekit:
+      libGL
+      libX11
+      libXext
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      apple-sdk_15
+      # ScreenCaptureKit, required by livekit, is only available on 12.3 and up:
+      # https://developer.apple.com/documentation/screencapturekit
+      (darwinMinVersionHook "12.3")
+    ];
 
   cargoBuildFlags = [
     "--package=zed"
     "--package=cli"
-  ]
-  ++ lib.optionals buildRemoteServer [ "--package=remote_server" ];
+  ] ++ lib.optionals buildRemoteServer [ "--package=remote_server" ];
 
   # Required on darwin because we don't have access to the
   # proprietary Metal shader compiler.
@@ -225,81 +227,83 @@ rustPlatform.buildRustPackage (finalAttrs: {
     writableTmpDirAsHomeHook
   ];
 
-  checkFlags = [
-    # Flaky: unreliably fails on certain hosts (including Hydra)
-    "--skip=zed::tests::test_window_edit_state_restoring_enabled"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # Flaky: unreliably fails on certain hosts (including Hydra)
-    "--skip=zed::open_listener::tests::test_open_workspace_with_directory"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    # Fails on certain hosts (including Hydra) for unclear reason
-    "--skip=test_open_paths_action"
-  ];
+  checkFlags =
+    [
+      # Flaky: unreliably fails on certain hosts (including Hydra)
+      "--skip=zed::tests::test_window_edit_state_restoring_enabled"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # Flaky: unreliably fails on certain hosts (including Hydra)
+      "--skip=zed::open_listener::tests::test_open_workspace_with_directory"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      # Fails on certain hosts (including Hydra) for unclear reason
+      "--skip=test_open_paths_action"
+    ];
 
-  installPhase = ''
-    runHook preInstall
+  installPhase =
+    ''
+      runHook preInstall
 
-    release_target="target/${stdenv.hostPlatform.rust.cargoShortTarget}/release"
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    # cargo-bundle expects the binary in target/release
-    mv $release_target/zed target/release/zed
+      release_target="target/${stdenv.hostPlatform.rust.cargoShortTarget}/release"
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      # cargo-bundle expects the binary in target/release
+      mv $release_target/zed target/release/zed
 
-    pushd crates/zed
+      pushd crates/zed
 
-    # Note that this is GNU sed, while Zed's bundle-mac uses BSD sed
-    sed -i "s/package.metadata.bundle-stable/package.metadata.bundle/" Cargo.toml
-    export CARGO_BUNDLE_SKIP_BUILD=true
-    app_path=$(cargo bundle --release | xargs)
+      # Note that this is GNU sed, while Zed's bundle-mac uses BSD sed
+      sed -i "s/package.metadata.bundle-stable/package.metadata.bundle/" Cargo.toml
+      export CARGO_BUNDLE_SKIP_BUILD=true
+      app_path=$(cargo bundle --release | xargs)
 
-    # We're not using Zed's fork of cargo-bundle, so we must manually append their plist extensions
-    # Remove closing tags from Info.plist (last two lines)
-    head -n -2 $app_path/Contents/Info.plist > Info.plist
-    # Append extensions
-    cat resources/info/*.plist >> Info.plist
-    # Add closing tags
-    printf "</dict>\n</plist>\n" >> Info.plist
-    mv Info.plist $app_path/Contents/Info.plist
+      # We're not using Zed's fork of cargo-bundle, so we must manually append their plist extensions
+      # Remove closing tags from Info.plist (last two lines)
+      head -n -2 $app_path/Contents/Info.plist > Info.plist
+      # Append extensions
+      cat resources/info/*.plist >> Info.plist
+      # Add closing tags
+      printf "</dict>\n</plist>\n" >> Info.plist
+      mv Info.plist $app_path/Contents/Info.plist
 
-    popd
+      popd
 
-    mkdir -p $out/Applications $out/bin
-    # Zed expects git next to its own binary
-    ln -s ${lib.getExe git} $app_path/Contents/MacOS/git
-    mv $release_target/cli $app_path/Contents/MacOS/cli
-    mv $app_path $out/Applications/
+      mkdir -p $out/Applications $out/bin
+      # Zed expects git next to its own binary
+      ln -s ${lib.getExe git} $app_path/Contents/MacOS/git
+      mv $release_target/cli $app_path/Contents/MacOS/cli
+      mv $app_path $out/Applications/
 
-    # Physical location of the CLI must be inside the app bundle as this is used
-    # to determine which app to start
-    ln -s $out/Applications/Zed.app/Contents/MacOS/cli $out/bin/zeditor
-  ''
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
-    install -Dm755 $release_target/zed $out/libexec/zed-editor
-    install -Dm755 $release_target/cli $out/bin/zeditor
+      # Physical location of the CLI must be inside the app bundle as this is used
+      # to determine which app to start
+      ln -s $out/Applications/Zed.app/Contents/MacOS/cli $out/bin/zeditor
+    ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      install -Dm755 $release_target/zed $out/libexec/zed-editor
+      install -Dm755 $release_target/cli $out/bin/zeditor
 
-    install -Dm644 $src/crates/zed/resources/app-icon@2x.png $out/share/icons/hicolor/1024x1024@2x/apps/zed.png
-    install -Dm644 $src/crates/zed/resources/app-icon.png $out/share/icons/hicolor/512x512/apps/zed.png
+      install -Dm644 $src/crates/zed/resources/app-icon@2x.png $out/share/icons/hicolor/1024x1024@2x/apps/zed.png
+      install -Dm644 $src/crates/zed/resources/app-icon.png $out/share/icons/hicolor/512x512/apps/zed.png
 
-    # extracted from https://github.com/zed-industries/zed/blob/v0.141.2/script/bundle-linux (envsubst)
-    # and https://github.com/zed-industries/zed/blob/v0.141.2/script/install.sh (final desktop file name)
-    (
-      export DO_STARTUP_NOTIFY="true"
-      export APP_CLI="zeditor"
-      export APP_ICON="zed"
-      export APP_NAME="Zed"
-      export APP_ARGS="%U"
-      mkdir -p "$out/share/applications"
-      ${lib.getExe envsubst} < "crates/zed/resources/zed.desktop.in" > "$out/share/applications/dev.zed.Zed.desktop"
-    )
-  ''
-  + lib.optionalString buildRemoteServer ''
-    install -Dm755 $release_target/remote_server $remote_server/bin/zed-remote-server-stable-$version
-  ''
-  + ''
-    runHook postInstall
-  '';
+      # extracted from https://github.com/zed-industries/zed/blob/v0.141.2/script/bundle-linux (envsubst)
+      # and https://github.com/zed-industries/zed/blob/v0.141.2/script/install.sh (final desktop file name)
+      (
+        export DO_STARTUP_NOTIFY="true"
+        export APP_CLI="zeditor"
+        export APP_ICON="zed"
+        export APP_NAME="Zed"
+        export APP_ARGS="%U"
+        mkdir -p "$out/share/applications"
+        ${lib.getExe envsubst} < "crates/zed/resources/zed.desktop.in" > "$out/share/applications/dev.zed.Zed.desktop"
+      )
+    ''
+    + lib.optionalString buildRemoteServer ''
+      install -Dm755 $release_target/remote_server $remote_server/bin/zed-remote-server-stable-$version
+    ''
+    + ''
+      runHook postInstall
+    '';
 
   nativeInstallCheckInputs = [
     versionCheckHook
@@ -322,15 +326,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
         zed-editor = finalAttrs.finalPackage;
         additionalPkgs = f;
       };
-    tests = {
-      remoteServerVersion = testers.testVersion {
-        package = finalAttrs.finalPackage.remote_server;
-        command = "zed-remote-server-stable-${finalAttrs.version} version";
+    tests =
+      {
+        remoteServerVersion = testers.testVersion {
+          package = finalAttrs.finalPackage.remote_server;
+          command = "zed-remote-server-stable-${finalAttrs.version} version";
+        };
+      }
+      // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+        withGles = zed-editor.override { withGLES = true; };
       };
-    }
-    // lib.optionalAttrs stdenv.hostPlatform.isLinux {
-      withGles = zed-editor.override { withGLES = true; };
-    };
   };
 
   meta = {


### PR DESCRIPTION
Hey,

This is my attempt to add https://github.com/GIScience/ohsome-planet, a very cool tool to convert OpenStreetMaps pbf files into geoparquet. This is very helpful on building cloud native services on top of OSM data so that client devices can directly query only the part of the larger datasets which they actually need without storing the OSM data in a separate database.

[Overture Maps](https://overturemaps.org/) exists too and shares data in a bit similiar manner but they don't include everything that OpenStreetMaps has.

It builds on my Mac but I didn't figure out how I can calculate the sha256 checksums. Sorry I'm still somewhat noob on packaging on nix but I'm willing to learn 🙇 😊.

Example usage:
```
$ nix-build -A ohsome-planet
...
Running phase: installPhase
Running phase: fixupPhase
checking for references to /private/tmp/nix-build-ohsome-planet-1.1.0.drv-0/ in /nix/store/942pyck6394n3w7lcd6ria54nw8258c4-ohsome-planet-1.1.0...
patching script interpreter paths in /nix/store/942pyck6394n3w7lcd6ria54nw8258c4-ohsome-planet-1.1.0
stripping (with command strip and flags -S) in  /nix/store/942pyck6394n3w7lcd6ria54nw8258c4-ohsome-planet-1.1.0/lib /nix/store/942pyck6394n3w7lcd6ria54nw8258c4-ohsome-planet-1.1.0/bin
/nix/store/942pyck6394n3w7lcd6ria54nw8258c4-ohsome-planet-1.1.0

# Download small dataset
$ curl -O https://download.geofabrik.de/europe/monaco-latest.osm.pbf

# Convert to parquet
/nix/store/942pyck6394n3w7lcd6ria54nw8258c4-ohsome-planet-1.1.0/bin/ohsome-planet contributions --pbf=monaco-latest.osm.pbf --output=parquet

# See the resulting files
$ tree parquet/contributions/latest/
out/contributions/latest/
├── node-0-21911886-latest-contribs.parquet
├── node-1-1097207537-latest-contribs.parquet
├── node-2-2341649642-latest-contribs.parquet
├── node-3-6482567748-latest-contribs.parquet
├── node-4-10110739817-latest-contribs.parquet
├── node-5-12641248321-latest-contribs.parquet
├── relation-0-latest-contribs.parquet
├── relation-1-latest-contribs.parquet
├── relation-2-latest-contribs.parquet
├── relation-3-latest-contribs.parquet
├── relation-4-latest-contribs.parquet
├── relation-5-latest-contribs.parquet
├── relation-6-latest-contribs.parquet
├── relation-7-latest-contribs.parquet
├── relation-8-latest-contribs.parquet
└── way-0-4097656-latest-contribs.parquet
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
