### PR TITLE
nginx: apply patch for CVE-2025-53859

### DIFF
--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -218,6 +218,13 @@ stdenv.mkDerivation {
         ./nix-etag-1.15.4.patch
         ./nix-skip-check-logs-path.patch
       ]
+      ++ lib.optionals (!lib.versionAtLeast version "1.29.1") [
+        (fetchpatch {
+          name = "CVE-2025-53859.patch";
+          url = "https://nginx.org/download/patch.2025.smtp.txt";
+          hash = "sha256-v49sLskFNMoKuG8HQISw8ST7ga6DS+ngJiL0D3sUyGk=";
+        })
+      ]
       ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
         (fetchpatch {
           url = "https://raw.githubusercontent.com/openwrt/packages/c057dfb09c7027287c7862afab965a4cd95293a3/net/nginx/patches/102-sizeof_test_fix.patch";


### PR DESCRIPTION
https://www.openwall.com/lists/oss-security/2025/08/13/5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`. (The nginx-proxyprotocol test fails because the build of sniproxy is broken for unrelated reason.)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 433604`
Commit: `cca6e62d329a8ca9d701682a5678bc8b5ebc75b8`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 21 packages built:</summary>
  <ul>
    <li>angie</li>
    <li>angie.doc</li>
    <li>angieQuic</li>
    <li>angieQuic.doc</li>
    <li>devpi-client</li>
    <li>devpi-client.dist</li>
    <li>devpi-server</li>
    <li>devpi-server.dist</li>
    <li>nginx (nginxStable)</li>
    <li>nginx.doc (nginxStable.doc)</li>
    <li>nginxMainline</li>
    <li>nginxMainline.doc</li>
    <li>nginxQuic</li>
    <li>nginxQuic.doc</li>
    <li>nginxShibboleth</li>
    <li>nginxShibboleth.doc</li>
    <li>openresty</li>
    <li>openresty.doc</li>
    <li>python313Packages.devpi-ldap</li>
    <li>python313Packages.devpi-ldap.dist</li>
    <li>tests.testers.lycheeLinkCheck.network</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
