### PR TITLE
terminal-typeracer: 2.1.3 -> 2.1.5

### DIFF
--- a/pkgs/by-name/te/terminal-typeracer/package.nix
+++ b/pkgs/by-name/te/terminal-typeracer/package.nix
@@ -4,29 +4,27 @@
   fetchFromGitLab,
   rustPlatform,
   pkg-config,
-  libgit2,
   openssl,
   sqlite,
   libiconv,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "terminal-typeracer";
-  version = "2.1.3";
+  version = "2.1.5";
 
   src = fetchFromGitLab {
     owner = "ttyperacer";
     repo = "terminal-typeracer";
-    rev = "v${version}";
-    hash = "sha256-S3OW6KihRd6ReTWUXRb1OWC7+YoxehjFRBxcnJVgImU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7LKpOO+PVGGtFJh1dZW/n/zovTxxZbb2VQwzgmjZhIY=";
   };
 
-  cargoHash = "sha256-WYqbG0iSVvnRLCy5Qs4wr72LjQ6uPgskVWP62Af0RQ8=";
+  cargoHash = "sha256-PECQ6KoHLPgUosC7gxniIoLHA5tWb0JfAUm93XFCcpk=";
 
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [
-    libgit2
     openssl
     sqlite
   ]
@@ -34,15 +32,17 @@ rustPlatform.buildRustPackage rec {
     libiconv
   ];
 
-  OPENSSL_NO_VENDOR = 1;
-  LIBGIT2_NO_VENDOR = 1;
+  env = {
+    OPENSSL_NO_VENDOR = 1;
+    LIBGIT2_NO_VENDOR = 0;
+  };
 
-  meta = with lib; {
+  meta = {
     description = "Open source terminal based version of Typeracer written in rust";
     homepage = "https://gitlab.com/ttyperacer/terminal-typeracer";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ yoctocell ];
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ yoctocell ];
     mainProgram = "typeracer";
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Update terminal-typeracer to v2.1.5.

Reason for change:
libgit2-sys requires libgit2 version >=1.7.2, <1.8.0. To satisfy this constraint and ensure a successful build, LIBGIT2_NO_VENDOR is now set to 0, so the crate uses its vendored libgit2 instead of the nixpkgs version (1.9.x)

Changelog:

[v2.1.4](https://gitlab.com/ttyperacer/terminal-typeracer/-/releases/v2.1.4)

[v2.1.5](https://gitlab.com/ttyperacer/terminal-typeracer/-/releases/v2.1.5)
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
