### PR TITLE
fish-lsp: 1.0.9-1 -> 1.0.10

### DIFF
--- a/pkgs/by-name/fi/fish-lsp/package.nix
+++ b/pkgs/by-name/fi/fish-lsp/package.nix
@@ -15,18 +15,18 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "fish-lsp";
-  version = "1.0.9-1";
+  version = "1.0.10";
 
   src = fetchFromGitHub {
     owner = "ndonfris";
     repo = "fish-lsp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NyEhvW5NMqvESdbauxur7xWAzQiQdTVklGMYhckNAnw=";
+    hash = "sha256-OZiqEef4jE1H47mweVCzhaRCSsFdpgUdCSuhWRz2n2M=";
   };
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = finalAttrs.src + "/yarn.lock";
-    hash = "sha256-xB4kWpPQbA1OkXNr5sozPIP96dLJhwoDUpesE6DORzg=";
+    hash = "sha256-N9P2mmqAfbg/Kpqx+vZbb+fhaD1I/3UjiJaEqFPJyO0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fi/fish-lsp/package.nix
+++ b/pkgs/by-name/fi/fish-lsp/package.nix
@@ -75,7 +75,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   doDist = false;
 
-  passthru.updateScript = nix-update-script { };
+  # fish-lsp adds tags for all its pre-release versions, which leads to
+  # incorrect r-ryantm bumps. This regex allows a dash at the end followed by a
+  # number (like `v1.0.9-1`). but it prevents matches with a dash followed by
+  # text (like `v1.0.11-pre.10`). or, of course, no dash at all
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "v\\d+\\.\\d+\\.\\d+(?:-\\d+)?$"
+    ];
+  };
 
   meta = {
     description = "LSP implementation for the fish shell language";


### PR DESCRIPTION
Also comes with a fix to the `updateScript`, so the bot doesn't keep bumping the version to pre-releases. Ran this command locally to see if it made a difference:
```sh
nix-update fish-lsp --use-update-script
```
And got some encouraging results:
```
nix_update.errors.VersionError: No version matched the regex. The following versions were found:
v1.0.11-pre.11
v1.0.11-pre.10
v1.0.11-pre.9
v1.0.11-pre.8
v1.0.11-pre.7
v1.0.11-pre.6
v1.0.11-pre.5
v1.0.11-pre.3
v1.0.11-pre.2
v1.0.11-pre.1


--- SHOWING ERROR LOG FOR fish-lsp-1.0.10 ----------------------
The update script for fish-lsp-1.0.10 failed with exit code 1
```
For once, a failure is actually *good*!

cc @adamcstephens, who I discussed the regex with on Matrix.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
