### PR TITLE
markdown-oxide: 0.25.6 -> 0.25.8

### DIFF
--- a/pkgs/by-name/ma/markdown-oxide/package.nix
+++ b/pkgs/by-name/ma/markdown-oxide/package.nix
@@ -5,16 +5,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "markdown-oxide";
-  version = "0.25.6";
+  version = "0.25.8";
 
   src = fetchFromGitHub {
     owner = "Feel-ix-343";
     repo = "markdown-oxide";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GIwvypvfHwOmT5Y01Xho9ClD9PcY+K2PJAd5VPEIr/8=";
+    hash = "sha256-Y3xMiWnLHDVeRn1KbmsC/5yJWhukKFB6X9VHnuEkFU8=";
   };
 
-  cargoHash = "sha256-c6m/sbCbXIYQ5FMm7cdiuMJrX2iz64ZHFiiRuvSGu+Y=";
+  cargoHash = "sha256-M4LwkF031bv7aIC9aEh5bF6Vk/DJt3DH1Rh3dUNopX4=";
 
   meta = {
     description = "Markdown LSP server inspired by Obsidian";


### PR DESCRIPTION
Changelog: https://github.com/Feel-ix-343/markdown-oxide/releases/tag/v0.25.8
Diff: https://github.com/Feel-ix-343/markdown-oxide/compare/v0.25.6...v0.25.8

`--version` shows 0.25.6 because of upstream lag

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
