### PR TITLE
nixos/cpu/amd: allow overriding microcode pkg

### DIFF
--- a/nixos/modules/hardware/cpu/amd-microcode.nix
+++ b/nixos/modules/hardware/cpu/amd-microcode.nix
@@ -4,6 +4,10 @@
   pkgs,
   ...
 }:
+
+let
+  cfg = config.hardware.cpu.amd;
+in
 {
   ###### interface
   options = {
@@ -16,12 +20,13 @@
       '';
     };
 
+    hardware.cpu.amd.microcodePackage = lib.mkPackageOption pkgs "microcode-amd" { };
   };
 
   ###### implementation
   config = lib.mkIf config.hardware.cpu.amd.updateMicrocode {
     # Microcode updates must be the first item prepended in the initrd
-    boot.initrd.prepend = lib.mkOrder 1 [ "${pkgs.microcode-amd}/amd-ucode.img" ];
+    boot.initrd.prepend = lib.mkOrder 1 [ "${cfg.microcodePackage}/amd-ucode.img" ];
   };
 
 }


### PR DESCRIPTION
As per the discussion in https://github.com/NixOS/nixpkgs/pull/413202#issuecomment-3191849162, let users decide which microcode to load.

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] with my configuration
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
