### PR TITLE
treewide: Fix `finalAttrs.doCheck` by explicitly setting doCheck to the conditional in mkDerivation

### DIFF
--- a/pkgs/applications/blockchains/bitcoin-knots/default.nix
+++ b/pkgs/applications/blockchains/bitcoin-knots/default.nix
@@ -134,7 +134,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [ python3 ];
 
-  doCheck = true;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   checkFlags = [
     "LC_ALL=en_US.UTF-8"

--- a/pkgs/applications/blockchains/bitcoin/default.nix
+++ b/pkgs/applications/blockchains/bitcoin/default.nix
@@ -172,7 +172,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [ python3 ];
 
-  doCheck = true;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   checkFlags = [
     "LC_ALL=en_US.UTF-8"

--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -359,7 +359,7 @@ lib.extendMkDerivation {
           ''
         );
 
-      doCheck = args.doCheck or true;
+      doCheck = args.doCheck or (stdenv.buildPlatform.canExecute stdenv.hostPlatform);
       checkPhase =
         args.checkPhase or ''
           runHook preCheck

--- a/pkgs/by-name/fe/feedbackd-device-themes/package.nix
+++ b/pkgs/by-name/fe/feedbackd-device-themes/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonOption "validate" (if finalAttrs.doCheck then "enabled" else "disabled"))
   ];
 
-  doCheck = true;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/by-name/gs/gsl-lite/package.nix
+++ b/pkgs/by-name/gs/gsl-lite/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Building tests is broken on Darwin.
-  doCheck = !stdenv.hostPlatform.isDarwin;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform && !stdenv.hostPlatform.isDarwin;
 
   meta = {
     description = "Single-file header-only version of ISO C++ GSL";

--- a/pkgs/by-name/gz/gz-cmake/package.nix
+++ b/pkgs/by-name/gz/gz-cmake/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [ python3 ];
 
-  doCheck = true;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   # Extract the version by matching the tag's prefix.
   passthru.updateScript = nix-update-script {

--- a/pkgs/by-name/in/iniparser/package.nix
+++ b/pkgs/by-name/in/iniparser/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "BUILD_TESTING" finalAttrs.doCheck)
   ];
-  doCheck = true;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   nativeCheckInputs = [
     ruby
     ctestCheckHook

--- a/pkgs/by-name/li/libvncserver/package.nix
+++ b/pkgs/by-name/li/libvncserver/package.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
   ];
 
-  doCheck = enableShared;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform && enableShared;
 
   meta = with lib; {
     description = "VNC server library";

--- a/pkgs/by-name/nl/nlopt/package.nix
+++ b/pkgs/by-name/nl/nlopt/package.nix
@@ -130,7 +130,7 @@ clangStdenv.mkDerivation (finalAttrs: {
       --no-directory-urls
   '';
 
-  doCheck = true;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   postFixup = ''
     substituteInPlace $out/lib/cmake/nlopt/NLoptLibraryDepends.cmake --replace-fail \

--- a/pkgs/by-name/so/sobjectizer/package.nix
+++ b/pkgs/by-name/so/sobjectizer/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # The tests require the shared library thanks to the patch.
-  doCheck = withShared;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform && withShared;
 
   # Receive semi-automated updates.
   passthru.updateScript = pkgs.nix-update-script { };

--- a/pkgs/by-name/tp/tpm2-pkcs11/package.nix
+++ b/pkgs/by-name/tp/tpm2-pkcs11/package.nix
@@ -158,7 +158,7 @@ chosenStdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
-  doCheck = true;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   dontStrip = true;
   dontPatchELF = true;
 

--- a/pkgs/by-name/z3/z3/package.nix
+++ b/pkgs/by-name/z3/z3/package.nix
@@ -103,7 +103,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "Z3_JAVA_JAR_INSTALLDIR" "${placeholder "java"}/share/java")
   ];
 
-  doCheck = true;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   checkPhase = ''
     runHook preCheck
 

--- a/pkgs/development/cuda-modules/packages/cudnn-frontend/package.nix
+++ b/pkgs/development/cuda-modules/packages/cudnn-frontend/package.nix
@@ -99,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
     nlohmann_json
   ];
 
-  doCheck = true;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   postInstall = optionalString finalAttrs.doCheck ''
     moveToOutput "bin/legacy_samples" "$legacy_samples"

--- a/pkgs/tools/system/nvtop/build-nvtop.nix
+++ b/pkgs/tools/system/nvtop/build-nvtop.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
     + (lib.optionalString nvidia "addDriverRunpath $out/bin/nvtop");
 
   # https://github.com/Syllo/nvtop/commit/33ec008e26a00227a666ccb11321e9971a50daf8
-  doCheck = !stdenv.hostPlatform.isDarwin;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform && !stdenv.hostPlatform.isDarwin;
 
   passthru = {
     tests.version = testers.testVersion {


### PR DESCRIPTION
`finalAttrs.doCheck` does not include the conditionals in `mkDerivation` which disable `doCheck` on `!canExecute` cross.

This is better than changing all `finalAttrs.doCheck` to
`finalAttrs.finalPackage.doCheck` because it works without conditional
`outputs` and it addresses the comment in `mkDerivation` about not using
`doCheck = true`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
