### PR TITLE
python313Packages.pyjpegls: init at 1.5.1

### DIFF
--- a/pkgs/development/python-modules/highdicom/default.nix
+++ b/pkgs/development/python-modules/highdicom/default.nix
@@ -7,6 +7,7 @@
   numpy,
   pillow,
   pydicom,
+  pyjpegls,
   pylibjpeg,
   pylibjpeg-libjpeg,
   pylibjpeg-openjpeg,
@@ -44,6 +45,7 @@ buildPythonPackage rec {
     numpy
     pillow
     pydicom
+    pyjpegls
     typing-extensions
   ];
 
@@ -55,32 +57,12 @@ buildPythonPackage rec {
     ];
   };
 
-  pythonRemoveDeps = [
-    "pyjpegls" # not directly used
-  ];
-
   nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.libjpeg;
   preCheck = ''
     export HOME=$TMP/test-home
     mkdir -p $HOME/.pydicom/
     ln -s ${test_data}/data_store/data $HOME/.pydicom/data
   '';
-
-  disabledTests = [
-    # require pyjpegls
-    "test_construction_10"
-    "test_jpegls_monochrome"
-    "test_jpegls_rgb"
-    "test_jpeglsnearlossless_monochrome"
-    "test_jpeglsnearlossless_rgb"
-    "test_multi_frame_sm_image_ushort_encapsulated_jpegls"
-    "test_monochrome_jpegls"
-    "test_monochrome_jpegls_near_lossless"
-    "test_rgb_jpegls"
-    "test_construction_autotile"
-    "test_pixel_types_fractional"
-    "test_pixel_types_labelmap"
-  ];
 
   pythonImportsCheck = [
     "highdicom"

--- a/pkgs/development/python-modules/pydicom/default.nix
+++ b/pkgs/development/python-modules/pydicom/default.nix
@@ -10,6 +10,7 @@
   # optional/test dependencies
   gdcm,
   pillow,
+  pyjpegls,
   pylibjpeg-libjpeg,
   writableTmpDirAsHomeHook,
 }:
@@ -44,7 +45,7 @@ buildPythonPackage rec {
   optional-dependencies = {
     pixeldata = [
       pillow
-      #pyjpegls # not in nixpkgs
+      pyjpegls
       #pylibjpeg.optional-dependencies.openjpeg # infinite recursion
       #pylibjpeg.optional-dependencies.rle # not in nixpkgs
       pylibjpeg-libjpeg

--- a/pkgs/development/python-modules/pyjpegls/default.nix
+++ b/pkgs/development/python-modules/pyjpegls/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  charls,
+  cython,
+  numpy,
+  pillow,
+  setuptools,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pyjpegls";
+  version = "1.5.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pydicom";
+    repo = "pyjpegls";
+    tag = "v${version}";
+    hash = "sha256-ha/nYvfzgoZDpVolMKMG9ZXqojy6x/2oPcvbWDvdKk4=";
+  };
+
+  # replace vendored 'charls' submodule with Nixpkgs's:
+  postPatch = ''
+    rmdir lib/charls
+    cp -ar ${charls.src} lib/charls
+  '';
+
+  pythonRelaxDeps = [ "numpy" ];
+
+  build-system = [
+    cython
+    numpy
+    setuptools
+  ];
+
+  dependencies = [
+    numpy
+    pillow
+  ];
+
+  pythonImportsCheck = [ "jpeg_ls" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "JPEG-LS for Python via CharLS C++ Library";
+    homepage = "https://github.com/pydicom/pyjpegls";
+    changelog = "https://github.com/pydicom/pyjpegls/releases/tag/v${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13102,6 +13102,8 @@ self: super: with self; {
 
   pyjnius = callPackage ../development/python-modules/pyjnius { };
 
+  pyjpegls = callPackage ../development/python-modules/pyjpegls { };
+
   pyjson5 = callPackage ../development/python-modules/pyjson5 { };
 
   pyjsparser = callPackage ../development/python-modules/pyjsparser { };


### PR DESCRIPTION
python313Packages.highdicom: add missing pyjpegls dependency
python313Packages.pydicom: add missing pyjpegls optional dependency

Init [pyjpegls](https://github.com/pydicom/pyjpegls), a Python library providing JPEG-LS support via the `charls` C++ library, a dependency of `python313Packages.highdicom` previously missing from Nixpkgs, and re-enable `highdicom` tests depending on `pyjpegls` support.

The unvendoring is not the most elegant (we replace the vendored source with Nixpkgs's source, thus recompiling charls) but due to some custom code in `setup.py` getting the usual `buildInputs = [ charls ]` to work would end up being more gnarly and brittle. This library takes only a few seconds to compile so should be fine.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
