### PR TITLE
atproto-goat: 0-unstable-2025-02-01 -> 0-unstable-2025-08-13

### DIFF
--- a/pkgs/by-name/at/atproto-goat/package.nix
+++ b/pkgs/by-name/at/atproto-goat/package.nix
@@ -11,20 +11,18 @@ buildGoModule rec {
 
   src = fetchFromGitHub {
     owner = "bluesky-social";
-    repo = "indigo";
-    rev = "fd270fbccf0ca858ed2eccdeff246a303c0be045";
-    hash = "sha256-1WK3tMz8WbuIGTHYwD0or+9D0KVezhnv3EDdK11KKp8=";
+    repo = "goat";
+    rev = "e79169f1d8fba9838274b1106d74751fc54eeb9c";
+    hash = "sha256-cLS44J6MlSSti7NRd9vSsdWXoYiMGwt3odg5p60W6ew=";
   };
 
   postPatch = ''
-    substituteInPlace cmd/goat/main.go \
+    substituteInPlace main.go \
       --replace-fail "versioninfo.Short()" '"${version}"' \
-      --replace-fail '"github.com/carlmjohnson/versioninfo"' ""
+      --replace-fail '"github.com/earthboundkid/versioninfo/v2"' ""
   '';
 
-  vendorHash = "sha256-pGc29fgJFq8LP7n/pY1cv6ExZl88PAeFqIbFEhB3xXs=";
-
-  subPackages = [ "cmd/goat" ];
+  vendorHash = "sha256-l9oSdTAO1YxfrBjMWJDzlmhaZkbo90FGTk5LedjbZB8=";
 
   passthru.updateScript = unstableGitUpdater {
     hardcodeZeroVersion = true;
@@ -32,7 +30,7 @@ buildGoModule rec {
 
   meta = {
     description = "Go AT protocol CLI tool";
-    homepage = "https://github.com/bluesky-social/indigo/blob/main/cmd/goat/README.md";
+    homepage = "https://github.com/bluesky-social/goat/blob/main/README.md";
     license = with lib.licenses; [
       mit
       asl20


### PR DESCRIPTION
Update repo URL to latest. Also updated to latest buildable commit for good measure.
changelog: https://github.com/bluesky-social/goat/blob/main/CHANGELOG.md

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
