### PR TITLE
lixPackageSets.git: 2.94.0-pre-20250807_8bbd5e1d0df9 -> 2.94.0-pre-20250815_86303ffb057e

### DIFF
--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -26,6 +26,7 @@ assert lib.assertMsg (
   boehmgc,
   boost,
   brotli,
+  busybox,
   busybox-sandbox-shell,
   bzip2,
   callPackage,
@@ -140,10 +141,8 @@ stdenv.mkDerivation (finalAttrs: {
     # python3.withPackages does not splice properly, see https://github.com/NixOS/nixpkgs/issues/305858
     (buildPackages.python3.withPackages (
       p:
-      [
-        p.python-frontmatter
-        p.toml
-      ]
+      [ p.python-frontmatter ]
+      ++ lib.optionals (lib.versionOlder version "2.94") [ p.toml ]
       ++ lib.optionals finalAttrs.doInstallCheck [
         p.aiohttp
         p.pytest
@@ -203,6 +202,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals hasExternalLixDoc [ lix-doc ]
   ++ lib.optionals (!isLegacyParser) [ pegtl ]
+  ++ lib.optionals (lib.versionOlder version "2.94") [ libsodium ]
   # NOTE(Raito): I'd have expected that the LLVM packaging would inject the
   # libunwind library path directly in the wrappers, but it does inject
   # -lunwind without injecting the library path...
@@ -286,7 +286,13 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     (lib.mesonOption "sandbox-shell" "${busybox-sandbox-shell}/bin/busybox")
-  ];
+  ]
+  ++
+    lib.optionals
+      (stdenv.hostPlatform.isLinux && finalAttrs.doInstallCheck && lib.versionAtLeast version "2.94")
+      [
+        (lib.mesonOption "build-test-shell" "${busybox}/bin")
+      ];
 
   ninjaFlags = [ "-v" ];
 

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -166,15 +166,22 @@ lib.makeExtensible (
       attrName = "git";
 
       lix-args = rec {
-        version = "2.94.0-pre-20250807_${builtins.substring 0 12 src.rev}";
+        version = "2.94.0-pre-20250912_${builtins.substring 0 12 src.rev}";
 
         src = fetchFromGitea {
           domain = "git.lix.systems";
           owner = "lix-project";
           repo = "lix";
-          rev = "8bbd5e1d0df9c31b4d86ba07bc85beb952e42ccb";
-          hash = "sha256-P+WiN95OjCqHhfygglS/VOFTSj7qNdL5XQDo2wxhQqg=";
+          rev = "d90e4a65812c6d3dd90aed7e44941eba3215f876";
+          hash = "sha256-rbf0ptj4BTSwsitKQu3FuaiJwhNDePGBeBJovm5HLdQ=";
         };
+
+        patches = [
+          # Bumping to toml11 ≥4.0.0 makes integer parsing throw (as it should) instead of saturate on overflow.
+          # However, the updated version is not in nixpkgs yet, and the released versions still have the saturation bug.
+          # Hence reverting the bump for now seems to be the least bad option.
+          ./revert-toml11-bump.patch
+        ];
 
         cargoDeps = rustPlatform.fetchCargoVendor {
           name = "lix-${version}";

--- a/pkgs/tools/package-management/lix/revert-toml11-bump.patch
+++ b/pkgs/tools/package-management/lix/revert-toml11-bump.patch
@@ -1,0 +1,192 @@
+diff --git a/doc/manual/rl-next/toml-number-overflow.md b/doc/manual/rl-next/toml-number-overflow.md
+deleted file mode 100644
+index 1522213cb4..0000000000
+--- a/doc/manual/rl-next/toml-number-overflow.md
++++ /dev/null
+@@ -1,14 +0,0 @@
+----
+-synopsis: Reject overflowing TOML integer literals
+-issues: []
+-cls: [3916]
+-category: "Breaking Changes"
+-credits: [emilazy]
+----
+-
+-The toml11 library used by Lix was updated. The new
+-version aligns with the [TOML v1.0.0 specification’s
+-requirement](https://toml.io/en/v1.0.0#integer) to reject integer
+-literals that cannot be losslessly parsed. This means that code like
+-`builtins.fromTOML "v=0x8000000000000000"` will now produce an error
+-rather than silently saturating the integer result.
+diff --git a/lix/libexpr/primops/fromTOML.cc b/lix/libexpr/primops/fromTOML.cc
+index 9d4b5e6abf..3e26773eac 100644
+--- a/lix/libexpr/primops/fromTOML.cc
++++ b/lix/libexpr/primops/fromTOML.cc
+@@ -65,10 +65,13 @@
+             val,
+             toml::parse(
+                 tomlStream,
+-                "fromTOML", /* the "filename" */
++                "fromTOML" /* the "filename" */
++#if HAVE_TOML11_4
++                ,
+                 toml::spec::v(
+                     1, 0, 0
+                 ) // Be explicit that we are parsing TOML 1.0.0 without extensions
++#endif
+             )
+         );
+     } catch (std::exception & e) { // NOLINT(lix-foreign-exceptions) // TODO: toml::syntax_error
+diff --git a/meson.build b/meson.build
+index 7b229ccefb..d4a36eb285 100644
+--- a/meson.build
++++ b/meson.build
+@@ -363,7 +363,10 @@
+   dependency('gmock_main', required : enable_tests, include_type : 'system'),
+ ]
+ 
+-toml11 = dependency('toml11', version : '>=4.0.0', required : true, method : 'cmake', include_type : 'system')
++toml11 = dependency('toml11', version : '>=3.7.0', required : true, method : 'cmake', include_type : 'system')
++configdata += {
++  'HAVE_TOML11_4': toml11.version().version_compare('>= 4.0.0').to_int(),
++}
+ 
+ pegtl = dependency(
+   'pegtl',
+diff --git a/misc/toml11.nix b/misc/toml11.nix
+deleted file mode 100644
+index c53be3da1b..0000000000
+--- a/misc/toml11.nix
++++ /dev/null
+@@ -1,47 +0,0 @@
+-{
+-  lib,
+-  stdenv,
+-  fetchFromGitHub,
+-  cmake,
+-}:
+-
+-stdenv.mkDerivation (finalAttrs: {
+-  pname = "toml11";
+-  version = "4.4.0";
+-
+-  src = fetchFromGitHub {
+-    owner = "ToruNiina";
+-    repo = "toml11";
+-    rev = "v${finalAttrs.version}";
+-    hash = "sha256-sgWKYxNT22nw376ttGsTdg0AMzOwp8QH3E8mx0BZJTQ=";
+-  };
+-
+-  nativeBuildInputs = [
+-    cmake
+-  ];
+-
+-  meta = with lib; {
+-    homepage = "https://github.com/ToruNiina/toml11";
+-    description = "TOML for Modern C++";
+-    longDescription = ''
+-      toml11 is a C++11 (or later) header-only toml parser/encoder depending
+-      only on C++ standard library.
+-
+-      - It is compatible to the latest version of TOML v1.0.0.
+-      - It is one of the most TOML standard compliant libraries, tested with
+-        the language agnostic test suite for TOML parsers by BurntSushi.
+-      - It shows highly informative error messages.
+-      - It has configurable container. You can use any random-access containers
+-        and key-value maps as backend containers.
+-      - It optionally preserves comments without any overhead.
+-      - It has configurable serializer that supports comments, inline tables,
+-        literal strings and multiline strings.
+-      - It supports user-defined type conversion from/into toml values.
+-      - It correctly handles UTF-8 sequences, with or without BOM, both on posix
+-        and Windows.
+-    '';
+-    license = licenses.mit;
+-    maintainers = with maintainers; [ ];
+-    platforms = platforms.unix ++ platforms.windows;
+-  };
+-})
+diff --git a/package.nix b/package.nix
+index eb0e5c602a..c1c948ee7e 100644
+--- a/package.nix
++++ b/package.nix
+@@ -55,8 +55,6 @@
+   rustc,
+   sqlite,
+   systemtap-lix ? __forDefaults.systemtap-lix,
+-  # FIXME: remove default after dropping NixOS 25.05
+-  toml11-lix ? __forDefaults.toml11-lix,
+   toml11,
+   util-linuxMinimal ? utillinuxMinimal,
+   utillinuxMinimal ? null,
+@@ -117,9 +115,6 @@
+     build-release-notes = callPackage ./maintainers/build-release-notes.nix { };
+ 
+     passt-lix = callPackage ./misc/passt.nix { };
+-
+-    toml11-lix =
+-      if lib.versionOlder toml11.version "4.4.0" then callPackage ./misc/toml11.nix { } else toml11;
+   },
+ }:
+ 
+@@ -344,7 +339,7 @@
+     libarchive
+     boost
+     lowdown
+-    toml11-lix
++    toml11
+     pegtl
+     capnproto
+     dtrace-headers
+diff --git a/tests/functional2/lang/fromTOML-overflowing/eval-fail-overflow.err.exp b/tests/functional2/lang/fromTOML-overflowing/eval-fail-overflow.err.exp
+deleted file mode 100644
+index 0c90e85edf..0000000000
+--- a/tests/functional2/lang/fromTOML-overflowing/eval-fail-overflow.err.exp
++++ /dev/null
+@@ -1,13 +0,0 @@
+-error:
+-       … while calling the 'fromTOML' builtin
+-         at /pwd/in.nix:1:1:
+-            1| builtins.fromTOML ''attr = 9223372036854775808''
+-             | ^
+-            2|
+-
+-       error: while parsing TOML: [error] toml::parse_dec_integer: too large integer: current max digits = 2^63
+-        --> fromTOML
+-          |
+-        1 | attr = 9223372036854775808
+-          |                           ^-- must be < 2^63
+-       
+diff --git a/tests/functional2/lang/fromTOML-overflowing/eval-fail-underflow.err.exp b/tests/functional2/lang/fromTOML-overflowing/eval-fail-underflow.err.exp
+deleted file mode 100644
+index a287e18655..0000000000
+--- a/tests/functional2/lang/fromTOML-overflowing/eval-fail-underflow.err.exp
++++ /dev/null
+@@ -1,13 +0,0 @@
+-error:
+-       … while calling the 'fromTOML' builtin
+-         at /pwd/in.nix:1:1:
+-            1| builtins.fromTOML ''attr = -9223372036854775809''
+-             | ^
+-            2|
+-
+-       error: while parsing TOML: [error] toml::parse_dec_integer: too large integer: current max digits = 2^63
+-        --> fromTOML
+-          |
+-        1 | attr = -9223372036854775809
+-          |                            ^-- must be < 2^63
+-       
+diff --git a/tests/functional2/lang/fromTOML-overflowing/eval-okay-overflow.out.exp b/tests/functional2/lang/fromTOML-overflowing/eval-okay-overflow.out.exp
+new file mode 100644
+index 0000000000..e241ca9ba4
+--- /dev/null
++++ b/tests/functional2/lang/fromTOML-overflowing/eval-okay-overflow.out.exp
+@@ -0,0 +1,1 @@
++{ attr = 9223372036854775807; }
+diff --git a/tests/functional2/lang/fromTOML-overflowing/eval-okay-underflow.out.exp b/tests/functional2/lang/fromTOML-overflowing/eval-okay-underflow.out.exp
+new file mode 100644
+index 0000000000..83b822591f
+--- /dev/null
++++ b/tests/functional2/lang/fromTOML-overflowing/eval-okay-underflow.out.exp
+@@ -0,0 +1,1 @@
++{ attr = -9223372036854775808; }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
