### PR TITLE
jspecify: init at 1.0.0

### DIFF
--- a/pkgs/by-name/js/jspecify/package.nix
+++ b/pkgs/by-name/js/jspecify/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchMavenArtifact,
+  jre_minimal,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "jspecify";
+  version = "1.0.0";
+
+  src = fetchMavenArtifact {
+    groupId = "org.jspecify";
+    artifactId = "jspecify";
+    version = finalAttrs.version;
+    hash = "sha256-H61ua+dVd4Hk0zcp1Jrhzcj92m/kd7sMxozjUer9+6s=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 ${finalAttrs.src.jar} $out/share/java/${finalAttrs.pname}-${finalAttrs.version}.jar
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://jspecify.dev";
+    description = "Standard Annotations for Java Static Analysis";
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    inherit (jre_minimal.meta) platforms;
+    maintainers = with lib.maintainers; [ msgilligan ];
+  };
+})


### PR DESCRIPTION
[JSpecify](https://jspecify.dev) provides "Standard Annotations for Java Static Analysis". Notably, version 1.0.0 provides nullability annotations that pretty much the entire Java and Kotlin communities have agreed (finally!) to standardize on.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
