### PR TITLE
word-snatchers-cli: init at 4.1.0

### DIFF
--- a/pkgs/by-name/wo/word-snatchers-cli/package.nix
+++ b/pkgs/by-name/wo/word-snatchers-cli/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "word-snatchers-cli";
+  version = "4.1.0";
+
+  src = fetchFromGitHub {
+    owner = "akgondber";
+    repo = "word-snatchers-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-T3xBVes4ykE/UiAEXCytwrgopxyFxvvowMaTbglUM6w=";
+  };
+
+  npmDepsHash = "sha256-TLz4NePVMRJ8BdCFg+pnMVbiXOXIr7mz0q1L9GTbXGM=";
+
+  dontNpmBuild = true;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Game of unscramble the letters to spell out a word fitting the given definition";
+    homepage = "https://github.com/akgondber/word-snatchers-cli";
+    changelog = "https://github.com/akgondber/word-snatchers-cli/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "word-snatchers-cli";
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
