### PR TITLE
[Backport release-25.05] immich: 1.136.0 -> 1.138.0 

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -55,6 +55,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `immich` requires that, if your current version of immich is below v1.132.0, that you first upgrade to an immich version between 1.132.0 and 1.136.0 (inclusive). See https://immich.app/errors/#typeorm-upgrade for more information.
+
 - `apptainer` and `singularity` deprecate the workaround of overriding `vendorHash` and related attributes via `<pkg>.override`,
   in favour of the unified overriding of the same group of attributes via `<pkg>.overrideAttrs`.
   The compatibility layer will be removed in future releases.

--- a/pkgs/by-name/im/immich-machine-learning/package.nix
+++ b/pkgs/by-name/im/immich-machine-learning/package.nix
@@ -17,6 +17,7 @@ python.pkgs.buildPythonApplication rec {
   pyproject = true;
 
   pythonRelaxDeps = [
+    "numpy"
     "pillow"
     "pydantic-settings"
   ];

--- a/pkgs/by-name/im/immich/sources.json
+++ b/pkgs/by-name/im/immich/sources.json
@@ -1,26 +1,26 @@
 {
-  "version": "1.136.0",
-  "hash": "sha256-IMog1lvitT1fNKlT4pv/5Qlg/2JNkBNZrBu65NRAgJ0=",
+  "version": "1.137.3",
+  "hash": "sha256-oKDIx63LayDWhd4uE16rqFWmmwwSWUsUvgZKsgE3KWg=",
   "components": {
     "cli": {
-      "npmDepsHash": "sha256-+cMBzlvnSAwlutVm1F0Sa2LEAP6ppOvI9XjDb40xWW4=",
-      "version": "2.2.73"
+      "npmDepsHash": "sha256-Cjk95tsQM89LkMq6H3B5WYdYrMi3hB6d1XpN2xhHv2U=",
+      "version": "2.2.77"
     },
     "server": {
-      "npmDepsHash": "sha256-kVmoxOd7ErLmLKBkanb8IOUJ3ccpzUHBkaLgnvli0Uw=",
-      "version": "1.136.0"
+      "npmDepsHash": "sha256-CvczIXE3Z3LwZezG7kbfJqg2fak2BRXTr0op1Jo1LIg=",
+      "version": "1.137.3"
     },
     "web": {
-      "npmDepsHash": "sha256-CxQQbqIhqhWqtlV4BWQDPkg0tm3wPXC6BcCFb/6mM+o=",
-      "version": "1.136.0"
+      "npmDepsHash": "sha256-PcNgD/JFt3221Qgi54XzQZNa53iw3BUe31DM8k+nz/4=",
+      "version": "1.137.3"
     },
     "open-api/typescript-sdk": {
-      "npmDepsHash": "sha256-z9W3YGqoUV90TXoyEnR069pLvirzDAisgQZdaJEOlSg=",
-      "version": "1.136.0"
+      "npmDepsHash": "sha256-M4ahH6ZP0E3wEgK4VLqSsNjhMFNVTMeRFdzU9EO53vE=",
+      "version": "1.137.3"
     },
     "geonames": {
-      "timestamp": "20250725064853",
-      "hash": "sha256-UzP8JapHTCpk5/6X5usLLXQUfqEOUgkq76CTIBZoz08="
+      "timestamp": "20250801182552",
+      "hash": "sha256-jfC/FgfeSz1tdtYc1EqQ/HJw5LlYQSyGntPuXv24JVY="
     }
   }
 }

--- a/pkgs/by-name/im/immich/sources.json
+++ b/pkgs/by-name/im/immich/sources.json
@@ -20,7 +20,7 @@
     },
     "geonames": {
       "timestamp": "20250812073904",
-      "hash": "sha256-1ZvFkaNdG5s25YwP5CsblvIFT4rlvNrCBiPNR+lAPTQ="
+      "hash": "sha256-02ADfg5wHT1R3vu6imPP22BbT5Y5315eRGmI0mEryGc="
     }
   }
 }

--- a/pkgs/by-name/im/immich/sources.json
+++ b/pkgs/by-name/im/immich/sources.json
@@ -1,26 +1,26 @@
 {
-  "version": "1.137.3",
-  "hash": "sha256-oKDIx63LayDWhd4uE16rqFWmmwwSWUsUvgZKsgE3KWg=",
+  "version": "1.138.0",
+  "hash": "sha256-yOGqQMy2PdGlHAtfuLB74UokGIwzi3yCiaBOZ/Orsf0=",
   "components": {
     "cli": {
-      "npmDepsHash": "sha256-Cjk95tsQM89LkMq6H3B5WYdYrMi3hB6d1XpN2xhHv2U=",
-      "version": "2.2.77"
+      "npmDepsHash": "sha256-NFEAsy1SabGvQMX+k7jIuBLdfjhb3v9x1O2T9EbTPEM=",
+      "version": "2.2.78"
     },
     "server": {
-      "npmDepsHash": "sha256-CvczIXE3Z3LwZezG7kbfJqg2fak2BRXTr0op1Jo1LIg=",
-      "version": "1.137.3"
+      "npmDepsHash": "sha256-B/j4b0ETfM+K9v757egm1DUTynfnFHb8PVRFhxq1H5Y=",
+      "version": "1.138.0"
     },
     "web": {
-      "npmDepsHash": "sha256-PcNgD/JFt3221Qgi54XzQZNa53iw3BUe31DM8k+nz/4=",
-      "version": "1.137.3"
+      "npmDepsHash": "sha256-LkGeZPyfJ6wo1O5I13OL9Iz6mjRNXjTNOi5BVoQWQs4=",
+      "version": "1.138.0"
     },
     "open-api/typescript-sdk": {
-      "npmDepsHash": "sha256-M4ahH6ZP0E3wEgK4VLqSsNjhMFNVTMeRFdzU9EO53vE=",
-      "version": "1.137.3"
+      "npmDepsHash": "sha256-n1OTaqwfVy3RB6hi2rRGGjSNXsrFRwZMSyKfEuYy57U=",
+      "version": "1.138.0"
     },
     "geonames": {
-      "timestamp": "20250812073904",
-      "hash": "sha256-02ADfg5wHT1R3vu6imPP22BbT5Y5315eRGmI0mEryGc="
+      "timestamp": "20250815003647",
+      "hash": "sha256-GYO+fbdXC2z0scne9kh+JLpp7h9k2w0tkIcyYDbNusA="
     }
   }
 }

--- a/pkgs/by-name/im/immich/sources.json
+++ b/pkgs/by-name/im/immich/sources.json
@@ -19,8 +19,8 @@
       "version": "1.137.3"
     },
     "geonames": {
-      "timestamp": "20250801182552",
-      "hash": "sha256-jfC/FgfeSz1tdtYc1EqQ/HJw5LlYQSyGntPuXv24JVY="
+      "timestamp": "20250812073904",
+      "hash": "sha256-1ZvFkaNdG5s25YwP5CsblvIFT4rlvNrCBiPNR+lAPTQ="
     }
   }
 }


### PR DESCRIPTION
Manual backport of #430306 #433026 #433127 #433868 to `release-25.05`.

Closes: #432932 (backport PR without the needed release note entry for #430306)

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.