### PR TITLE
vmctl: 0.99-unstable-2024-05-14 -> 1.00

### DIFF
--- a/pkgs/by-name/vm/vmctl/package.nix
+++ b/pkgs/by-name/vm/vmctl/package.nix
@@ -16,13 +16,13 @@
 
 stdenvNoCC.mkDerivation {
   pname = "vmctl";
-  version = "0.99-unstable-2024-05-14";
+  version = "1.00";
 
   src = fetchFromGitHub {
     owner = "SamsungDS";
     repo = "vmctl";
-    rev = "5b6b7084b8cba06b474c0e020df965237f2c832c";
-    hash = "sha256-yDgaY2RJXBjWkMSQb4JaJzMGLFzowfOGixSRzzv2iIk=";
+    rev = "8cc71d4350f4f5814ffd7a3091a5c1a9d2e25158";
+    hash = "sha256-nIJEgd62yq3DKhaMnB2OEaGN/zC5/Z5cTtO3iQEVF44=";
   };
 
   dontBuild = true;


### PR DESCRIPTION
Update the vmctl package to the latests stable 1.00 vmctl version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
