### PR TITLE
hid-fanatecff: Init at 0.2.2

### DIFF
--- a/nixos/modules/hardware/hid-fanatecff.nix
+++ b/nixos/modules/hardware/hid-fanatecff.nix
@@ -1,0 +1,19 @@
+{ lib, config, ... }:
+
+let
+  cfg = config.hardware.hid-fanatecff;
+  inherit (config.boot.kernelPackages) hid-fanatecff;
+  inherit (lib) maintainers mkEnableOption mkIf;
+in
+{
+  options.hardware.hid-fanatecff = {
+    enable = mkEnableOption "hid-fanatecff, a Linux kernel driver that aims to add support for Fanatec devices";
+  };
+
+  config = mkIf cfg.enable {
+    boot.extraModulePackages = [ hid-fanatecff ];
+    services.udev.packages = [ hid-fanatecff ];
+  };
+
+  meta.maintainers = with maintainers; [ rake5k ];
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -73,6 +73,7 @@
   ./hardware/gpgsmartcards.nix
   ./hardware/graphics.nix
   ./hardware/hackrf.nix
+  ./hardware/hid-fanatecff.nix
   ./hardware/i2c.nix
   ./hardware/infiniband.nix
   ./hardware/inputmodule.nix

--- a/pkgs/os-specific/linux/hid-fanatecff/default.nix
+++ b/pkgs/os-specific/linux/hid-fanatecff/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  kernel,
+  kernelModuleMakeFlags,
+  bashNonInteractive,
+  linuxConsoleTools,
+  nix-update-script,
+}:
+
+let
+  moduleDir = "lib/modules/${kernel.modDirVersion}/kernel/drivers/hid";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hid-fanatecff";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "gotzl";
+    repo = "hid-fanatecff";
+    tag = finalAttrs.version;
+    hash = "sha256-aVuTnrxw7zWMZ1U21DUKDvcYlIp7iHJHaX8ijmUd/TE=";
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  postPatch = ''
+    mkdir -p $out/{lib/udev/rules.d,${moduleDir}}
+
+    sed -i '/depmod/d' Makefile
+    substituteInPlace Makefile \
+      --replace-fail '/etc/udev/rules.d' "$out/lib/udev/rules.d"
+
+    substituteInPlace fanatec.rules \
+      --replace-fail '/usr/bin/evdev-joystick' '${lib.getExe' linuxConsoleTools "evdev-joystick"}' \
+      --replace-fail '/bin/sh' '${lib.getExe bashNonInteractive}'
+  '';
+
+  makeFlags = kernelModuleMakeFlags ++ [
+    "KVERSION=${kernel.modDirVersion}"
+    "KERNEL_SRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "MODULEDIR=$(out)/${moduleDir}"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Linux module driver for Fanatec driving wheels";
+    homepage = "https://github.com/gotzl/hid-fanatecff";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ rake5k ];
+    platforms = lib.platforms.linux;
+    mainProgram = "hid-fanatecff";
+  };
+})

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -481,6 +481,8 @@ in
 
         nct6687d = callPackage ../os-specific/linux/nct6687d { };
 
+        hid-fanatecff = callPackage ../os-specific/linux/hid-fanatecff { };
+
         new-lg4ff = callPackage ../os-specific/linux/new-lg4ff { };
 
         zenergy = callPackage ../os-specific/linux/zenergy { };


### PR DESCRIPTION
New package for https://github.com/gotzl/hid-fanatecff, a driver for Fanatec driving wheels and a NixOS module for enabling it.

Fixes #271117

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
