### PR TITLE
python313Packages.highdicom: 0.25.1 -> 0.26.1

### DIFF
--- a/pkgs/development/python-modules/highdicom/default.nix
+++ b/pkgs/development/python-modules/highdicom/default.nix
@@ -6,7 +6,6 @@
   pytestCheckHook,
   numpy,
   pillow,
-  pillow-jpls,
   pydicom,
   pylibjpeg,
   pylibjpeg-libjpeg,
@@ -25,7 +24,7 @@ let
 in
 buildPythonPackage rec {
   pname = "highdicom";
-  version = "0.25.1";
+  version = "0.26.1";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -34,7 +33,7 @@ buildPythonPackage rec {
     owner = "MGHComputationalPathology";
     repo = "highdicom";
     tag = "v${version}";
-    hash = "sha256-AwKaqCqPjLyNwXomV/pxijpsTQajekBO/rgLQJpuYww=";
+    hash = "sha256-zaa0daGMQHktYkG56JA2a7s5UZSv8AbinO5roe9rWQc=";
   };
 
   build-system = [
@@ -44,7 +43,6 @@ buildPythonPackage rec {
   dependencies = [
     numpy
     pillow
-    pillow-jpls
     pydicom
     typing-extensions
   ];
@@ -70,6 +68,7 @@ buildPythonPackage rec {
 
   disabledTests = [
     # require pyjpegls
+    "test_construction_10"
     "test_jpegls_monochrome"
     "test_jpegls_rgb"
     "test_jpeglsnearlossless_monochrome"
@@ -98,11 +97,11 @@ buildPythonPackage rec {
   # updates the wrong fetcher
   passthru.skipBulkUpdate = true;
 
-  meta = with lib; {
+  meta = {
     description = "High-level DICOM abstractions for Python";
     homepage = "https://highdicom.readthedocs.io";
     changelog = "https://github.com/ImagingDataCommons/highdicom/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ bcdarwin ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcdarwin ];
   };
 }


### PR DESCRIPTION
Routine update ([changelog](https://github.com/ImagingDataCommons/highdicom/compare/v0.25.1...v0.26.1)).

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
