### PR TITLE
[Backport release-25.05] coin3d: 4.0.3 -> 4.0.5

### DIFF
--- a/pkgs/by-name/co/coin3d/package.nix
+++ b/pkgs/by-name/co/coin3d/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "coin";
-  version = "4.0.3";
+  version = "4.0.4";
 
   src = fetchFromGitHub {
     owner = "coin3d";
     repo = "coin";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-dUFmcUOdNc3ZFtr+Hnh3Q3OY/JA/WxmiRJiU2RFSSus=";
+    hash = "sha256-Zk9tlGMbNhfHKv+Z5VFWr1g3wNuPFzof+7vsLAlOBC4=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/co/coin3d/package.nix
+++ b/pkgs/by-name/co/coin3d/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "coin";
-  version = "4.0.4";
+  version = "4.0.5";
 
   src = fetchFromGitHub {
     owner = "coin3d";
     repo = "coin";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Zk9tlGMbNhfHKv+Z5VFWr1g3wNuPFzof+7vsLAlOBC4=";
+    hash = "sha256-2lfy33Qx0AjKDfwwRn7hjaz7mPQsr7MRB9v75qshGjM=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Manual backport of #430467 #432926 to `release-25.05`. See also #420051 and #428028.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.