### PR TITLE
gnuradioMinimal.pkgs.osmosdr: make it possible to disable features

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -240,6 +240,22 @@
 
 - We now use the upstream wrapper script for Gradle, supporting both the `JAVA_HOME` and `GRADLE_OPTS` environment variables.
 
+- `gnuradio`: Overriding the `.pkgs` package set is now possible with a `packageOverrides` function, like with `python.pkgs` and other language-specific package sets.
+Example:
+
+```nix
+gnuradioMinimal.override {
+  packageOverrides = grSelf: grSuper: {
+    osmosdr = grSuper.osmosdr.override {
+      airspy = null;
+      hackrf = null;
+      libbladeRF = null;
+      soapysdr-with-plugins = null;
+    };
+  };
+}
+```
+
 ## Nixpkgs Library {#sec-nixpkgs-release-26.05-lib}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/pkgs/applications/radio/gnuradio/wrapper.nix
+++ b/pkgs/applications/radio/gnuradio/wrapper.nix
@@ -56,6 +56,7 @@
   ],
   # Allow to add whatever you want to the wrapper
   extraMakeWrapperArgs ? [ ],
+  packageOverrides ? (self: super: { }),
 }:
 
 let
@@ -191,7 +192,12 @@ let
   );
 
   packages = import ../../../top-level/gnuradio-packages.nix {
-    inherit lib stdenv newScope;
+    inherit
+      lib
+      stdenv
+      newScope
+      packageOverrides
+      ;
     gnuradio = unwrapped;
   };
   passthru = unwrapped.passthru // {

--- a/pkgs/by-name/gn/gnuradioMinimal/package.nix
+++ b/pkgs/by-name/gn/gnuradioMinimal/package.nix
@@ -3,6 +3,7 @@
   volk,
   uhdMinimal,
   packageOverrides ? (self: super: { }),
+  unwrappedFeaturesOverride ? { },
 }:
 # A build without gui components and other utilities not needed for end user
 # libraries
@@ -28,6 +29,7 @@ gnuradio.override {
       # Doesn't make it reference python eventually, but makes reverse
       # dependencies require python to use cmake files of GR.
       gr-ctrlport = false;
-    };
+    }
+    // unwrappedFeaturesOverride;
   };
 }

--- a/pkgs/by-name/gn/gnuradioMinimal/package.nix
+++ b/pkgs/by-name/gn/gnuradioMinimal/package.nix
@@ -2,11 +2,13 @@
   gnuradio,
   volk,
   uhdMinimal,
