### PR TITLE
flake: split into multiple files

### DIFF
--- a/doc/flake-support.nix
+++ b/doc/flake-support.nix
@@ -1,0 +1,4 @@
+{ lib, imports, ... }:
+{
+  outputs.htmlDocs.nixpkgsManual = lib.mapAttrs (_: jobSet: jobSet.manual) imports.pkgs.jobs;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,269 +1,54 @@
-# Experimental flake interface to Nixpkgs.
-# See https://github.com/NixOS/rfcs/pull/49 for details.
+/*
+  The Nixpkgs flake interface. Flakes are experimental—see
+  https://github.com/NixOS/rfcs/pull/49 for details.
+
+  This file and the other `flake-support.nix` files involved compose together
+  to create the flake interface. This composition logic could be implemented
+  in various different ways. For example, the logic could be more abstract,
+  making use of `lib.recursiveUpdate` and overall fewer lines of code in this
+  file. Another example is usage of the Nixpkgs module system, benefiting from
+  its option value merging feature and arguably some type checking.
+
+  But the ability to understand this highly visible implementation without the
+  need for Nix expertise was determined to be important. Also, any
+  implementation in which the output data structure is not a hard-coded literal
+  would unfortunately mean that in order for some attributes to evaluate, some
+  files that are in essence unnecessary for that evaluation would be nonetheless
+  evaluated to some extent—a performance penalty that is deemed highly
+  undesirable considering the pervasive use of this interface.
+*/
 {
   description = "A collection of packages for the Nix package manager";
 
   outputs =
     { self }:
     let
-      libVersionInfoOverlay = import ./lib/flake-version-info.nix self;
-      lib = (import ./lib).extend libVersionInfoOverlay;
+      lib = import ./lib;
 
-      forAllSystems = lib.genAttrs lib.systems.flakeExposed;
+      args = { inherit directories lib self; };
 
-      jobs = forAllSystems (
-        system:
-        import ./pkgs/top-level/release.nix {
-          nixpkgs = self;
-          inherit system;
-        }
-      );
+      directories = {
+        lib = import ./lib/flake-support.nix args;
+        pkgs = import ./pkgs/top-level/flake-support.nix args;
+        nixos = import ./nixos/flake-support.nix args;
+        doc = import ./doc/flake-support.nix args;
+        devShell = import ./flake/dev-shell.nix args;
+        formatter = import ./flake/formatter.nix args;
+      };
     in
     {
-      /**
-        `nixpkgs.lib` is a combination of the [Nixpkgs library](https://nixos.org/manual/nixpkgs/unstable/#id-1.4), and other attributes
-        that are _not_ part of the Nixpkgs library, but part of the Nixpkgs flake:
-
-        - `lib.nixosSystem` for creating a NixOS system configuration
-
-        - `lib.nixos` for other NixOS-provided functionality, such as [`runTest`](https://nixos.org/manual/nixos/unstable/#sec-call-nixos-test-outside-nixos)
-      */
-      # DON'T USE lib.extend TO ADD NEW FUNCTIONALITY.
-      # THIS WAS A MISTAKE. See the warning in lib/default.nix.
-      lib = lib.extend (
-        final: prev: {
-
-          /**
-            Other NixOS-provided functionality, such as [`runTest`](https://nixos.org/manual/nixos/unstable/#sec-call-nixos-test-outside-nixos).
-            See also `lib.nixosSystem`.
-          */
-          nixos = import ./nixos/lib { lib = final; };
-
-          /**
-            Create a NixOS system configuration.
-
-            Example:
-
-                lib.nixosSystem {
-                  modules = [ ./configuration.nix ];
-                }
-
-            Inputs:
-
-            - `modules` (list of paths or inline modules): The NixOS modules to include in the system configuration.
-
-            - `specialArgs` (attribute set): Extra arguments to pass to all modules, that are available in `imports` but can not be extended or overridden by the `modules`.
-
-            - `modulesLocation` (path): A default location for modules that aren't passed by path, used for error messages.
-
-            Legacy inputs:
-
-            - `system`: Legacy alias for `nixpkgs.hostPlatform`, but this is already set in the generated `hardware-configuration.nix`, included by `configuration.nix`.
-            - `pkgs`: Legacy alias for `nixpkgs.pkgs`; use `nixpkgs.pkgs` and `nixosModules.readOnlyPkgs` instead.
-          */
-          nixosSystem =
-            args:
-            import ./nixos/lib/eval-config.nix (
-              {
-                lib = final;
-                # Allow system to be set modularly in nixpkgs.system.
-                # We set it to null, to remove the "legacy" entrypoint's
-                # non-hermetic default.
-                system = null;
-
-                modules = args.modules ++ [
-                  # This module is injected here since it exposes the nixpkgs self-path in as
-                  # constrained of contexts as possible to avoid more things depending on it and
-                  # introducing unnecessary potential fragility to changes in flakes itself.
-                  #
-                  # See: failed attempt to make pkgs.path not copy when using flakes:
-                  # https://github.com/NixOS/nixpkgs/pull/153594#issuecomment-1023287913
-                  (
-                    {
-                      config,
-                      pkgs,
-                      lib,
-                      ...
-                    }:
-                    {
-                      config.nixpkgs.flake.source = self.outPath;
-                    }
-                  )
-                ];
-              }
-              // removeAttrs args [ "modules" ]
-            );
-        }
-      );
-
-      checks = forAllSystems (
-        system:
-        { }
-        //
-          lib.optionalAttrs
-            (
-              # Exclude x86_64-freebsd because "Failed to evaluate rustc-wrapper-1.85.0: «broken»: is marked as broken"
-              system != "x86_64-freebsd"
-            )
-            {
-              tarball = jobs.${system}.tarball;
-            }
-        //
-          lib.optionalAttrs
-            (
-              self.legacyPackages.${system}.stdenv.hostPlatform.isLinux
-              # Exclude power64 due to "libressl is not available on the requested hostPlatform" with hostPlatform being power64
-              && !self.legacyPackages.${system}.stdenv.targetPlatform.isPower64
-              # Exclude armv6l-linux because "cannot bootstrap GHC on this platform ('armv6l-linux' with libc 'defaultLibc')"
-              && system != "armv6l-linux"
-              # Exclude armv7l-linux because "cannot bootstrap GHC on this platform ('armv7l-linux' with libc 'defaultLibc')"
-              && system != "armv7l-linux"
-              # Exclude powerpc64le-linux because "cannot bootstrap GHC on this platform ('powerpc64le-linux' with libc 'defaultLibc')"
-              && system != "powerpc64le-linux"
-              # Exclude riscv64-linux because "cannot bootstrap GHC on this platform ('riscv64-linux' with libc 'defaultLibc')"
-              && system != "riscv64-linux"
-            )
-            {
-              # Test that ensures that the nixosSystem function can accept a lib argument
-              # Note: prefer not to extend or modify `lib`, especially if you want to share reusable modules
-              #       alternatives include: `import` a file, or put a custom library in an option or in `_module.args.<libname>`
-              nixosSystemAcceptsLib =
-                (self.lib.nixosSystem {
-                  pkgs = self.legacyPackages.${system};
-                  lib = self.lib.extend (
-                    final: prev: {
-                      ifThisFunctionIsMissingTheTestFails = final.id;
-                    }
-                  );
-                  modules = [
-                    ./nixos/modules/profiles/minimal.nix
-                    (
-                      { lib, ... }:
-                      lib.ifThisFunctionIsMissingTheTestFails {
-                        # Define a minimal config without eval warnings
-                        nixpkgs.hostPlatform = "x86_64-linux";
-                        boot.loader.grub.enable = false;
-                        fileSystems."/".device = "nodev";
-                        fileSystems."/".fsType = "none";
-                        # See https://search.nixos.org/options?show=system.stateVersion&query=stateversion
-                        system.stateVersion = lib.trivial.release; # DON'T do this in real configs!
-                      }
-                    )
-                  ];
-                }).config.system.build.toplevel;
-            }
-      );
-
+      inherit (directories.lib.outputs) lib;
+      inherit (directories.pkgs.outputs) legacyPackages;
+      checks = lib.zipAttrsWith (name: lib.foldl lib.mergeAttrs { }) [
+        directories.pkgs.outputs.checks
+        directories.nixos.outputs.checks
+      ];
       htmlDocs = {
-        nixpkgsManual = builtins.mapAttrs (_: jobSet: jobSet.manual) jobs;
-        nixosManual =
-          (import ./nixos/release-small.nix {
-            nixpkgs = self;
-          }).nixos.manual;
+        inherit (directories.nixos.outputs.htmlDocs) nixosManual;
+        inherit (directories.doc.outputs.htmlDocs) nixpkgsManual;
       };
-
-      devShells = forAllSystems (
-        system:
-        { }
-        //
-          lib.optionalAttrs
-            (
-              # Exclude armv6l-linux because "Package ‘ghc-9.6.6’ in .../pkgs/development/compilers/ghc/common-hadrian.nix:579 is not available on the requested hostPlatform"
-              system != "armv6l-linux"
-              # Exclude armv7l-linux because "cannot bootstrap GHC on this platform ('armv7l-linux' with libc 'defaultLibc')"
-              && system != "armv7l-linux"
-              # Exclude powerpc64le-linux because "cannot bootstrap GHC on this platform ('powerpc64le-linux' with libc 'defaultLibc')"
-              && system != "powerpc64le-linux"
-              # Exclude riscv64-linux because "Package ‘ghc-9.6.6’ in .../pkgs/development/compilers/ghc/common-hadrian.nix:579 is not available on the requested hostPlatform"
-              && system != "riscv64-linux"
-              # Exclude x86_64-freebsd because "Package ‘ghc-9.6.6’ in .../pkgs/development/compilers/ghc/common-hadrian.nix:579 is not available on the requested hostPlatform"
-              && system != "x86_64-freebsd"
-            )
-            {
-              /**
-                A shell to get tooling for Nixpkgs development. See nixpkgs/shell.nix.
-              */
-              default = import ./shell.nix { inherit system; };
-            }
-      );
-
-      formatter = lib.filterAttrs (
-        system: _:
-        # Exclude armv6l-linux because "cannot bootstrap GHC on this platform ('armv6l-linux' with libc 'defaultLibc')"
-        system != "armv6l-linux"
-        # Exclude armv7l-linux because "cannot bootstrap GHC on this platform ('armv7l-linux' with libc 'defaultLibc')"
-        && system != "armv7l-linux"
-        # Exclude powerpc64le-linux because "cannot bootstrap GHC on this platform ('powerpc64le-linux' with libc 'defaultLibc')"
-        && system != "powerpc64le-linux"
-        # Exclude riscv64-linux because "cannot bootstrap GHC on this platform ('riscv64-linux' with libc 'defaultLibc')"
-        && system != "riscv64-linux"
-        # Exclude x86_64-freebsd because "Package ‘go-1.22.12-freebsd-amd64-bootstrap’ in /nix/store/0yw40qnrar3lvc5hax5n49abl57apjbn-source/pkgs/development/compilers/go/binary.nix:50 is not available on the requested hostPlatform"
-        && system != "x86_64-freebsd"
-      ) (forAllSystems (system: (import ./ci { inherit system; }).fmt.pkg));
-
-      /**
-        A nested structure of [packages](https://nix.dev/manual/nix/latest/glossary#package-attribute-set) and other values.
-
-        The "legacy" in `legacyPackages` doesn't imply that the packages exposed
-        through this attribute are "legacy" packages. Instead, `legacyPackages`
-        is used here as a substitute attribute name for `packages`. The problem
-        with `packages` is that it makes operations like `nix flake show
-        nixpkgs` unusably slow due to the sheer number of packages the Nix CLI
-        needs to evaluate. But when the Nix CLI sees a `legacyPackages`
-        attribute it displays `omitted` instead of evaluating all packages,
-        which keeps `nix flake show` on Nixpkgs reasonably fast, though less
-        information rich.
-
-        The reason why finding the tree structure of `legacyPackages` is slow,
-        is that for each attribute in the tree, it is necessary to check whether
-        the attribute value is a package or a package set that needs further
-        evaluation. Evaluating the attribute value tends to require a significant
-        amount of computation, even considering lazy evaluation.
-      */
-      legacyPackages = forAllSystems (
-        system:
-        (import ./. {
-          inherit system;
-          overlays = import ./pkgs/top-level/impure-overlays.nix ++ [
-            (final: prev: {
-              lib = prev.lib.extend libVersionInfoOverlay;
-            })
-          ];
-        })
-      );
-
-      /**
-        Optional modules that can be imported into a NixOS configuration.
-
-        Example:
-
-            # flake.nix
-            outputs = { nixpkgs, ... }: {
-              nixosConfigurations = {
-                foo = nixpkgs.lib.nixosSystem {
-                  modules = [
-                    ./foo/configuration.nix
-                    nixpkgs.nixosModules.notDetected
-                  ];
-                };
-              };
-            };
-      */
-      nixosModules = {
-        notDetected = ./nixos/modules/installer/scan/not-detected.nix;
-
-        /**
-          Make the `nixpkgs.*` configuration read-only. Guarantees that `pkgs`
-          is the way you initialize it.
-
-          Example:
-
-              {
-                imports = [ nixpkgs.nixosModules.readOnlyPkgs ];
-                nixpkgs.pkgs = nixpkgs.legacyPackages.x86_64-linux;
-              }
-        */
-        readOnlyPkgs = ./nixos/modules/misc/nixpkgs/read-only.nix;
-      };
+      inherit (directories.nixos.outputs) nixosModules;
+      inherit (directories.devShell.outputs) devShells;
+      inherit (directories.formatter.outputs) formatter;
     };
 }

--- a/flake/dev-shell.nix
+++ b/flake/dev-shell.nix
@@ -1,0 +1,19 @@
+{ lib, ... }:
+{
+  outputs.devShells =
+    lib.genAttrs
+      (lib.filter (
+        system:
+        # Because "Package ‘ghc-9.6.6’ in .../pkgs/development/compilers/ghc/common-hadrian.nix:579 is not available on the requested hostPlatform"
+        !lib.elem system [
+          "armv6l-linux"
+          "armv7l-linux"
+          "powerpc64le-linux"
+          "riscv64-linux"
+          "x86_64-freebsd"
+        ]
+      ) lib.systems.flakeExposed)
+      (system: {
+        default = import ../shell.nix { inherit system; };
+      });
+}

--- a/flake/fake.nix
+++ b/flake/fake.nix
@@ -1,0 +1,13 @@
+let
+  flake-compat = import (
+    builtins.fetchTarball {
+      url = "https://git.lix.systems/lix-project/flake-compat/archive/549f2762aebeff29a2e5ece7a7dc0f955281a1d1.tar.gz";
+      sha256 = "sha256:0g4izwn5k7qpavlk3w41a92rhnp4plr928vmrhc75041vzm3vb1l";
+    }
+  );
+  flake = flake-compat {
+    src = ../.;
+    copySourceTreeToStore = false;
+  };
+in
+flake.defaultNix

--- a/flake/formatter.nix
+++ b/flake/formatter.nix
@@ -1,0 +1,18 @@
+{ lib, ... }:
+{
+  outputs.formatter = lib.genAttrs (lib.filter (
+    system:
+    !lib.elem system [
+      # Because "cannot bootstrap GHC on this platform ('armv6l-linux' with libc 'defaultLibc')"
+      "armv6l-linux"
+      # Exclude armv7l-linux because "cannot bootstrap GHC on this platform ('armv7l-linux' with libc 'defaultLibc')"
+      "armv7l-linux"
+      # Exclude powerpc64le-linux because "cannot bootstrap GHC on this platform ('powerpc64le-linux' with libc 'defaultLibc')"
+      "powerpc64le-linux"
+      # Because "cannot bootstrap GHC on this platform ('riscv64-linux' with libc 'defaultLibc')"
+      "riscv64-linux"
+      # Because "Package ‘go-1.22.12-freebsd-amd64-bootstrap’ in /nix/store/0yw40qnrar3lvc5hax5n49abl57apjbn-source/pkgs/development/compilers/go/binary.nix:50 is not available on the requested hostPlatform"
+      "x86_64-freebsd"
+    ]
+  ) lib.systems.flakeExposed) (system: (import ../ci { inherit system; }).fmt.pkg);
+}

--- a/lib/flake-support.nix
+++ b/lib/flake-support.nix
@@ -1,0 +1,19 @@
+{
+  imports,
+  lib,
+  self,
+}:
+let
+  flakeVersionInfoOverlay = (import ./flake-version-info.nix self);
+in
+{
+  # The `lib` flake output is the [Nixpkgs library](https://nixos.org/manual/nixpkgs/unstable/#id-1.4)
+  # extended with some additional attributes. Those are defined in other flake modules, such as the NixOS one.
+  #
+  # DON'T USE `lib.extend` TO ADD NEW FUNCTIONALITY.
+  # THIS WAS A MISTAKE. See the warning in `./default.nix`.
+  outputs.lib = lib.foldl (cur: overlay: cur.extend overlay) lib [
+    flakeVersionInfoOverlay
+    imports.nixos.libOverlay
+  ];
+}

--- a/nixos/flake-support.nix
+++ b/nixos/flake-support.nix
@@ -1,0 +1,146 @@
+{ lib, self, ... }:
+{
+  libOverlay = (
+    final: prev: {
+      /**
+        Other NixOS-provided functionality, such as [`runTest`](https://nixos.org/manual/nixos/unstable/#sec-call-nixos-test-outside-nixos).
+        See also `lib.nixosSystem`.
+      */
+      nixos = import ./lib { lib = final; };
+
+      /**
+        Create a NixOS system configuration.
+
+        Example:
+
+            lib.nixosSystem {
+              modules = [ ./configuration.nix ];
+            }
+
+        Inputs:
+
+        - `modules` (list of paths or inline modules): The NixOS modules to include in the system configuration.
+
+        - `specialArgs` (attribute set): Extra arguments to pass to all modules, that are available in `imports` but can not be extended or overridden by the `modules`.
+
+        - `modulesLocation` (path): A default location for modules that aren't passed by path, used for error messages.
+
+        Legacy inputs:
+
+        - `system`: Legacy alias for `nixpkgs.hostPlatform`, but this is already set in the generated `hardware-configuration.nix`, included by `configuration.nix`.
+        - `pkgs`: Legacy alias for `nixpkgs.pkgs`; use `nixpkgs.pkgs` and `nixosModules.readOnlyPkgs` instead.
+      */
+      nixosSystem =
+        args:
+        import ./lib/eval-config.nix (
+          {
+            lib = final;
+            # Allow system to be set modularly in nixpkgs.system.
+            # We set it to null, to remove the "legacy" entrypoint's
+            # non-hermetic default.
+            system = null;
+
+            modules = args.modules ++ [
+              # This module is injected here since it exposes the nixpkgs self-path in as
+              # constrained of contexts as possible to avoid more things depending on it and
+              # introducing unnecessary potential fragility to changes in flakes itself.
+              #
+              # See: failed attempt to make pkgs.path not copy when using flakes:
+              # https://github.com/NixOS/nixpkgs/pull/153594#issuecomment-1023287913
+              {
+                config.nixpkgs.flake.source = self.outPath;
+              }
+            ];
+          }
+          // builtins.removeAttrs args [ "modules" ]
+        );
+    }
+  );
+
+  outputs = {
+    checks =
+      # Test that ensures that the nixosSystem function can accept a lib argument
+      # Note: prefer not to extend or modify `lib`, especially if you want to share reusable modules
+      #       alternatives include: `import` a file, or put a custom library in an option or in `_module.args.<libname>`
+      lib.genAttrs
+        (lib.filter (
+          system:
+          self.legacyPackages.${system}.stdenv.hostPlatform.isLinux
+          # Exclude power64 due to "libressl is not available on the requested hostPlatform" with hostPlatform being power64
+          && !self.legacyPackages.${system}.targetPlatform.isPower64
+          # Exclude armv6l-linux because "cannot bootstrap GHC on this platform ('armv6l-linux' with libc 'defaultLibc')"
+          && system != "armv6l-linux"
+          # Exclude armv7l-linux because "cannot bootstrap GHC on this platform ('armv7l-linux' with libc 'defaultLibc')"
+          && system != "armv7l-linux"
+          # Exclude powerpc64le-linux because "cannot bootstrap GHC on this platform ('powerpc64le-linux' with libc 'defaultLibc')"
+          && system != "powerpc64le-linux"
+          # Exclude riscv64-linux because "cannot bootstrap GHC on this platform ('riscv64-linux' with libc 'defaultLibc')"
+          && system != "riscv64-linux"
+        ) lib.systems.flakeExposed)
+        (system: {
+          nixosSystemAcceptsLib =
+            (self.lib.nixosSystem {
+              pkgs = self.legacyPackages.${system};
+              lib = self.lib.extend (
+                final: prev: {
+                  ifThisFunctionIsMissingTheTestFails = final.id;
+                }
+              );
+              modules = [
+                ./modules/profiles/minimal.nix
+                (
+                  { lib, ... }:
+                  lib.ifThisFunctionIsMissingTheTestFails {
+                    # Define a minimal config without eval warnings
+                    nixpkgs.hostPlatform = "x86_64-linux";
+                    boot.loader.grub.enable = false;
+                    fileSystems."/".device = "nodev";
+                    fileSystems."/".fsType = "none";
+                    # See https://search.nixos.org/options?show=system.stateVersion&query=stateversion
+                    system.stateVersion = lib.trivial.release; # DON'T do this in real configs!
+                  }
+                )
+              ];
+            }).config.system.build.toplevel;
+        });
+
+    htmlDocs.nixosManual =
+      (import ./release-small.nix {
+        nixpkgs = self;
+      }).nixos.manual;
+
+    /**
+      Optional modules that can be imported into a NixOS configuration.
+
+      Example:
+
+          # flake.nix
+          outputs = { nixpkgs, ... }: {
+            nixosConfigurations = {
+              foo = nixpkgs.lib.nixosSystem {
+                modules = [
+                  ./foo/configuration.nix
+                  nixpkgs.nixosModules.notDetected
+                ];
+              };
+            };
+          };
+    */
+    nixosModules = {
+      notDetected = ./modules/installer/scan/not-detected.nix;
+
+      /**
+        Make the `nixpkgs.*` configuration read-only. Guarantees that `pkgs`
+        is the way you initialize it.
+
+        Example:
+
+            {
+              imports = [ nixpkgs.nixosModules.readOnlyPkgs ];
+              nixpkgs.pkgs = nixpkgs.legacyPackages.x86_64-linux;
+            }
+      */
+      readOnlyPkgs = ./modules/misc/nixpkgs/read-only.nix;
+    };
+  };
+}

--- a/pkgs/top-level/flake-support.nix
+++ b/pkgs/top-level/flake-support.nix
@@ -1,0 +1,38 @@
+{ lib, self, ... }:
+let
+  jobs = lib.genAttrs lib.systems.flakeExposed (
+    system:
+    import ./release.nix {
+      nixpkgs = self;
+      inherit system;
+    }
+  );
+in
+{
+  inherit jobs;
+
+  outputs = {
+    legacyPackages = lib.genAttrs lib.systems.flakeExposed (
+      system:
+      import ../.. {
+        inherit system;
+        overlays = import ./impure-overlays.nix ++ [
+          (final: prev: {
+            lib = prev.lib.extend (import ../../lib/flake-version-info.nix self);
+          })
+        ];
+      }
+    );
+
+    checks =
+      lib.genAttrs
+        (lib.filter (
+          system:
+          # Exclude x86_64-freebsd because "Failed to evaluate rustc-wrapper-1.85.0: «broken»: is marked as broken"
+          system != "x86_64-freebsd"
+        ) lib.systems.flakeExposed)
+        (system: {
+          inherit (jobs.${system}) tarball;
+        });
+  };
+}


### PR DESCRIPTION
Following up from #431169.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
