### PR TITLE
rusk: init at 0.1.1

### DIFF
--- a/pkgs/by-name/ru/rusk/package.nix
+++ b/pkgs/by-name/ru/rusk/package.nix
@@ -1,0 +1,36 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  rustPlatform,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rusk";
+  version = "0.6.10";
+
+  src = fetchFromGitHub {
+    owner = "tagirov";
+    repo = "rusk";
+    tag = finalAttrs.version;
+    hash = "sha256-gZTnevMzn/L26OoDdYb/i3vL3xcM72cuNht3NU5G7TA=";
+  };
+
+  cargoHash = "sha256-LZUVajVyPIPBWz/9aNOBlVqeLS7OVfbJfT2qDhznPOY=";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  doCheck = false; # FIXME: https://github.com/tagirov/rusk/issues/8
+
+  meta = {
+    description = "Minimal terminal task manager";
+    homepage = "https://github.com/tagirov/rusk";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "rusk";
+  };
+})


### PR DESCRIPTION
Currently using my fork before upstream PR gets merged

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
