### PR TITLE
codex: 0.21.0 -> 0.22.0

### DIFF
--- a/pkgs/by-name/co/codex/package.nix
+++ b/pkgs/by-name/co/codex/package.nix
@@ -14,18 +14,18 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "codex";
-  version = "0.21.0";
+  version = "0.22.0";
 
   src = fetchFromGitHub {
     owner = "openai";
     repo = "codex";
     tag = "rust-v${finalAttrs.version}";
-    hash = "sha256-9hwDAkrMW0llcYJdkrUCSdh3guRcUCmx8MDkHLyY6v0=";
+    hash = "sha256-JTwtydW8LLBH/55+8a/BbqlZtkXsFKbT8dGoDEAjk1c=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/codex-rs";
 
-  cargoHash = "sha256-ykG3howLyA4kA7cjP8Gx+usRcgQoVHW0ECQzTUigG8A=";
+  cargoHash = "sha256-3PljlyPfDsnjGmR/0iM7Fu1TnyDj31pKVcOU/izsL30=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -50,27 +50,27 @@ rustPlatform.buildRustPackage (finalAttrs: {
   checkFlags = [
     # Wants to access /bin/zsh
     "--skip=shell::tests::test_run_with_profile_escaping_and_execution"
+    # Wants to access unix sockets
+    "--skip=allow_unix_socketpair_recvfrom"
     # Fails with 'stream ended unexpectedly: InternalAgentDied'
     "--skip=includes_base_instructions_override_in_request"
-    # Fails with 'stream ended unexpectedly: InternalAgentDied'
     "--skip=includes_user_instructions_message_in_request"
-    # Fails with 'stream ended unexpectedly: InternalAgentDied'
     "--skip=originator_config_override_is_used"
-    # Fails with 'called `Result::unwrap()` on an `Err` value: NotPresent'
-    "--skip=azure_overrides_assign_properties_used_for_responses_url"
-    # Fails with 'stream ended unexpectedly: InternalAgentDied'
     "--skip=prefixes_context_and_instructions_once_and_consistently_across_requests"
     # Fails with 'called `Result::unwrap()` on an `Err` value: NotPresent'
+    "--skip=azure_overrides_assign_properties_used_for_responses_url"
     "--skip=env_var_overrides_loaded_auth"
     # Version 0.0.0 hardcoded
     "--skip=test_conversation_create_and_send_message_ok"
-    # Version 0.0.0 hardcoded
     "--skip=test_send_message_session_not_found"
-    # Version 0.0.0 hardcoded
     "--skip=test_send_message_success"
     # Assertion fails
     "--skip=diff_render::tests::ui_snapshot_add_details"
     "--skip=diff_render::tests::ui_snapshot_update_details_with_rename"
+    # Attempted to creat a NULL object
+    "--skip=test_apply_patch_tool"
+    # Needs access to python3. However, adding python3 to nativeCHeckInputs doesn't resolve the issue
+    "--skip=python_multiprocessing_lock_works_under_sandbox"
   ];
 
   postInstall = lib.optionalString installShellCompletions ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
