### PR TITLE
python3Packages.lifelines: modernize build, disable broken test

### DIFF
--- a/pkgs/development/python-modules/lifelines/default.nix
+++ b/pkgs/development/python-modules/lifelines/default.nix
@@ -16,15 +16,14 @@
   pythonOlder,
   scikit-learn,
   scipy,
+  setuptools,
   sybil,
 }:
 
 buildPythonPackage rec {
   pname = "lifelines";
   version = "0.30.0";
-  format = "setuptools";
-
-  disabled = pythonOlder "3.9";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "CamDavidsonPilon";
@@ -33,7 +32,9 @@ buildPythonPackage rec {
     hash = "sha256-rbt0eON8Az5jDvj97RDn3ppWyjbrSa/xumbwhq21g6g=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     autograd
     autograd-gamma
     formulaic
@@ -57,13 +58,17 @@ buildPythonPackage rec {
 
   disabledTestPaths = [ "lifelines/tests/test_estimation.py" ];
 
-  disabledTests = [ "test_datetimes_to_durations_with_different_frequencies" ];
+  disabledTests = [
+    "test_datetimes_to_durations_with_different_frequencies"
+    # AssertionError
+    "test_mice_scipy"
+  ];
 
-  meta = with lib; {
+  meta = {
     description = "Survival analysis in Python";
     homepage = "https://lifelines.readthedocs.io";
     changelog = "https://github.com/CamDavidsonPilon/lifelines/blob/v${version}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [ swflint ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ swflint ];
   };
 }


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/304067210

1. `test_mice_scipy` fails with an incorrect result. Disabled the test. (Nothing appropriate found in repo's issues.)
2. Also modernized the build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
