### PR TITLE
nomad: 1.10.3 -> 1.10.4

### DIFF
--- a/pkgs/applications/networking/cluster/nomad/default.nix
+++ b/pkgs/applications/networking/cluster/nomad/default.nix
@@ -40,10 +40,10 @@ let
           inherit hash;
         };
 
-        # Nomad requires Go 1.24.4, but nixpkgs doesn't have it in unstable yet.
+        # Nomad requires Go 1.24.6, but nixpkgs doesn't have it in unstable yet.
         postPatch = ''
           substituteInPlace go.mod \
-            --replace-warn "go 1.24.4" "go 1.24.3"
+            --replace-warn "go 1.24.6" "go 1.24.5"
         '';
 
         nativeBuildInputs = [ installShellFiles ];
@@ -91,9 +91,9 @@ rec {
 
   nomad_1_10 = generic {
     buildGoModule = buildGo124Module;
-    version = "1.10.3";
-    hash = "sha256-sDOo7b32H/d5OJ6CRyga1rZZk55bFTi4ynHL/aIH87w=";
-    vendorHash = "sha256-bpCnpeRk329vUd9e6x7iCh+1ouSGd4o4Hq79K0qchJ8=";
+    version = "1.10.4";
+    hash = "sha256-lQtKSU0wcrU+HEUc6N/svpf5uAaWK68G5kY/tI2Sy8Q=";
+    vendorHash = "sha256-tclD02oinoypx80TLni+DUpB5mYKRBqsmScp2VsUDc0=";
     license = lib.licenses.bsl11;
     passthru.tests.nomad = nixosTests.nomad;
     preCheck = ''


### PR DESCRIPTION
https://github.com/hashicorp/nomad/releases/tag/v1.10.4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
