### PR TITLE
lelwel: init at 0.10.0

### DIFF
--- a/pkgs/by-name/le/lelwel/package.nix
+++ b/pkgs/by-name/le/lelwel/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "lelwel";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "0x2a-42";
+    repo = "lelwel";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-l1817wl0x7mkgHRKxFhoPUUW1gPzfwpvP+4eEjEZrz8=";
+  };
+
+  cargoHash = "sha256-KRQCO7rmqM4mEm+qtTXar2vTcaYiHFI5hekT6Oq/xEE=";
+
+  buildFeatures = [
+    "cli"
+    "lsp"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "Resilient LL(1) parser generator for Rust";
+    longDescription = ''
+      Lelwel (Language for Extended LL(1) parsing With Error
+      resilience and Lossless syntax trees) generates recursive
+      descent parsers for Rust using LL(1) grammars with extensions
+      for direct left recursion, operator precedence, semantic
+      predicates, semantic actions, and a restricted ordered choice.
+    '';
+    homepage = "https://github.com/0x2a-42/lelwel";
+    changelog = "https://github.com/0x2a-42/lelwel/releases/tag/v${finalAttrs.version}";
+    mainProgram = "llw";
+    maintainers = with lib.maintainers; [ kpbaks ];
+    license = with lib.licenses; [
+      asl20 # OR
+      mit
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[lelwel](https://github.com/0x2a-42/lelwel) is a resilient LL(1) parser generator for Rust.

The derivation outputs two binaries:
- `$out/bin/llw` Generate Rust code from lelwel grammar files.
- `$out/bin/lelwel-ls` an LSP server for lelwel grammar files.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
