### PR TITLE
mypaint-brushes1: fix build with autotools 1.18

### DIFF
--- a/pkgs/development/libraries/mypaint-brushes/1.0.nix
+++ b/pkgs/development/libraries/mypaint-brushes/1.0.nix
@@ -24,7 +24,15 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
 
-  preConfigure = "./autogen.sh";
+  # don't rely on rigid autotools versions, instead preload whatever is in $PATH in the build environment.
+  # mypaint-brushes1 1.3.1 only officially supports autotools up to 1.16,
+  # unstable git versions support up to autotools 1.17.
+  # However, we are now on autotools 1.18, so this would break.
+  preConfigure = ''
+    export AUTOMAKE=automake
+    export ACLOCAL=aclocal
+    ./autogen.sh
+  '';
 
   meta = with lib; {
     homepage = "http://mypaint.org/";


### PR DESCRIPTION
Analogous fix to #432779

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
