### PR TITLE
[Backport release-25.05] conman: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8410,6 +8410,12 @@
     githubId = 10290864;
     name = "Peter Frank";
   };
+  frantathefranta = {
+    github = "frantathefranta";
+    githubId = 64412753;
+    name = "Franta Bartik";
+    email = "fb@franta.us";
+  };
   franzmondlichtmann = {
     name = "Franz Schroepf";
     email = "franz-schroepf@t-online.de";

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -18,6 +18,8 @@
 
 - [qBittorrent](https://www.qbittorrent.org/), is a bittorrent client programmed in C++ / Qt that uses libtorrent by Arvid Norberg. Available as [services.qbittorrent](#opt-services.qbittorrent.enable).
 
+- [conman](https://github.com/dun/conman), a serial console management program. Available as [services.conman](#opt-services.conman.enable).
+
 ## Backward Incompatibilities {#sec-release-25.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -797,6 +797,7 @@
   ./services/misc/clipcat.nix
   ./services/misc/clipmenu.nix
   ./services/misc/confd.nix
+  ./services/misc/conman.nix
   ./services/misc/cpuminer-cryptonight.nix
   ./services/misc/db-rest.nix
   ./services/misc/devmon.nix

--- a/nixos/modules/services/misc/conman.nix
+++ b/nixos/modules/services/misc/conman.nix
@@ -1,0 +1,89 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  options = {
+    services.conman = {
+      enable = lib.mkEnableOption ''
+        Enable the conman Console manager.
+
+        Either `configFile` or `config` must be specified.
+      '';
+      package = lib.mkPackageOption pkgs "conman" { };
+
+      configFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = "/run/secrets/conman.conf";
+        description = ''
+          The absolute path to the configuration file.
+
+          Either `configFile` or `config` must be specified.
+
+          See <https://github.com/dun/conman/wiki/Man-5-conman.conf#files>.
+        '';
+      };
+      config = lib.mkOption {
+        type = lib.types.nullOr lib.types.lines;
+        default = null;
+        example = ''
+          server coredump=off
+          server keepalive=on
+          server loopback=off
+          server timestamp=1h
+
+          # global config
+          global log="/var/log/conman/%N.log"
+          global seropts="9600,8n1"
+          global ipmiopts="U:<user>,P:<password>"
+        '';
+        description = ''
+          The configuration object.
+
+          Either `configFile` or `config` must be specified.
+
+          See <https://github.com/dun/conman/wiki/Man-5-conman.conf#files>.
+        '';
+      };
+    };
+  };
+  meta.maintainers = with lib.maintainers; [
+    frantathefranta
+  ];
+
+  config =
+    let
+      cfg = config.services.conman;
+      configFile =
+        if cfg.configFile != null then
+          cfg.configFile
+        else
+          pkgs.writeTextFile {
+            name = "conman.conf";
+            text = cfg.config;
+          };
+    in
+    lib.mkIf cfg.enable {
+      assertions = [
+        {
+          assertion =
+            (cfg.configFile != null) && (cfg.config == null) || (cfg.configFile == null && cfg.config != null);
+          message = "Either but not both `configFile` and `config` must be specified for conman.";
+        }
+      ];
+      environment.systemPackages = [ cfg.package ];
+      systemd.services.conmand = {
+        description = "serial console management program";
+        documentation = [ "man:conman(8)" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          ExecStart = "${cfg.package}/bin/conmand -F -c ${configFile}";
+          KillMode = "process";
+        };
+      };
+    };
+}

--- a/pkgs/by-name/co/conman/package.nix
+++ b/pkgs/by-name/co/conman/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  freeipmi,
+  autoreconfHook,
+  pkg-config,
+  fetchFromGitHub,
+  tcp_wrappers,
+  stdenv,
+  expect,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "conman";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "dun";
+    repo = "conman";
+    tag = "conman-${finalAttrs.version}";
+    hash = "sha256-CHWvHYTmTiEpEfHm3TF5aCKBOW2GsT9Vv4ehpj775NQ=";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    freeipmi # For libipmiconsole.so.2
+    tcp_wrappers # For libwrap.so.0
+    expect # For conman/*.exp scripts
+  ];
+
+  meta = {
+    description = "The Console Manager";
+    homepage = "https://github.com/dun/conman";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      frantathefranta
+    ];
+  };
+
+})


### PR DESCRIPTION
Manual backport of #430136 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.