### PR TITLE
xfce.xfce4-panel: 4.20.4 -> 4.20.5

### DIFF
--- a/pkgs/desktops/xfce/core/xfce4-panel/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-panel/default.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   mkXfceDerivation,
-  fetchpatch,
   python3,
   cairo,
   exo,
@@ -28,18 +27,9 @@
 mkXfceDerivation {
   category = "xfce";
   pname = "xfce4-panel";
-  version = "4.20.4";
+  version = "4.20.5";
 
-  sha256 = "sha256-P1EZefpGRZ0DQ5S4Okw9pyly23d+UdPp5xMj1wJc44c=";
-
-  patches = [
-    # Fixes panel not shown on external display after reconnecting
-    # https://gitlab.xfce.org/xfce/xfce4-panel/-/issues/925
-    (fetchpatch {
-      url = "https://gitlab.xfce.org/xfce/xfce4-panel/-/commit/e2451cacd950f4b7539efd1e5e36b067515dba9b.patch";
-      hash = "sha256-h2iPlghHJeHD9PJp6RJrRx4MBsaqXuNclAJW6CKHE4A=";
-    })
-  ];
+  sha256 = "sha256-Jftj+EmmsKfK9jk8rj5uMjpteFUHFgOpoEol8JReDNI=";
 
   nativeBuildInputs = [
     python3


### PR DESCRIPTION
https://gitlab.xfce.org/xfce/xfce4-panel/-/compare/xfce4-panel-4.20.4...xfce4-panel-4.20.5



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

