### PR TITLE
mcp-nixos: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/by-name/mc/mcp-nixos/package.nix
+++ b/pkgs/by-name/mc/mcp-nixos/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "mcp-nixos";
-  version = "1.0.0";
+  version = "1.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "utensils";
     repo = "mcp-nixos";
     tag = "v${version}";
-    hash = "sha256-NwP+zM1VGLOzIm+mLZVK9/9ImFwuiWhRJ9QK3hGpQsY=";
+    hash = "sha256-NFy38FrU4N+bk4qGyRnrpf2AaBrlQyC9SyRbCLm/d9Y=";
   };
 
   patches = [
@@ -25,9 +25,12 @@ python3Packages.buildPythonApplication rec {
 
   dependencies = with python3Packages; [
     beautifulsoup4
+    fastmcp
     mcp
     requests
   ];
+
+  pythonRelaxDeps = [ "fastmcp" ];
 
   nativeCheckInputs = with python3Packages; [
     anthropic
@@ -43,11 +46,11 @@ python3Packages.buildPythonApplication rec {
 
   disabledTestPaths = [
     # Require network access
-    "tests/test_nixhub_evals.py"
-    "tests/test_mcp_behavior_evals.py"
-    "tests/test_option_info_improvements.py"
+    "tests/test_nixhub.py"
+    "tests/test_mcp_behavior.py"
+    "tests/test_options.py"
     # Requires configured channels
-    "tests/test_dynamic_channels.py"
+    "tests/test_channels.py"
   ];
 
   pythonImportsCheck = [ "mcp_nixos" ];

--- a/pkgs/by-name/mc/mcp-nixos/tests-mock-nix-channels.patch
+++ b/pkgs/by-name/mc/mcp-nixos/tests-mock-nix-channels.patch
@@ -1,11 +1,12 @@
 diff --git a/tests/conftest.py b/tests/conftest.py
-index 0a11295..1172182 100644
+index baae124..2b4bf01 100644
 --- a/tests/conftest.py
 +++ b/tests/conftest.py
-@@ -3,6 +3,30 @@
- import pytest  # pylint: disable=unused-import
+@@ -1,6 +1,27 @@
+ """Minimal test configuration for refactored MCP-NixOS."""
  
  
++import pytest
 +@pytest.fixture(autouse=True)
 +def mock_get_channels(monkeypatch):
 +    """Mock get_channels function to return fixed channels for all tests."""
@@ -23,11 +24,7 @@ index 0a11295..1172182 100644
 +    monkeypatch.setattr('mcp_nixos.server.get_channels', mock_channels)
 +
 +    # Also patch any imported references in test modules
-+    monkeypatch.setattr('tests.test_channel_handling.get_channels', mock_channels)
-+    monkeypatch.setattr('tests.test_dynamic_channels.get_channels', mock_channels, raising=False)
-+    monkeypatch.setattr('tests.test_mcp_behavior_comprehensive.get_channels', mock_channels, raising=False)
-+    monkeypatch.setattr('tests.test_real_world_scenarios.get_channels', mock_channels, raising=False)
-+    monkeypatch.setattr('tests.test_server_comprehensive.get_channels', mock_channels, raising=False)
++    monkeypatch.setattr('tests.test_server.get_channels', mock_channels)
 +
 +
  def pytest_addoption(parser):


### PR DESCRIPTION
https://github.com/utensils/mcp-nixos/releases/tag/v1.0.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
