### PR TITLE
qman: init at 1.5.1

### DIFF
--- a/pkgs/by-name/qm/qman/package.nix
+++ b/pkgs/by-name/qm/qman/package.nix
@@ -1,0 +1,174 @@
+{
+  bzip2,
+  cunit,
+  fetchFromGitHub,
+  groff,
+  lib,
+  man,
+  meson,
+  ncurses,
+  ninja,
+  nix-update-script,
+  pkg-config,
+  python3Packages,
+  stdenv,
+  versionCheckHook,
+  writeShellScript,
+  xdg-utils,
+  xz,
+  zlib,
+}:
+
+let
+  # On darwin, skip xdg-utils and just use /usr/bin/open
+  utils =
+    if stdenv.hostPlatform.isDarwin then
+      {
+        open = "/usr/bin/open";
+        email = writeShellScript "open-mailto" ''
+          uris=()
+          while (( $# )); do
+            uris+=mailto:"$1"
+            shift
+          done
+          /usr/bin/open "''${uris[@]}"
+        '';
+      }
+    else
+      {
+        open = lib.getExe' xdg-utils "xdg-open";
+        email = lib.getExe' xdg-utils "xdg-email";
+      };
+  /*
+    We substitute some paths into the manpage.  Sticking a full store
+    path with hash in there causes layout problems so we get rid of
+    the hash.
+  */
+  escapedPathForMan =
+    path:
+    lib.escapeShellArg (
+      /*
+        I don't know manpage syntax, but the existing paths in there
+        escape hyphens so we will too.
+      */
+      lib.replaceString "-" "\\-" (
+        let
+          result = builtins.match "${lib.escapeRegex builtins.storeDir}/[a-z0-9]{32}-(.*)" (toString path);
+        in
+        if result == null then toString path else "${builtins.storeDir}/…-${builtins.head result}"
+      )
+    );
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qman";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "plp13";
+    repo = "qman";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-z3ILbbwcCYZT8qabVaGnMCyZRag8djEI32i6G7cLL2A=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    python3Packages.cogapp
+  ];
+
+  buildInputs = [
+    bzip2
+    ncurses
+    xz
+    zlib
+  ];
+
+  doCheck = true;
+  checkInputs = [ cunit ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  # qman crashes if the TERM env var isn't present
+  versionCheckKeepEnvironment = [ "TERM" ];
+
+  mesonFlags = [
+    (lib.mesonEnable "tests" finalAttrs.doCheck)
+    /*
+      qman by default will install a config file into /etc/xdg/qman.
+      Rather than disable that, we're just redirecting that here,
+      because it also installs themes and we want the themes to be
+      available somewhere.  qman will still check
+      /etc/xdg/qman/qman.conf even with changing this, as long as we
+      remember to delete the qman.conf file it installs into the
+      configdir.
+    */
+    (lib.mesonOption "configdir" "${placeholder "out"}/etc/xdg/qman")
+  ];
+
+  postPatch = ''
+    patchShebangs --build src/qman_tests_list.sh
+
+    substituteInPlace src/config_def.py \
+      --replace-fail /usr/bin/man ${lib.getExe man} \
+      --replace-fail /usr/bin/groff ${lib.getExe' groff "groff"} \
+      --replace-fail /usr/bin/whatis ${lib.getExe' man "whatis"} \
+      --replace-fail /usr/bin/apropos ${lib.getExe' man "apropos"} \
+      --replace-fail /usr/bin/xdg-open ${utils.open} \
+      --replace-fail /usr/bin/xdg-email ${utils.email}
+
+    substituteInPlace man/qman.1 \
+      --replace-fail /usr/bin/man ${escapedPathForMan (lib.getExe man)} \
+      --replace-fail /usr/bin/groff ${escapedPathForMan (lib.getExe' groff "groff")} \
+      --replace-fail /usr/bin/whatis ${escapedPathForMan (lib.getExe' man "whatis")} \
+      --replace-fail /usr/bin/apropos ${escapedPathForMan (lib.getExe' man "apropos")} \
+      --replace-fail '/usr/bin/xdg\-open' ${escapedPathForMan utils.open} \
+      --replace-fail '/usr/bin/xdg\-email' ${escapedPathForMan utils.email}
+  '';
+
+  /*
+    Here's where we remember to remove the qman.conf file at our new
+    configdir, so that way /etc/xdg/qman/qman.conf and
+    /etc/qman/qman.conf will work.  That file does tweak a few
+    settings away from their defaults, but that means it better
+    matches its documentation (e.g. qman docs say mouse support is
+    disabled by default, but the sample qman.conf file it installs
+    enables it).
+  */
+  postInstall = ''
+    rm $out/etc/xdg/qman/qman.conf
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Modern man page viewer";
+    longDescription = ''
+      Unix manual pages are lovely.  They are concise, well-written,
+      complete, and downright useful.  However, the standard way of
+      accessing them from the command-line hasn't changed since the
+      early days.
+
+      Qman aims to change that.  It's a modern, full-featured manual
+      page viewer featuring hyperlinks, web browser like navigation, a
+      table of contents for each page, incremental search, on-line
+      help, and more.  It also strives to be fast and tiny, so that it
+      can be used everywhere.  For this reason, it's been written in
+      plain C and has only minimal dependencies.
+    '';
+    changelog = "https://github.com/plp13/qman/tree/${finalAttrs.src.tag}#new-in-this-version";
+    homepage = "https://github.com/plp13/qman";
+    license = lib.licenses.bsd2;
+    mainProgram = "qman";
+    maintainers = with lib.maintainers; [
+      kpbaks
+      lilyball
+      yiyu
+    ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
