### PR TITLE
lux-cli: 0.13.3 -> 0.15.1

### DIFF
--- a/pkgs/by-name/lu/lux-cli/package.nix
+++ b/pkgs/by-name/lu/lux-cli/package.nix
@@ -6,7 +6,7 @@
   lib,
   libgit2,
   libgpg-error,
-  luajit,
+  lua5_4,
   makeWrapper,
   nix,
   openssl,
@@ -17,18 +17,18 @@
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "lux-cli";
 
-  version = "0.13.3";
+  version = "0.15.1";
 
   src = fetchFromGitHub {
     owner = "nvim-neorocks";
     repo = "lux";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RmdxqpmqOs/1a9KmakWAHJUkiQ6I2t4VROiSocRnx84=";
+    hash = "sha256-1u0zDGUytuMhqe7NOJeXd1DKch8P7FT02MYgMkX3eMc=";
   };
 
   buildAndTestSubdir = "lux-cli";
 
-  cargoHash = "sha256-vin86rAmUbHJJuhChZi3ndj57wTCv945sVF6+by6Dlc=";
+  cargoHash = "sha256-C84VZfpMua1RrFhTFhWfY2xZAPDtNllkAbdHljlYdZs=";
 
   nativeInstallCheckInputs = [
     versionCheckHook
@@ -48,7 +48,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     gpgme
     libgit2
     libgpg-error
-    luajit
+    lua5_4
     openssl
   ];
 
@@ -61,7 +61,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoTestFlags = "--lib"; # Disable impure integration tests
 
   nativeCheckInputs = [
-    luajit
+    lua5_4
     nix
   ];
 

--- a/pkgs/development/lua-modules/lux-lua.nix
+++ b/pkgs/development/lua-modules/lux-lua.nix
@@ -56,8 +56,11 @@ rustPlatform.buildRustPackage rec {
     LUX_SKIP_IMPURE_TESTS = 1; # Disable impure unit tests
   };
 
-  postBuild = ''
+  buildPhase = ''
+    runHook preBuild
     cargo xtask-${luaFeature} dist
+    mkdir -p $out
+    runHook postBuild
   '';
 
   installPhase = ''

--- a/pkgs/development/lua-modules/lux-lua.nix
+++ b/pkgs/development/lua-modules/lux-lua.nix
@@ -62,8 +62,8 @@ rustPlatform.buildRustPackage rec {
 
   installPhase = ''
     runHook preInstall
-    install -D -v target/dist/${luaVersionDir}/* -t $out/${luaVersionDir}
-    install -D -v target/dist/lib/pkgconfig/* -t $out/lib/pkgconfig
+    cp -r target/dist/share $out
+    cp -r target/dist/lib $out
     runHook postInstall
   '';
 


### PR DESCRIPTION
- Updated `lux-cli` to version 0.15.1
- The way `lux-lua` is distributed has changed, so I have updated that too in `luaPackages.lux-lua`
- Simplified the `luaPackages.lux-lua` build to run `xtask` in the `buildPhase`. This prevents a redundant compilation of `lux-lua`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
