### PR TITLE
nixos/phpfpm: set systemd Type to notify-reload when possible

### DIFF
--- a/nixos/modules/services/web-servers/phpfpm/default.nix
+++ b/nixos/modules/services/web-servers/phpfpm/default.nix
@@ -264,6 +264,7 @@ in
     services.phpfpm.settings = {
       error_log = "syslog";
       daemonize = false;
+      systemd_interval = lib.mkDefault 10;
     };
 
     systemd.slices.system-phpfpm = {
@@ -296,7 +297,7 @@ in
             ProtectHome = true;
             # XXX: We need AF_NETLINK to make the sendmail SUID binary from postfix work
             RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6 AF_NETLINK";
-            Type = "notify";
+            Type = if cfg.settings.systemd_interval != 0 then "notify-reload" else "notify";
             ExecStart = "${poolOpts.phpPackage}/bin/php-fpm -y ${cfgFile} -c ${iniFile}";
             ExecReload = "${pkgs.coreutils}/bin/kill -USR2 $MAINPID";
             RuntimeDirectory = "phpfpm";

--- a/nixos/modules/services/web-servers/phpfpm/default.nix
+++ b/nixos/modules/services/web-servers/phpfpm/default.nix
@@ -297,13 +297,23 @@ in
             ProtectHome = true;
             # XXX: We need AF_NETLINK to make the sendmail SUID binary from postfix work
             RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6 AF_NETLINK";
-            Type = if cfg.settings.systemd_interval != 0 then "notify-reload" else "notify";
             ExecStart = "${poolOpts.phpPackage}/bin/php-fpm -y ${cfgFile} -c ${iniFile}";
-            ExecReload = "${pkgs.coreutils}/bin/kill -USR2 $MAINPID";
             RuntimeDirectory = "phpfpm";
             RuntimeDirectoryPreserve = true; # Relevant when multiple processes are running
             Restart = "always";
-          };
+          }
+          // (
+            if cfg.settings.systemd_interval != 0 then
+              {
+                Type = "notify-reload";
+                ReloadSignal = "USR2";
+              }
+            else
+              {
+                Type = "notify";
+                ExecReload = "${coreutils}/bin/kill -USR2 $MAINPID";
+              }
+          );
       }
     ) cfg.pools;
   };

--- a/pkgs/development/interpreters/php/service.nix
+++ b/pkgs/development/interpreters/php/service.nix
@@ -155,6 +155,7 @@ in
     php-fpm.settings = {
       error_log = "syslog";
       daemonize = false;
+      systemd_interval = lib.mkDefault 10;
     };
 
     process.argv = [
@@ -170,7 +171,7 @@ in
       documentation = [ "man:php-fpm(8)" ];
 
       serviceConfig = {
-        Type = "notify";
+        Type = if cfg.settings.systemd_interval != 0 then "notify-reload" else "notify";
         ExecReload = "${coreutils}/bin/kill -USR2 $MAINPID";
         RuntimeDirectory = "php-fpm";
         RuntimeDirectoryPreserve = true;
@@ -185,6 +186,7 @@ in
       conditions = [ "service/syslogd/ready" ];
       reload = "${coreutils}/bin/kill -USR2 $MAINPID";
       notify = "systemd";
+      nohup = cfg.settings.systemd_interval == 0;
     };
   };
 

--- a/pkgs/development/interpreters/php/service.nix
+++ b/pkgs/development/interpreters/php/service.nix
@@ -171,12 +171,22 @@ in
       documentation = [ "man:php-fpm(8)" ];
 
       serviceConfig = {
-        Type = if cfg.settings.systemd_interval != 0 then "notify-reload" else "notify";
-        ExecReload = "${coreutils}/bin/kill -USR2 $MAINPID";
         RuntimeDirectory = "php-fpm";
         RuntimeDirectoryPreserve = true;
         Restart = "always";
-      };
+      }
+      // (
+        if cfg.settings.systemd_interval != 0 then
+          {
+            Type = "notify-reload";
+            ReloadSignal = "USR2";
+          }
+        else
+          {
+            Type = "notify";
+            ExecReload = "${coreutils}/bin/kill -USR2 $MAINPID";
+          }
+      );
     };
 
   }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

as promised in https://github.com/NixOS/nixpkgs/pull/430490#discussion_r2258445519 adding `notify-reload` support

from `php-fpm` documentation:
> systemd_interval [int](https://www.php.net/manual/en/language.types.integer.php)
>
>    When FPM is build with systemd integration, specify the interval, in second, between health report notification to systemd. Set to 0 to disable. Default value: 10.

i browsed through the `php-fpm` source and basically if this option isn't `0` then `php-fpm` will write `READY=1\n` to the `systemd` socket every `n` seconds as defined in config... which means incidentally `notify-reload` will work

---

btw... @roberth any idea what is going on here? did something change or was this error missed somehow in the last PR? when i run `nix-build -A nixosTests.php.fpm-modular` i get this error:
```
       error: The option `nodes.machine.system.services.php-fpm.meta' does not exist. Definition values:
       - In `/home/aaron/nixpkgs/pkgs/development/interpreters/php/service.nix':
           {
             maintainers = [
               {
                 email =
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
