### PR TITLE
jetbrains: 2025.1.2.1 -> 2025.2.2

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/versions.json
+++ b/pkgs/applications/editors/jetbrains/bin/versions.json
@@ -19,18 +19,18 @@
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.tar.gz",
-      "version": "2025.2.1",
-      "sha256": "1a0dea8a82920818e40b552950e90caf39bcf6ca9ae4e973a1d49e7db0498ecc",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.1.tar.gz",
-      "build_number": "252.23892.464"
+      "version": "2025.2.2",
+      "sha256": "59c793fabaa3ae6563c3118939c069f8baddb1bab489bccd7acddd0cf17de107",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.2.tar.gz",
+      "build_number": "252.25557.34"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}.tar.gz",
-      "version": "2025.1.2.1",
-      "sha256": "1759516154a989ad1bcbc0e0cc29eb7b50c5c96b910c1a8926ae87ea5aa07ea6",
-      "url": "https://download.jetbrains.com/python/dataspell-2025.1.2.1.tar.gz",
-      "build_number": "251.26927.91"
+      "version": "2025.2",
+      "sha256": "fd37e488b990e3e395a12c3ebbdb2b4df87c58eb9bb6c82fd38a0322b5c2fb2b",
+      "url": "https://download.jetbrains.com/python/dataspell-2025.2.tar.gz",
+      "build_number": "252.23892.514"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
@@ -43,10 +43,10 @@
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}.tar.gz",
-      "version": "2025.2",
-      "sha256": "d285c10055af9002db8c913557535ba46e3158c5733b236add3d71f93873e85a",
-      "url": "https://download.jetbrains.com/go/goland-2025.2.tar.gz",
-      "build_number": "252.23892.449"
+      "version": "2025.2.0.1",
+      "sha256": "6a835b97bfa86938b45c902f3aad8b3c9c5265840473404c1d664149b0bd7434",
+      "url": "https://download.jetbrains.com/go/goland-2025.2.0.1.tar.gz",
+      "build_number": "252.23892.530"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
@@ -84,26 +84,26 @@
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.tar.gz",
-      "version": "2025.2",
-      "sha256": "356dc81511bbd361c7f106fda8597503c6b9797d36a3a04434bbf0ec35a02434",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.tar.gz",
-      "build_number": "252.23892.439"
+      "version": "2025.2.0.1",
+      "sha256": "2b95c6169c6f9bb00657e24cecdad23281c423b661918c09781894f3508f8672",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.0.1.tar.gz",
+      "build_number": "252.23892.515"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.tar.gz",
-      "version": "2025.2",
-      "sha256": "bc3fbb31ea10e171686b9be8734051382233748502f124393c52848aefe97b32",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.tar.gz",
-      "build_number": "252.23892.439"
+      "version": "2025.2.0.1",
+      "sha256": "555a20eb9a695f52430fc3ef1b43c229186df5bf1c8962de55db0ef7eb308fb4",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.0.1.tar.gz",
+      "build_number": "252.23892.515"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.tar.gz",
-      "version": "2025.1.5",
-      "sha256": "b10e21b764e504e33468ee93885fee1102c0b96bd628d1d7c0a19ce6e83910d6",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.5.tar.gz",
-      "build_number": "251.27812.87"
+      "version": "2025.2",
+      "sha256": "661d5e8fc12e6373e7a84ee197aa755d77c2e3fe0246284c79bc20682d39d309",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.tar.gz",
+      "build_number": "252.23892.524"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
@@ -158,18 +158,18 @@
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.tar.gz",
-      "version": "2025.2.1",
-      "sha256": "da21f165bce024ed6e99275350da41fa49e8ac51a47da50ed7a1e104edc06aa0",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.1-aarch64.tar.gz",
-      "build_number": "252.23892.464"
+      "version": "2025.2.2",
+      "sha256": "cb5a8e32343f56bb33721edb8488d74198a5a9b738610a0ed97c0e0a636910fe",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.2-aarch64.tar.gz",
+      "build_number": "252.25557.34"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}-aarch64.tar.gz",
-      "version": "2025.1.2.1",
-      "sha256": "a982a7e8d5b1c293b68983be792a60a885567e9af825e0fce4b2a4b6ac30c9ae",
-      "url": "https://download.jetbrains.com/python/dataspell-2025.1.2.1-aarch64.tar.gz",
-      "build_number": "251.26927.91"
+      "version": "2025.2",
+      "sha256": "3c4261682f54a283ce693315dde5f2a472fec91887cf37b8c6b87c73ce245d2c",
+      "url": "https://download.jetbrains.com/python/dataspell-2025.2-aarch64.tar.gz",
+      "build_number": "252.23892.514"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
@@ -182,10 +182,10 @@
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}-aarch64.tar.gz",
-      "version": "2025.2",
-      "sha256": "99a5f3e0455fddf62ce92644cb53906e4600da6d2d2dad89164c594c31faa157",
-      "url": "https://download.jetbrains.com/go/goland-2025.2-aarch64.tar.gz",
-      "build_number": "252.23892.449"
+      "version": "2025.2.0.1",
+      "sha256": "377439d9cae41631624c848c61fcb91f1034c6997582346388d8d9f806b6e72f",
+      "url": "https://download.jetbrains.com/go/goland-2025.2.0.1-aarch64.tar.gz",
+      "build_number": "252.23892.530"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
@@ -223,26 +223,26 @@
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.tar.gz",
-      "version": "2025.2",
-      "sha256": "2aab469f976c4aa7d6686c8cc81d647960a9496ea2f3aed01f1c09448b443efb",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2-aarch64.tar.gz",
-      "build_number": "252.23892.439"
+      "version": "2025.2.0.1",
+      "sha256": "820f8f1a749d2544a4e4511ff23e8b55f3fe5faa4e0b715ba44999f784c5ac94",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.0.1-aarch64.tar.gz",
+      "build_number": "252.23892.515"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.tar.gz",
-      "version": "2025.2",
-      "sha256": "27a88a70b8c97be56cdc759cdd7612e55156d67c8bed5a5e23a5af42776bade9",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2-aarch64.tar.gz",
-      "build_number": "252.23892.439"
+      "version": "2025.2.0.1",
+      "sha256": "d5a00d4774ad5861fad457494b644bb0ee4c6017f1f6c881da4afd23b44fdaf7",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.0.1-aarch64.tar.gz",
+      "build_number": "252.23892.515"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.tar.gz",
-      "version": "2025.1.5",
-      "sha256": "15b70a589a0827c6408e15eb8e20dfc2e378df66bb528514a577eeae22079553",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.5-aarch64.tar.gz",
-      "build_number": "251.27812.87"
+      "version": "2025.2",
+      "sha256": "19b8c6322aac489888afe9eea81dcb6a114b4cc75d525ee3ea8a86899c6b42c7",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2-aarch64.tar.gz",
+      "build_number": "252.23892.524"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
@@ -297,18 +297,18 @@
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.dmg",
-      "version": "2025.2.1",
-      "sha256": "e6c7fd2777ec7f621fa08b6d2d599c84b765d94be9d2b7a62f840ea6253cb9fe",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.1.dmg",
-      "build_number": "252.23892.464"
+      "version": "2025.2.2",
+      "sha256": "7e3993f6fbf4254e81ce7b19fd173ac6a3f93a7d60b4d897f3fd73136ff7dc2e",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.2.dmg",
+      "build_number": "252.25557.34"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}.dmg",
-      "version": "2025.1.2.1",
-      "sha256": "21915425a004b9148ab5fb634ab919d328a692847f3229bcd060fc46c2b91e76",
-      "url": "https://download.jetbrains.com/python/dataspell-2025.1.2.1.dmg",
-      "build_number": "251.26927.91"
+      "version": "2025.2",
+      "sha256": "36bd810a0ab4fab0edcc135ef472a731f55c25af80d40b1e6d36a833302d525c",
+      "url": "https://download.jetbrains.com/python/dataspell-2025.2.dmg",
+      "build_number": "252.23892.514"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
@@ -321,10 +321,10 @@
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}.dmg",
-      "version": "2025.2",
-      "sha256": "c42e150a88b9d9ef033a7ff3678eb891408668afe83179d4f678bb674dc8e424",
-      "url": "https://download.jetbrains.com/go/goland-2025.2.dmg",
-      "build_number": "252.23892.449"
+      "version": "2025.2.0.1",
+      "sha256": "67056fa41a9e72b0d0a268f648d3dae6ba0304beae8883cf97bf95ab875195cd",
+      "url": "https://download.jetbrains.com/go/goland-2025.2.0.1.dmg",
+      "build_number": "252.23892.530"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
@@ -362,26 +362,26 @@
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.dmg",
-      "version": "2025.2",
-      "sha256": "ee808240caab0d50932fe25cd3d93aeeb8a531bfbc5b034f0eff72716c3eb6a5",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.dmg",
-      "build_number": "252.23892.439"
+      "version": "2025.2.0.1",
+      "sha256": "0fa4e9c93bcb1f0d56dd7faecbb01b38d3c07fbbcf4fc8c0ad4dc5dc2f15b5a9",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.0.1.dmg",
+      "build_number": "252.23892.515"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.dmg",
-      "version": "2025.2",
-      "sha256": "66c6ae1e9e6531bc87f7527221d06647ce18fea15484ad9f371cc51f99a271a0",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.dmg",
-      "build_number": "252.23892.439"
+      "version": "2025.2.0.1",
+      "sha256": "440e613cc7e9d02ea27c921168b27a120e0eed5d084d878a6e7f9af3c874ac1a",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.0.1.dmg",
+      "build_number": "252.23892.515"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.dmg",
-      "version": "2025.1.5",
-      "sha256": "ed39b7f3770bb186014e8cdd6e314b4dfbb0f90e8d24be8b175fbf71ef7957ac",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.5.dmg",
-      "build_number": "251.27812.87"
+      "version": "2025.2",
+      "sha256": "c03da6f4c519e1c697ada502f43d1152e41614262970cbbf4df15d2f470658f3",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.dmg",
+      "build_number": "252.23892.524"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
@@ -436,18 +436,18 @@
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.dmg",
-      "version": "2025.2.1",
-      "sha256": "865a887cc89076eac601bc073e74d6cb1b5711aaf8f4c39a2f7bd18648d9cc6e",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.1-aarch64.dmg",
-      "build_number": "252.23892.464"
+      "version": "2025.2.2",
+      "sha256": "eec04b3602062cf5dd6be20b0c77ce4a384c0727bd43403d1eb9646b268439f6",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.2-aarch64.dmg",
+      "build_number": "252.25557.34"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}-aarch64.dmg",
-      "version": "2025.1.2.1",
-      "sha256": "97588c238523b2c492a322a0751173f908f31eb27e0d38f81dd51f670690a9a5",
-      "url": "https://download.jetbrains.com/python/dataspell-2025.1.2.1-aarch64.dmg",
-      "build_number": "251.26927.91"
+      "version": "2025.2",
+      "sha256": "484c6889a929c3ec572711164600ad93c927b57a3487636d672db77a1e9483f5",
+      "url": "https://download.jetbrains.com/python/dataspell-2025.2-aarch64.dmg",
+      "build_number": "252.23892.514"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
@@ -460,10 +460,10 @@
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}-aarch64.dmg",
-      "version": "2025.2",
-      "sha256": "043600466d739338b9d24a472547b3d7133505165032459e9fe6f913b6920eac",
-      "url": "https://download.jetbrains.com/go/goland-2025.2-aarch64.dmg",
-      "build_number": "252.23892.449"
+      "version": "2025.2.0.1",
+      "sha256": "e35b7f2ec7e63c0c348e172ddf10410ff108189c4a4a1e4dcfc75c757908b12b",
+      "url": "https://download.jetbrains.com/go/goland-2025.2.0.1-aarch64.dmg",
+      "build_number": "252.23892.530"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
@@ -501,26 +501,26 @@
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.dmg",
-      "version": "2025.2",
-      "sha256": "9fd11b6e5fe28d5e3cac86cac554b4e04f775254d141f3c7ec07ee9801ce8a00",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2-aarch64.dmg",
-      "build_number": "252.23892.439"
+      "version": "2025.2.0.1",
+      "sha256": "acdbfd143a7da358cbd9b1410eff8763f9650c58f9a976d80a9aa8977f358e00",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.0.1-aarch64.dmg",
+      "build_number": "252.23892.515"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.dmg",
-      "version": "2025.2",
-      "sha256": "54b761294795146c575a22ea5d53bc7c0a05ab906836b544ff6b830b4b79b41b",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2-aarch64.dmg",
-      "build_number": "252.23892.439"
+      "version": "2025.2.0.1",
+      "sha256": "9d3265dd828c45681ba608ee2325b3b560396b7048290d7c69714cbc99e86fd7",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.0.1-aarch64.dmg",
+      "build_number": "252.23892.515"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.dmg",
-      "version": "2025.1.5",
-      "sha256": "74decd2d7fb0ee97587e9de165b1630bac8a9ba8ad55aa8a64e9c5e173551adb",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.5-aarch64.dmg",
-      "build_number": "251.27812.87"
+      "version": "2025.2",
+      "sha256": "ec385a005fb740e6b12a5232ae57c7d189b3d32ac4813734b04d4257421368a3",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2-aarch64.dmg",
+      "build_number": "252.23892.524"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -324,6 +324,9 @@ rec {
         lttng-ust_2_12
         musl
       ]
