### PR TITLE
buildUBoot: switch to using lib.extendMkDerivation

### DIFF
--- a/pkgs/misc/uboot/build-uboot.nix
+++ b/pkgs/misc/uboot/build-uboot.nix
@@ -145,6 +145,7 @@ lib.extendMkDerivation {
         maintainers = with lib.maintainers; [
           dezgeg
           lopsided98
+          jmbaur
         ];
       }
       // (args.meta or { })

--- a/pkgs/misc/uboot/build-uboot.nix
+++ b/pkgs/misc/uboot/build-uboot.nix
@@ -1,0 +1,156 @@
+{
+  bc,
+  bison,
+  buildPackages,
+  darwin,
+  fetchurl,
+  flex,
+  gnutls,
+  installShellFiles,
+  lib,
+  libuuid,
+  ncurses,
+  openssl,
+  perl,
+  python3,
+  stdenv,
+  swig,
+  which,
+}:
+
+let
+  # Dependencies for the tools need to be included as either native or cross,
+  # depending on which we're building
+  toolsDeps = [
+    ncurses # tools/kwboot
+    libuuid # tools/mkeficapsule
+    gnutls # tools/mkeficapsule
+    openssl # tools/mkimage and tools/env/fw_printenv
+  ];
+in
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+
+  excludeDrvArgNames = [
+    "extraMeta"
+    "pythonScriptsToInstall"
+  ];
+
+  extendDrvArgs =
+    finalAttrs:
+    {
+      crossTools ? false,
+      defconfig,
+      extraConfig ? "",
+      filesToInstall,
+      installDir ? "$out",
+      pythonScriptsToInstall ? { },
+      ...
+    }@args:
+    {
+      pname = "uboot-${defconfig}";
+
+      version = args.version or "2025.07";
+      src = args.src or fetchurl {
+        url = "https://ftp.denx.de/pub/u-boot/u-boot-${finalAttrs.version}.tar.bz2";
+        hash = "sha256-D5M/bFpCaJW/MG6T5qxTxghw5LVM2lbZUhG+yZ5jvsc=";
+      };
+
+      patches =
+        (args.patches or [ ])
+        ++ (lib.warnIf (args ? extraPatches)
+          "buildUBoot now accepts `patches`, please switch from using `extraPatches` to `patches`"
+          args.extraPatches or [ ]
+        );
+
+      postPatch = ''
+        ${lib.concatMapStrings (script: ''
+          substituteInPlace ${script} \
+            --replace-fail "#!/usr/bin/env python3" "#!${pythonScriptsToInstall.${script}}/bin/python3"
+        '') (builtins.attrNames pythonScriptsToInstall)}
+        patchShebangs tools
+        patchShebangs scripts
+      '';
+
+      nativeBuildInputs = [
+        ncurses # tools/kwboot
+        bc
+        bison
+        flex
+        installShellFiles
+        (python3.pythonOnBuildForHost.withPackages (p: [
+          p.libfdt
+          p.setuptools # for pkg_resources
+          p.pyelftools
+        ]))
+        swig
+        which # for scripts/dtc-version.sh
+        perl # for old build (secureboot)
+      ]
+      ++ lib.optionals (!crossTools) toolsDeps
+      ++ lib.optionals stdenv.buildPlatform.isDarwin [ darwin.DarwinTools ]; # sw_vers command is needed on darwin
+      depsBuildBuild = [ buildPackages.gccStdenv.cc ]; # gccStdenv is needed for Darwin buildPlatform
+      buildInputs = lib.optionals crossTools toolsDeps;
+
+      hardeningDisable = [ "all" ];
+
+      enableParallelBuilding = true;
+
+      makeFlags = [
+        "DTC=${lib.getExe buildPackages.dtc}"
+        "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+        "HOSTCFLAGS=-fcommon"
+      ]
+      ++ (args.makeFlags or [ ])
+      ++ (lib.warnIf (args ? extraMakeFlags)
+        "buildUBoot now accepts `makeFlags`, please switch from using `extraMakeFlags` to `makeFlags`"
+        args.extraMakeFlags or [ ]
+      );
+
+      inherit extraConfig;
+      passAsFile = [ "extraConfig" ];
+
+      configurePhase = ''
+        runHook preConfigure
+
+        make -j$NIX_BUILD_CORES ${defconfig}
+
+        cat $extraConfigPath >> .config
+
+        runHook postConfigure
+      '';
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p ${installDir}
+        cp ${
+          lib.concatStringsSep " " (filesToInstall ++ builtins.attrNames pythonScriptsToInstall)
+        } ${installDir}
+
+        mkdir -p "$out/nix-support"
+        ${lib.concatMapStrings (file: ''
+          echo "file binary-dist ${installDir}/${builtins.baseNameOf file}" >> "$out/nix-support/hydra-build-products"
+        '') (filesToInstall ++ builtins.attrNames pythonScriptsToInstall)}
+
+        runHook postInstall
+      '';
+
+      dontStrip = true;
+
+      meta = {
+        homepage = "https://www.denx.de/wiki/U-Boot/";
+        description = "Boot loader for embedded systems";
+        license = lib.licenses.gpl2Plus;
+        maintainers = with lib.maintainers; [
+          dezgeg
+          lopsided98
+        ];
+      }
+      // (args.meta or { })
+      // (lib.warnIf (args ? extraMeta)
+        "buildUBoot now accepts `meta`, please switch from using `extraMeta` to `meta`"
+        args.extraMeta or { }
+      );
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11119,9 +11119,10 @@ with pkgs;
     withoutInitTools = true;
   };
 
+  buildUBoot = callPackage ../misc/uboot/build-uboot.nix { };
+
   # Upstream U-Boots:
   inherit (callPackage ../misc/uboot { })
-    buildUBoot
     ubootTools
     ubootA20OlinuxinoLime
     ubootA20OlinuxinoLime2EMMC


### PR DESCRIPTION
By switching to `lib.extendMkDerivation`, users can use the "finalAttrs" style when constructing their uboot builds. In addition, move buildUBoot to its own callPackage'd file, which allows for all arguments used to construct `buildUBoot` to be easily overridable. This was previously difficult and cumbersome to do due to the buildUBoot enclosing the function arguments in `pkgs/misc/uboot/default.nix`, but not being available on the package-set to override said arguments.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
