### PR TITLE
python3Packages.stockfish: init at 5.2.0

### DIFF
--- a/pkgs/development/python-modules/stockfish/default.nix
+++ b/pkgs/development/python-modules/stockfish/default.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  wheel,
+  # For tests
+  stockfish,
+  runCommand,
+  python,
+}:
+
+buildPythonPackage rec {
+  pname = "stockfish";
+  version = "3.28.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-h2QSfABDSqhbf8ocBkgA5+qQe7NibM1LWD8OkRsBQHA=";
+  };
+
+  # The original setup.py requires pytest-runner which has been
+  # removed from nixpkgs. We replace it with a minimal setup.py
+  # that avoids this deprecated dependency.
+  prePatch = ''
+        cat > setup.py << 'EOF'
+    from setuptools import setup, find_packages
+
+    with open("README.md", "r", encoding="utf-8") as fh:
+        long_description = fh.read()
+
+    setup(
+        name="stockfish",
+        version="3.28.0",
+        author="Ilya Zhelyabuzhsky",
+        author_email="zhelyabuzhsky@icloud.com",
+        description="Integrates the Stockfish chess engine with Python",
+        long_description=long_description,
+        long_description_content_type="text/markdown",
+        url="https://github.com/zhelyabuzhsky/stockfish",
+        packages=find_packages(),
+        classifiers=[
+            "Programming Language :: Python :: 3",
+            "License :: OSI Approved :: MIT License",
+            "Operating System :: OS Independent",
+        ],
+        python_requires='>=3.7',
+    )
+    EOF
+  '';
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  # Tests require network access and additional setup
+  doCheck = false;
+
+  pythonImportsCheck = [ "stockfish" ];
+
+  passthru.tests = {
+    # Basic import test
+    basic-import =
+      runCommand "stockfish-test-import"
+        {
+          buildInputs = [ (python.withPackages (ps: [ ps.stockfish ])) ];
+        }
+        ''
+          python3 -c "from stockfish import Stockfish; print('✓ ok')"
+          touch $out
+        '';
+  };
+
+  meta = {
+    description = "Integrates the Stockfish chess engine with Python";
+    homepage = "https://github.com/zhelyabuzhsky/stockfish";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jamerrq ];
+    longDescription = ''
+      Python wrapper for the Stockfish chess engine. Requires the stockfish
+      chess engine binary to be available in PATH or specified explicitly.
+
+      Usage with Nix:
+      nix-shell -p 'python3.withPackages (ps: [ ps.stockfish ])' stockfish
+    '';
+  };
+}

--- a/pkgs/development/python-modules/stockfish/default.nix
+++ b/pkgs/development/python-modules/stockfish/default.nix
@@ -5,10 +5,6 @@
   pythonOlder,
   setuptools,
   wheel,
-  # For tests
-  stockfish,
-  runCommand,
-  python,
 }:
 
 buildPythonPackage rec {
@@ -23,70 +19,23 @@ buildPythonPackage rec {
     hash = "sha256-h2QSfABDSqhbf8ocBkgA5+qQe7NibM1LWD8OkRsBQHA=";
   };
 
-  # The original setup.py requires pytest-runner which has been
-  # removed from nixpkgs. We replace it with a minimal setup.py
-  # that avoids this deprecated dependency.
-  prePatch = ''
-        cat > setup.py << 'EOF'
-    from setuptools import setup, find_packages
-
-    with open("README.md", "r", encoding="utf-8") as fh:
-        long_description = fh.read()
-
-    setup(
-        name="stockfish",
-        version="3.28.0",
-        author="Ilya Zhelyabuzhsky",
-        author_email="zhelyabuzhsky@icloud.com",
-        description="Integrates the Stockfish chess engine with Python",
-        long_description=long_description,
-        long_description_content_type="text/markdown",
-        url="https://github.com/zhelyabuzhsky/stockfish",
-        packages=find_packages(),
-        classifiers=[
-            "Programming Language :: Python :: 3",
-            "License :: OSI Approved :: MIT License",
-            "Operating System :: OS Independent",
-        ],
-        python_requires='>=3.7',
-    )
-    EOF
-  '';
+  patches = [ ./setup.patch ];
 
   build-system = [
     setuptools
     wheel
   ];
 
-  # Tests require network access and additional setup
+  # Tests fail due to stockfish version incompatibility
+  # https://github.com/py-stockfish/stockfish/issues/17
   doCheck = false;
 
   pythonImportsCheck = [ "stockfish" ];
 
-  passthru.tests = {
-    # Basic import test
-    basic-import =
-      runCommand "stockfish-test-import"
-        {
-          buildInputs = [ (python.withPackages (ps: [ ps.stockfish ])) ];
-        }
-        ''
-          python3 -c "from stockfish import Stockfish; print('✓ ok')"
-          touch $out
-        '';
-  };
-
   meta = {
     description = "Integrates the Stockfish chess engine with Python";
-    homepage = "https://github.com/zhelyabuzhsky/stockfish";
+    homepage = "https://github.com/py-stockfish/stockfish";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ jamerrq ];
-    longDescription = ''
-      Python wrapper for the Stockfish chess engine. Requires the stockfish
-      chess engine binary to be available in PATH or specified explicitly.
-
-      Usage with Nix:
-      nix-shell -p 'python3.withPackages (ps: [ ps.stockfish ])' stockfish
-    '';
   };
 }