+  packageOverrides ? (self: super: { }),
 }:
 # A build without gui components and other utilities not needed for end user
 # libraries
 gnuradio.override {
   doWrap = false;
+  inherit packageOverrides;
   unwrapped = gnuradio.unwrapped.override {
     volk = volk.override {
       # So it will not reference python

--- a/pkgs/development/gnuradio-modules/mkDerivation.nix
+++ b/pkgs/development/gnuradio-modules/mkDerivation.nix
@@ -8,37 +8,38 @@ mkDerivation:
 args:
 
 let
-# Common validation and processing logic
-processArgs = args:
-# Check if it's supposed to not get built for the current gnuradio version
-if (builtins.hasAttr "disabled" args) && args.disabled then
-  let
-    name = args.name or "${args.pname}";
-  in
-  throw "Package ${name} is incompatible with GNURadio ${unwrapped.versionAttr.major}"
-else
+  # Common validation and processing logic
+  processArgs =
+    args:
+    # Check if it's supposed to not get built for the current gnuradio version
+    if (builtins.hasAttr "disabled" args) && args.disabled then
+      let
+        name = args.name or "${args.pname}";
+      in
+      throw "Package ${name} is incompatible with GNURadio ${unwrapped.versionAttr.major}"
+    else
 
-if builtins.hasAttr "disabledForGRafter" args then
-  throw ''
-    `disabledForGRafter` is superseded by `disabled`.
-    Use `disabled = gnuradioAtLeast "${args.disabledForGRafter}";` instead.
-  ''
-else
+    if builtins.hasAttr "disabledForGRafter" args then
+      throw ''
+        `disabledForGRafter` is superseded by `disabled`.
+        Use `disabled = gnuradioAtLeast "${args.disabledForGRafter}";` instead.
+      ''
+    else
 
-  let
-    args_ = {
-      enableParallelBuilding = args.enableParallelBuilding or true;
-      nativeBuildInputs = (args.nativeBuildInputs or [ ]);
-      # We add gnuradio and volk itself by default - most gnuradio based packages
-      # will not consider it a dependency worth mentioning and it will almost
-      # always be needed
-      buildInputs = (args.buildInputs or [ ]) ++ [
-        unwrapped
-        unwrapped.volk
-      ];
-    };
-  in
-  args // args_;
+      let
+        args_ = {
+          enableParallelBuilding = args.enableParallelBuilding or true;
+          nativeBuildInputs = (args.nativeBuildInputs or [ ]);
+          # We add gnuradio and volk itself by default - most gnuradio based packages
+          # will not consider it a dependency worth mentioning and it will almost
+          # always be needed
+          buildInputs = (args.buildInputs or [ ]) ++ [
+            unwrapped
+            unwrapped.volk
+          ];
+        };
+      in
+      args // args_;
 
 in
 if builtins.isFunction args then

--- a/pkgs/development/gnuradio-modules/mkDerivation.nix
+++ b/pkgs/development/gnuradio-modules/mkDerivation.nix
@@ -7,6 +7,9 @@ mkDerivation:
 
 args:
 
+let
+# Common validation and processing logic
+processArgs = args:
 # Check if it's supposed to not get built for the current gnuradio version
 if (builtins.hasAttr "disabled" args) && args.disabled then
   let
@@ -35,4 +38,12 @@ else
       ];
     };
   in
-  mkDerivation (args // args_)
+  args // args_;
+
+in
+if builtins.isFunction args then
+  # Function form: args is (finalAttrs -> attrset)
+  mkDerivation (finalAttrs: processArgs (args finalAttrs))
+else
+  # Attrset form: args is attrset
+  mkDerivation (processArgs args)

--- a/pkgs/development/gnuradio-modules/osmosdr/default.nix
+++ b/pkgs/development/gnuradio-modules/osmosdr/default.nix
@@ -28,13 +28,13 @@
   soapysdr-with-plugins,
 }:
 
-mkDerivation rec {
+mkDerivation (finalAttrs: {
   pname = "gr-osmosdr";
   version = "0.2.6";
 
   src = fetchgit {
     url = "https://gitea.osmocom.org/sdr/gr-osmosdr";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-jCUzBY1pYiEtcRQ97t9F6uEMVYw2NU0eoB5Xc2H6pGQ=";
   };
 
@@ -100,4 +100,4 @@ mkDerivation rec {
     maintainers = with lib.maintainers; [ bjornfor ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/development/gnuradio-modules/osmosdr/default.nix
+++ b/pkgs/development/gnuradio-modules/osmosdr/default.nix
@@ -1,12 +1,16 @@
 {
   lib,
-  stdenv,
   mkDerivation,
+  gnuradioAtLeast,
   fetchgit,
   fetchpatch,
   gnuradio,
+
+  # native
   cmake,
   pkg-config,
+
+  # buildInputs
   logLib,
   libsndfile,
   mpir,
@@ -22,7 +26,6 @@
   libbladeRF,
   rtl-sdr,
   soapysdr-with-plugins,
-  gnuradioAtLeast,
 }:
 
 mkDerivation rec {

--- a/pkgs/development/gnuradio-modules/osmosdr/default.nix
+++ b/pkgs/development/gnuradio-modules/osmosdr/default.nix
@@ -26,6 +26,7 @@
   libbladeRF,
   rtl-sdr,
   soapysdr-with-plugins,
+  features ? { },
 }:
 
 mkDerivation (finalAttrs: {
@@ -61,12 +62,8 @@ mkDerivation (finalAttrs: {
     fftwFloat
     gmp
     icu
-    airspy
-    hackrf
-    libbladeRF
-    rtl-sdr
-    soapysdr-with-plugins
   ]
+  ++ finalAttrs.finalPackage.passthru.enabledFeaturesDeps
   ++ lib.optionals (gnuradio.hasFeature "gr-blocks") [
     libsndfile
   ]
@@ -83,7 +80,8 @@ mkDerivation (finalAttrs: {
   ];
   cmakeFlags = [
     (if (gnuradio.hasFeature "python-support") then "-DENABLE_PYTHON=ON" else "-DENABLE_PYTHON=OFF")
-  ];
+  ]
+  ++ finalAttrs.finalPackage.passthru.enabledFeaturesCmakeFlags;
   nativeBuildInputs = [
     cmake
     pkg-config
@@ -92,6 +90,25 @@ mkDerivation (finalAttrs: {
     python.pkgs.mako
     python
   ];
+  passthru = {
+    featuresDeps = {
+      # Other features don't have dependencies but can still be disabled in the
+      # `features` argument.
+      airspy = [ airspy ];
+      bladerf = [ libbladeRF ];
+      hackrf = [ hackrf ];
+      rtl = [ rtl-sdr ];
+      soapy = [ soapysdr-with-plugins ];
+    };
+    enabledFeaturesDeps = lib.pipe finalAttrs.finalPackage.passthru.featuresDeps [
+      (lib.filterAttrs (name: deps: features.${name} or true))
+      lib.attrValues
+      lib.flatten
+    ];
+    enabledFeaturesCmakeFlags = lib.mapAttrsToList (
+      feat: val: lib.cmakeBool "ENABLE_${lib.toUpper feat}" val
+    ) features;
+  };
 
   meta = {
     description = "Gnuradio block for OsmoSDR and rtl-sdr";

--- a/pkgs/top-level/gnuradio-packages.nix
+++ b/pkgs/top-level/gnuradio-packages.nix
@@ -3,6 +3,7 @@
   stdenv,
   newScope,
   gnuradio, # unwrapped gnuradio
+  packageOverrides,
 }:
 
 lib.makeScope newScope (
@@ -34,21 +35,21 @@ lib.makeScope newScope (
         inherit (gnuradio) uhd;
       }
     );
+
+    # Base package set without overrides
+    basePackages = {
+      inherit callPackage mkDerivation mkDerivationWith;
+
+      bladeRF = callPackage ../development/gnuradio-modules/bladeRF/default.nix { };
+
+      lora_sdr = callPackage ../development/gnuradio-modules/lora_sdr/default.nix { };
+
+      osmosdr = callPackage ../development/gnuradio-modules/osmosdr/default.nix { };
+
+      fosphor = callPackage ../development/gnuradio-modules/fosphor/default.nix { };
+
+      gr-difi = callPackage ../development/gnuradio-modules/gr-difi/default.nix { };
+    };
   in
-  {
-
-    inherit callPackage mkDerivation mkDerivationWith;
-
-    ### Packages
-
-    bladeRF = callPackage ../development/gnuradio-modules/bladeRF/default.nix { };
-
-    lora_sdr = callPackage ../development/gnuradio-modules/lora_sdr/default.nix { };
-
-    osmosdr = callPackage ../development/gnuradio-modules/osmosdr/default.nix { };
-
-    fosphor = callPackage ../development/gnuradio-modules/fosphor/default.nix { };
-
-    gr-difi = callPackage ../development/gnuradio-modules/gr-difi/default.nix { };
-  }
+  basePackages // (packageOverrides self basePackages)
 )


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
