### PR TITLE
python313Packages.scanpy: init at 1.11.4

### DIFF
--- a/pkgs/development/python-modules/scanpy/default.nix
+++ b/pkgs/development/python-modules/scanpy/default.nix
@@ -1,0 +1,182 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatch-vcs,
+  hatchling,
+  anndata,
+  h5py,
+  joblib,
+  legacy-api-wrap,
+  matplotlib,
+  natsort,
+  networkx,
+  numba,
+  numpy,
+  packaging,
+  pandas,
+  patsy,
+  pynndescent,
+  scikit-learn,
+  scipy,
+  seaborn,
+  session-info2,
+  statsmodels,
+  tqdm,
+  typing-extensions,
+  umap-learn,
+  dask,
+  dask-ml,
+
+  igraph,
+  leidenalg,
+  scikit-image,
+  scikit-misc,
+  zarr,
+  pytestCheckHook,
+  pytest-cov-stub,
+  pytest-mock,
+  pytest-randomly,
+  pytest-rerunfailures,
+  pytest-xdist,
+  tuna,
+}:
+
+buildPythonPackage rec {
+  pname = "scanpy";
+  version = "1.11.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "scverse";
+    repo = "scanpy";
+    tag = version;
+    hash = "sha256-EvNelorfLOpYLGGZ1RSq4+jk6emuCWCKBdUop24iLf4=";
+  };
+
+  build-system = [
+    hatch-vcs
+    hatchling
+  ];
+
+  dependencies = [
+    anndata
+    h5py
+    joblib
+    legacy-api-wrap
+    matplotlib
+    natsort
+    networkx
+    numba
+    numpy
+    packaging
+    pandas
+    patsy
+    pynndescent
+    scikit-learn
+    scipy
+    seaborn
+    session-info2
+    statsmodels
+    tqdm
+    typing-extensions
+    umap-learn
+  ];
+
+  optional-dependencies = {
+    # commented attributes are due to some dependencies not being in Nixpkgs
+    #bbknn = [
+    #  bbknn
+    #];
+    dask = [
+      anndata
+      dask
+    ];
+    dask-ml = [
+      dask-ml
+    ];
+    #harmony = [
+    #  harmonypy
+    #];
+    leiden = [
+      igraph
+      leidenalg
+    ];
+    #louvain = [
+    #  igraph
+    #  louvain
+    #];
+    #magic = [
+    #  magic-impute
+    #];
+    paga = [
+      igraph
+    ];
+    #rapids = [
+    #  cudf
+    #  cugraph
+    #  cuml
+    #];
+    #scanorama = [
+    #  scanorama
+    #];
+    scrublet = [
+      scikit-image
+    ];
+    skmisc = [
+      scikit-misc
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+    pytest-mock
+    pytest-randomly
+    pytest-rerunfailures
+    pytest-xdist
+    tuna
+    zarr
+  ];
+
+  preCheck = ''
+    export NUMBA_CACHE_DIR=$(mktemp -d);
+  '';
+
+  disabledTestPaths = [
+    # try to download data:
+    "tests/test_aggregated.py"
+    "tests/test_highly_variable_genes.py"
+    "tests/test_normalization.py"
+    "tests/test_pca.py"
+    "tests/test_plotting.py"
+    "tests/test_plotting_embedded/"
+  ];
+
+  disabledTests = [
+    # try to download data:
+    "scanpy.get._aggregated.aggregate"
+    "scanpy.plotting._tools.scatterplots.spatial"
+    "test_clip"
+    "test_download_failure"
+    "test_mean_var"
+    "test_regress_out_int"
+    "test_score_with_reference"
+
+    # fails to find the trivial test script for some reason:
+    "test_external"
+  ];
+
+  pythonImportsCheck = [
+    "scanpy"
+  ];
+
+  meta = {
+    description = "Single-cell analysis in Python which scales to >100M cells";
+    homepage = "https://scanpy.readthedocs.io";
+    changelog = "https://github.com/scverse/scanpy/releases/tag/${src.tag}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+    mainProgram = "scanpy";
+  };
+}

--- a/pkgs/development/python-modules/session-info2/default.nix
+++ b/pkgs/development/python-modules/session-info2/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatch-docstring-description,
+  hatch-vcs,
+  hatchling,
+  coverage,
+  ipykernel,
+  jupyter-client,
+  pytestCheckHook,
+  pytest-asyncio,
+  pytest-subprocess,
+  testing-common-database,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage rec {
+  pname = "session-info2";
+  version = "0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "scverse";
+    repo = "session-info2";
+    tag = "v${version}";
+    hash = "sha256-DsI2mFM7xZgSm24yVzF6B+2aruKsjkTKZAmJPg7mWgg=";
+  };
+
+  build-system = [
+    hatch-docstring-description
+    hatch-vcs
+    hatchling
+  ];
+
+  nativeCheckInputs = [
+    coverage
+    ipykernel
+    jupyter-client
+    pytestCheckHook
+    pytest-asyncio
+    pytest-subprocess
+    testing-common-database
+    writableTmpDirAsHomeHook
+  ];
+
+  pythonImportsCheck = [
+    "session_info2"
+  ];
+
+  meta = {
+    description = "Report Python session information";
+    homepage = "https://session-info2.readthedocs.io";
+    changelog = "https://github.com/scverse/session-info2/releases/tag/${src.tag}";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16157,6 +16157,8 @@ self: super: with self; {
 
   scancode-toolkit = callPackage ../development/python-modules/scancode-toolkit { };
 
+  scanpy = callPackage ../development/python-modules/scanpy { };
+
   scapy = callPackage ../development/python-modules/scapy {
     inherit (pkgs) libpcap; # Avoid confusion with python package of the same name
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16407,6 +16407,8 @@ self: super: with self; {
 
   service-identity = callPackage ../development/python-modules/service-identity { };
 
+  session-info2 = callPackage ../development/python-modules/session-info2 { };
+
   setproctitle = callPackage ../development/python-modules/setproctitle { };
 
   setupmeta = callPackage ../development/python-modules/setupmeta { };


### PR DESCRIPTION
python313Packages.anndata: move tests to passthru and enable tests using scanpy
python313Packages.session-info2: init at 0.2

Init [scanpy](https://github.com/scverse/scanpy), a toolkit for analyzing single-cell gene expression data at scale. This addresses #313389 at least partially.

Also refactored `python313Packages.anndata` to run all tests depending on `scanpy` via `passthru.tests` to avoid circularity.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
