### PR TITLE
hyphen: Add more languages

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -103,6 +103,8 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
 
 - `services.frp` now supports multiple instances through `services.frp.instances` to make it possible to run multiple frp clients or servers at the same time.
 
+- `hyphen` now supports over 40 language variants through `hyphenDicts` and now allows to enable all supported languages through `hyphenDicts.all`.
+
 - [services.resolved](#opt-services.resolved.enable) module was converted to RFC42-style settings. The moved options have also been renamed to match the upstream names. Aliases mean current configs will continue to function, but users should move to the new options as convenient.
 
 - `services.openssh` now supports generating host SSH keys by setting `services.openssh.generateHostKeys = true` while leaving `services.openssh.enable` disabled.  This is particularly useful for systems that have no need of an SSH daemon but want SSH host keys for other purposes such as using agenix or sops-nix.

--- a/pkgs/development/libraries/hyphen/dictionaries.nix
+++ b/pkgs/development/libraries/hyphen/dictionaries.nix
@@ -13,13 +13,14 @@ let
   libreofficeCommit = "9e27d044d98e65f89af8c86df722a77be827bdc8";
   libreofficeSubdir = "de";
 
-  mkDictFromLibreofficeGit =
+  # this does not assume any structure for dictFilePath and readmeFilePath
+  mkDictFromLibreofficeGitCustom =
     {
       subdir,
       shortName,
       shortDescription,
-      dictFileName,
-      readmeFileName,
+      dictFilePath,
+      readmeFilePath ? "",
     }:
     stdenv.mkDerivation rec {
       version = "24.8";
@@ -41,39 +42,106 @@ let
         runHook preInstall
         cd $src/${subdir}
         install -dm755 "$out/share/hyphen"
-        install -m644 "hyph_${dictFileName}.dic" "$out/share/hyphen"
+        install -m644 "${dictFilePath}" "$out/share/hyphen"
         # docs
-        install -dm755 "$out/share/doc/"
-        install -m644 "README_${readmeFileName}.txt" "$out/share/doc/${pname}.txt"
+        if [ -n "${readmeFilePath}" ]; then
+          install -dm755 "$out/share/doc/"
+          install -m644 "${readmeFilePath}" "$out/share/doc/${pname}.txt"
+        fi
         runHook postInstall
       '';
+    };
+
+  # wrapper for backwards compatibility
+  mkDictFromLibreofficeGit =
+    {
+      subdir,
+      shortName,
+      shortDescription,
+      dictFileName,
+      readmeFileName ? "",
+    }:
+    mkDictFromLibreofficeGitCustom {
+      inherit subdir;
+      inherit shortName;
+      inherit shortDescription;
+      dictFilePath = "hyph_${dictFileName}.dic";
+      readmeFilePath = if (readmeFileName != "") then "README_${readmeFileName}.txt" else "";
     };
 
 in
 rec {
 
-  # ENGLISH
+  # see https://wiki.documentfoundation.org/Development/Dictionaries
+  # for a list of available hyphenation dictionaries
 
-  en_US = en-us;
-  en-us = stdenv.mkDerivation {
-    nativeBuildInputs = hyphen.nativeBuildInputs;
-    version = hyphen.version;
-    pname = "hyphen-dict-en-us";
-    src = hyphen.src;
-    meta = {
-      inherit (hyphen.meta)
-        homepage
-        platforms
-        license
-        maintainers
-        ;
-      description = "Hyphen dictionary for English (United States)";
-    };
-    installPhase = ''
-      runHook preInstall
-      make install-hyphDATA
-      runHook postInstall
-    '';
+  # see https://github.com/LibreOffice/dictionaries
+  # for the sources and to find the names of the README files
+
+  # AFRIKAANS
+
+  af_ZA = af-za;
+  af-za = mkDictFromLibreofficeGit {
+    subdir = "af_ZA";
+    shortName = "af-za";
+    shortDescription = "Afrikaans";
+    dictFileName = "af_ZA";
+    readmeFileName = "af_ZA";
+  };
+
+  # BELARUSSIAN
+
+  be_BY = be-by;
+  be-by = mkDictFromLibreofficeGit {
+    subdir = "be_BY";
+    shortName = "be-by";
+    shortDescription = "Belarussian";
+    dictFileName = "be_BY";
+    readmeFileName = "be_BY";
+  };
+
+  # BULGARIAN
+
+  bg_BG = bg-bg;
+  bg-bg = mkDictFromLibreofficeGit {
+    subdir = "bg_BG";
+    shortName = "bg-bg";
+    shortDescription = "Bulgarian";
+    dictFileName = "bg_BG";
+    readmeFileName = "hyph_bg_BG";
+  };
+
+  # CATALAN
+
+  ca_ES = ca-es;
+  ca-es = mkDictFromLibreofficeGitCustom {
+    subdir = "ca";
+    shortName = "ca-es";
+    shortDescription = "Catalan";
+    dictFilePath = "dictionaries/hyph_ca.dic";
+    readmeFilePath = "README_hyph_ca.txt";
+  };
+
+  # CZECH
+
+  cs_CZ = cs-cz;
+  cs-cz = mkDictFromLibreofficeGit {
+    subdir = "cs_CZ";
+    shortName = "cs-cz";
+    shortDescription = "Czech";
+    dictFileName = "cs_CZ";
+    readmeFileName = "cs";
+  };
+
+  # DANISH
+
+  da_DK = da-dk;
+  da-dk = mkDictFromLibreofficeGitCustom {
+    subdir = "da_DK";
+    shortName = "da-dk";
+    shortDescription = "Danish";
+    dictFilePath = "hyph_da_DK.dic";
+    readmeFilePath = "HYPH_da_DK_README.txt";
   };
 
   # GERMAN
@@ -105,6 +173,243 @@ rec {
     readmeFileName = "hyph_de";
   };
 
+  # GREEK
+
+  el_GR = el-gr;
+  el-gr = mkDictFromLibreofficeGit {
+    subdir = "el_GR";
+    shortName = "el-gr";
+    shortDescription = "Greek";
+    dictFileName = "el_GR";
+    readmeFileName = "hyph_el_GR";
+  };
+
+  # ENGLISH
+
+  en_GB = en-gb;
+  en-gb = mkDictFromLibreofficeGit {
+    subdir = "en";
+    shortName = "en-gb";
+    shortDescription = "English (Great Britain)";
+    dictFileName = "en_GB";
+    readmeFileName = "hyph_en_GB";
+  };
+
+  en_US = en-us;
+  en-us = stdenv.mkDerivation {
+    nativeBuildInputs = hyphen.nativeBuildInputs;
+    version = hyphen.version;
+    pname = "hyphen-dict-en-us";
+    src = hyphen.src;
+    meta = {
+      inherit (hyphen.meta)
+        homepage
+        platforms
+        license
+        maintainers
+        ;
+      description = "Hyphen dictionary for English (United States)";
+    };
+    installPhase = ''
+      runHook preInstall
+      make install-hyphDATA
+      runHook postInstall
+    '';
+  };
+
+  # ESPERANTO
+
+  eo = mkDictFromLibreofficeGitCustom {
+    subdir = "eo";
+    shortName = "eo";
+    shortDescription = "Esperanto";
+    dictFilePath = "hyph_eo.dic";
+    readmeFilePath = "desc_eo.txt";
+  };
+
+  # SPANISH
+
+  es_ES = es-es;
+  es-es = mkDictFromLibreofficeGit {
+    subdir = "es";
+    shortName = "es-es";
+    shortDescription = "Spanish (Spain)";
+    dictFileName = "es";
+    readmeFileName = "hyph_es";
+  };
+
+  # ESTONIAN
+
+  et_EE = et-ee;
+  et-ee = mkDictFromLibreofficeGit {
+    subdir = "et_EE";
+    shortName = "et-ee";
+    shortDescription = "Estonian";
+    dictFileName = "et_EE";
+    readmeFileName = "hyph_et_EE";
+  };
+
+  # FRENCH
+
+  fr_FR = fr-fr;
+  fr-fr = mkDictFromLibreofficeGit {
+    subdir = "fr_FR";
+    shortName = "fr-fr";
+    shortDescription = "French";
+    dictFileName = "fr";
+    readmeFileName = "hyph_fr";
+  };
+
+  # CROATIAN
+
+  hr_HR = hr-hr;
+  hr-hr = mkDictFromLibreofficeGit {
+    subdir = "hr_HR";
+    shortName = "hr-hr";
+    shortDescription = "Croatian";
+    dictFileName = "hr_HR";
+    readmeFileName = "hyph_hr_HR";
+  };
+
+  # HUNGARIAN
+
+  hu_HU = hu-hu;
+  hu-hu = mkDictFromLibreofficeGit {
+    subdir = "hu_HU";
+    shortName = "hu-hu";
+    shortDescription = "Hungarian";
+    dictFileName = "hu_HU";
+    readmeFileName = "hyph_hu_HU";
+  };
+
+  # INDONESIAN
+
+  id_ID = id-id;
+  id-id = mkDictFromLibreofficeGitCustom {
+    subdir = "id";
+    shortName = "id-id";
+    shortDescription = "Indonesian";
+    dictFilePath = "hyph_id_ID.dic";
+    readmeFilePath = "README-dict.adoc";
+  };
+
+  # ITALIAN
+
+  it_IT = it-it;
+  it-it = mkDictFromLibreofficeGit {
+    subdir = "it_IT";
+    shortName = "it-it";
+    shortDescription = "Italian";
+    dictFileName = "it_IT";
+    readmeFileName = "hyph_it_IT";
+  };
+
+  # LITHUANIAN
+
+  lt_LT = lt-lt;
+  lt-lt = mkDictFromLibreofficeGitCustom {
+    subdir = "lt_LT";
+    shortName = "lt-lt";
+    shortDescription = "Lithuanian";
+    dictFilePath = "hyph_lt.dic";
+    readmeFilePath = "README_hyph";
+  };
+
+  # LATVIAN
+
+  lv_LV = lv-lv;
+  lv-lv = mkDictFromLibreofficeGit {
+    subdir = "lv_LV";
+    shortName = "lv-lv";
+    shortDescription = "Latvian";
+    dictFileName = "lv_LV";
+    readmeFileName = "hyph_lv_LV";
+  };
+
+  # MONGOLIAN
+
+  mn_MN = mn-mn;
+  mn-mn = mkDictFromLibreofficeGit {
+    subdir = "mn_MN";
+    shortName = "mn-mn";
+    shortDescription = "Mongolian";
+    dictFileName = "mn_MN";
+    readmeFileName = "mn_MN";
+  };
+
+  # DUTCH
+
+  nl_NL = nl-nl;
+  nl-nl = mkDictFromLibreofficeGit {
+    subdir = "nl_NL";
+    shortName = "nl-nl";
+    shortDescription = "Dutch";
+    dictFileName = "nl_NL";
+    readmeFileName = "NL";
+  };
+
+  # NORWEGIAN
+
+  nb_NO = nb-no;
+  nb-no = mkDictFromLibreofficeGit {
+    subdir = "no";
+    shortName = "nb-no";
+    shortDescription = "Norwegian (Bokmål)";
+    dictFileName = "nb_NO";
+    readmeFileName = "hyph_NO";
+  };
+
+  nn_NO = nn-no;
+  nn-no = mkDictFromLibreofficeGit {
+    subdir = "no";
+    shortName = "nn-no";
+    shortDescription = "Norwegian (Nynorsk)";
+    dictFileName = "nn_NO";
+    readmeFileName = "hyph_NO";
+  };
+
+  # POLISH
+
+  pl_PL = pl-pl;
+  pl-pl = mkDictFromLibreofficeGit {
+    subdir = "pl_PL";
+    shortName = "pl-pl";
+    shortDescription = "Polish";
+    dictFileName = "pl_PL";
+    readmeFileName = "pl";
+  };
+
+  # PORTUGUESE
+
+  pt_BR = pt-br;
+  pt-br = mkDictFromLibreofficeGit {
+    subdir = "pt_BR";
+    shortName = "pt-br";
+    shortDescription = "Portuguese (Brazil)";
+    dictFileName = "pt_BR";
+    readmeFileName = "hyph_pt_BR";
+  };
+
+  pt_PT = pt-pt;
+  pt-pt = mkDictFromLibreofficeGit {
+    subdir = "pt_PT";
+    shortName = "pt-pt";
+    shortDescription = "Portuguese (Portugal)";
+    dictFileName = "pt_PT";
+    readmeFileName = "hyph_pt_PT";
+  };
+
+  # ROMANIAN
+
+  ro_RO = ro-ro;
+  ro-ro = mkDictFromLibreofficeGit {
+    subdir = "ro";
+    shortName = "ro-ro";
+    shortDescription = "Romanian";
+    dictFileName = "ro_RO";
+    readmeFileName = "RO";
+  };
+
   # RUSSIAN
 
   ru_RU = ru-ru;
@@ -115,4 +420,114 @@ rec {
     dictFileName = "ru_RU";
     readmeFileName = "ru_RU";
   };
+
+  # SLOVAK
+
+  sk_SK = sk-sk;
+  sk-sk = mkDictFromLibreofficeGit {
+    subdir = "sk_SK";
+    shortName = "sk-sk";
+    shortDescription = "Slovak";
+    dictFileName = "sk_SK";
+    readmeFileName = "sk";
+  };
+
+  # SLOVENIAN
+
+  sl_SI = sl-si;
+  sl-si = mkDictFromLibreofficeGit {
+    subdir = "sl_SI";
+    shortName = "sl-si";
+    shortDescription = "Slovenian";
+    dictFileName = "sl_SI";
+    readmeFileName = "hyph_sl_SI";
+  };
+
+  # ALBANIAN
+
+  sq_AL = sq-al;
+  sq-al = mkDictFromLibreofficeGit {
+    subdir = "sq_AL";
+    shortName = "sq-al";
+    shortDescription = "Albanian";
+    dictFileName = "sq_AL";
+    readmeFileName = "hyph_sq_AL";
+  };
+
+  # SERBIAN
+
+  sr_SR = sr-sr;
+  sr-sr = mkDictFromLibreofficeGitCustom {
+    subdir = "sr";
+    shortName = "sr-sr";
+    shortDescription = "Serbian (Cyrillic)";
+    dictFilePath = "hyph_sr.dic";
+    readmeFilePath = "README.txt";
+  };
+
+  sr_SR_LATN = sr-sr-latn;
+  sr-sr-latn = mkDictFromLibreofficeGitCustom {
+    subdir = "sr";
+    shortName = "sr-sr-latn";
+    shortDescription = "Serbian (Latin)";
+    dictFilePath = "hyph_sr-Latn.dic";
+    readmeFilePath = "README.txt";
+  };
+
+  # SWEDISH
+
+  sv_SE = sv-se;
+  sv-se = mkDictFromLibreofficeGit {
+    subdir = "sv_SE";
+    shortName = "sv-se";
+    shortDescription = "Swedish";
+    dictFileName = "sv";
+    readmeFileName = "hyph_sv";
+  };
+
+  # TELUGU
+
+  te_IN = te-in;
+  te-in = mkDictFromLibreofficeGit {
+    subdir = "te_IN";
+    shortName = "te-in";
+    shortDescription = "Telugu";
+    dictFileName = "te_IN";
+    readmeFileName = "hyph_te_IN";
+  };
+
+  # THAI
+
+  th_TH = th-th;
+  th-th = mkDictFromLibreofficeGit {
+    subdir = "th_TH";
+    shortName = "th-th";
+    shortDescription = "Thai";
+    dictFileName = "th_TH";
+    readmeFileName = "hyph_th_TH";
+  };
+
+  # UKRAINIAN
+
+  uk_UA = uk-ua;
+  uk-ua = mkDictFromLibreofficeGit {
+    subdir = "uk_UA";
+    shortName = "uk-ua";
+    shortDescription = "Ukrainian";
+    dictFileName = "uk_UA";
+    readmeFileName = "hyph_uk_UA";
+  };
+
+  # ZULU
+
+  zu_ZA = zu-za;
+  zu-za = mkDictFromLibreofficeGitCustom {
+    subdir = "zu_ZA";
+    shortName = "zu-za";
+    shortDescription = "Zulu";
+    dictFilePath = "hyph_zu_ZA.dic";
+    # no readme file provided, leave empty
+  };
+
 }
+

--- a/pkgs/development/libraries/hyphen/dictionaries.nix
+++ b/pkgs/development/libraries/hyphen/dictionaries.nix
@@ -6,6 +6,7 @@
   lib,
   fetchgit,
   fetchurl,
+  symlinkJoin,
 }:
 
 let
@@ -69,465 +70,472 @@ let
       readmeFilePath = if (readmeFileName != "") then "README_${readmeFileName}.txt" else "";
     };
 
