### PR TITLE
tdf: 0.2.0 -> 0.4.1

### DIFF
--- a/pkgs/by-name/td/tdf/package.nix
+++ b/pkgs/by-name/td/tdf/package.nix
@@ -4,34 +4,30 @@
   rustPlatform,
   pkg-config,
   cairo,
-  glib,
-  poppler,
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tdf";
-  version = "0.2.0";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "itsjunetime";
     repo = "tdf";
     fetchSubmodules = true;
-    rev = "a2b728fae3c5b0addfa64e8d3e44eac6fd50f1d9";
-    hash = "sha256-0as/tKw0nKkZn+5q5PlKwK+LZK0xWXDAdiD3valVjBs=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-yttuWWKIrh54eJSdKejDTswoDarNifD5DtfQHSlL3rE=";
   };
 
-  cargoHash = "sha256-krIPfi4SM4uCw7NLauudwh1tgAaB8enDWnMC5X16n48=";
+  cargoHash = "sha256-UB7G5tl90CNq/aYUaUOpgGJcEL9ND3pJ29/lpIkh2iU=";
 
   nativeBuildInputs = [ pkg-config ];
+
   buildInputs = [
+    rustPlatform.bindgenHook
     cairo
-    glib
-    poppler
   ];
 
-  strictDeps = true;
-
-  # No tests are currently present
+  # Tests depend on cpuprofiler, which is not packaged in nixpkgs
   doCheck = false;
 
   # requires nightly features (feature(portable_simd))
@@ -40,12 +36,12 @@ rustPlatform.buildRustPackage {
   meta = {
     description = "Tui-based PDF viewer";
     homepage = "https://github.com/itsjunetime/tdf";
-    license = lib.licenses.gpl3Plus;
+    license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [
       luftmensch-luftmensch
       DieracDelta
     ];
     mainProgram = "tdf";
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bump tdf. Tested on linux. Supersedes #413528

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
