### PR TITLE
python313Packages.pylibjpeg-libjpeg: unvendor libjpeg source

### DIFF
--- a/pkgs/by-name/li/libjpeg-tools/package.nix
+++ b/pkgs/by-name/li/libjpeg-tools/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libjpeg-tools";
+  version = "1.71";
+
+  src = fetchFromGitHub {
+    owner = "thorfdbg";
+    repo = "libjpeg";
+    rev = "25f71280913fde7400801772bbf885bb3e873242";
+    hash = "sha256-40yb9EujJp9y1PnuYLcPxK31Kj2Q4UQ5YBwXQFYXI/Y=";
+  };
+
+  outputs = [
+    "out"
+    "lib"
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    make lib
+    make final
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -m755 -D jpeg $out/bin/jpeg
+    install -m644 -D libjpeg.so $lib/lib/libjpeg
+    runHook postInstall
+  '';
+
+  doCheck = false; # no tests
+
+  meta = {
+    description = "A complete implementation of 10918-1 (JPEG) coming from jpeg.org (the ISO group) with extensions for HDR, lossless and alpha channel coding standardized as ISO/IEC 18477 (JPEG XT)";
+    homepage = "https://github.com/thorfdbg/libjpeg";
+    license = with lib.licenses; [ gpl3 ];
+    changelog = "https://github.com/thorfdbg/libjpeg/README.history";
+    maintainers = with lib.maintainers; [ bcdarwin ];
+    platforms = lib.platforms.unix;
+    mainProgram = "jpeg";
+    # clang build fails with "ld: symbol(s) not found for architecture arm64" (on aarch64-darwin)
+    broken = stdenv.hostPlatform.isDarwin;
+  };
+})

--- a/pkgs/development/python-modules/pylibjpeg-libjpeg/default.nix
+++ b/pkgs/development/python-modules/pylibjpeg-libjpeg/default.nix
@@ -11,6 +11,7 @@
   pydicom,
   pylibjpeg-data,
   pylibjpeg,
+  libjpeg-tools,
 }:
 
 let
@@ -25,13 +26,15 @@ let
       owner = "pydicom";
       repo = "pylibjpeg-libjpeg";
       tag = "v${self.version}";
-      hash = "sha256-xqSA1cutTsH9k4l9CW96n/CURzkAyDi3PZylZeedVjA=";
-      fetchSubmodules = true;
+      hash = "sha256-P01pofPLTOa5ynsCkLnxiMzVfCg4tbT+/CcpPTeSViw=";
     };
 
     postPatch = ''
       substituteInPlace pyproject.toml \
         --replace-fail 'poetry-core >=1.8,<2' 'poetry-core'
+      rmdir lib/libjpeg
+      cp -r ${libjpeg-tools.src} lib/libjpeg
+      chmod u+w lib/libjpeg
     '';
 
     build-system = [


### PR DESCRIPTION
libjpeg-tools: init at 1.71

Init yet another [libjpeg](https://github.com/thorfdbg/libjpeg) as `libjpeg-tools` (Debian's name for this package; Repology calls it `libjpeg-thorfdbg`) and use this to unvendor (or technically re-vendor) the libjpeg source in `python313Packages.pylibjpeg-libjpeg`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
