### PR TITLE
postgresql: CVE-2025-8714 + CVE-2025-8715

### DIFF
--- a/pkgs/servers/sql/postgresql/13.nix
+++ b/pkgs/servers/sql/postgresql/13.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "13.21";
-  rev = "refs/tags/REL_13_21";
-  hash = "sha256-je3nC8zymK9pIISWSv/hMNeloYuiB7ulLinWFzqAWFc=";
+  version = "13.22";
+  rev = "refs/tags/REL_13_22";
+  hash = "sha256-6zHA+WU1FroUbGJcTAeEbPKBVQY7SKpT5+Kxe9ZhtoM=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql13/disable-test-collate.icu.utf8.patch?id=69faa146ec9fff3b981511068f17f9e629d4688b";

--- a/pkgs/servers/sql/postgresql/14.nix
+++ b/pkgs/servers/sql/postgresql/14.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "14.18";
-  rev = "refs/tags/REL_14_18";
-  hash = "sha256-pGPTq4I8WQnysVh3hHi/1Fto5vqtIbdGBu7EyBonIoo=";
+  version = "14.19";
+  rev = "refs/tags/REL_14_19";
+  hash = "sha256-z8MEeLae4W4YqGBNcPtKnUENxnixugnv5Q6r+LW4uu8=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql14/disable-test-collate.icu.utf8.patch?id=56999e6d0265ceff5c5239f85fdd33e146f06cb7";

--- a/pkgs/servers/sql/postgresql/15.nix
+++ b/pkgs/servers/sql/postgresql/15.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "15.13";
-  rev = "refs/tags/REL_15_13";
-  hash = "sha256-6guX2ms54HhJJ0MoHfQb5MI9qrcA0niJ06oa1glsFuY=";
+  version = "15.14";
+  rev = "refs/tags/REL_15_14";
+  hash = "sha256-KzN0gsEY6wFLqNYMxbTj2NH+4IWO0pplWP4XO/fqRLM=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql15/dont-use-locale-a-on-musl.patch?id=f424e934e6d076c4ae065ce45e734aa283eecb9c";

--- a/pkgs/servers/sql/postgresql/16.nix
+++ b/pkgs/servers/sql/postgresql/16.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "16.9";
-  rev = "refs/tags/REL_16_9";
-  hash = "sha256-CLLCT4wiCWeLqMdtGdXM2/DtlENLWSey6nNtOcfNPRw=";
+  version = "16.10";
+  rev = "refs/tags/REL_16_10";
+  hash = "sha256-1zG8+G/lNA1xm0hxLVEilIaI+25d4gfpqA2aCb4+taY=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql16/dont-use-locale-a-on-musl.patch?id=08a24be262339fd093e641860680944c3590238e";

--- a/pkgs/servers/sql/postgresql/17.nix
+++ b/pkgs/servers/sql/postgresql/17.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "17.5";
-  rev = "refs/tags/REL_17_5";
-  hash = "sha256-jWV7hglu7IPMZbqHrZVZHLbZYjVuDeut7nH50aSQIBc=";
+  version = "17.6";
+  rev = "refs/tags/REL_17_6";
+  hash = "sha256-/7C+bjmiJ0/CvoAc8vzTC50vP7OsrM6o0w+lmmHvKvU=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";


### PR DESCRIPTION
CVE-2025-8714 + CVE-2025-8715

please backport to 25,05 as well

Release Notes:
- https://www.postgresql.org/docs/release/17.6/
- https://www.postgresql.org/docs/release/16.10/
- https://www.postgresql.org/docs/release/15.14/
- https://www.postgresql.org/docs/release/14.19/
- https://www.postgresql.org/docs/release/13.22/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
