### PR TITLE
androidndkPackages_{21,23,24,25,26}: drop

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -37,6 +37,7 @@
 - `stdenv.mkDerivation` and other derivation builders that use it no longer allow the value of `env` to be anything but an attribute set, for the purpose of setting environment variables that are available to the [builder](https://nix.dev/manual/nix/latest/store/derivation/#builder) process. An environment variable called `env` can still be provided by means of `mkDerivation { env.env = ...; }`, though we recommend to use a more specific name than "env".
 
 - The default Android NDK version has been raised to 27, and the default SDK version to 35.
+  NDK 21–26 have been removed, as they are end‐of‐life.
 
 - `conftest` since `0.60.0` has moved to use rego `v1` as default. To continue using `v0` use `--rego-version v0`. For more information about upgrading to Rego v1 syntax, see the [upstream docs](https://www.openpolicyagent.org/docs/latest/v0-upgrade/).
 

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -36,6 +36,8 @@
 
 - `stdenv.mkDerivation` and other derivation builders that use it no longer allow the value of `env` to be anything but an attribute set, for the purpose of setting environment variables that are available to the [builder](https://nix.dev/manual/nix/latest/store/derivation/#builder) process. An environment variable called `env` can still be provided by means of `mkDerivation { env.env = ...; }`, though we recommend to use a more specific name than "env".
 
+- The default Android NDK version has been raised to 27, and the default SDK version to 35.
+
 - `conftest` since `0.60.0` has moved to use rego `v1` as default. To continue using `v0` use `--rego-version v0`. For more information about upgrading to Rego v1 syntax, see the [upstream docs](https://www.openpolicyagent.org/docs/latest/v0-upgrade/).
 
 - `stalwart-mail` since `0.13.0` "introduces a significant redesign of the MTA’s delivery and queueing subsystem". See [the upgrading announcement for the `0.13.0` release](https://github.com/stalwartlabs/stalwart/blob/89b561b5ca1c5a11f2a768b4a2cfef0f473b7a01/UPGRADING.md#upgrading-from-v012x-and-v011x-to-v013x).

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -72,8 +72,8 @@ rec {
   armv7a-android-prebuilt = {
     config = "armv7a-unknown-linux-androideabi";
     rust.rustcTarget = "armv7-linux-androideabi";
-    androidSdkVersion = "33";
-    androidNdkVersion = "26";
+    androidSdkVersion = "35";
+    androidNdkVersion = "27";
     useAndroidPrebuilt = true;
   }
   // platforms.armv7a-android;
@@ -81,15 +81,15 @@ rec {
   aarch64-android-prebuilt = {
     config = "aarch64-unknown-linux-android";
     rust.rustcTarget = "aarch64-linux-android";
-    androidSdkVersion = "33";
-    androidNdkVersion = "26";
+    androidSdkVersion = "35";
+    androidNdkVersion = "27";
     useAndroidPrebuilt = true;
   };
 
   aarch64-android = {
     config = "aarch64-unknown-linux-android";
-    androidSdkVersion = "33";
-    androidNdkVersion = "26";
+    androidSdkVersion = "35";
+    androidNdkVersion = "27";
     libc = "bionic";
     useAndroidPrebuilt = false;
     useLLVM = true;

--- a/pkgs/development/androidndk-pkgs/default.nix
+++ b/pkgs/development/androidndk-pkgs/default.nix
@@ -4,7 +4,6 @@
   buildPackages,
   pkgs,
   targetPackages,
-  androidndkPkgs_23,
   config,
 }:
 
@@ -54,12 +53,6 @@ let
 in
 
 lib.recurseIntoAttrs {
-  "21" = makeNdkPkgs "21.0.6113669" pkgs.llvmPackages_14; # "9"
-  "23" = makeNdkPkgs "23.1.7779620" pkgs.llvmPackages_14; # "12"
-  # Versions below 24 use a version not available in nixpkgs/old version which could be removed in the near future so use 14 for them as this is only used to get the hardening flags.
-  "24" = makeNdkPkgs "24.0.8215888" pkgs.llvmPackages_14;
-  "25" = makeNdkPkgs "25.2.9519653" pkgs.llvmPackages_14;
-  "26" = makeNdkPkgs "26.3.11579264" pkgs.llvmPackages_17;
   "27" = makeNdkPkgs "27.0.12077973" pkgs.llvmPackages_18;
   "28" = makeNdkPkgs "28.0.13004108" pkgs.llvmPackages_19;
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -283,7 +283,12 @@ mapAliases {
   ansible_2_14 = throw "Ansible 2.14 goes end of life in 2024/05 and can't be supported throughout the 24.05 release cycle"; # Added 2024-04-11
   ansible_2_15 = throw "Ansible 2.15 goes end of life in 2024/11 and can't be supported throughout the 24.11 release cycle"; # Added 2024-11-08
   antennas = throw "antennas has been removed as it only works with tvheadend, which nobody was willing to maintain and was stuck on an unmaintained version that required FFmpeg 4; please see https://github.com/NixOS/nixpkgs/pull/332259 if you are interested in maintaining a newer version"; # Added 2024-08-21
-  androidndkPkgs_23b = lib.warnOnInstantiate "The package set `androidndkPkgs_23b` has been renamed to `androidndkPkgs_23`." androidndkPkgs_23; # Added 2024-07-21
+  androidndkPkgs_21 = throw "androidndkPkgs_21 has been removed, as it is EOL"; # Added 2025-08-09
+  androidndkPkgs_23 = throw "androidndkPkgs_23 has been removed, as it is EOL"; # Added 2025-08-09
+  androidndkPkgs_23b = throw "androidndkPkgs_23b has been removed, as it is EOL"; # Added 2025-08-09
+  androidndkPkgs_24 = throw "androidndkPkgs_24 has been removed, as it is EOL"; # Added 2025-08-09
+  androidndkPkgs_25 = throw "androidndkPkgs_25 has been removed, as it is EOL"; # Added 2025-08-09
+  androidndkPkgs_26 = throw "androidndkPkgs_26 has been removed, as it is EOL"; # Added 2025-08-09
   ankisyncd = throw "ankisyncd is dead, use anki-sync-server instead"; # Added 2024-08-10
   ao = libfive; # Added 2024-10-11
   anbox = throw "'anbox' has been removed as the upstream project is unmaintained, see https://github.com/anbox/.github/blob/main/profile/README.md"; # Added 2025-01-04

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1776,11 +1776,6 @@ with pkgs;
   androidenv = callPackage ../development/mobile/androidenv { };
 
   androidndkPkgs = androidndkPkgs_27;
-  androidndkPkgs_21 = (callPackage ../development/androidndk-pkgs { })."21";
-  androidndkPkgs_23 = (callPackage ../development/androidndk-pkgs { })."23";
-  androidndkPkgs_24 = (callPackage ../development/androidndk-pkgs { })."24";
-  androidndkPkgs_25 = (callPackage ../development/androidndk-pkgs { })."25";
-  androidndkPkgs_26 = (callPackage ../development/androidndk-pkgs { })."26";
   androidndkPkgs_27 = (callPackage ../development/androidndk-pkgs { })."27";
   androidndkPkgs_28 = (callPackage ../development/androidndk-pkgs { })."28";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1775,7 +1775,7 @@ with pkgs;
 
   androidenv = callPackage ../development/mobile/androidenv { };
 
-  androidndkPkgs = androidndkPkgs_26;
+  androidndkPkgs = androidndkPkgs_27;
   androidndkPkgs_21 = (callPackage ../development/androidndk-pkgs { })."21";
   androidndkPkgs_23 = (callPackage ../development/androidndk-pkgs { })."23";
   androidndkPkgs_24 = (callPackage ../development/androidndk-pkgs { })."24";


### PR DESCRIPTION
@numinit Hello! I would appreciate your assistance in my insatiable quest to delete end‐of‐life compilers. These NDKs not only depend on EOL LLVM versions but they’re also EOL themselves according to Google so this is kind of a double treat for me.

I don’t have much Android experience, though, so let me know if the NDK bump to the latest LTS here makes sense, or if we should just jump to the latest stable, or what, and if we should be bumping the SDK at the same time or not. I have not really tested any of this. Let me know if you want a release note too.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