+      ++ lib.optionals stdenv.hostPlatform.isLinux [
+        xorg.xcbutilkeysyms
+      ]
       ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch) [
         expat
         libxml2

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -16,18 +16,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.23774.423": "https://plugins.jetbrains.com/files/164/818417/IdeaVIM-2.27.0.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/164/818417/IdeaVIM-2.27.0.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/164/818417/IdeaVIM-2.27.0.zip",
-        "252.23892.409": "https://plugins.jetbrains.com/files/164/818417/IdeaVIM-2.27.0.zip",
-        "252.23892.411": "https://plugins.jetbrains.com/files/164/818417/IdeaVIM-2.27.0.zip",
-        "252.23892.415": "https://plugins.jetbrains.com/files/164/818417/IdeaVIM-2.27.0.zip",
-        "252.23892.419": "https://plugins.jetbrains.com/files/164/818417/IdeaVIM-2.27.0.zip",
-        "252.23892.426": "https://plugins.jetbrains.com/files/164/818417/IdeaVIM-2.27.0.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/164/818417/IdeaVIM-2.27.0.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/164/818417/IdeaVIM-2.27.0.zip",
-        "252.23892.452": "https://plugins.jetbrains.com/files/164/818417/IdeaVIM-2.27.0.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/164/818417/IdeaVIM-2.27.0.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/164/822112/IdeaVIM-2.27.1.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/164/822112/IdeaVIM-2.27.1.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/164/822112/IdeaVIM-2.27.1.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/164/822112/IdeaVIM-2.27.1.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/164/822112/IdeaVIM-2.27.1.zip",
+        "252.23892.419": "https://plugins.jetbrains.com/files/164/822112/IdeaVIM-2.27.1.zip",
+        "252.23892.426": "https://plugins.jetbrains.com/files/164/822112/IdeaVIM-2.27.1.zip",
+        "252.23892.452": "https://plugins.jetbrains.com/files/164/822112/IdeaVIM-2.27.1.zip",
+        "252.23892.515": "https://plugins.jetbrains.com/files/164/822112/IdeaVIM-2.27.1.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/164/822112/IdeaVIM-2.27.1.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/164/822112/IdeaVIM-2.27.1.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/164/822112/IdeaVIM-2.27.1.zip"
       },
       "name": "ideavim"
     },
@@ -47,7 +47,7 @@
       ],
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/1347/770332/scala-intellij-bin-2025.1.25.zip",
-        "252.23892.409": "https://plugins.jetbrains.com/files/1347/815326/scala-intellij-bin-2025.2.26.zip"
+        "252.23892.409": "https://plugins.jetbrains.com/files/1347/832458/scala-intellij-bin-2025.2.28.zip"
       },
       "name": "scala"
     },
@@ -69,16 +69,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip"
       },
       "name": "stringmanipulation"
     },
@@ -100,16 +100,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip"
       },
       "name": "handlebars-mustache"
     },
@@ -131,16 +131,16 @@
       "builds": {
         "251.23774.423": null,
         "251.25410.129": null,
-        "251.27812.87": null,
         "252.23892.409": "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/6954/827441/Kotlin-252.25557.23-IJ.zip"
       },
       "name": "kotlin"
     },
@@ -162,16 +162,16 @@
       "builds": {
         "251.23774.423": null,
         "251.25410.129": null,
-        "251.27812.87": "https://plugins.jetbrains.com/files/6981/806736/ini-251.27812.54.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/6981/818238/ini-252.23892.449.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/6981/818238/ini-252.23892.449.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/6981/818238/ini-252.23892.449.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/6981/818238/ini-252.23892.449.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/6981/818238/ini-252.23892.449.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/6981/818238/ini-252.23892.449.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/6981/818238/ini-252.23892.449.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/6981/818238/ini-252.23892.449.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/6981/818238/ini-252.23892.449.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/6981/818238/ini-252.23892.449.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/6981/818238/ini-252.23892.449.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/6981/818238/ini-252.23892.449.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/6981/828495/ini-252.25557.34.zip"
       },
       "name": "ini"
     },
