### PR TITLE
fetchMavenArtifact: fix metadata support

### DIFF
--- a/pkgs/build-support/fetchmavenartifact/default.nix
+++ b/pkgs/build-support/fetchmavenartifact/default.nix
@@ -31,6 +31,8 @@ args@{
   # and `urls` can be specified, not both.
   url ? "",
   urls ? [ ],
+  # Metadata
+  meta ? { },
   # The rest of the arguments are just forwarded to `fetchurl`.
   ...
 }:
@@ -71,6 +73,7 @@ let
       "classifier"
       "repos"
       "url"
+      "meta"
     ]
     // {
       urls = urls_;
@@ -79,7 +82,7 @@ let
   );
 in
 stdenv.mkDerivation {
-  inherit pname version;
+  inherit pname version meta;
   dontUnpack = true;
   # By moving the jar to $out/share/java we make it discoverable by java
   # packages packages that mention this derivation in their buildInputs.


### PR DESCRIPTION
Fix `fetchMavenArtifact` to forward the "meta" attribute to `mkDerivation` rather than `fetchurl`.

By fixing that issue, it adds support for the "meta" attribute of fetchMavenArtifact, making it usable as direct replacement for `stdenv.mkDerivation` in most cases.

Background: For many Java packages, the derivation created by fetchMavenArtifact is wrapped into another derivation that copies over all files, just to be able to specify the metadata via the "meta" attribute in the outer derivation.  This is cumbersome, because it is extra code that is unnecessarily convoluted. And it is wasteful, as all downloaded JAR files are stored twice into the Nix store, for the outer and the inner derivation, until the next "gc" or "optimize" action happens.

Solution: All those derivations could instead be created by a single call to fetchMavenArtifact, without copying their downloaded JAR files twice into the Nix store, if fetchMavenArtifact would just forward the "meta" attribute properly. This commit does exactly that.

See PR #427538 for an example on how simple Java derivations from Maven Artifacts can be:

```nix
{ fetchMavenArtifact, lib }:
fetchMavenArtifact {
  groupId = "...";
  artifactId = "...";
  version = "...";
  hash = "sha256-...";
  meta = {
    homepage = "....";
    description = "...";
    license = ...;
    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
    maintainers = [ ... ];
  };
}
```

Also, reusing pieces of another package, such as its version number or most of it metadata, works the exact same way as we are used to with `stdenv.mkDerivation`:

```nix
{ fetchMavenArtifact, lib, some-other-package }:
fetchMavenArtifact {
  groupId = "...";
  artifactId = "...";
  inherit (some-other-package) version;
  hash = "sha256-...";
  meta = some-other-package.meta // {
    description = "...";
    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
  };
}
```

Again, see PR #427538 for a practical example of reusing metadata.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - **(via the `junixsocket-*` packages, see PR #427538)**
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
