### PR TITLE
comet-gog_heroic: init at 0.2.0; comet-gog: refactor, add dummy-service passthru

### DIFF
--- a/pkgs/by-name/co/comet-gog/package.nix
+++ b/pkgs/by-name/co/comet-gog/package.nix
@@ -6,6 +6,10 @@
   rustPlatform,
   fetchFromGitHub,
   buildPackages,
+
+  meson,
+  ninja,
+  pkgsCross,
 }:
 
 let
@@ -44,6 +48,29 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # TECHNICALLY, we could remove this, but then we'd be using the vendored precompiled protoc binary...
   env.PROTOC = lib.getExe' buildPackages.protobuf "protoc";
+
+  passthru.dummy-service = stdenv.mkDerivation {
+    pname = "galaxy-dummy-service";
+    inherit (finalAttrs) version src;
+
+    sourceRoot = "${finalAttrs.src.name}/dummy-service";
+
+    nativeBuildInputs = [
+      meson
+      ninja
+      pkgsCross.mingwW64.buildPackages.gcc
+    ];
+
+    mesonFlags = [
+      "--cross-file meson/x86_64-w64-mingw32.ini"
+    ];
+
+    installPhase = ''
+      runHook preInstall
+      install -D GalaxyCommunication.exe -t "$out"/
+      runHook postInstall
+    '';
+  };
 
   meta = {
     changelog = "https://github.com/imLinguin/comet/releases/tag/${finalAttrs.src.tag}";

--- a/pkgs/by-name/co/comet-gog/package.nix
+++ b/pkgs/by-name/co/comet-gog/package.nix
@@ -1,37 +1,56 @@
 {
+  comet-gog_kind ? "latest",
+
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
-  protobuf,
+  buildPackages,
 }:
 
-rustPlatform.buildRustPackage rec {
+let
+  versionInfoTable = {
+    "latest" = {
+      version = "0.3.1";
+      srcHash = "sha256-asg2xp9A5abmsF+CgOa+ScK2sQwSNFQXD5Qnm76Iyhg=";
+      cargoHash = "sha256-K0lQuk2PBwnVlkRpYNo4Z7to/Lx2fY6RIlkgmMjvEtc=";
+    };
+    # version pin that is compatible with heroic
+    "heroic" = {
+      version = "0.2.0";
+      srcHash = "sha256-LAEt2i/SRABrz+y2CTMudrugifLgHNxkMSdC8PXYF0E=";
+      cargoHash = "sha256-SvDE+QqaSK0+4XgB3bdmqOtwxBDTlf7yckTR8XjmMXc=";
+    };
+  };
+
+  versionInfo = versionInfoTable.${comet-gog_kind};
+in
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "comet-gog";
-  version = "0.3.1";
+  inherit (versionInfo) version cargoHash;
 
   src = fetchFromGitHub {
     owner = "imLinguin";
     repo = "comet";
-    tag = "v${version}";
-    hash = "sha256-asg2xp9A5abmsF+CgOa+ScK2sQwSNFQXD5Qnm76Iyhg=";
+    tag = "v${finalAttrs.version}";
+    hash = versionInfo.srcHash;
     fetchSubmodules = true;
   };
-
-  cargoHash = "sha256-K0lQuk2PBwnVlkRpYNo4Z7to/Lx2fY6RIlkgmMjvEtc=";
 
   # error: linker `aarch64-linux-gnu-gcc` not found
   postPatch = ''
     rm .cargo/config.toml
   '';
 
-  env.PROTOC = lib.getExe' protobuf "protoc";
+  # TECHNICALLY, we could remove this, but then we'd be using the vendored precompiled protoc binary...
+  env.PROTOC = lib.getExe' buildPackages.protobuf "protoc";
 
   meta = {
-    changelog = "https://github.com/imLinguin/comet/releases/tag/v${version}";
+    changelog = "https://github.com/imLinguin/comet/releases/tag/${finalAttrs.src.tag}";
     description = "Open Source implementation of GOG Galaxy's Communication Service";
     homepage = "https://github.com/imLinguin/comet";
     license = lib.licenses.gpl3Plus;
     mainProgram = "comet";
     maintainers = with lib.maintainers; [ tomasajt ];
   };
-}
+})

--- a/pkgs/by-name/co/comet-gog/package.nix
+++ b/pkgs/by-name/co/comet-gog/package.nix
@@ -78,6 +78,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/imLinguin/comet";
     license = lib.licenses.gpl3Plus;
     mainProgram = "comet";
-    maintainers = with lib.maintainers; [ tomasajt ];
+    maintainers = with lib.maintainers; [
+      tomasajt
+      aidalgol
+    ];
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2643,6 +2643,8 @@ with pkgs;
 
   cocoapods-beta = lowPrio (callPackage ../development/tools/cocoapods { beta = true; });
 
+  comet-gog_heroic = callPackage ../by-name/co/comet-gog/package.nix { comet-gog_kind = "heroic"; };
+
   compass = callPackage ../development/tools/compass { };
 
   cone = callPackage ../development/compilers/cone {


### PR DESCRIPTION
Complementary PR for https://github.com/NixOS/nixpkgs/pull/432183

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
