### PR TITLE
nixos/lib/make-btrfs-fs: replace fakeroot with unshare

### DIFF
--- a/nixos/lib/make-btrfs-fs.nix
+++ b/nixos/lib/make-btrfs-fs.nix
@@ -18,7 +18,7 @@
   uuid ? "44444444-4444-4444-8888-888888888888",
   btrfs-progs,
   libfaketime,
-  fakeroot,
+  util-linux,
 }:
 
 let
@@ -30,7 +30,7 @@ pkgs.stdenv.mkDerivation {
   nativeBuildInputs = [
     btrfs-progs
     libfaketime
-    fakeroot
+    util-linux
   ]
   ++ lib.optional compressImage zstd;
 
@@ -58,7 +58,7 @@ pkgs.stdenv.mkDerivation {
     cp ${sdClosureInfo}/registration ./rootImage/nix-path-registration
 
     touch $img
-    faketime -f "1970-01-01 00:00:01" fakeroot mkfs.btrfs -L ${volumeLabel} -U ${uuid} -r ./rootImage --shrink $img
+    faketime -f "1970-01-01 00:00:01" unshare --map-root-user mkfs.btrfs -L ${volumeLabel} -U ${uuid} -r ./rootImage --shrink $img
 
     if ! btrfs check $img; then
       echo "--- 'btrfs check' failed for BTRFS image ---"


### PR DESCRIPTION
Replaced fakeroot with unshare.

Version 6.10.1 of `btrfs-progs` reworked the implementation of the `-r` option in `mkfs.btrfs`. Prior to this version, the file system produced by `make-btrfs-fs` was owned by root due to the use of `fakeroot`. However, the changes made to the `-r` option are incompatible with `fakeroot`, so the resulting file system is generally not owned by root.

The aforementioned version of `btrfs-progs` was introduced to nixpkgs in August 2024, and affects the current implementation of `make-btrfs-fs`.

There is a  bug report in `fakeroot` tracking this issue: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1081976

The resulting file system not being owned by root can cause errors when attempting to boot, as documented here:
Closes https://github.com/NixOS/nixpkgs/issues/401263

By switching to `unshare`, the original behaviour whereby the file system is owned by root is preserved.

Tested by building the image and inspecting the resulting files.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
