### PR TITLE
alive2: 20.0 -> 21.0

### DIFF
--- a/pkgs/by-name/al/alive2/package.nix
+++ b/pkgs/by-name/al/alive2/package.nix
@@ -5,7 +5,7 @@
   re2c,
   z3,
   hiredis,
-  llvm_18,
+  llvm,
   cmake,
   ninja,
   nix-update-script,
@@ -13,13 +13,13 @@
 
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "alive2";
-  version = "20.0";
+  version = "21.0";
 
   src = fetchFromGitHub {
     owner = "AliveToolkit";
     repo = "alive2";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-4QNrBRGH+rxXwb7zTRYAixxipN3ybcXuWCmO+BLU9r4=";
+    hash = "sha256-LL6/Epn6iHQJGKb8PX+U6zvXK/WTlvOIJPr6JuGRsSU=";
   };
 
   nativeBuildInputs = [
@@ -30,7 +30,7 @@ clangStdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     z3
     hiredis
-    llvm_18
+    llvm
   ];
   strictDeps = true;
 
@@ -42,7 +42,7 @@ clangStdenv.mkDerivation (finalAttrs: {
 
   env = {
     ALIVE2_HOME = "$PWD";
-    LLVM2_HOME = "${llvm_18}";
+    LLVM2_HOME = "${llvm}";
     LLVM2_BUILD = "$LLVM2_HOME/build";
   };
 


### PR DESCRIPTION
https://github.com/AliveToolkit/alive2/releases/tag/v21.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
