### PR TITLE
[Backport release-25.05] carapace: 1.3.3 -> 1.4.1

### DIFF
--- a/pkgs/shells/carapace/default.nix
+++ b/pkgs/shells/carapace/default.nix
@@ -9,16 +9,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "carapace";
-  version = "1.3.3";
+  version = "1.4.1";
 
   src = fetchFromGitHub {
     owner = "carapace-sh";
     repo = "carapace-bin";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-dVM5XFFNXAVoN2xshq5k0Y6vSrfSNS0bIptcloX/uSg=";
+    hash = "sha256-aI69LQuyXUGqxjcUIH3J8AG7cgn/onBg0mZc+zz+YrA=";
   };
 
-  vendorHash = "sha256-XRbqxL2ANWi2aZbB30tNBxJoBIoDoMxKXMpOx++JJ6M=";
+  vendorHash = "sha256-AwR+Oh1Rlg1z/pYdc9VDvp/FLH1ZiPsP/q4lks3VqqE=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/issues/431446
https://github.com/nix-community/home-manager/issues/7517

---

Resolves #431446 

---

Will resolve [this home-manager issue](https://github.com/nix-community/home-manager/issues/7517) upon this PRs successful merge and backporting through hydra to nixpkgs-25.05 and PR in the home-manager repo that updates the flake input for their 25.05 branch.

---

Summary: 
Nushell with carapace integration (and some direnv issues) was not working on nixpkgs-25.05, some breaking changes were made to nushell and carapace and we have confirmed that nushell v0.106.1 and carapace v1.4.1 do indeed work when installed together.

*NOTE: the direnv issue is reportedly resolved via [this PR](https://github.com/nix-community/home-manager/pull/7081)

---

Changelogs:
[nushell v0.106.0](https://www.nushell.sh/blog/2025-07-23-nushell_0_106_0.html)
[nushell v0.106.1](https://www.nushell.sh/blog/2025-07-30-nushell_0_106_1.html)
[carapace v1.4.1](https://github.com/carapace-sh/carapace-bin/releases/tag/v1.4.1)

---

Need help with the following items as they are beyond my scope of knowledge:
- Ensuring that no other packages are broken due to these backports as mentioned [here](https://github.com/nix-community/home-manager/issues/7517#issuecomment-3158066598)

---

Mention Issue Owners: 
@marienz
@Nytelife26
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
---

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
