### PR TITLE
varnish60: 6.0.14 -> 6.0.15, varnish77: 7.7.1 -> 7.7.2

### DIFF
--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -114,7 +114,7 @@ in
   };
   # EOL 2026-03-15
   varnish77 = common {
-    version = "7.7.1";
-    hash = "sha256-TAbFyZaApCm3KTT5/VE5Y/fhuoVTszyn7BLIWlwrdRo=";
+    version = "7.7.2";
+    hash = "sha256-/ad1DhKBog6czMbGZkgdJDf6fA2BZZLIbk+3un/EZK0=";
   };
 }

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -109,8 +109,8 @@ in
 {
   # EOL (LTS) TBA
   varnish60 = common {
-    version = "6.0.14";
-    hash = "sha256-tZlBf3ppntxxYSufEJ86ot6ujvnbfIyZOu9B3kDJ72k=";
+    version = "6.0.15";
+    hash = "sha256-VV0G10Glo+svBju+3G8gmRMF3w4nz8oj6X1v/28q5qw=";
   };
   # EOL 2026-03-15
   varnish77 = common {


### PR DESCRIPTION
Fixes CVE-2025-8671
https://varnish-cache.org/security/VSV00017.html

Changes:
https://github.com/varnishcache/varnish-cache/blob/7.7/doc/changes.rst#varnish-cache-772-2025-08-05
https://github.com/varnishcache/varnish-cache/blob/6.0/doc/changes.rst#varnish-cache-6014-2025-05-12

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
