### PR TITLE
gpt4all-cuda: use gcc12 for cuda (fixes build)

### DIFF
--- a/pkgs/by-name/gp/gpt4all/package.nix
+++ b/pkgs/by-name/gp/gpt4all/package.nix
@@ -2,7 +2,6 @@
   lib,
   config,
   stdenv,
-  gcc12Stdenv,
   fetchFromGitHub,
   fetchurl,
   cmake,
@@ -56,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Override environment to force nvcc to use the correct host compiler
   preBuild = lib.optionalString cudaSupport ''
-    export NVCC_APPEND_FLAGS="--compiler-bindir ${gcc12Stdenv.cc}/bin"
+    export NVCC_APPEND_FLAGS="--compiler-bindir ${cudaPackages.backendStdenv.cc}/bin"
   '';
 
   buildInputs = [
@@ -93,8 +92,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "LLMODEL_KOMPUTE" false)
   ]
   ++ lib.optionals cudaSupport [
-    "-DCUDA_HOST_COMPILER=${gcc12Stdenv.cc}/bin/c++"
-    "-DCMAKE_CUDA_HOST_COMPILER=${gcc12Stdenv.cc}/bin/c++"
+    "-DCUDA_HOST_COMPILER=${cudaPackages.backendStdenv.cc}/bin/c++"
+    "-DCMAKE_CUDA_HOST_COMPILER=${cudaPackages.backendStdenv.cc}/bin/c++"
   ]
   ++ lib.optionals (!cudaSupport) [
     (lib.cmakeBool "LLMODEL_CUDA" false)

--- a/pkgs/by-name/gp/gpt4all/package.nix
+++ b/pkgs/by-name/gp/gpt4all/package.nix
@@ -2,6 +2,7 @@
   lib,
   config,
   stdenv,
+  gcc12Stdenv,
   fetchFromGitHub,
   fetchurl,
   cmake,
@@ -55,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Override environment to force nvcc to use the correct host compiler
   preBuild = lib.optionalString cudaSupport ''
-    export NVCC_APPEND_FLAGS="--compiler-bindir ${cudaPackages.backendStdenv.cc}/bin"
+    export NVCC_APPEND_FLAGS="--compiler-bindir ${gcc12Stdenv.cc}/bin"
   '';
 
   buildInputs = [
@@ -92,8 +93,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "LLMODEL_KOMPUTE" false)
   ]
   ++ lib.optionals cudaSupport [
-    "-DCUDA_HOST_COMPILER=${cudaPackages.backendStdenv.cc}/bin/c++"
-    "-DCMAKE_CUDA_HOST_COMPILER=${cudaPackages.backendStdenv.cc}/bin/c++"
+    "-DCUDA_HOST_COMPILER=${gcc12Stdenv.cc}/bin/c++"
+    "-DCMAKE_CUDA_HOST_COMPILER=${gcc12Stdenv.cc}/bin/c++"
   ]
   ++ lib.optionals (!cudaSupport) [
     (lib.cmakeBool "LLMODEL_CUDA" false)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes #409674

Cuda was not happy that gcc14 was being used as the cuda compiler. For the cuda bits we should be using gcc12.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
