### PR TITLE
nixosTests.jellyseerr: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -771,6 +771,7 @@ in
   isso = runTest ./isso.nix;
   jackett = runTest ./jackett.nix;
   jellyfin = runTest ./jellyfin.nix;
+  jellyseerr = runTest ./jellyseerr.nix;
   jenkins = runTest ./jenkins.nix;
   jenkins-cli = runTest ./jenkins-cli.nix;
   jibri = runTest ./jibri.nix;

--- a/nixos/tests/jellyseerr.nix
+++ b/nixos/tests/jellyseerr.nix
@@ -1,0 +1,18 @@
+{ lib, ... }:
+{
+  name = "jellyseerr";
+  meta.maintainers = with lib.maintainers; [ matteopacini ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.jellyseerr.enable = true;
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("jellyseerr.service")
+    machine.wait_for_open_port(5055)
+    machine.succeed("curl --fail http://localhost:5055/")
+  '';
+}

--- a/pkgs/by-name/je/jellyseerr/package.nix
+++ b/pkgs/by-name/je/jellyseerr/package.nix
@@ -9,6 +9,7 @@
   python3Packages,
   sqlite,
   nix-update-script,
+  nixosTests,
 }:
 
 let
@@ -78,7 +79,10 @@ stdenv.mkDerivation (finalAttrs: {
       --set NODE_ENV production
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    inherit (nixosTests) jellyseerr;
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Fork of overseerr for jellyfin support";


### PR DESCRIPTION
Added simple test for Jellyseerr to make things slightly more robust

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
