### PR TITLE
nixos/tests: Use autoFormat

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -20,25 +20,17 @@ let
 
   cfg = config.virtualisation;
 
-  opt = options.virtualisation;
-
   qemu = cfg.qemu.package;
 
   hostPkgs = cfg.host.pkgs;
 
   consoles = lib.concatMapStringsSep " " (c: "console=${c}") cfg.qemu.consoles;
 
-  driveOpts =
+  driveOptions =
     { ... }:
     {
 
       options = {
-
-        file = mkOption {
-          type = types.str;
-          description = "The file image used for this drive.";
-        };
-
         driveExtraOpts = mkOption {
           type = types.attrsOf types.str;
           default = { };
@@ -299,7 +291,9 @@ let
 
     ${lib.pipe cfg.emptyDiskImages [
       (lib.imap0 (
-        idx: size: ''
+        idx:
+        { size, ... }:
+        ''
           test -e "empty${builtins.toString idx}.qcow2" || ${qemu}/bin/qemu-img create -f qcow2 "empty${builtins.toString idx}.qcow2" "${builtins.toString size}M"
         ''
       ))
@@ -477,7 +471,20 @@ in
     };
 
     virtualisation.emptyDiskImages = mkOption {
-      type = types.listOf types.ints.positive;
+      type = types.listOf (
+        types.coercedTo types.ints.positive (size: { inherit size; }) (
+          types.submodule {
+            options.size = mkOption {
+              type = types.ints.positive;
+              description = "The size of the disk in MiB";
+            };
+            options.driveConfig = mkOption {
+              type = lib.types.submodule driveOptions;
+              description = "Drive configuration to pass to {option}`virtualisation.qemu.drives`";
+            };
+          }
+        )
+      );
       default = [ ];
       description = ''
         Additional disk images to provide to the VM. The value is
@@ -829,7 +836,18 @@ in
       };
 
       drives = mkOption {
-        type = types.listOf (types.submodule driveOpts);
+        type = types.listOf (
+          types.submodule {
+            imports = [ driveOptions ];
+
+            options = {
+              file = mkOption {
+                type = types.str;
+                description = "The file image used for this drive.";
+              };
+            };
+          }
+        );
         description = "Drives passed to qemu.";
       };
 
@@ -1310,10 +1328,16 @@ in
           driveExtraOpts.format = "raw";
         }
       ])
-      (imap0 (idx: _: {
-        file = "$(pwd)/empty${toString idx}.qcow2";
-        driveExtraOpts.werror = "report";
-      }) cfg.emptyDiskImages)
+      (imap0 (
+        idx: imgCfg:
+        lib.mkMerge [
+          {
+            file = "$(pwd)/empty${toString idx}.qcow2";
+            driveExtraOpts.werror = "report";
+          }
+          imgCfg.driveConfig
+        ]
+      ) cfg.emptyDiskImages)
     ];
 
     # By default, use mkVMOverride to enable building test VMs (e.g. via

