### PR TITLE
gimp3Plugins.gimp-xsanecli: init at d4fa7e8afc

### DIFF
--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -215,6 +215,28 @@ lib.makeScope pkgs.newScope (
       };
     };
 
+    gimp-xsanecli = pluginDerivation rec {
+      pname = "gimp-xsanecli";
+      version = "d4fa7e8afc";
+
+      src = builtins.fetchTarball {
+        url = "https://yingtongli.me/git/gimp-xsanecli/archive/d4fa7e8afcc5a86e00263d4d71e2279cf295ec02.tar.gz";
+        sha256 = "sha256:0zjslf63vhs1yl8qpc9103ifb11flpdh9cnn5nm8d5rnkgkjrj4j";
+      };
+
+      installPhase = ''
+        mkdir -p $out/${gimp.targetPluginDir}/${pname};
+        cp ${src}/* $out/${gimp.targetPluginDir}/${pname};
+      '';
+
+      meta = with lib; {
+        broken = gimp.majorVersion != "3.0";
+        description = "XSane scanner plugin for GIMP";
+        homepage = "https://yingtongli.me/git/gimp-xsanecli";
+        license = with licenses; [ gpl3Plus ];
+      };
+    };
+
     resynthesizer = pluginDerivation rec {
       /*
         menu:


### PR DESCRIPTION
gimp3Plugins.gimp-xsanecli: init at d4fa7e8afc

Adds the gimp-xsanecli plugin package, allowing use of Xsane scanners directly from GIMP.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
