### PR TITLE
ruri: 3.8 -> 3.9.1

### DIFF
--- a/pkgs/by-name/ru/ruri/cmake-install.patch
+++ b/pkgs/by-name/ru/ruri/cmake-install.patch
@@ -1,0 +1,20 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -201,7 +201,7 @@
+     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+     add_library(ruri SHARED ${SOURCES})
+-    install (TARGETS ruri DESTINATION /usr/lib/)
++    install (TARGETS ruri)
+ else ()
+ # add the executable
+     set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
+@@ -215,7 +215,7 @@
+             VERBATIM
+         )
+     endif()
+-    install (TARGETS ruri DESTINATION /usr/bin/)
++    install (TARGETS ruri)
+ endif()
+ 
+ add_custom_target(

--- a/pkgs/by-name/ru/ruri/package.nix
+++ b/pkgs/by-name/ru/ruri/package.nix
@@ -4,36 +4,38 @@
   fetchFromGitHub,
   libcap,
   libseccomp,
+  cmake,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ruri";
-  version = "3.8";
+  version = "3.9.1";
 
   src = fetchFromGitHub {
-    owner = "Moe-hacker";
+    owner = "RuriOSS";
     repo = "ruri";
-    rev = "v${finalAttrs.version}";
-    fetchSubmodules = false;
-    sha256 = "sha256-gf+WJPGeLbMntBk8ryTSsV9L4J3N4Goh9eWBIBj5FA4=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-stM4hSLdSqmYUZ/XBD3Y1GylrrGRISlcy8LN07HREpQ=";
   };
+
+  patches = [
+    ./cmake-install.patch
+  ];
 
   buildInputs = [
     libcap
     libseccomp
   ];
 
-  installPhase = ''
-    runHook preInstall
-    install -Dm755 ruri $out/bin/ruri
-    runHook postInstall
-  '';
+  nativeBuildInputs = [
+    cmake
+  ];
 
   meta = {
     description = "Self-contained Linux container implementation";
     homepage = "https://wiki.crack.moe/ruri";
     downloadPage = "https://github.com/Moe-hacker/ruri";
-    changelog = "https://github.com/Moe-hacker/ruri/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/Moe-hacker/ruri/releases/tag/${finalAttrs.src.tag}";
     mainProgram = "ruri";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;


### PR DESCRIPTION
Release notes:
- https://github.com/RuriOSS/ruri/releases/tag/v3.9.0
- https://github.com/RuriOSS/ruri/releases/tag/v3.9.1

Changelog: https://github.com/RuriOSS/ruri/compare/v3.8...v3.9.1

Supersedes and closes https://github.com/NixOS/nixpkgs/pull/433118.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
