### PR TITLE
ci/github-script/prepare: init from actions/get-merge-commit

### DIFF
--- a/.github/actions/get-merge-commit/action.yml
+++ b/.github/actions/get-merge-commit/action.yml
@@ -35,50 +35,11 @@ runs:
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         script: |
-          for (const retryInterval of [5, 10, 20, 40, 80]) {
-            console.log("Checking whether the pull request can be merged...")
-            const prInfo = (await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number
-            })).data
-
-            if (prInfo.state != 'open') throw new Error ("PR is not open anymore.")
-
-            if (prInfo.mergeable == null) {
-              console.log(`GitHub is still computing whether this PR can be merged, waiting ${retryInterval} seconds before trying again...`)
-              await new Promise(resolve => setTimeout(resolve, retryInterval * 1000))
-              continue
-            }
-
-            let mergedSha, targetSha
-
-            if (prInfo.mergeable) {
-              console.log("The PR can be merged.")
-
-              mergedSha = prInfo.merge_commit_sha
-              targetSha = (await github.rest.repos.getCommit({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: prInfo.merge_commit_sha
-              })).data.parents[0].sha
-            } else {
-              console.log("The PR has a merge conflict.")
-
-              mergedSha = prInfo.head.sha
-              targetSha = (await github.rest.repos.compareCommitsWithBasehead({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                basehead: `${prInfo.base.sha}...${prInfo.head.sha}`
-              })).data.merge_base_commit.sha
-            }
-
-            console.log(`Checking the commits:\nmerged:${mergedSha}\ntarget:${targetSha}`)
-            core.setOutput('mergedSha', mergedSha)
-            core.setOutput('targetSha', targetSha)
-            return
-          }
-          throw new Error("Not retrying anymore. It's likely that GitHub is having internal issues: check https://www.githubstatus.com.")
+          require('./ci/github-script/prepare.js')({
+            github,
+            context,
+            core,
+          })
 
     - if: inputs.merged-as-untrusted && (inputs.mergedSha || steps.commits.outputs.mergedSha)
       # Would be great to do the checkouts in git worktrees of the existing spare checkout instead,

