### PR TITLE
grpc: fix 1.74 build for darwin: drop redundant patch

### DIFF
--- a/pkgs/by-name/gr/grpc/package.nix
+++ b/pkgs/by-name/gr/grpc/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   fetchpatch,
-  fetchurl,
   buildPackages,
   cmake,
   zlib,
@@ -54,11 +53,6 @@ stdenv.mkDerivation rec {
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # fix build of 1.63.0 and newer on darwin: https://github.com/grpc/grpc/issues/36654
     ./dynamic-lookup-darwin.patch
-    # https://github.com/grpc/grpc/issues/39170
-    (fetchurl {
-      url = "https://raw.githubusercontent.com/rdhafidh/vcpkg/0ae97b7b81562bd66ab99d022551db1449c079f9/ports/grpc/00017-add-src-upb.patch";
-      hash = "sha256-0zaJqeCM90DTtUR6xCUorahUpiJF3D/KODYkUXQh2ok=";
-    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
**Note:** this seems to work but I do not currently have the resources to do more extensive checks. Please help test it!

grpc is currently failing on darwin with `duplicate symbols` on staging-next, see:
- log: https://hydra.nixos.org/build/304610081/nixlog/3 (x86) and https://hydra.nixos.org/build/305151253/nixlog/2 (arm)
- nix review reports: https://malob.github.io/nix-review-tools-reports/nixpkgs:staging-next/nixpkgs_staging-next_1817718.html

It seems that the patch to fix `undefined symbols` in c14ffc40d969a8e6967a849f5c140f8bacb85ab0 is now causing `duplicate symbols`. Removing the patch seems to fix the build:
- log of the successful build: https://github.com/bryango/nix-build-action/actions/runs/17018298955/job/48243790676
- Tested on top of 83e12d408046828916796f9a16c852f41e3bcb7f

This PR should cause no rebuild on linux.

Friendly ping @scraptux @vcunat for review!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
