### PR TITLE
starkiller: init at 3.0.1

### DIFF
--- a/pkgs/by-name/st/starkiller/package.nix
+++ b/pkgs/by-name/st/starkiller/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchYarnDeps,
+  yarnConfigHook,
+  nodejs_24,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "starkiller";
+  version = "3.0.1";
+
+  src = fetchFromGitHub {
+    owner = "bc-security";
+    repo = "starkiller";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-+q+toH5AvIdFPOY0Q06lWDlPrhIpEnukV+8JlwDZVPE=";
+  };
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = finalAttrs.src + "/yarn.lock";
+    hash = "sha256-fkpYRnBEM/nUtdqnWMb7Trqa5SnCrdX7RUYgd73RGFE=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Copying the workaround from
+    # https://github.com/NixOS/nixpkgs/pull/386706
+    pushd node_modules/vue-demi
+    yarn run postinstall
+    popd
+
+    yarn --offline build
+
+    runHook postBuild
+  '';
+
+  postInstall = ''
+    mkdir $out
+    cp -r dist/** $out
+  '';
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    # Needed for executing package.json scripts
+    nodejs_24
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    homepage = "https://github.com/BC-SECURITY/Starkiller";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    description = "Web UI for Empire";
+    maintainers = with lib.maintainers; [
+      fzakaria
+      vrose
+    ];
+  };
+})


### PR DESCRIPTION
Adds new package http://github.com/BC-SECURITY/Starkiller
We are working towards having [Empire](https://github.com/BC-SECURITY/Empire) in nixpkgs and this is one if its dependencies.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
