### PR TITLE
cartero: 0.2.2 -> 0.2.4

### DIFF
--- a/pkgs/by-name/ca/cartero/package.nix
+++ b/pkgs/by-name/ca/cartero/package.nix
@@ -15,21 +15,27 @@
   libadwaita,
   gtksourceview5,
   openssl,
+  python313,
+  gtk4,
+  shared-mime-info,
+  glib,
+  hicolor-icon-theme,
+  pango,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "cartero";
-  version = "0.2.2";
+  version = "0.2.4";
 
   src = fetchFromGitHub {
     owner = "danirod";
     repo = "cartero";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WQ1pGAIFOwXZ+cokHTBPkFrTGikqpEYxK7J5LFqoeH0=";
+    hash = "sha256-l6UYsidMqTsEiabviWGAsEOFyDslpP2wIws0Yk10se4=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-vmpBZqRo3Wc7E1d/UzZWDfV96cI9WaSykdxEOTN9KvU=";
+    hash = "sha256-HUwIbrWt9coPjUKRL1nnt0NurwkEGV/Z07BHySnVfQo=";
   };
 
   nativeBuildInputs = [
@@ -42,14 +48,25 @@ stdenv.mkDerivation (finalAttrs: {
     blueprint-compiler
     wrapGAppsHook4
     desktop-file-utils
-    libxml2 # xmllint
+    libxml2
+    python313
+    gtk4
+    shared-mime-info
+    glib
+    hicolor-icon-theme
   ];
 
   buildInputs = [
     libadwaita
     gtksourceview5
     openssl
+    pango
+    libadwaita
   ];
+
+  postPatch = ''
+    patchShebangs --build build-aux/gen-version.py
+  '';
 
   meta = {
     description = "Make HTTP requests and test APIs";


### PR DESCRIPTION
Update Cartero to version 0.2.4.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc