### PR TITLE
nixos/zookeeper: replace outdated log4j with logback.xml

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -112,7 +112,7 @@
 - The `zigbee2mqtt` package was updated to version 2.x, which contains breaking changes. See the [discussion](https://github.com/Koenkk/zigbee2mqtt/discussions/24198) for further information.
 
 - []{#sec-release-25.11-incompatibilities-sourcehut-removed} The `services.sourcehut` module and corresponding `sourcehut` packages were removed due to being broken and unmaintained.
-
+- The zookeeper project changed their logging tool to logback, therefore `services.zookeeper.logging` option has been updated to expect a logback compatible string.
 - The `dovecot` systemd service was renamed from `dovecot2` to `dovecot`. The former is now just an alias. Update any overrides on the systemd unit to the new name.
 
 - `Prosody` has been updated to major release 13 which removed some obsoleted modules and brought a couple of major and breaking changes:

--- a/nixos/modules/services/misc/zookeeper.nix
+++ b/nixos/modules/services/misc/zookeeper.nix
@@ -19,7 +19,7 @@ let
     name = "zookeeper-conf";
     paths = [
       (pkgs.writeTextDir "zoo.cfg" zookeeperConfig)
-      (pkgs.writeTextDir "log4j.properties" cfg.logging)
+      (pkgs.writeTextDir "logback.xml" cfg.logging)
     ];
   };
 
@@ -71,14 +71,27 @@ in
     };
 
     logging = lib.mkOption {
-      description = "Zookeeper logging configuration.";
+      description = "Zookeeper logging configuration, logback.xml.";
       default = ''
-        zookeeper.root.logger=INFO, CONSOLE
-        log4j.rootLogger=INFO, CONSOLE
-        log4j.logger.org.apache.zookeeper.audit.Log4jAuditLogger=INFO, CONSOLE
-        log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-        log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-        log4j.appender.CONSOLE.layout.ConversionPattern=[myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n
+        <configuration>
+          <property name="zookeeper.console.threshold" value="INFO" />
+          <property name="zookeeper.log.dir" value="." />
+          <property name="zookeeper.log.file" value="zookeeper.log" />
+          <property name="zookeeper.log.threshold" value="INFO" />
+          <property name="zookeeper.log.maxfilesize" value="256MB" />
+          <property name="zookeeper.log.maxbackupindex" value="20" />
+          <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+              <pattern>%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n</pattern>
+            </encoder>
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+              <level>''${zookeeper.console.threshold}</level>
+            </filter>
+          </appender>
+          <root level="INFO">
+            <appender-ref ref="CONSOLE" />
+          </root>
+        </configuration>
       '';
       type = lib.types.lines;
     };


### PR DESCRIPTION
How hard I tried to minimize log output I would still see no change, turns out 2022 they changed from log4j.properties to use logback.xml instead

Would be nice with some hand holding I dont really make Prs, I reused the nixos option logging, but the syntax have changed, so I believe its a breaking change.

See issue https://issues.apache.org/jira/browse/ZOOKEEPER-4427 

See commit https://github.com/apache/zookeeper/commit/85551f9be5b054fa4aee0636597b12bda2ecb2e8


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
