### PR TITLE
[Backport release-25.05] aide: 0.19 -> 0.19.2

### DIFF
--- a/pkgs/by-name/ai/aide/package.nix
+++ b/pkgs/by-name/ai/aide/package.nix
@@ -16,11 +16,11 @@
 
 stdenv.mkDerivation rec {
   pname = "aide";
-  version = "0.19";
+  version = "0.19.1";
 
   src = fetchurl {
     url = "https://github.com/aide/aide/releases/download/v${version}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-5/ugIUvgEpnXY1m/8pdSM+0kEzLkz8//Wc0baomrpeQ=";
+    sha256 = "sha256-bfi/XwQD10r329uR6zyPYf4H6WRmnbjPoe5+TuPpC1I=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/ai/aide/package.nix
+++ b/pkgs/by-name/ai/aide/package.nix
@@ -44,13 +44,13 @@ stdenv.mkDerivation rec {
     "--sysconfdir=/etc"
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://aide.github.io/";
     changelog = "https://github.com/aide/aide/blob/v${version}/ChangeLog";
     description = "File and directory integrity checker";
     mainProgram = "aide";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ happysalada ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ happysalada ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/ai/aide/package.nix
+++ b/pkgs/by-name/ai/aide/package.nix
@@ -16,11 +16,11 @@
 
 stdenv.mkDerivation rec {
   pname = "aide";
-  version = "0.19.1";
+  version = "0.19.2";
 
   src = fetchurl {
     url = "https://github.com/aide/aide/releases/download/v${version}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-bfi/XwQD10r329uR6zyPYf4H6WRmnbjPoe5+TuPpC1I=";
+    sha256 = "sha256-I3YrBfRhEe3rPIoFAWyHMcAb24wfkb5IwVbDGrhedMQ=";
   };
 
   buildInputs = [


### PR DESCRIPTION
Manual backport of #422866 and #433706 (and part of a treewide) to `release-25.05`.

- [x] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.