### PR TITLE
sail-riscv: 0.7 -> 0.8

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -186,6 +186,8 @@
 
 - `hsd` has been upgraded to version 8. See [their changelog](https://github.com/handshake-org/hsd/blob/v8.0.0/docs/release-notes/release-notes-8.x.md) for important instructions before upgrading.
 
+- `sail-riscv` 0.8 follows [upstream](https://github.com/riscv/sail-riscv/blob/7cc4620eb1a57bfe04832baccdcf5727e9459bd4/doc/ChangeLog.md) and provides only a single binary, `sail_riscv_sim`.
+
 - `podofo` has been updated from `0.9.8` to `1.0.0`. These releases are by nature very incompatible due to major API changes. The legacy versions can be found under `podofo_0_10` and `podofo_0_9`.
   Changelog: https://github.com/podofo/podofo/blob/1.0.0/CHANGELOG.md, API-Migration-Guide: https://github.com/podofo/podofo/blob/1.0.0/API-MIGRATION.md.
 

--- a/pkgs/applications/virtualization/sail-riscv/default.nix
+++ b/pkgs/applications/virtualization/sail-riscv/default.nix
@@ -7,19 +7,18 @@
   pkg-config,
   sail,
   ninja,
-  zlib,
   z3,
 }:
 
 stdenv.mkDerivation rec {
   pname = "sail-riscv";
-  version = "0.7";
+  version = "0.8";
 
   src = fetchFromGitHub {
     owner = "riscv";
     repo = "sail-riscv";
     rev = version;
-    hash = "sha256-Keu96+yHWUEFO3rRLvF7rzcJmF3y/V/uyK7TIFj0Xw0=";
+    hash = "sha256-50ATe3DQcdyNOqP85mEMyEwxzpBOplzRN9ulaJNo9zo=";
   };
 
   nativeBuildInputs = [
@@ -30,22 +29,12 @@ stdenv.mkDerivation rec {
     sail
   ];
   buildInputs = [
-    zlib
     gmp
   ];
   strictDeps = true;
 
-  preBuild = ''
-    ninja \
-      riscv_sim_rv32d      \
-      riscv_sim_rv32d_rvfi \
-      riscv_sim_rv32f      \
-      riscv_sim_rv32f_rvfi \
-      riscv_sim_rv64d      \
-      riscv_sim_rv64d_rvfi \
-      riscv_sim_rv64f      \
-      riscv_sim_rv64f_rvfi
-  '';
+  # sail-riscv 0.8 fails to install without compressed_changelog
+  ninjaFlags = [ "compressed_changelog" ];
 
   meta = with lib; {
     homepage = "https://github.com/riscv/sail-riscv";


### PR DESCRIPTION
Thanks to improved runtime configuration, there is a single binary,
sail_riscv_sim, instead of a binary for each base architecture.

The zlib dependency actually got dropped in 0.7: fb6dd20fec53 ("Bump
required sail compiler version to 0.19 and remove zlib dependency")

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
