### PR TITLE
togo: init at 1.0.5

### DIFF
--- a/pkgs/by-name/to/togo/package.nix
+++ b/pkgs/by-name/to/togo/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "togo";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "prime-run";
+    repo = "togo";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vrRqPkgoz5CRgNOz34z9WtDMnZiltojrv9y2i5iKTHw=";
+  };
+
+  vendorHash = "sha256-7IPI02EXnEiy2OsysxL0xKZl/YASAo6xBXvUeNjYyfU=";
+
+  ldflags = with finalAttrs; [
+    "-s"
+    "-w"
+    "-X=main.version=${version}"
+    "-X=main.commit=${src.tag}"
+    "-X=main.date=1970-01-01T00:00:00Z"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fast and simple CLI/TUI task and todo manager";
+    longDescription = ''
+      togo is a command line task/todo management utility designed to
+      be simple, fast, and easy to use.
+    '';
+    homepage = "https://github.com/prime-run/togo";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "togo";
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
