### PR TITLE
naps2: 7.5.3 -> 8.2.1

### DIFF
--- a/pkgs/by-name/na/naps2/01-donate-button.patch
+++ b/pkgs/by-name/na/naps2/01-donate-button.patch
@@ -1,0 +1,14 @@
+diff --git a/NAPS2.Lib/EtoForms/Ui/AboutForm.cs b/NAPS2.Lib/EtoForms/Ui/AboutForm.cs
+--- a/NAPS2.Lib/EtoForms/Ui/AboutForm.cs
++++ b/NAPS2.Lib/EtoForms/Ui/AboutForm.cs
+@@ -26,8 +26,8 @@ public class AboutForm : EtoDialogBase
+         _donateButton = C.Button(UiStrings.Donate, () => ProcessHelper.OpenUrl(DONATE_URL));
+         _donateButton.BackgroundColor = Color.FromRgb(0xfeda96);
+         _donateButton.TextColor = Color.FromRgb(0x1b464e);
+-        _donateButton.Font = new Font(_donateButton.Font.Family, _donateButton.Font.Size * 11 / 10,
+-            FontStyle.Italic | FontStyle.Bold);
++        try { _donateButton.Font = new Font(_donateButton.Font.Family, _donateButton.Font.Size * 11 / 10,
++            FontStyle.Italic | FontStyle.Bold); } catch {};
+         EtoPlatform.Current.ConfigureDonateButton(_donateButton);
+ 
+         _enableDebugLogging.Checked = config.Get(c => c.EnableDebugLogging);

--- a/pkgs/by-name/na/naps2/02-button-dpi.patch
+++ b/pkgs/by-name/na/naps2/02-button-dpi.patch
@@ -1,0 +1,14 @@
+diff --git a/NAPS2.Lib/EtoForms/Layout/C.cs b/NAPS2.Lib/EtoForms/Layout/C.cs
+--- a/NAPS2.Lib/EtoForms/Layout/C.cs
++++ b/NAPS2.Lib/EtoForms/Layout/C.cs
+@@ -121,8 +121,8 @@ public static class C
+         if (flags.HasFlag(ButtonFlags.LargeText))
+         {
+             var baseFontSize = button.Font.Size;
+-            EtoPlatform.Current.AttachDpiDependency(button,
+-                _ => button.Font = new Font(button.Font.Family, baseFontSize * 4 / 3));
++            EtoPlatform.Current.AttachDpiDependency(button, _ => {
++                try { button.Font = new Font(button.Font.Family, baseFontSize * 4 / 3); } catch {}});
+         }
+         EtoPlatform.Current.ConfigureImageButton(button, flags);
+         return button;

--- a/pkgs/by-name/na/naps2/deps.json
+++ b/pkgs/by-name/na/naps2/deps.json
@@ -161,6 +161,11 @@
   },
   {
     "pname": "Microsoft.NETCore.Platforms",
+    "version": "1.1.0",
+    "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
     "version": "1.1.1",
     "hash": "sha256-8hLiUKvy/YirCWlFwzdejD2Db3DaXhHxT7GSZx/znJg="
   },
@@ -173,6 +178,11 @@
     "pname": "Microsoft.NETCore.Targets",
     "version": "1.1.0",
     "hash": "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ="
+  },
+  {
+    "pname": "Microsoft.NETCore.Targets",
+    "version": "1.1.3",
+    "hash": "sha256-WLsf1NuUfRWyr7C7Rl9jiua9jximnVvzy6nk2D2bVRc="
   },
   {
     "pname": "Microsoft.NETCore.Targets",
@@ -196,13 +206,13 @@
   },
   {
     "pname": "NAPS2.NTwain",
-    "version": "1.0.0",
-    "hash": "sha256-jXpUVhX8c9CutPJH5Q2JvJjPBRrV6gI0yI/mA8PgDSE="
+    "version": "1.0.1",
+    "hash": "sha256-WSU/KBDz2zcnoYMH/38UsOMVB9+mOIJkqfKVzT58bGE="
   },
   {
     "pname": "NAPS2.Pdfium.Binaries",
-    "version": "1.1.0",
-    "hash": "sha256-mg88JinIvTJZHtaPoEQbVsL5PBO5iUiNMvcQ4M2c2GY="
+    "version": "1.2.0",
+    "hash": "sha256-wbOjJzCnTm+hN4uQEY8glfeuL1R8WEYQm1/obZ9tLmM="
   },
   {
     "pname": "NAPS2.PdfSharp",
@@ -211,8 +221,8 @@
   },
   {
     "pname": "NAPS2.Tesseract.Binaries",
-    "version": "1.2.0",
-    "hash": "sha256-4rtFr6ydc+LRgYK7asVRnMSigI2iwU2poG6TJ52eKlQ="
+    "version": "1.4.0",
+    "hash": "sha256-cX+0nD7hLroL2pyRsB2mAErHLuG04B7fcm273BQpL5E="
   },
   {
     "pname": "NAPS2.Wia",
@@ -391,6 +401,11 @@
   },
   {
     "pname": "runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-Jy01KhtcCl2wjMpZWH+X3fhHcVn+SyllWFY8zWlz/6I="
+  },
+  {
+    "pname": "runtime.native.System.Security.Cryptography.OpenSsl",
     "version": "4.3.2",
     "hash": "sha256-xqF6LbbtpzNC9n1Ua16PnYgXHU0LvblEROTfK4vIxX8="
   },
