### PR TITLE
nixos/greetd: avoid systemd boot messages interrupt greetd

### DIFF
--- a/nixos/modules/services/display-managers/greetd.nix
+++ b/nixos/modules/services/display-managers/greetd.nix
@@ -59,6 +59,16 @@ in
         because every greetd restart will trigger the autologin again.
       '';
     };
+
+    useTextGreeter = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether the greeter uses text-based user interfaces (For example, tuigreet).
+
+        When set to true, some systemd service configuration will be adjusted to avoid systemd boot messages interrupt TUI.
+      '';
+    };
   };
   config = lib.mkIf cfg.enable {
 
@@ -108,7 +118,19 @@ in
         KeyringMode = "shared";
 
         Type = "idle";
-      };
+      }
+      // (lib.optionalAttrs cfg.useTextGreeter {
+        StandardInput = "tty";
+        StandardOutput = "tty";
+        # Without this errors will spam on screen
+        StandardError = "journal";
+
+        # Without these bootlogs will spam on screen
+        TTYPath = "/dev/tty1";
+        TTYReset = true;
+        TTYVHangup = true;
+        TTYVTDisallocate = true;
+      });
 
       # Don't kill a user session when using nixos-rebuild
       restartIfChanged = false;


### PR DESCRIPTION
Before #428972, greetd users can set `vt` to number other than 1 to avoid systemd boot messages interrupt tuigreet (or other tui greeter). Now `vt` is fixed to 1, so some other configuration is needed.

I have tested it in my nixos configuration using greetd with tuigreet. There are some other comments proving that this PR works.

- comments (the first two links point to different comments within the same PR):
  
  - https://github.com/NixOS/nixpkgs/pull/428972#issuecomment-3157744792
  - https://github.com/NixOS/nixpkgs/pull/428972#issuecomment-3168365800
  - https://github.com/nukdokplex/ncaa/commit/0e0f9d95de22474f5e497f524b99fe5f7e584b68

- reference: https://www.reddit.com/r/NixOS/comments/u0cdpi/tuigreet_with_xmonad_how/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
