### PR TITLE
Revert "tiled: 1.11.2 -> 1.11.90", disable auto update

### DIFF
--- a/pkgs/applications/editors/tiled/default.nix
+++ b/pkgs/applications/editors/tiled/default.nix
@@ -28,13 +28,14 @@ in
 
 stdenv.mkDerivation rec {
   pname = "tiled";
-  version = "1.11.90";
+  # nixpkgs-update: no auto update
+  version = "1.11.2";
 
   src = fetchFromGitHub {
     owner = "mapeditor";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-gGsozdFEE5c315DF+EsIY9wGv50wwrOBycejTkVwEHA=";
+    sha256 = "sha256-9oUKn51MQcsStgIJrp9XW5YAIpAUcO0kzfGnYA3gz/E=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#403048, 1.11.90 is actually older than 1.11.2, see #433541