--- a/nixos/tests/bees.nix
+++ b/nixos/tests/bees.nix
@@ -5,29 +5,33 @@
   nodes.machine =
     { config, pkgs, ... }:
     {
-      boot.initrd.postDeviceCommands = ''
-        ${pkgs.btrfs-progs}/bin/mkfs.btrfs -f -L aux1 /dev/vdb
-        ${pkgs.btrfs-progs}/bin/mkfs.btrfs -f -L aux2 /dev/vdc
-      '';
       virtualisation.emptyDiskImages = [
-        4096
-        4096
+        {
+          size = 4096;
+          driveConfig.deviceExtraOpts.serial = "aux1";
+        }
+        {
+          size = 4096;
+          driveConfig.deviceExtraOpts.serial = "aux2";
+        }
       ];
       virtualisation.fileSystems = {
         "/aux1" = {
           # filesystem configured to be deduplicated
-          device = "/dev/disk/by-label/aux1";
+          device = "/dev/disk/by-id/virtio-aux1";
           fsType = "btrfs";
+          autoFormat = true;
         };
         "/aux2" = {
           # filesystem not configured to be deduplicated
-          device = "/dev/disk/by-label/aux2";
+          device = "/dev/disk/by-id/virtio-aux2";
           fsType = "btrfs";
+          autoFormat = true;
         };
       };
       services.beesd.filesystems = {
         aux1 = {
-          spec = "LABEL=aux1";
+          spec = "/dev/disk/by-id/virtio-aux1";
           hashTableSizeMB = 16;
           verbosity = "debug";
         };

--- a/nixos/tests/glusterfs.nix
+++ b/nixos/tests/glusterfs.nix
@@ -19,17 +19,18 @@ let
       networking.firewall.enable = false;
       services.glusterfs.enable = true;
 
-      # create a mount point for the volume
-      boot.initrd.postDeviceCommands = ''
-        ${pkgs.e2fsprogs}/bin/mkfs.ext4 -L data /dev/vdb
-      '';
-
-      virtualisation.emptyDiskImages = [ 1024 ];
+      virtualisation.emptyDiskImages = [
+        {
+          size = 1024;
+          driveConfig.deviceExtraOpts.serial = "data";
+        }
+      ];
 
       virtualisation.fileSystems = {
         "/data" = {
-          device = "/dev/disk/by-label/data";
+          device = "/dev/disk/by-id/virtio-data";
           fsType = "ext4";
+          autoFormat = true;
         };
       };
     };

--- a/nixos/tests/hardened.nix
+++ b/nixos/tests/hardened.nix
@@ -24,14 +24,17 @@
       imports = [ ../modules/profiles/hardened.nix ];
       environment.memoryAllocator.provider = "graphene-hardened";
       nix.settings.sandbox = false;
-      virtualisation.emptyDiskImages = [ 4096 ];
-      boot.initrd.postDeviceCommands = ''
-        ${pkgs.dosfstools}/bin/mkfs.vfat -n EFISYS /dev/vdb
-      '';
+      virtualisation.emptyDiskImages = [
+        {
+          size = 4096;
+          driveConfig.deviceExtraOpts.serial = "deferred";
+        }
+      ];
       virtualisation.fileSystems = {
-        "/efi" = {
-          device = "/dev/disk/by-label/EFISYS";
+        "/deferred" = {
+          device = "/dev/disk/by-id/virtio-deferred";
           fsType = "vfat";
+          autoFormat = true;
           options = [ "noauto" ];
         };
       };
@@ -87,10 +90,9 @@
 
       # Test deferred mount
       with subtest("Deferred mounts work"):
-          machine.fail("mountpoint -q /efi")  # was deferred
-          machine.execute("mkdir -p /efi")
-          machine.succeed("mount /dev/disk/by-label/EFISYS /efi")
-          machine.succeed("mountpoint -q /efi")  # now mounted
+          machine.fail("mountpoint -q /deferred")  # was deferred
+          machine.systemctl("start deferred.mount")
+          machine.succeed("mountpoint -q /deferred")  # now mounted
 
 
       # Test Nix dæmon usage

--- a/nixos/tests/moosefs.nix
+++ b/nixos/tests/moosefs.nix
@@ -22,15 +22,18 @@ let
   chunkserver =
     { pkgs, ... }:
     {
-      virtualisation.emptyDiskImages = [ 4096 ];
-      boot.initrd.postDeviceCommands = ''
-        ${pkgs.e2fsprogs}/bin/mkfs.ext4 -L data /dev/vdb
-      '';
+      virtualisation.emptyDiskImages = [
+        {
+          size = 4096;
+          driveConfig.deviceExtraOpts.serial = "data";
+        }
+      ];
 
       fileSystems = pkgs.lib.mkVMOverride {
         "/data" = {
-          device = "/dev/disk/by-label/data";
+          device = "/dev/disk/by-id/virtio-data";
           fsType = "ext4";
+          autoFormat = true;
         };
       };
 

--- a/nixos/tests/orangefs.nix
+++ b/nixos/tests/orangefs.nix
@@ -5,16 +5,19 @@ let
     { pkgs, ... }:
     {
       networking.firewall.allowedTCPPorts = [ 3334 ];
-      boot.initrd.postDeviceCommands = ''
-        ${pkgs.e2fsprogs}/bin/mkfs.ext4 -L data /dev/vdb
-      '';
 
-      virtualisation.emptyDiskImages = [ 4096 ];
+      virtualisation.emptyDiskImages = [
+        {
+          size = 4096;
+          driveConfig.deviceExtraOpts.serial = "data";
+        }
+      ];
 
       virtualisation.fileSystems = {
         "/data" = {
-          device = "/dev/disk/by-label/data";
+          device = "/dev/disk/by-id/virtio-data";
           fsType = "ext4";
+          autoFormat = true;
         };
       };
 

--- a/nixos/tests/saunafs.nix
+++ b/nixos/tests/saunafs.nix
@@ -20,15 +20,18 @@ let
   chunkserver =
     { pkgs, ... }:
     {
-      virtualisation.emptyDiskImages = [ 4096 ];
-      boot.initrd.postDeviceCommands = ''
-        ${pkgs.e2fsprogs}/bin/mkfs.ext4 -L data /dev/vdb
-      '';
+      virtualisation.emptyDiskImages = [
+        {
+          size = 4096;
+          driveConfig.deviceExtraOpts.serial = "data";
+        }
+      ];
 
       fileSystems = pkgs.lib.mkVMOverride {
         "/data" = {
-          device = "/dev/disk/by-label/data";
+          device = "/dev/disk/by-id/virtio-data";
           fsType = "ext4";
+          autoFormat = true;
         };
       };
 

--- a/nixos/tests/snapper.nix
+++ b/nixos/tests/snapper.nix
@@ -5,16 +5,18 @@
   nodes.machine =
     { pkgs, lib, ... }:
     {
-      boot.initrd.postDeviceCommands = ''
-        ${pkgs.btrfs-progs}/bin/mkfs.btrfs -f -L aux /dev/vdb
-      '';
-
-      virtualisation.emptyDiskImages = [ 4096 ];
+      virtualisation.emptyDiskImages = [
+        {
+          size = 4096;
+          driveConfig.deviceExtraOpts.serial = "aux";
+        }
+      ];
 
       virtualisation.fileSystems = {
         "/home" = {
-          device = "/dev/disk/by-label/aux";
+          device = "/dev/disk/by-id/virtio-aux";
           fsType = "btrfs";
+          autoFormat = true;
         };
       };
       services.snapper.configs.home.SUBVOLUME = "/home";

--- a/nixos/tests/swap-file-btrfs.nix
+++ b/nixos/tests/swap-file-btrfs.nix
@@ -5,20 +5,18 @@
   meta.maintainers = with lib.maintainers; [ oxalica ];
 
   nodes.machine =
-    { pkgs, ... }:
+    { config, pkgs, ... }:
     {
       virtualisation.useDefaultFilesystems = false;
 
       virtualisation.rootDevice = "/dev/vda";
 
-      boot.initrd.postDeviceCommands = ''
-        ${pkgs.btrfs-progs}/bin/mkfs.btrfs --label root /dev/vda
-      '';
-
+      boot.initrd.systemd.enable = true;
       virtualisation.fileSystems = {
         "/" = {
-          device = "/dev/disk/by-label/root";
+          device = config.virtualisation.rootDevice;
           fsType = "btrfs";
+          autoFormat = true;
         };
       };
 


### PR DESCRIPTION
This will make it simpler to transition to systemd initrd by default, by removing unnecessary initrd scripts in the NixOS tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
