### PR TITLE
radicle-tui: init at 0.6.0

### DIFF
--- a/pkgs/by-name/ra/radicle-tui/package.nix
+++ b/pkgs/by-name/ra/radicle-tui/package.nix
@@ -1,0 +1,109 @@
+{
+  lib,
+  rustPlatform,
+  fetchgit,
+  stdenv,
+  libiconv,
+  zlib,
+  radicle-node,
+  makeBinaryWrapper,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "radicle-tui";
+  version = "0.6.0";
+
+  src = fetchgit {
+    url = "https://seed.radicle.xyz/z39mP9rQAaGmERfUMPULfPUi473tY.git";
+    rev = "refs/namespaces/z6MkswQE8gwZw924amKatxnNCXA55BMupMmRg7LvJuim2C1V/refs/tags/${finalAttrs.version}";
+    hash = "sha256-rz9l9GtycqZoROUI6Hn0Fv5Br0YCIrcHlEWLMP4hasQ=";
+    leaveDotGit = true;
+    postFetch = ''
+      git -C $out rev-parse HEAD > $out/.git_head
+      git -C $out log -1 --pretty=%ct HEAD > $out/.git_time
+      rm -rf $out/.git
+    '';
+  };
+
+  cargoHash = "sha256-f9D4RKWw7y6z9rERuF7F6soyNITvKa6QVt34biZZ5JY=";
+
+  postPatch = ''
+    substituteInPlace build.rs \
+      --replace-fail "GIT_HEAD={hash}" "GIT_HEAD=$(<.git_head)" \
+      --replace-fail "GIT_COMMIT_TIME={commit_time}" "GIT_COMMIT_TIME=$(<.git_time)"
+  '';
+
+  nativeCheckInputs = [ radicle-node ];
+
+  checkFlags = [
+    "--skip=cli::can_be_executed"
+    "--skip=cli::empty_command_is_forwarded"
+    "--skip=cli::help_command_is_forwarded"
+    "--skip=cli::version_command_is_forwarded"
+    "--skip=commands::tui_inbox::cli::empty_operation"
+    "--skip=commands::tui_inbox::cli::empty_operation_is_not_forwarded"
+    "--skip=commands::tui_inbox::cli::empty_operation_is_not_forwarded_explicitly"
+    "--skip=commands::tui_inbox::cli::empty_operation_with_help_is_forwarded"
+    "--skip=commands::tui_inbox::cli::list_operation_is_not_forwarded"
+    "--skip=commands::tui_inbox::cli::list_operation_is_not_forwarded_explicitly"
+    "--skip=commands::tui_inbox::cli::list_operation_with_help_is_forwarded"
+    "--skip=commands::tui_inbox::cli::unknown_operation_show_is_forwarded"
+    "--skip=commands::tui_patch::cli::empty_operation"
+    "--skip=commands::tui_patch::cli::empty_operation_is_not_forwarded"
+    "--skip=commands::tui_patch::cli::empty_operation_is_not_forwarded_explicitly"
+    "--skip=commands::tui_patch::cli::empty_operation_with_help_is_forwarded"
+    "--skip=commands::tui_patch::cli::list_operation_is_not_forwarded"
+    "--skip=commands::tui_patch::cli::list_operation_is_not_forwarded_explicitly"
+    "--skip=commands::tui_patch::cli::list_operation_with_help_is_forwarded"
+    "--skip=commands::tui_patch::cli::unknown_operation_edit_is_forwarded"
+    "--skip=commands::tui_patch::cli::unknown_operation_is_not_forwarded"
+    "--skip=commands::tui_patch::cli::unknown_operation_show_is_forwarded"
+    "--skip=commands::tui_patch::review::test::app_with_single_file_multiple_hunks_can_be_constructed"
+    "--skip=commands::tui_patch::review::test::app_with_single_hunk_can_be_constructed"
+    "--skip=commands::tui_patch::review::test::first_hunk_is_selected_by_default"
+    "--skip=commands::tui_patch::review::test::hunk_can_be_selected"
+    "--skip=commands::tui_patch::review::test::hunks_are_rejected_by_default"
+    "--skip=commands::tui_patch::review::test::multiple_files_single_hunk_can_be_accepted"
+    "--skip=commands::tui_patch::review::test::single_file_multiple_hunks_only_last_can_be_accepted"
+    "--skip=commands::tui_patch::review::test::single_file_single_hunk_can_be_accepted"
+  ];
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    libiconv
+    zlib
+  ];
+
+  propagatedUserEnvPkgs = [ radicle-node ];
+
+  postInstall = ''
+    wrapProgram $out/bin/rad-tui \
+      --suffix PATH : ${lib.makeBinPath finalAttrs.propagatedUserEnvPkgs}
+  '';
+
+  # versionCheckHook doesn't support multiple arguments yet
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheckPhase
+    $out/bin/rad-tui --version --no-forward | grep -F 'rad-tui ${finalAttrs.version}'
+    runHook postInstallCheckPhase
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Radicle terminal user interface";
+    homepage = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z39mP9rQAaGmERfUMPULfPUi473tY";
+    changelog = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z39mP9rQAaGmERfUMPULfPUi473tY/tree/CHANGELOG.md";
+    license = with lib.licenses; [
+      asl20 # or
+      mit
+    ];
+    maintainers = with lib.maintainers; [
+      matthiasbeyer
+      defelo
+    ];
+    mainProgram = "rad-tui";
+  };
+})

--- a/pkgs/by-name/ra/radicle-tui/update.sh
+++ b/pkgs/by-name/ra/radicle-tui/update.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p coreutils gnused gitMinimal nix-update
+
+set -euo pipefail
+
+dirname="$(dirname "${BASH_SOURCE[0]}")"
+
+url=$(nix-instantiate --eval --raw -A radicle-tui.src.url)
+old_ref=$(nix-instantiate --eval --raw -A radicle-tui.src.rev)
+new_ref=$(git ls-remote "$url" 'refs/namespaces/*/refs/tags/*' | cut -f2 | tail -1)
+
+[[ "$old_ref" =~ ^refs/namespaces/([^/]+)/refs/tags/([^/]+)$ ]]
+old_node="${BASH_REMATCH[1]}"
+
+[[ "$new_ref" =~ ^refs/namespaces/([^/]+)/refs/tags/([^/]+)$ ]]
+new_node="${BASH_REMATCH[1]}"
+version="${BASH_REMATCH[2]}"
+
+sed -i "s/${old_node}/${new_node}/g" "${dirname}/package.nix"
+nix-update --version="$version" radicle-tui


### PR DESCRIPTION
I did not yet fully understand how the checkout process here works, so this fails to check out the 0.6.0 tag.

Maybe someone with knowledge of radicle can help? @lorenzleutgeb maybe :laughing: ?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
