### PR TITLE
hyprmagnifier: init at unstable-2025-05-16

### DIFF
--- a/pkgs/by-name/hy/hyprmagnifier/package.nix
+++ b/pkgs/by-name/hy/hyprmagnifier/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
+  hyprwayland-scanner,
+  libxkbcommon,
+  pango,
+  libjpeg,
+  hyprutils,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation {
+  pname = "hyprmagnifier";
+  version = "0.0.1-unstable-2025-05-16";
+
+  src = fetchFromGitHub {
+    owner = "st0rmbtw";
+    repo = "hyprmagnifier";
+    rev = "ce05ed35a1a7f9df976be7ee604d291ddad9c91c";
+    hash = "sha256-vsQnL3R7lPKsUlDQKXirWMj/3qI377g7PkKlN+eVDTI=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    hyprwayland-scanner
+  ];
+
+  buildInputs = [
+    wayland
+    wayland-protocols
+    wayland-scanner
+    hyprwayland-scanner
+    libxkbcommon
+    pango
+    libjpeg
+    hyprutils
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "wlroots-compatible Wayland magnifier that does not suck";
+    homepage = "https://github.com/st0rmbtw/hyprmagnifier";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      matthewcroughan
+    ];
+    mainProgram = "hyprmagnifier";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x]  aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
