### PR TITLE
postgresql.tests.postgresql.postgresql-backup-all: fix random dump

### DIFF
--- a/nixos/modules/services/backup/postgresql-backup.nix
+++ b/nixos/modules/services/backup/postgresql-backup.nix
@@ -124,10 +124,7 @@ in
         type = lib.types.separatedString " ";
         default = "-C";
         description = ''
-          Command line options for pg_dump. This options is not used
-          if `config.services.postgresqlBackup.backupAll` is enabled.
-          Note that config.services.postgresqlBackup.backupAll is also active,
-          when no databases where specified.
+          Command line options for pg_dump or pg_dumpall.
         '';
       };
 
@@ -177,7 +174,7 @@ in
       ];
     })
     (lib.mkIf (cfg.enable && cfg.backupAll) {
-      systemd.services.postgresqlBackup = postgresqlBackupService "all" "pg_dumpall";
+      systemd.services.postgresqlBackup = postgresqlBackupService "all" "pg_dumpall ${cfg.pgdumpOptions}";
     })
     (lib.mkIf (cfg.enable && !cfg.backupAll) {
       systemd.services = lib.listToAttrs (

--- a/nixos/tests/postgresql/postgresql.nix
+++ b/nixos/tests/postgresql/postgresql.nix
@@ -65,6 +65,7 @@ let
           services.postgresqlBackup = {
             enable = true;
             databases = lib.optional (!backupAll) "postgres";
+            pgdumpOptions = "--restrict-key=ABCDEFGHIJKLMNOPQRSTUVWXYZ";
           };
         };
 


### PR DESCRIPTION
The new `\restrict` migitation creates random keys in the dump file by default, which breaks a before/after test for the backup module. By making the restrict key reproducible, the test passes again.

Needed to add a new option to the module, because otherwise the "all" case was not reproducible either. We could also just use `pgdumpOptions` for `pg_dumpall`, but since the option description explicitly mentions not to, I wasn't sure about that. We need to backport this to 25.05, otherwise those tests will stay broken.

That being said, if we're OK with "breaking" this promise and using the `pgdumpOptions` for the "all" case as well, I would like that more.

Fixes https://github.com/NixOS/nixpkgs/pull/433756#issuecomment-3190874033

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