-in
-rec {
+  dicts = rec {
 
-  # see https://wiki.documentfoundation.org/Development/Dictionaries
-  # for a list of available hyphenation dictionaries
+    # see https://wiki.documentfoundation.org/Development/Dictionaries
+    # for a list of available hyphenation dictionaries
 
-  # see https://github.com/LibreOffice/dictionaries
-  # for the sources and to find the names of the README files
+    # see https://github.com/LibreOffice/dictionaries
+    # for the sources and to find the names of the README files
 
-  # AFRIKAANS
+    # AFRIKAANS
 
-  af_ZA = af-za;
-  af-za = mkDictFromLibreofficeGit {
-    subdir = "af_ZA";
-    shortName = "af-za";
-    shortDescription = "Afrikaans";
-    dictFileName = "af_ZA";
-    readmeFileName = "af_ZA";
-  };
-
-  # BELARUSSIAN
-
-  be_BY = be-by;
-  be-by = mkDictFromLibreofficeGit {
-    subdir = "be_BY";
-    shortName = "be-by";
-    shortDescription = "Belarussian";
-    dictFileName = "be_BY";
-    readmeFileName = "be_BY";
-  };
-
-  # BULGARIAN
-
-  bg_BG = bg-bg;
-  bg-bg = mkDictFromLibreofficeGit {
-    subdir = "bg_BG";
-    shortName = "bg-bg";
-    shortDescription = "Bulgarian";
-    dictFileName = "bg_BG";
-    readmeFileName = "hyph_bg_BG";
-  };
-
-  # CATALAN
-
-  ca_ES = ca-es;
-  ca-es = mkDictFromLibreofficeGitCustom {
-    subdir = "ca";
-    shortName = "ca-es";
-    shortDescription = "Catalan";
-    dictFilePath = "dictionaries/hyph_ca.dic";
-    readmeFilePath = "README_hyph_ca.txt";
-  };
-
-  # CZECH
-
-  cs_CZ = cs-cz;
-  cs-cz = mkDictFromLibreofficeGit {
-    subdir = "cs_CZ";
-    shortName = "cs-cz";
-    shortDescription = "Czech";
-    dictFileName = "cs_CZ";
-    readmeFileName = "cs";
-  };
-
-  # DANISH
-
-  da_DK = da-dk;
-  da-dk = mkDictFromLibreofficeGitCustom {
-    subdir = "da_DK";
-    shortName = "da-dk";
-    shortDescription = "Danish";
-    dictFilePath = "hyph_da_DK.dic";
-    readmeFilePath = "HYPH_da_DK_README.txt";
-  };
-
-  # GERMAN
-
-  de_DE = de-de;
-  de-de = mkDictFromLibreofficeGit {
-    subdir = "de";
-    shortName = "de-de";
-    shortDescription = "German (Germany)";
-    dictFileName = "de_DE";
-    readmeFileName = "hyph_de";
-  };
-
-  de_AT = de-at;
-  de-at = mkDictFromLibreofficeGit {
-    subdir = "de";
-    shortName = "de-at";
-    shortDescription = "German (Austria)";
-    dictFileName = "de_AT";
-    readmeFileName = "hyph_de";
-  };
-
-  de_CH = de-ch;
-  de-ch = mkDictFromLibreofficeGit {
-    subdir = "de";
-    shortName = "de-ch";
-    shortDescription = "German (Switzerland)";
-    dictFileName = "de_CH";
-    readmeFileName = "hyph_de";
-  };
-
-  # GREEK
-
-  el_GR = el-gr;
-  el-gr = mkDictFromLibreofficeGit {
-    subdir = "el_GR";
-    shortName = "el-gr";
-    shortDescription = "Greek";
-    dictFileName = "el_GR";
-    readmeFileName = "hyph_el_GR";
-  };
-
-  # ENGLISH
-
-  en_GB = en-gb;
-  en-gb = mkDictFromLibreofficeGit {
-    subdir = "en";
-    shortName = "en-gb";
-    shortDescription = "English (Great Britain)";
-    dictFileName = "en_GB";
-    readmeFileName = "hyph_en_GB";
-  };
-
-  en_US = en-us;
-  en-us = stdenv.mkDerivation {
-    nativeBuildInputs = hyphen.nativeBuildInputs;
-    version = hyphen.version;
-    pname = "hyphen-dict-en-us";
-    src = hyphen.src;
-    meta = {
-      inherit (hyphen.meta)
-        homepage
-        platforms
-        license
-        maintainers
-        ;
-      description = "Hyphen dictionary for English (United States)";
+    af_ZA = af-za;
+    af-za = mkDictFromLibreofficeGit {
+      subdir = "af_ZA";
+      shortName = "af-za";
+      shortDescription = "Afrikaans";
+      dictFileName = "af_ZA";
+      readmeFileName = "af_ZA";
     };
-    installPhase = ''
-      runHook preInstall
-      make install-hyphDATA
-      runHook postInstall
-    '';
+
+    # BELARUSSIAN
+
+    be_BY = be-by;
+    be-by = mkDictFromLibreofficeGit {
+      subdir = "be_BY";
+      shortName = "be-by";
+      shortDescription = "Belarussian";
+      dictFileName = "be_BY";
+      readmeFileName = "be_BY";
+    };
+
+    # BULGARIAN
+
+    bg_BG = bg-bg;
+    bg-bg = mkDictFromLibreofficeGit {
+      subdir = "bg_BG";
+      shortName = "bg-bg";
+      shortDescription = "Bulgarian";
+      dictFileName = "bg_BG";
+      readmeFileName = "hyph_bg_BG";
+    };
+
+    # CATALAN
+
+    ca_ES = ca-es;
+    ca-es = mkDictFromLibreofficeGitCustom {
+      subdir = "ca";
+      shortName = "ca-es";
+      shortDescription = "Catalan";
+      dictFilePath = "dictionaries/hyph_ca.dic";
+      readmeFilePath = "README_hyph_ca.txt";
+    };
+
+    # CZECH
+
+    cs_CZ = cs-cz;
+    cs-cz = mkDictFromLibreofficeGit {
+      subdir = "cs_CZ";
+      shortName = "cs-cz";
+      shortDescription = "Czech";
+      dictFileName = "cs_CZ";
+      readmeFileName = "cs";
+    };
+
+    # DANISH
+
+    da_DK = da-dk;
+    da-dk = mkDictFromLibreofficeGitCustom {
+      subdir = "da_DK";
+      shortName = "da-dk";
+      shortDescription = "Danish";
+      dictFilePath = "hyph_da_DK.dic";
+      readmeFilePath = "HYPH_da_DK_README.txt";
+    };
+
+    # GERMAN
+
+    de_DE = de-de;
+    de-de = mkDictFromLibreofficeGit {
+      subdir = "de";
+      shortName = "de-de";
+      shortDescription = "German (Germany)";
+      dictFileName = "de_DE";
+      readmeFileName = "hyph_de";
+    };
+
+    de_AT = de-at;
+    de-at = mkDictFromLibreofficeGit {
+      subdir = "de";
+      shortName = "de-at";
+      shortDescription = "German (Austria)";
+      dictFileName = "de_AT";
+      readmeFileName = "hyph_de";
+    };
+
+    de_CH = de-ch;
+    de-ch = mkDictFromLibreofficeGit {
+      subdir = "de";
+      shortName = "de-ch";
+      shortDescription = "German (Switzerland)";
+      dictFileName = "de_CH";
+      readmeFileName = "hyph_de";
+    };
+
+    # GREEK
+
+    el_GR = el-gr;
+    el-gr = mkDictFromLibreofficeGit {
+      subdir = "el_GR";
+      shortName = "el-gr";
+      shortDescription = "Greek";
+      dictFileName = "el_GR";
+      readmeFileName = "hyph_el_GR";
+    };
+
+    # ENGLISH
+
+    en_GB = en-gb;
+    en-gb = mkDictFromLibreofficeGit {
+      subdir = "en";
+      shortName = "en-gb";
+      shortDescription = "English (Great Britain)";
+      dictFileName = "en_GB";
+      readmeFileName = "hyph_en_GB";
+    };
+
+    en_US = en-us;
+    en-us = stdenv.mkDerivation {
+      nativeBuildInputs = hyphen.nativeBuildInputs;
+      version = hyphen.version;
+      pname = "hyphen-dict-en-us";
+      src = hyphen.src;
+      meta = {
+        inherit (hyphen.meta)
+          homepage
+          platforms
+          license
+          maintainers
+          ;
+        description = "Hyphen dictionary for English (United States)";
+      };
+      installPhase = ''
+        runHook preInstall
+        make install-hyphDATA
+        runHook postInstall
+      '';
+    };
+
+    # ESPERANTO
+
+    eo = mkDictFromLibreofficeGitCustom {
+      subdir = "eo";
+      shortName = "eo";
+      shortDescription = "Esperanto";
+      dictFilePath = "hyph_eo.dic";
+      readmeFilePath = "desc_eo.txt";
+    };
+
+    # SPANISH
+
+    es_ES = es-es;
+    es-es = mkDictFromLibreofficeGit {
+      subdir = "es";
+      shortName = "es-es";
+      shortDescription = "Spanish (Spain)";
+      dictFileName = "es";
+      readmeFileName = "hyph_es";
+    };
+
+    # ESTONIAN
+
+    et_EE = et-ee;
+    et-ee = mkDictFromLibreofficeGit {
+      subdir = "et_EE";
+      shortName = "et-ee";
+      shortDescription = "Estonian";
+      dictFileName = "et_EE";
+      readmeFileName = "hyph_et_EE";
+    };
+
+    # FRENCH
+
+    fr_FR = fr-fr;
+    fr-fr = mkDictFromLibreofficeGit {
+      subdir = "fr_FR";
+      shortName = "fr-fr";
+      shortDescription = "French";
+      dictFileName = "fr";
+      readmeFileName = "hyph_fr";
+    };
+
+    # CROATIAN
+
+    hr_HR = hr-hr;
+    hr-hr = mkDictFromLibreofficeGit {
+      subdir = "hr_HR";
+      shortName = "hr-hr";
+      shortDescription = "Croatian";
+      dictFileName = "hr_HR";
+      readmeFileName = "hyph_hr_HR";
+    };
+
+    # HUNGARIAN
+
+    hu_HU = hu-hu;
+    hu-hu = mkDictFromLibreofficeGit {
+      subdir = "hu_HU";
+      shortName = "hu-hu";
+      shortDescription = "Hungarian";
+      dictFileName = "hu_HU";
+      readmeFileName = "hyph_hu_HU";
+    };
+
+    # INDONESIAN
+
+    id_ID = id-id;
+    id-id = mkDictFromLibreofficeGitCustom {
+      subdir = "id";
+      shortName = "id-id";
+      shortDescription = "Indonesian";
+      dictFilePath = "hyph_id_ID.dic";
+      readmeFilePath = "README-dict.adoc";
+    };
+
+    # ITALIAN
+
+    it_IT = it-it;
+    it-it = mkDictFromLibreofficeGit {
+      subdir = "it_IT";
+      shortName = "it-it";
+      shortDescription = "Italian";
+      dictFileName = "it_IT";
+      readmeFileName = "hyph_it_IT";
+    };
+
+    # LITHUANIAN
+
+    lt_LT = lt-lt;
+    lt-lt = mkDictFromLibreofficeGitCustom {
+      subdir = "lt_LT";
+      shortName = "lt-lt";
+      shortDescription = "Lithuanian";
+      dictFilePath = "hyph_lt.dic";
+      readmeFilePath = "README_hyph";
+    };
+
+    # LATVIAN
+
+    lv_LV = lv-lv;
+    lv-lv = mkDictFromLibreofficeGit {
+      subdir = "lv_LV";
+      shortName = "lv-lv";
+      shortDescription = "Latvian";
+      dictFileName = "lv_LV";
+      readmeFileName = "hyph_lv_LV";
+    };
+
+    # MONGOLIAN
+
+    mn_MN = mn-mn;
+    mn-mn = mkDictFromLibreofficeGit {
+      subdir = "mn_MN";
+      shortName = "mn-mn";
+      shortDescription = "Mongolian";
+      dictFileName = "mn_MN";
+      readmeFileName = "mn_MN";
+    };
+
+    # DUTCH
+
+    nl_NL = nl-nl;
+    nl-nl = mkDictFromLibreofficeGit {
+      subdir = "nl_NL";
+      shortName = "nl-nl";
+      shortDescription = "Dutch";
+      dictFileName = "nl_NL";
+      readmeFileName = "NL";
+    };
+
+    # NORWEGIAN
+
+    nb_NO = nb-no;
+    nb-no = mkDictFromLibreofficeGit {
+      subdir = "no";
+      shortName = "nb-no";
+      shortDescription = "Norwegian (Bokmål)";
+      dictFileName = "nb_NO";
+      readmeFileName = "hyph_NO";
+    };
+
+    nn_NO = nn-no;
+    nn-no = mkDictFromLibreofficeGit {
+      subdir = "no";
+      shortName = "nn-no";
+      shortDescription = "Norwegian (Nynorsk)";
+      dictFileName = "nn_NO";
+      readmeFileName = "hyph_NO";
+    };
+
+    # POLISH
+
+    pl_PL = pl-pl;
+    pl-pl = mkDictFromLibreofficeGit {
+      subdir = "pl_PL";
+      shortName = "pl-pl";
+      shortDescription = "Polish";
+      dictFileName = "pl_PL";
+      readmeFileName = "pl";
+    };
+
+    # PORTUGUESE
+
+    pt_BR = pt-br;
+    pt-br = mkDictFromLibreofficeGit {
+      subdir = "pt_BR";
+      shortName = "pt-br";
+      shortDescription = "Portuguese (Brazil)";
+      dictFileName = "pt_BR";
+      readmeFileName = "hyph_pt_BR";
+    };
+
+    pt_PT = pt-pt;
+    pt-pt = mkDictFromLibreofficeGit {
+      subdir = "pt_PT";
+      shortName = "pt-pt";
+      shortDescription = "Portuguese (Portugal)";
+      dictFileName = "pt_PT";
+      readmeFileName = "hyph_pt_PT";
+    };
+
+    # ROMANIAN
+
+    ro_RO = ro-ro;
+    ro-ro = mkDictFromLibreofficeGit {
+      subdir = "ro";
+      shortName = "ro-ro";
+      shortDescription = "Romanian";
+      dictFileName = "ro_RO";
+      readmeFileName = "RO";
+    };
+
+    # RUSSIAN
+
+    ru_RU = ru-ru;
+    ru-ru = mkDictFromLibreofficeGit {
+      subdir = "ru_RU";
+      shortName = "ru-ru";
+      shortDescription = "Russian (Russia)";
+      dictFileName = "ru_RU";
+      readmeFileName = "ru_RU";
+    };
+
+    # SLOVAK
+
+    sk_SK = sk-sk;
+    sk-sk = mkDictFromLibreofficeGit {
+      subdir = "sk_SK";
+      shortName = "sk-sk";
+      shortDescription = "Slovak";
+      dictFileName = "sk_SK";
+      readmeFileName = "sk";
+    };
+
+    # SLOVENIAN
+
+    sl_SI = sl-si;
+    sl-si = mkDictFromLibreofficeGit {
+      subdir = "sl_SI";
+      shortName = "sl-si";
+      shortDescription = "Slovenian";
+      dictFileName = "sl_SI";
+      readmeFileName = "hyph_sl_SI";
+    };
+
+    # ALBANIAN
+
+    sq_AL = sq-al;
+    sq-al = mkDictFromLibreofficeGit {
+      subdir = "sq_AL";
+      shortName = "sq-al";
+      shortDescription = "Albanian";
+      dictFileName = "sq_AL";
+      readmeFileName = "hyph_sq_AL";
+    };
+
+    # SERBIAN
+
+    sr_SR = sr-sr;
+    sr-sr = mkDictFromLibreofficeGitCustom {
+      subdir = "sr";
+      shortName = "sr-sr";
+      shortDescription = "Serbian (Cyrillic)";
+      dictFilePath = "hyph_sr.dic";
+      readmeFilePath = "README.txt";
+    };
+
+    sr_SR_LATN = sr-sr-latn;
+    sr-sr-latn = mkDictFromLibreofficeGitCustom {
+      subdir = "sr";
+      shortName = "sr-sr-latn";
+      shortDescription = "Serbian (Latin)";
+      dictFilePath = "hyph_sr-Latn.dic";
+      readmeFilePath = "README.txt";
+    };
+
+    # SWEDISH
+
+    sv_SE = sv-se;
+    sv-se = mkDictFromLibreofficeGit {
+      subdir = "sv_SE";
+      shortName = "sv-se";
+      shortDescription = "Swedish";
+      dictFileName = "sv";
+      readmeFileName = "hyph_sv";
+    };
+
+    # TELUGU
+
+    te_IN = te-in;
+    te-in = mkDictFromLibreofficeGit {
+      subdir = "te_IN";
+      shortName = "te-in";
+      shortDescription = "Telugu";
+      dictFileName = "te_IN";
+      readmeFileName = "hyph_te_IN";
+    };
+
+    # THAI
+
+    th_TH = th-th;
+    th-th = mkDictFromLibreofficeGit {
+      subdir = "th_TH";
+      shortName = "th-th";
+      shortDescription = "Thai";
+      dictFileName = "th_TH";
+      readmeFileName = "hyph_th_TH";
+    };
+
+    # UKRAINIAN
+
+    uk_UA = uk-ua;
+    uk-ua = mkDictFromLibreofficeGit {
+      subdir = "uk_UA";
+      shortName = "uk-ua";
+      shortDescription = "Ukrainian";
+      dictFileName = "uk_UA";
+      readmeFileName = "hyph_uk_UA";
+    };
+
+    # ZULU
+
+    zu_ZA = zu-za;
+    zu-za = mkDictFromLibreofficeGitCustom {
+      subdir = "zu_ZA";
+      shortName = "zu-za";
+      shortDescription = "Zulu";
+      dictFilePath = "hyph_zu_ZA.dic";
+      # no readme file provided, leave empty
+    };
+
   };
 
-  # ESPERANTO
-
-  eo = mkDictFromLibreofficeGitCustom {
-    subdir = "eo";
-    shortName = "eo";
-    shortDescription = "Esperanto";
-    dictFilePath = "hyph_eo.dic";
-    readmeFilePath = "desc_eo.txt";
+in
+dicts
+// {
+  all = symlinkJoin {
+    name = "hyphen-all";
+    paths = lib.unique (lib.attrValues dicts);
   };
-
-  # SPANISH
-
-  es_ES = es-es;
-  es-es = mkDictFromLibreofficeGit {
-    subdir = "es";
-    shortName = "es-es";
-    shortDescription = "Spanish (Spain)";
-    dictFileName = "es";
-    readmeFileName = "hyph_es";
-  };
-
-  # ESTONIAN
-
-  et_EE = et-ee;
-  et-ee = mkDictFromLibreofficeGit {
-    subdir = "et_EE";
-    shortName = "et-ee";
-    shortDescription = "Estonian";
-    dictFileName = "et_EE";
-    readmeFileName = "hyph_et_EE";
-  };
-
-  # FRENCH
-
-  fr_FR = fr-fr;
-  fr-fr = mkDictFromLibreofficeGit {
-    subdir = "fr_FR";
-    shortName = "fr-fr";
-    shortDescription = "French";
-    dictFileName = "fr";
-    readmeFileName = "hyph_fr";
-  };
-
-  # CROATIAN
-
-  hr_HR = hr-hr;
-  hr-hr = mkDictFromLibreofficeGit {
-    subdir = "hr_HR";
-    shortName = "hr-hr";
-    shortDescription = "Croatian";
-    dictFileName = "hr_HR";
-    readmeFileName = "hyph_hr_HR";
-  };
-
-  # HUNGARIAN
-
-  hu_HU = hu-hu;
-  hu-hu = mkDictFromLibreofficeGit {
-    subdir = "hu_HU";
-    shortName = "hu-hu";
-    shortDescription = "Hungarian";
-    dictFileName = "hu_HU";
-    readmeFileName = "hyph_hu_HU";
-  };
-
-  # INDONESIAN
-
-  id_ID = id-id;
-  id-id = mkDictFromLibreofficeGitCustom {
-    subdir = "id";
-    shortName = "id-id";
-    shortDescription = "Indonesian";
-    dictFilePath = "hyph_id_ID.dic";
-    readmeFilePath = "README-dict.adoc";
-  };
-
-  # ITALIAN
-
-  it_IT = it-it;
-  it-it = mkDictFromLibreofficeGit {
-    subdir = "it_IT";
-    shortName = "it-it";
-    shortDescription = "Italian";
-    dictFileName = "it_IT";
-    readmeFileName = "hyph_it_IT";
-  };
-
-  # LITHUANIAN
-
-  lt_LT = lt-lt;
-  lt-lt = mkDictFromLibreofficeGitCustom {
-    subdir = "lt_LT";
-    shortName = "lt-lt";
-    shortDescription = "Lithuanian";
-    dictFilePath = "hyph_lt.dic";
-    readmeFilePath = "README_hyph";
-  };
-
-  # LATVIAN
-
-  lv_LV = lv-lv;
-  lv-lv = mkDictFromLibreofficeGit {
-    subdir = "lv_LV";
-    shortName = "lv-lv";
-    shortDescription = "Latvian";
-    dictFileName = "lv_LV";
-    readmeFileName = "hyph_lv_LV";
-  };
-
-  # MONGOLIAN
-
-  mn_MN = mn-mn;
-  mn-mn = mkDictFromLibreofficeGit {
-    subdir = "mn_MN";
-    shortName = "mn-mn";
-    shortDescription = "Mongolian";
-    dictFileName = "mn_MN";
-    readmeFileName = "mn_MN";
-  };
-
-  # DUTCH
-
-  nl_NL = nl-nl;
-  nl-nl = mkDictFromLibreofficeGit {
-    subdir = "nl_NL";
-    shortName = "nl-nl";
-    shortDescription = "Dutch";
-    dictFileName = "nl_NL";
-    readmeFileName = "NL";
-  };
-
-  # NORWEGIAN
-
-  nb_NO = nb-no;
-  nb-no = mkDictFromLibreofficeGit {
-    subdir = "no";
-    shortName = "nb-no";
-    shortDescription = "Norwegian (Bokmål)";
-    dictFileName = "nb_NO";
-    readmeFileName = "hyph_NO";
-  };
-
-  nn_NO = nn-no;
-  nn-no = mkDictFromLibreofficeGit {
-    subdir = "no";
-    shortName = "nn-no";
-    shortDescription = "Norwegian (Nynorsk)";
-    dictFileName = "nn_NO";
-    readmeFileName = "hyph_NO";
-  };
-
-  # POLISH
-
-  pl_PL = pl-pl;
-  pl-pl = mkDictFromLibreofficeGit {
-    subdir = "pl_PL";
-    shortName = "pl-pl";
-    shortDescription = "Polish";
-    dictFileName = "pl_PL";
-    readmeFileName = "pl";
-  };
-
-  # PORTUGUESE
-
-  pt_BR = pt-br;
-  pt-br = mkDictFromLibreofficeGit {
-    subdir = "pt_BR";
-    shortName = "pt-br";
-    shortDescription = "Portuguese (Brazil)";
-    dictFileName = "pt_BR";
-    readmeFileName = "hyph_pt_BR";
-  };
-
-  pt_PT = pt-pt;
-  pt-pt = mkDictFromLibreofficeGit {
-    subdir = "pt_PT";
-    shortName = "pt-pt";
-    shortDescription = "Portuguese (Portugal)";
-    dictFileName = "pt_PT";
-    readmeFileName = "hyph_pt_PT";
-  };
-
-  # ROMANIAN
-
-  ro_RO = ro-ro;
-  ro-ro = mkDictFromLibreofficeGit {
-    subdir = "ro";
-    shortName = "ro-ro";
-    shortDescription = "Romanian";
-    dictFileName = "ro_RO";
-    readmeFileName = "RO";
-  };
-
-  # RUSSIAN
-
-  ru_RU = ru-ru;
-  ru-ru = mkDictFromLibreofficeGit {
-    subdir = "ru_RU";
-    shortName = "ru-ru";
-    shortDescription = "Russian (Russia)";
-    dictFileName = "ru_RU";
-    readmeFileName = "ru_RU";
-  };
-
-  # SLOVAK
-
-  sk_SK = sk-sk;
-  sk-sk = mkDictFromLibreofficeGit {
-    subdir = "sk_SK";
-    shortName = "sk-sk";
-    shortDescription = "Slovak";
-    dictFileName = "sk_SK";
-    readmeFileName = "sk";
-  };
-
-  # SLOVENIAN
-
-  sl_SI = sl-si;
-  sl-si = mkDictFromLibreofficeGit {
-    subdir = "sl_SI";
-    shortName = "sl-si";
-    shortDescription = "Slovenian";
-    dictFileName = "sl_SI";
-    readmeFileName = "hyph_sl_SI";
-  };
-
-  # ALBANIAN
-
-  sq_AL = sq-al;
-  sq-al = mkDictFromLibreofficeGit {
-    subdir = "sq_AL";
-    shortName = "sq-al";
-    shortDescription = "Albanian";
-    dictFileName = "sq_AL";
-    readmeFileName = "hyph_sq_AL";
-  };
-
-  # SERBIAN
-
-  sr_SR = sr-sr;
-  sr-sr = mkDictFromLibreofficeGitCustom {
-    subdir = "sr";
-    shortName = "sr-sr";
-    shortDescription = "Serbian (Cyrillic)";
-    dictFilePath = "hyph_sr.dic";
-    readmeFilePath = "README.txt";
-  };
-
-  sr_SR_LATN = sr-sr-latn;
-  sr-sr-latn = mkDictFromLibreofficeGitCustom {
-    subdir = "sr";
-    shortName = "sr-sr-latn";
-    shortDescription = "Serbian (Latin)";
-    dictFilePath = "hyph_sr-Latn.dic";
-    readmeFilePath = "README.txt";
-  };
-
-  # SWEDISH
-
-  sv_SE = sv-se;
-  sv-se = mkDictFromLibreofficeGit {
-    subdir = "sv_SE";
-    shortName = "sv-se";
-    shortDescription = "Swedish";
-    dictFileName = "sv";
-    readmeFileName = "hyph_sv";
-  };
-
-  # TELUGU
-
-  te_IN = te-in;
-  te-in = mkDictFromLibreofficeGit {
-    subdir = "te_IN";
-    shortName = "te-in";
-    shortDescription = "Telugu";
-    dictFileName = "te_IN";
-    readmeFileName = "hyph_te_IN";
-  };
-
-  # THAI
-
-  th_TH = th-th;
-  th-th = mkDictFromLibreofficeGit {
-    subdir = "th_TH";
-    shortName = "th-th";
-    shortDescription = "Thai";
-    dictFileName = "th_TH";
-    readmeFileName = "hyph_th_TH";
-  };
-
-  # UKRAINIAN
-
-  uk_UA = uk-ua;
-  uk-ua = mkDictFromLibreofficeGit {
-    subdir = "uk_UA";
-    shortName = "uk-ua";
-    shortDescription = "Ukrainian";
-    dictFileName = "uk_UA";
-    readmeFileName = "hyph_uk_UA";
-  };
-
-  # ZULU
-
-  zu_ZA = zu-za;
-  zu-za = mkDictFromLibreofficeGitCustom {
-    subdir = "zu_ZA";
-    shortName = "zu-za";
-    shortDescription = "Zulu";
-    dictFilePath = "hyph_zu_ZA.dic";
-    # no readme file provided, leave empty
-  };
-
 }
-


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds packages for the hyphenation dictionaries for all missing languages in the `hyphenDict` module, which allows to pre-configure hyphenation dictionaries for LibreOffice.

It also adds a `hyphenDicts.all` package that installs all available hyphenation dictionaries using `symLinkJoin`.

To test, add
```
hyphenDicts.all
```
to `environment.systemPackages`. LibreOffice should then pick up the hyphenation dictionaries automatically.

Some dictionaries do not fit the file layout assumed in `mkDictFromLibreofficeGit` (specifically, some have their dictionaries in a different subdirectory than the README, the README file name doesn't start with `README_`, etc.). This required to add a `mkDictFromLibreofficeGitCustom` function that allows to freely set the dictionary and README path.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
