### PR TITLE
treewide: remove nixfmt from update scripts' shebangs

### DIFF
--- a/pkgs/by-name/gr/gren/update.sh
+++ b/pkgs/by-name/gr/gren/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p cabal2nix curl jq nix-update nixfmt
+#!nix-shell -i bash -p cabal2nix curl jq nix-update
 
 set -euo pipefail
 

--- a/pkgs/by-name/mu/music-assistant/update-providers.py
+++ b/pkgs/by-name/mu/music-assistant/update-providers.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -I nixpkgs=./. -i python3 -p "music-assistant.python.withPackages (ps: music-assistant.dependencies ++ (with ps; [ jinja2 packaging ]))" -p nixfmt pyright ruff isort
+#!nix-shell -I nixpkgs=./. -i python3 -p "music-assistant.python.withPackages (ps: music-assistant.dependencies ++ (with ps; [ jinja2 packaging ]))" -p pyright ruff isort
 import asyncio
 import json
 import os.path

--- a/pkgs/development/compilers/dotnet/update.sh
+++ b/pkgs/development/compilers/dotnet/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -I nixpkgs=./. -i bash -p curl jq nix gnused nixfmt
+#!nix-shell -I nixpkgs=./. -i bash -p curl jq nix gnused
 # shellcheck shell=bash
 
 set -Eeuo pipefail

--- a/pkgs/os-specific/linux/kernel/update-xanmod.sh
+++ b/pkgs/os-specific/linux/kernel/update-xanmod.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p bash nix-prefetch curl jq gawk gnused nixfmt
+#!nix-shell -i bash -p bash nix-prefetch curl jq gawk gnused
 
 set -euo pipefail
 

--- a/pkgs/servers/home-assistant/update-component-packages.py
+++ b/pkgs/servers/home-assistant/update-component-packages.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i python3 -p "python3.withPackages (ps: with ps; [ packaging rich ])" -p pyright ruff isort nixfmt
+#! nix-shell -i python3 -p "python3.withPackages (ps: with ps; [ packaging rich ])" -p pyright ruff isort
 #
 # This script downloads Home Assistant's source tarball.
 # Inside the homeassistant/components directory, each integration has an associated manifest.json,

--- a/pkgs/servers/x11/xorg/update.py
+++ b/pkgs/servers/x11/xorg/update.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell --pure --keep NIX_PATH -i python3 -p nix git nixfmt "python3.withPackages (ps: [ ps. packaging ps.beautifulsoup4 ps.requests ])"
+#!nix-shell -i python3 -p nix git "python3.withPackages (ps: [ ps. packaging ps.beautifulsoup4 ps.requests ])"
 
 # Usage: Run ./update.py from the directory containing tarballs.list. The script checks for the
 # latest versions of all packages, updates the expressions if any update is found, and commits


### PR DESCRIPTION
We expect all of these update scripts to be run inside a nixpkgs' nix-shell environment, which will provide the correct nixfmt including treefmt configuration.

We already did this as part of b68cc636d3d150925699486e3122a1d8da4e4984, but more occurences sneaked in or were left over.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