@@ -193,16 +193,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip"
       },
       "name": "acejump"
     },
@@ -224,16 +224,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip"
       },
       "name": "grep-console"
     },
@@ -255,16 +255,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip"
       },
       "name": "file-watchers"
     },
@@ -297,16 +297,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip"
       },
       "name": "cucumber-for-java"
     },
@@ -346,14 +346,14 @@
       ],
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/7322/805188/python-ce-251.27812.49.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/7322/819231/python-ce-252.23892.458.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/7322/819231/python-ce-252.23892.458.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/7322/819231/python-ce-252.23892.458.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/7322/819231/python-ce-252.23892.458.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/7322/819231/python-ce-252.23892.458.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/7322/819231/python-ce-252.23892.458.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/7322/819231/python-ce-252.23892.458.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/7322/819231/python-ce-252.23892.458.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/7322/819231/python-ce-252.23892.458.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/7322/819231/python-ce-252.23892.458.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/7322/827486/python-ce-252.25557.23.zip"
       },
       "name": "python-community-edition"
     },
@@ -375,16 +375,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip"
       },
       "name": "asciidoc"
     },
@@ -406,16 +406,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "251.25410.129": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.27812.87": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.23892.409": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.23892.411": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.23892.415": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.23892.419": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.23892.426": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "252.23892.439": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "252.23892.449": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.23892.452": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "252.23892.464": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar"
+        "252.23892.515": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.23892.524": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.23892.530": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.25557.34": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar"
       },
       "name": "wakatime"
     },
@@ -437,16 +437,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip"
       },
       "name": "gittoolbox"
     },
@@ -468,16 +468,16 @@
       "builds": {
         "251.23774.423": null,
         "251.25410.129": null,
-        "251.27812.87": "https://plugins.jetbrains.com/files/7724/805402/clouds-docker-impl-251.27812.52.zip",
-        "252.23892.409": "https://plugins.jetbrains.com/files/7724/819808/clouds-docker-impl-252.23892.464.zip",
-        "252.23892.411": "https://plugins.jetbrains.com/files/7724/819808/clouds-docker-impl-252.23892.464.zip",
-        "252.23892.415": "https://plugins.jetbrains.com/files/7724/819808/clouds-docker-impl-252.23892.464.zip",
-        "252.23892.419": "https://plugins.jetbrains.com/files/7724/819808/clouds-docker-impl-252.23892.464.zip",
-        "252.23892.426": "https://plugins.jetbrains.com/files/7724/819808/clouds-docker-impl-252.23892.464.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/7724/819808/clouds-docker-impl-252.23892.464.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/7724/819808/clouds-docker-impl-252.23892.464.zip",
-        "252.23892.452": "https://plugins.jetbrains.com/files/7724/819808/clouds-docker-impl-252.23892.464.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/7724/819808/clouds-docker-impl-252.23892.464.zip"
+        "252.23892.409": "https://plugins.jetbrains.com/files/7724/826726/clouds-docker-impl-252.23892.515.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/7724/826726/clouds-docker-impl-252.23892.515.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/7724/826726/clouds-docker-impl-252.23892.515.zip",
+        "252.23892.419": "https://plugins.jetbrains.com/files/7724/826726/clouds-docker-impl-252.23892.515.zip",
+        "252.23892.426": "https://plugins.jetbrains.com/files/7724/826726/clouds-docker-impl-252.23892.515.zip",
+        "252.23892.452": "https://plugins.jetbrains.com/files/7724/826726/clouds-docker-impl-252.23892.515.zip",
+        "252.23892.515": "https://plugins.jetbrains.com/files/7724/826726/clouds-docker-impl-252.23892.515.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/7724/826726/clouds-docker-impl-252.23892.515.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/7724/826726/clouds-docker-impl-252.23892.515.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/7724/829211/clouds-docker-impl-252.25557.35.zip"
       },
       "name": "docker"
     },
@@ -499,16 +499,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/8097/802996/graphql-251.27812.12.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip"
       },
       "name": "graphql"
     },
@@ -529,15 +529,15 @@
       "builds": {
         "251.23774.423": null,
         "251.25410.129": null,
-        "251.27812.87": null,
         "252.23892.409": null,
         "252.23892.411": null,
         "252.23892.415": null,
         "252.23892.419": null,
         "252.23892.426": null,
-        "252.23892.439": null,
-        "252.23892.449": null,
-        "252.23892.464": null
+        "252.23892.515": null,
+        "252.23892.524": null,
+        "252.23892.530": null,
+        "252.25557.34": null
       },
       "name": "-deprecated-rust"
     },
@@ -558,15 +558,15 @@
       "builds": {
         "251.23774.423": null,
         "251.25410.129": null,
-        "251.27812.87": null,
         "252.23892.409": null,
         "252.23892.411": null,
         "252.23892.415": null,
         "252.23892.419": null,
         "252.23892.426": null,
-        "252.23892.439": null,
-        "252.23892.449": null,
-        "252.23892.464": null
+        "252.23892.515": null,
+        "252.23892.524": null,
+        "252.23892.530": null,
+        "252.25557.34": null
       },
       "name": "-deprecated-rust-beta"
     },
@@ -588,16 +588,16 @@
       "builds": {
         "251.23774.423": null,
         "251.25410.129": null,
-        "251.27812.87": "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/8195/819801/toml-252.23892.464.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/8195/819801/toml-252.23892.464.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/8195/819801/toml-252.23892.464.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/8195/819801/toml-252.23892.464.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/8195/819801/toml-252.23892.464.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/8195/819801/toml-252.23892.464.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/8195/819801/toml-252.23892.464.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/8195/819801/toml-252.23892.464.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/8195/819801/toml-252.23892.464.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/8195/819801/toml-252.23892.464.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/8195/819801/toml-252.23892.464.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/8195/819801/toml-252.23892.464.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/8195/828228/toml-252.25557.32.zip"
       },
       "name": "toml"
     },
@@ -630,16 +630,16 @@
       "builds": {
         "251.23774.423": null,
         "251.25410.129": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
-        "252.23892.409": "https://plugins.jetbrains.com/files/8554/819797/featuresTrainer-252.23892.464.zip",
-        "252.23892.411": "https://plugins.jetbrains.com/files/8554/819797/featuresTrainer-252.23892.464.zip",
-        "252.23892.415": "https://plugins.jetbrains.com/files/8554/819797/featuresTrainer-252.23892.464.zip",
-        "252.23892.419": "https://plugins.jetbrains.com/files/8554/819797/featuresTrainer-252.23892.464.zip",
-        "252.23892.426": "https://plugins.jetbrains.com/files/8554/819797/featuresTrainer-252.23892.464.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/8554/819797/featuresTrainer-252.23892.464.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/8554/819797/featuresTrainer-252.23892.464.zip",
-        "252.23892.452": "https://plugins.jetbrains.com/files/8554/819797/featuresTrainer-252.23892.464.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/8554/819797/featuresTrainer-252.23892.464.zip"
+        "252.23892.409": "https://plugins.jetbrains.com/files/8554/826552/featuresTrainer-252.23892.514.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/8554/826552/featuresTrainer-252.23892.514.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/8554/826552/featuresTrainer-252.23892.514.zip",
+        "252.23892.419": "https://plugins.jetbrains.com/files/8554/826552/featuresTrainer-252.23892.514.zip",
+        "252.23892.426": "https://plugins.jetbrains.com/files/8554/826552/featuresTrainer-252.23892.514.zip",
+        "252.23892.452": "https://plugins.jetbrains.com/files/8554/826552/featuresTrainer-252.23892.514.zip",
+        "252.23892.515": "https://plugins.jetbrains.com/files/8554/826552/featuresTrainer-252.23892.514.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/8554/826552/featuresTrainer-252.23892.514.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/8554/826552/featuresTrainer-252.23892.514.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/8554/828474/featuresTrainer-252.25557.34.zip"
       },
       "name": "ide-features-trainer"
     },
@@ -661,16 +661,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip"
       },
       "name": "nixidea"
     },
@@ -692,16 +692,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip"
       },
       "name": "gherkin"
     },
@@ -723,16 +723,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip"
       },
       "name": "-env-files"
     },
@@ -743,7 +743,7 @@
       ],
       "builds": {
         "252.23892.409": "https://plugins.jetbrains.com/files/9568/808965/go-plugin-252.23892.360.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/9568/808965/go-plugin-252.23892.360.zip"
+        "252.23892.530": "https://plugins.jetbrains.com/files/9568/808965/go-plugin-252.23892.360.zip"
       },
       "name": "go"
     },
