### PR TITLE
bili-live-tool: init at 0.3.9

### DIFF
--- a/pkgs/by-name/bi/bili-live-tool/package.nix
+++ b/pkgs/by-name/bi/bili-live-tool/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+let
+  version = "0.3.9";
+in
+python3Packages.buildPythonApplication {
+  pname = "bili-live-tool";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "chenxi-Eumenides";
+    repo = "bilibili_live_tool";
+    tag = "v${version}";
+    hash = "sha256-gNzR9cDy4sixQOSWAXeX5qOoGkaFOjBU//+iHvG0lG8=";
+  };
+
+  postPatch = ''
+    tee >> pyproject.toml <<TOML
+    [tool.setuptools]
+    packages = ["src"]
+    TOML
+  '';
+
+  pyproject = true;
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    image
+    pypinyin
+    qrcode
+    requests
+  ];
+
+  preInstall = ''
+    mkdir -p $out/bin
+    { echo '#!/bin/python'; cat main_cli.py; } > $out/bin/bili-live-tool
+    chmod +x $out/bin/bili-live-tool
+  '';
+
+  nativeCheckInputs = with python3Packages; [ unittestCheckHook ];
+  unittestFlags = [
+    "-s"
+    "unittest"
+    "-v"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool to start and stop streaming and getting streaming codes for Bilibili live";
+    homepage = "https://github.com/chenxi-Eumenides/bilibili_live_tool";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+    mainProgram = "bili-live-tool";
+  };
+}

--- a/pkgs/development/python-modules/image/default.nix
+++ b/pkgs/development/python-modules/image/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  pillow,
+  django,
+  six,
+}:
+
+let
+  pname = "image";
+  version = "1.5.33";
+in
+buildPythonPackage rec {
+  inherit pname version;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-uqLgkXgnfapQ8i/W0dUex48ZwSaIkhy5q1gIdD8JcSY=";
+  };
+
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  dependencies = [
+    pillow
+    django
+    six
+  ];
+
+  pythonImportsCheck = [ "image" ];
+
+  meta = {
+    description = "Django application for image and video processing";
+    homepage = "https://github.com/francescortiz/image";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6900,6 +6900,8 @@ self: super: with self; {
 
   ilua = callPackage ../development/python-modules/ilua { };
 
+  image = callPackage ../development/python-modules/image { };
+
   image-diff = callPackage ../development/python-modules/image-diff { };
 
   image-go-nord = callPackage ../development/python-modules/image-go-nord { };


### PR DESCRIPTION
[bili-live-tool](https://github.com/chenxi-Eumenides/bilibili_live_tool): Tool to start and stop streaming and getting streaming codes for Bilibili live.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
