### PR TITLE
{twitter-color-emoji,noto-fonts-color-emoji}: Enable `strictDeps`, Fix cross

### DIFF
--- a/pkgs/by-name/no/noto-fonts-color-emoji/package.nix
+++ b/pkgs/by-name/no/noto-fonts-color-emoji/package.nix
@@ -3,6 +3,7 @@
   stdenvNoCC,
   fetchFromGitHub,
   buildPackages,
+  python3Packages,
   pkg-config,
   cairo,
   imagemagick,
@@ -23,6 +24,8 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-GYBnMpSUDNjAOZtbRPSmbW39TWP5ljEMukQRwq4J9U4=";
   };
 
+  strictDeps = true;
+
   depsBuildBuild = [
     buildPackages.stdenv.cc
     pkg-config
@@ -35,7 +38,7 @@ stdenvNoCC.mkDerivation rec {
     nototools
     pngquant
     which
-    buildPackages.python3.pkgs.fonttools
+    python3Packages.fonttools
   ];
 
   postPatch = ''

--- a/pkgs/by-name/tw/twitter-color-emoji/package.nix
+++ b/pkgs/by-name/tw/twitter-color-emoji/package.nix
@@ -3,16 +3,8 @@
 
 {
   lib,
-  stdenv,
+  stdenvNoCC,
   fetchFromGitHub,
-  cairo,
-  imagemagick,
-  nototools,
-  pkg-config,
-  pngquant,
-  python3,
-  which,
-  zopfli,
   noto-fonts-color-emoji,
 }:
 
@@ -27,7 +19,7 @@ let
     hash = "sha256-FLOqXDpSFyClBlG5u3IRL0EKeu1mckCfRizJh++IWxo=";
   };
 in
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "twitter-color-emoji";
   inherit version;
 
@@ -43,16 +35,7 @@ stdenv.mkDerivation rec {
     mv ${twemojiSrc.name} ${noto-fonts-color-emoji.src.name}
   '';
 
-  nativeBuildInputs = [
-    cairo
-    python3.pkgs.fonttools
-    imagemagick
-    nototools
-    pkg-config
-    pngquant
-    which
-    zopfli
-  ];
+  inherit (noto-fonts-color-emoji) strictDeps depsBuildBuild nativeBuildInputs;
 
   postPatch =
     let


### PR DESCRIPTION
twitter-color-emoji is already copying some attrs from noto-fonts-color-emoji so let's copy the deps too to fix cross.

Cleanup the `buildPackages.python3.pkgs` by using `python3Packages` which is spliced.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