@@ -765,16 +765,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
         "251.25410.129": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.27812.87": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
         "252.23892.409": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
         "252.23892.411": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
         "252.23892.415": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
         "252.23892.419": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
         "252.23892.426": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
-        "252.23892.439": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
-        "252.23892.449": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
         "252.23892.452": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
-        "252.23892.464": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar"
+        "252.23892.515": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.23892.524": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.23892.530": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.25557.34": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar"
       },
       "name": "ansi-highlighter-premium"
     },
@@ -796,16 +796,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
       },
       "name": "key-promoter-x"
     },
@@ -825,18 +825,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.23774.423": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
-        "252.23892.409": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
-        "252.23892.411": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
-        "252.23892.415": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
-        "252.23892.419": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
-        "252.23892.426": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
-        "252.23892.452": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/9836/823111/intellij-randomness-3.4.1.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/9836/823111/intellij-randomness-3.4.1.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/9836/823111/intellij-randomness-3.4.1.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/9836/823111/intellij-randomness-3.4.1.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/9836/823111/intellij-randomness-3.4.1.zip",
+        "252.23892.419": "https://plugins.jetbrains.com/files/9836/823111/intellij-randomness-3.4.1.zip",
+        "252.23892.426": "https://plugins.jetbrains.com/files/9836/823111/intellij-randomness-3.4.1.zip",
+        "252.23892.452": "https://plugins.jetbrains.com/files/9836/823111/intellij-randomness-3.4.1.zip",
+        "252.23892.515": "https://plugins.jetbrains.com/files/9836/823111/intellij-randomness-3.4.1.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/9836/823111/intellij-randomness-3.4.1.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/9836/823111/intellij-randomness-3.4.1.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/9836/823111/intellij-randomness-3.4.1.zip"
       },
       "name": "randomness"
     },
@@ -858,16 +858,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip"
       },
       "name": "csv-editor"
     },
@@ -887,18 +887,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.23774.423": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
-        "252.23892.409": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
-        "252.23892.411": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
-        "252.23892.415": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
-        "252.23892.419": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
-        "252.23892.426": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
-        "252.23892.452": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/10080/831413/intellij-rainbow-brackets-2025.3.3.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/10080/831413/intellij-rainbow-brackets-2025.3.3.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/10080/831413/intellij-rainbow-brackets-2025.3.3.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/10080/831413/intellij-rainbow-brackets-2025.3.3.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/10080/831413/intellij-rainbow-brackets-2025.3.3.zip",
+        "252.23892.419": "https://plugins.jetbrains.com/files/10080/831413/intellij-rainbow-brackets-2025.3.3.zip",
+        "252.23892.426": "https://plugins.jetbrains.com/files/10080/831413/intellij-rainbow-brackets-2025.3.3.zip",
+        "252.23892.452": "https://plugins.jetbrains.com/files/10080/831413/intellij-rainbow-brackets-2025.3.3.zip",
+        "252.23892.515": "https://plugins.jetbrains.com/files/10080/831413/intellij-rainbow-brackets-2025.3.3.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/10080/831413/intellij-rainbow-brackets-2025.3.3.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/10080/831413/intellij-rainbow-brackets-2025.3.3.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/10080/831413/intellij-rainbow-brackets-2025.3.3.zip"
       },
       "name": "rainbow-brackets"
     },
@@ -920,16 +920,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
       },
       "name": "dot-language"
     },
@@ -951,16 +951,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip"
       },
       "name": "hocon"
     },
@@ -981,15 +981,15 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip"
       },
       "name": "go-template"
     },
@@ -1011,16 +1011,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/11058/818728/Extra_Icons-2025.1.12.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/11058/818728/Extra_Icons-2025.1.12.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/11058/818728/Extra_Icons-2025.1.12.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/11058/818728/Extra_Icons-2025.1.12.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/11058/818728/Extra_Icons-2025.1.12.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/11058/818728/Extra_Icons-2025.1.12.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/11058/818728/Extra_Icons-2025.1.12.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/11058/818728/Extra_Icons-2025.1.12.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/11058/818728/Extra_Icons-2025.1.12.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/11058/818728/Extra_Icons-2025.1.12.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/11058/818728/Extra_Icons-2025.1.12.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/11058/818728/Extra_Icons-2025.1.12.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/11058/818728/Extra_Icons-2025.1.12.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/11058/818728/Extra_Icons-2025.1.12.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/11058/818728/Extra_Icons-2025.1.12.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/11058/818728/Extra_Icons-2025.1.12.zip"
       },
       "name": "extra-icons"
     },
@@ -1040,18 +1040,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.23774.423": "https://plugins.jetbrains.com/files/11349/817799/aws-toolkit-jetbrains-standalone-3.88.251.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/11349/817799/aws-toolkit-jetbrains-standalone-3.88.251.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/11349/817799/aws-toolkit-jetbrains-standalone-3.88.251.zip",
-        "252.23892.409": "https://plugins.jetbrains.com/files/11349/817795/aws-toolkit-jetbrains-standalone-3.88.252.zip",
-        "252.23892.411": "https://plugins.jetbrains.com/files/11349/817795/aws-toolkit-jetbrains-standalone-3.88.252.zip",
-        "252.23892.415": "https://plugins.jetbrains.com/files/11349/817795/aws-toolkit-jetbrains-standalone-3.88.252.zip",
-        "252.23892.419": "https://plugins.jetbrains.com/files/11349/817795/aws-toolkit-jetbrains-standalone-3.88.252.zip",
-        "252.23892.426": "https://plugins.jetbrains.com/files/11349/817795/aws-toolkit-jetbrains-standalone-3.88.252.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/11349/817795/aws-toolkit-jetbrains-standalone-3.88.252.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/11349/817795/aws-toolkit-jetbrains-standalone-3.88.252.zip",
-        "252.23892.452": "https://plugins.jetbrains.com/files/11349/817795/aws-toolkit-jetbrains-standalone-3.88.252.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/11349/817795/aws-toolkit-jetbrains-standalone-3.88.252.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/11349/821624/aws-toolkit-jetbrains-standalone-3.89.251.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/11349/821624/aws-toolkit-jetbrains-standalone-3.89.251.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/11349/821620/aws-toolkit-jetbrains-standalone-3.89.252.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/11349/821620/aws-toolkit-jetbrains-standalone-3.89.252.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/11349/821620/aws-toolkit-jetbrains-standalone-3.89.252.zip",
+        "252.23892.419": "https://plugins.jetbrains.com/files/11349/821620/aws-toolkit-jetbrains-standalone-3.89.252.zip",
+        "252.23892.426": "https://plugins.jetbrains.com/files/11349/821620/aws-toolkit-jetbrains-standalone-3.89.252.zip",
+        "252.23892.452": "https://plugins.jetbrains.com/files/11349/821620/aws-toolkit-jetbrains-standalone-3.89.252.zip",
+        "252.23892.515": "https://plugins.jetbrains.com/files/11349/821620/aws-toolkit-jetbrains-standalone-3.89.252.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/11349/821620/aws-toolkit-jetbrains-standalone-3.89.252.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/11349/821620/aws-toolkit-jetbrains-standalone-3.89.252.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/11349/821620/aws-toolkit-jetbrains-standalone-3.89.252.zip"
       },
       "name": "aws-toolkit"
     },
@@ -1060,7 +1060,7 @@
         "rider"
       ],
       "builds": {
-        "251.27812.87": "https://plugins.jetbrains.com/files/12024/667413/ReSharperPlugin.CognitiveComplexity-2025.1.0-eap01.zip"
+        "252.23892.524": "https://plugins.jetbrains.com/files/12024/717598/ReSharperPlugin.CognitiveComplexity-2025.1.0.zip"
       },
       "name": "cognitivecomplexity"
     },
@@ -1082,16 +1082,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip"
       },
       "name": "vscode-keymap"
     },
@@ -1113,16 +1113,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip"
       },
       "name": "eclipse-keymap"
     },
@@ -1144,16 +1144,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
       },
       "name": "rainbow-csv"
     },
@@ -1175,16 +1175,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip"
       },
       "name": "visual-studio-keymap"
     },
@@ -1206,16 +1206,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
       },
       "name": "indent-rainbow"
     },
@@ -1237,16 +1237,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/14004/803006/protoeditor-251.27812.12.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip"
       },
       "name": "protocol-buffers"
     },
@@ -1268,16 +1268,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "251.25410.129": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.27812.87": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.23892.409": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.23892.411": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.23892.415": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.23892.419": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.23892.426": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "252.23892.439": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "252.23892.449": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.23892.452": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "252.23892.464": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
+        "252.23892.515": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.23892.524": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.23892.530": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.25557.34": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
       },
       "name": "darcula-pitch-black"
     },
