### PR TITLE
 qman: init at 0.15.0

### DIFF
--- a/pkgs/by-name/qm/qman/package.nix
+++ b/pkgs/by-name/qm/qman/package.nix
@@ -1,0 +1,94 @@
+{
+  lib,
+  stdenv,
+  meson,
+  ninja,
+  pkg-config,
+  cmake,
+  man,
+  groff,
+  xdg-utils,
+  fetchFromGitHub,
+  cogapp,
+  ncurses,
+  zlib,
+  bzip2,
+  xz,
+  cunit,
+  nix-update-script,
+  versionCheckHook,
+  testers,
+  qman,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qman";
+  version = "1.5.0";
+
+  src = fetchFromGitHub {
+    owner = "plp13";
+    repo = "qman";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-pgxRk3XSR+pqPlfL65BTLI3vvGTP0GooT5ovompbx7E=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+    cmake
+    cogapp
+  ];
+
+  buildInputs = [
+    ncurses
+    zlib
+    bzip2
+    xz
+    cunit
+  ];
+
+  # https://github.com/plp13/qman/blob/main/doc/BUILDING.md#meson-options
+  mesonFlags = [
+    (lib.mesonEnable "man-pages" true)
+    (lib.mesonEnable "gzip" true)
+    (lib.mesonEnable "bzip2" true)
+    (lib.mesonEnable "lzma" true)
+    (lib.mesonEnable "tests" true)
+    (lib.mesonEnable "docs" false)
+    (lib.mesonEnable "config" false)
+  ];
+
+  postPatch = ''
+    # qman uses absolute path lookups to find external programs such as `man`
+    # instead of traversing $PATH.
+    # https://github.com/plp13/qman/blob/v1.5.0/src/config_def.py#L180-L186
+    substituteInPlace ./src/config_def.py \
+      --replace-fail /usr/bin/man ${man}/bin/man \
+      --replace-fail /usr/bin/whatis ${man}/bin/whatis \
+      --replace-fail /usr/bin/apropos ${man}/bin/apropos \
+      --replace-fail /usr/bin/groff ${groff}/bin/groff \
+      --replace-fail /usr/bin/xdg-open ${xdg-utils}/bin/xdg-open \
+      --replace-fail /usr/bin/xdg-email ${xdg-utils}/bin/xdg-email
+
+    patchShebangs ./src/qman_tests_list.sh
+  '';
+
+  doCheck = true;
+
+  doInstallCheck = false;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion { package = qman; };
+  };
+
+  meta = {
+    description = "Modern TUI man page viewer";
+    homepage = "https://github.com/plp13/qman";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.kpbaks ];
+    mainProgram = "qman";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16212,4 +16212,8 @@ with pkgs;
   davis = callPackage ../by-name/da/davis/package.nix {
     php = php83; # https://github.com/tchapi/davis/issues/195
   };
+
+  qman = callPackage ../by-name/qm/qman/package.nix {
+    cogapp = python3Packages.cogapp;
+  };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add [qman](https://github.com/plp13/qman). A TUI to browse `man` pages.

Created as a draft PR, because I would like some guidance on how to make the `versionCheckHook` work. For reasons unknown to me the build fail when `doInstallCheck = true;`. But if I build the package using `nix-build --attr qman`, and then run

```bash
if [[ "$(./result/bin/qman --version)" =~ "1.5.0" ]]; then
  echo "version matches"
fi
```
it does succeed. From looking at the implementation of https://github.com/NixOS/nixpkgs/blob/d8fbefa0196ca295d8b1566a4409961c7816e432/pkgs/by-name/ve/versionCheckHook/hook.sh#L13-L24 it seems to do the same check, albeit with the command run in a modified environment using `env`.

I have added `passthru.tests.version` but I am unsure of how you can test it locally.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
