### PR TITLE
linuxPackages.nvidiaPackages.production: 570.181 -> 580.76.05

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -72,12 +72,12 @@ rec {
   stable = if stdenv.hostPlatform.system == "i686-linux" then legacy_390 else production;
 
   production = generic {
-    version = "570.181";
-    sha256_64bit = "sha256-8G0lzj8YAupQetpLXcRrPCyLOFA9tvaPPvAWurjj3Pk=";
-    sha256_aarch64 = "sha256-1pUDdSm45uIhg0HEhfhak9XT/IE/XUVbdtrcpabZ3KU=";
-    openSha256 = "sha256-U/uqAhf83W/mns/7b2cU26B7JRMoBfQ3V6HiYEI5J48=";
-    settingsSha256 = "sha256-iBx/X3c+1NSNmG+11xvGyvxYSMbVprijpzySFeQVBzs=";
-    persistencedSha256 = "sha256-RoAcutBf5dTKdAfkxDPtMsktFVQt5uPIPtkAkboQwcQ=";
+    version = "580.76.05";
+    sha256_64bit = "sha256-IZvmNrYJMbAhsujB4O/4hzY8cx+KlAyqh7zAVNBdl/0=";
+    sha256_aarch64 = "sha256-NL2DswzVWQQMVM092NmfImqKbTk9VRgLL8xf4QEvGAQ=";
+    openSha256 = "sha256-xEPJ9nskN1kISnSbfBigVaO6Mw03wyHebqQOQmUg/eQ=";
+    settingsSha256 = "sha256-ll7HD7dVPHKUyp5+zvLeNqAb6hCpxfwuSyi+SAXapoQ=";
+    persistencedSha256 = "sha256-bs3bUi8LgBu05uTzpn2ugcNYgR5rzWEPaTlgm0TIpHY=";
   };
 
   latest = selectHighestVersion production (generic {


### PR DESCRIPTION
- Highlights since R580 Beta Release, 580.65.06
  - Updated egl-x11 to version 1.0.3.
  - Updated egl-wayland to version 1.1.20. https://github.com/NixOS/nixpkgs/pull/431501
  - Added an "OutputBitsPerComponent" MetaMode attribute that can be used to control the number of bits per color component transmitted via a display connector. If not specified, the driver will choose an optimal color format.
- Highlights from R580 Beta Release, 580.65.06
  - Fixed a bug that could cause Vulkan applications to hang when destroying swapchains after a lost device event.
  - Fixed a bug that could allow atomic commit and other DRM operations to return success status despite having failed due to handling an interrupt:
  - https://github.com/NVIDIA/open-gpu-kernel-modules/issues/832
  - Fixed a bug that could cause GTK 4 applications to crash when using the Vulkan backend on Wayland.
  - Fixed a bug that could intermittently cause llama.cpp to crash on exit when using the Vulkan backend:
  - https://github.com/ggml-org/llama.cpp/issues/10528
  - Added support for the fifo-v1 Wayland protocol on Vulkan.
  - Updated GPU clock value reporting in nvidia-settings, NVML, and nvidia-smi to show clocks before thermal and idle slowdowns for better consistency with the equivalent functionality on Windows.
  - Fixed compatibility with Bigscreen Beyond Head Mounted Displays.
  - Fixed a bug that could result in a black screen when setting specific modes on HDMI displays.
  - Fixed a bug that caused blank or frozen screens under the following conditions: nvidia-drm is loaded with the modeset=1 and fbdev=1 parameters, using a Maxwell or Pascal series GPU, and more than one display device of differing resolutions are connected.
  - Fixed a bug that caused nvidia-suspend.service to fail when available system memory is low.
  - Enabled RMIntrLockingMode by default. This feature can help reduce stutter especially when using virtual reality. This feature was originally introduced in the r570 series. It can be disabled by loading nvidia.ko with the `NVreg_RegistryDwords=RMIntrLockingMode=0` kernel module parameter.
  - Implemented another feature that can reduce time spent in the interrupt top half for low latency display interrupts by deferring the work until later. This feature is experimental and disabled by default. This feature can be enabled by loading nvidia.ko with the `NVreg_RegistryDwords=RmEnableAggressiveVblank=1` kernel module parameter.
  - Fixed a bug that could cause blank rendering on some single-buffered GLX applications when running on Xwayland.
  - Fixed a bug that could cause a kernel use-after-free on pre-Turing GPUs.
  - Fixed a bug that could cause OpenGL applications and compositors to stall when using NVIDIA as a PRIME Display Offload sink ("Reverse PRIME"), potentially resulting in a black screen.
  - Fixed a bug that led to increasing memory usage in X11 OpenGL and Vulkan applications after suspend/resume cycles.
  - Fixed a bug that could cause 32-bit x86 applications running on recent builds of glibc to crash on dlopen().

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
