### PR TITLE
plex-desktop: switch to libxml2_13 that has patches for 5 CVEs

### DIFF
--- a/pkgs/by-name/pl/plex-desktop/package.nix
+++ b/pkgs/by-name/pl/plex-desktop/package.nix
@@ -57,6 +57,7 @@ let
     buildInputs = [
       elfutils
       ffmpeg_6-headless
+      libedit
       libpulseaudio
       libva
       libxkbcommon
@@ -105,8 +106,6 @@ let
       rm $out/lib/libEGL.so*
       rm $out/lib/libdrm.so*
       rm $out/lib/libdrm*
-
-      ln -s ${libedit}/lib/libedit.so.0 $out/lib/libedit.so.2
 
       # Keep dependencies where the version from nixpkgs is higher.
       cp usr/lib/x86_64-linux-gnu/libasound.so.2 $out/lib/libasound.so.2

--- a/pkgs/by-name/pl/plex-desktop/package.nix
+++ b/pkgs/by-name/pl/plex-desktop/package.nix
@@ -12,6 +12,7 @@
   libpulseaudio,
   libva,
   libxkbcommon,
+  libxml2_13,
   makeShellWrapper,
   minizip,
   nss,
@@ -59,6 +60,7 @@ let
       libpulseaudio
       libva
       libxkbcommon
+      libxml2_13
       minizip
       nss
       stdenv.cc.cc
@@ -116,7 +118,6 @@ let
       cp usr/lib/x86_64-linux-gnu/libtiff.so.5 $out/lib/libtiff.so.5
       cp usr/lib/x86_64-linux-gnu/libwebp.so.6 $out/lib/libwebp.so.6
       cp usr/lib/x86_64-linux-gnu/libxkbfile.so.1.0.2 $out/lib/libxkbfile.so.1
-      cp usr/lib/x86_64-linux-gnu/libxml2.so.2 $out/lib/libxml2.so.2
       cp usr/lib/x86_64-linux-gnu/libxslt.so.1.1.34 $out/lib/libxslt.so.1
 
       runHook postInstall


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Part of https://github.com/NixOS/nixpkgs/issues/434341

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