--- a/pkgs/development/python-modules/stockfish/default.nix
+++ b/pkgs/development/python-modules/stockfish/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+  stockfish,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "stockfish";
+  version = "5.2.0";
+  pyproject = true;
+
+  # The PyPI sdist does not ship the test suite
+  src = fetchFromGitHub {
+    owner = "py-stockfish";
+    repo = "stockfish";
+    tag = finalAttrs.version;
+    hash = "sha256-YdT7O00U9V7zEwIqDdwQ+FSL6xu/7lAXj53aT4IldEQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    stockfish
+  ];
+
+  # Upstream enables coverage reporting through addopts, which is not useful here
+  pytestFlags = [
+    "-o"
+    "addopts="
+  ];
+
+  disabledTests = [
+    # These search with a wall-clock time budget, so the move they settle on
+    # depends on how fast the machine is
+    # https://github.com/py-stockfish/stockfish/issues/17
+    "test_get_best_move_remaining_time_first_move"
+    "test_get_best_move_remaining_time_not_first_move"
+  ];
+
+  pythonImportsCheck = [ "stockfish" ];
+
+  meta = {
+    description = "Integrates the Stockfish chess engine with Python";
+    homepage = "https://github.com/py-stockfish/stockfish";
+    changelog = "https://github.com/py-stockfish/stockfish/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jamerrq ];
+  };
+})

--- a/pkgs/development/python-modules/stockfish/setup.patch
+++ b/pkgs/development/python-modules/stockfish/setup.patch
@@ -1,0 +1,10 @@
+--- a/setup.py
++++ b/setup.py
+@@ -17,7 +17,6 @@ setup(
+     long_description_content_type="text/markdown",
+     packages=find_packages(include=["stockfish", "stockfish.*"]),
+     install_requires=[],
+-    setup_requires=["pytest-runner"],
+     tests_require=["pytest", "pytest-cov"],
+     classifiers=[
+         "Programming Language :: Python",

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17469,6 +17469,8 @@ self: super: with self; {
 
   stm32loader = callPackage ../development/python-modules/stm32loader { };
 
+  stockfish = callPackage ../development/python-modules/stockfish { };
+
   stomp-py = callPackage ../development/python-modules/stomp-py { };
 
   stone = callPackage ../development/python-modules/stone { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19929,6 +19929,8 @@ self: super: with self; {
 
   stm32loader = callPackage ../development/python-modules/stm32loader { };
 
+  stockfish = callPackage ../development/python-modules/stockfish { inherit (pkgs) stockfish; };
+
   stomp-py = callPackage ../development/python-modules/stomp-py { };
 
   stone = callPackage ../development/python-modules/stone { };


### PR DESCRIPTION
Python wrapper for the Stockfish chess engine: https://github.com/py-stockfish/stockfish

The engine binary is not a dependency of this package. `Stockfish()` defaults to looking up `stockfish` on `PATH`, so users install the engine separately.

The test suite is only published in the GitHub repository and not in the PyPI sdist, so `src` uses `fetchFromGitHub` in order to run it. 157 tests pass against stockfish 18. The two `remaining_time` tests are disabled because they search with a wall-clock time budget, so the move the engine settles on depends on how fast the builder is — this reproduces in the build sandbox but not in a shell, and is the substance of py-stockfish/stockfish#17.

Force pushes are a rebase onto current master, squashing the review fixes into the single init commit.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

The upstream test suite runs in `checkPhase` via `pytestCheckHook`, so there is no `passthru.tests`. This package installs a library and no binaries, so there is nothing in `./result/bin/`.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

---

AI disclosure (per [Automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy)):

Claude Code (Anthropic, model Claude Opus 4.5) was used to help draft parts of this patch (`pkgs/development/python-modules/stockfish/default.nix`). I reviewed and understood the generated output, tested the build locally (`nix-build -A python3Packages.stockfish`) and ran the package's test suite before submitting, and I take responsibility for the correctness and licensing of the contribution.