### PR TITLE
[Backport release-25.05] agenix-cli: 0.1.0 -> 0.1.2

### DIFF
--- a/pkgs/by-name/ag/agenix-cli/package.nix
+++ b/pkgs/by-name/ag/agenix-cli/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "cole-h";
     repo = "agenix-cli";
-    rev = "v${version}";
+    tag = "v${version}";
     sha256 = "sha256-0+QVY1sDhGF4hAN6m2FdKZgm9V1cuGGjY4aitRBnvKg=";
   };
 

--- a/pkgs/by-name/ag/agenix-cli/package.nix
+++ b/pkgs/by-name/ag/agenix-cli/package.nix
@@ -7,16 +7,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "agenix-cli";
-  version = "0.1.0";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "cole-h";
     repo = "agenix-cli";
     tag = "v${version}";
-    sha256 = "sha256-0+QVY1sDhGF4hAN6m2FdKZgm9V1cuGGjY4aitRBnvKg=";
+    sha256 = "sha256-eJp6t8h8uOP0YupYn8x6VAAmUbVrXypxNMGx4SK/6d8=";
   };
 
-  cargoHash = "sha256-xpA9BTA7EK3Pw8EJOjIq1ulBAcX4yNhc4kqhxsoCbv0=";
+  cargoHash = "sha256-2xTkCdWKQVg8Sp0LDkC/LH9GYBXNpxdoLX30Ndz0muM=";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ag/agenix-cli/package.nix
+++ b/pkgs/by-name/ag/agenix-cli/package.nix
@@ -5,14 +5,14 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "agenix-cli";
   version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "cole-h";
     repo = "agenix-cli";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-eJp6t8h8uOP0YupYn8x6VAAmUbVrXypxNMGx4SK/6d8=";
   };
 
@@ -30,4 +30,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ misuzu ];
     mainProgram = "agenix";
   };
-}
+})


### PR DESCRIPTION
Manual backport of #432199 (and part of a treewide) to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.