### PR TITLE
lib: deprecate `fromHexString` on dodgy inputs

### DIFF
--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -386,33 +386,19 @@ runTests {
     expected = 9223372036854775807;
   };
 
+  testFromHexStringLeadingZeroes = {
+    expr = fromHexString "00ffffffffffffff";
+    expected = 72057594037927935;
+  };
+
   testFromHexStringWithPrefix = {
-    expr = fromHexString "0Xf";
+    expr = fromHexString "0xf";
     expected = 15;
   };
 
-  # FIXME: This might be bad and should potentially be deprecated.
-  testFromHexStringQuestionableMixedCase = {
+  testFromHexStringMixedCase = {
     expr = fromHexString "eEeEe";
     expected = 978670;
-  };
-
-  # FIXME: This is probably bad and should potentially be deprecated.
-  testFromHexStringQuestionableUnderscore = {
-    expr = fromHexString "F_f";
-    expected = 255;
-  };
-
-  # FIXME: This is definitely bad and should be deprecated.
-  testFromHexStringBadComment = {
-    expr = fromHexString "0 # oops";
-    expected = 0;
-  };
-
-  # FIXME: Oh my god.
-  testFromHexStringAwfulInjection = {
-    expr = fromHexString "1\nwhoops = {}";
-    expected = 1;
   };
 
   testToBaseDigits = {

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -1119,14 +1119,21 @@ in
     ```
   */
   fromHexString =
-    value:
+    str:
     let
-      noPrefix = lib.strings.removePrefix "0x" (lib.strings.toLower value);
+      match = builtins.match "(0x)?([0-7]?[0-9A-Fa-f]{1,15})" str;
     in
-    let
-      parsed = builtins.fromTOML "v=0x${noPrefix}";
-    in
-    parsed.v;
+    if match != null then
+      (builtins.fromTOML "v=0x${builtins.elemAt match 1}").v
+    else
+      # TODO: Turn this into a `throw` in 26.05.
+      assert lib.warn "fromHexString: ${
+        lib.generators.toPretty { } str
+      } is not a valid input and will be rejected in 26.05" true;
+      let
+        noPrefix = lib.strings.removePrefix "0x" (lib.strings.toLower str);
+      in
+      (builtins.fromTOML "v=0x${noPrefix}").v;
 
   /**
     Convert the given positive integer to a string of its hexadecimal


### PR DESCRIPTION
See <https://github.com/NixOS/nixpkgs/pull/433710>.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
