### PR TITLE
python3Packages.arro3: Init at 0.5.1

### DIFF
--- a/pkgs/development/python-modules/arro3/default.nix
+++ b/pkgs/development/python-modules/arro3/default.nix
@@ -1,0 +1,122 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  pytestCheckHook,
+  geoarrow-types,
+  pyarrow,
+  numpy,
+  pandas,
+}:
+let
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "kylebarron";
+    repo = "arro3";
+    tag = "py-v${version}";
+    hash = "sha256-RTr+mf5slfxxvXp9cwPuy08AZUswPtIIRz+vngdg/k0=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit version src;
+    pname = "arro3-vendor";
+    hash = "sha256-YQA8Z86Ul8yAHncMgYrGmNe10KSpubHjaokCjaqTAxo=";
+  };
+
+  commonMeta = {
+    homepage = "https://github.com/kylebarron/arro3";
+    changelog = "https://github.com/kylebarron/arro3/releases/tag/py-v${version}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.mslingsby ];
+  };
+
+  buildArro3Package =
+    {
+      pname,
+      subdir,
+      description,
+      pythonImportsCheck,
+      dependencies ? [ ],
+    }:
+    buildPythonPackage rec {
+      inherit
+        pname
+        version
+        src
+        cargoDeps
+        dependencies
+        pythonImportsCheck
+        ;
+      pyproject = true;
+
+      sourceRoot = "${src.name}/${subdir}";
+      cargoRoot = "..";
+
+      nativeBuildInputs = with rustPlatform; [
+        cargoSetupHook
+        maturinBuildHook
+      ];
+
+      env = {
+        CARGO_TARGET_DIR = "./target";
+      };
+
+      # Avoid infinite recursion in tests.
+      # arro3-core tests depends on arro3-compute and arro3-compute depends on arro3-core
+      passthru.tests = { inherit arro3-tests; };
+
+      meta = commonMeta // {
+        inherit description;
+      };
+    };
+
+  arro3-core = buildArro3Package {
+    pname = "arro3-core";
+    subdir = "arro3-core";
+    description = "Core library for representing Arrow data in Python";
+    pythonImportsCheck = [ "arro3.core" ];
+  };
+
+  arro3-compute = buildArro3Package {
+    pname = "arro3-compute";
+    subdir = "arro3-compute";
+    description = "Rust-based compute kernels for Arrow in Python";
+    pythonImportsCheck = [ "arro3.compute" ];
+    dependencies = [ arro3-core ];
+  };
+
+  arro3-io = buildArro3Package {
+    pname = "arro3-io";
+    subdir = "arro3-io";
+    description = "Rust-based readers and writers for Arrow in Python";
+    pythonImportsCheck = [ "arro3.io" ];
+    dependencies = [ arro3-core ];
+  };
+
+  arro3-tests = buildPythonPackage {
+    pname = "arro3-tests";
+    version = arro3-core.version;
+
+    format = "other";
+    dontBuild = true;
+    dontInstall = true;
+
+    inherit src;
+
+    nativeCheckInputs = [
+      pytestCheckHook
+      geoarrow-types
+      pandas
+      pyarrow
+      numpy
+      arro3-core
+      arro3-compute
+      arro3-io
+    ];
+  };
+in
+{
+  inherit arro3-core arro3-io arro3-compute;
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -905,6 +905,12 @@ self: super: with self; {
 
   arris-tg2492lg = callPackage ../development/python-modules/arris-tg2492lg { };
 
+  arro3-compute = (callPackage ../development/python-modules/arro3 { }).arro3-compute;
+
+  arro3-core = (callPackage ../development/python-modules/arro3 { }).arro3-core;
+
+  arro3-io = (callPackage ../development/python-modules/arro3 { }).arro3-io;
+
   arrow = callPackage ../development/python-modules/arrow { };
 
   arsenic = callPackage ../development/python-modules/arsenic { };


### PR DESCRIPTION
A minimal Python library for Apache Arrow, connecting to the Rust arrow crate. The source repo contains 3 subpackages, which are built as individual packages

Required as dependency of the [deltalake pkg](https://github.com/NixOS/nixpkgs/blob/nixos-25.05/pkgs/development/python-modules/deltalake/default.nix) in v1.x.x.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
