### PR TITLE
libvfn: init at 5.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12216,6 +12216,12 @@
     githubId = 310981;
     name = "Joel Burget";
   };
+  joelgranados = {
+    email = "joel.granados.oss@joelgranados.com";
+    github = "Joelgranados";
+    githubId = 356364;
+    name = "Joel Granados";
+  };
   joelmo = {
     email = "joel.moberg@gmail.com";
     github = "joelmo";

--- a/pkgs/by-name/li/libvfn/package.nix
+++ b/pkgs/by-name/li/libvfn/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  perl,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libvfn";
+  version = "5.1.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "SamsungDS";
+    repo = "libvfn";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-CEVjJVeDEEJcJX2/6fwKGBHDsxgN+pL7fJWvQ+iCh3Y=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    perl
+  ];
+
+  postPatch = ''
+    patchShebangs scripts/trace.pl scripts/ctags.sh scripts/sparse.py
+  '';
+
+  mesonFlags = [
+    (lib.mesonEnable "docs" false)
+    (lib.mesonEnable "libnvme" false)
+    (lib.mesonBool "profiling" false)
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Zero-dependency library for interacting with PCIe-based NVMe devices from user-space";
+    longDescription = ''
+      libvfn is a zero-dependency library for interacting with PCIe-based NVMe
+      devices from user-space using the Linux kernel vfio-pci driver. The core
+      of the library is excessively low-level and aims to allow controller
+      verification and testing teams to interact with the NVMe device at the
+      register and queue level.
+    '';
+    homepage = "https://github.com/SamsungDS/libvfn";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ joelgranados ];
+
+    # Explicit list of tested platforms. The abstractions on other platforms
+    # are untested and might not work. More will be added as we test them.
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryNativeCode
+    ];
+  };
+})


### PR DESCRIPTION
## Summary
This PR adds libvfn, a new package for interacting with PCIe-based NVMe devices from user-space.

## Changes Made
* New Package: libvfn 5.1.0
* Added myself as a maintainer

##Why This Package is Needed

libvfn enables user-space device testing and verification, which is particularly valuable for:
- NVMe controller verification and testing teams
- Low-level NVMe device interaction and debugging
- User-space driver development for PCIe NVMe devices

But can be extended to other PCI use cases, Like smart nics and the like.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
