### PR TITLE
nextcloud31Packages.apps.memories: 7.5.2 -> 7.6.1

### DIFF
--- a/pkgs/servers/nextcloud/packages/apps/memories.nix
+++ b/pkgs/servers/nextcloud/packages/apps/memories.nix
@@ -7,6 +7,7 @@
   fetchFromGitHub,
   lib,
   replaceVars,
+  php83,
 
   ncVersion,
 }:
@@ -73,8 +74,9 @@ stdenv.mkDerivation rec {
     rm appinfo/signature.json
     rm -rf bin-ext/
 
+    sed -i 's/EXIFTOOL_VER = .*/EXIFTOOL_VER = @;/' lib/Service/BinExt.php
     substituteInPlace lib/Service/BinExt.php \
-      --replace-fail "EXIFTOOL_VER = '12.70'" "EXIFTOOL_VER = '${exiftool.version}'"
+      --replace-fail "EXIFTOOL_VER = @" "EXIFTOOL_VER = '${exiftool.version}'"
   '';
 
   installPhase = ''

--- a/pkgs/servers/nextcloud/packages/apps/memories.nix
+++ b/pkgs/servers/nextcloud/packages/apps/memories.nix
@@ -15,9 +15,9 @@ let
   latestVersionForNc = {
     "31" = latestVersionForNc."30";
     "30" = {
-      version = "7.5.2";
-      appHash = "sha256-BfxJDCGsiRJrZWkNJSQF3rSFm/G3zzQn7C6DCETSzw4=";
-      srcHash = "sha256-imBO/64NW5MiozpufbMRcTI9WCaN8grnHlVo+fsUNlU=";
+      version = "7.6.1";
+      appHash = "sha256-uRZBTwhdNr3OUw021WvTnEBcLd49EQbVr9bvU97zblc=";
+      srcHash = "sha256-eKvdv3ng4YwPmFu7eapYvD8A2cliryAhPf6NDBJjX6c=";
     };
   };
   currentVersionInfo =

--- a/pkgs/servers/nextcloud/packages/apps/memories.nix
+++ b/pkgs/servers/nextcloud/packages/apps/memories.nix
@@ -7,7 +7,6 @@
   fetchFromGitHub,
   lib,
   replaceVars,
-  php83,
 
   ncVersion,
 }:


### PR DESCRIPTION
Bumped Memories Nextcloud app

see https://github.com/pulsejet/memories/blob/master/CHANGELOG.md

The version of exiftool also changed so I replaced the code that does the substitution of that version by one that is more flexible. (I used sed and substitureInPlace such that it would still error if it was not found)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
