### PR TITLE
python313Packages.noisereduce: init at 3.0.3

### DIFF
--- a/pkgs/development/python-modules/noisereduce/default.nix
+++ b/pkgs/development/python-modules/noisereduce/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  joblib,
+  matplotlib,
+  numpy,
+  pytestCheckHook,
+  scipy,
+  setuptools,
+  torch,
+  tqdm,
+}:
+
+buildPythonPackage rec {
+  pname = "noisereduce";
+  version = "3.0.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "timsainb";
+    repo = "noisereduce";
+    tag = "v${version}";
+    hash = "sha256-CMXbl+9L01rtsD8BZ3nNomacsChy/1EGdUdWz7Ytbjk=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    joblib
+    matplotlib
+    numpy
+    scipy
+    tqdm
+  ];
+
+  optional-dependencies = {
+    PyTorch = [ torch ];
+  };
+
+  nativeCheckInputs = [ pytestCheckHook ] ++ lib.flatten (builtins.attrValues optional-dependencies);
+
+  pythonImportsCheck = [ "noisereduce" ];
+
+  meta = {
+    description = "Noise reduction using spectral gating (speech, bioacoustics, audio, time-domain signals";
+    homepage = "https://github.com/timsainb/noisereduce";
+    changelog = "https://github.com/timsainb/noisereduce/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10467,6 +10467,8 @@ self: super: with self; {
 
   noiseprotocol = callPackage ../development/python-modules/noiseprotocol { };
 
+  noisereduce = callPackage ../development/python-modules/noisereduce { };
+
   nomadnet = callPackage ../development/python-modules/nomadnet { };
 
   nominal = callPackage ../development/python-modules/nominal { };


### PR DESCRIPTION
Noise reduction using spectral gating (speech, bioacoustics, audio, time-domain signals

https://github.com/timsainb/noisereduce

Closes #351989
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