@@ -1299,16 +1299,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "251.25410.129": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.27812.87": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.23892.409": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.23892.411": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.23892.415": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.23892.419": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.23892.426": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "252.23892.439": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "252.23892.449": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.23892.452": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "252.23892.464": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
+        "252.23892.515": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.23892.524": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.23892.530": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.25557.34": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
       },
       "name": "mario-progress-bar"
     },
@@ -1330,16 +1330,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
         "251.25410.129": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.27812.87": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
         "252.23892.409": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
         "252.23892.411": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
         "252.23892.415": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
         "252.23892.419": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
         "252.23892.426": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "252.23892.439": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "252.23892.449": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
         "252.23892.452": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "252.23892.464": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar"
+        "252.23892.515": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "252.23892.524": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "252.23892.530": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "252.25557.34": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar"
       },
       "name": "which-key"
     },
@@ -1361,16 +1361,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/16604/818726/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.12.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/16604/818726/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.12.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/16604/818726/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.12.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/16604/818726/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.12.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/16604/818726/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.12.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/16604/818726/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.12.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/16604/818726/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.12.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/16604/818726/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.12.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/16604/818726/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.12.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/16604/818726/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.12.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/16604/818726/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.12.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/16604/818726/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.12.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/16604/818726/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.12.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/16604/818726/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.12.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/16604/818726/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.12.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/16604/818726/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.12.zip"
       },
       "name": "extra-toolwindow-colorful-icons"
     },
@@ -1390,18 +1390,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.23774.423": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
-        "252.23892.409": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
-        "252.23892.411": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
-        "252.23892.415": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
-        "252.23892.419": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
-        "252.23892.426": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
-        "252.23892.452": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/17718/827394/github-copilot-intellij-1.5.53-243.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/17718/827394/github-copilot-intellij-1.5.53-243.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/17718/827394/github-copilot-intellij-1.5.53-243.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/17718/827394/github-copilot-intellij-1.5.53-243.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/17718/827394/github-copilot-intellij-1.5.53-243.zip",
+        "252.23892.419": "https://plugins.jetbrains.com/files/17718/827394/github-copilot-intellij-1.5.53-243.zip",
+        "252.23892.426": "https://plugins.jetbrains.com/files/17718/827394/github-copilot-intellij-1.5.53-243.zip",
+        "252.23892.452": "https://plugins.jetbrains.com/files/17718/827394/github-copilot-intellij-1.5.53-243.zip",
+        "252.23892.515": "https://plugins.jetbrains.com/files/17718/827394/github-copilot-intellij-1.5.53-243.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/17718/827394/github-copilot-intellij-1.5.53-243.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/17718/827394/github-copilot-intellij-1.5.53-243.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/17718/827394/github-copilot-intellij-1.5.53-243.zip"
       },
       "name": "github-copilot"
     },
@@ -1423,16 +1423,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
       },
       "name": "netbeans-6-5-keymap"
     },
@@ -1454,16 +1454,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip"
       },
       "name": "catppuccin-theme"
     },
@@ -1485,16 +1485,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip"
       },
       "name": "codeglance-pro"
     },
@@ -1514,18 +1514,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.23774.423": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
-        "251.25410.129": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
-        "251.27812.87": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
-        "252.23892.409": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
-        "252.23892.411": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
-        "252.23892.415": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
-        "252.23892.419": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
-        "252.23892.426": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
-        "252.23892.439": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
-        "252.23892.449": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
-        "252.23892.452": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
-        "252.23892.464": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar"
+        "251.23774.423": "https://plugins.jetbrains.com/files/18922/827073/GerryThemes.jar",
+        "251.25410.129": "https://plugins.jetbrains.com/files/18922/827073/GerryThemes.jar",
+        "252.23892.409": "https://plugins.jetbrains.com/files/18922/827073/GerryThemes.jar",
+        "252.23892.411": "https://plugins.jetbrains.com/files/18922/827073/GerryThemes.jar",
+        "252.23892.415": "https://plugins.jetbrains.com/files/18922/827073/GerryThemes.jar",
+        "252.23892.419": "https://plugins.jetbrains.com/files/18922/827073/GerryThemes.jar",
+        "252.23892.426": "https://plugins.jetbrains.com/files/18922/827073/GerryThemes.jar",
+        "252.23892.452": "https://plugins.jetbrains.com/files/18922/827073/GerryThemes.jar",
+        "252.23892.515": "https://plugins.jetbrains.com/files/18922/827073/GerryThemes.jar",
+        "252.23892.524": "https://plugins.jetbrains.com/files/18922/827073/GerryThemes.jar",
+        "252.23892.530": "https://plugins.jetbrains.com/files/18922/827073/GerryThemes.jar",
+        "252.25557.34": "https://plugins.jetbrains.com/files/18922/827073/GerryThemes.jar"
       },
       "name": "gerry-themes"
     },
@@ -1547,16 +1547,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
       },
       "name": "better-direnv"
     },
@@ -1578,16 +1578,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip"
       },
       "name": "mermaid"
     },
@@ -1609,16 +1609,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
       },
       "name": "ferris"
     },
@@ -1640,16 +1640,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip"
       },
       "name": "code-complexity"
     },
@@ -1671,16 +1671,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip"
       },
       "name": "developer-tools"
     },
@@ -1696,14 +1696,14 @@
         "webstorm"
       ],
       "builds": {
-        "251.27812.87": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/21962/810863/clouds-docker-gateway-252.23892.363.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/21962/810863/clouds-docker-gateway-252.23892.363.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/21962/810863/clouds-docker-gateway-252.23892.363.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/21962/810863/clouds-docker-gateway-252.23892.363.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/21962/810863/clouds-docker-gateway-252.23892.363.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/21962/810863/clouds-docker-gateway-252.23892.363.zip",
-        "252.23892.452": "https://plugins.jetbrains.com/files/21962/810863/clouds-docker-gateway-252.23892.363.zip"
+        "252.23892.452": "https://plugins.jetbrains.com/files/21962/810863/clouds-docker-gateway-252.23892.363.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/21962/810863/clouds-docker-gateway-252.23892.363.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/21962/810863/clouds-docker-gateway-252.23892.363.zip"
       },
       "name": "dev-containers"
     },
@@ -1736,18 +1736,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.23774.423": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
-        "252.23892.409": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
-        "252.23892.411": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
-        "252.23892.415": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
-        "252.23892.419": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
-        "252.23892.426": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
-        "252.23892.452": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/22707/823138/continue-intellij-extension-1.0.35.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/22707/823138/continue-intellij-extension-1.0.35.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/22707/823138/continue-intellij-extension-1.0.35.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/22707/823138/continue-intellij-extension-1.0.35.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/22707/823138/continue-intellij-extension-1.0.35.zip",
+        "252.23892.419": "https://plugins.jetbrains.com/files/22707/823138/continue-intellij-extension-1.0.35.zip",
+        "252.23892.426": "https://plugins.jetbrains.com/files/22707/823138/continue-intellij-extension-1.0.35.zip",
+        "252.23892.452": "https://plugins.jetbrains.com/files/22707/823138/continue-intellij-extension-1.0.35.zip",
+        "252.23892.515": "https://plugins.jetbrains.com/files/22707/823138/continue-intellij-extension-1.0.35.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/22707/823138/continue-intellij-extension-1.0.35.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/22707/823138/continue-intellij-extension-1.0.35.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/22707/823138/continue-intellij-extension-1.0.35.zip"
       },
       "name": "continue"
     },
@@ -1767,18 +1767,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.23774.423": "https://plugins.jetbrains.com/files/22857/716106/vcs-gitlab-IU-251.23774.435-IU.zip",
+        "251.23774.423": null,
         "251.25410.129": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip",
