### PR TITLE
check-meta: Clarify error message about unsupported platform

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -534,7 +534,7 @@ let
         reason = "unsupported";
         errormsg = ''
           is not available on the requested hostPlatform:
-            hostPlatform.config = "${hostPlatform.config}"
+            hostPlatform.system = "${hostPlatform.system}"
             package.meta.platforms = ${toPretty' (attrs.meta.platforms or [ ])}
             package.meta.badPlatforms = ${toPretty' (attrs.meta.badPlatforms or [ ])}
         '';


### PR DESCRIPTION
Right now if you are specifying supported platforms using meta.platforms you can get a bit misleading error message:

    $ nix-build default.nix
    error:
          … in the condition of the assert statement
            at /nix/store/53pzmaza73pl8q2yl1q62h7ncx21nxc1-source/lib/customisation.nix:419:9:
              418|       drvPath =
              419|         assert condition;
                |         ^
              420|         drv.drvPath;

          … while evaluating the attribute 'handled'
            at /nix/store/53pzmaza73pl8q2yl1q62h7ncx21nxc1-source/pkgs/stdenv/generic/check-meta.nix:643:9:
              642|         # or, alternatively, just output a warning message.
              643|         handled = (
                |         ^
              644|           if valid == "yes" then

          (stack trace truncated; use '--show-trace' to show the full, detailed trace)

          error: Package ‘test’ in /home/kamil/code/test/default.nix:3 is not available on the requested hostPlatform:
            hostPlatform.config = "aarch64-none-elf"
            package.meta.platforms = [
              "aarch64-none-elf"
            ]
            package.meta.badPlatforms = [ ]
          , refusing to evaluate.

          a) To temporarily allow packages that are unsupported for this system, you can use an environment variable
              for a single invocation of the nix tools.

                $ export NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1

              Note: When using `nix shell`, `nix build`, `nix develop`, etc with a flake,
                    then pass `--impure` in order to allow use of environment variables.

          b) For `nixos-rebuild` you can set
            { nixpkgs.config.allowUnsupportedSystem = true; }
          in configuration.nix to override this.

          c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
            { allowUnsupportedSystem = true; }
          to ~/.config/nixpkgs/config.nix.

It is not clear why this derivation cannot be built for "aarch64-none-elf" target since error message list this triplet in package.meta.platforms right below hostPlatform.config. The issue is that package.meta.platforms is checked against hostPlatform.system field, not hostPlatform.config field:
https://github.com/NixOS/nixpkgs/blob/b134951a4c9f3c995fd7be05f3243f8ecd65d798/lib/meta.nix#L103 And in this case hostPlatform.system is "aarch64-none" while hostPlatform.config is "aarch64-none-efi".

I think that it would be better to print hostPlatform.system in error message.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
