### PR TITLE
nix-serve: 2024-09-18 -> 2024-09-20

### DIFF
--- a/pkgs/by-name/ni/nix-serve/package.nix
+++ b/pkgs/by-name/ni/nix-serve/package.nix
@@ -3,17 +3,14 @@
   stdenv,
   fetchFromGitHub,
   bzip2,
-  nixVersions,
+  nix,
   makeWrapper,
   nixosTests,
-  fetchpatch,
 }:
 
 let
-  rev = "77ffa33d83d2c7c6551c5e420e938e92d72fec24";
-  sha256 = "sha256-MJRdVO2pt7wjOu5Hk0eVeNbk5bK5+Uo/Gh9XfO4OlMY=";
-  nix = nixVersions.nix_2_24;
-  inherit (nix.perl-bindings) perl;
+  rev = "a7e046db4b29d422fc9aac60ea6b82b31399951a";
+  sha256 = "sha256-6ZQ0OLijq6UtOtUqRdFC19+helhU0Av6MvGCZf6XmcQ=";
 in
 
 stdenv.mkDerivation {
@@ -26,14 +23,6 @@ stdenv.mkDerivation {
     inherit rev sha256;
   };
 
-  patches = [
-    # Part of https://github.com/edolstra/nix-serve/pull/61
-    (fetchpatch {
-      url = "https://github.com/edolstra/nix-serve/commit/9e434fff4486afeb3cc3f631f6dc56492b204704.patch";
-      sha256 = "sha256-TxQ6q6UApTKsYIMdr/RyrkKSA3k47stV63bTbxchNTU=";
-    })
-  ];
-
   nativeBuildInputs = [ makeWrapper ];
 
   dontBuild = true;
@@ -42,20 +31,20 @@ stdenv.mkDerivation {
     install -Dm0755 nix-serve.psgi $out/libexec/nix-serve/nix-serve.psgi
 
     makeWrapper ${
-      perl.withPackages (p: [
+      nix.perl-bindings.perl.withPackages (p: [
         p.DBDSQLite
         p.Plack
         p.Starman
         nix.perl-bindings
       ])
     }/bin/starman $out/bin/nix-serve \
-                --prefix PATH : "${
-                  lib.makeBinPath [
-                    bzip2
-                    nix
-                  ]
-                }" \
-                --add-flags $out/libexec/nix-serve/nix-serve.psgi
+      --prefix PATH : "${
+        lib.makeBinPath [
+          bzip2
+          nix
+        ]
+      }" \
+      --add-flags $out/libexec/nix-serve/nix-serve.psgi
   '';
 
   /**


### PR DESCRIPTION
we don't need to pin nix, because perl bindings are stable enough.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
