### PR TITLE
reprepro: init at 5.4.7

### DIFF
--- a/pkgs/by-name/re/reprepro/package.nix
+++ b/pkgs/by-name/re/reprepro/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  versionCheckHook,
+  nix-update-script,
+  bzip2,
+  db,
+  gpgme,
+  libarchive,
+  xz,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "reprepro";
+  version = "5.4.7";
+
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "debian";
+    repo = "reprepro";
+    tag = "reprepro-${finalAttrs.version}";
+    hash = "sha256-bGfVWOmcXvaE+t9jiZFrnaUTKVPJqGqbPFyThhKK8gQ=";
+  };
+
+  buildInputs = [
+    bzip2
+    db
+    gpgme
+    libarchive
+    xz
+    zlib
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    versionCheckHook
+  ];
+
+  doInstallCheck = true;
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://salsa.debian.org/debian/reprepro/";
+    description = "Debian package repository producer";
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ baloo ];
+    platforms = lib.platforms.all;
+    mainProgram = "reprepro";
+  };
+})


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
