### PR TITLE
qrtool: 0.11.8 -> 0.12.1

### DIFF
--- a/pkgs/by-name/qr/qrtool/package.nix
+++ b/pkgs/by-name/qr/qrtool/package.nix
@@ -7,14 +7,14 @@
   installShellFiles,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "qrtool";
   version = "0.12.1";
 
   src = fetchFromGitHub {
     owner = "sorairolake";
     repo = "qrtool";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-I/LyDHV3pbRj+utzJBLvkgstEOodLkvfQT6uMLnOEgM=";
   };
 
@@ -36,12 +36,12 @@ rustPlatform.buildRustPackage rec {
       --zsh <($out/bin/qrtool completion zsh)
   '';
 
-  meta = with lib; {
-    maintainers = with maintainers; [ philiptaron ];
+  meta = {
     description = "Utility for encoding and decoding QR code images";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     homepage = "https://sorairolake.github.io/qrtool/book/index.html";
     changelog = "https://sorairolake.github.io/qrtool/book/changelog.html";
     mainProgram = "qrtool";
+    maintainers = with lib.maintainers; [ philiptaron ];
   };
-}
+})

--- a/pkgs/by-name/qr/qrtool/package.nix
+++ b/pkgs/by-name/qr/qrtool/package.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "qrtool";
-  version = "0.11.8";
+  version = "0.12.1";
 
   src = fetchFromGitHub {
     owner = "sorairolake";
     repo = "qrtool";
     rev = "v${version}";
-    hash = "sha256-f/2AaNnojtZMhJod6ukLwEq+Bsu6O2oTD9OWGL8IS80=";
+    hash = "sha256-I/LyDHV3pbRj+utzJBLvkgstEOodLkvfQT6uMLnOEgM=";
   };
 
-  cargoHash = "sha256-wXs3Y0g+inUU3Qho5UhZOJhNDs65HS6FjPdZQBuwLM0=";
+  cargoHash = "sha256-c1sw0zyJZDvJe3Hcn1W4UPkqTKqRhywHpR6HLrqAN+A=";
 
   nativeBuildInputs = [
     asciidoctor
@@ -28,13 +28,12 @@ rustPlatform.buildRustPackage rec {
   postInstall = ''
     # Built by ./build.rs using `asciidoctor`
     installManPage ./target/*/release/build/qrtool*/out/*.?
-
   ''
   + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd qrtool \
-      --bash <($out/bin/qrtool --generate-completion bash) \
-      --fish <($out/bin/qrtool --generate-completion fish) \
-      --zsh <($out/bin/qrtool --generate-completion zsh)
+      --bash <($out/bin/qrtool completion bash) \
+      --fish <($out/bin/qrtool completion fish) \
+      --zsh <($out/bin/qrtool completion zsh)
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Diff: https://github.com/sorairolake/qrtool/compare/v0.11.8...v0.12.1
Changelog: https://sorairolake.github.io/qrtool/book/changelog.html

Resolves #433624.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
