### PR TITLE
kbd: link compression libs directly

### DIFF
--- a/nixos/modules/config/console.nix
+++ b/nixos/modules/config/console.nix
@@ -195,7 +195,6 @@ in
             "${config.boot.initrd.systemd.package}/lib/systemd/systemd-vconsole-setup"
             "${config.boot.initrd.systemd.package.kbd}/bin/setfont"
             "${config.boot.initrd.systemd.package.kbd}/bin/loadkeys"
-            "${config.boot.initrd.systemd.package.kbd.gzip}/bin/gzip" # Fonts and keyboard layouts are compressed
           ]
           ++ lib.optionals (cfg.font != null && lib.hasPrefix builtins.storeDir cfg.font) [
             "${cfg.font}"

--- a/pkgs/by-name/kb/kbd/package.nix
+++ b/pkgs/by-name/kb/kbd/package.nix
@@ -1,34 +1,38 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchgit,
   nixosTests,
   autoreconfHook,
   pkg-config,
   flex,
+  perl,
+  bison,
+  autoPatchelfHook,
   check,
   pam,
   bash,
   bashNonInteractive,
   coreutils,
-  gzip,
+  zlib,
   bzip2,
   xz,
   zstd,
   gitUpdater,
+  pkgsCross,
   withVlock ? true,
-  compress ? false,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "kbd";
-  version = "2.8.0";
+  version = "2.8.0-unstable-2025-08-12";
 
   __structuredAttrs = true;
 
-  src = fetchurl {
-    url = "mirror://kernel/linux/utils/kbd/${pname}-${version}.tar.xz";
-    hash = "sha256-AfWAbafR009ZS3sqauGrIyFTRM8QZOjtzTqQ/vl3ahE=";
+  src = fetchgit {
+    url = "https://git.kernel.org/pub/scm/linux/kernel/git/legion/kbd.git";
+    rev = "46295167a55643e941c8cdcfd2cb76bd138c851c";
+    hash = "sha256-m1aVfsEme/BnyJogOPvGcOrSJfli8B/TrGxOm4POt0w=";
   };
 
   # vlock is moved into its own output, since it depends on pam. This
@@ -41,20 +45,6 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals withVlock [
     "vlock"
-  ];
-
-  configureFlags = [
-    "--enable-optional-progs"
-    "--enable-libkeymap"
-    "--disable-nls"
-    (lib.enableFeature withVlock "vlock")
-  ]
-  ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
-    "ac_cv_func_malloc_0_nonnull=yes"
-    "ac_cv_func_realloc_0_nonnull=yes"
-  ]
-  ++ lib.optionals (!compress) [
-    "--disable-compress"
   ];
 
   patches = [
@@ -73,68 +63,87 @@ stdenv.mkDerivation rec {
     mv fgGIod/trf{,-fgGIod}.map
     mv colemak/{en-latin9,colemak}.map
     popd
-
-    sed -i '
-      1i prefix:=$(vlock)
-      1i bindir := $(vlock)/bin' \
-      src/vlock/Makefile.in \
-      src/vlock/Makefile.am
-  ''
-  + lib.optionalString compress ''
-    # Fix paths to decompressors. Trailing space to avoid replacing `xz` in `".xz"`.
-    substituteInPlace src/libkbdfile/kbdfile.c \
-      --replace-fail 'gzip '  '${gzip}/bin/gzip ' \
-      --replace-fail 'bzip2 ' '${bzip2.bin}/bin/bzip2 ' \
-      --replace-fail 'xz '    '${xz.bin}/bin/xz ' \
-      --replace-fail 'zstd '  '${zstd.bin}/bin/zstd '
   '';
 
+  preConfigure = ''
+    # Perl and Bash only used during build time
+    patchShebangs --build contrib/
+  '';
+
+  configureFlags = [
+    "--enable-optional-progs"
+    "--enable-libkeymap"
+    "--disable-nls"
+    (lib.enableFeature withVlock "vlock")
+  ]
+  ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
+    "ac_cv_func_malloc_0_nonnull=yes"
+    "ac_cv_func_realloc_0_nonnull=yes"
+  ];
+
+  strictDeps = true;
   enableParallelBuilding = true;
 
-  postInstall = ''
-    for s in unicode_{start,stop}; do
-      substituteInPlace ''${!outputBin}/bin/$s \
-        --replace-fail /usr/bin/tty ${coreutils}/bin/tty
-      moveToOutput "bin/$s" "$scripts"
-    done
-  '';
-
-  buildInputs = [
-    check
-    bash
-  ]
-  ++ lib.optionals withVlock [ pam ];
-
-  NIX_LDFLAGS = lib.optional stdenv.hostPlatform.isStatic "-laudit";
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
     flex
+    perl
+    bison
+    autoPatchelfHook # for patching dlopen()
   ];
-  strictDeps = true;
 
-  outputChecks.out.disallowedRequisites = lib.optionals (!compress) [
+  nativeCheckInputs = [
+    check
+  ];
+
+  buildInputs = [
+    zlib
+    bzip2
+    xz
+    zstd
+    bash
+  ]
+  ++ lib.optionals withVlock [ pam ];
+
+  postInstall = ''
+    substituteInPlace $out/bin/unicode_{start,stop} \
+      --replace-fail /usr/bin/tty ${coreutils}/bin/tty
+
+    moveToOutput bin/unicode_start $scripts
+    moveToOutput bin/unicode_stop $scripts
+  ''
+  + lib.optionalString withVlock ''
+    moveToOutput bin/vlock $vlock
+    moveToOutput etc/pam.d/vlock $vlock
+  '';
+
+  outputChecks.out.disallowedRequisites = [
     bash
     bashNonInteractive
   ];
 
-  passthru.tests = {
-    inherit (nixosTests) keymap kbd-setfont-decompress kbd-update-search-paths-patch;
-  };
   passthru = {
-    gzip = gzip;
     updateScript = gitUpdater {
       # No nicer place to find latest release.
       url = "https://github.com/legionus/kbd.git";
       rev-prefix = "v";
     };
+    tests = {
+      cross =
+        let
+          systemString = if stdenv.buildPlatform.isAarch64 then "gnu64" else "aarch64-multiplatform";
+        in
+        pkgsCross.${systemString}.kbd;
+      inherit (nixosTests) keymap kbd-setfont-decompress kbd-update-search-paths-patch;
+    };
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://kbd-project.org/";
     description = "Linux keyboard tools and keyboard maps";
-    platforms = platforms.linux;
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ davidak ];
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ davidak ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12529,10 +12529,6 @@ with pkgs;
 
   kbibtex = libsForQt5.callPackage ../applications/office/kbibtex { };
 
-  kbdCompressed = callPackage ../by-name/kb/kbd/package.nix {
-    compress = true;
-  };
-
   kexi = libsForQt5.callPackage ../applications/office/kexi { };
 
   kiwix = libsForQt5.callPackage ../applications/misc/kiwix { };


### PR DESCRIPTION
- Clean up derivation
- Remove NIX_LDFLAGS which achieved nothing. Static compilation works
  without it on master. It's unclear what this should've ever achieved.
  kbd doesn't link against audit.
- Build directly from source now instead of the preconfigured tarball
  (avoids xz-style issues)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
