### PR TITLE
nixos/jitsi-meet: fix prosody configuration

### DIFF
--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -307,7 +307,6 @@ in
         "speakerstats"
         "external_services"
         "conference_duration"
-        "end_conference"
         "muc_lobby_rooms"
         "muc_breakout_rooms"
         "av_moderation"
@@ -348,7 +347,9 @@ in
           ''
             muc_mapper_domain_base = "${cfg.hostName}"
 
-            cross_domain_websocket = true;
+            http_cors_override = {
+              websocket = { enabled = true }
+            }
             consider_websocket_secure = true;
 
             unlimited_jids = {
@@ -381,7 +382,6 @@ in
           conference_duration_component = "conferenceduration.${cfg.hostName}"
           end_conference_component = "endconference.${cfg.hostName}"
 
-          c2s_require_encryption = false
           lobby_muc = "lobby.${cfg.hostName}"
           breakout_rooms_muc = "breakout.${cfg.hostName}"
           room_metadata_component = "metadata.${cfg.hostName}"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

jitsi-meet broke with #429967 and while the infinite recursion was fixed with #432371, the prosody config still currently fails to build. this is the output of building `prosody.cfg.lua` when trying to run the nixos test for jitsi-meet (`NIXPKGS_ALLOW_INSECURE=1 nix-build -A nixosTests.jitsi-meet`):

```
startup             warn        Configuration warning: ./prosody.cfg.lua:145: Duplicate option 'restrict_room_creation'
startup             warn        Configuration warning: ./prosody.cfg.lua:165: Duplicate option 'restrict_room_creation'
startup             warn        Configuration warning: ./prosody.cfg.lua:204: Duplicate option 'restrict_room_creation'
startup             warn        Configuration warning: ./prosody.cfg.lua:259: Duplicate option 'c2s_require_encryption'
Checking config...
    The following configuration files have been loaded:
      -  ./prosody.cfg.lua
    mod_end_conference is enabled both in modules_enabled and as Component "endconference.server" "end_conference"
    This means the service is enabled on all VirtualHosts as well as the Component.
    Are you sure this what you want? It may cause unexpected behaviour.

    You have some deprecated options in the global section:
    'cross_domain_websocket' -- instead, use 'http_cors_override', see https://prosody.im/doc/http#cross-domain-cors-support

    Some of your hosts may be missing features due to a lack of configuration.
    For more details, use the 'prosodyctl check features' command.
Done.

Problems found, see above.
```

this pr fixes the nixos test for jitsi meet which apparently no one has tested until now.

CC: @SuperSandro2000 @Lassulus @pinpox 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
