### PR TITLE
home-assistant-custom-components.octopus_energy: 16.0.2 -> 16.1.0, nix-update-script regex fix

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/octopus_energy/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/octopus_energy/package.nix
@@ -42,9 +42,8 @@ buildHomeAssistantComponent rec {
 
   passthru.updateScript = nix-update-script {
     extraArgs = [
-      "--version-regex"
       # Ignore pre-release versions ("beta")
-      "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+      "--version-regex=^v([0-9]+\\.[0-9]+\\.[0-9])$"
     ];
   };
 

--- a/pkgs/servers/home-assistant/custom-components/octopus_energy/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/octopus_energy/package.nix
@@ -11,13 +11,13 @@
 buildHomeAssistantComponent rec {
   owner = "BottlecapDave";
   domain = "octopus_energy";
-  version = "16.0.2";
+  version = "16.1.0";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "HomeAssistant-OctopusEnergy";
     tag = "v${version}";
-    hash = "sha256-/lhM00CNVPoZ8oohPuJ5j0pf0Dmxym3eycdkknlaAug=";
+    hash = "sha256-QQyDQQpVghapBUxUSlHjnrpi3tBEYLOdJiARnL4mYbc=";
   };
 
   dependencies = [ pydantic ];


### PR DESCRIPTION
- Updated the component to the latest release version: https://github.com/BottlecapDave/HomeAssistant-OctopusEnergy/releases/tag/v16.1.0
- Fixed the regex for `nix-update-script` - the previous iteration was not picking up the update

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