--- a/.github/actions/get-merge-commit/action.yml
+++ b/.github/actions/get-merge-commit/action.yml
@@ -35,8 +35,6 @@ runs:
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         script: |
-          if (context.eventName == 'push') return core.setOutput('mergedSha', context.sha)
-
           for (const retryInterval of [5, 10, 20, 40, 80]) {
             console.log("Checking whether the pull request can be merged...")
             const prInfo = (await github.rest.pulls.get({

--- a/.github/workflows/codeowners-v2.yml
+++ b/.github/workflows/codeowners-v2.yml
@@ -53,7 +53,9 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          sparse-checkout: .github/actions
+          sparse-checkout: |
+            .github/actions
+            ci/github-script
       - name: Check if the PR can be merged and checkout the merge and target commits
         uses: ./.github/actions/get-merge-commit
         with:

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -378,6 +378,7 @@ jobs:
       - name: Check if the PR can be merged and checkout the merge commit
         uses: ./.github/actions/get-merge-commit
         with:
+          mergedSha: ${{ inputs.mergedSha }}
           merged-as-untrusted: true
 
       - name: Install Nix

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions
+            ci/github-script
             ci/supportedBranches.js
             ci/supportedSystems.json
       - name: Check if the PR can be merged and get the test merge commit

--- a/ci/github-script/prepare.js
+++ b/ci/github-script/prepare.js
@@ -1,0 +1,46 @@
+module.exports = async function ({ github, context, core }) {
+  for (const retryInterval of [5, 10, 20, 40, 80]) {
+    console.log("Checking whether the pull request can be merged...")
+    const prInfo = (await github.rest.pulls.get({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: context.payload.pull_request.number
+    })).data
+
+    if (prInfo.state != 'open') throw new Error ("PR is not open anymore.")
+
+    if (prInfo.mergeable == null) {
+      console.log(`GitHub is still computing whether this PR can be merged, waiting ${retryInterval} seconds before trying again...`)
+      await new Promise(resolve => setTimeout(resolve, retryInterval * 1000))
+      continue
+    }
+
+    let mergedSha, targetSha
+
+    if (prInfo.mergeable) {
+      console.log("The PR can be merged.")
+
+      mergedSha = prInfo.merge_commit_sha
+      targetSha = (await github.rest.repos.getCommit({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        ref: prInfo.merge_commit_sha
+      })).data.parents[0].sha
+    } else {
+      console.log("The PR has a merge conflict.")
+
+      mergedSha = prInfo.head.sha
+      targetSha = (await github.rest.repos.compareCommitsWithBasehead({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        basehead: `${prInfo.base.sha}...${prInfo.head.sha}`
+      })).data.merge_base_commit.sha
+    }
+
+    console.log(`Checking the commits:\nmerged:${mergedSha}\ntarget:${targetSha}`)
+    core.setOutput('mergedSha', mergedSha)
+    core.setOutput('targetSha', targetSha)
+    return
+  }
+  throw new Error("Not retrying anymore. It's likely that GitHub is having internal issues: check https://www.githubstatus.com.")
+}

--- a/ci/github-script/prepare.js
+++ b/ci/github-script/prepare.js
@@ -1,46 +1,58 @@
-module.exports = async function ({ github, context, core }) {
+module.exports = async ({ github, context, core }) => {
   for (const retryInterval of [5, 10, 20, 40, 80]) {
-    console.log("Checking whether the pull request can be merged...")
-    const prInfo = (await github.rest.pulls.get({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      pull_number: context.payload.pull_request.number
-    })).data
+    console.log('Checking whether the pull request can be merged...')
+    const prInfo = (
+      await github.rest.pulls.get({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        pull_number: context.payload.pull_request.number,
+      })
+    ).data
 
-    if (prInfo.state != 'open') throw new Error ("PR is not open anymore.")
+    if (prInfo.state !== 'open') throw new Error('PR is not open anymore.')
 
     if (prInfo.mergeable == null) {
-      console.log(`GitHub is still computing whether this PR can be merged, waiting ${retryInterval} seconds before trying again...`)
-      await new Promise(resolve => setTimeout(resolve, retryInterval * 1000))
+      console.log(
+        `GitHub is still computing whether this PR can be merged, waiting ${retryInterval} seconds before trying again...`,
+      )
+      await new Promise((resolve) => setTimeout(resolve, retryInterval * 1000))
       continue
     }
 
     let mergedSha, targetSha
 
     if (prInfo.mergeable) {
-      console.log("The PR can be merged.")
+      console.log('The PR can be merged.')
 
       mergedSha = prInfo.merge_commit_sha
-      targetSha = (await github.rest.repos.getCommit({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        ref: prInfo.merge_commit_sha
-      })).data.parents[0].sha
+      targetSha = (
+        await github.rest.repos.getCommit({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          ref: prInfo.merge_commit_sha,
+        })
+      ).data.parents[0].sha
     } else {
-      console.log("The PR has a merge conflict.")
+      console.log('The PR has a merge conflict.')
 
       mergedSha = prInfo.head.sha
-      targetSha = (await github.rest.repos.compareCommitsWithBasehead({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        basehead: `${prInfo.base.sha}...${prInfo.head.sha}`
-      })).data.merge_base_commit.sha
+      targetSha = (
+        await github.rest.repos.compareCommitsWithBasehead({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          basehead: `${prInfo.base.sha}...${prInfo.head.sha}`,
+        })
+      ).data.merge_base_commit.sha
     }
 
-    console.log(`Checking the commits:\nmerged:${mergedSha}\ntarget:${targetSha}`)
+    console.log(
+      `Checking the commits:\nmerged:${mergedSha}\ntarget:${targetSha}`,
+    )
     core.setOutput('mergedSha', mergedSha)
     core.setOutput('targetSha', targetSha)
     return
   }
-  throw new Error("Not retrying anymore. It's likely that GitHub is having internal issues: check https://www.githubstatus.com.")
+  throw new Error(
+    "Not retrying anymore. It's likely that GitHub is having internal issues: check https://www.githubstatus.com.",
+  )
 }

--- a/ci/github-script/run
+++ b/ci/github-script/run
@@ -40,6 +40,17 @@ async function run(action, owner, repo, pull_number, dry = true) {
 }
 
 program
+  .command('prepare')
+  .description('Prepare relevant information of a pull request.')
+  .argument('<owner>', 'Owner of the GitHub repository to check (Example: NixOS)')
+  .argument('<repo>', 'Name of the GitHub repository to check (Example: nixpkgs)')
+  .argument('<pr>', 'Number of the Pull Request to check')
+  .action(async (owner, repo, pr) => {
+    const prepare = (await import('./prepare.js')).default
+    run(prepare, owner, repo, pr)
+  })
+
+program
   .command('commits')
   .description('Check commit structure of a pull request.')
   .argument('<owner>', 'Owner of the GitHub repository to check (Example: NixOS)')


### PR DESCRIPTION
I'm currently working on extending the `prepare` step with "branch verification" similar to https://github.com/NixOS/nixpkgs/blob/master/ci/request-reviews/verify-base-branch.sh, just for the whole PR, not just code owners.

This is some preparatory work to be able to iterate on the `prepare` / `get-merge-commit` JavaScript code locally and a few smaller refactors.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
