### PR TITLE
hidviz: fix path of internal library

### DIFF
--- a/pkgs/by-name/hi/hidviz/package.nix
+++ b/pkgs/by-name/hi/hidviz/package.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     substituteInPlace libhidx/cmake_modules/Findasio.cmake --replace-fail '/usr/include/asio' '${lib.getDev asio}/include/asio'
+    substituteInPlace libhidx/libhidx/src/Connector.cc --replace-fail '/usr/local/libexec' "$out/libexec"
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
Before this update, `hidviz` could not find the binary of its own daemon process. By substituting the search path to point to the correct location in nix store, it now can find its own daemon. 

**before**: (When clicking on select device)
```sh
strace hidviz 2>&1|grep daemon
# access("/$[path from where `hidviz` was called]/../libhidx/libhidx_server_daemon/libhidx_server_daemon", X_OK) = -1 ENOENT (No such file or directory)
# access("/$[path from where `hidviz` was called]/../libexec/libhidx_server_daemon", X_OK) = -1 ENOENT (No such file or directory)
# access("/usr/local/libexec/libhidx_server_daemon", X_OK) = -1 ENOENT (No such file or directory)
# access("/usr/libexec/libhidx_server_daemon", X_OK) = -1 ENOENT (No such file or directory)
```
And there was a GUI error popup message.

**after**:
```sh
strace ./result/bin/hidviz 2>&1| grep daemon
# access("/$[path from where `hidviz` was called]/../libhidx/libhidx_server_daemon/libhidx_server_daemon", X_OK) = -1 ENOENT (No such file or directory)
# access("/$[path from where `hidviz` was called]/../libexec/libhidx_server_daemon", X_OK) = -1 ENOENT (No such file or directory)
# access("/nix/store/aq0sgajw3yxi0z4i63sjzwqd7zv2pr5h-hidviz-0.2.1/libexec/libhidx_server_daemon", X_OK) = 0
```
And the application works  :D

This error occured becuase `hidviz` searches in `/proc/self/cwd/../libexec/.....` which obviously doesn't work unless you are in some development environment for `hidviz` I guess, **or** alternatively in `/usr/local/libexec` **or** in `/usr/libexec` both of which don't work on NixOS.

---
**Tests**: 
There seem to not be any passthru tests? (Run in the local git repo, with the changes)
```sh
nix-build --attr pkgs.hidviz.passthru.tests
# error: attribute 'tests' in selection path 'pkgs.hidviz.passthru.tests' not found
```
The `nixpkgs-review pr https://github.com/NixOS/nixpkgs/pull/434489` seemed to output no errors.

---

> [!NOTE] 
> I tried to follow all the guidelines and I did read the docs but it's a whole lot and this is my first PR. I am happy for you to give me feedback.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
