### PR TITLE
ntfs3g: use external FUSE, set meta.mainProgram

### DIFF
--- a/pkgs/by-name/nt/ntfs3g/package.nix
+++ b/pkgs/by-name/nt/ntfs3g/package.nix
@@ -12,6 +12,7 @@
   crypto ? false,
   libgcrypt,
   gnutls,
+  fuse,
 }:
 
 stdenv.mkDerivation rec {
@@ -35,13 +36,11 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gettext
     libuuid
+    fuse
   ]
   ++ lib.optionals crypto [
     gnutls
     libgcrypt
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    macfuse-stubs
   ];
 
   # Note: libgcrypt is listed here non-optionally because its m4 macros are
@@ -68,6 +67,7 @@ stdenv.mkDerivation rec {
     "--enable-extras"
     "--with-mount-helper=${mount}/bin/mount"
     "--with-umount-helper=${mount}/bin/umount"
+    "--with-fuse=external"
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     "--with-modprobe-helper=${kmod}/bin/modprobe"

--- a/pkgs/by-name/nt/ntfs3g/package.nix
+++ b/pkgs/by-name/nt/ntfs3g/package.nix
@@ -84,6 +84,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/tuxera/ntfs-3g";
     description = "FUSE-based NTFS driver with full write support";
     maintainers = with maintainers; [ dezgeg ];
+    mainProgram = "ntfs-3g";
     platforms = with platforms; darwin ++ linux;
     license = with licenses; [
       gpl2Plus # ntfs-3g itself


### PR DESCRIPTION
On Linux, by default, the ntfs-3g binaries attempt to perform `mount()` by themselves (through the included libfuse-lite). Thus, the binaries will not function when run unprivileged. Usually, they are installed setuid root, but Nix clears the setuid bit on everything in the store, so ntfs-3g as built by us was unusable for unprivileged users on Linux.

In order to let unprivileged users use ntfs-3g, configure the build to use the "external" FUSE implementation `pkgs.fuse`, which arranges for its own binaries to be setuid root.

Also set `meta.mainProgram`. The net effect is that an unprivileged user can `nix run nixpkgs#ntfs3g` and it will mostly just work. (`-o no_def_opts` also needs to be passed to avoid ntfs-3g setting `-o allow_other`.)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
