### PR TITLE
home-assistant: 2025.8.1 -> 2025.8.2

### DIFF
--- a/pkgs/development/python-modules/aiodhcpwatcher/default.nix
+++ b/pkgs/development/python-modules/aiodhcpwatcher/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "aiodhcpwatcher";
-  version = "1.2.0";
+  version = "1.2.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "bdraco";
     repo = "aiodhcpwatcher";
     rev = "v${version}";
-    hash = "sha256-Jyaxqs3vckXmqUNhYFA912abDhtZ9UBgGnm+qw/N9Ws=";
+    hash = "sha256-+BF3sBam8O9I4tY7QqnA4iNcJFsK9+imS8pY3N/v1HY=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/airos/default.nix
+++ b/pkgs/development/python-modules/airos/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "airos";
-  version = "0.2.7";
+  version = "0.2.11";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "CoMPaTech";
     repo = "python-airos";
     tag = "v${version}";
-    hash = "sha256-c/YVjNEy1nI6ClYk8BgLai+zRCwiblTFSJ5Rxx3UaeU=";
+    hash = "sha256-rPgrnLMcqUDd1+WL6uwb5Umu3a844B301l+O/GEyCGA=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/bleak-retry-connector/default.nix
+++ b/pkgs/development/python-modules/bleak-retry-connector/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "bleak-retry-connector";
-  version = "4.0.0";
+  version = "4.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Bluetooth-Devices";
     repo = "bleak-retry-connector";
     tag = "v${version}";
-    hash = "sha256-zF1wGDpcUK/88A+2JHuu2bU1tYmJIvSfdZX/IZEmauQ=";
+    hash = "sha256-6x9n8DG7nyGLFCcPAEyIy3sWZ4sthgFT24/Owv0KTsQ=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/cookidoo-api/default.nix
+++ b/pkgs/development/python-modules/cookidoo-api/default.nix
@@ -4,6 +4,7 @@
   aioresponses,
   buildPythonPackage,
   fetchFromGitHub,
+  isodate,
   lib,
   pytest-asyncio,
   pytestCheckHook,
@@ -13,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "cookidoo-api";
-  version = "0.13.0";
+  version = "0.14.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "miaucl";
     repo = "cookidoo-api";
     tag = version;
-    hash = "sha256-QFOGue5VzM1mrgw+WWBvb5dreDUlmBoYv/vEzQta+LA=";
+    hash = "sha256-EWAD33ZF1k76FujQdgBaIzx06zmqh0CfdpknWrs0YLU=";
   };
 
   build-system = [ setuptools ];
@@ -28,6 +29,7 @@ buildPythonPackage rec {
   dependencies = [
     aiofiles
     aiohttp
+    isodate
   ];
 
   pythonImportsCheck = [ "cookidoo_api" ];

--- a/pkgs/development/python-modules/python-snoo/default.nix
+++ b/pkgs/development/python-modules/python-snoo/default.nix
@@ -4,20 +4,21 @@
   fetchFromGitHub,
   poetry-core,
   aiohttp,
+  aiomqtt,
   freenub,
   mashumaro,
 }:
 
 buildPythonPackage rec {
   pname = "python-snoo";
-  version = "0.7.0";
+  version = "0.8.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Lash-L";
     repo = "python-snoo";
     tag = "v${version}";
-    hash = "sha256-AHCQeajCUCDjLmlbSrVmp2C9NB2naXsYAe6mCbWQfmQ=";
+    hash = "sha256-V+abmzQhzbRY+aJDThV+qXExNLKiahwxVR8WnXEP1vc=";
   };
 
   postPatch = ''
@@ -29,6 +30,7 @@ buildPythonPackage rec {
 
   dependencies = [
     aiohttp
+    aiomqtt
     freenub
     mashumaro
   ];

--- a/pkgs/development/python-modules/uiprotect/default.nix
+++ b/pkgs/development/python-modules/uiprotect/default.nix
@@ -40,7 +40,7 @@
 
 buildPythonPackage rec {
   pname = "uiprotect";
-  version = "7.20.0";
+  version = "7.21.1";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     owner = "uilibs";
     repo = "uiprotect";
     tag = "v${version}";
-    hash = "sha256-mrTRLwqHiYsdVsmtsEv1ZZvhLquednbT0ME4HO1wC4I=";
+    hash = "sha256-8OxEEQuCMKHTYIpa9pfgyAhgkCMy6wpvJDMcckbV8wY=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2025.8.1";
+  version = "2025.8.2";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -341,7 +341,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2025.8.1";
+  hassVersion = "2025.8.2";
 
 in
 python.pkgs.buildPythonApplication rec {
@@ -362,13 +362,13 @@ python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-o1j1ejSMa6T18nNxrmvNcOSWAMbi8b11wgHKO+w5gHA=";
+    hash = "sha256-z/wEYitbn8D0LEUTnBfDWfeo+NdDxX42Ifz2D5pbM8I=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-6LyI3t/+wKIVIcVwCny9AIYEaONiwc4GFmbwqjv/9r8=";
+    hash = "sha256-6VnXCc6NWwKUQWmIB/xJmR2AZgfXEXh8DNmoKzSY3GI=";
   };
 
   build-system = with python.pkgs; [

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.270";
+  version = "0.13.271";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     rev = "refs/tags/${version}";
-    hash = "sha256-SDeQuzBZ1Fd97qotyWL6oB2CTB+qfplMN6yOaJguRmI=";
+    hash = "sha256-2XRj7W0XKKQovP8azU3VzyZaGTCYYxCtzwPWvAVv75M=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2025.8.1";
+  version = "2025.8.2";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-EmZ79AmJpfdsI/VHasRC8OzUEsX0nv8zZfEEum1jneI=";
+    hash = "sha256-E4/j08PMAi4zetJtBSZWLoCB4NUlgr+wzytfRgybL34=";
   };
 
   build-system = [


### PR DESCRIPTION
    https://github.com/home-assistant/core/releases/tag/2025.8.2
    https://github.com/uilibs/uiprotect/blob/v7.21.1/CHANGELOG.md
    https://github.com/Lash-L/python-snoo/blob/v0.8.3/CHANGELOG.md
    https://github.com/miaucl/cookidoo-api/releases/tag/0.14.0
    https://github.com/bluetooth-devices/bleak-retry-connector/blob/v4.0.1/CHANGELOG.md
    https://github.com/CoMPaTech/python-airos/releases/tag/v0.2.11
    https://github.com/bdraco/aiodhcpwatcher/blob/v1.2.1/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
