### PR TITLE
gnuradio: fix cross compilation

### DIFF
--- a/pkgs/applications/radio/gnuradio/default.nix
+++ b/pkgs/applications/radio/gnuradio/default.nix
@@ -67,7 +67,7 @@ let
       # when gr-qtgui is disabled, icu needs to be included, otherwise
       # building with boost 1.7x fails
       ++ lib.optionals (!(hasFeature "gr-qtgui")) [ icu ];
-      pythonNative = with python.pkgs; [
+      pythonNative = with python.pythonOnBuildForHost.pkgs; [
         mako
         six
       ];
@@ -337,6 +337,8 @@ stdenv.mkDerivation (
         # This is the only python reference worth removing, if needed.
         + lib.optionalString (!hasFeature "python-support") ''
           remove-references-to -t ${python} $out/lib/cmake/gnuradio/GnuradioConfig.cmake
+        ''
+        + lib.optionalString (!hasFeature "python-support" && hasFeature "gnuradio-runtime") ''
           remove-references-to -t ${python} $(readlink -f $out/lib/libgnuradio-runtime${stdenv.hostPlatform.extensions.sharedLibrary})
           remove-references-to -t ${python.pkgs.pybind11} $out/lib/cmake/gnuradio/gnuradio-runtimeTargets.cmake
         '';

--- a/pkgs/applications/radio/gnuradio/shared.nix
+++ b/pkgs/applications/radio/gnuradio/shared.nix
@@ -64,11 +64,9 @@ in
         # Abuse this unavoidable "iteration" to set this flag which we want as
         # well - it means: Don't turn on features just because their deps are
         # satisfied, let only our cmakeFlags decide.
-        "-DENABLE_DEFAULT=OFF"
-      else if hasFeature feat then
-        "-DENABLE_${info.cmakeEnableFlag}=ON"
+        (lib.cmakeBool "ENABLE_DEFAULT" false)
       else
-        "-DENABLE_${info.cmakeEnableFlag}=OFF"
+        (lib.cmakeBool "ENABLE_${info.cmakeEnableFlag}" (hasFeature feat))
     )
   ) featuresInfo;
   disallowedReferences = [

--- a/pkgs/applications/radio/gnuradio/shared.nix
+++ b/pkgs/applications/radio/gnuradio/shared.nix
@@ -72,7 +72,6 @@ in
     )
   ) featuresInfo;
   disallowedReferences = [
-    # TODO: Should this be conditional?
     stdenv.cc
     stdenv.cc.cc
   ]

--- a/pkgs/applications/radio/gnuradio/shared.nix
+++ b/pkgs/applications/radio/gnuradio/shared.nix
@@ -24,6 +24,7 @@ let
     minor = builtins.elemAt (lib.splitVersion version) 2;
     patch = builtins.elemAt (lib.splitVersion version) 3;
   };
+  cross = stdenv.hostPlatform != stdenv.buildPlatform;
 in
 {
   src =
@@ -57,7 +58,12 @@ in
       ))
     ) featuresInfo
   );
-  cmakeFlags = lib.mapAttrsToList (
+  cmakeFlags = [
+    # https://pybind11.readthedocs.io/en/stable/changelog.html#version-2-13-0-june-25-2024
+    (lib.cmakeBool "CMAKE_CROSSCOMPILING" cross)
+    (lib.cmakeBool "PYBIND11_USE_CROSSCOMPILING" (cross && hasFeature "gnuradio-runtime"))
+  ]
+  ++ lib.mapAttrsToList (
     feat: info:
     (
       if feat == "basic" then

--- a/pkgs/applications/radio/gnuradio/shared.nix
+++ b/pkgs/applications/radio/gnuradio/shared.nix
@@ -54,7 +54,9 @@ in
       feat: info:
       (lib.optionals (hasFeature feat) (
         (lib.optionals (builtins.hasAttr "runtime" info) info.runtime)
-        ++ (lib.optionals (builtins.hasAttr "pythonRuntime" info) info.pythonRuntime)
+        ++ (lib.optionals (
+          builtins.hasAttr "pythonRuntime" info && hasFeature "python-support"
+        ) info.pythonRuntime)
       ))
     ) featuresInfo
   );


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
