### PR TITLE
doxx: init at 0-unstable-2025-08-18

### DIFF
--- a/pkgs/by-name/do/doxx/package.nix
+++ b/pkgs/by-name/do/doxx/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "TUI document viewer for `docx` files";
+    description = "Terminal document viewer for .docx files";
     longDescription = ''
       `doxx` is a lightning-fast, terminal-native document viewer for
       Microsoft Word files. Built with Rust for performance and

--- a/pkgs/by-name/do/doxx/package.nix
+++ b/pkgs/by-name/do/doxx/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "doxx";
+  version = "0-unstable-2025-08-18";
+
+  src = fetchFromGitHub {
+    owner = "bgreenwell";
+    repo = "doxx";
+    rev = "5c957470de1fa937cf96cd847286e2d3ee37cbee";
+    hash = "sha256-ZCvb8FnGdpzEDqYCIFjg+hiO3OZNnZ2+dSDVLx+crTU=";
+  };
+
+  cargoHash = "sha256-1i+IAQc55HYrqJm3Hx0frphSQp7jYGa6i0eOvHVMdCI=";
+
+  postInstall = ''
+    rm $out/bin/generate_test_docs
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "TUI document viewer for `docx` files";
+    longDescription = ''
+      `doxx` is a lightning-fast, terminal-native document viewer for
+      Microsoft Word files. Built with Rust for performance and
+      reliability, it brings Word documents to your command line with
+      beautiful rendering, smart table support, and powerful export
+      capabilities.
+    '';
+    homepage = "https://github.com/bgreenwell/doxx";
+    changelog = "https://github.com/bgreenwell/doxx/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "doxx";
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
