### PR TITLE
voxinput: 0.4.0 -> 0.6.1

### DIFF
--- a/pkgs/by-name/vo/voxinput/package.nix
+++ b/pkgs/by-name/vo/voxinput/package.nix
@@ -1,35 +1,51 @@
 {
-  lib,
   buildGoModule,
   fetchFromGitHub,
-  nix-update-script,
   makeWrapper,
-  testers,
+  pkg-config,
   libpulseaudio,
   dotool,
+  libGL,
+  xorg,
+  libxkbcommon,
+  wayland,
+  lib,
   stdenv,
+  nix-update-script,
+  testers,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "voxinput";
-  version = "0.4.0";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "richiejp";
     repo = "VoxInput";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-kIKvgPojlkIpDjxaFsHXEvHX3txW9GbachRFksA/Ymg=";
+    hash = "sha256-04RLlE8e8W6vTOz7GF8yEkysp3cwTSOgE1Uk7qXG/ws=";
   };
 
-  vendorHash = "sha256-Qcc/Y7xRaERuu3SIvn/jwTtj+xKii4EZvFsewGG687Y=";
+  vendorHash = "sha256-0osfAJROLn8Iru576M5lq5dwFaw2PVBs6LBscZf3Vxw=";
 
   nativeBuildInputs = [
     makeWrapper
+    pkg-config
   ];
 
   buildInputs = [
     libpulseaudio
     dotool
+
+    libGL
+    xorg.libX11.dev
+    xorg.libXcursor
+    xorg.libXi
+    xorg.libXinerama
+    xorg.libXrandr
+    xorg.libXxf86vm
+    libxkbcommon
+    wayland
   ];
 
   # To take advantage of the udev rule something like `services.udev.packages = [ nixpkgs.voxinput ]`
@@ -44,7 +60,7 @@ buildGoModule (finalAttrs: {
     echo 'KERNEL=="uinput", GROUP="input", MODE="0620", OPTIONS+="static_node=uinput"' > $out/lib/udev/rules.d/99-voxinput.rules
   '';
 
-  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+  postFixup = lib.optionalString stdenv.hostPlatform.isElf ''
     patchelf $out/bin/.voxinput-wrapped \
       --add-rpath ${lib.makeLibraryPath [ libpulseaudio ]}
   '';


### PR DESCRIPTION
Diff: https://github.com/richiejp/VoxInput/compare/refs/tags/v0.4.0...refs/tags/v0.6.1

Changelog: https://github.com/richiejp/VoxInput/releases/tag/v0.6.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Since [v0.5.0](https://github.com/richiejp/VoxInput/releases/tag/v0.5.0) there is a GUI that requires more dependencies and need to change the packaging

The auto-update bot can't do it alone

I mainly mixed the previous packaging with [package made in the `flake.nix` of the repo](https://github.com/richiejp/VoxInput/blob/9789e54031c328c068a972b825edd25a9125fd84/flake.nix#L34)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
