### PR TITLE
rclone-ui: 1.0.4 -> 1.7.1

### DIFF
--- a/pkgs/by-name/rc/rclone-ui/package.nix
+++ b/pkgs/by-name/rc/rclone-ui/package.nix
@@ -20,26 +20,26 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rclone-ui";
-  version = "1.0.4";
+  version = "1.7.1";
 
   src = fetchFromGitHub {
     owner = "rclone-ui";
     repo = "rclone-ui";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KTi/vCHiZVRAmQAiVXSWHCTTv1NnsvM5UZg8cpuFbRQ=";
+    hash = "sha256-Rc3otUWcwzEjwDEe1NwWjqjlFK5/b59oKDOUzvvea00=";
   };
 
   npmDeps = fetchNpmDeps {
     name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
     inherit (finalAttrs) src;
     forceGitDeps = true;
-    hash = "sha256-18QkqqYS1kGY701FbFBHLvr5WBkJzxFgR9VMnydeelY=";
+    hash = "sha256-Rj0iv0TxOTnxpiHhA4gu2d9hdm3lhslZYvx4Jx1jmeU=";
   };
 
   cargoRoot = "src-tauri";
   buildAndTestSubdir = finalAttrs.cargoRoot;
 
-  cargoHash = "sha256-o21of2eS2KZtg1U1E6RwdaA8jGhEVzg7HkgOv1k5wxI=";
+  cargoHash = "sha256-OG0raNHwukMJkIlsmVvHVJ30FMhpxKeYjuyi6Clm104=";
 
   # Disable tauri bundle updater, can be removed when #389107 is merged
   patches = [ ./remove_updater.patch ];
@@ -78,6 +78,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Cross-platform desktop GUI for rclone & S3";
     homepage = "https://github.com/rclone-ui/rclone-ui";
+    downloadPage = "https://github.com/rclone-ui/rclone-ui";
     changelog = "https://github.com/rclone-ui/rclone-ui/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ genga898 ];

--- a/pkgs/by-name/rc/rclone-ui/remove_updater.patch
+++ b/pkgs/by-name/rc/rclone-ui/remove_updater.patch
@@ -1,23 +1,23 @@
 diff --git a/src-tauri/src/lib.rs b/src-tauri/src/lib.rs
-index 001faa3..2d7ae0c 100644
+index 04ea191..72d178d 100644
 --- a/src-tauri/src/lib.rs
 +++ b/src-tauri/src/lib.rs
-@@ -82,7 +82,6 @@ pub fn run() {
-     let _guard = minidump::init(&client);
+@@ -83,7 +83,6 @@ pub fn run() {
  	
      let mut app = tauri::Builder::default()
+         .plugin(tauri_plugin_clipboard_manager::init())
 -        .plugin(tauri_plugin_updater::Builder::new().build())
          .plugin(tauri_plugin_os::init())
          .plugin(tauri_plugin_notification::init())
          .plugin(tauri_plugin_process::init())
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index 4f9df22..58d6c06 100644
+index 8b1c89f..1705861 100644
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
-@@ -86,14 +86,9 @@
+@@ -86,16 +86,9 @@
                  "installMode": "both"
              },
-             "signCommand": "trusted-signing-cli %1 -e https://eus.codesigning.azure.net -a sign-1 -c Sign1"
+             "signCommand": "trusted-signing-cli -e https://eus.codesigning.azure.net -a sign-1 -c Sign1 -d Rclone %1"
 -        },
 -        "createUpdaterArtifacts": true
 +        }
@@ -25,7 +25,9 @@ index 4f9df22..58d6c06 100644
      "plugins": {
 -        "updater": {
 -            "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDIyNDFENEZGNjFDNTBGOEYKUldTUEQ4VmgvOVJCSWhVZmw0enhmcW1kWFk3TS9mMzBDRjVEZWdxKzQ5ZmRhTlYvT2gvdFNMbE8K",
--            "endpoints": ["https://github.com/FTCHD/rclone-ui/releases/latest/download/latest.json"]
+-            "endpoints": [
+-                "https://github.com/rclone-ui/rclone-ui/releases/latest/download/latest.json"
+-            ]
 -        },
          "fs": {
              "requireLiteralLeadingDot": false


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