-        "252.23892.409": "https://plugins.jetbrains.com/files/22857/819822/vcs-gitlab-IU-252.23892.464-IU.zip",
-        "252.23892.411": "https://plugins.jetbrains.com/files/22857/819822/vcs-gitlab-IU-252.23892.464-IU.zip",
-        "252.23892.415": "https://plugins.jetbrains.com/files/22857/819822/vcs-gitlab-IU-252.23892.464-IU.zip",
-        "252.23892.419": "https://plugins.jetbrains.com/files/22857/819822/vcs-gitlab-IU-252.23892.464-IU.zip",
-        "252.23892.426": "https://plugins.jetbrains.com/files/22857/819822/vcs-gitlab-IU-252.23892.464-IU.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/22857/819822/vcs-gitlab-IU-252.23892.464-IU.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/22857/819822/vcs-gitlab-IU-252.23892.464-IU.zip",
-        "252.23892.452": "https://plugins.jetbrains.com/files/22857/819822/vcs-gitlab-IU-252.23892.464-IU.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/22857/819822/vcs-gitlab-IU-252.23892.464-IU.zip"
+        "252.23892.409": "https://plugins.jetbrains.com/files/22857/826717/vcs-gitlab-IU-252.23892.515-IU.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/22857/826717/vcs-gitlab-IU-252.23892.515-IU.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/22857/826717/vcs-gitlab-IU-252.23892.515-IU.zip",
+        "252.23892.419": "https://plugins.jetbrains.com/files/22857/826717/vcs-gitlab-IU-252.23892.515-IU.zip",
+        "252.23892.426": "https://plugins.jetbrains.com/files/22857/826717/vcs-gitlab-IU-252.23892.515-IU.zip",
+        "252.23892.452": "https://plugins.jetbrains.com/files/22857/826717/vcs-gitlab-IU-252.23892.515-IU.zip",
+        "252.23892.515": "https://plugins.jetbrains.com/files/22857/826717/vcs-gitlab-IU-252.23892.515-IU.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/22857/826717/vcs-gitlab-IU-252.23892.515-IU.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/22857/826717/vcs-gitlab-IU-252.23892.515-IU.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/22857/829212/vcs-gitlab-IU-252.25557.35-IU.zip"
       },
       "name": "gitlab"
     },
@@ -1800,16 +1800,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip"
       },
       "name": "catppuccin-icons"
     },
@@ -1831,16 +1831,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
       },
       "name": "mermaid-chart"
     },
@@ -1862,16 +1862,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
         "252.23892.409": null,
         "252.23892.411": null,
         "252.23892.415": null,
         "252.23892.419": null,
         "252.23892.426": null,
-        "252.23892.439": null,
-        "252.23892.449": null,
         "252.23892.452": null,
-        "252.23892.464": null
+        "252.23892.515": null,
+        "252.23892.524": null,
+        "252.23892.530": null,
+        "252.25557.34": null
       },
       "name": "oxocarbon"
     },
@@ -1893,16 +1893,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/23927/818724/Extra_IDE_Tweaks_Subscription-2025.1.11.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/23927/818724/Extra_IDE_Tweaks_Subscription-2025.1.11.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/23927/818724/Extra_IDE_Tweaks_Subscription-2025.1.11.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/23927/818724/Extra_IDE_Tweaks_Subscription-2025.1.11.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/23927/818724/Extra_IDE_Tweaks_Subscription-2025.1.11.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/23927/818724/Extra_IDE_Tweaks_Subscription-2025.1.11.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/23927/818724/Extra_IDE_Tweaks_Subscription-2025.1.11.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/23927/818724/Extra_IDE_Tweaks_Subscription-2025.1.11.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/23927/818724/Extra_IDE_Tweaks_Subscription-2025.1.11.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/23927/818724/Extra_IDE_Tweaks_Subscription-2025.1.11.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/23927/818724/Extra_IDE_Tweaks_Subscription-2025.1.11.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/23927/818724/Extra_IDE_Tweaks_Subscription-2025.1.11.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/23927/818724/Extra_IDE_Tweaks_Subscription-2025.1.11.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/23927/818724/Extra_IDE_Tweaks_Subscription-2025.1.11.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/23927/818724/Extra_IDE_Tweaks_Subscription-2025.1.11.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/23927/818724/Extra_IDE_Tweaks_Subscription-2025.1.11.zip"
       },
       "name": "extra-ide-tweaks"
     },
@@ -1924,16 +1924,16 @@
       "builds": {
         "251.23774.423": "https://plugins.jetbrains.com/files/24559/818729/Extra_Tools_Pack-2025.1.14.zip",
         "251.25410.129": "https://plugins.jetbrains.com/files/24559/818729/Extra_Tools_Pack-2025.1.14.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/24559/818729/Extra_Tools_Pack-2025.1.14.zip",
         "252.23892.409": "https://plugins.jetbrains.com/files/24559/818729/Extra_Tools_Pack-2025.1.14.zip",
         "252.23892.411": "https://plugins.jetbrains.com/files/24559/818729/Extra_Tools_Pack-2025.1.14.zip",
         "252.23892.415": "https://plugins.jetbrains.com/files/24559/818729/Extra_Tools_Pack-2025.1.14.zip",
         "252.23892.419": "https://plugins.jetbrains.com/files/24559/818729/Extra_Tools_Pack-2025.1.14.zip",
         "252.23892.426": "https://plugins.jetbrains.com/files/24559/818729/Extra_Tools_Pack-2025.1.14.zip",
-        "252.23892.439": "https://plugins.jetbrains.com/files/24559/818729/Extra_Tools_Pack-2025.1.14.zip",
-        "252.23892.449": "https://plugins.jetbrains.com/files/24559/818729/Extra_Tools_Pack-2025.1.14.zip",
         "252.23892.452": "https://plugins.jetbrains.com/files/24559/818729/Extra_Tools_Pack-2025.1.14.zip",
-        "252.23892.464": "https://plugins.jetbrains.com/files/24559/818729/Extra_Tools_Pack-2025.1.14.zip"
+        "252.23892.515": "https://plugins.jetbrains.com/files/24559/818729/Extra_Tools_Pack-2025.1.14.zip",
+        "252.23892.524": "https://plugins.jetbrains.com/files/24559/818729/Extra_Tools_Pack-2025.1.14.zip",
+        "252.23892.530": "https://plugins.jetbrains.com/files/24559/818729/Extra_Tools_Pack-2025.1.14.zip",
+        "252.25557.34": "https://plugins.jetbrains.com/files/24559/818729/Extra_Tools_Pack-2025.1.14.zip"
       },
       "name": "extra-tools-pack"
     },
@@ -1950,15 +1950,15 @@
         "webstorm"
       ],
       "builds": {
-        "251.27812.87": null,
         "252.23892.409": null,
         "252.23892.411": null,
         "252.23892.415": null,
         "252.23892.419": null,
         "252.23892.426": null,
-        "252.23892.449": null,
         "252.23892.452": null,
-        "252.23892.464": null
+        "252.23892.524": null,
+        "252.23892.530": null,
+        "252.25557.34": null
       },
       "name": "nix-lsp"
     },
@@ -1978,31 +1978,31 @@
       ],
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
-        "251.27812.87": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
         "252.23892.409": null,
         "252.23892.411": null,
         "252.23892.415": null,
         "252.23892.419": null,
         "252.23892.426": null,
-        "252.23892.439": null,
-        "252.23892.449": null,
         "252.23892.452": null,
