### PR TITLE
[Backport release-25.05] freecad: 1.0.1 -> 1.0.2, various fixes

### DIFF
--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -23,7 +23,7 @@
   opencascade-occt_7_6,
   opencascade-occt,
   pkg-config,
-  python311Packages,
+  python3Packages,
   spaceNavSupport ? stdenv.hostPlatform.isLinux,
   ifcSupport ? false,
   stdenv,
@@ -40,7 +40,7 @@
   nix-update-script,
 }:
 let
-  inherit (python311Packages)
+  inherit (python3Packages)
     boost
     gitpython
     ifcopenshell

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -147,6 +147,11 @@ freecad-utils.makeCustomizable (
         url = "https://github.com/FreeCAD/FreeCAD/commit/8e04c0a3dd9435df0c2dec813b17d02f7b723b19.patch?full_index=1";
         hash = "sha256-H6WbJFTY5/IqEdoi5N+7D4A6pVAmZR4D+SqDglwS18c=";
       })
+      # https://github.com/FreeCAD/FreeCAD/pull/22221
+      (fetchpatch {
+        url = "https://github.com/FreeCAD/FreeCAD/commit/3d2b7dc9c7ac898b30fe469b7cbd424ed1bca0a2.patch?full_index=1";
+        hash = "sha256-XCQdv/+dYdJ/ptA2VKrD63qYILyaP276ISMkmWLtT30=";
+      })
     ];
 
     cmakeFlags = [

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -77,7 +77,7 @@ freecad-utils.makeCustomizable (
     src = fetchFromGitHub {
       owner = "FreeCAD";
       repo = "FreeCAD";
-      rev = finalAttrs.version;
+      tag = finalAttrs.version;
       hash = "sha256-VFTNawXxu2ofjj2Frg4OfVhiMKFywBhm7lZunP85ZEQ=";
       fetchSubmodules = true;
     };

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -150,6 +150,12 @@ freecad-utils.makeCustomizable (
         url = "https://github.com/FreeCAD/FreeCAD/commit/3d2b7dc9c7ac898b30fe469b7cbd424ed1bca0a2.patch?full_index=1";
         hash = "sha256-XCQdv/+dYdJ/ptA2VKrD63qYILyaP276ISMkmWLtT30=";
       })
+      # Inform Coin to use EGL when on Wayland
+      # https://github.com/FreeCAD/FreeCAD/pull/21917
+      (fetchpatch {
+        url = "https://github.com/FreeCAD/FreeCAD/commit/60aa5ff3730d77037ffad0c77ba96b99ef0c7df3.patch?full_index=1";
+        hash = "sha256-K6PWQ1U+/fsjDuir7MiAKq71CAIHar3nKkO6TKYl32k=";
+      })
     ];
 
     cmakeFlags = [

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -25,7 +25,7 @@
   pkg-config,
   python3Packages,
   spaceNavSupport ? stdenv.hostPlatform.isLinux,
-  ifcSupport ? false,
+  ifcSupport ? false, # Now a no-op, retained on 25.05 branch for backport compat.
   stdenv,
   swig,
   vtk,
@@ -45,6 +45,7 @@ let
     [
       boost
       gitpython # for addon manager
+      ifcopenshell
       matplotlib
       opencamlib
       pivy
@@ -55,9 +56,6 @@ let
       python
       pyyaml # (at least for) PyrateWorkbench
       scipy
-    ]
-    ++ lib.optionals ifcSupport [
-      ifcopenshell
     ]
     ++ lib.optionals (qtVersion == 5) [
       pyside2

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -151,7 +151,6 @@ freecad-utils.makeCustomizable (
 
     cmakeFlags = [
       "-Wno-dev" # turns off warnings which otherwise makes it hard to see what is going on
-      "-DBUILD_FLAT_MESH:BOOL=ON"
       "-DBUILD_DRAWING=ON"
       "-DBUILD_FLAT_MESH:BOOL=ON"
       "-DINSTALL_TO_SITEPACKAGES=OFF"

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -72,13 +72,13 @@ in
 freecad-utils.makeCustomizable (
   stdenv.mkDerivation (finalAttrs: {
     pname = "freecad";
-    version = "1.0.1";
+    version = "1.0.2";
 
     src = fetchFromGitHub {
       owner = "FreeCAD";
       repo = "FreeCAD";
       tag = finalAttrs.version;
-      hash = "sha256-VFTNawXxu2ofjj2Frg4OfVhiMKFywBhm7lZunP85ZEQ=";
+      hash = "sha256-J//O/ABMFa3TFYwR0wc8d1UTA5iSFnEP2thOjuCN+uE=";
       fetchSubmodules = true;
     };
 
@@ -144,11 +144,6 @@ freecad-utils.makeCustomizable (
       (fetchpatch {
         url = "https://github.com/FreeCAD/FreeCAD/commit/8e04c0a3dd9435df0c2dec813b17d02f7b723b19.patch?full_index=1";
         hash = "sha256-H6WbJFTY5/IqEdoi5N+7D4A6pVAmZR4D+SqDglwS18c=";
-      })
-      # https://github.com/FreeCAD/FreeCAD/pull/22221
-      (fetchpatch {
-        url = "https://github.com/FreeCAD/FreeCAD/commit/3d2b7dc9c7ac898b30fe469b7cbd424ed1bca0a2.patch?full_index=1";
-        hash = "sha256-XCQdv/+dYdJ/ptA2VKrD63qYILyaP276ISMkmWLtT30=";
       })
       # Inform Coin to use EGL when on Wayland
       # https://github.com/FreeCAD/FreeCAD/pull/21917

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -17,7 +17,6 @@
   libspnav,
   libXmu,
   medfile,
-  mpi,
   ninja,
   ode,
   opencascade-occt_7_6,
@@ -106,7 +105,6 @@ freecad-utils.makeCustomizable (
       libGLU
       libXmu
       medfile
-      mpi
       ode
       vtk
       xercesc

--- a/pkgs/by-name/fr/freecad/tests/default.nix
+++ b/pkgs/by-name/fr/freecad/tests/default.nix
@@ -1,9 +1,7 @@
 {
   callPackage,
-  freecad,
 }:
 {
   python-path = callPackage ./python-path.nix { };
   modules = callPackage ./modules.nix { };
-  withIfcSupport = freecad.override { ifcSupport = true; };
 }


### PR DESCRIPTION
Manual backport of #412903 #421276 #422675 #434105 (and two treewides) to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.