### PR TITLE
vscode-extensions.rooveterinaryinc.roo-cline: 3.25.10 -> 3.25.13

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/rooveterinaryinc.roo-cline/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/rooveterinaryinc.roo-cline/default.nix
@@ -8,8 +8,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     publisher = "RooVeterinaryInc";
     name = "roo-cline";
-    version = "3.25.10";
-    hash = "sha256-j9ydB6hR+Qx4HvBDMrYGev2K/vsG6ASeOQHhhYheEuw=";
+    version = "3.25.13";
+    hash = "sha256-n9QJjcRd1958uJdf7X7rV/6nBdFX6VPiA8N03t8rzHQ=";
   };
 
   passthru.updateScript = vscode-extension-update-script { };


### PR DESCRIPTION
Roo Code version bump to 3.25.13

Release notes from https://github.com/RooCodeInc/Roo-Code/releases

[Release v3.25.13](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.25.13) [Latest](https://github.com/RooCodeInc/Roo-Code/releases/latest)
[3.25.13] - 2025-08-12

    Add Sonnet 1M context checkbox to Bedrock
    Fix: add --no-messages flag to ripgrep to suppress file access errors (https://github.com/RooCodeInc/Roo-Code/issues/6756 by @R-omk, PR by @app/roomote)
    Add support for AGENT.md alongside AGENTS.md (https://github.com/RooCodeInc/Roo-Code/issues/6912 by @Brendan-Z, PR by @app/roomote)
    Remove deprecated GPT-4.5 Preview model (thanks @PeterDaveHello!)

[Release v3.25.12](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.25.12)
[3.25.12] - 2025-08-12

    Update: Claude Sonnet 4 context window configurable to 1 million tokens in Anthropic provider (thanks @daniel-lxs!)
    Add: Minimal reasoning support to OpenRouter (thanks @daniel-lxs!)
    Fix: Add configurable API request timeout for local providers (https://github.com/RooCodeInc/Roo-Code/issues/6521 by @dabockster, PR by @app/roomote)
    Fix: Add --no-sandbox flag to browser launch options (https://github.com/RooCodeInc/Roo-Code/issues/6632 by @QuinsZouls, PR by @QuinsZouls)
    Fix: Ensure JSON files respect .rooignore during indexing (https://github.com/RooCodeInc/Roo-Code/issues/6690 by @evermoving, PR by @app/roomote)
    Add: New Chutes provider models (https://github.com/RooCodeInc/Roo-Code/issues/6698 by @fstandhartinger, PR by @app/roomote)
    Add: OpenAI gpt-oss models to Amazon Bedrock dropdown (https://github.com/RooCodeInc/Roo-Code/issues/6752 by @josh-clanton-powerschool, PR by @app/roomote)
    Fix: Correct tool repetition detector to not block first tool call when limit is 1 (https://github.com/RooCodeInc/Roo-Code/issues/6834 by @NaccOll, PR by @app/roomote)
    Fix: Improve checkpoint service initialization handling (thanks @NaccOll!)
    Update: Improve zh-TW Traditional Chinese locale (thanks @PeterDaveHello!)
    Add: Task expand and collapse translations (thanks @app/roomote!)
    Update: Exclude GPT-5 models from 20% context window output token cap (thanks @app/roomote!)
    Fix: Truncate long model names in model selector to prevent overflow (thanks @app/roomote!)
    Add: Requesty base url support (thanks @requesty-JohnCosta27!)

[Release v3.25.11](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.25.11)
[3.25.11] - 2025-08-11

    Add: Native OpenAI provider support for Codex Mini model (https://github.com/RooCodeInc/Roo-Code/issues/5386 by @KJ7LNW, PR by @daniel-lxs)
    Add: IO Intelligence Provider support (thanks @ertan2002!)
    Fix: MCP startup issues and remove refresh notifications (thanks @hannesrudolph!)
    Fix: Improvements to GPT-5 OpenAI provider configuration (thanks @hannesrudolph!)
    Fix: Clarify codebase_search path parameter as optional and improve tool descriptions (thanks @app/roomote!)
    Fix: Bedrock provider workaround for LiteLLM passthrough issues (thanks @jr!)
    Fix: Token usage and cost being underreported on cancelled requests (thanks @chrarnoldus!)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
