### PR TITLE
libx11: don't propagate libxcb, fix all packages i could find that need it

### DIFF
--- a/pkgs/by-name/an/anvil-editor/package.nix
+++ b/pkgs/by-name/an/anvil-editor/package.nix
@@ -51,6 +51,7 @@ buildGo123Module (finalAttrs: {
     vulkan-headers
     libGL
     xorg.libX11
+    xorg.libxcb
     xorg.libXcursor
     xorg.libXfixes
   ];

--- a/pkgs/by-name/az/azahar/package.nix
+++ b/pkgs/by-name/az/azahar/package.nix
@@ -105,6 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
     pipewire
     qt6.qtwayland
     xorg.libX11
+    xorg.libxcb
     xorg.libXext
   ]
   ++ optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/by-name/es/espanso/package.nix
+++ b/pkgs/by-name/es/espanso/package.nix
@@ -7,6 +7,7 @@
   extra-cmake-modules,
   dbus,
   libX11,
+  libxcb,
   libXi,
   libXtst,
   libnotify,
@@ -80,6 +81,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libXi
     libXtst
     libX11
+    libxcb
     xclip
     xdotool
   ];

--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -129,6 +129,7 @@ stdenv.mkDerivation (finalAttrs: {
     pipewire
     hwdata
     xorg.libX11
+    xorg.libxcb
     wayland
     wayland-protocols
     vulkan-loader

--- a/pkgs/by-name/go/gossip/package.nix
+++ b/pkgs/by-name/go/gossip/package.nix
@@ -17,6 +17,7 @@
   wayland-scanner,
   nix-update-script,
   libX11,
+  libxcb,
   libXcursor,
   libXi,
   libXrandr,
@@ -65,6 +66,7 @@ rustPlatform.buildRustPackage rec {
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     wayland
     libX11
+    libxcb
     libXcursor
     libXi
     libXrandr

--- a/pkgs/by-name/go/gotraceui/package.nix
+++ b/pkgs/by-name/go/gotraceui/package.nix
@@ -5,6 +5,7 @@
   buildGoModule,
   libGL,
   libX11,
+  libxcb,
   libXcursor,
   libXfixes,
   libxkbcommon,
@@ -42,6 +43,7 @@ buildGoModule rec {
     libxkbcommon
     wayland
     libX11
+    libxcb
     libXcursor
     libXfixes
     libGL

--- a/pkgs/by-name/li/libuiohook/package.nix
+++ b/pkgs/by-name/li/libuiohook/package.nix
@@ -6,6 +6,7 @@
   cmake,
   pkg-config,
   libX11,
+  libxcb,
   libxkbcommon,
   xinput,
   xorg,
@@ -30,6 +31,7 @@ stdenv.mkDerivation rec {
   buildInputs = lib.optionals (!stdenv.hostPlatform.isDarwin) (
     [
       libX11
+      libxcb
       libxkbcommon
       xinput
     ]

--- a/pkgs/by-name/li/libx11/package.nix
+++ b/pkgs/by-name/li/libx11/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   propagatedBuildInputs = [
     xorgproto
-    libxcb
   ];
 
   configureFlags =

--- a/pkgs/by-name/me/mesa-demos/package.nix
+++ b/pkgs/by-name/me/mesa-demos/package.nix
@@ -6,6 +6,7 @@
   libGL,
   libGLU,
   libX11,
+  libxcb,
   libXext,
   libgbm,
   mesa,
@@ -45,6 +46,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libglut
     libX11
+    libxcb
     libXext
     libGL
     libGLU

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -147,6 +147,7 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optionals x11Support [
       xorg.libX11
+      xorg.libxcb
       xorg.libXScrnSaver
       xorg.libXcursor
       xorg.libXext

--- a/pkgs/by-name/sl/slstatus/package.nix
+++ b/pkgs/by-name/sl/slstatus/package.nix
@@ -5,6 +5,7 @@
   pkg-config,
   writeText,
   libX11,
+  libxcb,
   libXau,
   libXdmcp,
   config,
@@ -39,6 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     libX11
+    libxcb
     libXau
     libXdmcp
   ]

--- a/pkgs/by-name/wl/wlx-overlay-s/package.nix
+++ b/pkgs/by-name/wl/wlx-overlay-s/package.nix
@@ -6,6 +6,7 @@
   lib,
   libGL,
   libX11,
+  libxcb,
   libXext,
   libXrandr,
   libxkbcommon,
@@ -62,6 +63,7 @@ rustPlatform.buildRustPackage rec {
     fontconfig
     libGL
     libX11
+    libxcb
     libXext
     libXrandr
     libxkbcommon

--- a/pkgs/by-name/xi/xidlehook/package.nix
+++ b/pkgs/by-name/xi/xidlehook/package.nix
@@ -28,6 +28,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [
     xorg.libX11
+    xorg.libxcb
     xorg.libXScrnSaver
     libpulseaudio
   ];

--- a/pkgs/by-name/xk/xkbmon/package.nix
+++ b/pkgs/by-name/xk/xkbmon/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   libX11,
+  libxcb,
 }:
 
 stdenv.mkDerivation rec {
@@ -16,7 +17,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-EWW6L6NojzXodDOET01LMcQT8/1JIMpOD++MCiM3j1Y=";
   };
 
-  buildInputs = [ libX11 ];
+  buildInputs = [
+    libX11
+    libxcb
+  ];
 
   installPhase = "install -D -t $out/bin xkbmon";
 

--- a/pkgs/development/libraries/gstreamer/vaapi/default.nix
+++ b/pkgs/development/libraries/gstreamer/vaapi/default.nix
@@ -64,6 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     libdrm
     udev
     xorg.libX11
+    xorg.libxcb
     xorg.libXext
     xorg.libXv
     xorg.libXrandr

--- a/pkgs/development/libraries/libva/default.nix
+++ b/pkgs/development/libraries/libva/default.nix
@@ -9,6 +9,7 @@
   libdrm,
   minimal ? false,
   libX11,
+  libxcb,
   libXext,
   libXfixes,
   wayland,
@@ -54,6 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals (!minimal) [
     libX11
+    libxcb
     libXext
     libXfixes
     wayland

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -165,6 +165,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals x11Support [
     libcanberra
     xorg.libX11
+    xorg.libxcb
     xorg.libXfixes
   ]
   ++ lib.optionals bluezSupport [


### PR DESCRIPTION
context: #431322 #402103
`libx11` provides 2 pkg-config files: `x11.pc` and `x11-xcb.pc`.
Only `x11-xcb.pc` requires `libxcb`, so any package that only needs `x11.pc` won't need `libxcb`.
This PR removes the propagation and fixes (probably most) packages that depended on it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
