### PR TITLE
postgresql: fix build

### DIFF
--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -425,15 +425,16 @@ let
         substituteInPlace "src/Makefile.global.in" --subst-var out
         substituteInPlace "src/common/config_info.c" --subst-var dev
         cat ${./pg_config.env.mk} >> src/common/Makefile
-
-        # This test always fails on hardware with >1 NUMA node: the sysfs
-        # dirs providing information about the topology are hidden in the sandbox,
-        # so postgres assumes there's only a single node `0`. However,
-        # the test checks on which NUMA nodes the allocated pages are which is >1
-        # on such hardware. This in turn triggers a safeguard in the view
-        # which breaks the test.
-        # Manual tests confirm that the testcase behaves properly outside of the
-        # Nix sandbox.
+      ''
+      # This test always fails on hardware with >1 NUMA node: the sysfs
+      # dirs providing information about the topology are hidden in the sandbox,
+      # so postgres assumes there's only a single node `0`. However,
+      # the test checks on which NUMA nodes the allocated pages are which is >1
+      # on such hardware. This in turn triggers a safeguard in the view
+      # which breaks the test.
+      # Manual tests confirm that the testcase behaves properly outside of the
+      # Nix sandbox.
+      + lib.optionalString (atLeast "18") ''
         substituteInPlace src/test/regress/parallel_schedule \
           --replace-fail numa ""
       ''


### PR DESCRIPTION
The test is only available on PostgreSQL 18, thus the replace will fail on anything lower.

Fixes https://github.com/NixOS/nixpkgs/pull/432495#issuecomment-3190718477

cc @trofi

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
