### PR TITLE
secretlint: init at 11.0.2

### DIFF
--- a/pkgs/by-name/se/secretlint/package.nix
+++ b/pkgs/by-name/se/secretlint/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  makeWrapper,
+  nodejs,
+  pnpm_10,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "secretlint";
+  version = "11.0.2";
+
+  src = fetchFromGitHub {
+    owner = "secretlint";
+    repo = "secretlint";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LJ1zYv0w7e9fPLfhzfCdasloRUdcy8lfMIQTyHqAY/Y=";
+  };
+
+  pnpmDeps = pnpm_10.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    fetcherVersion = 2;
+    hash = "sha256-jEmpyj83ORKUWHzVYoFzKdaB7epLam33nP7t0z5QmlE=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs
+    pnpm_10.configHook
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  buildPhase = ''
+    runHook preBuild
+    pnpm run build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin $out/lib
+    cp -r node_modules $out/lib/
+    cp -r packages $out/lib/
+    cp -r examples $out/lib/
+    makeWrapper ${lib.getExe nodejs} $out/bin/secretlint \
+      --inherit-argv0 \
+      --prefix NODE_PATH : "$out/lib/node_modules" \
+      --add-flags $out/lib/packages/secretlint/bin/secretlint.js
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Pluggable linting tool to prevent committing credentials";
+    homepage = "https://github.com/secretlint/secretlint";
+    changelog = "https://github.com/secretlint/secretlint/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.amadejkastelic ];
+    mainProgram = "secretlint";
+  };
+})


### PR DESCRIPTION
Closes #434241

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
