### PR TITLE
clippy: fix cross linting

### DIFF
--- a/pkgs/development/compilers/rust/clippy-wrapper.nix
+++ b/pkgs/development/compilers/rust/clippy-wrapper.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  runCommand,
+  clippy-unwrapped,
+  rustc-unwrapped,
+  makeWrapper,
+}:
+
+runCommand "${clippy-unwrapped.pname}-wrapper-${clippy-unwrapped.version}"
+  {
+    preferLocalBuild = true;
+    strictDeps = true;
+    inherit (clippy-unwrapped) outputs;
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    meta = clippy-unwrapped.meta // {
+      description = "${clippy-unwrapped.meta.description} (wrapper script)";
+      priority = 10;
+    };
+  }
+
+  ''
+    mkdir -p $out/bin
+    makeWrapper ${clippy-unwrapped}/bin/cargo-clippy $out/bin/cargo-clippy \
+      --set-default SYSROOT ${rustc-unwrapped}
+
+    makeWrapper ${clippy-unwrapped}/bin/clippy-driver $out/bin/clippy-driver \
+      --set-default SYSROOT ${rustc-unwrapped}
+
+    ${lib.concatMapStrings (output: "ln -s ${clippy-unwrapped.${output}} \$${output}\n") (
+      lib.remove "out" clippy-unwrapped.outputs
+    )}
+  ''

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -127,12 +127,8 @@ in
             self.callPackage ./cargo_cross.nix { };
         cargo-auditable = self.callPackage ./cargo-auditable.nix { };
         cargo-auditable-cargo-wrapper = self.callPackage ./cargo-auditable-cargo-wrapper.nix { };
-        clippy = self.callPackage ./clippy.nix {
-          # We want to use self, not buildRustPackages, so that
-          # buildPackages.clippy uses the cross compiler and supports
-          # linting for the target platform.
-          rustPlatform = makeRustPlatform self;
-        };
+        clippy-unwrapped = self.callPackage ./clippy.nix { };
+        clippy = if !fastCross then self.clippy-unwrapped else self.callPackage ./clippy-wrapper.nix { };
       }
     );
   };


### PR DESCRIPTION
Clippy uses `clippy-driver` for linting, which needs to be pointed to the correct sysroot, just like our rustc.
`cargo-clippy` needs to be patched to find the wrapped `clippy-driver`.

Fixes: https://github.com/NixOS/nixpkgs/issues/278508

We should probably upstream this patch, but I wanted to get reviews about the approach first before contacting upstream.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
