### PR TITLE
nrfutil: fix dynamically linked executable issue and drop darwin support

### DIFF
--- a/pkgs/by-name/nr/nrfutil/source.nix
+++ b/pkgs/by-name/nr/nrfutil/source.nix
@@ -4,12 +4,4 @@
     name = "x86_64-unknown-linux-gnu";
     hash = "sha256-R3OF/340xEab+0zamfwvejY16fjy/3TrzMvQaBlVxHw=";
   };
-  x86_64-darwin = {
-    name = "x86_64-apple-darwin";
-    hash = "sha256-cnZkVkTbQ/+ciITPEx2vxxZchCC54T0JOApB4HKp8e0=";
-  };
-  aarch64-darwin = {
-    name = "aarch64-apple-darwin";
-    hash = "sha256-5VxDQ25tW+qTXHwkltpaAm4AnQvA18qGMaflYQzE2pQ=";
-  };
 }

--- a/pkgs/by-name/nr/nrfutil/update.sh
+++ b/pkgs/by-name/nr/nrfutil/update.sh
@@ -14,8 +14,6 @@ declare -A versions
 declare -A hashes
 
 architectures["x86_64-linux"]="x86_64-unknown-linux-gnu"
-architectures["x86_64-darwin"]="x86_64-apple-darwin"
-architectures["aarch64-darwin"]="aarch64-apple-darwin"
 
 BASE_URL="https://files.nordicsemi.com/artifactory/swtools/external/nrfutil"
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
* drop darwin support as one of nrfutil's deps, segger-jlink does not support darwin.
* fix dynamically linked executable issue by using autoPatchelfHook to link gcc and zlib. #398197

pinging maintainer @h7x4

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

Fixes #398197