### PR TITLE
nginxModules.acme: init at 0.4.1

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1078,6 +1078,7 @@ in
   nfs4 = handleTest ./nfs { version = 4; };
   nghttpx = runTest ./nghttpx.nix;
   nginx = runTest ./nginx.nix;
+  nginx-acme = runTest ./nginx-acme.nix;
   nginx-auth = runTest ./nginx-auth.nix;
   nginx-etag = runTest ./nginx-etag.nix;
   nginx-etag-compression = runTest ./nginx-etag-compression.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1153,6 +1153,7 @@ in
   nfs4 = handleTest ./nfs { version = 4; };
   nghttpx = runTest ./nghttpx.nix;
   nginx = runTest ./nginx.nix;
+  nginx-acme = runTest ./nginx-acme.nix;
   nginx-auth = runTest ./nginx-auth.nix;
   nginx-etag = runTest ./nginx-etag.nix;
   nginx-etag-compression = runTest ./nginx-etag-compression.nix;

--- a/nixos/tests/nginx-acme.nix
+++ b/nixos/tests/nginx-acme.nix
@@ -1,93 +1,97 @@
 { ... }:
 let
   domain = "example.test";
+  makeNginxConfig =
+    challenge:
+    {
+      nodes,
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      fqdn = config.networking.fqdn;
+      httpChallenge = challenge == "http";
+    in
+    {
+      security.pki.certificateFiles = [ nodes.acme.test-support.acme.caCert ];
+      services.resolved.enable = true;
+      networking.firewall.allowedTCPPorts = [
+        443
+      ]
+      ++ lib.optionals httpChallenge [ 80 ];
+      networking.domain = domain;
+      environment.systemPackages = [ pkgs.openssl ];
+      services.nginx = {
+        enable = true;
+        additionalModules = [ pkgs.nginxModules.acme ];
+        appendHttpConfig = ''
+          resolver 127.0.0.53:53;
+          acme_issuer default {
+            uri         https://${nodes.acme.test-support.acme.caDomain}/dir;
+            state_path  /var/cache/nginx/acme;
+            accept_terms_of_service;
+            challenge ${challenge};
+          }
+          acme_shared_zone zone=ngx_acme_shared:1M;
+        ''
+        + lib.optionalString httpChallenge ''
+          server {
+            server_name ${fqdn};
+            # listener on port 80 is required to process ACME HTTP-01 challenges
+            listen 0.0.0.0:80;
+            listen [::0]:80;
+
+            location / {
+              return 404;
+            }
+          }
+        '';
+        virtualHosts."${fqdn}" =
+          let
+            testroot = pkgs.runCommand "testroot" { } ''
+              mkdir -p $out
+              echo "<html><body>Hello World!</body></html>" > $out/index.html
+            '';
+          in
+          {
+            listen = [
+              {
+                addr = "0.0.0.0";
+                port = 443;
+                ssl = true;
+              }
+              {
+                addr = "[::0]";
+                port = 443;
+                ssl = true;
+              }
+            ];
+            root = testroot;
+            extraConfig = ''
+              acme_certificate default;
+
+              ssl_certificate $acme_certificate;
+              ssl_certificate_key $acme_certificate_key;
+            '';
+          };
+      };
+    };
 in
 {
   name = "nginx-acme";
 
   nodes = {
     acme =
-      { nodes, ... }:
+      { ... }:
       {
         imports = [ ./common/acme/server ];
       };
 
-    webserver =
-      {
-        nodes,
-        config,
-        lib,
-        pkgs,
-        ...
-      }:
-      let
-        fqdn = config.networking.fqdn;
-      in
-      {
-        security.pki.certificateFiles = [ nodes.acme.test-support.acme.caCert ];
-        services.resolved.enable = true;
-        networking.firewall.allowedTCPPorts = [
-          80
-          443
-        ];
-        networking.domain = domain;
-        environment.systemPackages = [ pkgs.openssl ];
-        services.nginx = {
-          enable = true;
-          package = pkgs.nginx.override {
-            withDebug = true;
-          };
-          additionalModules = [ pkgs.nginxModules.acme ];
-          # logError = "stderr debug";
-          appendHttpConfig = ''
-            resolver 127.0.0.53:53;
-            acme_issuer default {
-              uri         https://${nodes.acme.test-support.acme.caDomain}/dir;
-              state_path  /var/cache/nginx/acme;
-              accept_terms_of_service;
-            }
-            acme_shared_zone zone=ngx_acme_shared:1M;
-            server {
-              server_name ${fqdn};
-              # listener on port 80 is required to process ACME HTTP-01 challenges
-              listen 0.0.0.0:80;
-              listen [::0]:80;
+    webserverhttpchallenge = makeNginxConfig "http";
 
-              location / {
-                return 404;
-              }
-            }
-          '';
-          virtualHosts."${fqdn}" =
-            let
-              testroot = pkgs.runCommand "testroot" { } ''
-                mkdir -p $out
-                echo "<html><body>Hello World!</body></html>" > $out/index.html
-              '';
-            in
-            {
-              listen = [
-                {
-                  addr = "0.0.0.0";
-                  port = 443;
-                  ssl = true;
-                }
-                {
-                  addr = "[::0]";
-                  port = 443;
-                  ssl = true;
-                }
-              ];
-              root = testroot;
-              extraConfig = ''
-                acme_certificate default;
-
-                ssl_certificate $acme_certificate;
-                ssl_certificate_key $acme_certificate_key;
-              '';
-            };
-        };
-      };
+    webservertlschallenge = makeNginxConfig "tls-alpn";
   };
   testScript =
     { nodes, ... }:
@@ -95,15 +99,22 @@ in
       ${(import acme/utils.nix).pythonUtils}
 
       ca_domain = "${nodes.acme.test-support.acme.caDomain}"
-      fqdn = "${nodes.webserver.networking.fqdn}"
+      fqdn_http_challenge = "${nodes.webserverhttpchallenge.networking.fqdn}"
+      fqdn_tls_challenge = "${nodes.webservertlschallenge.networking.fqdn}"
 
       acme.start()
       wait_for_running(acme)
       acme.wait_for_open_port(443)
 
-      webserver.start()
-      webserver.wait_for_unit("nginx")
-      download_ca_certs(webserver, ca_domain)
-      check_connection(webserver, fqdn)
+      webserverhttpchallenge.start()
+      webservertlschallenge.start()
+
+      webserverhttpchallenge.wait_for_unit("nginx")
+      download_ca_certs(webserverhttpchallenge, ca_domain)
+      check_connection(webserverhttpchallenge, fqdn_http_challenge)
+
+      webservertlschallenge.wait_for_unit("nginx")
+      download_ca_certs(webservertlschallenge, ca_domain)
+      check_connection(webservertlschallenge, fqdn_tls_challenge)
     '';
 }

--- a/nixos/tests/nginx-acme.nix
+++ b/nixos/tests/nginx-acme.nix
@@ -1,0 +1,109 @@
+{ ... }:
+let
+  domain = "example.test";
+in
+{
+  name = "nginx-acme";
+
+  nodes = {
+    acme =
+      { nodes, ... }:
+      {
+        imports = [ ./common/acme/server ];
+      };
+
+    webserver =
+      {
+        nodes,
+        config,
+        lib,
+        pkgs,
+        ...
+      }:
+      let
+        fqdn = config.networking.fqdn;
+      in
+      {
+        security.pki.certificateFiles = [ nodes.acme.test-support.acme.caCert ];
+        services.resolved.enable = true;
+        networking.firewall.allowedTCPPorts = [
+          80
+          443
+        ];
+        networking.domain = domain;
+        environment.systemPackages = [ pkgs.openssl ];
+        services.nginx = {
+          enable = true;
+          package = pkgs.nginx.override {
+            withDebug = true;
+          };
+          additionalModules = [ pkgs.nginxModules.acme ];
+          # logError = "stderr debug";
+          appendHttpConfig = ''
+            resolver 127.0.0.53:53;
+            acme_issuer default {
+              uri         https://${nodes.acme.test-support.acme.caDomain}/dir;
+              state_path  /var/cache/nginx/acme;
+              accept_terms_of_service;
+            }
+            acme_shared_zone zone=ngx_acme_shared:1M;
+            server {
+              server_name ${fqdn};
+              # listener on port 80 is required to process ACME HTTP-01 challenges
+              listen 0.0.0.0:80;
+              listen [::0]:80;
+
+              location / {
+                return 404;
+              }
+            }
+          '';
+          virtualHosts."${fqdn}" =
+            let
+              testroot = pkgs.runCommand "testroot" { } ''
+                mkdir -p $out
+                echo "<html><body>Hello World!</body></html>" > $out/index.html
+              '';
+            in
+            {
+              listen = [
+                {
+                  addr = "0.0.0.0";
+                  port = 443;
+                  ssl = true;
+                }
+                {
+                  addr = "[::0]";
+                  port = 443;
+                  ssl = true;
+                }
+              ];
+              root = testroot;
+              extraConfig = ''
+                acme_certificate default;
+
+                ssl_certificate $acme_certificate;
+                ssl_certificate_key $acme_certificate_key;
+              '';
+            };
+        };
+      };
+  };
+  testScript =
+    { nodes, ... }:
+    ''
+      ${(import acme/utils.nix).pythonUtils}
+
+      ca_domain = "${nodes.acme.test-support.acme.caDomain}"
+      fqdn = "${nodes.webserver.networking.fqdn}"
+
+      acme.start()
+      wait_for_running(acme)
+      acme.wait_for_open_port(443)
+
+      webserver.start()
+      webserver.wait_for_unit("nginx")
+      download_ca_certs(webserver, ca_domain)
+      check_connection(webserver, fqdn)
+    '';
+}

--- a/nixos/tests/nginx-acme.nix
+++ b/nixos/tests/nginx-acme.nix
@@ -26,8 +26,8 @@ let
       services.nginx = {
         enable = true;
         additionalModules = [ pkgs.nginxModules.acme ];
+        resolver.addresses = [ "127.0.0.53:53" ];
         appendHttpConfig = ''
-          resolver 127.0.0.53:53;
           acme_issuer default {
             uri         https://${nodes.acme.test-support.acme.caDomain}/dir;
             state_path  /var/cache/nginx/acme;

--- a/nixos/tests/nginx-acme.nix
+++ b/nixos/tests/nginx-acme.nix
@@ -50,9 +50,8 @@ let
         '';
         virtualHosts."${fqdn}" =
           let
-            testroot = pkgs.runCommand "testroot" { } ''
-              mkdir -p $out
-              echo "<html><body>Hello World!</body></html>" > $out/index.html
+            testroot = pkgs.writeText "index.html" ''
+              <html><body>Hello World!</body></html>
             '';
           in
           {

--- a/nixos/tests/nginx-acme.nix
+++ b/nixos/tests/nginx-acme.nix
@@ -30,7 +30,7 @@ let
         appendHttpConfig = ''
           acme_issuer default {
             uri         https://${nodes.acme.test-support.acme.caDomain}/dir;
-            state_path  /var/cache/nginx/acme;
+            state_path  /var/lib/nginx/acme;
             accept_terms_of_service;
             challenge ${challenge};
           }
@@ -76,6 +76,7 @@ let
             '';
           };
       };
+      systemd.services.nginx.serviceConfig.StateDirectory = "nginx";
     };
 in
 {

--- a/nixos/tests/nginx-acme.nix
+++ b/nixos/tests/nginx-acme.nix
@@ -1,0 +1,120 @@
+{ ... }:
+let
+  domain = "example.test";
+  makeNginxConfig =
+    challenge:
+    {
+      nodes,
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      fqdn = config.networking.fqdn;
+      httpChallenge = challenge == "http";
+    in
+    {
+      security.pki.certificateFiles = [ nodes.acme.test-support.acme.caCert ];
+      services.resolved.enable = true;
+      networking.firewall.allowedTCPPorts = [
+        443
+      ]
+      ++ lib.optionals httpChallenge [ 80 ];
+      networking.domain = domain;
+      environment.systemPackages = [ pkgs.openssl ];
+      services.nginx = {
+        enable = true;
+        additionalModules = [ pkgs.nginxModules.acme ];
+        resolver.addresses = [ "127.0.0.53:53" ];
+        appendHttpConfig = ''
+          acme_issuer default {
+            uri         https://${nodes.acme.test-support.acme.caDomain}/dir;
+            state_path  /var/lib/nginx/acme;
+            accept_terms_of_service;
+            challenge ${challenge};
+          }
+          acme_shared_zone zone=ngx_acme_shared:1M;
+        ''
+        + lib.optionalString httpChallenge ''
+          server {
+            server_name ${fqdn};
+            # listener on port 80 is required to process ACME HTTP-01 challenges
+            listen 0.0.0.0:80;
+            listen [::0]:80;
+
+            location / {
+              return 404;
+            }
+          }
+        '';
+        virtualHosts."${fqdn}" =
+          let
+            testroot = pkgs.writeText "index.html" ''
+              <html><body>Hello World!</body></html>
+            '';
+          in
+          {
+            listen = [
+              {
+                addr = "0.0.0.0";
+                port = 443;
+                ssl = true;
+              }
+              {
+                addr = "[::0]";
+                port = 443;
+                ssl = true;
+              }
+            ];
+            root = testroot;
+            extraConfig = ''
+              acme_certificate default;
+
+              ssl_certificate $acme_certificate;
+              ssl_certificate_key $acme_certificate_key;
+            '';
+          };
+      };
+      systemd.services.nginx.serviceConfig.StateDirectory = "nginx";
+    };
+in
+{
+  name = "nginx-acme";
+
+  nodes = {
+    acme =
+      { ... }:
+      {
+        imports = [ ./common/acme/server ];
+      };
+
+    webserverhttpchallenge = makeNginxConfig "http";
+
+    webservertlschallenge = makeNginxConfig "tls-alpn";
+  };
+  testScript =
+    { nodes, ... }:
+    ''
+      ${(import acme/utils.nix).pythonUtils}
+
+      ca_domain = "${nodes.acme.test-support.acme.caDomain}"
+      fqdn_http_challenge = "${nodes.webserverhttpchallenge.networking.fqdn}"
+      fqdn_tls_challenge = "${nodes.webservertlschallenge.networking.fqdn}"
+
+      acme.start()
+      wait_for_running(acme)
+      acme.wait_for_open_port(443)
+
+      webserverhttpchallenge.start()
+      webservertlschallenge.start()
+
+      webserverhttpchallenge.wait_for_unit("nginx")
+      download_ca_certs(webserverhttpchallenge, ca_domain)
+      check_connection(webserverhttpchallenge, fqdn_http_challenge)
+
+      webservertlschallenge.wait_for_unit("nginx")
+      download_ca_certs(webservertlschallenge, ca_domain)
+      check_connection(webservertlschallenge, fqdn_tls_challenge)
+    '';
+}

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -78,8 +78,8 @@ let
             name = "acme";
             owner = "nginx";
             repo = "nginx-acme";
-            rev = "v0.1.1";
-            hash = "sha256-wnO+lDhtAvBYlaN9vg6spSsfqgHhueODeTkuWKBFswc=";
+            rev = "v0.2.0";
+            hash = "sha256-as+5cdwzpM4tvCxcgCIr877VJf4DduNTGRg29vChDnM=";
           };
           combined =
             runCommand "vendored-repo"
@@ -89,9 +89,6 @@ let
                 ];
                 cargoDeps = rustPlatform.importCargoLock {
                   lockFile = "${src}/Cargo.lock";
-                  outputHashes = {
-                    "nginx-sys-0.5.0" = "sha256-nyJofVcObsWLVe/bYCM0W7oeKwN4PlDe/ue74En+zAY=";
-                  };
                 };
               }
               ''

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -111,14 +111,12 @@ let
         openssl
         cargo
         rustPlatform.bindgenHook
