### PR TITLE
odin2: 2.3.4 -> 2.4.1

### DIFF
--- a/pkgs/by-name/od/odin2/package.nix
+++ b/pkgs/by-name/od/odin2/package.nix
@@ -18,14 +18,14 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "odin2";
   version = "2.3.4";
 
   src = fetchFromGitHub {
     owner = "TheWaveWarden";
     repo = "odin2";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-N96Nb7G6hqfh8DyMtHbttl/fRZUkS8f2KfPSqeMAhHY=";
   };
@@ -89,4 +89,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ magnetophon ];
     mainProgram = "Odin2";
   };
-}
+})

--- a/pkgs/by-name/od/odin2/package.nix
+++ b/pkgs/by-name/od/odin2/package.nix
@@ -15,6 +15,7 @@
   libXrandr,
   libGL,
   gcc-unwrapped,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -77,6 +78,8 @@ stdenv.mkDerivation rec {
     cp -r LV2/Odin2.lv2 $out/lib/lv2
     cp -r CLAP/Odin2.clap $out/lib/clap
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Odin 2 Synthesizer Plugin";

--- a/pkgs/by-name/od/odin2/package.nix
+++ b/pkgs/by-name/od/odin2/package.nix
@@ -15,6 +15,8 @@
   libXrandr,
   libGL,
   gcc-unwrapped,
+  copyDesktopItems,
+  makeDesktopItem,
   nix-update-script,
 }:
 
@@ -33,6 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
+    copyDesktopItems
   ];
 
   buildInputs = [
@@ -71,13 +74,34 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   installPhase = ''
-    mkdir -p $out/bin $out/lib/vst3 $out/lib/lv2 $out/lib/clap
+    mkdir -p $out/bin $out/lib/vst3 $out/lib/lv2 $out/lib/clap $out/share/icons/hicolor/512x512/apps
     cd Odin2_artefacts/Release
     cp Standalone/Odin2 $out/bin
     cp -r VST3/Odin2.vst3 $out/lib/vst3
     cp -r LV2/Odin2.lv2 $out/lib/lv2
     cp -r CLAP/Odin2.clap $out/lib/clap
+    # There’s no application icon, so the vendor’s logo will have to do.
+    cp $src/manual/graphics/logo.png $out/share/icons/hicolor/512x512/apps/odin2.png
+    copyDesktopItems
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Odin2";
+      desktopName = "Odin 2";
+      comment = "Odin 2 Free Synthesizer";
+      icon = "odin2";
+      startupNotify = true;
+      categories = [
+        "AudioVideo"
+        "Audio"
+        "Midi"
+        "Music"
+      ];
+      dbusActivatable = false;
+      exec = "Odin2";
+    })
+  ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/od/odin2/package.nix
+++ b/pkgs/by-name/od/odin2/package.nix
@@ -20,20 +20,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "odin2";
-  version = "2.3.4";
+  version = "2.4.1";
 
   src = fetchFromGitHub {
     owner = "TheWaveWarden";
     repo = "odin2";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-N96Nb7G6hqfh8DyMtHbttl/fRZUkS8f2KfPSqeMAhHY=";
+    hash = "sha256-j/rZvBNBTDo2vwESXbGIXR89PHOI1HK8hvzV7y6dJHI=";
   };
-
-  postPatch = ''
-    sed '1i#include <utility>' -i \
-      libs/JUCELV2/modules/juce_gui_basics/windows/juce_ComponentPeer.h # gcc12
-  '';
 
   nativeBuildInputs = [
     cmake
@@ -63,6 +58,11 @@ stdenv.mkDerivation (finalAttrs: {
       "-lXrandr"
     ]
   );
+
+  # JUCE wants to write to $HOME/.{lv2,vst3}
+  preConfigure = ''
+    export HOME="$TMPDIR"
+  '';
 
   cmakeFlags = [
     "-DCMAKE_AR=${gcc-unwrapped}/bin/gcc-ar"


### PR DESCRIPTION
There’s been a new release, though I can’t seem to find any release notes anywhere.

Added a desktop file, since there’s a standalone executable in addition to the plugins.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
