### PR TITLE
xcbuild: fix crash when home directory is missing

### DIFF
--- a/pkgs/by-name/xc/xcbuild/package.nix
+++ b/pkgs/by-name/xc/xcbuild/package.nix
@@ -81,6 +81,8 @@ stdenv.mkDerivation (finalAttrs: {
     ./patches/Suppress-unknown-key-warnings.patch
     # Don't pipe stdout / stderr of processes launched by xcrun
     ./patches/fix-interactive-apps.patch
+    # Fallback to $HOME and correctly handle missing home directories
+    ./patches/fix-no-home-directory-crash.patch
   ];
 
   prePatch = ''

--- a/pkgs/by-name/xc/xcbuild/patches/fix-no-home-directory-crash.patch
+++ b/pkgs/by-name/xc/xcbuild/patches/fix-no-home-directory-crash.patch
@@ -1,0 +1,39 @@
+From 4da8e2e3e91aa1a92db95c33a62e1e76525e40cc Mon Sep 17 00:00:00 2001
+From: andre4ik3 <andre4ik3@fastmail.com>
+Date: Fri, 15 Aug 2025 09:39:33 +0000
+Subject: [PATCH] Fix crash when no home directory is set
+
+---
+ Libraries/process/Sources/DefaultUser.cpp | 15 +++++++++++----
+ 1 file changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/Libraries/process/Sources/DefaultUser.cpp b/Libraries/process/Sources/DefaultUser.cpp
+index 54e464e0..466e63cd 100644
+--- a/Libraries/process/Sources/DefaultUser.cpp
++++ b/Libraries/process/Sources/DefaultUser.cpp
+@@ -269,11 +269,18 @@ userHomeDirectory() const
+     CloseHandle(process);
+     return WideStringToString(buffer);
+ #else
+-    char *home = ::getpwuid(::getuid())->pw_dir;
+-    if (home != nullptr) {
++    if (struct passwd const *pw = ::getpwuid(::getuid())) {
++        if (pw->pw_name != nullptr) {
++            return std::string(pw->pw_dir);
++        }
++    }
++
++    // Fallback to $HOME if no home is set
++    const char* home = std::getenv("HOME");
++    if (home && *home) {
+         return std::string(home);
+-    } else {
+-        return ext::nullopt;
+     }
++
++    return ext::nullopt;
+ #endif
+ }
+-- 
+2.50.1
+


### PR DESCRIPTION
Fixes crash that occurs when using `xcbuild` in combination with `auto-allocate-uids`. The crash occurs when it tries to lookup the user's home directory from `passwd`, but the user record doesn't exist, and it crashes while dereferencing a pointer to the home directory.

Instead of crashing, I added a patch that changes the fallback handling to be in line with the other getters for UID, GID, and group name. It will try to get it from `passwd`, failing that, it will look in `$HOME` (as the Nix build environment sets it to `/homeless-shelter`), and if there is still nothing it will return, instead of crashing.

<details>
<summary>Demo</summary>

Showing `auto-allocate-uids` is enabled:

```
❯ cat /etc/nix/nix.conf | grep auto-allocate-uids
auto-allocate-uids = true
experimental-features = nix-command flakes auto-allocate-uids cgroups fetch-closure
```

Load up Nix repl and build the `xcbuild` with patches (note the `nixpkgs` loaded is the original, unpatched Nixpkgs to avoid rebuilding the world due to `xcbuild` being part of `stdenv`):

```
❯ nix repl
Nix 2.28.4
Type :? for help.
nix-repl> :lf nixpkgs
nix-repl> xcbuild = legacyPackages.aarch64-darwin.xcbuild.overrideAttrs (prev: { patches = prev.patches ++ [ ./patches/fix-no-home-directory-crash.patch ]; })

nix-repl> :b xcbuild

This derivation produced the following outputs:
  out -> /nix/store/qkwpn0sia64qsa77ijl6s555j7wdyrw4-xcbuild-0.1.1-unstable-2019-11-20
  xcrun -> /nix/store/1pxlav5mzvvjgdix32rzm6vagn2xryf4-xcbuild-0.1.1-unstable-2019-11-20-xcrun
```

Build `xcbuildHook`:

```
nix-repl> xcbuildHook = legacyPackages.aarch64-darwin.xcbuildHook.overrideAttrs { propagatedBuildInputs = [xcbuild]; }

nix-repl> :b xcbuildHook

This derivation produced the following outputs:
  out -> /nix/store/vc34ygdsf17idwh0wrss7f8zkd77rrfr-xcbuild-hook
```

Then build MoltenVK, this is an example package that makes use of `xcbuild`/`xcbuildHook`:

```
nix-repl> moltenvk = legacyPackages.aarch64-darwin.moltenvk.override { inherit xcbuildHook; }

nix-repl> :b moltenvk

This derivation produced the following outputs:
  bin -> /nix/store/s8yfx81qnci48lz1hyfs6kicyiy1n2gi-MoltenVK-1.2.11-bin
  dev -> /nix/store/r64zbiz51fsfh36d20jbs39wd2qvps46-MoltenVK-1.2.11-dev
  out -> /nix/store/mh07a0v7y42vcsznp0lflqvkgq1wpbsf-MoltenVK-1.2.11
```

And now try to build the original MoltenVK with unpatched `xcbuild`, the trivial override is needed to force a build from source. As seen below, `xcbuild` crashes:

```
nix-repl> :b legacyPackages.aarch64-darwin.moltenvk.overrideAttrs (prev: { postPatch = "\n${prev.postPatch or ""}"; })
error: builder for '/nix/store/ql3mi8gll6w1gw6v15ilb7cxxsjlg720-MoltenVK-1.2.11.drv' failed with exit code 139;
       last 16 log lines:
       > structuredAttrs is enabled
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/wq1mkymb065hwy8785b1k71z1z3kfj0b-source
       > source root is source
       > Running phase: patchPhase
       > applying patch /nix/store/6rf7y0djv569y9xl0gw0fn24rkbh7fic-856c8237ac3b32178caae3408effc35bedfdffa1.patch?full_index=1
       > patching file Docs/Whats_New.md
       > Hunk #1 succeeded at 11 with fuzz 2 (offset -7 lines).
       > patching file MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > running xcodebuild: -configuration Release -project MoltenVKPackaging.xcodeproj -scheme MoltenVK\ Package\ \(macOS\ only\) -destination generic/platform=macOS -arch arm64
       > warning: destination option not implemented
       > /nix/store/rs3givrw75l2qck44h3d0v5inc6qr2av-xcbuild-hook/nix-support/setup-hook: line 1: 89884 Segmentation fault: 11     xcodebuild SYMROOT=$PWD/Products OBJROOT=$PWD/Intermediates "${flagsArray[@]}" build
       For full logs, run:
         nix log /nix/store/ql3mi8gll6w1gw6v15ilb7cxxsjlg720-MoltenVK-1.2.11.drv
```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
