### PR TITLE
flutter335: fix macos build

### DIFF
--- a/pkgs/development/compilers/flutter/versions/3_35/patches/fix-macos-build-macos-assemble-sh.patch
+++ b/pkgs/development/compilers/flutter/versions/3_35/patches/fix-macos-build-macos-assemble-sh.patch
@@ -1,0 +1,59 @@
+Fix for macOS build issue in Flutter >= 3.35
+
+Since version 3.35, the behavior of macos_assemble.sh and xcode_backend.sh
+is almost identical. This caused the same error for macOS that previously
+occurred for iOS.
+
+Derived from the iOS patch: ./fix-ios-build-xcode-backend-sh.patch
+
+Example error:
+```
+$ flutter run -d macos
+Launching lib/main.dart on macOS in debug mode...
+Target debug_unpack_macos failed: Error: Flutter failed to create a directory at "/<nix-store>/XXXX-flutter-3.35.1-unwrapped/bin/cache/artifacts".
+Please ensure that the SDK and/or project is installed in a location that has read/write permissions for the current user.
+Failed to copy Flutter framework.
+** BUILD FAILED **
+```
+
+---
+
+diff --git a/packages/flutter_tools/bin/macos_assemble.sh b/packages/flutter_tools/bin/macos_assemble.sh
+index 28acf8842..d0f2923df 100644
+--- a/packages/flutter_tools/bin/macos_assemble.sh
++++ b/packages/flutter_tools/bin/macos_assemble.sh
+@@ -13,29 +13,13 @@
+ # exit on error, or usage of unset var
+ set -euo pipefail
+ 
+-# Needed because if it is set, cd may print the path it changed to.
+-unset CDPATH
+-
+-function follow_links() (
+-  cd -P "$(dirname -- "$1")"
+-  file="$PWD/$(basename -- "$1")"
+-  while [[ -h "$file" ]]; do
+-    cd -P "$(dirname -- "$file")"
+-    file="$(readlink -- "$file")"
+-    cd -P "$(dirname -- "$file")"
+-    file="$PWD/$(basename -- "$file")"
+-  done
+-  echo "$file"
+-)
+-
+-PROG_NAME="$(follow_links "${BASH_SOURCE[0]}")"
+-BIN_DIR="$(cd "${PROG_NAME%/*}" ; pwd -P)"
+-FLUTTER_ROOT="$BIN_DIR/../../.."
+-DART="$FLUTTER_ROOT/bin/dart"
++# Run `dart ./xcode_backend.dart` with the dart from $FLUTTER_ROOT.
++dart="${FLUTTER_ROOT}/bin/dart"
++xcode_backend_dart="$(dirname "${BASH_SOURCE[0]}")/xcode_backend.dart"
+ 
+ # Main entry point.
+ if [[ $# == 0 ]]; then
+-  "$DART" "$BIN_DIR/xcode_backend.dart" "build" "macos"
++  exec "${dart}" "${xcode_backend_dart}" "build" "macos"
+ else
+-  "$DART" "$BIN_DIR/xcode_backend.dart" "$@" "macos"
++  exec "${dart}" "${xcode_backend_dart}" "$@" "macos"
+ fi


### PR DESCRIPTION
Fix for macOS build issue in Flutter >= 3.35

Since version 3.35, the behavior of macos_assemble.sh and xcode_backend.sh is almost identical. This caused the same error for macOS that previously occurred for iOS.

Derived from the iOS patch: [fix-ios-build-xcode-backend-sh.patch](https://github.com/nixos/nixpkgs/blob/2ad04a351806c8ee97d1c0b65ca4ca7bd8b4e37d/pkgs/development/compilers/flutter/versions/3_35/patches/fix-ios-build-xcode-backend-sh.patch)

Example error:
```
$ flutter run -d macos
Launching lib/main.dart on macOS in debug mode...
Target debug_unpack_macos failed: Error: Flutter failed to create a directory at "/<nix-store>/XXXX-flutter-3.35.1-unwrapped/bin/cache/artifacts".
Please ensure that the SDK and/or project is installed in a location that has read/write permissions for the current user.
Failed to copy Flutter framework.
** BUILD FAILED **
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
