### PR TITLE
python3Packages.google-cloud-storage: 3.2.0 -> 3.3.0

### DIFF
--- a/pkgs/development/python-modules/google-cloud-storage/default.nix
+++ b/pkgs/development/python-modules/google-cloud-storage/default.nix
@@ -100,6 +100,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/googleapis/python-storage";
     changelog = "https://github.com/googleapis/python-storage/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ sarahec ];
   };
 }

--- a/pkgs/development/python-modules/google-cloud-storage/default.nix
+++ b/pkgs/development/python-modules/google-cloud-storage/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "google-cloud-storage";
-  version = "3.2.0";
+  version = "3.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "googleapis";
     repo = "python-storage";
     tag = "v${version}";
-    hash = "sha256-05jPtpsEQYqReDaeLj/Vzkz761jZfLQXC20WjTIPVc8=";
+    hash = "sha256-I0wC/BV8fJr3JW1nyq2TPJZlZaT4+h2lJBdGTttSzRo=";
   };
 
   pythonRelaxDeps = [ "google-auth" ];
@@ -76,7 +76,6 @@ buildPythonPackage rec {
   ];
 
   disabledTestPaths = [
-    "samples/"
     "tests/unit/test_bucket.py"
     "tests/system/test_blob.py"
     "tests/system/test_bucket.py"

--- a/pkgs/development/python-modules/google-cloud-storage/default.nix
+++ b/pkgs/development/python-modules/google-cloud-storage/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   google-auth,
   google-cloud-core,
   google-cloud-iam,
@@ -21,12 +21,11 @@ buildPythonPackage rec {
   version = "3.2.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
-
-  src = fetchPypi {
-    pname = "google_cloud_storage";
-    inherit version;
-    hash = "sha256-3syoQwdgNvRWMxmMEl0YYf+/R+v1wOO5jcubLbFViWw=";
+  src = fetchFromGitHub {
+    owner = "googleapis";
+    repo = "python-storage";
+    tag = "v${version}";
+    hash = "sha256-05jPtpsEQYqReDaeLj/Vzkz761jZfLQXC20WjTIPVc8=";
   };
 
   pythonRelaxDeps = [ "google-auth" ];
@@ -52,6 +51,11 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  enabledTestPaths = [
+    "tests/unit/"
+    "tests/system/"
+  ];
+
   disabledTests = [
     # Disable tests which require credentials and network access
     "create"
@@ -72,6 +76,7 @@ buildPythonPackage rec {
   ];
 
   disabledTestPaths = [
+    "samples/"
     "tests/unit/test_bucket.py"
     "tests/system/test_blob.py"
     "tests/system/test_bucket.py"
@@ -90,11 +95,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "google.cloud.storage" ];
 
-  meta = with lib; {
+  meta = {
     description = "Google Cloud Storage API client library";
     homepage = "https://github.com/googleapis/python-storage";
     changelog = "https://github.com/googleapis/python-storage/blob/v${version}/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = [ ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ];
   };
 }


### PR DESCRIPTION
1. `fetchPypi` -> `fetchFromGitHub`
2. Added sarahec as maintainer
3. Bump to version 3.3.0


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
