### PR TITLE
bmaptool: 3.8.0 -> 3.9.0

### DIFF
--- a/pkgs/by-name/bm/bmaptool/package.nix
+++ b/pkgs/by-name/bm/bmaptool/package.nix
@@ -20,7 +20,7 @@ python3Packages.buildPythonApplication rec {
     python3Packages.hatchling
   ];
 
-  propagatedBuildInputs = with python3Packages; [ six ];
+  dependencies = with python3Packages; [ six ];
 
   # tests fail only on hydra.
   doCheck = false;

--- a/pkgs/by-name/bm/bmaptool/package.nix
+++ b/pkgs/by-name/bm/bmaptool/package.nix
@@ -6,15 +6,19 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "bmaptool";
-  version = "3.8.0";
-  format = "setuptools";
+  version = "3.9.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "yoctoproject";
     repo = "bmaptool";
     rev = "v${version}";
-    hash = "sha256-YPY3sNuZ/TASNBPH94iqG6AuBRq5KjioKiuxAcu94+I=";
+    hash = "sha256-9KSBv420HJvK5fUg7paFJqA2MCw36BfaeAG4NME/co8=";
   };
+
+  build-system = [
+    python3Packages.hatchling
+  ];
 
   propagatedBuildInputs = with python3Packages; [ six ];
 

--- a/pkgs/by-name/bm/bmaptool/package.nix
+++ b/pkgs/by-name/bm/bmaptool/package.nix
@@ -25,12 +25,12 @@ python3Packages.buildPythonApplication rec {
   # tests fail only on hydra.
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "BMAP Tools";
     homepage = "https://github.com/yoctoproject/bmaptool";
-    license = licenses.gpl2Only;
-    maintainers = [ maintainers.dezgeg ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ dezgeg ];
+    platforms = lib.platforms.linux;
     mainProgram = "bmaptool";
   };
 }


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
