### PR TITLE
phosh: 0.44.1 -> 0.48.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2070,6 +2070,12 @@
     githubId = 29145250;
     name = "Armeen Mahdian";
   };
+  armelclo = {
+    email = "armel@armelclo.fr";
+    github = "ArmelClo";
+    githubId = 61419525;
+    name = "Armel Cloarec";
+  };
   armijnhemel = {
     email = "armijn@tjaldur.nl";
     github = "armijnhemel";

--- a/pkgs/applications/window-managers/phosh/default.nix
+++ b/pkgs/applications/window-managers/phosh/default.nix
@@ -164,6 +164,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [
       masipcat
       zhaofengli
+      armelclo
     ];
     platforms = platforms.linux;
     mainProgram = "phosh-session";

--- a/pkgs/applications/window-managers/phosh/default.nix
+++ b/pkgs/applications/window-managers/phosh/default.nix
@@ -1,8 +1,8 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  directoryListingUpdater,
+  fetchFromGitLab,
+  nix-update-script,
   meson,
   ninja,
   pkg-config,
@@ -39,16 +39,40 @@
   evolution-data-server,
   nixosTests,
   gmobile,
+  appstream,
 }:
 
+let
+  # Derived from subprojects/libcall-ui.wrap
+  libcall-ui = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    group = "World";
+    owner = "Phosh";
+    repo = "libcall-ui";
+    tag = "v0.1.4";
+    hash = "sha256-6fiqdvagcMnvaZ9UxC05haBwObcsqwgJL/V03LuSMF8=";
+  };
+
+  # Derived from subprojects/gvc.wrap
+  gvc = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "libgnome-volume-control";
+    rev = "5f9768a2eac29c1ed56f1fbb449a77a3523683b6";
+    hash = "sha256-gdgTnxzH8BeYQAsvv++Yq/8wHi7ISk2LTBfU8hk12NM=";
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "phosh";
-  version = "0.44.1";
+  version = "0.48.0";
 
