### PR TITLE
cctv-viewer: init at 0.1.9-unstable-2025-06-13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24995,6 +24995,12 @@
     matrix = "@tensor5:matrix.org";
     name = "Nicola Squartini";
   };
+  teohz = {
+    email = "gitstuff@teohz.com";
+    github = "teohz";
+    githubId = 77596774;
+    name = "Teohz";
+  };
   teozkr = {
     email = "teo@nullable.se";
     github = "nightkr";

--- a/pkgs/by-name/cc/cctv-viewer/package.nix
+++ b/pkgs/by-name/cc/cctv-viewer/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  qt5,
+  ffmpeg,
+  gtest,
+  libva,
+}:
+
+stdenv.mkDerivation {
+  pname = "cctv-viewer";
+  version = "0.1.9-unstable-2025-06-13";
+
+  src = fetchFromGitHub {
+    owner = "iEvgeny";
+    repo = "cctv-viewer";
+    rev = "8a8fff2612ae2123b8be156c954a29706383b480";
+    hash = "sha256-Euw9S+iONAEENkFwo169x/+pcyeTXLe8wb70KKjv3bE=";
+    fetchSubmodules = true;
+  };
+
+  cmakeFlags = [
+    "-DBUILD_TESTS=OFF"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qt5.wrapQtAppsHook
+    qt5.qttools
+    gtest
+  ];
+
+  buildInputs = [
+    qt5.qtbase
+    qt5.qtquickcontrols2
+    qt5.qtsvg
+    qt5.qtmultimedia
+    qt5.qtgraphicaleffects
+    ffmpeg
+    libva
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D cctv-viewer --target-directory=$out/bin
+    install -Dm644 $src/cctv-viewer.desktop --target-directory=$out/share/applications
+    install -Dm644 $src/images/cctv-viewer.svg --target-directory=$out/share/icons/hicolor/scalable/apps
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Viewer and mounter for video streams";
+    homepage = "https://cctv-viewer.org";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ teohz ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
cctv-viewer: init at 0.1.9

Adds the `cctv-viewer` package, a simple Qt-based application for simultaneously viewing multiple video streams.

Homepage: https://cctv-viewer.org

The packaging required adding several Qt dependencies (`qtmultimedia`, `qtgraphicaleffects`, `qttools`) and `libva` for hardware acceleration. The `gtest` package was also added as a dependency to satisfy the build-time configuration of the upstream.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
