### PR TITLE
filebrowser: 2.40.1 -> 2.42.5, add update script

### DIFF
--- a/pkgs/by-name/fi/filebrowser/package.nix
+++ b/pkgs/by-name/fi/filebrowser/package.nix
@@ -1,64 +1,61 @@
 {
   lib,
-  stdenv,
   fetchFromGitHub,
-  buildGo123Module,
-  nodejs_22,
+  buildGoModule,
+  buildNpmPackage,
   pnpm_9,
-
+  nix-update-script,
   nixosTests,
 }:
 
 let
-  version = "2.40.1";
+  version = "2.42.5";
 
   pnpm = pnpm_9;
-  nodejs = nodejs_22;
 
   src = fetchFromGitHub {
     owner = "filebrowser";
     repo = "filebrowser";
     rev = "v${version}";
-    hash = "sha256-UsY5pJU0eVeYQVi7Wqf4RrBfPLQv78zHi96mTLJJS1o=";
+    hash = "sha256-6AZwWdYQlaQ30Q5ohi9ovlUJZZ+u7Wqc5mfRW/3t7Zs=";
   };
 
-  frontend = stdenv.mkDerivation (finalAttrs: {
+  frontend = buildNpmPackage rec {
     pname = "filebrowser-frontend";
     inherit version src;
 
-    nativeBuildInputs = [
-      nodejs
-      pnpm.configHook
-    ];
+    sourceRoot = "${src.name}/frontend";
 
-    pnpmRoot = "frontend";
+    npmConfigHook = pnpm.configHook;
+    npmDeps = pnpmDeps;
 
     pnpmDeps = pnpm.fetchDeps {
-      inherit (finalAttrs) pname version src;
+      inherit
+        pname
+        version
+        src
+        sourceRoot
+        ;
       fetcherVersion = 2;
-      sourceRoot = "${src.name}/frontend";
-      hash = "sha256-AwjMQ9LDJ72x5JYdtLF4V3nxJTYiCb8e/RVyK3IwPY4=";
+      hash = "sha256-uGEw6Wt6hXEcYQzXYzfgo3fcCX7Hj39bLHsT1rsGy74=";
     };
 
     installPhase = ''
       runHook preInstall
 
-      pnpm install -C frontend --frozen-lockfile
-      pnpm run -C frontend build
-
       mkdir $out
-      mv frontend/dist $out
+      mv dist $out
 
       runHook postInstall
     '';
-  });
+  };
 
 in
-buildGo123Module {
+buildGoModule {
   pname = "filebrowser";
   inherit version src;
 
-  vendorHash = "sha256-FY5rPzWAzkrDaFktTM7VxO/hMk17/x21PL1sKq0zlxg=";
+  vendorHash = "sha256-aVtL64Cm+nqum/qHFvplpEawgMXM2S6l8QFrJBzLVtU=";
 
   excludedPackages = [ "tools" ];
 
@@ -71,6 +68,7 @@ buildGo123Module {
   ];
 
   passthru = {
+    updateScript = nix-update-script { };
     inherit frontend;
     tests = {
       inherit (nixosTests) filebrowser;


### PR DESCRIPTION
- switch from mkderivation to buildNpmPackage for update-script
- switch to buildGoModule as 'Newer toolchain versions should build projects developed against older toolchains without problems.'
- add update-script for ryantm updates as this project is now active and publishing new builds every week.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
