### PR TITLE
python3Packages.reflex: 0.7.14 -> 0.8.6

### DIFF
--- a/pkgs/development/python-modules/reflex-chakra/default.nix
+++ b/pkgs/development/python-modules/reflex-chakra/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   hatchling,
+  uv-dynamic-versioning,
   pythonOlder,
   reflex,
   pytestCheckHook,
@@ -10,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "reflex-chakra";
-  version = "0.7.1";
+  version = "0.8.2post1";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -19,11 +20,19 @@ buildPythonPackage rec {
     owner = "reflex-dev";
     repo = "reflex-chakra";
     tag = "v${version}";
-    hash = "sha256-dAenwsFhRj9BzdGyaC38TwBWog95H0mSA0ullt4otHA=";
+    hash = "sha256-DugZRZpGP90EFkBjpAS1XkjrNPG6WWwCQPUcEZJ0ff8=";
   };
 
-  build-system = [ hatchling ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail ', "uv-dynamic-versioning"' "" \
+      --replace-fail 'source = "uv-dynamic-versioning"' 'source = "env"${"\n"}variable = "version"'
+  '';
 
+  build-system = [
+    hatchling
+    uv-dynamic-versioning
+  ];
   dependencies = [ reflex ];
 
   pythonImportsCheck = [ "reflex_chakra" ];

--- a/pkgs/development/python-modules/reflex-hosting-cli/default.nix
+++ b/pkgs/development/python-modules/reflex-hosting-cli/default.nix
@@ -18,17 +18,18 @@
 
 buildPythonPackage rec {
   pname = "reflex-hosting-cli";
-  version = "0.1.50";
+  version = "0.1.54";
   pyproject = true;
 
   # source is not published https://github.com/reflex-dev/reflex/issues/3762
   src = fetchPypi {
     pname = "reflex_hosting_cli";
     inherit version;
-    hash = "sha256-1ZTTc09P/0rTNhiqsNDB2RMLcUjKt1rIWtufakkFWkg=";
+    hash = "sha256-agfG9nKCvKqWUOfXZ54S25jMYPSg9oVItcu0PTbIoB4=";
   };
 
   pythonRelaxDeps = [
+    "click"
     "rich"
     "pipdeptree"
   ];

--- a/pkgs/development/python-modules/reflex/default.nix
+++ b/pkgs/development/python-modules/reflex/default.nix
@@ -7,7 +7,6 @@
   build,
   ruff,
   dill,
-  fastapi,
   granian,
   hatchling,
   httpx,
@@ -43,14 +42,14 @@
 
 buildPythonPackage rec {
   pname = "reflex";
-  version = "0.7.14";
+  version = "0.8.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "reflex-dev";
     repo = "reflex";
     tag = "v${version}";
-    hash = "sha256-yuVBQYP0YlvAIWF/+oSfCLbfj1GLtnYajU3WoolyTjY=";
+    hash = "sha256-Tas67x9UEFSR7yyENvixzCWbbKgP+OBMw6prnxWgCQo=";
   };
 
   # 'rich' is also somehow checked when building the wheel,
@@ -59,9 +58,9 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = [
     # needed
+    "click"
+    "starlette"
     "rich"
-    # preventative
-    "fastapi"
   ];
 
   build-system = [ hatchling ];
@@ -70,7 +69,6 @@ buildPythonPackage rec {
     alembic
     build # used in custom_components/custom_components.py
     dill # used in state.py
-    fastapi
     granian
     granian.optional-dependencies.reload
     httpx


### PR DESCRIPTION
- **python3Packages.reflex: 0.7.14 -> 0.8.6**
- **python3Packages.reflex-chakra: 0.7.1 -> 0.8.2post1**
- **python3Packages.reflex-hosting-cli: 0.1.50 -> 0.1.54**

Changelogs:
* https://github.com/reflex-dev/reflex/releases/tag/v0.8.6
* https://github.com/reflex-dev/reflex-chakra/releases/tag/v0.8.2post1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
