### PR TITLE
dt: 1.3.1-unstable-2024-07-16 -> 1.3.2

### DIFF
--- a/pkgs/by-name/dt/dt/package.nix
+++ b/pkgs/by-name/dt/dt/package.nix
@@ -3,21 +3,23 @@
   stdenv,
   fetchFromGitHub,
   testers,
-  zig_0_12,
+  zig_0_14,
 }:
-
+let
+  zig = zig_0_14;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "dt";
-  version = "1.3.1-unstable-2024-07-16";
+  version = "1.3.2";
 
   src = fetchFromGitHub {
     owner = "so-dang-cool";
     repo = "dt";
-    rev = "0d16ca2867131e99a93a412231465cf68f2e594f";
-    hash = "sha256-pfTlOMJpOPbXZaJJvOKDUyCZxFHNLRRUteJFWT9IKOU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-D80Ld5nBrTM8PLUz3SFWMiWTXvbd4EnpzNVRft59r2M=";
   };
 
-  nativeBuildInputs = [ zig_0_12.hook ];
+  nativeBuildInputs = [ zig.hook ];
 
   passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
@@ -37,8 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
       In short, dt is intended to be generally useful, with zero pretense of
       elegance.
     '';
-    # TODO: uncomment when dt pushes a new release
-    # changelog = "https://github.com/so-dang-cool/dt/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/so-dang-cool/dt/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ booniepepper ];
     platforms = lib.platforms.unix;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