-        "252.23892.464": null
+        "252.23892.515": null,
+        "252.23892.524": null,
+        "252.23892.530": null,
+        "252.25557.34": null
       },
       "name": "markdtask"
     }
   },
   "files": {
     "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip": "sha256-frvQ+Dm1ueID6+vNlja0HtecGyn+ppq9GTgmU3kQ+58=",
-    "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip": "sha256-X02u3BiuX9V2pQqgrs4qcKbN2IlcXhuVb56knZKMwzU=",
+    "https://plugins.jetbrains.com/files/10080/831413/intellij-rainbow-brackets-2025.3.3.zip": "sha256-jOIt/BAP+vUnnSbrVaB/3Nfv8w+OSNWGFhSoFCVgSsM=",
     "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip": "sha256-25vtwXuBNiYL9E0pKG4dqJDkwX1FckAErdqRPKXybQA=",
     "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip": "sha256-GO0bXJsHx9O1A6M9NUCv9m4JwKHs5plwSssgx+InNqE=",
     "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip": "sha256-zX1nEdq84wwQvGhV664V5bNBPVTI4zWo306JtjXcGkE=",
     "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip": "sha256-XKv4jEKOk2O++VdHycGoLgICsusULbWRlQ0J5p+KgAE=",
     "https://plugins.jetbrains.com/files/11058/818728/Extra_Icons-2025.1.12.zip": "sha256-bCnzLM8TUy/4hQJPnodsXL8q5h1P4upbx24wKb3CteU=",
-    "https://plugins.jetbrains.com/files/11349/817795/aws-toolkit-jetbrains-standalone-3.88.252.zip": "sha256-LUGbKTrAuGIMGWzkAu7bIaVcm1GSRADrrh3JhSgdmRc=",
-    "https://plugins.jetbrains.com/files/11349/817799/aws-toolkit-jetbrains-standalone-3.88.251.zip": "sha256-MuUz3CUqmxTiXZuZJ/TieFXOfVR/u4eHLoaCeBoKWrc=",
-    "https://plugins.jetbrains.com/files/12024/667413/ReSharperPlugin.CognitiveComplexity-2025.1.0-eap01.zip": "sha256-SWIXjxnwAf9dju1oOgzePrTY0lPNNX54Afp5OIkGGi4=",
+    "https://plugins.jetbrains.com/files/11349/821620/aws-toolkit-jetbrains-standalone-3.89.252.zip": "sha256-Rl75ZzoJl6TvTx1OMePLBVheI8InH+nI4xVmEGj8p5g=",
+    "https://plugins.jetbrains.com/files/11349/821624/aws-toolkit-jetbrains-standalone-3.89.251.zip": "sha256-/PG3q6Xd3bBX6fi9/Mrm52JBlXP5z2SG16L8bdSY6IU=",
+    "https://plugins.jetbrains.com/files/12024/717598/ReSharperPlugin.CognitiveComplexity-2025.1.0.zip": "sha256-vHTnhg3gxkno5w98PQFL/V/xiUmbGMMemo7qmCveF6Y=",
     "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip": "sha256-obbLL8n6gK8oFw8NnJbdAylPHfTv4GheBDnVFOUpwL0=",
     "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip": "sha256-V3Vk6UYLUSiSmypD+g0DCX1sPw3/wZqvLxFhbkTqY34=",
     "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip": "sha256-HC1s5FqSLVgPNKc5Wiw0RFC6KpozxmjKzbh9rS9nFwc=",
@@ -2012,34 +2012,31 @@
     "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip": "sha256-5qDjLRMNwn+1QVN8cKUYlakQ8aBRiTyGuA7se3l9BI0=",
     "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip": "sha256-eKwDE+PMtYhrGbDDZPS5cimssH+1xV4GF6RXXg/3urU=",
     "https://plugins.jetbrains.com/files/1347/770332/scala-intellij-bin-2025.1.25.zip": "sha256-h9GNGjqTc+h+x/0TRilKmqGoPsxhPmXIKoGC/s4/PKg=",
-    "https://plugins.jetbrains.com/files/1347/815326/scala-intellij-bin-2025.2.26.zip": "sha256-rcFM+JlWk6dG17yci/nfwAkZQBlr+vV/ZoaKC3zahSo=",
+    "https://plugins.jetbrains.com/files/1347/832458/scala-intellij-bin-2025.2.28.zip": "sha256-lAqV+2yzp586EwxX3ZEnTnR5cdJfjoPn1RDAKC5dSyU=",
     "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip": "sha256-ZYn365EY8+VP1TKM4wBotMj1hYbSSr4J1K5oIZlE2SE=",
     "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip": "sha256-WK9ukN6g2tCmeljFXwv3F+xFI/VZKlIeFs8DXqPcIKA=",
-    "https://plugins.jetbrains.com/files/14004/803006/protoeditor-251.27812.12.zip": "sha256-EPL6bUZmdBXrkfeGyx7uf73kWGM/drxic/poSXJinS8=",
     "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar": "sha256-eXInfAqY3yEZRXCAuv3KGldM1pNKEioNwPB0rIGgJFw=",
     "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar": "sha256-mB09zvUg1hLXl9lgW1NEU+DyVel1utZv6s+mFykckYY=",
     "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar": "sha256-Z3q0d4jCqeBwzW0jSSM3q4MTAPaTqQuwnV3ZVHfOMR4=",
-    "https://plugins.jetbrains.com/files/164/818417/IdeaVIM-2.27.0.zip": "sha256-UYYDZ7jXJqHcpzaTafbwaiyuHAW4a/nPyXZndryg2iQ=",
+    "https://plugins.jetbrains.com/files/164/822112/IdeaVIM-2.27.1.zip": "sha256-nM3JZS5nHZc7zXetKuR0WI51mmGD6dpSkw8jnQSS3Mo=",
     "https://plugins.jetbrains.com/files/16604/818726/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.12.zip": "sha256-OTr5iG0ivYx+lP9VzEF9resMG5ARj9LuBnwqXohmaH0=",
-    "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip": "sha256-rP2PplN9rOnKGWMdmXphdMeV0AqoauT0aIoKkgM7Hjw=",
+    "https://plugins.jetbrains.com/files/17718/827394/github-copilot-intellij-1.5.53-243.zip": "sha256-v9tBz3OMFvwkJ7HPJXG6VwRHjgEGp4v6vBI2QvcaM/Q=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
     "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip": "sha256-fa9GiD/PNGy8AEao99vW3DBF1FKSulu3t+wO7mdr5fk=",
     "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip": "sha256-/1lyQq7JANhcKmIaaBHZ8ZCR4p23sLjLTTq9/68Fz+c=",
-    "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar": "sha256-Njx/k4fTX1U8jgh1oSvGg/32I5cdVryhHxNqBs7L1fg=",
+    "https://plugins.jetbrains.com/files/18922/827073/GerryThemes.jar": "sha256-mG0VSF+DzGu9p2NMRe+0E0iZ+xXwsQ3D2GPE7+DvlyI=",
     "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip": "sha256-hoFfIid7lClHDiT+ZH3H+tFSvWYb1tSRZH1iif+kWrM=",
     "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip": "sha256-QTh77pyi4lh7V0DGPFx9kERjFCop219d76wTDwD0SYY=",
     "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip": "sha256-N66Bh0AwHmg5N9PNguRAGtpJ/dLMWMp3rxjTgz9poFo=",
     "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip": "sha256-hevU8OwVr5HjMLpROZm3NiZI+PW2f7eNTxD+1aZsC8Q=",
     "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip": "sha256-8agNBVenqaV9DlvRmFP7ul3IZfj9Dij8v/h8QMUb72E=",
     "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip": "sha256-lOPUSxlbgagD0SuXTw+fEdwTxxfUHP1Kl6L+u/oa4fs=",
-    "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip": "sha256-kfXB36mIOn82pq+22ryztxY9K6CgwwNarNKcLuIH9G4=",
     "https://plugins.jetbrains.com/files/21962/810863/clouds-docker-gateway-252.23892.363.zip": "sha256-ZAhVR7fPls5Xgwmsm+LFYcj+PENF4F7Nh4F3R4SXzH0=",
     "https://plugins.jetbrains.com/files/22407/818405/intellij-rust-252.23892.452.zip": "sha256-Q81oaxg4/YgCOkZ9NobQjmd/NKGReuz4hxvEdHTFiac=",
-    "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip": "sha256-UxVzxs2ToLkq1/q6s44pggUMNFoObdxNbJdPJVUTNBA=",
-    "https://plugins.jetbrains.com/files/22857/716106/vcs-gitlab-IU-251.23774.435-IU.zip": "sha256-zNNFPPPnYLkSzXX3CA1IMA0cjeXMcPY58+v80/KjVkg=",
+    "https://plugins.jetbrains.com/files/22707/823138/continue-intellij-extension-1.0.35.zip": "sha256-XuZ52O/lOalOV/cyphMwFtPttt/rpqIoAxOs1vWx/e8=",
     "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip": "sha256-PwxExt+Dlq11Y5UdEwFr/2BJPST3EYY7r/3gsXoxGzo=",
-    "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip": "sha256-pLB6vIl7bgtu2tu/7OpcnAkMFEc+iEVyRJgxmSl35hk=",
-    "https://plugins.jetbrains.com/files/22857/819822/vcs-gitlab-IU-252.23892.464-IU.zip": "sha256-S5RmNVL+dcDaUb8f0Cv8eQJ8TpCd0aDn7JBdHalu+z0=",
+    "https://plugins.jetbrains.com/files/22857/826717/vcs-gitlab-IU-252.23892.515-IU.zip": "sha256-1fkImbCktws9WcnJSwnMiZ7ULc3hKj9TiFXuNDf+L/U=",
+    "https://plugins.jetbrains.com/files/22857/829212/vcs-gitlab-IU-252.25557.35-IU.zip": "sha256-7fLyaf7JNH3FwKSH+HsQcGNszzzVMUy2qsFmcWgW0/g=",
     "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip": "sha256-TZNCi4kRc7NNcV89j2UhT6y1+l1L512xTN/yTztjQfY=",
     "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip": "sha256-ssaSY1I6FopLBgVKHUyjBrqzxHLSuI/swtDfQWJ7gxU=",
     "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip": "sha256-+cLKIu8abGXZqJ3GutQsoQQg3s0wkmk5qKosW0O8RII=",
@@ -2050,8 +2047,9 @@
     "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip": "sha256-34s7pOsqMaGoVYhCuAZtylNwplQOtNQJUppepsl4F4Q=",
     "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip": "sha256-iWKLgk+eWhUmv/lH9+B2HI97d++EYvLwGgtRsJf4aSE=",
     "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip": "sha256-pQGVguF7zzzasLm2tlmtvqiPtdFN4Q5NKRwYx1r62fM=",
-    "https://plugins.jetbrains.com/files/6981/806736/ini-251.27812.54.zip": "sha256-olPIXYib4IUF/qmTzTOmEEXq01I8ji7no4dqSTJvqhY=",
+    "https://plugins.jetbrains.com/files/6954/827441/Kotlin-252.25557.23-IJ.zip": "sha256-QhghDaVjeC8XU4u/HpIKd2JQeH6h7yRohkK4m0trNsc=",
     "https://plugins.jetbrains.com/files/6981/818238/ini-252.23892.449.zip": "sha256-H+ve44o4oKp14Mww4cFa6aCO7ipN/0M7Re5Lg8PNfJc=",
+    "https://plugins.jetbrains.com/files/6981/828495/ini-252.25557.34.zip": "sha256-SNrHSWzVwbWDNYhGF+ldezeXVKewS6iQfcNtIcZGBE0=",
     "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip": "sha256-BW47ZEUINVnhV0RZ1np7Dkf3lfyrtKoZ9ej/SVct2Xs=",
     "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip": "sha256-KcRoHqvCcC6qRz58DHkQ6AFqnpyqPhETekuMWBQYYw8=",
     "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip": "sha256-jNHP/vaCaolmvNUQRGmIgSR1ykjDtKqyJ69UIn5cz70=",
@@ -2062,32 +2060,33 @@
     "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip": "sha256-SgldikXjVx6hUw3LqcN8/NxLLBfnr/LUc/SrIIACl7k=",
     "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip": "sha256-HfTd3zT/7sOrYutEkEzpFAu6AijrFrpHJg1ftP3N87Y=",
     "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip": "sha256-gN9XqO/x41scgJ9dzTdC4i4hIZJpwSeR7OjU2BG8gzU=",
-    "https://plugins.jetbrains.com/files/7322/805188/python-ce-251.27812.49.zip": "sha256-53cIBQbvP13Py0nN5ZXJBLH3xA5/tz2ba4hhVWRaFSM=",
     "https://plugins.jetbrains.com/files/7322/819231/python-ce-252.23892.458.zip": "sha256-BFycp1qz7r+X4ohvy7oFnT76dGNGrqpMZrWO71q8ah8=",
+    "https://plugins.jetbrains.com/files/7322/827486/python-ce-252.25557.23.zip": "sha256-ywoEFCw4wNx2nvPf5CxHnM5Fc0zu9zmizyvFC/ksNvY=",
     "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip": "sha256-6VpRIidsf8iWJeR3OarwwgS1NDXj9j6bLnxU/YBskeY=",
     "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar": "sha256-DobKZKokueqq0z75d2Fo3BD8mWX9+LpGdT9C7Eu2fHc=",
     "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip": "sha256-lSgPEqhTvr+xm+9Or01IQABgjNugoUZHLUgUFZaOLs0=",
-    "https://plugins.jetbrains.com/files/7724/805402/clouds-docker-impl-251.27812.52.zip": "sha256-irzstm3qMkiJSVsXGunYdMvThvPX1KU4Cf85ZDf3/9o=",
-    "https://plugins.jetbrains.com/files/7724/819808/clouds-docker-impl-252.23892.464.zip": "sha256-0Mz1BuAdHZ87KcIepSudLkFJt/du7PeJVOy14Jj18V8=",
+    "https://plugins.jetbrains.com/files/7724/826726/clouds-docker-impl-252.23892.515.zip": "sha256-D21m3wQENj79cODe7vX2UuBqta3Tv8ctSf5Rk1VkX84=",
+    "https://plugins.jetbrains.com/files/7724/829211/clouds-docker-impl-252.25557.35.zip": "sha256-6qeGPeLCBPKFmjE07yjHSTQPq0eHh3d3HxNyV9wNPf8=",
     "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip": "sha256-O+gSW36MwqQqUiZBQl8J4NFNK+jFowtT9k1ykhSraxM=",
     "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip": "sha256-eLh0p5vDNG7fUV7pqbIbkL30dpPj19NE9JbwcDwxZXs=",
-    "https://plugins.jetbrains.com/files/8097/802996/graphql-251.27812.12.zip": "sha256-Pju+Kre4EKRoKYEPsj74+JFvd+VyXSb7EMDo00eCz10=",
-    "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip": "sha256-WGGDyxE1ElguDMm7dONA2f0k3u+Tl1vZp3HMLkr5bFw=",
+    "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip": "sha256-wN3+7++f6i0MvEmOTiWZgAW1QzM5HiD7jSAMS8jWC5s=",
     "https://plugins.jetbrains.com/files/8195/819801/toml-252.23892.464.zip": "sha256-CXbS+/k9a4YqYPRxd5OWGxtal2+5ECshavcOSrYqca0=",
+    "https://plugins.jetbrains.com/files/8195/828228/toml-252.25557.32.zip": "sha256-z0hIeOb0UXSpmuerL5EYKaKfSH/oQCtKCr3O752SMgU=",
     "https://plugins.jetbrains.com/files/8327/809293/Minecraft_Development-2025.1-1.8.6.zip": "sha256-mePVZa+63bheH85ylkbX9oOX1Nq/IYLAGHHseOJx520=",
     "https://plugins.jetbrains.com/files/8327/809294/Minecraft_Development-2025.2-1.8.6.zip": "sha256-NOuzQ+CL+Z8n5gwMBaberLyMvS5KNmXKwZ+j88+SFqU=",
     "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip": "sha256-iK3cy0Nf87rLV0m/t3LJv65Klij/9L5l9ad2UW9O00w=",
-    "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip": "sha256-qcMxLM2Y/Q18r718VasRMAlKppbH+ra/6eKCkmVL88s=",
-    "https://plugins.jetbrains.com/files/8554/819797/featuresTrainer-252.23892.464.zip": "sha256-BIz14Jbr9vX7GLdxW4u23lY8bFUm4SOu1CBj0i827A8=",
+    "https://plugins.jetbrains.com/files/8554/826552/featuresTrainer-252.23892.514.zip": "sha256-AQLuTcRERFq2ZfzOqUGMte/pLe7/3g6G+9UqNMuUYiY=",
+    "https://plugins.jetbrains.com/files/8554/828474/featuresTrainer-252.25557.34.zip": "sha256-ydCebS4OHac4Y2Y9X53fvKzYZLRmIaTCKJCE1qwPkjg=",
     "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip": "sha256-JShheBoOBiWM9HubMUJvBn4H3DnWykvqPyrmetaCZiM=",
     "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip": "sha256-Boy61dRieXmWrnTMfqqYZbdG/DNQ24KdguKN2fcZ+eg=",
     "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip": "sha256-KrC3EK4wYLSxWywF8I8nVx6tkclr1wAMya1Z1XF0QY8=",
+    "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip": "sha256-y66kYTYD+R9Sert2JHWGwFFIgc5UJTssZrjgvzOjljk=",
     "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip": "sha256-0c/2qbuu+M6z0gvpme+Mkv23JlQKNTUU+9GL9mh2IFw=",
     "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip": "sha256-N0DNEtF3FDcRirfjfSCCVUbDIA4SB35F/9XY1tPXXmg=",
     "https://plugins.jetbrains.com/files/9568/808965/go-plugin-252.23892.360.zip": "sha256-7RuJXLGB5bcfHQnp/p69hjccgJKbCvYCGG634WQ8wQ4=",
     "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar": "sha256-XYCD4kOHDeIKhti0T175xhBHR8uscaFN4c9CNlUaCDs=",
     "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar": "sha256-mp1k2BdksxbGH4zUp/7DnjcGi5OXJ7UekCfX6dWZOtU=",
     "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip": "sha256-Mzmmq0RzMKZeKfBSo7FHvzeEtPGIrwqEDLAONQEsR1M=",
-    "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip": "sha256-mg0xdvhe/CSKJqmwACKHfk9zoRqfSz6xNPRP1njFClg="
+    "https://plugins.jetbrains.com/files/9836/823111/intellij-randomness-3.4.1.zip": "sha256-BFlrdhQVhERwCqRIkiYHN/gUnMBv8gfGt+LX1Debvmw="
   }
 }


### PR DESCRIPTION
```
jetbrains.datagrip: 2025.2.1 -> 2025.2.2
jetbrains.dataspell: 2025.1.2.1 -> 2025.2
jetbrains.goland: 2025.2 -> 2025.2.0.1
jetbrains.pycharm-community: 2025.2 -> 2025.2.0.1
jetbrains.pycharm-professional: 2025.2 -> 2025.2.0.1
jetbrains.rider: 2025.1.5 -> 2025.2
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