-  src = fetchurl {
-    # Release tarball which includes subprojects gvc and libcall-ui
-    url = with finalAttrs; "https://sources.phosh.mobi/releases/${pname}/${pname}-${version}.tar.xz";
-    hash = "sha256-rczGr7YSmVFu13oa3iSTmSQ4jsjl7lv38zQtD7WmDis=";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    group = "World";
+    owner = "Phosh";
+    repo = "phosh";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HnjR0hVjkGfoD8RYCJqpGjRhl0W+QO8tYwSo71XFL6A=";
   };
 
   nativeBuildInputs = [
@@ -71,7 +95,6 @@ stdenv.mkDerivation (finalAttrs: {
     callaudiod
     evolution-data-server
     pulseaudio
-    glib
     modemmanager
     gcr
     networkmanager
@@ -87,6 +110,7 @@ stdenv.mkDerivation (finalAttrs: {
     upower
     wayland
     feedbackd
+    appstream
   ];
 
   nativeCheckInputs = [
@@ -97,10 +121,16 @@ stdenv.mkDerivation (finalAttrs: {
   # Temporarily disabled - Test is broken (SIGABRT)
   doCheck = false;
 
+  postPatch = ''
+    ln -s ${libcall-ui} subprojects/libcall-ui
+    ln -s ${gvc} subprojects/gvc
+  '';
+
   mesonFlags = [
     "-Dcompositor=${phoc}/bin/phoc"
     # Save some time building if tests are disabled
     "-Dtests=${lib.boolToString finalAttrs.finalPackage.doCheck}"
+    "-Dc_args=-I${glib.dev}/include/gio-unix-2.0/"
   ];
 
   checkPhase = ''
@@ -123,7 +153,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     providedSessions = [ "phosh" ];
     tests.phosh = nixosTests.phosh;
-    updateScript = directoryListingUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
+++ b/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
@@ -98,7 +98,10 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.gnome.org/World/Phosh/phosh-mobile-settings";
     changelog = "https://gitlab.gnome.org/World/Phosh/phosh-mobile-settings/-/blob/v${version}/debian/changelog";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ rvl ];
+    maintainers = with lib.maintainers; [
+      rvl
+      armelclo
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
+++ b/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitLab,
   nixosTests,
-  directoryListingUpdater,
+  nix-update-script,
   meson,
   ninja,
   pkg-config,
@@ -20,11 +20,26 @@
   json-glib,
   gsound,
   gmobile,
+  gnome-desktop,
+  libpulseaudio,
+  libportal,
+  libportal-gtk4,
+  glib,
 }:
 
+let
+  # Derived from subprojects/gvc.wrap
+  gvc = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "libgnome-volume-control";
+    rev = "5f9768a2eac29c1ed56f1fbb449a77a3523683b6";
+    hash = "sha256-gdgTnxzH8BeYQAsvv++Yq/8wHi7ISk2LTBfU8hk12NM=";
+  };
+in
 stdenv.mkDerivation rec {
   pname = "phosh-mobile-settings";
-  version = "0.41.0";
+  version = "0.48.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
@@ -32,7 +47,7 @@ stdenv.mkDerivation rec {
     owner = "Phosh";
     repo = "phosh-mobile-settings";
     rev = "v${version}";
-    hash = "sha256-t5qngjQcjPltUGbcZ+CF5FbZtZkV/cD3xUhuApQbKHo=";
+    hash = "sha256-XnXwTjZnPlGNUmqizcIQdJ6SmrQ0dq9jNEhNsmDPzyM=";
   };
 
   nativeBuildInputs = [
@@ -42,6 +57,7 @@ stdenv.mkDerivation rec {
     pkg-config
     wayland-scanner
     wrapGAppsHook4
+    glib.dev
   ];
 
   buildInputs = [
@@ -55,22 +71,25 @@ stdenv.mkDerivation rec {
     json-glib
     gsound
     gmobile
+    gnome-desktop
+    libpulseaudio
+    libportal
+    libportal-gtk4
   ];
 
   postPatch = ''
-    # There are no schemas to compile.
-    substituteInPlace meson.build \
-      --replace 'glib_compile_schemas: true' 'glib_compile_schemas: false'
+    ln -s ${gvc} subprojects/gvc
   '';
 
   postInstall = ''
     # this is optional, but without it phosh-mobile-settings won't know about lock screen plugins
     ln -s '${phosh}/lib/phosh' "$out/lib/phosh"
+    glib-compile-schemas "$out/share/glib-2.0/schemas"
   '';
 
   passthru = {
     tests.phosh = nixosTests.phosh;
-    updateScript = directoryListingUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/gm/gmobile/package.nix
+++ b/pkgs/by-name/gm/gmobile/package.nix
@@ -52,7 +52,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Functions useful in mobile related, glib based projects";
     homepage = "https://gitlab.gnome.org/World/Phosh/gmobile";
     license = lib.licenses.lgpl21Plus;
-    maintainers = with lib.maintainers; [ donovanglover ];
+    maintainers = with lib.maintainers; [
+      donovanglover
+      armelclo
+    ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/gm/gmobile/package.nix
+++ b/pkgs/by-name/gm/gmobile/package.nix
@@ -11,19 +11,21 @@
   libuev,
   gobject-introspection,
   udevCheckHook,
+  vala,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  name = "gmobile";
-  version = "0.2.1";
+  pname = "gmobile";
+  version = "0.4.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     group = "World";
     owner = "Phosh";
     repo = "gmobile";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-5OQ2JT7YeEYzKXafwgg0xJk2AvtFw2dtcH3mt+cm1bI=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5WRsHbwReLy3ZMbfsyjr3VsGawaQoXMFIDtKw3P/loA=";
   };
 
   nativeBuildInputs = [
@@ -39,9 +41,12 @@ stdenv.mkDerivation (finalAttrs: {
     glib
     json-glib
     libuev
+    vala
   ];
 
   doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Functions useful in mobile related, glib based projects";

--- a/pkgs/by-name/ph/phoc/package.nix
+++ b/pkgs/by-name/ph/phoc/package.nix
@@ -19,17 +19,27 @@
   wayland,
   libdrm,
   libxkbcommon,
-  wlroots_0_17,
+  wlroots_0_19,
   xorg,
-  directoryListingUpdater,
+  nix-update-script,
   nixosTests,
   testers,
   gmobile,
 }:
 
+let
+  # Derived from subprojects/gvdb.wrap
+  gvdb = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "gvdb";
+    rev = "4758f6fb7f889e074e13df3f914328f3eecb1fd3";
+    hash = "sha256-4mqoHPlrMPenoGPwDqbtv4/rJ/uq9Skcm82pRvOxNIk=";
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "phoc";
-  version = "0.44.1";
+  version = "0.48.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
@@ -37,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "Phosh";
     repo = "phoc";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Whke7wTRp5NaRauiiQZLjs0pSD1uAyr0aAhlK5e1+Hw=";
+    hash = "sha256-ve69Na6iZwsNM0y7AZ0p/CObUfE6uEbhOV4sb5NaCYg=";
   };
 
   nativeBuildInputs = [
@@ -66,11 +76,15 @@ stdenv.mkDerivation (finalAttrs: {
     gmobile
   ];
 
+  postPatch = ''
+    ln -s ${gvdb} subprojects/gvdb
+  '';
+
   mesonFlags = [ "-Dembed-wlroots=disabled" ];
 
   # Patch wlroots to remove a check which crashes Phosh.
   # This patch can be found within the phoc source tree.
-  wlroots = wlroots_0_17.overrideAttrs (old: {
+  wlroots = wlroots_0_19.overrideAttrs (old: {
     patches = (old.patches or [ ]) ++ [
       (stdenvNoCC.mkDerivation {
         name = "0001-Revert-layer-shell-error-on-0-dimension-without-anch.patch";
@@ -87,7 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
     tests.version = testers.testVersion {
       package = finalAttrs.finalPackage;
     };
-    updateScript = directoryListingUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/ph/phoc/package.nix
+++ b/pkgs/by-name/ph/phoc/package.nix
@@ -112,6 +112,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [
       masipcat
       zhaofengli
+      armelclo
     ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
phosh changelogs:
- [0.42.0](https://phosh.mobi/releases/rel-0.42.0/)
- [0.43.0](https://phosh.mobi/releases/rel-0.43.0/)
- [0.43.1](https://phosh.mobi/releases/rel-0.43.1/)
- [0.44.0](https://phosh.mobi/releases/rel-0.44.0/)
- [0.44.1](https://phosh.mobi/releases/rel-0.44.1/)
- [0.45.0](https://phosh.mobi/releases/rel-0.45.0/)
- [0.46.0](https://phosh.mobi/releases/rel-0.46.0/)
- [0.47.0](https://phosh.mobi/releases/rel-0.47.0/)
- [0.48.0](https://phosh.mobi/releases/rel-0.48.0/)

phosh-mobile-settings [changelog](https://gitlab.gnome.org/World/Phosh/phosh-mobile-settings/-/blob/v0.49_rc1/NEWS?ref_type=tags#L11)

phoc [changelog](https://gitlab.gnome.org/World/Phosh/phoc/-/blob/main/NEWS?ref_type=phoc-0.48.x)

gmobile [changelog](https://gitlab.gnome.org/World/Phosh/gmobile/-/blob/v0.4.0/NEWS?ref_type=v0.4.0)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
