### PR TITLE
vector: 0.48.0 → 0.49.0

### DIFF
--- a/nixos/tests/vector/dnstap.nix
+++ b/nixos/tests/vector/dnstap.nix
@@ -268,17 +268,40 @@ in
       tableDDL = pkgs.writeText "table.sql" ''
         CREATE TABLE IF NOT EXISTS dnstap.records (
           timestamp DateTime64(6),
-          dataType LowCardinality(String),
-          dataTypeId UInt8,
-          messageType LowCardinality(String),
-          messageTypeId UInt8,
+          dataType Enum('Message' = 1),
+          messageType Enum(
+            'AuthQuery' = 1,
+            'AuthResponse' = 2,
+            'ResolverQuery' = 3,
+            'ResolverResponse' = 4,
+            'ClientQuery' = 5,
+            'ClientResponse' = 6,
+            'ForwarderQuery' = 7,
+            'ForwarderResponse' = 8,
+            'StubQuery' = 9,
+            'StubResponse' = 10,
+            'ToolQuery' = 11,
+            'ToolResponse' = 12,
+            'UpdateQuery' = 13,
+            'UpdateResponse' = 14
+          ),
+          queryZone Nullable(String),
           requestData Nullable(JSON),
+          responseAddress String,
           responseData Nullable(JSON),
           responsePort UInt16,
           serverId LowCardinality(String),
           serverVersion LowCardinality(String),
-          socketFamily LowCardinality(String),
-          socketProtocol LowCardinality(String),
+          socketFamily Enum('INET' = 1, 'INET6' = 2),
+          socketProtocol Enum(
+            'UDP' = 1,
+            'TCP' = 2,
+            'DOT' = 3,
+            'DOH' = 4,
+            'DNSCryptUDP' = 5,
+            'DNSCryptTCP' = 6,
+            'DOQ' = 7
+          ),
           sourceAddress String,
           sourcePort UInt16,
         )
@@ -304,7 +327,7 @@ in
           JSONExtractString(requestData.question[1]::String, 'domainName') as domain,
           JSONExtractString(requestData.question[1]::String, 'questionType') as record_type
         FROM dnstap.records
-        WHERE messageTypeId = 5 # ClientQuery
+        WHERE messageType = 'ClientQuery'
       '';
 
       selectDomainCountQuery = pkgs.writeText "select-domain-count.sql" ''

--- a/pkgs/by-name/ve/vector/package.nix
+++ b/pkgs/by-name/ve/vector/package.nix
@@ -25,7 +25,7 @@
 
 let
   pname = "vector";
-  version = "0.48.0";
+  version = "0.49.0";
 in
 rustPlatform.buildRustPackage {
   inherit pname version;
@@ -34,10 +34,10 @@ rustPlatform.buildRustPackage {
     owner = "vectordotdev";
     repo = "vector";
     rev = "v${version}";
-    hash = "sha256-qgf3aMZc1cgPlsAzgtaXLUx99KwN5no1amdkwFVyl4Y=";
+    hash = "sha256-sow1BFJgwOOajJ7dTmoUNJ3OpI9/73Uigrcb1CIBOE8=";
   };
 
-  cargoHash = "sha256-t8mfZpLrzrxj1WUpJPqZWyfBf9XobcqZY/hAeVGzhcM=";
+  cargoHash = "sha256-a7923ubtads5ZLjc+27RHtPFKmgv0aMOxiSrvIVr5VA=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
* https://github.com/vectordotdev/vector/releases/tag/v0.49.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
