### PR TITLE
_0xffff: init at 0.10

### DIFF
--- a/pkgs/by-name/_0/_0xffff/package.nix
+++ b/pkgs/by-name/_0/_0xffff/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libusb-compat-0_1,
+  versionCheckHook,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "0xFFFF";
+  version = "0.10";
+
+  src = fetchFromGitHub {
+    owner = "pali";
+    repo = "0xFFFF";
+    tag = finalAttrs.version;
+    hash = "sha256-RTpiH6OpC1hRbhLW5Em01oDQdpAZ/mfggCDLSUzOC9s=";
+  };
+
+  strictDeps = true;
+
+  buildInputs = [ libusb-compat-0_1 ];
+
+  installFlags = [
+    "DESTDIR=$(out)"
+    "PREFIX="
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "-h";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open Free Fiasco Firmware Flasher for Maemo devices";
+    homepage = "https://github.com/pali/0xFFFF";
+    changelog = "https://github.com/pali/0xFFFF/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "0xFFFF";
+  };
+})


### PR DESCRIPTION
Add 0xFFFF, a firmware flasher for Nokia phones.

Cc: @leandrofriedrich

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
