### PR TITLE
visusort: init at 0-unstable-2025-08-13

### DIFF
--- a/pkgs/by-name/vi/visusort/package.nix
+++ b/pkgs/by-name/vi/visusort/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustpython,
+  makeWrapper,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "visusort";
+  version = "0-unstable-2025-08-13";
+
+  src = fetchFromGitHub {
+    owner = "crypticsaiyan";
+    repo = "visusort";
+    rev = "8bb1d118037eb059a768166d7221004e8c9dd50b";
+    hash = "sha256-+Sg5XM6f0k7favnSj9r0UWVszRF97ZAp0yCuSb5DRBo=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postPatch = ''
+    substituteInPlace visusort.py \
+      --replace-fail './main' '${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}-cli'
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    $CXX $(find . -name "*.cpp") \
+      --output=${finalAttrs.meta.mainProgram}-cli \
+      --optimize=3 \
+      -s
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D ${finalAttrs.meta.mainProgram}-cli --target-directory=$out/bin
+    install -Dm644 visusort.py --target-directory=$out/lib
+
+    makeWrapper ${lib.getExe rustpython} $out/bin/${finalAttrs.meta.mainProgram} \
+      --add-flags $out/lib/visusort.py
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "TUI and CLI tool to visualize sorting algorithms";
+    homepage = "https://github.com/crypticsaiyan/visusort";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "visusort";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
