### PR TITLE
nginxMainline: 1.27.5 -> 1.29.1

### DIFF
--- a/pkgs/servers/http/nginx/mainline.nix
+++ b/pkgs/servers/http/nginx/mainline.nix
@@ -1,6 +1,6 @@
 { callPackage, ... }@args:
 
 callPackage ./generic.nix args {
-  version = "1.27.5";
-  hash = "sha256-6WrOu5wqbbigAMPdGzLsuhuBDwzVhiMtTZIeN2Z03Q4=";
+  version = "1.29.1";
+  hash = "sha256-xYn35+2AHdvZBK+/PeJq4k6wzOJ8dxei6U33+xLWrSc=";
 }


### PR DESCRIPTION
Fixes CVE-2025-53859

Changes:
```
Changes with nginx 1.29.1                                        13 Aug 2025

    *) Security: processing of a specially crafted login/password when using
       the "none" authentication method in the ngx_mail_smtp_module might
       cause worker process memory disclosure to the authentication server
       (CVE-2025-53859).

    *) Change: now TLSv1.3 certificate compression is disabled by default.

    *) Feature: the "ssl_certificate_compression" directive.

    *) Feature: support for 0-RTT in QUIC when using OpenSSL 3.5.1 or newer.

    *) Bugfix: the 103 response might be buffered when using HTTP/2 and the
       "early_hints" directive.

    *) Bugfix: in handling "Host" and ":authority" header lines with equal
       values when using HTTP/2; the bug had appeared in 1.17.9.

    *) Bugfix: in handling "Host" header lines with a port when using
       HTTP/3.

    *) Bugfix: nginx could not be built on NetBSD 10.0.

    *) Bugfix: in the "none" parameter of the "smtp_auth" directive.

Changes with nginx 1.29.0                                        24 Jun 2025

    *) Feature: support for response code 103 from proxy and gRPC backends;
       the "early_hints" directive.

    *) Feature: loading of secret keys from hardware tokens with OpenSSL
       provider.

    *) Feature: support for the "so_keepalive" parameter of the "listen"
       directive on macOS.

    *) Change: the logging level of SSL errors in a QUIC handshake has been
       changed from "error" to "crit" for critical errors, and to "info" for
       the rest; the logging level of unsupported QUIC transport parameters
       has been lowered from "info" to "debug".

    *) Change: the native nginx/Windows binary release is now built using
       Windows SDK 10.

    *) Bugfix: nginx could not be built by gcc 15 if ngx_http_v2_module or
       ngx_http_v3_module modules were used.

    *) Bugfix: nginx might not be built by gcc 14 or newer with -O3 -flto
       optimization if ngx_http_v3_module was used.

    *) Bugfixes and improvements in HTTP/3.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests` (The nginx-proxyprotocol test fails because the build of sniproxy is broken for unrelated reason)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 433600`
Commit: `a93581ee44ee4236a5b3c52f7a22682af7652447`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 4 packages built:</summary>
  <ul>
    <li>nginxMainline</li>
    <li>nginxMainline.doc</li>
    <li>nginxQuic</li>
    <li>nginxQuic.doc</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
