### PR TITLE
python3Packages.google-cloud-datacatalog: use gitUpdater due to monorepo

### DIFF
--- a/pkgs/development/python-modules/google-cloud-datacatalog/default.nix
+++ b/pkgs/development/python-modules/google-cloud-datacatalog/default.nix
@@ -2,11 +2,11 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  gitUpdater,
   google-api-core,
   grpc-google-iam-v1,
   libcst,
   mock,
-  nix-update-script,
   proto-plus,
   protobuf,
   pytest-asyncio,
@@ -47,11 +47,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "google.cloud.datacatalog" ];
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--version-regex"
-      "google-cloud-datacatalog-v([0-9.]+)"
-    ];
+  passthru = {
+    # python update script sets the wrong tag
+    skipBulkUpdate = true;
+    updateScript = gitUpdater {
+      rev-prefix = "google-cloud-datacatalog-v";
+    };
   };
 
   meta = {

--- a/quash
+++ b/quash
@@ -1,0 +1,7 @@
+[1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mstluyuq[39m [38;5;3mseclark@nextquestion.net[39m [38;5;14m2025-08-21 16:50:29[39m [38;5;12m37[38;5;8m337e31[39m[0m
+│  [1m[38;5;3m(no description set)[39m[0m
+○  [1m[38;5;5mp[0m[38;5;8mowlmqll[39m [38;5;3mseclark@nextquestion.net[39m [38;5;6m2025-08-17 16:07:21[39m [38;5;5mdatacatalog-updater[39m [38;5;2mgit_head()[39m [1m[38;5;4m3a[0m[38;5;8m5998af[39m
+│  python3Packages.google-cloud-datacatalog: use gitUpdater due to monorepo
+[1m[38;5;14m◆[0m  [1m[38;5;5mv[0m[38;5;8mrkxnlny[39m [38;5;3mpyrox@pyrox.dev[39m [38;5;6m2025-08-17 07:58:20[39m [1m[38;5;4m32[0m[38;5;8me53310[39m
+│  [38;5;2m(empty)[39m dendrite: 0.14.1 -> 0.15.2 (#433879)
+~


### PR DESCRIPTION
`python3Packages.google-cloud-datacatalog` is in the `google-cloud-python` monorepo. Since that repo releases packages at high frequency, any one of them can go unrecognized by `nix-update-script` (which uses a fairly small window when looking at releases). Using `gitUpdater` is more robust in these cases.

1. `nix-update-script` -> `gitUpdater`
2. `skipBulkUpdates = true` to sidestep a problem with `python-library-updater`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
