### PR TITLE
has: 1.5.0 -> 1.5.2

### DIFF
--- a/pkgs/by-name/ha/has/package.nix
+++ b/pkgs/by-name/ha/has/package.nix
@@ -6,13 +6,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "has";
-  version = "1.5.0";
+  version = "1.5.2";
 
   src = fetchFromGitHub {
     owner = "kdabir";
     repo = "has";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-TL8VwFx2tf+GkBwz0ILQg0pwcLJSTky57Wx9OW5+lS4=";
+    hash = "sha256-sqpKI9RHo0VlGUNU71mIzw4LzExji2FN2FBOAIVo4jI=";
   };
 
   dontBuild = true;


### PR DESCRIPTION
Updated *has* from v1.5.0 to the latest version v1.5.2.

## Changelog
### [v1.5.2](https://github.com/kdabir/has/releases/tag/v1.5.2)
Added tests for --verion, -v, --help, -h

### [v1.5.1](https://github.com/kdabir/has/releases/tag/v1.5.1)
Fixes shellcheck warnings
Refine git clone commands in Dockerfiles
Add more "Build and Compile" tools
Supercharge has with various tools
CI: Upgrade GitHub Actions
Contribution friendly

[Full Changelog: v.1.5.0...v1.5.1](https://github.com/kdabir/has/compare/v.1.5.0...v1.5.1)

## Tests
- Ran `./result/bin/has git curl node` and verified that *has* found both `git` and `curl` and displayed the version number. Whilst `node` displayed an error due to not having it installed on my system.
- Verified that `--version` worked as intended.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
