### PR TITLE
haskellPackages.{liquidhaskell, liquidhaskell-boot, liquid-fixpoint, smtlib-backends-process, smtlib-backends-tests}: unbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -3196,6 +3196,24 @@ with haskellLib;
       }
       + "/libssh2";
   } super.libssh2;
+
+  # 2025-8-13: Too strict bound on tasty <1.15; relaxed on Hackage as of today
+  smtlib-backends-tests = doJailbreak super.smtlib-backends-tests;
+
+  # 2025-8-19: dontCheck because of: https://github.com/ucsd-progsys/liquid-fixpoint/issues/760
+  # i.e. tests assume existence of .git and also fail for some versions of CVC5,
+  # including the current one in nixpkgs.
+  liquid-fixpoint = dontCheck super.liquid-fixpoint;
+
+  # 2025-8-18: Too strict bound on Diff <0.6; relaxed on Hackage as of today
+  liquidhaskell-boot = doJailbreak super.liquidhaskell-boot;
+
+  # 2025-8-19: jailbreak because of the restrictive bytestring ==0.12.1.0,
+  # but we have 0.12.2.0. This was relaxed on Hackage to allow 0.12.2.0 on 2025-08-17.
+  liquidhaskell = doJailbreak super.liquidhaskell;
+
+  # 2025-8-13: Too strict bound on QuickCheck <2.15; relaxed on Hackage as of today
+  rest-rewrite = doJailbreak super.rest-rewrite;
 }
 // import ./configuration-tensorflow.nix { inherit pkgs haskellLib; } self super
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -3638,7 +3638,6 @@ broken-packages:
   - lio-simple # failure in job https://hydra.nixos.org/build/233200711 at 2023-09-02
   - lipsum-gen # failure in job https://hydra.nixos.org/build/233233734 at 2023-09-02
   - liquid # failure in job https://hydra.nixos.org/build/233255883 at 2023-09-02
-  - liquid-fixpoint # failure in job https://hydra.nixos.org/build/233213637 at 2023-09-02
   - liquidhaskell-cabal # failure in job https://hydra.nixos.org/build/233249946 at 2023-09-02
   - Liquorice # failure in job https://hydra.nixos.org/build/233193923 at 2023-09-02
   - list-mux # failure in job https://hydra.nixos.org/build/233206407 at 2023-09-02
@@ -5632,8 +5631,6 @@ broken-packages:
   - smsaero # failure in job https://hydra.nixos.org/build/233215880 at 2023-09-02
   - smt-lib # failure in job https://hydra.nixos.org/build/233208443 at 2023-09-02
   - SmtLib # failure in job https://hydra.nixos.org/build/233213271 at 2023-09-02
-  - smtlib-backends-process # failure in job https://hydra.nixos.org/build/233209223 at 2023-09-02
-  - smtlib-backends-tests # failure in job https://hydra.nixos.org/build/295097081 at 2025-04-22
   - smtlib2 # failure in job https://hydra.nixos.org/build/233251831 at 2023-09-02
   - smtp-mail-ng # failure in job https://hydra.nixos.org/build/233220094 at 2023-09-02
   - SMTPClient # failure in job https://hydra.nixos.org/build/233247599 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -31,6 +31,11 @@ default-package-overrides:
   - hiedb < 0.7
   # 2025-08-03: need to match stackage version of hosc
   - hsc3 >= 0.21 && < 0.22
+  # liquidhaskell-boot 0.9.10.1.2 requires this specific version of liquid-fixpoint
+  - liquid-fixpoint == 0.9.6.3.2
+  # liquidhaskell(-boot) support one GHC at a time, so we choose the one matching the current GHC (9.10)
+  - liquidhaskell == 0.9.10.*
+  - liquidhaskell-boot == 0.9.10.*
 # keep-sorted end
 
 # keep-sorted start skip_lines=1 case=no numeric=yes
@@ -189,6 +194,12 @@ package-maintainers:
     - BNFC-meta
     - alex-meta
     - happy-meta
+    - liquid-fixpoint
+    - liquidhaskell
+    - liquidhaskell-boot
+    - smtlib-backends
+    - smtlib-backends-process
+    - smtlib-backends-tests
     - vector-hashtables
   arturcygan:
     - hevm

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -2042,8 +2042,6 @@ dont-distribute-packages:
  - liquid-platform
  - liquid-prelude
  - liquid-vector
- - liquidhaskell
- - liquidhaskell-boot
  - liquidhaskell-cabal-demo
  - list-t-attoparsec
  - list-t-html-parser


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
