### PR TITLE
scmpuff: 0.5.0 -> 0.6.0, some quality-of-life changes

### DIFF
--- a/pkgs/by-name/sc/scmpuff/package.nix
+++ b/pkgs/by-name/sc/scmpuff/package.nix
@@ -2,8 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  testers,
-  scmpuff,
+  versionCheckHook,
 }:
 
 buildGoModule rec {
@@ -25,10 +24,9 @@ buildGoModule rec {
     "-X main.VERSION=${version}"
   ];
 
-  passthru.tests.version = testers.testVersion {
-    package = scmpuff;
-    command = "scmpuff version";
-  };
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
 
   meta = with lib; {
     description = "Add numbered shortcuts to common git commands";

--- a/pkgs/by-name/sc/scmpuff/package.nix
+++ b/pkgs/by-name/sc/scmpuff/package.nix
@@ -40,7 +40,10 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/mroth/scmpuff";
     changelog = "https://github.com/mroth/scmpuff/releases/tag/v${finalAttrs.version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ cpcloud ];
+    maintainers = with maintainers; [
+      cpcloud
+      christoph-heiss
+    ];
     mainProgram = "scmpuff";
   };
 })

--- a/pkgs/by-name/sc/scmpuff/package.nix
+++ b/pkgs/by-name/sc/scmpuff/package.nix
@@ -5,34 +5,42 @@
   versionCheckHook,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "scmpuff";
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "mroth";
     repo = "scmpuff";
-    rev = "v${version}";
-    sha256 = "sha256-+L0W+M8sZdUSCWj9Ftft1gkRRfWMHdxon2xNnotx8Xs=";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-c8F7BgjbR/w2JH8lE2t93s8gj6cWbTQGIkgYTQp9R3U=";
   };
 
-  vendorHash = "sha256-7WHVSEz3y1nxWfbxkzkfHhINLC8+snmWknHyUUpNy7c=";
+  vendorHash = "sha256-7xSMToc5rlxogS0N9H6siauu8i33zUA5/omqXAszDOg=";
 
   ldflags = [
     "-s"
     "-w"
-    "-X main.VERSION=${version}"
+    # see .goreleaser.yml in the repository
+    "-X main.version=${finalAttrs.version}"
+    "-X main.commit=${finalAttrs.src.rev}"
+    "-X main.date=1970-01-01T00:00:00Z"
+    "-X main.builtBy=nixpkgs"
+    "-X main.treeState=clean"
   ];
+
+  strictDeps = true;
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "version";
+  versionCheckProgramArg = "--version";
 
   meta = with lib; {
-    description = "Add numbered shortcuts to common git commands";
+    description = "Numeric file shortcuts for common git commands";
     homepage = "https://github.com/mroth/scmpuff";
+    changelog = "https://github.com/mroth/scmpuff/releases/tag/v${finalAttrs.version}";
     license = licenses.mit;
     maintainers = with maintainers; [ cpcloud ];
     mainProgram = "scmpuff";
   };
-}
+})


### PR DESCRIPTION
Replaces #429689.

Some quality-of-life changes to the module are also done along the way:

- use `finalAttrs` pattern instead of `rec`
- update meta.description
- add meta.changelog

@cpcloud: Are you still using/interested in maintaining this package? 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
