### PR TITLE
recursiveGetAttrsetWithJqPrefix: fix top level values

### DIFF
--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -219,14 +219,14 @@ let
               let
                 escapedName = ''"${replaceStrings [ ''"'' "\\" ] [ ''\"'' "\\\\" ] name}"'';
               in
-              recurse (prefix + "." + escapedName) item.${name}
+              recurse (prefix + (if prefix == "." then "" else ".") + escapedName) item.${name}
             ) (attrNames item)
           else if isList item then
             imap0 (index: item: recurse (prefix + "[${toString index}]") item) item
           else
             [ ];
       in
-      listToAttrs (flatten (recurse "" item));
+      listToAttrs (flatten (recurse "." item));
 
     /*
       Takes an attrset and a file path and generates a bash snippet that


### PR DESCRIPTION
This PR allows recursiveGetAttrsetWithJqPrefix to properly handle top level value such as dictionaries, which will have a empty `name` and cause `jq` to fail, and arrays where `[0]` would be used instead of the correct `.[0]`.

Example:

```nix
let
  nixpkgs = fetchTarball "https://github.com/Prince213/nixpkgs/archive/refs/heads/push-rvnmkknmmznx.tar.gz";
  pkgs = import nixpkgs { };
  utils = import "${nixpkgs}/nixos/lib/utils.nix" {
    inherit pkgs;
    inherit (pkgs) lib;
    config = null;
  };
in
pkgs.runCommand "result.json" { } ''
  ${utils.genJqSecretsReplacementSnippet {
    _secret = pkgs.writeText "secret" (
      builtins.toJSON {
        answer = 42;
      }
    );
    quote = false;
  } "result.json"}
  cp result.json "$out"
''
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
