### PR TITLE
vscode-extensions.google.geminicodeassist: init at 2.48.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/Google.geminicodeassist/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/Google.geminicodeassist/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "geminicodeassist";
+    publisher = "Google";
+    version = "2.48.0";
+    hash = "sha256-Pcq8NpfgokmyQmMO6fA0AU8/ytjdUFYBcIG2HsEBLaU=";
+  };
+  meta = {
+    changelog = "https://marketplace.visualstudio.com/items/Google.geminicodeassist/changelog";
+    description = "AI-assisted development powered by Gemini";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=Google.geminicodeassist";
+    homepage = "https://gemini.google.com";
+    license = lib.licenses.unfree;
+    maintainers = [ lib.maintainers.flacks ];
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -2031,6 +2031,8 @@ let
 
       Google.gemini-cli-vscode-ide-companion = callPackage ./Google.gemini-cli-vscode-ide-companion { };
 
+      Google.geminicodeassist = callPackage ./Google.geminicodeassist { };
+
       grapecity.gc-excelviewer = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "gc-excelviewer";


### PR DESCRIPTION
Add VSCode extension geminicodeassist at 2.48.0.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
