### PR TITLE
gitlab: 18.2.1 -> 18.2.2

### DIFF
--- a/pkgs/by-name/gi/gitaly/package.nix
+++ b/pkgs/by-name/gi/gitaly/package.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  version = "18.2.1";
+  version = "18.2.2";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 
@@ -21,7 +21,7 @@ let
       owner = "gitlab-org";
       repo = "gitaly";
       rev = "v${version}";
-      hash = "sha256-h4JklXImKwudJT3pb/UhHwQHKd87c5aSH1xYC0lRWKo=";
+      hash = "sha256-+OmduG9neb15m3i57qPfE42HI4w/zgmA5T6bhlwzrT0=";
     };
 
     vendorHash = "sha256-RjDV4NGmmdT9STQBHiYf3UUYwPmuSg6970/W/ekxin0=";

--- a/pkgs/by-name/gi/gitlab-container-registry/fix-broken-urlcache-tests.diff
+++ b/pkgs/by-name/gi/gitlab-container-registry/fix-broken-urlcache-tests.diff
@@ -1,0 +1,22 @@
+diff --git a/registry/storage/driver/middleware/urlcache/urlcache_test.go b/registry/storage/driver/middleware/urlcache/urlcache_test.go
+index 67ef4abc0e..6644c80837 100644
+--- a/registry/storage/driver/middleware/urlcache/urlcache_test.go
++++ b/registry/storage/driver/middleware/urlcache/urlcache_test.go
+@@ -37,7 +37,7 @@
+ 			name:        "missing redis cache",
+ 			options:     make(map[string]any),
+ 			wantErr:     true,
+-			errContains: "urlcache middleware requires `cache` Redis configured",
++			errContains: "`_redisCache` key has not been passed to urlcache middleware",
+ 		},
+ 		{
+ 			name: "default configuration with redis",
+@@ -231,7 +231,7 @@
+ 				"_redisCache": "not a redis cache",
+ 			},
+ 			wantErr:     true,
+-			errContains: "unusable redis cache object",
++			errContains: "redis cache passed to the middleware cannot be used as the type is wrong",
+ 		},
+ 	}
+ 

--- a/pkgs/by-name/gi/gitlab-container-registry/package.nix
+++ b/pkgs/by-name/gi/gitlab-container-registry/package.nix
@@ -6,7 +6,7 @@
 
 buildGoModule rec {
   pname = "gitlab-container-registry";
-  version = "4.25.0";
+  version = "4.26.0";
   rev = "v${version}-gitlab";
 
   # nixpkgs-update: no auto update
@@ -14,10 +14,16 @@ buildGoModule rec {
     owner = "gitlab-org";
     repo = "container-registry";
     inherit rev;
-    hash = "sha256-7jzKFC29NAHi5iag6aA/5LzH6IyqMa3yAxtzV9OsBnQ=";
+    hash = "sha256-XACKJW5sRXNM4Q24DXEVtjzhVfxoBd+JWHJr1s01ocA=";
   };
 
-  vendorHash = "sha256-z9IlfyJ48FQzhbY38GbZaeQjg3cMDU8tLCXKhazP64A=";
+  patches = [
+    # https://gitlab.com/gitlab-org/container-registry/-/merge_requests/2447
+    # Can be removed with next released when merged
+    ./fix-broken-urlcache-tests.diff
+  ];
+
+  vendorHash = "sha256-J4p3vXLmDFYl/z6crqanlmG1FB4Dq04HLx9IhC3usQ4=";
 
   checkFlags =
     let

--- a/pkgs/by-name/gi/gitlab-pages/package.nix
+++ b/pkgs/by-name/gi/gitlab-pages/package.nix
@@ -6,14 +6,14 @@
 
 buildGoModule rec {
   pname = "gitlab-pages";
-  version = "18.2.1";
+  version = "18.2.2";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-pages";
     rev = "v${version}";
-    hash = "sha256-z1Pl3xeaoqeF/9qOVcuCpuciu1r6NQ4UhlLe9gy9+nE=";
+    hash = "sha256-PPa9SYyE3G+peP2xSpNw7WDDO7WiWKSRpd5tBODkA0g=";
   };
 
   vendorHash = "sha256-OubXCpvGtGqegQmdb6R1zw/0DfQ4FdbJGt7qYYRnWnA=";

--- a/pkgs/by-name/gi/gitlab/data.json
+++ b/pkgs/by-name/gi/gitlab/data.json
@@ -1,15 +1,15 @@
 {
-  "version": "18.2.1",
-  "repo_hash": "1i0y46w18476gn98fmkixdjiyrwajz2347p57dg2ijch4ivzpmlv",
-  "yarn_hash": "04mqinnbhr6zgab2p1bq6y6b20bf4c4cynkgfc67mzm9xhybr3fk",
+  "version": "18.2.2",
+  "repo_hash": "0fqpfprxmgxaz5g0d5z4gsir1zj9fkhli7iq1ahx413ymsiqrxd0",
+  "yarn_hash": "0c6njrciqcjaswh784yxly4qza6k2ghq1ljbdkcn65cna4f4hwgk",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v18.2.1-ee",
+  "rev": "v18.2.2-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "18.2.1",
-    "GITLAB_PAGES_VERSION": "18.2.1",
+    "GITALY_SERVER_VERSION": "18.2.2",
+    "GITLAB_PAGES_VERSION": "18.2.2",
     "GITLAB_SHELL_VERSION": "14.43.0",
     "GITLAB_ELASTICSEARCH_INDEXER_VERSION": "5.7.0",
-    "GITLAB_WORKHORSE_VERSION": "18.2.1"
+    "GITLAB_WORKHORSE_VERSION": "18.2.2"
   }
 }

--- a/pkgs/by-name/gi/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/by-name/gi/gitlab/gitlab-workhorse/default.nix
@@ -10,7 +10,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "18.2.1";
+  version = "18.2.2";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {


### PR DESCRIPTION
https://about.gitlab.com/releases/2025/08/13/patch-release-gitlab-18-2-2-released/

Also includes yet another bug fix for a gitlab-container-registry test.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
