### PR TITLE
ISSUE_TEMPLATE: add the package request stub

### DIFF
--- a/.github/ISSUE_TEMPLATE/10_package_request.yml
+++ b/.github/ISSUE_TEMPLATE/10_package_request.yml
@@ -1,0 +1,41 @@
+name: "Request: Nix Package"
+description: "Package requests are no longer accepted. Please open a Pull Request with your desired package instead."
+title: "Package Request"
+labels: ["0.kind: packaging request", "4.workflow: auto-close"]
+body:
+  - type: "markdown"
+    attributes:
+      value: |
+        <p align="center">
+          <a href="https://nixos.org">
+            <picture>
+              <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/NixOS/nixos-artwork/refs/heads/master/logo/nixos.svg">
+              <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/NixOS/nixos-artwork/refs/heads/master/logo/nixos-white.svg">
+              <img src="https://raw.githubusercontent.com/NixOS/nixos-artwork/refs/heads/master/logo/nixos.svg" width="400px" alt="NixOS logo">
+            </picture>
+          </a>
+        </p>
+
+        Thank you for your interest in packaging new software in Nixpkgs.
+        Unfortunately, to mitigate the unsustainable growth of unmaintained packages, **Nixpkgs is no longer accepting package requests** via Issues.
+
+        As a [volunteer community][community], we are always open to new contributors.
+        If you wish to see this package in Nixpkgs, **we encourage you to [contribute] it yourself, via a Pull Request**.
+        Anyone can [become a package maintainer][maintainers]!
+        You can find language-specific packaging information in the [Nixpkgs Manual][nixpkgs].
+        Should you need any help, please reach out to the community on [Matrix] or [Discourse].
+
+        [community]: https://nixos.org/community
+        [contribute]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#quick-start-to-adding-a-package
+        [maintainers]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
+        [nixpkgs]: https://nixos.org/manual/nixpkgs/unstable/
+        [Matrix]: https://matrix.to/#/#dev:nixos.org
+        [Discourse]: https://discourse.nixos.org/c/dev/14
+
+        ---
+  - type: "checkboxes"
+    id: "ignored"
+    attributes:
+      label: "Issues for new package requests are not accepted. Please open a Pull Request instead."
+      options:
+        - label: "I didn't read any of that."


### PR DESCRIPTION
This isn't an issue template; it's a stub that will be auto-closed by CI[^1] and is meant to discourage future package requests, and encourage more pull requests.

See the full discussion on https://github.com/NixOS/nixpkgs/issues/425040.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]: I don't actually know how CI works, so I have no idea how to implement that.
