### PR TITLE
nixos/bcachefs: handle `/` (root filesystem) in autoScrub service

### DIFF
--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -228,8 +228,6 @@ in
         inherit assertions;
         # needed for systemd-remount-fs
         system.fsPackages = [ pkgs.bcachefs-tools ];
-        # FIXME: Remove this line when the LTS (default) kernel is at least version 6.7
-        boot.kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
         services.udev.packages = [ pkgs.bcachefs-tools ];
 
         systemd = {

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -316,7 +316,7 @@ in
             scrubTimer =
               fs:
               let
-                fs' = utils.escapeSystemdPath fs;
+                fs' = if fs == "/" then "root" else utils.escapeSystemdPath fs;
               in
               lib.nameValuePair "bcachefs-scrub-${fs'}" {
                 description = "regular bcachefs scrub timer on ${fs}";
@@ -336,7 +336,7 @@ in
             scrubService =
               fs:
               let
-                fs' = utils.escapeSystemdPath fs;
+                fs' = if fs == "/" then "root" else utils.escapeSystemdPath fs;
               in
               lib.nameValuePair "bcachefs-scrub-${fs'}" {
                 description = "bcachefs scrub on ${fs}";


### PR DESCRIPTION
Before: the service and timer name was like:

```
❯  systemctl status bcachefs-scrub--.service
○ bcachefs-scrub--.service - bcachefs scrub on /
     Loaded: loaded (/etc/systemd/system/bcachefs-scrub--.service; linked; preset: ignored)
     Active: inactive (dead)
TriggeredBy: ● bcachefs-scrub--.timer
```

After:

```
❯  systemctl status bcachefs-scrub--.service
Unit bcachefs-scrub--.service could not be found.

❯  systemctl status bcachefs-scrub-root.service
○ bcachefs-scrub-root.service - bcachefs scrub on /
     Loaded: loaded (/etc/systemd/system/bcachefs-scrub-root.service; linked; preset: ignored)
     Active: inactive (dead)
TriggeredBy: ● bcachefs-scrub-root.timer
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
- Tested, as applicable:
  - [x] Tested with my configuration
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
