### PR TITLE
orb: init at 0-unstable-2025-08-09

### DIFF
--- a/pkgs/by-name/or/orb/package.nix
+++ b/pkgs/by-name/or/orb/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  ncurses,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "orb";
+  version = "0-unstable-2025-08-09";
+
+  src = fetchFromGitHub {
+    owner = "ayuzur";
+    repo = "orb";
+    rev = "d346d71aa56d8cb017f01add8b94b6c11fce83a5";
+    hash = "sha256-455vS/lUzcs6XGklF3yJC3mK0LVTcxQSfiaOQV5YxFA=";
+  };
+
+  strictDeps = true;
+
+  buildInputs = [ ncurses ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail "gcc" "$CC"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D bin/orb --target-directory=$out/bin
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Exploding terminal orb timer";
+    homepage = "https://github.com/ayuzur/orb";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "orb";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
