### PR TITLE
lanraragi: 0.9.21 -> 0.9.41

### DIFF
--- a/pkgs/by-name/la/lanraragi/fix-paths.patch
+++ b/pkgs/by-name/la/lanraragi/fix-paths.patch
@@ -86,15 +86,16 @@ index ee29c507..6bdfc1bd 100644
      # Folder location can be overriden by LRR_LOG_DIRECTORY
      if ( $ENV{LRR_LOG_DIRECTORY} ) {
 diff --git a/lib/LANraragi/Utils/TempFolder.pm b/lib/LANraragi/Utils/TempFolder.pm
-index 792b1c1b..f0eb341b 100644
+index a5ab8a83..64a56255 100644
 --- a/lib/LANraragi/Utils/TempFolder.pm
 +++ b/lib/LANraragi/Utils/TempFolder.pm
-@@ -20,7 +20,7 @@ our @EXPORT_OK = qw(get_temp get_tempsize clean_temp_full clean_temp_partial);
+@@ -13,7 +13,7 @@ our @EXPORT_OK = qw(get_temp);
  #Get the current tempfolder.
  #This can be called from any process safely as it uses FindBin.
  sub get_temp {
--    my $temp_folder = "$FindBin::Bin/../public/temp";
-+    my $temp_folder = "./public/temp";
+-    my $temp_folder = "$FindBin::Bin/../temp";
++    my $temp_folder = "./temp";
  
      # Folder location can be overriden by LRR_TEMP_DIRECTORY
      if ( $ENV{LRR_TEMP_DIRECTORY} ) {
+

--- a/pkgs/by-name/la/lanraragi/install.patch
+++ b/pkgs/by-name/la/lanraragi/install.patch
@@ -1,5 +1,5 @@
 diff --git a/tools/install.pl b/tools/install.pl
-index f09218f..a63de58 100644
+index 9e155f0..a63de58 100644
 --- a/tools/install.pl
 +++ b/tools/install.pl
 @@ -9,6 +9,7 @@ use Config;
@@ -10,7 +10,7 @@ index f09218f..a63de58 100644
  
  #Vendor dependencies
  my @vendor_css = (
-@@ -90,32 +91,6 @@ if ( $ENV{HOMEBREW_FORMULA_PREFIX} ) {
+@@ -90,33 +91,6 @@ if ( $ENV{HOMEBREW_FORMULA_PREFIX} ) {
      $cpanopt = " -l " . $ENV{HOMEBREW_FORMULA_PREFIX} . "/libexec";
  }
  
@@ -19,6 +19,7 @@ index f09218f..a63de58 100644
 -install_package( "Config::AutoConf", $cpanopt );
 -IPC::Cmd->import('can_run');
 -require Config::AutoConf;
+-
 -
 -say("\r\nWill now check if all LRR software dependencies are met. \r\n");
 -
@@ -43,7 +44,7 @@ index f09218f..a63de58 100644
  #Check for PerlMagick
  say("Checking for ImageMagick/PerlMagick...");
  my $imgk;
-@@ -135,37 +110,11 @@ if ($@) {
+@@ -136,37 +110,11 @@ if ($@) {
      say("OK!");
  }
  
@@ -81,7 +82,7 @@ index f09218f..a63de58 100644
      make_path getcwd . "/public/css/vendor";
      make_path getcwd . "/public/css/webfonts";
      make_path getcwd . "/public/js/vendor";
-@@ -212,19 +161,3 @@ sub cp_node_module {
+@@ -213,19 +161,3 @@ sub cp_node_module {
  
  }
  

--- a/pkgs/by-name/la/lanraragi/package.nix
+++ b/pkgs/by-name/la/lanraragi/package.nix
@@ -11,13 +11,13 @@
 
 buildNpmPackage rec {
   pname = "lanraragi";
-  version = "0.9.21";
+  version = "0.9.41";
 
   src = fetchFromGitHub {
     owner = "Difegue";
     repo = "LANraragi";
-    rev = "v.${version}";
-    hash = "sha256-2YdQeBW1MQiUs5nliloISaxG0yhFJ6ulkU/Urx8PN3Y=";
+    tag = "v.${version}";
+    hash = "sha256-HF2g8rrcV6f6ZTKmveS/yjil/mBxpvRUFyauv5f+qQ8=";
   };
 
   patches = [
@@ -67,6 +67,9 @@ buildNpmPackage rec {
       TimeLocal
       YAMLPP
       StringSimilarity
+      CHI
+      CacheFastMmap
+      LocaleMaketextLexicon
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ LinuxInotify2 ];
 
@@ -123,7 +126,7 @@ buildNpmPackage rec {
   passthru.tests.module = nixosTests.lanraragi;
 
   meta = {
-    changelog = "https://github.com/Difegue/LANraragi/releases/tag/${src.rev}";
+    changelog = "https://github.com/Difegue/LANraragi/releases/tag/${src.tag}";
     description = "Web application for archival and reading of manga/doujinshi";
     homepage = "https://github.com/Difegue/LANraragi";
     license = lib.licenses.mit;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -22422,10 +22422,10 @@ with self;
 
   Mojolicious = buildPerlPackage {
     pname = "Mojolicious";
-    version = "9.36";
+    version = "9.39";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SRI/Mojolicious-9.36.tar.gz";
-      hash = "sha256-UX7Pb9hqC3xhadVRAiOL+YUWGNt2L7ANTPDZTGJSAV8=";
+      url = "mirror://cpan/authors/id/S/SR/SRI/Mojolicious-9.39.tar.gz";
+      hash = "sha256-EwpJDXfXYTn3NM4biU1Fm64DgF+x89/dWPxE/oKvPP0=";
     };
     meta = {
       description = "Real-time web framework";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -21462,10 +21462,10 @@ with self;
 
   Minion = buildPerlPackage {
     pname = "Minion";
-    version = "10.30";
+    version = "10.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SRI/Minion-10.30.tar.gz";
-      hash = "sha256-twS9ZuxK8cAzlGifAsCsBIDr0GzpzKFykVAbkgLG7Rw=";
+      url = "mirror://cpan/authors/id/S/SR/SRI/Minion-10.31.tar.gz";
+      hash = "sha256-MGj5kDPmnfCBRbWEqR7iJPTpfcYkLhAiIegiCj8oUDs=";
     };
     propagatedBuildInputs = [
       Mojolicious


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Description of changes

Updated to latest upstream from 0.9.21;

Relevant changelogs:
- [0.9.22](https://github.com/Difegue/LANraragi/releases/tag/v.0.9.22)
- [0.9.30](https://github.com/Difegue/LANraragi/releases/tag/v.0.9.30)
- [0.9.31](https://github.com/Difegue/LANraragi/releases/tag/v0.9.31)
- [0.9.40](https://github.com/Difegue/LANraragi/releases/tag/v.0.9.40)
- [0.9.41](https://github.com/Difegue/LANraragi/releases/tag/v.0.9.41)

Updated perl dependencies that needed bumping up;
Added perl dependencies to the main package;
Updated path fix patch.

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