-        #rustPlatform.cargoSetupHook
-        #rustPlatform.maturinBuildHook
         rustc
         pkg-config
       ];
 
       meta = with lib; {
-        description = "An NGINX module with the implementation of the automatic certificate management (ACMEv2) protocol";
+        description = "Implementation of the automatic certificate management (ACMEv2) protocol";
         homepage = "https://github.com/nginx/nginx-acme";
         license = with licenses; [ asl20 ];
         maintainers = with maintainers; [ nyanloutre ];

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -78,8 +78,8 @@ let
             name = "acme";
             owner = "nginx";
             repo = "nginx-acme";
-            rev = "v0.2.0";
-            hash = "sha256-as+5cdwzpM4tvCxcgCIr877VJf4DduNTGRg29vChDnM=";
+            rev = "v0.3.0";
+            hash = "sha256-6Jmo9yFBh//k2oc4Lsycck0doNHuyigbZ7vvIOIa3VY=";
           };
           combined =
             runCommand "vendored-repo"

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -78,8 +78,8 @@ let
             name = "acme";
             owner = "nginx";
             repo = "nginx-acme";
-            rev = "v0.3.0";
-            hash = "sha256-6Jmo9yFBh//k2oc4Lsycck0doNHuyigbZ7vvIOIa3VY=";
+            tag = "v0.3.1";
+            hash = "sha256-0oxpEI/+vQFgavjieqtgTabem78Y9ibCu/gK41tlaco=";
           };
           combined =
             runCommand "vendored-repo"

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -8,9 +8,11 @@
   fetchhg,
   runCommand,
   stdenv,
