### PR TITLE
isabelle: add option to build with emacs integration

### DIFF
--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -18,6 +18,7 @@
   isabelle-components,
   symlinkJoin,
   fetchhg,
+  withEmacsIntegration ? false,
 }:
 
 let
@@ -51,6 +52,13 @@ let
       mkdir -p $out/lib
       cp libsha1.so $out/lib/
     '';
+  };
+
+  isabelle-emacs-src = fetchFromGitHub {
+    owner = "m-fleury";
+    repo = "isabelle-emacs";
+    rev = "Isabelle2025-vsce";
+    hash = "sha256-L9yKm0qrK/BJzoTTwlaX30actZTg6P4+gt2j+JKQ+oo=";
   };
 
 in
@@ -97,6 +105,13 @@ stdenv.mkDerivation (finalAttrs: {
   postUnpack = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mv $sourceRoot ${finalAttrs.dirname}
     sourceRoot=${finalAttrs.dirname}
+  '';
+
+  prePatch = lib.optionalString withEmacsIntegration ''
+    rm -rf src/
+    cp -r ${isabelle-emacs-src}/src ./
+    cp ${isabelle-emacs-src}/etc/build.props etc/
+    chmod -R +w ./src
   '';
 
   postPatch = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15242,6 +15242,8 @@ with pkgs;
   };
   isabelle-components = recurseIntoAttrs (callPackage ../by-name/is/isabelle/components { });
 
+  isabelle-emacs = isabelle.override { withEmacsIntegration = true; };
+
   lean3 = lean;
 
   leo2 = callPackage ../applications/science/logic/leo2 {


### PR DESCRIPTION
Add an option to the isabelle package to enable the emacs-lsp support patched in by
https://github.com/m-fleury/isabelle-emacs

Since the isabelle source tarball contains some things that are not included in this repository, it is not sufficient
to override the src attribute. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
