### PR TITLE
python313Packages.local-attention: init at 1.11.2, python313Packages.hyper-connections: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/hyper-connections/default.nix
+++ b/pkgs/development/python-modules/hyper-connections/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  einops,
+  fetchFromGitHub,
+  hatchling,
+  pytestCheckHook,
+  torch,
+}:
+
+buildPythonPackage rec {
+  pname = "hyper-connections";
+  version = "0.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "lucidrains";
+    repo = "hyper-connections";
+    tag = version;
+    hash = "sha256-9dMiyxzrZBlDxKeehXjoIjbzAkGSkAFxQZZX3LJJAig=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    einops
+    torch
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "hyper_connections" ];
+
+  meta = {
+    description = "Module to make multiple residual streams";
+    homepage = "https://github.com/lucidrains/hyper-connections";
+    changelog = "https://github.com/lucidrains/hyper-connections/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/local-attention/default.nix
+++ b/pkgs/development/python-modules/local-attention/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  einops,
+  fetchFromGitHub,
+  hyper-connections,
+  pytestCheckHook,
+  setuptools,
+  torch,
+}:
+
+buildPythonPackage rec {
+  pname = "local-attention";
+  version = "1.11.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "lucidrains";
+    repo = "local-attention";
+    tag = version;
+    hash = "sha256-2gBPALJAflLf7Y8L5wnNw4fHcvIOKjOncLsebkhrYkU=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "'pytest-runner'," ""
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    einops
+    hyper-connections
+    torch
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "local_attention" ];
+
+  meta = {
+    description = "Module for local windowed attention for language modeling";
+    homepage = "https://github.com/lucidrains/local-attention";
+    changelog = "https://github.com/lucidrains/local-attention/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6796,6 +6796,8 @@ self: super: with self; {
 
   hypchat = callPackage ../development/python-modules/hypchat { };
 
+  hyper-connections = callPackage ../development/python-modules/hyper-connections { };
+
   hypercorn = callPackage ../development/python-modules/hypercorn { };
 
   hyperframe = callPackage ../development/python-modules/hyperframe { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8645,6 +8645,8 @@ self: super: with self; {
 
   loca = callPackage ../development/python-modules/loca { };
 
+  local-attention = callPackage ../development/python-modules/local-attention { };
+
   localimport = callPackage ../development/python-modules/localimport { };
 
   localstack-client = callPackage ../development/python-modules/localstack-client { };


### PR DESCRIPTION
Module for local windowed attention for language modeling

https://github.com/lucidrains/local-attention


Closes #359108
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
