### PR TITLE
neolight: init at 1.4.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1762,6 +1762,7 @@
   ./services/x11/hardware/synaptics.nix
   ./services/x11/hardware/wacom.nix
   ./services/x11/imwheel.nix
+  ./services/x11/neolight.nix
   ./services/x11/picom.nix
   ./services/x11/redshift.nix
   ./services/x11/touchegg.nix

--- a/nixos/modules/services/x11/neolight.nix
+++ b/nixos/modules/services/x11/neolight.nix
@@ -1,0 +1,30 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.xserver.xkb.neolight;
+in
+{
+  options.services.xserver.xkb.neolight = {
+    package = lib.mkPackageOption pkgs "neolight" { };
+    enable = lib.mkEnableOption "neolight xkb layout, extra keyboard layers for programming based on Neo";
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    environment.sessionVariables.XKB_CONFIG_ROOT = lib.mkForce "${cfg.package}/share/X11/xkb";
+
+    assertions = [
+      {
+        assertion = config.services.xserver.xkb.extraLayouts == { };
+        message = "Neolight conflicts with xkb.extraLayouts";
+      }
+    ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ drafolin ];
+}

--- a/pkgs/by-name/ne/neolight/package.nix
+++ b/pkgs/by-name/ne/neolight/package.nix
@@ -1,0 +1,100 @@
+{
+  xkeyboard_config,
+  ed,
+  fetchFromGitHub,
+  lib,
+}:
+xkeyboard_config.overrideAttrs (old: {
+  neolightSrc = fetchFromGitHub {
+    owner = "mihi314";
+    repo = "neolight";
+    tag = "v1.4.0";
+    hash = "sha256-m1beegjPPiyQpmiqp5NvCCjBvpebH79A0R7PNjc0Xd8=";
+  };
+
+  postInstall = ''
+    cd $out/share/X11/xkb
+    cp $neolightSrc/linux/neolight_symbols symbols/neolight
+    cp $neolightSrc/linux/neolight_types types/neolight
+
+    ${ed}/bin/ed -v rules/evdev.xml <<EOF
+    /<layoutList>/
+    a
+    <!-- BEGIN neolight -->
+        <layout>
+          <configItem>
+            <name>neolight</name>
+            <shortDescription>de</shortDescription>
+            <description>German (Neolight)</description>
+            <countryList>
+              <iso3166Id>DE</iso3166Id>
+            </countryList>
+            <languageList>
+              <iso639Id>deu</iso639Id>
+            </languageList>
+          </configItem>
+          <variantList>
+            <variant>
+              <configItem>
+                <name>de_escape_keys</name>
+                <description>German (Neolight + escape keys)</description>
+              </configItem>
+            </variant>
+          </variantList>
+        </layout>
+    <!-- END neolight -->
+    .
+    /<optionList>/
+    a
+    <!-- BEGIN neolight -->
+        <group allowMultipleSelection="false">
+          <configItem>
+            <name>neolight</name>
+            <description>Neolight</description>
+          </configItem>
+          <option>
+            <configItem>
+              <name>neolight</name>
+              <description>Add the neolight layers to the first layout</description>
+            </configItem>
+          </option>
+          <option>
+            <configItem>
+              <name>neolight:escape_keys</name>
+              <description>Add the neolight layers and additional escape keys to the first layout</description>
+            </configItem>
+          </option>
+        </group>
+    <!-- END neolight -->
+    .
+    w
+    EOF
+
+    ${ed}/bin/ed -v types/complete <<EOF
+    /};/
+    i
+    include "neolight"
+    .
+    w
+    EOF
+
+    ${ed}/bin/ed -v rules/evdev <<EOF
+    a
+    // BEGIN NEOLIGHT
+    ! option   = symbols
+      neolight = +neolight(layers)
+      neolight:escape_keys = +neolight(layers)+neolight(escape_keys)
+      neolight:jp = +neolight(jp)
+    // END NEOLIGHT
+    .
+    w
+    EOF
+  '';
+
+  meta = {
+    maintainers = with lib.maintainers; [ drafolin ];
+    homepage = "https://github.com/mihi314/neolight";
+    description = "Neolight is a fork of the XKB layout for programming based on Neo";
+    license = lib.licenses.gpl3Plus;
+  };
+})


### PR DESCRIPTION
Packaged [neolight](github.com/mihi314/neolight) for nixos, depending on xkeyboard_config
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
