### PR TITLE
elmerfem: use qt6Packages

### DIFF
--- a/pkgs/by-name/el/elmerfem/package.nix
+++ b/pkgs/by-name/el/elmerfem/package.nix
@@ -11,9 +11,9 @@
   libGL,
   libGLU,
   opencascade-occt,
-  libsForQt5,
+  qt6Packages,
   tbb,
-  vtkWithQt5,
+  vtkWithQt6,
   llvmPackages,
 }:
 stdenv.mkDerivation rec {
@@ -33,21 +33,20 @@ stdenv.mkDerivation rec {
     cmake
     gfortran
     pkg-config
-    libsForQt5.wrapQtAppsHook
+    qt6Packages.wrapQtAppsHook
   ];
 
   buildInputs = [
     mpi
     blas
     liblapack
-    libsForQt5.qtbase
-    libsForQt5.qtscript
-    libsForQt5.qwt
+    qt6Packages.qtbase
+    qt6Packages.qwt
     libGL
     libGLU
     opencascade-occt
     tbb
-    vtkWithQt5
+    vtkWithQt6
   ]
   ++ lib.optional stdenv.cc.isClang llvmPackages.openmp;
 
@@ -68,7 +67,10 @@ stdenv.mkDerivation rec {
     (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
     (lib.cmakeFeature "CMAKE_INSTALL_INCLUDEDIR" "include")
     (lib.cmakeFeature "CMAKE_OpenGL_GL_PREFERENCE" "GLVND")
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     (lib.cmakeBool "USE_MACOS_PACKAGE_MANAGER" false)
+    (lib.cmakeFeature "QWT_INCLUDE_DIR" "${qt6Packages.qwt}/lib/qwt.framework/Headers")
   ];
 
   meta = with lib; {

--- a/pkgs/by-name/el/elmerfem/package.nix
+++ b/pkgs/by-name/el/elmerfem/package.nix
@@ -55,22 +55,20 @@ stdenv.mkDerivation rec {
     patchShebangs ./
   '';
 
-  storepath = placeholder "out";
-
   NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
 
   cmakeFlags = [
-    "-DELMER_INSTALL_LIB_DIR=${storepath}/lib"
-    "-DWITH_OpenMP:BOOLEAN=TRUE"
-    "-DWITH_MPI:BOOLEAN=TRUE"
-    "-DWITH_QT5:BOOLEAN=TRUE"
-    "-DWITH_OCC:BOOLEAN=TRUE"
-    "-DWITH_VTK:BOOLEAN=TRUE"
-    "-DWITH_ELMERGUI:BOOLEAN=TRUE"
-    "-DCMAKE_INSTALL_LIBDIR=lib"
-    "-DCMAKE_INSTALL_INCLUDEDIR=include"
-    "-DCMAKE_OpenGL_GL_PREFERENCE=GLVND"
-    "-DUSE_MACOS_PACKAGE_MANAGER=False"
+    (lib.cmakeFeature "ELMER_INSTALL_LIB_DIR" "${placeholder "out"}/lib")
+    (lib.cmakeBool "WITH_OpenMP" true)
+    (lib.cmakeBool "WITH_MPI" true)
+    (lib.cmakeBool "WITH_QT6" true)
+    (lib.cmakeBool "WITH_OCC" true)
+    (lib.cmakeBool "WITH_VTK" true)
+    (lib.cmakeBool "WITH_ELMERGUI" true)
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
+    (lib.cmakeFeature "CMAKE_INSTALL_INCLUDEDIR" "include")
+    (lib.cmakeFeature "CMAKE_OpenGL_GL_PREFERENCE" "GLVND")
+    (lib.cmakeBool "USE_MACOS_PACKAGE_MANAGER" false)
   ];
 
   meta = with lib; {


### PR DESCRIPTION
prepare for droping vtkWithQt5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
