### PR TITLE
lib: fix overflowing `fromHexString` tests and example

### DIFF
--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -390,6 +390,30 @@ runTests {
     expected = 15;
   };
 
+  # FIXME: This might be bad and should potentially be deprecated.
+  testFromHexStringQuestionableMixedCase = {
+    expr = fromHexString "eEeEe";
+    expected = 978670;
+  };
+
+  # FIXME: This is probably bad and should potentially be deprecated.
+  testFromHexStringQuestionableUnderscore = {
+    expr = fromHexString "F_f";
+    expected = 255;
+  };
+
+  # FIXME: This is definitely bad and should be deprecated.
+  testFromHexStringBadComment = {
+    expr = fromHexString "0 # oops";
+    expected = 0;
+  };
+
+  # FIXME: Oh my god.
+  testFromHexStringAwfulInjection = {
+    expr = fromHexString "1\nwhoops = {}";
+    expected = 1;
+  };
+
   testToBaseDigits = {
     expr = toBaseDigits 2 6;
     expected = [

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -380,8 +380,9 @@ runTests {
     expected = 255;
   };
 
-  testFromHexStringSecondExample = {
-    expr = fromHexString (builtins.hashString "sha256" "test");
+  # Highest supported integer value in Nix.
+  testFromHexStringMaximum = {
+    expr = fromHexString "7fffffffffffffff";
     expected = 9223372036854775807;
   };
 

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -1114,7 +1114,7 @@ in
     fromHexString "FF"
     => 255
 
-    fromHexString (builtins.hashString "sha256" "test")
+    fromHexString "0x7fffffffffffffff"
     => 9223372036854775807
     ```
   */


### PR DESCRIPTION
`fromHexString` is backed by `builtins.fromTOML`. Per [the TOML v1.0.0 specification]:

> Arbitrary 64-bit signed integers (from −2^63 to 2^63−1) should be
> accepted and handled losslessly. If an integer cannot be represented
> losslessly, an error must be thrown.

[the TOML v1.0.0 specification]: <https://toml.io/en/v1.0.0#integer>

The saturating behaviour of the toml11 version currently used by Nix is not lossless, and is therefore a violation of the TOML specification. We should not be relying on it. This blocks the update of toml11, as it became stricter about reporting this condition.

This, yes, is arguably an evaluation compatibility break. However, integer overflow was recently explicitly defined as an error by both Nix and Lix, as opposed to the C++ undefined behaviour it was previously implemented as:

* <https://nix.dev/manual/nix/stable/release-notes/rl-2.25>
* <https://docs.lix.systems/manual/lix/stable/release-notes/rl-2.91.html#fixes>

This included changing `builtins.fromJSON` to explicitly reject overflowing integer literals. I believe that the case for `builtins.fromTOML` is comparable, and that we are effectively testing undefined behaviour in TOML and the Nix language here, in the same way that we would have been if we had tests relying on overflowing integer arithmetic. I am not aware of any use of this behaviour outside of these tests; the reverted toml11 bump in Nix did not break the 23.11 evaluation regression test, for example.

C++ undefined behaviour is not involved here, as toml11 used the C++ formatted input functions that are specified to saturate on invalid values. But it’s still a violation of the TOML specification caused by insufficient error checking in the old version of the library, and inconsistent with the handling of overflowing literals in the rest of Nix.

Let’s fix this so that Nix implementations can correctly flag up this error and we can unblock the toml11 update.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
