### PR TITLE
python3Packages.busylight-for-humans: add optional dependencies of busyserve

### DIFF
--- a/pkgs/development/python-modules/busylight-for-humans/default.nix
+++ b/pkgs/development/python-modules/busylight-for-humans/default.nix
@@ -3,6 +3,7 @@
   bitvector-for-humans,
   buildPythonPackage,
   fetchFromGitHub,
+  fastapi,
   hidapi,
   loguru,
   poetry-core,
@@ -11,6 +12,7 @@
   pytestCheckHook,
   pythonOlder,
   typer,
+  uvicorn,
   webcolors,
   udevCheckHook,
 }:
@@ -39,6 +41,13 @@ buildPythonPackage rec {
     typer
     webcolors
   ];
+
+  optional-dependencies = {
+    webapi = [
+      fastapi
+      uvicorn
+    ];
+  };
 
   nativeCheckInputs = [
     pytestCheckHook


### PR DESCRIPTION
BusyLight for Humans [includes a web server](https://jnyjny.github.io/busylight/api/) which currently fails to run:

```console
$ nix-shell --packages 'python3Packages.busylight-for-humans' --run 'busyserve'
The package `uvicorn` is missing, unable to serve the busylight API.
```

This change makes available [its dependencies](https://github.com/JnyJny/busylight/blob/v0.35.2/pyproject.toml#L26):

```console
$ nix-shell --packages 'python3Packages.busylight-for-humans.overridePythonAttrs (p: { dependencies = p.dependencies ++ p.optional-dependencies.webapi; })' --run 'busyserve'
INFO:     Started server process [47202]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
