### PR TITLE
python313Packages.pyflipper: 0.18-unstable-2024-04-15 -> 0.21

### DIFF
--- a/pkgs/development/python-modules/pyflipper/default.nix
+++ b/pkgs/development/python-modules/pyflipper/default.nix
@@ -8,9 +8,9 @@
   websocket-client,
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "pyflipper";
-  version = "0.18-unstable-2024-04-15";
+  version = "0.21";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -18,9 +18,8 @@ buildPythonPackage {
   src = fetchFromGitHub {
     owner = "wh00hw";
     repo = "pyFlipper";
-    # https://github.com/wh00hw/pyFlipper/issues/20
-    rev = "e8a82a25eb766fac53a2e6e5fff6505f60cf0897";
-    hash = "sha256-CQ6oVVkLxyoNoe7L0USfal1980VkfiuHc4cqXTsZ2Jc=";
+    tag = "v${version}";
+    hash = "sha256-IMd9RzGblfsyDH4TC+ip5a2zx4gzXbzjIaWMldEy5xk=";
   };
 
   build-system = [ setuptools ];
@@ -38,6 +37,7 @@ buildPythonPackage {
   meta = {
     description = "Flipper Zero Python CLI Wrapper";
     homepage = "https://github.com/wh00hw/pyFlipper";
+    changelog = "https://github.com/wh00hw/pyFlipper/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ siraben ];
   };


### PR DESCRIPTION
Diff: https://github.com/wh00hw/pyFlipper/compare/refs/tags/v0.18-unstable-2024-04-15...refs/tags/v0.21

Changelog: https://github.com/wh00hw/pyFlipper/releases/tag/v0.21


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
