### PR TITLE
home-assistant: disable broken component tests

### DIFF
--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -60,6 +60,12 @@ let
       # outdated snapshot
       "tests/components/backup/test_sensors.py::test_sensors"
     ];
+    bosch_alarm = [
+      # outdated snapshots
+      "tests/components/bosch_alarm/test_binary_sensor.py::test_binary_sensor[None-solution_3000]"
+      "tests/components/bosch_alarm/test_binary_sensor.py::test_binary_sensor[None-amax_3000]"
+      "tests/components/bosch_alarm/test_binary_sensor.py::test_binary_sensor[None-b5512]"
+    ];
     bmw_connected_drive = [
       # outdated snapshot
       "tests/components/bmw_connected_drive/test_binary_sensor.py::test_entity_state_attrs"

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -105,6 +105,12 @@ let
     openai_conversation = [
       # outdated snapshot
       "tests/components/openai_conversation/test_conversation.py::test_function_call"
+      # Pydantic validation error
+      "tests/components/openai_conversation/test_conversation.py"
+      "tests/components/openai_conversation/test_ai_task.py"
+      # TypeError: object ImagesResponse can't be used in 'await' expression
+      "tests/components/openai_conversation/test_init.py::test_generate_image_service"
+      "tests/components/openai_conversation/test_init.py::test_generate_image_service_error"
     ];
     overseerr = [
       # imports broken future module

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -84,6 +84,13 @@ let
       # outdated snapshot in eve_weather_sensor variant
       "tests/components/matter/test_number.py::test_numbers"
     ];
+    minecraft_server = [
+      # FileNotFoundError: [Errno 2] No such file or directory: '/etc/resolv.conf'
+      "tests/components/minecraft_server/test_binary_sensor.py"
+      "tests/components/minecraft_server/test_diagnostics.py"
+      "tests/components/minecraft_server/test_init.py"
+      "tests/components/minecraft_server/test_sensor.py"
+    ];
     modem_callerid = [
       # aioserial mock produces wrong state
       "tests/components/modem_callerid/test_init.py::test_setup_entry"

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -95,6 +95,13 @@ let
       # aioserial mock produces wrong state
       "tests/components/modem_callerid/test_init.py::test_setup_entry"
     ];
+    nzbget = [
+      # type assertion fails due to introduction of parameterized type
+      "tests/components/nzbget/test_config_flow.py::test_user_form"
+      "tests/components/nzbget/test_config_flow.py::test_user_form_show_advanced_options"
+      "tests/components/nzbget/test_config_flow.py::test_user_form_cannot_connect"
+      "tests/components/nzbget/test_init.py::test_async_setup_raises_entry_not_ready"
+    ];
     openai_conversation = [
       # outdated snapshot
       "tests/components/openai_conversation/test_conversation.py::test_function_call"


### PR DESCRIPTION
Disabled broken tests

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
