### PR TITLE
kubelet: data-dir should set to /var/lib/kubelet, so that plugins can register properly

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -377,7 +377,7 @@ in
                         --pod-infra-container-image=pause \
                         ${optionalString (cfg.manifests != { }) "--pod-manifest-path=/etc/${manifestPath}"} \
                         ${optionalString (taints != "") "--register-with-taints=${taints}"} \
-                        --root-dir=${top.dataDir} \
+                        --root-dir=/var/lib/kubelet \
                         ${optionalString (cfg.verbosity != null) "--v=${toString cfg.verbosity}"} \
                         ${cfg.extraOpts}
           '';


### PR DESCRIPTION


`data-dir` in systemd unit file of `kubelet` is set to `services.kubernetes.dataDir`, which defaults to /var/lib/kubernetes. CNI plugins, such as Cilium, will register itself to /var/lib/kubelet/plugins_registry, which `kubelet` scan plugins from /var/lib/kubernetes/plugins_registry by current configuration. Kubelet can not find the plugins.

This pull request set `data-dir` to /var/lib/kubelet.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
