### PR TITLE
workflows/check: use regular checkout

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,13 +38,13 @@ jobs:
     permissions:
       pull-requests: write
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 10
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          fetch-depth: 0
-          filter: tree:0
           path: trusted
+          sparse-checkout: |
+            ci/github-script
 
       - name: Install dependencies
         run: npm install bottleneck


### PR DESCRIPTION
The filtered checkout we used before was a nice idea, but only worked for small numbers of commits in a PR. It would fetch the whole history initially, but only fetch objects on demand. This turns out to be much too slow in a [PR with 18 commits](https://github.com/NixOS/nixpkgs/pull/433177), regularly hitting the 10 minute timeout, even when running it locally.

The new approach uses regular checkouts again. In contrast to the old style, before we switched to the filtered checkout, this only fetches exactly the commits we need - and all of them at once. This is significantly faster than both other approaches, and scales much better. A bigger number of commits doesn't have much of an effect, if any at all.

Reproducing the same locally, it takes ~ 20 seconds for the job to run including the `git fetch` - even with these 18 commits. Overall, I expect the job to possibly take less than 1 minute now - for any PR.

cc @dtomvan

## Things done

- [x] Tested locally.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
