### PR TITLE
recordbox: 0.10.3 -> 0.10.4

### DIFF
--- a/pkgs/by-name/re/recordbox/package.nix
+++ b/pkgs/by-name/re/recordbox/package.nix
@@ -8,6 +8,7 @@
   desktop-file-utils,
   fetchFromGitea,
   glib,
+  glycin-loaders,
   gst_all_1,
   gtk4,
   hicolor-icon-theme,
@@ -83,6 +84,22 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   cargoCheckType = if (finalAttrs.mesonBuildType != "debug") then "release" else "debug";
+
+  # Workaround copied from https://github.com/NixOS/nixpkgs/blob/e39fe935fc7537bee0440935c12f5c847735a291/pkgs/by-name/lo/loupe/package.nix#L60-L74
+  preConfigure = ''
+    # Dirty approach to add patches after cargoSetupPostUnpackHook
+    # We should eventually use a cargo vendor patch hook instead
+    pushd ../$(stripHash $cargoDeps)/glycin-2.*
+      patch -p3 < ${glycin-loaders.passthru.glycinPathsPatch}
+    popd
+  '';
+  preFixup = ''
+    # Needed for the glycin crate to find loaders.
+    # https://gitlab.gnome.org/sophie-h/glycin/-/blob/0.1.beta.2/glycin/src/config.rs#L44
+    gappsWrapperArgs+=(
+      --prefix XDG_DATA_DIRS : "${glycin-loaders}/share"
+    )
+  '';
 
   checkPhase = ''
     runHook preCheck

--- a/pkgs/by-name/re/recordbox/package.nix
+++ b/pkgs/by-name/re/recordbox/package.nix
@@ -27,19 +27,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "recordbox";
-  version = "0.10.3";
+  version = "0.10.4";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "edestcroix";
     repo = "Recordbox";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-o2cKVRpuAwE+/TI5mwtSvkCFaXN349GP9dDlgdh3Luk=";
+    hash = "sha256-9rrVlD+ODl+U9bPzbXGLQBLkbnfAm4SmJHRcVife33A=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-0/tKL5UW1QuhsddivU/r8n3T3xyRaGLRVpKuXcc4fmU=";
+    hash = "sha256-W60X69/fEq/X6AK1sbT6rb+SsF/oPzfUvrar0fihr88=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
Preemptive PR for the imminent release fixing [edestcroix/Recordbox#182](https://codeberg.org/edestcroix/Recordbox/issues/182). I'll update the commit with the diff and release notes upon release.

@getchoo Should `--generate-lockfile` be removed from the update script after https://github.com/NixOS/nixpkgs/pull/425279?


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
