### PR TITLE
nixos-rebuild-ng: make path part of Flake absolute

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -86,7 +86,11 @@ class Flake:
 
     @override
     def __str__(self) -> str:
-        return f"{self.path}#{self.attr}"
+        if isinstance(self.path, Path):
+            # https://github.com/NixOS/nixpkgs/issues/433726
+            return f"{self.path.absolute()}#{self.attr}"
+        else:
+            return f"{self.path}#{self.attr}"
 
     @classmethod
     def parse(cls, flake_str: str, target_host: Remote | None = None) -> Self:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -71,6 +71,14 @@ def test_flake_to_attr() -> None:
     )
 
 
+def test_flake__str__(monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
+    assert str(m.Flake("github:nixos/nixpkgs", "attr")) == "github:nixos/nixpkgs#attr"
+    assert str(m.Flake(Path("/etc/nixos"), "attr")) == "/etc/nixos#attr"
+    with monkeypatch.context() as patch_context:
+        patch_context.chdir(tmpdir)
+        assert str(m.Flake(Path("."), "attr")) == f"{tmpdir}#attr"
+
+
 @patch("platform.node", autospec=True)
 def test_flake_from_arg(
     mock_node: Mock, monkeypatch: MonkeyPatch, tmpdir: Path

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -54,7 +54,7 @@ def test_build(mock_run: Mock) -> None:
 )
 def test_build_flake(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
     monkeypatch.chdir(tmpdir)
-    flake = m.Flake.parse(".#hostname")
+    flake = m.Flake.parse("/flake.nix#hostname")
 
     assert n.build_flake(
         "config.system.build.toplevel",
@@ -68,7 +68,7 @@ def test_build_flake(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> 
             "nix-command flakes",
             "build",
             "--print-out-paths",
-            '.#nixosConfigurations."hostname".config.system.build.toplevel',
+            '/flake.nix#nixosConfigurations."hostname".config.system.build.toplevel',
             "--no-link",
             "--nix-flag",
             "foo",
@@ -173,7 +173,7 @@ def test_build_remote_flake(
     mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path
 ) -> None:
     monkeypatch.chdir(tmpdir)
-    flake = m.Flake.parse(".#hostname")
+    flake = m.Flake.parse("/flake.nix#hostname")
     build_host = m.Remote("user@host", [], None)
     monkeypatch.setenv("NIX_SSHOPTS", "--ssh opts")
 
@@ -194,7 +194,7 @@ def test_build_remote_flake(
                     "nix-command flakes",
                     "eval",
                     "--raw",
-                    '.#nixosConfigurations."hostname".config.system.build.toplevel.drvPath',
+                    '/flake.nix#nixosConfigurations."hostname".config.system.build.toplevel.drvPath',
                     "--flake",
                 ],
                 stdout=PIPE,
@@ -291,7 +291,7 @@ def test_edit(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 def test_edit_flake(mock_run: Mock) -> None:
-    flake = m.Flake.parse(".#attr")
+    flake = m.Flake.parse("/flake.nix#attr")
     n.edit_flake(flake, {"commit_lock_file": True})
     mock_run.assert_called_with(
         [
@@ -301,7 +301,7 @@ def test_edit_flake(mock_run: Mock) -> None:
             "edit",
             "--commit-lock-file",
             "--",
-            '.#nixosConfigurations."attr"',
+            '/flake.nix#nixosConfigurations."attr"',
         ],
         check=False,
     )
@@ -385,7 +385,7 @@ def test_get_build_image_variants(mock_run: Mock, tmp_path: Path) -> None:
     ),
 )
 def test_get_build_image_variants_flake(mock_run: Mock) -> None:
-    flake = m.Flake(Path("flake.nix"), "myAttr")
+    flake = m.Flake(Path("/flake.nix"), "myAttr")
     assert n.get_build_image_variants_flake(flake, {"eval_flag": True}) == {
         "azure": "nixos-image-azure-25.05.20250102.6df2492-x86_64-linux.vhd",
         "vmware": "nixos-image-vmware-25.05.20250102.6df2492-x86_64-linux.vmdk",
@@ -395,7 +395,7 @@ def test_get_build_image_variants_flake(mock_run: Mock) -> None:
             "nix",
             "eval",
             "--json",
-            "flake.nix#myAttr.config.system.build.images",
+            "/flake.nix#myAttr.config.system.build.images",
             "--apply",
             "builtins.attrNames",
             "--eval-flag",


### PR DESCRIPTION
Fix: #433726.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
