### PR TITLE
git-unroll: 0-unstable-2024-11-04 -> 0-unstable-2025-08-14

### DIFF
--- a/pkgs/by-name/gi/git-unroll/package.nix
+++ b/pkgs/by-name/gi/git-unroll/package.nix
@@ -15,14 +15,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "git-unroll";
-  version = "0-unstable-2024-11-04";
+  version = "0-unstable-2025-08-14";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "gm6k";
     repo = "git-unroll";
-    rev = "9243bb8a6a9f6875e21a5c64320b66f7fdaf9b3f";
-    hash = "sha256-1MjbB1EVgmU0HlUibrKOkjmxQ8wseocSJENiAqyHcjU=";
+    rev = "a66aad56af0440e1d6e807518af298264861b2c7";
+    hash = "sha256-Mpc2p+W8PqQ6Os9AJJJwvL00a4cjFKBUTBG5bF+IzL4=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Updating to latest git commit which implements a more robust logic for fetching required sub-module commits.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
