### PR TITLE
termpicker: init at 1.4.1

### DIFF
--- a/pkgs/by-name/te/termpicker/package.nix
+++ b/pkgs/by-name/te/termpicker/package.nix
@@ -1,0 +1,54 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+  makeBinaryWrapper,
+  nix-update-script,
+  versionCheckHook,
+  wl-clipboard,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "termpicker";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "ChausseBenjamin";
+    repo = "termpicker";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-V1ZwkvlMLTNjk6hdnpByS/7zR7U7kChuKMVP0H+BJD8=";
+  };
+
+  vendorHash = "sha256-M5YZaJdv9D8NkwD+T8tAtGH5P4IKcgjqpUoKVfLo+C0=";
+
+  ldflags = [
+    "-s"
+    "-X=main.version=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  propagatedUserEnvPkgs = [ wl-clipboard ];
+
+  postInstall = ''
+    rm $out/bin/documentation
+    mkdir --parents $out/share/man/man1
+    go run ./internal/documentation > $out/share/man/man1/termpicker.1
+
+    wrapProgram $out/bin/${finalAttrs.meta.mainProgram} \
+      --prefix PATH : ${lib.makeBinPath finalAttrs.propagatedUserEnvPkgs}
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Color picker for the terminal";
+    homepage = "https://github.com/ChausseBenjamin/termpicker";
+    license = lib.licenses.beerware;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "termpicker";
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
