### PR TITLE
pihole-ftl: fix `useDnsmasqConfig = true` and add test

### DIFF
--- a/nixos/modules/services/networking/dnsmasq.nix
+++ b/nixos/modules/services/networking/dnsmasq.nix
@@ -118,6 +118,8 @@ in
       configFile = lib.mkOption {
         type = lib.types.package;
         readOnly = true;
+        default = dnsmasqConf;
+        defaultText = lib.literalExpression "Path of dnsmasq config file";
         description = ''
           Path to the configuration file of dnsmasq.
         '';
@@ -137,8 +139,6 @@ in
         conf-file = lib.mkDefault (lib.optional cfg.resolveLocalQueries "/etc/dnsmasq-conf.conf");
         resolv-file = lib.mkDefault (lib.optional cfg.resolveLocalQueries "/etc/dnsmasq-resolv.conf");
       };
-
-      configFile = dnsmasqConf;
     };
 
     networking.nameservers = lib.optional cfg.resolveLocalQueries "127.0.0.1";

--- a/nixos/tests/pihole-ftl/default.nix
+++ b/nixos/tests/pihole-ftl/default.nix
@@ -2,4 +2,5 @@
 
 {
   basic = runTest ./basic.nix;
+  dnsmasq = runTest ./dnsmasq.nix;
 }

--- a/nixos/tests/pihole-ftl/dnsmasq.nix
+++ b/nixos/tests/pihole-ftl/dnsmasq.nix
@@ -1,0 +1,20 @@
+let
+  port = "9077";
+in
+{
+  name = "pihole-ftl-dnsmasq";
+
+  nodes.machine = {
+    services.pihole-ftl = {
+      enable = true;
+      useDnsmasqConfig = true;
+      settings.webserver.port = port;
+    };
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("pihole-ftl.service")
+    machine.wait_for_open_port(${port})
+  '';
+}

--- a/pkgs/by-name/dn/dnsmasq/package.nix
+++ b/pkgs/by-name/dn/dnsmasq/package.nix
@@ -106,6 +106,7 @@ stdenv.mkDerivation rec {
     inherit (nixosTests) dnscrypt-proxy;
     kubernetes-dns-single = nixosTests.kubernetes.dns-single-node;
     kubernetes-dns-multi = nixosTests.kubernetes.dns-multi-node;
+    pihole-ftl-dnsmasq = nixosTests.pihole-ftl.dnsmasq;
   };
 
   meta = with lib; {

--- a/pkgs/by-name/pi/pihole-ftl/package.nix
+++ b/pkgs/by-name/pi/pihole-ftl/package.nix
@@ -77,8 +77,11 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.settingsTemplate = ./pihole.toml;
-  passthru.tests = nixosTests.pihole-ftl;
+  passthru = {
+    settingsTemplate = ./pihole.toml;
+
+    tests = nixosTests.pihole-ftl;
+  };
 
   meta = {
     description = "Pi-hole FTL engine";


### PR DESCRIPTION
Fixes #429395

To prevent this in the future, I've added a test. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