@@ -466,6 +481,11 @@
   },
   {
     "pname": "SharpZipLib",
+    "version": "1.3.3",
+    "hash": "sha256-HWEQTKh9Ktwg/zIl079dAiH+ob2ShWFAqLgG6XgIMr4="
+  },
+  {
+    "pname": "SharpZipLib",
     "version": "1.4.2",
     "hash": "sha256-/giVqikworG2XKqfN9uLyjUSXr35zBuZ2FX2r8X/WUY="
   },
@@ -473,6 +493,11 @@
     "pname": "SimpleBase",
     "version": "1.3.1",
     "hash": "sha256-FtRIcfLYXxUftEhq8kHgNNkahde6Fv2hPVGZNezCW1Y="
+  },
+  {
+    "pname": "SixLabors.Fonts",
+    "version": "1.0.0-beta17",
+    "hash": "sha256-KnHduFn5h/mtHCpCFKg+ZIZi6fKjz2H2sqTIzwXCqOI="
   },
   {
     "pname": "SixLabors.Fonts",
@@ -578,6 +603,11 @@
     "pname": "System.Private.Uri",
     "version": "4.3.0",
     "hash": "sha256-fVfgcoP4AVN1E5wHZbKBIOPYZ/xBeSIdsNF+bdukIRM="
+  },
+  {
+    "pname": "System.Private.Uri",
+    "version": "4.3.2",
+    "hash": "sha256-jB2+W3tTQ6D9XHy5sEFMAazIe1fu2jrENUO0cb48OgU="
   },
   {
     "pname": "System.Reflection",

--- a/pkgs/by-name/na/naps2/package.nix
+++ b/pkgs/by-name/na/naps2/package.nix
@@ -14,32 +14,31 @@
 
 buildDotnetModule rec {
   pname = "naps2";
-  version = "7.5.3";
+  version = "8.2.1";
 
   src = fetchFromGitHub {
     owner = "cyanfish";
     repo = "naps2";
     tag = "v${version}";
-    hash = "sha256-vX+ZyCQsYqJjgYaufWJRnzX8retiFK5QHSP40bbBaCc=";
+    hash = "sha256-1OPFWmy9eDRnMJjYdzYubgfde7MNix8ZsSuN2ZHsvco=";
   };
+
+  patches = [
+    ./01-donate-button.patch
+    ./02-button-dpi.patch
+  ];
 
   projectFile = "NAPS2.App.Gtk/NAPS2.App.Gtk.csproj";
   nugetDeps = ./deps.json;
 
-  postPatch = ''
-    substituteInPlace NAPS2.Images.Gtk/NAPS2.Images.Gtk.csproj \
-      --replace-fail TargetFramework TargetFrameworks \
-  '';
-
   dotnetFlags = [
-    "-p:TargetFrameworks=net8"
-    "-p:EnablePreviewFeatures=true"
+    "-p:TargetFrameworks=net9"
   ];
 
   executables = [ "naps2" ];
 
-  dotnet-sdk = dotnetCorePackages.sdk_8_0;
-  dotnet-runtime = dotnetCorePackages.runtime_8_0;
+  dotnet-sdk = dotnetCorePackages.sdk_9_0;
+  dotnet-runtime = dotnetCorePackages.runtime_9_0;
 
   nativeBuildInputs = [ wrapGAppsHook3 ];
 
@@ -60,6 +59,14 @@ buildDotnetModule rec {
     install -D NAPS2.Lib/Icons/scanner-64-rev2.png $out/share/icons/hicolor/64x64/apps/com.naps2.Naps2.png
     install -D NAPS2.Lib/Icons/scanner-72-rev1.png $out/share/icons/hicolor/72x72/apps/com.naps2.Naps2.png
     install -D NAPS2.Lib/Icons/scanner-128.png $out/share/icons/hicolor/128x128/apps/com.naps2.Naps2.png
+    case "${stdenv.hostPlatform.system}" in
+      x86_64-linux)
+        chmod a+x $out/lib/naps2/_linux/tesseract
+        ;;
+      aarch64-linux)
+        chmod a+x $out/lib/naps2/_linuxarm/tesseract
+        ;;
+    esac
   '';
 
   meta = {


### PR DESCRIPTION
Update NAPS2 from version 7.5.3 to version 8.2.1.

**Release Notes**
https://github.com/cyanfish/naps2/blob/master/CHANGELOG.md
https://github.com/cyanfish/naps2/releases/tag/v8.2.1

**Change to File Permissions**
The file `$out/lib/naps2/_linux/tesseract` was present in v7.5.3, but for OCR in the NAPS2 binary to work the file needs to be executable. This has been implemented in this pull request. (_linux is _linuxarm on aarch64-linux)

**Patches**

***Application of Patch 01-donate-button.patch***
The following upstream commit https://github.com/cyanfish/naps2/commit/13aab9806b20c7bca23811f48f3d0cd32fbc2139 changed the format of the Donate Button in the About Dialog form from an image to text. The setting of the font can fail if the font is not installed and thus the dialog is not shown. Therefore, try to update the font and if it fails, fall back to the originally set font.

***Application of Patch 02-button-dpi.patch***
When attempting to use the "Email PDF" button, the setting of the font to be dpi-aware can fail if the font is not installed and thus the dialog is not shown. Therefore, try to update the font and if it fails, fall back to the originally set font.

***Removal of postPatch***
The patch is no longer required.

**Notes**
Closes https://github.com/NixOS/nixpkgs/issues/437037
Closes https://github.com/NixOS/nixpkgs/issues/394814

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
