### PR TITLE
windsurf: 1.11.5 -> 1.12.2

### DIFF
--- a/pkgs/by-name/wi/windsurf/info.json
+++ b/pkgs/by-name/wi/windsurf/info.json
@@ -1,20 +1,20 @@
 {
   "aarch64-darwin": {
-    "version": "1.11.5",
+    "version": "1.12.2",
     "vscodeVersion": "1.99.3",
-    "url": "https://windsurf-stable.codeiumdata.com/darwin-arm64/stable/f8b63909dde4ac913fee41e867b511a598b3b517/Windsurf-darwin-arm64-1.11.5.zip",
-    "sha256": "7f3a4122c72701c087d02e9ffd64d9432400c1468dfbec5890207e3ede3453f2"
+    "url": "https://windsurf-stable.codeiumdata.com/darwin-arm64/stable/b8f002c02d165600299a109bf21d02d139c52644/Windsurf-darwin-arm64-1.12.2.zip",
+    "sha256": "de998189f46c4389cad8b1b984984042864ff0492cc92a066451cd9338f1237c"
   },
   "x86_64-darwin": {
-    "version": "1.11.5",
+    "version": "1.12.2",
     "vscodeVersion": "1.99.3",
-    "url": "https://windsurf-stable.codeiumdata.com/darwin-x64/stable/f8b63909dde4ac913fee41e867b511a598b3b517/Windsurf-darwin-x64-1.11.5.zip",
-    "sha256": "685f45fbae8906523baa4744ead97204b254cf190092491aa235fa236393f5ca"
+    "url": "https://windsurf-stable.codeiumdata.com/darwin-x64/stable/b8f002c02d165600299a109bf21d02d139c52644/Windsurf-darwin-x64-1.12.2.zip",
+    "sha256": "bb5d0c002d76ccffac28a673b01c02b5a603a222b1f2a399d43951a9c1b3e2d3"
   },
   "x86_64-linux": {
-    "version": "1.11.5",
+    "version": "1.12.2",
     "vscodeVersion": "1.99.3",
-    "url": "https://windsurf-stable.codeiumdata.com/linux-x64/stable/f8b63909dde4ac913fee41e867b511a598b3b517/Windsurf-linux-x64-1.11.5.tar.gz",
-    "sha256": "cc83879091be631757de224d0a5b0e0b3bdc74bcd939f423ec3e02926643a7da"
+    "url": "https://windsurf-stable.codeiumdata.com/linux-x64/stable/b8f002c02d165600299a109bf21d02d139c52644/Windsurf-linux-x64-1.12.2.tar.gz",
+    "sha256": "ae1d3075237885c56bcb39d5b36f460f2a8ba4e4038c63f1d0b5795178e77c43"
   }
 }


### PR DESCRIPTION
Version bump via update script.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
