### PR TITLE
sointu: init at 0.4.1-unstable-2025-08-13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15608,6 +15608,12 @@
     githubId = 1729331;
     name = "Dominique Martinet";
   };
+  martinimoe = {
+    email = "moe@martini.moe";
+    github = "martinimoe";
+    githubId = 7438779;
+    name = "Martini Moe";
+  };
   martinjlowm = {
     email = "martin@martinjlowm.dk";
     github = "martinjlowm";

--- a/pkgs/by-name/so/sointu/package.nix
+++ b/pkgs/by-name/so/sointu/package.nix
@@ -1,0 +1,59 @@
+{
+  buildGo123Module,
+  fetchFromGitHub,
+  lib,
+  pkg-config,
+  nix-update-script,
+  alsa-lib,
+  libGL,
+  libxkbcommon,
+  vulkan-headers,
+  wayland,
+  xorg,
+}:
+
+buildGo123Module {
+  pname = "sointu";
+  version = "0.4.1-unstable-2025-08-13";
+
+  src = fetchFromGitHub {
+    owner = "vsariola";
+    repo = "sointu";
+    rev = "74fea4138fd788eddeb726440c872937de56fd1c";
+    hash = "sha256-kHK35Bt/+ucPCsFE3p72J3jSHzhOK9QKtJPG+3grBvs=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    libGL
+    libxkbcommon
+    vulkan-headers
+    wayland
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXfixes
+  ];
+
+  proxyVendor = true;
+  vendorHash = "sha256-gLDLKqu6k7/nwv6xHUE6MIYrbQFfVFAuUiMbLptcE5k=";
+
+  subPackages = [
+    "cmd/sointu-track"
+    "cmd/sointu-compile"
+    "cmd/sointu-play"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fork of 4klang that can target 386, amd64 and WebAssembly";
+    mainProgram = "sointu-track";
+    homepage = "https://github.com/vsariola/sointu";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ martinimoe ];
+  };
+}


### PR DESCRIPTION
This adds sointu, a software synthesizer used for small pc intros by the demoscene: https://github.com/vsariola/sointu

I also added myself to the maintainer list.

(This is my first contribution to nixpkgs and I'd be happy for any help and hints what I can do better!)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
