### PR TITLE
python313Packages.pyworxcloud: init at 4.1.43

### DIFF
--- a/pkgs/development/python-modules/pyworxcloud/default.nix
+++ b/pkgs/development/python-modules/pyworxcloud/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  paho-mqtt,
+  requests,
+  urllib3,
+}:
+
+buildPythonPackage rec {
+  pname = "pyworxcloud";
+  version = "4.1.43";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "MTrab";
+    repo = "pyworxcloud";
+    tag = "v${version}";
+    hash = "sha256-DMkyek9Y3vQnzcds5MUALVH3o1dW6X6eIkurFC8rLO4=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    paho-mqtt
+    requests
+    urllib3
+  ];
+
+  pythonImportsCheck = [ "pyworxcloud" ];
+
+  # Module has no tests
+  doCheck = false;
+
+  meta = {
+    description = "Module for integrating with Worx Cloud devices";
+    homepage = "https://github.com/MTrab/pyworxcloud";
+    changelog = "https://github.com/MTrab/pyworxcloud/releases/tag/${src.tag}";
+    license = with lib.licenses; [
+      gpl3Only
+      mit
+    ];
+    maintainers = with lib.maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15205,6 +15205,8 @@ self: super: with self; {
 
   pyworld = callPackage ../development/python-modules/pyworld { };
 
+  pyworxcloud = callPackage ../development/python-modules/pyworxcloud { };
+
   pyws66i = callPackage ../development/python-modules/pyws66i { };
 
   pyx = callPackage ../development/python-modules/pyx { };


### PR DESCRIPTION
Module for integrating with Worx Cloud devices

https://github.com/MTrab/pyworxcloud

Closes #310128
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
