### PR TITLE
sinkzone: init at 0.1.0

### DIFF
--- a/pkgs/by-name/si/sinkzone/package.nix
+++ b/pkgs/by-name/si/sinkzone/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "sinkzone";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "berbyte";
+    repo = "sinkzone";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-CYVaqtTvAGlN6o5gZxGgc+a25x5PlVmQEPYDBF9pehw=";
+  };
+
+  vendorHash = "sha256-JZwkL+EFCMP8m5wRVmARrAhfHy2/uAC74/f9PGYR4eg=";
+
+  # Patch man page path
+  postPatch = ''
+    substituteInPlace cmd/man.go \
+      --replace-fail 'filepath.Join(execDir, "docs", "sinkzone.1")' \
+                     '"${placeholder "out"}/share/man/man1/sinkzone.1.gz"' \
+      --replace-fail 'execDir :=' '_ =' # skip err: declared and not used
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  postInstall = ''
+    install -Dm444 docs/${finalAttrs.meta.mainProgram}.1 \
+      --target-directory=$out/share/man/man1
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "DNS-based productivity tool that blocks distractions and helps you stay focused";
+    longDescription = ''
+      The internet is infinite. Your focus isn’t. Sinkzone helps you
+      reclaim control by flipping the default: everything is blocked,
+      unless you explicitly allow it. No feeds. No pings. No surprise
+      connections. Allowlist-only internet for distraction-free work
+    '';
+    homepage = "https://github.com/berbyte/sinkzone";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "sinkzone";
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
