### PR TITLE
sftpman: 1.2.2 -> 2.1.0 (Rust rewrite)

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -115,6 +115,9 @@
 
 - `fetchgit`: Add `rootDir` argument to limit the resulting source to one subdirectory of the whole Git repository. Corresponding `--root-dir` option added to `nix-prefetch-git`.
 
+- `sftpman` has been updated to version 2, a rewrite in Rust which is mostly backward compatible but does include some changes to the CLI.
+  For more information, [check the project's README](https://github.com/spantaleev/sftpman-rs#is-sftpman-v2-compatible-with-sftpman-v1).
+
 - The `clickhouse` package now track the stable upstream version per [upstream's
   recommendation](https://clickhouse.com/docs/faq/operations/production). Users
   can continue to use the `clickhouse-lts` package if desired.

--- a/pkgs/by-name/sf/sftpman/package.nix
+++ b/pkgs/by-name/sf/sftpman/package.nix
@@ -1,35 +1,34 @@
 {
   lib,
-  python3Packages,
   fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
 }:
 
-python3Packages.buildPythonApplication rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sftpman";
-  version = "1.2.2";
-  pyproject = true;
+  version = "2.1.0";
+
+  passthru.updateScript = nix-update-script { };
 
   src = fetchFromGitHub {
     owner = "spantaleev";
-    repo = "sftpman";
-    rev = version;
-    hash = "sha256-YxqN4+u0nYUWehbyRhjddIo2sythH3E0fiPSyrUlWhM=";
+    repo = "sftpman-rs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6IhMBnp951mKfG054svFTezf3fpOEMJusRj45qVThmA=";
   };
 
-  build-system = with python3Packages; [ setuptools ];
-
-  checkPhase = ''
-    $out/bin/sftpman help
-  '';
-
-  pythonImportsCheck = [ "sftpman" ];
+  cargoHash = "sha256-TltizTFKrMvHNQcSoow9fuNLy6appYq9Y4LicEQrfRE=";
 
   meta = with lib; {
-    homepage = "https://github.com/spantaleev/sftpman";
+    homepage = "https://github.com/spantaleev/sftpman-rs";
     description = "Application that handles sshfs/sftp file systems mounting";
-    license = licenses.gpl3;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ contrun ];
+    license = licenses.agpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [
+      contrun
+      fugi
+    ];
     mainProgram = "sftpman";
   };
-}
+})


### PR DESCRIPTION
sftpman has been rewritten in Rust: https://github.com/spantaleev/sftpman-rs#why-was-sftpman-rewritten-from-python-to-rust

As explained in the readme, this v2 is mostly backward compatible with the v1 that was written in Python, i.e. the config files from v1 still work and most CLI commands are the same.

It should be noted that it now (definitely) only supports Linux, because it depends on the `procfs` crate.
However it seems like only Linux was really supported in the old version too, since it hard coded Linux-specific shell commands:
e.g. the `fusermount` command for unmounting, which works on Linux but not on macOS or FreeBSD according to `man 1 sshfs`.

(I added myself as maintainer since it's essentially a new package derivation.)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
