### PR TITLE
nixos/tests/nginx-variants: bring back handling of duplicate package names

### DIFF
--- a/nixos/tests/nginx-variants.nix
+++ b/nixos/tests/nginx-variants.nix
@@ -1,10 +1,10 @@
 { pkgs, runTest, ... }:
 builtins.listToAttrs (
   builtins.map
-    (nginxPackage: {
-      name = pkgs.lib.getName nginxPackage;
+    (packageName: {
+      name = packageName;
       value = runTest {
-        name = "nginx-variant-${pkgs.lib.getName nginxPackage}";
+        name = "nginx-variant-${packageName}";
 
         nodes.machine =
           { pkgs, ... }:
@@ -12,7 +12,7 @@ builtins.listToAttrs (
             services.nginx = {
               enable = true;
               virtualHosts.localhost.locations."/".return = "200 'foo'";
-              package = nginxPackage;
+              package = pkgs.${packageName};
             };
           };
 
@@ -24,13 +24,13 @@ builtins.listToAttrs (
       };
     })
     [
-      pkgs.angie
-      pkgs.angieQuic
-      pkgs.nginxStable
-      pkgs.nginxMainline
-      pkgs.nginxQuic
-      pkgs.nginxShibboleth
-      pkgs.openresty
-      pkgs.tengine
+      "angie"
+      "angieQuic"
+      "nginxStable"
+      "nginxMainline"
+      "nginxQuic"
+      "nginxShibboleth"
+      "openresty"
+      "tengine"
     ]
 )


### PR DESCRIPTION
Reverts the incorrect refactoring in 86efccfa45b058d51c429105dc2108e2ad1da005

Package names are non-unique, so tests were silently dropped from the attrset

Diff of `nix-instantiate <nixpkgs> -A nixosTests.nginx-variants`:

```diff
  /nix/store/iaf6c57rsmd5dbm4nn5kf9ykxl52928c-vm-test-run-nginx-variant-angie.drv
  /nix/store/vhpx0xpzyhqxgnjqfm56fqk1mlav803n-vm-test-run-nginx-variant-angieQuic.drv
- /nix/store/yf5qjsm2qi3wc8v9wyssqrqrcdhgnpjw-vm-test-run-nginx-variant-nginx.drv
+ /nix/store/adl7gymnhbddh6w7qq9qlfnn35y1fgfi-vm-test-run-nginx-variant-nginxMainline.drv
+ /nix/store/jpk64nr3kpvqjd5jns25n6i5dazh9i5s-vm-test-run-nginx-variant-nginxQuic.drv
+ /nix/store/hmzmpcynp8svpck0kzmlk715clrl2265-vm-test-run-nginx-variant-nginxShibboleth.drv
+ /nix/store/qj4qihphixn2yhv7b7rp82c983bhm84d-vm-test-run-nginx-variant-nginxStable.drv
  /nix/store/j5jdvwiiz72nx11dm1x61w4a4kanas6i-vm-test-run-nginx-variant-openresty.drv
  /nix/store/2g1pipchv72qwq7v1j3bgbzi1yhp5nv0-vm-test-run-nginx-variant-tengine.drv
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