+  rustPlatform,
 
   arpa2common,
   brotli,
+  cargo,
   curl,
   expat,
   fdk_aac,
@@ -30,7 +32,9 @@
   msgpuck,
   openssl,
   pam,
+  pkg-config,
   psol,
+  rustc,
   which,
   yajl,
   zlib,
@@ -66,6 +70,64 @@ in
 
 let
   self = {
+    acme = rec {
+      name = "acme";
+      src =
+        let
+          src = fetchFromGitHub {
+            name = "acme";
+            owner = "nginx";
+            repo = "nginx-acme";
+            rev = "v0.1.1";
+            hash = "sha256-wnO+lDhtAvBYlaN9vg6spSsfqgHhueODeTkuWKBFswc=";
+          };
+          combined =
+            runCommand "vendored-repo"
+              {
+                nativeBuildInputs = [
+                  rustPlatform.cargoSetupHook
+                ];
+                cargoDeps = rustPlatform.importCargoLock {
+                  lockFile = "${src}/Cargo.lock";
+                  outputHashes = {
+                    "nginx-sys-0.5.0" = "sha256-nyJofVcObsWLVe/bYCM0W7oeKwN4PlDe/ue74En+zAY=";
+                  };
+                };
+              }
+              ''
+                mkdir -p $out
+                cp -r ${src}/* $out/
+
+                runHook postUnpack
+                cp -r cargo-vendor-dir $out/
+                cp -r .cargo $out/
+              '';
+        in
+        combined;
+
+      preConfigure = ''
+        export NGX_RUSTC_OPT="--config ${src}/.cargo/config.toml"
+        export OPENSSL_NO_VENDOR=1
+      '';
+
+      inputs = [
+        openssl
+        cargo
+        rustPlatform.bindgenHook
+        #rustPlatform.cargoSetupHook
+        #rustPlatform.maturinBuildHook
+        rustc
+        pkg-config
+      ];
+
+      meta = with lib; {
+        description = "An NGINX module with the implementation of the automatic certificate management (ACMEv2) protocol";
+        homepage = "https://github.com/nginx/nginx-acme";
+        license = with licenses; [ asl20 ];
+        maintainers = with maintainers; [ nyanloutre ];
+      };
+    };
+
     akamai-token-validate = {
       name = "akamai-token-validate";
       src = fetchFromGitHub {

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -78,8 +78,8 @@ let
             name = "acme";
             owner = "nginx";
             repo = "nginx-acme";
-            tag = "v0.3.1";
-            hash = "sha256-0oxpEI/+vQFgavjieqtgTabem78Y9ibCu/gK41tlaco=";
+            tag = "v0.4.0";
+            hash = "sha256-FWb+4JxWcD10ruAdJNj+x3YAFN5DBK9y8PL62sJBy4Y=";
           };
           combined =
             runCommand "vendored-repo"

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -78,8 +78,8 @@ let
             name = "acme";
             owner = "nginx";
             repo = "nginx-acme";
-            tag = "v0.4.0";
-            hash = "sha256-FWb+4JxWcD10ruAdJNj+x3YAFN5DBK9y8PL62sJBy4Y=";
+            tag = "v0.4.1";
+            hash = "sha256-+Nvjij/2g0AM97mhYYjkbfhhuxdFS61hx+JwtV+IwIY=";
           };
           combined =
             runCommand "vendored-repo"

--- a/pkgs/servers/http/nginx/modules/acme/package.nix
+++ b/pkgs/servers/http/nginx/modules/acme/package.nix
@@ -1,0 +1,65 @@
+{
+  fetchFromGitHub,
+  lib,
+  runCommand,
+  rustPlatform,
+  openssl,
+  cargo,
+  rustc,
+  pkg-config,
+  mkNginxPlugin,
+}:
+
+mkNginxPlugin (finalAttrs: rec {
+  pname = "acme";
+  version = "0.4.1";
+  src =
+    let
+      src = fetchFromGitHub {
+        name = "acme";
+        owner = "nginx";
+        repo = "nginx-acme";
+        tag = "v${finalAttrs.version}";
+        hash = "sha256-+Nvjij/2g0AM97mhYYjkbfhhuxdFS61hx+JwtV+IwIY=";
+      };
+      combined =
+        runCommand "vendored-repo"
+          {
+            nativeBuildInputs = [
+              rustPlatform.cargoSetupHook
+            ];
+            cargoDeps = rustPlatform.importCargoLock {
+              lockFile = "${src}/Cargo.lock";
+            };
+          }
+          ''
+            mkdir -p $out
+            cp -r ${src}/* $out/
+
+            runHook postUnpack
+            cp -r cargo-vendor-dir $out/
+            cp -r .cargo $out/
+          '';
+    in
+    combined;
+
+  preConfigure = ''
+    export NGX_RUSTC_OPT="--config ${src}/.cargo/config.toml"
+    export OPENSSL_NO_VENDOR=1
+  '';
+
+  buildInputs = [
+    openssl
+    cargo
+    rustPlatform.bindgenHook
+    rustc
+    pkg-config
+  ];
+
+  meta = with lib; {
+    description = "Implementation of the automatic certificate management (ACMEv2) protocol";
+    homepage = "https://github.com/nginx/nginx-acme";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ nyanloutre ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://blog.nginx.org/blog/native-support-for-acme-protocol

I tried to build and test the new acme module (ngx_http_acme_module) for nginx.

This is a working proof of concept, many things can still be improved.

Maybe integrate this acme module directly in NixOS nginx module so it can be enabled with a simple flag.

I asked the @NixOS/acme team for a first review.

Someone from the @Nixos/rust team could also tell me if my way of packaging a Rust module is wrong and how it could be improved ?

The test is set up for http and tls challenges.

http challenge:
```
acme # [   43.269979] pebble[596]: Pebble 2025/10/09 09:53:11 Pulled a task from the Tasks queue: &va.vaTask{Identifier:acme.Identifier{Type:"dns", Value:"webserverhttpchallenge.example.test"}, Challenge:(*core.Challenge)(0xc000282500), Account:(*core.Account)(0xc0002f7c20), AccountURL:"https://acme.test/my-account/3d59df62ca11b768", Wildcard:false}
acme # [   43.297767] pebble[596]: Pebble 2025/10/09 09:53:11 Starting 3 validations.
acme # [   43.306745] pebble[596]: Pebble 2025/10/09 09:53:11 Attempting to validate w/ HTTP: http://webserverhttpchallenge.example.test:80/.well-known/acme-challenge/11GjOFtYwRyHx6JfT6cRDMMVINZtTweEXq2J7SynNcE
acme # [   43.322176] pebble[596]: Pebble 2025/10/09 09:53:11 Attempting to validate w/ HTTP: http://webserverhttpchallenge.example.test:80/.well-known/acme-challenge/11GjOFtYwRyHx6JfT6cRDMMVINZtTweEXq2J7SynNcE
acme # [   43.344918] pebble[596]: Pebble 2025/10/09 09:53:11 Attempting to validate w/ HTTP: http://webserverhttpchallenge.example.test:80/.well-known/acme-challenge/11GjOFtYwRyHx6JfT6cRDMMVINZtTweEXq2J7SynNcE
acme # [   43.436847] pebble[596]: Pebble 2025/10/09 09:53:11 authz -DklWr01K2IqZ5CkCtNQI8mTsOyn85FwgPbHeULGDwk set VALID by completed challenge dpfAL_MaophMObc8uLQ1zhu9lgznJ1BRNnKR7hAmvk0
webserverhttpchallenge: must succeed: openssl s_client -brief -CAfile /tmp/ca.crt -verify 2 -verify_return_error -verify_hostname webserverhttpchallenge.example.test -servername webserverhttpchallenge.example.test -connect webserverhttpchallenge.example.test:443 < /dev/null
webserverhttpchallenge # Connecting to 2001:db8:1::2
webserverhttpchallenge # CONNECTION ESTABLISHED
webserverhttpchallenge # Protocol version: TLSv1.3
webserverhttpchallenge # Ciphersuite: TLS_AES_256_GCM_SHA384
webserverhttpchallenge # Peer certificate:
webserverhttpchallenge # Hash used: SHA256
webserverhttpchallenge # Signature type: ecdsa_secp256r1_sha256
webserverhttpchallenge # Verification: OK
webserverhttpchallenge # Verified peername: webserverhttpchallenge.example.test
webserverhttpchallenge # Negotiated TLS1.3 group: X25519MLKEM768
webserverhttpchallenge # DONE
webserverhttpchallenge: (finished: must succeed: openssl s_client -brief -CAfile /tmp/ca.crt -verify 2 -verify_return_error -verify_hostname webserverhttpchallenge.example.test -servername webserverhttpchallenge.example.test -connect webserverhttpchallenge.example.test:443 < /dev/null, in 0.13 seconds)
```

tls challenge:
```
acme # [   42.177498] pebble[596]: Pebble 2025/10/09 09:53:10 Pulled a task from the Tasks queue: &va.vaTask{Identifier:acme.Identifier{Type:"dns", Value:"webservertlschallenge.example.test"}, Challenge:(*core.Challenge)(0xc000095ae0), Account:(*core.Account)(0xc0002464e0), AccountURL:"https://acme.test/my-account/5d69c863072762df", Wildcard:false}
acme # [   42.197322] pebble[596]: Pebble 2025/10/09 09:53:10 Starting 3 validations.
acme # [   42.269646] pebble[596]: Pebble 2025/10/09 09:53:10 authz Rg0gFMztw5ozJjVKq5Whmr5SuG7aehfyVSv4GeA0eXQ set VALID by completed challenge JXhKYxrFanv83taBrX_mUqJ5wKhvhd_EgHl3O-GZrz4
webservertlschallenge: must succeed: openssl s_client -brief -CAfile /tmp/ca.crt -verify 2 -verify_return_error -verify_hostname webservertlschallenge.example.test -servername webservertlschallenge.example.test -connect webservertlschallenge.example.test:443 < /dev/null
webservertlschallenge # Connecting to 2001:db8:1::3
webservertlschallenge # CONNECTION ESTABLISHED
webservertlschallenge # Protocol version: TLSv1.3
webservertlschallenge # Ciphersuite: TLS_AES_256_GCM_SHA384
webservertlschallenge # Peer certificate:
webservertlschallenge # Hash used: SHA256
webservertlschallenge # Signature type: ecdsa_secp256r1_sha256
webservertlschallenge # Verification: OK
webservertlschallenge # Verified peername: webservertlschallenge.example.test
webservertlschallenge # Negotiated TLS1.3 group: X25519MLKEM768
webservertlschallenge # DONE
webservertlschallenge: (finished: must succeed: openssl s_client -brief -CAfile /tmp/ca.crt -verify 2 -verify_return_error -verify_hostname webservertlschallenge.example.test -servername webservertlschallenge.example.test -connect webservertlschallenge.example.test:443 < /dev/null, in 0.17 seconds)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
