### PR TITLE
androidenv: autoupdate fix and prevent caching on hydra

### DIFF
--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -189,7 +189,7 @@ let
               archive:
               (fetchurl {
                 inherit (archive) url sha1;
-                preferLocalBuild = true;
+                inherit meta;
                 passthru = {
                   info = packageInfo;
                 };

--- a/pkgs/development/mobile/androidenv/repo.json
+++ b/pkgs/development/mobile/androidenv/repo.json
@@ -12,7 +12,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-10",
@@ -91,7 +91,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-11",
@@ -156,7 +156,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-12",
@@ -233,7 +233,7 @@
           }
         ],
         "displayName": "Google TV Addon",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-googletv-license",
         "name": "google_tv_addon",
         "path": "add-ons/addon-google_tv_addon-google-12",
@@ -280,7 +280,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-13",
@@ -357,7 +357,7 @@
           }
         ],
         "displayName": "Google TV Addon",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-googletv-license",
         "name": "google_tv_addon",
         "path": "add-ons/addon-google_tv_addon-google-13",
@@ -404,7 +404,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-14",
@@ -483,7 +483,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-15",
@@ -576,7 +576,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-16",
@@ -669,7 +669,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-17",
@@ -762,7 +762,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-18",
@@ -855,7 +855,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-19",
@@ -948,7 +948,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-21",
@@ -1041,7 +1041,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-22",
@@ -1134,7 +1134,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-23",
@@ -1227,7 +1227,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-24",
@@ -1320,7 +1320,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-25",
@@ -1413,7 +1413,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-3",
@@ -1478,7 +1478,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-4",
@@ -1543,7 +1543,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-5",
@@ -1608,7 +1608,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-6",
@@ -1673,7 +1673,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-7",
@@ -1738,7 +1738,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-8",
@@ -1803,7 +1803,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-9",
@@ -1869,7 +1869,7 @@
         }
       ],
       "displayName": "Android Support Repository",
-      "last-available-day": 20237,
+      "last-available-day": 20318,
       "license": "android-sdk-license",
       "name": "extras-android-m2repository",
       "path": "extras/android/m2repository",
@@ -1900,7 +1900,7 @@
         }
       ],
       "displayName": "Android Emulator hypervisor driver (installer)",
-      "last-available-day": 20237,
+      "last-available-day": 20318,
       "license": "android-sdk-license",
       "name": "extras-google-Android_Emulator_Hypervisor_Driver",
       "path": "extras/google/Android_Emulator_Hypervisor_Driver",
@@ -1931,7 +1931,7 @@
         }
       ],
       "displayName": "Google AdMob Ads SDK",
-      "last-available-day": 20237,
+      "last-available-day": 20318,
       "license": "android-sdk-license",
       "name": "extras-google-admob_ads_sdk",
       "path": "extras/google/admob_ads_sdk",
@@ -1960,7 +1960,7 @@
         }
       ],
       "displayName": "Google Analytics App Tracking SDK",
-      "last-available-day": 20237,
+      "last-available-day": 20318,
       "license": "android-sdk-license",
       "name": "extras-google-analytics_sdk_v2",
       "path": "extras/google/analytics_sdk_v2",
@@ -2010,7 +2010,7 @@
         }
       ],
       "displayName": "Android Auto Desktop Head Unit Emulator",
-      "last-available-day": 20237,
+      "last-available-day": 20318,
       "license": "android-sdk-license",
       "name": "extras-google-auto",
       "path": "extras/google/auto",
@@ -2036,7 +2036,7 @@
         }
       ],
       "displayName": "Google Cloud Messaging for Android Library",
-      "last-available-day": 20237,
+      "last-available-day": 20318,
       "license": "android-sdk-license",
       "name": "extras-google-gcm",
       "path": "extras/google/gcm",
@@ -2072,7 +2072,7 @@
         }
       },
       "displayName": "Google Play services",
-      "last-available-day": 20237,
+      "last-available-day": 20318,
       "license": "android-sdk-license",
       "name": "extras-google-google_play_services",
       "path": "extras/google/google_play_services",
@@ -2101,7 +2101,7 @@
         }
       ],
       "displayName": "Google Play services for Froyo",
-      "last-available-day": 20237,
+      "last-available-day": 20318,
       "license": "android-sdk-license",
       "name": "extras-google-google_play_services_froyo",
       "path": "extras/google/google_play_services_froyo",
@@ -2129,8 +2129,8 @@
           "url": "https://dl.google.com/android/repository/iasdk-1.9.0-1566514721.zip"
         }
       ],
-      "displayName": "Google Play Instant Development SDK",
-      "last-available-day": 20237,
+      "displayName": "Google Play Instant Development SDK (Deprecated)",
+      "last-available-day": 20318,
       "license": "android-sdk-license",
       "name": "extras-google-instantapps",
       "path": "extras/google/instantapps",
@@ -2168,7 +2168,7 @@
         }
       },
       "displayName": "Google Repository",
-      "last-available-day": 20237,
+      "last-available-day": 20318,
       "license": "android-sdk-license",
       "name": "extras-google-m2repository",
       "path": "extras/google/m2repository",
@@ -2197,7 +2197,7 @@
         }
       ],
       "displayName": "Google Play APK Expansion library",
-      "last-available-day": 20237,
+      "last-available-day": 20318,
       "license": "android-sdk-license",
       "name": "extras-google-market_apk_expansion",
       "path": "extras/google/market_apk_expansion",
@@ -2226,7 +2226,7 @@
         }
       ],
       "displayName": "Google Play Licensing Library",
-      "last-available-day": 20237,
+      "last-available-day": 20318,
       "license": "android-sdk-license",
       "name": "extras-google-market_licensing",
       "path": "extras/google/market_licensing",
@@ -2256,7 +2256,7 @@
         }
       ],
       "displayName": "Android Auto API Simulators",
-      "last-available-day": 20237,
+      "last-available-day": 20318,
       "license": "android-sdk-license",
       "name": "extras-google-simulators",
       "path": "extras/google/simulators",
@@ -2285,7 +2285,7 @@
         }
       ],
       "displayName": "Google USB Driver",
-      "last-available-day": 20237,
+      "last-available-day": 20318,
       "license": "android-sdk-license",
       "name": "extras-google-usb_driver",
       "path": "extras/google/usb_driver",
@@ -2314,7 +2314,7 @@
         }
       ],
       "displayName": "Google Web Driver",
-      "last-available-day": 20237,
+      "last-available-day": 20318,
       "license": "android-sdk-license",
       "name": "extras-google-webdriver",
       "path": "extras/google/webdriver",
@@ -2984,7 +2984,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-10-default-armeabi-v7a",
           "path": "system-images/android-10/default/armeabi-v7a",
@@ -3030,7 +3030,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-10-default-x86",
           "path": "system-images/android-10/default/x86",
@@ -3078,7 +3078,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-10-google_apis-armeabi-v7a",
           "path": "system-images/android-10/google_apis/armeabi-v7a",
@@ -3130,7 +3130,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-10-google_apis-x86",
           "path": "system-images/android-10/google_apis/x86",
@@ -3179,7 +3179,7 @@
             }
           ],
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-14-default-armeabi-v7a",
           "path": "system-images/android-14/default/armeabi-v7a",
@@ -3229,7 +3229,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-15-default-armeabi-v7a",
           "path": "system-images/android-15/default/armeabi-v7a",
@@ -3275,7 +3275,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-15-default-x86",
           "path": "system-images/android-15/default/x86",
@@ -3323,7 +3323,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-15-google_apis-armeabi-v7a",
           "path": "system-images/android-15/google_apis/armeabi-v7a",
@@ -3375,7 +3375,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-15-google_apis-x86",
           "path": "system-images/android-15/google_apis/x86",
@@ -3431,7 +3431,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-16-default-armeabi-v7a",
           "path": "system-images/android-16/default/armeabi-v7a",
@@ -3470,7 +3470,7 @@
             }
           ],
           "displayName": "MIPS System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "mips-android-sysimage-license",
           "name": "system-image-16-default-mips",
           "path": "system-images/android-16/default/mips",
@@ -3516,7 +3516,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-16-default-x86",
           "path": "system-images/android-16/default/x86",
@@ -3564,7 +3564,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-16-google_apis-armeabi-v7a",
           "path": "system-images/android-16/google_apis/armeabi-v7a",
@@ -3616,7 +3616,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-16-google_apis-x86",
           "path": "system-images/android-16/google_apis/x86",
@@ -3672,7 +3672,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-17-default-armeabi-v7a",
           "path": "system-images/android-17/default/armeabi-v7a",
@@ -3711,7 +3711,7 @@
             }
           ],
           "displayName": "MIPS System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "mips-android-sysimage-license",
           "name": "system-image-17-default-mips",
           "path": "system-images/android-17/default/mips",
@@ -3757,7 +3757,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-17-default-x86",
           "path": "system-images/android-17/default/x86",
@@ -3811,7 +3811,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-17-google_apis-armeabi-v7a",
           "path": "system-images/android-17/google_apis/armeabi-v7a",
@@ -3863,7 +3863,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-17-google_apis-x86",
           "path": "system-images/android-17/google_apis/x86",
@@ -3919,7 +3919,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-18-default-armeabi-v7a",
           "path": "system-images/android-18/default/armeabi-v7a",
@@ -3965,7 +3965,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-18-default-x86",
           "path": "system-images/android-18/default/x86",
@@ -4013,7 +4013,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-18-google_apis-armeabi-v7a",
           "path": "system-images/android-18/google_apis/armeabi-v7a",
@@ -4065,7 +4065,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-18-google_apis-x86",
           "path": "system-images/android-18/google_apis/x86",
@@ -4121,7 +4121,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-19-default-armeabi-v7a",
           "path": "system-images/android-19/default/armeabi-v7a",
@@ -4167,7 +4167,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-19-default-x86",
           "path": "system-images/android-19/default/x86",
@@ -4215,7 +4215,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-19-google_apis-armeabi-v7a",
           "path": "system-images/android-19/google_apis/armeabi-v7a",
@@ -4267,7 +4267,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-19-google_apis-x86",
           "path": "system-images/android-19/google_apis/x86",
@@ -4316,7 +4316,7 @@
             }
           ],
           "displayName": "Android TV ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-21-android-tv-armeabi-v7a",
           "path": "system-images/android-21/android-tv/armeabi-v7a",
@@ -4353,7 +4353,7 @@
             }
           ],
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-21-android-tv-x86",
           "path": "system-images/android-21/android-tv/x86",
@@ -4392,7 +4392,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-21-default-arm64-v8a",
           "path": "system-images/android-21/default/arm64-v8a",
@@ -4438,7 +4438,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-21-default-armeabi-v7a",
           "path": "system-images/android-21/default/armeabi-v7a",
@@ -4484,7 +4484,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-21-default-x86",
           "path": "system-images/android-21/default/x86",
@@ -4530,7 +4530,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-21-default-x86_64",
           "path": "system-images/android-21/default/x86_64",
@@ -4571,7 +4571,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-arm64-v8a",
           "path": "system-images/android-21/google_apis/arm64-v8a",
@@ -4623,7 +4623,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-armeabi-v7a",
           "path": "system-images/android-21/google_apis/armeabi-v7a",
@@ -4675,7 +4675,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-x86",
           "path": "system-images/android-21/google_apis/x86",
@@ -4727,7 +4727,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-x86_64",
           "path": "system-images/android-21/google_apis/x86_64",
@@ -4776,7 +4776,7 @@
             }
           ],
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-22-android-tv-x86",
           "path": "system-images/android-22/android-tv/x86",
@@ -4815,7 +4815,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-22-default-arm64-v8a",
           "path": "system-images/android-22/default/arm64-v8a",
@@ -4861,7 +4861,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-22-default-armeabi-v7a",
           "path": "system-images/android-22/default/armeabi-v7a",
@@ -4907,7 +4907,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-22-default-x86",
           "path": "system-images/android-22/default/x86",
@@ -4953,7 +4953,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-22-default-x86_64",
           "path": "system-images/android-22/default/x86_64",
@@ -4994,7 +4994,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-arm64-v8a",
           "path": "system-images/android-22/google_apis/arm64-v8a",
@@ -5046,7 +5046,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-armeabi-v7a",
           "path": "system-images/android-22/google_apis/armeabi-v7a",
@@ -5098,7 +5098,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-x86",
           "path": "system-images/android-22/google_apis/x86",
@@ -5150,7 +5150,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-x86_64",
           "path": "system-images/android-22/google_apis/x86_64",
@@ -5199,7 +5199,7 @@
             }
           ],
           "displayName": "Android TV ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-23-android-tv-armeabi-v7a",
           "path": "system-images/android-23/android-tv/armeabi-v7a",
@@ -5243,7 +5243,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-23-android-tv-x86",
           "path": "system-images/android-23/android-tv/x86",
@@ -5282,7 +5282,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-23-default-arm64-v8a",
           "path": "system-images/android-23/default/arm64-v8a",
@@ -5328,7 +5328,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-23-default-armeabi-v7a",
           "path": "system-images/android-23/default/armeabi-v7a",
@@ -5374,7 +5374,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-23-default-x86",
           "path": "system-images/android-23/default/x86",
@@ -5420,7 +5420,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-23-default-x86_64",
           "path": "system-images/android-23/default/x86_64",
@@ -5461,7 +5461,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-arm64-v8a",
           "path": "system-images/android-23/google_apis/arm64-v8a",
@@ -5513,7 +5513,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-armeabi-v7a",
           "path": "system-images/android-23/google_apis/armeabi-v7a",
@@ -5565,7 +5565,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-x86",
           "path": "system-images/android-23/google_apis/x86",
@@ -5617,7 +5617,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-x86_64",
           "path": "system-images/android-23/google_apis/x86_64",
@@ -5673,7 +5673,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-24-android-tv-x86",
           "path": "system-images/android-24/android-tv/x86",
@@ -5712,7 +5712,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-24-default-arm64-v8a",
           "path": "system-images/android-24/default/arm64-v8a",
@@ -5758,7 +5758,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-24-default-armeabi-v7a",
           "path": "system-images/android-24/default/armeabi-v7a",
@@ -5804,7 +5804,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-24-default-x86",
           "path": "system-images/android-24/default/x86",
@@ -5850,7 +5850,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-24-default-x86_64",
           "path": "system-images/android-24/default/x86_64",
@@ -5898,7 +5898,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-arm64-v8a",
           "path": "system-images/android-24/google_apis/arm64-v8a",
@@ -5950,7 +5950,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-x86",
           "path": "system-images/android-24/google_apis/x86",
@@ -6002,7 +6002,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-x86_64",
           "path": "system-images/android-24/google_apis/x86_64",
@@ -6056,7 +6056,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis_playstore-x86",
           "path": "system-images/android-24/google_apis_playstore/x86",
@@ -6112,7 +6112,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-25-android-tv-x86",
           "path": "system-images/android-25/android-tv/x86",
@@ -6158,7 +6158,7 @@
             }
           },
           "displayName": "Android Wear ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-25-android-wear-armeabi-v7a",
           "path": "system-images/android-25/android-wear/armeabi-v7a",
@@ -6202,7 +6202,7 @@
             }
           },
           "displayName": "Android Wear Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-25-android-wear-x86",
           "path": "system-images/android-25/android-wear/x86",
@@ -6241,7 +6241,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-25-default-arm64-v8a",
           "path": "system-images/android-25/default/arm64-v8a",
@@ -6287,7 +6287,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-25-default-x86",
           "path": "system-images/android-25/default/x86",
@@ -6333,7 +6333,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-25-default-x86_64",
           "path": "system-images/android-25/default/x86_64",
@@ -6374,7 +6374,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-arm64-v8a",
           "path": "system-images/android-25/google_apis/arm64-v8a",
@@ -6426,7 +6426,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-armeabi-v7a",
           "path": "system-images/android-25/google_apis/armeabi-v7a",
@@ -6478,7 +6478,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-x86",
           "path": "system-images/android-25/google_apis/x86",
@@ -6530,7 +6530,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-x86_64",
           "path": "system-images/android-25/google_apis/x86_64",
@@ -6584,7 +6584,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis_playstore-x86",
           "path": "system-images/android-25/google_apis_playstore/x86",
@@ -6655,7 +6655,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-preview-license",
           "name": "system-image-26-android-tv-x86",
           "path": "system-images/android-26/android-tv/x86",
@@ -6701,7 +6701,7 @@
             }
           },
           "displayName": "Android Wear Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-26-android-wear-x86",
           "path": "system-images/android-26/android-wear/x86",
@@ -6752,7 +6752,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-26-default-arm64-v8a",
           "path": "system-images/android-26/default/arm64-v8a",
@@ -6796,7 +6796,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-26-default-x86",
           "path": "system-images/android-26/default/x86",
@@ -6840,7 +6840,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-26-default-x86_64",
           "path": "system-images/android-26/default/x86_64",
@@ -6891,7 +6891,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-arm64-v8a",
           "path": "system-images/android-26/google_apis/arm64-v8a",
@@ -6958,7 +6958,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-x86",
           "path": "system-images/android-26/google_apis/x86",
@@ -7025,7 +7025,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-x86_64",
           "path": "system-images/android-26/google_apis/x86_64",
@@ -7094,7 +7094,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-preview-license",
           "name": "system-image-26-google_apis_playstore-x86",
           "path": "system-images/android-26/google_apis_playstore/x86",
@@ -7150,7 +7150,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-preview-license",
           "name": "system-image-27-android-tv-x86",
           "path": "system-images/android-27/android-tv/x86",
@@ -7201,7 +7201,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-27-default-arm64-v8a",
           "path": "system-images/android-27/default/arm64-v8a",
@@ -7245,7 +7245,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-27-default-x86",
           "path": "system-images/android-27/default/x86",
@@ -7289,7 +7289,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-27-default-x86_64",
           "path": "system-images/android-27/default/x86_64",
@@ -7340,7 +7340,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis-arm64-v8a",
           "path": "system-images/android-27/google_apis/arm64-v8a",
@@ -7407,7 +7407,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis-x86",
           "path": "system-images/android-27/google_apis/x86",
@@ -7476,7 +7476,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis_playstore-x86",
           "path": "system-images/android-27/google_apis_playstore/x86",
@@ -7537,7 +7537,7 @@
             }
           },
           "displayName": "Automotive Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-28-android-automotive-playstore-x86",
           "path": "system-images/android-28/android-automotive-playstore/x86",
@@ -7582,7 +7582,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-android-tv-x86",
           "path": "system-images/android-28/android-tv/x86",
@@ -7628,7 +7628,7 @@
             }
           },
           "displayName": "Wear OS Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-28-android-wear-x86",
           "path": "system-images/android-28/android-wear/x86",
@@ -7679,7 +7679,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-28-default-arm64-v8a",
           "path": "system-images/android-28/default/arm64-v8a",
@@ -7716,7 +7716,7 @@
             }
           ],
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-default-x86",
           "path": "system-images/android-28/default/x86",
@@ -7753,7 +7753,7 @@
             }
           ],
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-default-x86_64",
           "path": "system-images/android-28/default/x86_64",
@@ -7804,7 +7804,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis-arm64-v8a",
           "path": "system-images/android-28/google_apis/arm64-v8a",
@@ -7871,7 +7871,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis-x86",
           "path": "system-images/android-28/google_apis/x86",
@@ -7938,7 +7938,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis-x86_64",
           "path": "system-images/android-28/google_apis/x86_64",
@@ -7997,7 +7997,7 @@
             }
           },
           "displayName": "Google ARM64-V8a Play ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-28/google_apis_playstore/arm64-v8a",
@@ -8064,7 +8064,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis_playstore-x86",
           "path": "system-images/android-28/google_apis_playstore/x86",
@@ -8131,7 +8131,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis_playstore-x86_64",
           "path": "system-images/android-28/google_apis_playstore/x86_64",
@@ -8192,7 +8192,7 @@
             }
           },
           "displayName": "Automotive with Play Store Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-29-android-automotive-playstore-x86",
           "path": "system-images/android-29/android-automotive-playstore/x86",
@@ -8252,7 +8252,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-preview-license",
           "name": "system-image-29-android-tv-x86",
           "path": "system-images/android-29/android-tv/x86",
@@ -8291,7 +8291,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-29-default-arm64-v8a",
           "path": "system-images/android-29/default/arm64-v8a",
@@ -8354,7 +8354,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-29-default-x86",
           "path": "system-images/android-29/default/x86",
@@ -8417,7 +8417,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-29-default-x86_64",
           "path": "system-images/android-29/default/x86_64",
@@ -8468,7 +8468,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-29-google_apis-arm64-v8a",
           "path": "system-images/android-29/google_apis/arm64-v8a",
@@ -8525,7 +8525,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis-x86",
           "path": "system-images/android-29/google_apis/x86",
@@ -8582,7 +8582,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis-x86_64",
           "path": "system-images/android-29/google_apis/x86_64",
@@ -8641,7 +8641,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-29-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-29/google_apis_playstore/arm64-v8a",
@@ -8722,7 +8722,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis_playstore-x86",
           "path": "system-images/android-29/google_apis_playstore/x86",
@@ -8803,7 +8803,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis_playstore-x86_64",
           "path": "system-images/android-29/google_apis_playstore/x86_64",
@@ -8864,7 +8864,7 @@
             }
           },
           "displayName": "Automotive with Play Store Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-30-android-automotive-playstore-x86_64",
           "path": "system-images/android-30/android-automotive-playstore/x86_64",
@@ -8924,7 +8924,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-preview-license",
           "name": "system-image-30-android-tv-x86",
           "path": "system-images/android-30/android-tv/x86",
@@ -8970,7 +8970,7 @@
             }
           },
           "displayName": "China version of Wear OS 3 ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-30-android-wear-arm64-v8a",
           "path": "system-images/android-30/android-wear-cn/arm64-v8a",
@@ -9014,7 +9014,7 @@
             }
           },
           "displayName": "China version of Wear OS 3 Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-30-android-wear-x86",
           "path": "system-images/android-30/android-wear-cn/x86",
@@ -9053,7 +9053,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-30-default-arm64-v8a",
           "path": "system-images/android-30/default/arm64-v8a",
@@ -9102,7 +9102,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-30-default-x86_64",
           "path": "system-images/android-30/default/x86_64",
@@ -9153,7 +9153,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis-arm64-v8a",
           "path": "system-images/android-30/google_apis/arm64-v8a",
@@ -9220,7 +9220,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis-x86",
           "path": "system-images/android-30/google_apis/x86",
@@ -9287,7 +9287,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis-x86_64",
           "path": "system-images/android-30/google_apis/x86_64",
@@ -9353,7 +9353,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-30/google_apis_playstore/arm64-v8a",
@@ -9434,7 +9434,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis_playstore-x86",
           "path": "system-images/android-30/google_apis_playstore/x86",
@@ -9515,7 +9515,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis_playstore-x86_64",
           "path": "system-images/android-30/google_apis_playstore/x86_64",
@@ -9586,7 +9586,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-31-android-tv-arm64-v8a",
           "path": "system-images/android-31/android-tv/arm64-v8a",
@@ -9645,7 +9645,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-31-android-tv-x86",
           "path": "system-images/android-31/android-tv/x86",
@@ -9696,7 +9696,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-31-default-arm64-v8a",
           "path": "system-images/android-31/default/arm64-v8a",
@@ -9745,7 +9745,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-31-default-x86_64",
           "path": "system-images/android-31/default/x86_64",
@@ -9806,7 +9806,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis-arm64-v8a",
           "path": "system-images/android-31/google_apis/arm64-v8a",
@@ -9873,7 +9873,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-preview-license",
           "name": "system-image-31-google_apis-x86_64",
           "path": "system-images/android-31/google_apis/x86_64",
@@ -9949,7 +9949,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-31/google_apis_playstore/arm64-v8a",
@@ -10016,7 +10016,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis_playstore-x86_64",
           "path": "system-images/android-31/google_apis_playstore/x86_64",
@@ -10077,7 +10077,7 @@
             }
           },
           "displayName": "Android Automotive with Google Play arm64-v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-android-automotive-playstore-arm64-v8a",
           "path": "system-images/android-32/android-automotive-playstore/arm64-v8a",
@@ -10130,7 +10130,7 @@
             }
           },
           "displayName": "Android Automotive with Google Play x86_64 System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-android-automotive-playstore-x86_64",
           "path": "system-images/android-32/android-automotive-playstore/x86_64",
@@ -10185,7 +10185,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-32-default-arm64-v8a",
           "path": "system-images/android-32/default/arm64-v8a",
@@ -10234,7 +10234,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-32-default-x86_64",
           "path": "system-images/android-32/default/x86_64",
@@ -10295,7 +10295,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-32-google_apis-arm64-v8a",
           "path": "system-images/android-32/google_apis/arm64-v8a",
@@ -10362,7 +10362,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-google_apis-x86_64",
           "path": "system-images/android-32/google_apis/x86_64",
@@ -10438,7 +10438,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-32-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-32/google_apis_playstore/arm64-v8a",
@@ -10519,7 +10519,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-google_apis_playstore-x86_64",
           "path": "system-images/android-32/google_apis_playstore/x86_64",
@@ -10580,7 +10580,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs arm64-v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-33-android-automotive-arm64-v8a",
           "path": "system-images/android-33/android-automotive/arm64-v8a",
@@ -10633,7 +10633,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs x86_64 System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-33-android-automotive-x86_64",
           "path": "system-images/android-33/android-automotive/x86_64",
@@ -10698,7 +10698,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-33-android-tv-arm64-v8a",
           "path": "system-images/android-33/android-tv/arm64-v8a",
@@ -10757,7 +10757,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-33-android-tv-x86",
           "path": "system-images/android-33/android-tv/x86",
@@ -10803,7 +10803,7 @@
             }
           },
           "displayName": "Wear OS 4 ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-33-android-wear-arm64-v8a",
           "path": "system-images/android-33/android-wear/arm64-v8a",
@@ -10847,7 +10847,7 @@
             }
           },
           "displayName": "Wear OS 4 Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-33-android-wear-x86_64",
           "path": "system-images/android-33/android-wear/x86_64",
@@ -10898,7 +10898,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-33-default-arm64-v8a",
           "path": "system-images/android-33/default/arm64-v8a",
@@ -10947,7 +10947,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-33-default-x86_64",
           "path": "system-images/android-33/default/x86_64",
@@ -11008,7 +11008,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis-arm64-v8a",
           "path": "system-images/android-33/google_apis/arm64-v8a",
@@ -11075,7 +11075,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-33-google_apis-x86_64",
           "path": "system-images/android-33/google_apis/x86_64",
@@ -11144,7 +11144,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-33/google_apis_playstore/arm64-v8a",
@@ -11211,7 +11211,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-33-google_apis_playstore-x86_64",
           "path": "system-images/android-33/google_apis_playstore/x86_64",
@@ -11286,7 +11286,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-33-ext4/google_apis_playstore/arm64-v8a",
@@ -11335,7 +11335,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-preview-license",
           "name": "system-image-33x-google_apis_playstore-x86_64",
           "path": "system-images/android-33-ext4/google_apis_playstore/x86_64",
@@ -11398,7 +11398,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-34-android-tv-arm64-v8a",
           "path": "system-images/android-34/android-tv/arm64-v8a",
@@ -11458,7 +11458,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-34-android-tv-x86",
           "path": "system-images/android-34/android-tv/x86",
@@ -11498,7 +11498,7 @@
             }
           ],
           "displayName": "Wear OS 5 ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-34-android-wear-arm64-v8a",
           "path": "system-images/android-34/android-wear/arm64-v8a",
@@ -11535,7 +11535,7 @@
             }
           ],
           "displayName": "Wear OS 5 Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-34-android-wear-x86_64",
           "path": "system-images/android-34/android-wear/x86_64",
@@ -11586,7 +11586,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-34-default-arm64-v8a",
           "path": "system-images/android-34/default/arm64-v8a",
@@ -11635,7 +11635,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-34-default-x86_64",
           "path": "system-images/android-34/default/x86_64",
@@ -11696,7 +11696,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34-google_apis-arm64-v8a",
           "path": "system-images/android-34/google_apis/arm64-v8a",
@@ -11764,7 +11764,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-34-google_apis-x86_64",
           "path": "system-images/android-34/google_apis/x86_64",
@@ -11834,7 +11834,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-34/google_apis_playstore/arm64-v8a",
@@ -11903,7 +11903,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-34-google_apis_playstore-x86_64",
           "path": "system-images/android-34/google_apis_playstore/x86_64",
@@ -11966,7 +11966,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs arm64-v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-34x-android-automotive-arm64-v8a",
           "path": "system-images/android-34-ext9/android-automotive/arm64-v8a",
@@ -12019,7 +12019,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs x86_64 System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-34x-android-automotive-x86_64",
           "path": "system-images/android-34-ext9/android-automotive/x86_64",
@@ -12088,7 +12088,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-34-ext12/google_apis_playstore/arm64-v8a",
@@ -12137,7 +12137,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-34x-google_apis_playstore-x86_64",
           "path": "system-images/android-34-ext12/google_apis_playstore/x86_64",
@@ -12178,7 +12178,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 - Preview ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-preview-license",
           "name": "system-image-35-android-wear-arm64-v8a",
           "path": "system-images/android-35/android-wear/arm64-v8a",
@@ -12210,7 +12210,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 - Preview Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-preview-license",
           "name": "system-image-35-android-wear-x86_64",
           "path": "system-images/android-35/android-wear/x86_64",
@@ -12256,7 +12256,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-35-default-arm64-v8a",
           "path": "system-images/android-35/default/arm64-v8a",
@@ -12301,7 +12301,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-35-default-x86_64",
           "path": "system-images/android-35/default/x86_64",
@@ -12348,7 +12348,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-google_apis-arm64-v8a",
           "path": "system-images/android-35/google_apis/arm64-v8a",
@@ -12406,7 +12406,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-35-google_apis-x86_64",
           "path": "system-images/android-35/google_apis/x86_64",
@@ -12466,7 +12466,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-35/google_apis_playstore/arm64-v8a",
@@ -12524,7 +12524,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-35-google_apis_playstore-x86_64",
           "path": "system-images/android-35/google_apis_playstore/x86_64",
@@ -12584,7 +12584,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-page_size_16kb-arm64-v8a",
           "path": "system-images/android-35/google_apis_playstore_ps16k/arm64-v8a",
@@ -12646,7 +12646,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-35-page_size_16kb-x86_64",
           "path": "system-images/android-35/google_apis_playstore_ps16k/x86_64",
@@ -12700,7 +12700,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-35x-android-wear-arm64-v8a",
           "path": "system-images/android-35-ext15/android-wear/arm64-v8a",
@@ -12733,7 +12733,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-35x-android-wear-x86_64",
           "path": "system-images/android-35-ext15/android-wear/x86_64",
@@ -12780,7 +12780,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35x-google_apis-arm64-v8a",
           "path": "system-images/android-35-ext15/google_apis/arm64-v8a",
@@ -12829,7 +12829,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-35x-google_apis-x86_64",
           "path": "system-images/android-35-ext15/google_apis/x86_64",
@@ -12880,7 +12880,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-35-ext15/google_apis_playstore/arm64-v8a",
@@ -12929,7 +12929,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-35x-google_apis_playstore-x86_64",
           "path": "system-images/android-35-ext15/google_apis_playstore/x86_64",
@@ -12964,16 +12964,16 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "53f3fa2adea692b7eabf698d59fdc34d36ff08e4",
-              "size": 1139080003,
+              "sha1": "68c04da635bb6cf224e651661d510b91142c9687",
+              "size": 1138277876,
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/arm64-v8a-36_signed_r01.zip"
             }
           ],
-          "displayName": "Wear OS 6.0 - Preview ARM 64 v8a System Image (signed)",
-          "last-available-day": 20237,
+          "displayName": "Wear OS 6.0 ARM 64 v8a System Image (signed)",
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-36-android-wear-arm64-v8a",
-          "path": "system-images/signed/android-36/android-wear/arm64-v8a",
+          "path": "system-images/android-36/android-wear-signed/arm64-v8a",
           "revision": "36-android-wear-arm64-v8a",
           "revision-details": {
             "major:0": "1"
@@ -12987,7 +12987,7 @@
             },
             "extension-level:1": "17",
             "tag:3": {
-              "display:1": "Wear OS 6.0 - Preview",
+              "display:1": "Wear OS 6.0",
               "id:0": "android-wear"
             }
           }
@@ -12997,16 +12997,16 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "7ae6c4e1c614a649f75ccb653769ccd8cdb30e4a",
-              "size": 1116094453,
+              "sha1": "aafbeec62bc54dd4388022f57d981bf486211acd",
+              "size": 1115294480,
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/x86_64-36_signed_r01.zip"
             }
           ],
-          "displayName": "Wear OS 6.0 - Preview Intel x86_64 Atom System Image (signed)",
-          "last-available-day": 20237,
+          "displayName": "Wear OS 6.0 Intel x86_64 Atom System Image (signed)",
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-36-android-wear-x86_64",
-          "path": "system-images/signed/android-36/android-wear/x86_64",
+          "path": "system-images/android-36/android-wear-signed/x86_64",
           "revision": "36-android-wear-x86_64",
           "revision-details": {
             "major:0": "1"
@@ -13020,7 +13020,7 @@
             },
             "extension-level:1": "17",
             "tag:3": {
-              "display:1": "Wear OS 6.0 - Preview",
+              "display:1": "Wear OS 6.0",
               "id:0": "android-wear"
             }
           }
@@ -13050,7 +13050,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36-google_apis-arm64-v8a",
           "path": "system-images/android-36/google_apis/arm64-v8a",
@@ -13099,7 +13099,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-36-google_apis-x86_64",
           "path": "system-images/android-36/google_apis/x86_64",
@@ -13132,9 +13132,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "b4de516b43b508947d04484732351d9a36fee33f",
-              "size": 1874450592,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-36_r06.zip"
+              "sha1": "5b91ef80a5eb60d7b7167528db259c2a12d20e9c",
+              "size": 1886527965,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-36_r07.zip"
             }
           ],
           "dependencies": {
@@ -13144,19 +13144,19 @@
               },
               "min-revision:0": {
                 "major:0": "35",
-                "micro:2": "10",
-                "minor:1": "2"
+                "micro:2": "9",
+                "minor:1": "4"
               }
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-36/google_apis_playstore/arm64-v8a",
           "revision": "36-google_apis_playstore-arm64-v8a",
           "revision-details": {
-            "major:0": "6"
+            "major:0": "7"
           },
           "type-details": {
             "abi:5": "arm64-v8a",
@@ -13181,9 +13181,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "398e02989fb3c274dd2d99541cf71255de538651",
-              "size": 1912630049,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-36_r06.zip"
+              "sha1": "16fa3c441d29fde6c9eea2f766eecf77032d68b4",
+              "size": 1924689206,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-36_r07.zip"
             }
           ],
           "dependencies": {
@@ -13193,19 +13193,19 @@
               },
               "min-revision:0": {
                 "major:0": "35",
-                "micro:2": "10",
-                "minor:1": "2"
+                "micro:2": "9",
+                "minor:1": "4"
               }
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-36-google_apis_playstore-x86_64",
           "path": "system-images/android-36/google_apis_playstore/x86_64",
           "revision": "36-google_apis_playstore-x86_64",
           "revision-details": {
-            "major:0": "6"
+            "major:0": "7"
           },
           "type-details": {
             "abi:5": "x86_64",
@@ -13250,7 +13250,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36-page_size_16kb-arm64-v8a",
           "path": "system-images/android-36/google_apis_playstore_ps16k/arm64-v8a",
@@ -13303,7 +13303,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-36-page_size_16kb-x86_64",
           "path": "system-images/android-36/google_apis_playstore_ps16k/x86_64",
@@ -13328,6 +13328,208 @@
               "id:0": "google_apis_playstore"
             },
             "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      }
+    },
+    "36x": {
+      "google_apis": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "b19147a0a8f698bd1d8467a5db8f994ad4a3ac6a",
+              "size": 1865400318,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-36-ext18_r01.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Google APIs ARM 64 v8a System Image",
+          "last-available-day": 20318,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-36x-google_apis-arm64-v8a",
+          "path": "system-images/android-36-ext19/google_apis/arm64-v8a",
+          "revision": "36x-google_apis-arm64-v8a",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:5": "arm64-v8a",
+            "api-level:0": "36x",
+            "base-extension:2": "false",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "19",
+            "tag:3": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:4": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "a630fc642602137e6b00201b1ae343d54bc408dc",
+              "size": 1888216599,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-36-ext18_r01.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 20318,
+          "license": "android-sdk-license",
+          "name": "system-image-36x-google_apis-x86_64",
+          "path": "system-images/android-36-ext19/google_apis/x86_64",
+          "revision": "36x-google_apis-x86_64",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:5": "x86_64",
+            "api-level:0": "36x",
+            "base-extension:2": "false",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "19",
+            "tag:3": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:4": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      },
+      "google_apis_playstore": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "186363c4985a3821605faa263060e45c5c71ef8e",
+              "size": 1886730732,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-36-ext18_r01.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Google Play ARM 64 v8a System Image",
+          "last-available-day": 20318,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-36x-google_apis_playstore-arm64-v8a",
+          "path": "system-images/android-36-ext19/google_apis_playstore/arm64-v8a",
+          "revision": "36x-google_apis_playstore-arm64-v8a",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:5": "arm64-v8a",
+            "api-level:0": "36x",
+            "base-extension:2": "false",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "19",
+            "tag:3": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:4": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "5c067300bbfea9340d8a3c7336482fc2f5451f07",
+              "size": 1924885115,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-36-ext18_r01.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 20318,
+          "license": "android-sdk-license",
+          "name": "system-image-36x-google_apis_playstore-x86_64",
+          "path": "system-images/android-36-ext19/google_apis_playstore/x86_64",
+          "revision": "36x-google_apis_playstore-x86_64",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:5": "x86_64",
+            "api-level:0": "36x",
+            "base-extension:2": "false",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "19",
+            "tag:3": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:4": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -13360,7 +13562,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-google_apis-arm64-v8a",
           "path": "system-images/android-Baklava/google_apis/arm64-v8a",
@@ -13410,7 +13612,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-google_apis-x86_64",
           "path": "system-images/android-Baklava/google_apis/x86_64",
@@ -13462,7 +13664,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-Baklava/google_apis_playstore/arm64-v8a",
@@ -13512,7 +13714,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-google_apis_playstore-x86_64",
           "path": "system-images/android-Baklava/google_apis_playstore/x86_64",
@@ -13564,7 +13766,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-page_size_16kb-arm64-v8a",
           "path": "system-images/android-Baklava/google_apis_playstore_ps16k/arm64-v8a",
@@ -13618,7 +13820,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20237,
+          "last-available-day": 20318,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-page_size_16kb-x86_64",
           "path": "system-images/android-Baklava/google_apis_playstore_ps16k/x86_64",
@@ -13635,6 +13837,322 @@
               "xsi:type": "ns12:sysImgDetailsType"
             },
             "extension-level:2": "16",
+            "tag:4": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "tag:5": {
+              "display:1": "Google APIs PlayStore",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:6": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      }
+    },
+    "CANARY": {
+      "google_apis": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "d1f856a0a3b4034787b77c3f10e3e7fd75fa9531",
+              "size": 1910594067,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-36.0-CANARY_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Google APIs ARM 64 v8a System Image",
+          "last-available-day": 20318,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-CANARY-google_apis-arm64-v8a",
+          "path": "system-images/android-36.0-CANARY/google_apis/arm64-v8a",
+          "revision": "CANARY-google_apis-arm64-v8a",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:6": "arm64-v8a",
+            "api-level:0": "36.0",
+            "base-extension:3": "true",
+            "codename:1": "CANARY",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:2": "19",
+            "tag:4": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "06999469c59997683bbf08b6e4406ac8e4b61858",
+              "size": 1942528271,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-36.0-CANARY_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 20318,
+          "license": "android-sdk-preview-license",
+          "name": "system-image-CANARY-google_apis-x86_64",
+          "path": "system-images/android-36.0-CANARY/google_apis/x86_64",
+          "revision": "CANARY-google_apis-x86_64",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:6": "x86_64",
+            "api-level:0": "36.0",
+            "base-extension:3": "true",
+            "codename:1": "CANARY",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:2": "19",
+            "tag:4": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      },
+      "google_apis_playstore": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "54c5a2d2750bebd5eaa681b2a3d52c4b9b5d7298",
+              "size": 1937268325,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-36.0-CANARY_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Google Play ARM 64 v8a System Image",
+          "last-available-day": 20318,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-CANARY-google_apis_playstore-arm64-v8a",
+          "path": "system-images/android-36.0-CANARY/google_apis_playstore/arm64-v8a",
+          "revision": "CANARY-google_apis_playstore-arm64-v8a",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:6": "arm64-v8a",
+            "api-level:0": "36.0",
+            "base-extension:3": "true",
+            "codename:1": "CANARY",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:2": "19",
+            "tag:4": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "8afb6a1b2a7e7b4c090cd3aaa0a0eba86e448131",
+              "size": 1985255940,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-36.0-CANARY_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 20318,
+          "license": "android-sdk-preview-license",
+          "name": "system-image-CANARY-google_apis_playstore-x86_64",
+          "path": "system-images/android-36.0-CANARY/google_apis_playstore/x86_64",
+          "revision": "CANARY-google_apis_playstore-x86_64",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:6": "x86_64",
+            "api-level:0": "36.0",
+            "base-extension:3": "true",
+            "codename:1": "CANARY",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:2": "19",
+            "tag:4": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      },
+      "page_size_16kb": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "ab794ced3006692f3dcfab3d821c68b3d2b12cce",
+              "size": 1990330997,
+              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/arm64-v8a-playstore-ps16k-36.0-CANARY_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
+          "last-available-day": 20318,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-CANARY-page_size_16kb-arm64-v8a",
+          "path": "system-images/android-36.0-CANARY/google_apis_playstore_ps16k/arm64-v8a",
+          "revision": "CANARY-page_size_16kb-arm64-v8a",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:7": "arm64-v8a",
+            "api-level:0": "36.0",
+            "base-extension:3": "true",
+            "codename:1": "CANARY",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:2": "19",
+            "tag:4": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "tag:5": {
+              "display:1": "Google APIs PlayStore",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:6": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "bfc22a8e70c29c3b02af6bde5d644ecf2c18670f",
+              "size": 1982737255,
+              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/x86_64-playstore-ps16k-36.0-CANARY_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 20318,
+          "license": "android-sdk-preview-license",
+          "name": "system-image-CANARY-page_size_16kb-x86_64",
+          "path": "system-images/android-36.0-CANARY/google_apis_playstore_ps16k/x86_64",
+          "revision": "CANARY-page_size_16kb-x86_64",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:7": "x86_64",
+            "api-level:0": "36.0",
+            "base-extension:3": "true",
+            "codename:1": "CANARY",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:2": "19",
             "tag:4": {
               "display:1": "16 KB Page Size",
               "id:0": "page_size_16kb"
@@ -14226,12 +14744,12 @@
   },
   "latest": {
     "build-tools": "36.0.0",
-    "cmake": "4.0.2",
+    "cmake": "4.1.0",
     "cmdline-tools": "19.0",
-    "emulator": "35.6.9",
-    "ndk": "28.1.13356709",
+    "emulator": "36.1.9",
+    "ndk": "28.2.13676358",
     "ndk-bundle": "22.1.7171670",
-    "platform-tools": "35.0.2",
+    "platform-tools": "36.0.0",
     "platforms": "36",
     "skiaparser": "7",
     "sources": "36",
@@ -14300,7 +14818,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 17",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14349,7 +14867,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.0.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14398,7 +14916,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14447,7 +14965,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.1.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14496,7 +15014,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14545,7 +15063,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14594,7 +15112,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.2",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14643,7 +15161,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.3",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14692,7 +15210,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/19.1.0",
@@ -14740,7 +15258,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 20",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/20.0.0",
@@ -14788,7 +15306,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14837,7 +15355,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.0.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14886,7 +15404,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.0.2",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14935,7 +15453,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14984,7 +15502,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15033,7 +15551,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1.2",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/21.1.2",
@@ -15081,7 +15599,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 22",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15130,7 +15648,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 22.0.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/22.0.1",
@@ -15178,7 +15696,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15227,7 +15745,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.1",
@@ -15275,7 +15793,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.2",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.2",
@@ -15323,7 +15841,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.3",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.3",
@@ -15371,7 +15889,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.0",
@@ -15419,7 +15937,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.1",
@@ -15467,7 +15985,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.2",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.2",
@@ -15515,7 +16033,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.3",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.3",
@@ -15563,7 +16081,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.0",
@@ -15611,7 +16129,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.1",
@@ -15659,7 +16177,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.2",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.2",
@@ -15707,7 +16225,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.3",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.3",
@@ -15755,7 +16273,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.0",
@@ -15803,7 +16321,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.1",
@@ -15851,7 +16369,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.2",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.2",
@@ -15899,7 +16417,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.3",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.3",
@@ -15947,7 +16465,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.0",
@@ -15995,7 +16513,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.1",
@@ -16043,7 +16561,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.2",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.2",
@@ -16091,7 +16609,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.3",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.3",
@@ -16139,7 +16657,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.0",
@@ -16187,7 +16705,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28-rc1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16237,7 +16755,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28-rc2",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16287,7 +16805,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.1",
@@ -16335,7 +16853,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.2",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.2",
@@ -16383,7 +16901,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.3",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.3",
@@ -16431,7 +16949,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.0",
@@ -16479,7 +16997,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16529,7 +17047,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc2",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16579,7 +17097,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc3",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16629,7 +17147,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.1",
@@ -16677,7 +17195,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.2",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.2",
@@ -16725,7 +17243,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.3",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.3",
@@ -16773,7 +17291,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.0",
@@ -16821,7 +17339,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.1",
@@ -16869,7 +17387,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.2",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.2",
@@ -16917,7 +17435,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.3",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.3",
@@ -16958,7 +17476,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 31",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/31.0.0",
@@ -16999,7 +17517,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 32",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/32.0.0",
@@ -17040,7 +17558,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 32.1-rc1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/32.1.0-rc1",
@@ -17082,7 +17600,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.0",
@@ -17123,7 +17641,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.1",
@@ -17164,7 +17682,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.2",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.2",
@@ -17205,7 +17723,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.3",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.3",
@@ -17246,7 +17764,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0",
@@ -17287,7 +17805,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc1",
@@ -17329,7 +17847,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc2",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc2",
@@ -17371,7 +17889,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc3",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc3",
@@ -17413,7 +17931,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0",
@@ -17454,7 +17972,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc1",
@@ -17496,7 +18014,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc2",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc2",
@@ -17538,7 +18056,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc3",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc3",
@@ -17580,7 +18098,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc4",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc4",
@@ -17622,7 +18140,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35.0.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/35.0.1",
@@ -17663,7 +18181,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0",
@@ -17704,7 +18222,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc1",
@@ -17746,7 +18264,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc3",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc3",
@@ -17788,7 +18306,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc4",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc4",
@@ -17830,7 +18348,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc5",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc5",
@@ -17881,7 +18399,7 @@
           }
         ],
         "displayName": "CMake 3.10.2.4988404",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.10.2.4988404",
@@ -17922,7 +18440,7 @@
           }
         ],
         "displayName": "CMake 3.18.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.18.1",
@@ -17963,7 +18481,7 @@
           }
         ],
         "displayName": "CMake 3.22.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.22.1",
@@ -18004,7 +18522,7 @@
           }
         ],
         "displayName": "CMake 3.30.3",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.3",
@@ -18045,7 +18563,7 @@
           }
         ],
         "displayName": "CMake 3.30.4",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.4",
@@ -18086,7 +18604,7 @@
           }
         ],
         "displayName": "CMake 3.30.5",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.5",
@@ -18127,7 +18645,7 @@
           }
         ],
         "displayName": "CMake 3.31.0",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.0",
@@ -18168,7 +18686,7 @@
           }
         ],
         "displayName": "CMake 3.31.1",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.1",
@@ -18209,7 +18727,7 @@
           }
         ],
         "displayName": "CMake 3.31.4",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.4",
@@ -18250,7 +18768,7 @@
           }
         ],
         "displayName": "CMake 3.31.5",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.5",
@@ -18291,7 +18809,7 @@
           }
         ],
         "displayName": "CMake 3.31.6",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.6",
@@ -18339,7 +18857,7 @@
           }
         ],
         "displayName": "CMake 3.6.4111459",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.6.4111459",
@@ -18380,7 +18898,7 @@
           }
         ],
         "displayName": "CMake 4.0.2",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/4.0.2",
@@ -18389,6 +18907,88 @@
           "major:0": "4",
           "micro:2": "2",
           "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "4.0.3": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "595002f48fca924c9dcf7b3274277026024b7887",
+            "size": 30911219,
+            "url": "https://dl.google.com/android/repository/cmake-4.0.3-linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "11cd1bd2b921d5bc262b7d502403f185dd6001a4",
+            "size": 43161272,
+            "url": "https://dl.google.com/android/repository/cmake-4.0.3-darwin.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "edaff2f1c48e57f28c9a03945165b6a54b60aa15",
+            "size": 20622355,
+            "url": "https://dl.google.com/android/repository/cmake-4.0.3-windows.zip"
+          }
+        ],
+        "displayName": "CMake 4.0.3",
+        "last-available-day": 20318,
+        "license": "android-sdk-license",
+        "name": "cmake",
+        "path": "cmake/4.0.3",
+        "revision": "4.0.3",
+        "revision-details": {
+          "major:0": "4",
+          "micro:2": "3",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "4.1.0": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "c7df7c5094f58d61a53f615cd68e6e7fd0c41a76",
+            "size": 31268624,
+            "url": "https://dl.google.com/android/repository/cmake-4.1.0-linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "11ba32eb864c31fcf383456e21d9ab8e13c8d22c",
+            "size": 43658753,
+            "url": "https://dl.google.com/android/repository/cmake-4.1.0-darwin.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "3bc560fd2b487841fb0bad2f3585cff8aaf40cd5",
+            "size": 20951280,
+            "url": "https://dl.google.com/android/repository/cmake-4.1.0-windows.zip"
+          }
+        ],
+        "displayName": "CMake 4.1.0",
+        "last-available-day": 20318,
+        "license": "android-sdk-license",
+        "name": "cmake",
+        "path": "cmake/4.1.0",
+        "revision": "4.1.0",
+        "revision-details": {
+          "major:0": "4",
+          "micro:2": "0",
+          "minor:1": "1"
         },
         "type-details": {
           "element-attributes": {
@@ -18423,7 +19023,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/1.0",
@@ -18463,7 +19063,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/10.0",
@@ -18503,7 +19103,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/11.0",
@@ -18581,7 +19181,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/12.0",
@@ -18659,7 +19259,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/13.0",
@@ -18699,7 +19299,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/13.0-rc01",
@@ -18740,7 +19340,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/14.0-alpha01",
@@ -18781,7 +19381,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/16.0",
@@ -18821,7 +19421,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/16.0-alpha01",
@@ -18862,7 +19462,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/17.0",
@@ -18902,7 +19502,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/19.0",
@@ -18942,7 +19542,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/19.0-alpha01",
@@ -18983,7 +19583,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "obsolete": "true",
@@ -19024,7 +19624,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/2.1",
@@ -19064,7 +19664,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/3.0",
@@ -19104,7 +19704,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/4.0",
@@ -19144,7 +19744,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/5.0",
@@ -19184,7 +19784,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/6.0",
@@ -19224,7 +19824,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/7.0",
@@ -19264,7 +19864,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/8.0",
@@ -19304,7 +19904,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/9.0",
@@ -19321,96 +19921,6 @@
       }
     },
     "emulator": {
-      "32.1.10": {
-        "archives": [
-          {
-            "os": "macosx",
-            "sha1": "518eaa8575a2e5ae7bbb19847e0c25b7968a9e91",
-            "size": 309316195,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-9475343.zip"
-          },
-          {
-            "os": "linux",
-            "sha1": "71ef457eeeee6b55382abf4a5aaab5de7426e383",
-            "size": 270160041,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-9475343.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "a53b8e1026325b48cb722d91deeb128947971b8f",
-            "size": 333004087,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-9475343.zip"
-          }
-        ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
-        "displayName": "Android Emulator",
-        "last-available-day": 19579,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "32.1.10",
-        "revision-details": {
-          "major:0": "32",
-          "micro:2": "10",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "32.1.14": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "04bab7711660fc9891fd5dec347a9f533a87af1a",
-            "size": 270178945,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-10330179.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "f039bd816f82cda85ee4a2e14497bd00a1998867",
-            "size": 333010879,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-10330179.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "3db11e3541bfced7dbaadc976a13045fd7e1bbcc",
-            "size": 309337702,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-10330179.zip"
-          }
-        ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
-        "displayName": "Android Emulator",
-        "last-available-day": 19579,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "32.1.14",
-        "revision-details": {
-          "major:0": "32",
-          "micro:2": "14",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
       "32.1.15": {
         "archives": [
           {
@@ -19441,51 +19951,6 @@
         "revision-details": {
           "major:0": "32",
           "micro:2": "15",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "33.1.17": {
-        "archives": [
-          {
-            "os": "macosx",
-            "sha1": "cd989b0594ebe9382749b3a5dc026acb326e4de0",
-            "size": 341193257,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-10594030.zip"
-          },
-          {
-            "os": "linux",
-            "sha1": "72c3fb1591755ee5f5d662114a394d08247efc13",
-            "size": 261440080,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-10594030.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "cc302b5107e64348e957e4738530bcfbb58212a8",
-            "size": 363656447,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-10594030.zip"
-          }
-        ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
-        "displayName": "Android Emulator",
-        "last-available-day": 19579,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "33.1.17",
-        "revision-details": {
-          "major:0": "33",
-          "micro:2": "17",
           "minor:1": "1"
         },
         "type-details": {
@@ -20401,6 +20866,150 @@
             "xsi:type": "ns5:genericDetailsType"
           }
         }
+      },
+      "36.1.8": {
+        "archives": [
+          {
+            "arch": "x64",
+            "os": "linux",
+            "sha1": "85c198dcc67bc02c7682b410c362663f1221f127",
+            "size": 319200975,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-13784423.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "macosx",
+            "sha1": "478e9a9f93c7d56140a1748f8f2ee24404231f3a",
+            "size": 394949463,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-13784423.zip"
+          },
+          {
+            "arch": "aarch64",
+            "os": "macosx",
+            "sha1": "f73484c5c62d6211fe2741ce40b9e6b4b27e3cff",
+            "size": 312530769,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-13784423.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "windows",
+            "sha1": "c3c9a497085b0ce173a3ff053743c9191a49aa90",
+            "size": 440864909,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-13784423.zip"
+          }
+        ],
+        "displayName": "Android Emulator",
+        "last-available-day": 20318,
+        "license": "android-sdk-license",
+        "name": "emulator",
+        "path": "emulator",
+        "revision": "36.1.8",
+        "revision-details": {
+          "major:0": "36",
+          "micro:2": "8",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "36.1.9": {
+        "archives": [
+          {
+            "arch": "x64",
+            "os": "linux",
+            "sha1": "6640cd1d6ca5cf306cfe51d4957ace7e5f3c1d8c",
+            "size": 319203216,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-13823996.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "macosx",
+            "sha1": "7688a93c4162dd26e961fa26e260dbb638aa2679",
+            "size": 394943617,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-13823996.zip"
+          },
+          {
+            "arch": "aarch64",
+            "os": "macosx",
+            "sha1": "540cad31129eb9518082647a67cf634c51f565de",
+            "size": 312528104,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-13823996.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "windows",
+            "sha1": "b9542962753c1b2774691d758247cac6a2384655",
+            "size": 440857308,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-13823996.zip"
+          }
+        ],
+        "displayName": "Android Emulator",
+        "last-available-day": 20318,
+        "license": "android-sdk-license",
+        "name": "emulator",
+        "path": "emulator",
+        "revision": "36.1.9",
+        "revision-details": {
+          "major:0": "36",
+          "micro:2": "9",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "36.2.4": {
+        "archives": [
+          {
+            "arch": "x64",
+            "os": "linux",
+            "sha1": "287915ab3349c2304893dc0ed2fc27bff8219bd2",
+            "size": 324654299,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-13899551.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "macosx",
+            "sha1": "6134b9d9cfb201438a2bcf2d3c2469f708d77357",
+            "size": 401818934,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-13899551.zip"
+          },
+          {
+            "arch": "aarch64",
+            "os": "macosx",
+            "sha1": "f1c4fd99341f24bc22dce34db92d708636a9ca1e",
+            "size": 319414458,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-13899551.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "windows",
+            "sha1": "4e4ab339536f7cb26f5af4d8dfd4836bcffb46a0",
+            "size": 446720651,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-13899551.zip"
+          }
+        ],
+        "displayName": "Android Emulator",
+        "last-available-day": 20318,
+        "license": "android-sdk-preview-license",
+        "name": "emulator",
+        "path": "emulator",
+        "revision": "36.2.4",
+        "revision-details": {
+          "major:0": "36",
+          "micro:2": "4",
+          "minor:1": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       }
     },
     "extras": {
@@ -20526,7 +21135,7 @@
           }
         },
         "displayName": "NDK (Side by side) 16.1.4479499",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/16.1.4479499",
@@ -20588,7 +21197,7 @@
           }
         },
         "displayName": "NDK (Side by side) 17.2.4988734",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/17.2.4988734",
@@ -20650,7 +21259,7 @@
           }
         },
         "displayName": "NDK (Side by side) 18.1.5063045",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/18.1.5063045",
@@ -20712,7 +21321,7 @@
           }
         },
         "displayName": "NDK (Side by side) 19.0.5232133",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "obsolete": "true",
@@ -20775,7 +21384,7 @@
           }
         },
         "displayName": "NDK (Side by side) 19.2.5345600",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/19.2.5345600",
@@ -20837,7 +21446,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5392854",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "obsolete": "true",
@@ -20901,7 +21510,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5471264",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "obsolete": "true",
@@ -20965,7 +21574,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5594570",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/20.0.5594570",
@@ -21027,7 +21636,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.1.5948944",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/20.1.5948944",
@@ -21075,7 +21684,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.0.6011959",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.0.6011959",
@@ -21124,7 +21733,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.0.6113669",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.0.6113669",
@@ -21172,7 +21781,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6210238",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6210238",
@@ -21228,7 +21837,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6273396",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6273396",
@@ -21284,7 +21893,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6352462",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.1.6352462",
@@ -21339,7 +21948,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6363665",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6363665",
@@ -21395,7 +22004,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.2.6472646",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.2.6472646",
@@ -21450,7 +22059,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.3.6528147",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.3.6528147",
@@ -21505,7 +22114,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.4.7075529",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.4.7075529",
@@ -21560,7 +22169,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.0.6917172",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/22.0.6917172",
@@ -21616,7 +22225,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.0.7026061",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/22.0.7026061",
@@ -21671,7 +22280,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.1.7171670",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/22.1.7171670",
@@ -21726,7 +22335,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7123448",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7123448",
@@ -21782,7 +22391,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7196353",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7196353",
@@ -21838,7 +22447,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7272597",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7272597",
@@ -21894,7 +22503,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7344513",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7344513",
@@ -21943,7 +22552,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7421159",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7421159",
@@ -21992,7 +22601,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7530507",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7530507",
@@ -22041,7 +22650,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7599858",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.0.7599858",
@@ -22089,7 +22698,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.1.7779620",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.1.7779620",
@@ -22137,7 +22746,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.2.8568313",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.2.8568313",
@@ -22185,7 +22794,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.7856742",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.7856742",
@@ -22234,7 +22843,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.7956693",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.7956693",
@@ -22283,7 +22892,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.8079956",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.8079956",
@@ -22332,7 +22941,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.8215888",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/24.0.8215888",
@@ -22380,7 +22989,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8151533",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8151533",
@@ -22429,7 +23038,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8221429",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8221429",
@@ -22478,7 +23087,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8355429",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8355429",
@@ -22527,7 +23136,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8528842",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8528842",
@@ -22576,7 +23185,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8775105",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.0.8775105",
@@ -22624,7 +23233,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.1.8937393",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.1.8937393",
@@ -22672,7 +23281,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.2.9519653",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.2.9519653",
@@ -22720,7 +23329,7 @@
           }
         },
         "displayName": "NDK (Side by side) 26.0.10404224",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/26.0.10404224",
@@ -22762,7 +23371,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.0.10636728",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/26.0.10636728",
@@ -22804,7 +23413,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.0.10792818",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.0.10792818",
@@ -22845,7 +23454,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.1.10909125",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.1.10909125",
@@ -22886,7 +23495,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.2.11394342",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.2.11394342",
@@ -22927,7 +23536,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.3.11579264",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.3.11579264",
@@ -22968,7 +23577,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.11718014",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/27.0.11718014",
@@ -23010,7 +23619,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.11902837",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/27.0.11902837",
@@ -23052,7 +23661,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.12077973",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.0.12077973",
@@ -23093,7 +23702,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.1.12297006",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.1.12297006",
@@ -23134,7 +23743,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.2.12479018",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.2.12479018",
@@ -23143,6 +23752,47 @@
           "major:0": "27",
           "micro:2": "12479018",
           "minor:1": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "27.3.13750724": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "22105e410cf29afcf163760cc95522b9fb981121",
+            "size": 663956036,
+            "url": "https://dl.google.com/android/repository/android-ndk-r27d-linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "2970926d705988f79baa9b04c51b4f7914dd8c56",
+            "size": 839006233,
+            "url": "https://dl.google.com/android/repository/android-ndk-r27d-darwin.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "56607cbccd3642d4a1991f6bb3114a00f884f426",
+            "size": 781506724,
+            "url": "https://dl.google.com/android/repository/android-ndk-r27d-windows.zip"
+          }
+        ],
+        "displayName": "NDK (Side by side) 27.3.13750724",
+        "last-available-day": 20318,
+        "license": "android-sdk-license",
+        "name": "ndk",
+        "path": "ndk/27.3.13750724",
+        "revision": "27.3.13750724",
+        "revision-details": {
+          "major:0": "27",
+          "micro:2": "13750724",
+          "minor:1": "3"
         },
         "type-details": {
           "element-attributes": {
@@ -23175,7 +23825,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12433566",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12433566",
@@ -23217,7 +23867,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12674087",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12674087",
@@ -23259,7 +23909,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12916984",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12916984",
@@ -23301,7 +23951,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.13004108",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/28.0.13004108",
@@ -23342,7 +23992,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.1.13356709",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/28.1.13356709",
@@ -23351,6 +24001,47 @@
           "major:0": "28",
           "micro:2": "13356709",
           "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "28.2.13676358": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "a7b54a5de87fecd125a17d54f73c446199e72a64",
+            "size": 722261334,
+            "url": "https://dl.google.com/android/repository/android-ndk-r28c-linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "fc20a6bf15a30fb3428c9b60a7308793a362dc6d",
+            "size": 952495160,
+            "url": "https://dl.google.com/android/repository/android-ndk-r28c-darwin.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "086bba43ff2f5eb0e387b15c8278bb4e0d89ba1d",
+            "size": 748118221,
+            "url": "https://dl.google.com/android/repository/android-ndk-r28c-windows.zip"
+          }
+        ],
+        "displayName": "NDK (Side by side) 28.2.13676358",
+        "last-available-day": 20318,
+        "license": "android-sdk-license",
+        "name": "ndk",
+        "path": "ndk/28.2.13676358",
+        "revision": "28.2.13676358",
+        "revision-details": {
+          "major:0": "28",
+          "micro:2": "13676358",
+          "minor:1": "2"
         },
         "type-details": {
           "element-attributes": {
@@ -23383,7 +24074,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 29.0.13113456",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/29.0.13113456",
@@ -23393,6 +24084,90 @@
           "micro:2": "13113456",
           "minor:1": "0",
           "preview:3": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "29.0.13599879-rc2": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "06c29d6764526fb51407d08fcead41247ddd3b70",
+            "size": 773244047,
+            "url": "https://dl.google.com/android/repository/android-ndk-r29-beta2-linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "09be4f8fb626a9c93415198ea8e75d8d82f528fa",
+            "size": 1027864991,
+            "url": "https://dl.google.com/android/repository/android-ndk-r29-beta2-darwin.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "59b665f7506f1079771393f2c90f3cb29817ecfb",
+            "size": 821169899,
+            "url": "https://dl.google.com/android/repository/android-ndk-r29-beta2-windows.zip"
+          }
+        ],
+        "displayName": "NDK (Side by side) 29.0.13599879",
+        "last-available-day": 20318,
+        "license": "android-sdk-preview-license",
+        "name": "ndk",
+        "path": "ndk/29.0.13599879",
+        "revision": "29.0.13599879-rc2",
+        "revision-details": {
+          "major:0": "29",
+          "micro:2": "13599879",
+          "minor:1": "0",
+          "preview:3": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "29.0.13846066-rc3": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "277ccc0f9c56b05dd88e0af39446cd9402b13b0c",
+            "size": 784944032,
+            "url": "https://dl.google.com/android/repository/android-ndk-r29-beta3-linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "f1a4894f0ae115827539c0da251e78df565d9abd",
+            "size": 1049515449,
+            "url": "https://dl.google.com/android/repository/android-ndk-r29-beta3-darwin.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "51b40aa57d8058d901e70357734651ecc69d705a",
+            "size": 833874261,
+            "url": "https://dl.google.com/android/repository/android-ndk-r29-beta3-windows.zip"
+          }
+        ],
+        "displayName": "NDK (Side by side) 29.0.13846066",
+        "last-available-day": 20318,
+        "license": "android-sdk-preview-license",
+        "name": "ndk",
+        "path": "ndk/29.0.13846066",
+        "revision": "29.0.13846066-rc3",
+        "revision-details": {
+          "major:0": "29",
+          "micro:2": "13846066",
+          "minor:1": "0",
+          "preview:3": "3"
         },
         "type-details": {
           "element-attributes": {
@@ -23448,7 +24223,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23510,7 +24285,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23572,7 +24347,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23634,7 +24409,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -23697,7 +24472,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23759,7 +24534,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -23823,7 +24598,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -23887,7 +24662,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23949,7 +24724,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23997,7 +24772,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24046,7 +24821,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24094,7 +24869,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24150,7 +24925,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24206,7 +24981,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24261,7 +25036,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24317,7 +25092,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24372,7 +25147,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24427,7 +25202,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24482,7 +25257,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24538,7 +25313,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24593,7 +25368,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24648,7 +25423,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24704,7 +25479,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24760,7 +25535,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24816,7 +25591,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24835,70 +25610,8 @@
       }
     },
     "patcher": {
-      "1": {
-        "archives": [
-          {
-            "os": "all",
-            "sha1": "046699c5e2716ae11d77e0bad814f7f33fab261e",
-            "size": 1827327,
-            "url": "https://dl.google.com/android/repository/3534162-studio.sdk-patcher.zip"
-          }
-        ],
-        "displayName": "SDK Patch Applier v4",
-        "last-available-day": 19579,
-        "license": "android-sdk-license",
-        "name": "patcher",
-        "path": "patcher/v4",
-        "revision": "1",
-        "revision-details": {
-          "major:0": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      }
     },
     "platform-tools": {
-      "34.0.4": {
-        "archives": [
-          {
-            "os": "macosx",
-            "sha1": "ecc476b9801fcb6ea61605eedf60f85217964f09",
-            "size": 11208015,
-            "url": "https://dl.google.com/android/repository/platform-tools_r34.0.4-darwin.zip"
-          },
-          {
-            "os": "linux",
-            "sha1": "faaac1c05af0e3fa20baee6e8970d96fb53bfe58",
-            "size": 6325905,
-            "url": "https://dl.google.com/android/repository/platform-tools_r34.0.4-linux.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "d245eedc17259b15e799c312e9014f78aea3da21",
-            "size": 5992467,
-            "url": "https://dl.google.com/android/repository/platform-tools_r34.0.4-windows.zip"
-          }
-        ],
-        "displayName": "Android SDK Platform-Tools",
-        "last-available-day": 19579,
-        "license": "android-sdk-license",
-        "name": "platform-tools",
-        "path": "platform-tools",
-        "revision": "34.0.4",
-        "revision-details": {
-          "major:0": "34",
-          "micro:2": "4",
-          "minor:1": "0"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
       "34.0.5": {
         "archives": [
           {
@@ -25028,27 +25741,68 @@
           {
             "arch": "all",
             "os": "macosx",
-            "sha1": "48ebbd2fc67d894d7fd7b21679a7c8eb3fed9b28",
-            "size": 14186209,
+            "sha1": "69ffc978ad66667c6b2eb7979a09f5af20f83aaa",
+            "size": 14186137,
             "url": "https://dl.google.com/android/repository/platform-tools_r36.0.0-darwin.zip"
           },
           {
             "arch": "all",
             "os": "windows",
-            "sha1": "342b69dcbab46c9d3b802d7e21b95a91c8c9b3ff",
-            "size": 7138793,
+            "sha1": "18bb505f9fbfbdf1e44fca4d794e74e01b63d30e",
+            "size": 7138784,
             "url": "https://dl.google.com/android/repository/platform-tools_r36.0.0-win.zip"
           }
         ],
         "displayName": "Android SDK Platform-Tools",
-        "last-available-day": 20237,
-        "license": "android-sdk-preview-license",
+        "last-available-day": 20318,
+        "license": "android-sdk-license",
         "name": "platform-tools",
         "path": "platform-tools",
         "revision": "36.0.0",
         "revision-details": {
           "major:0": "36",
           "micro:2": "0",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "36.0.1": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "5ea5ed0ce3734d4f7dfed7f91eeda090101c3411",
+            "size": 8128518,
+            "url": "https://dl.google.com/android/repository/platform-tools_r36.0.1-linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "96dd111d89fb1e6c8f3a78781102dad7366fe9cc",
+            "size": 14597016,
+            "url": "https://dl.google.com/android/repository/platform-tools_r36.0.1-darwin.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "0a700d028bca11fbf5be6fc2187e9a8820f2d942",
+            "size": 7316031,
+            "url": "https://dl.google.com/android/repository/platform-tools_r36.0.1-win.zip"
+          }
+        ],
+        "displayName": "Android SDK Platform-Tools",
+        "last-available-day": 20318,
+        "license": "android-sdk-preview-license",
+        "name": "platform-tools",
+        "path": "platform-tools",
+        "revision": "36.0.1",
+        "revision-details": {
+          "major:0": "36",
+          "micro:2": "1",
           "minor:1": "0"
         },
         "type-details": {
@@ -25070,7 +25824,7 @@
           }
         ],
         "displayName": "Android SDK Platform 10",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-10",
@@ -25109,7 +25863,7 @@
           }
         ],
         "displayName": "Android SDK Platform 11",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-11",
@@ -25148,7 +25902,7 @@
           }
         ],
         "displayName": "Android SDK Platform 12",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-12",
@@ -25187,7 +25941,7 @@
           }
         ],
         "displayName": "Android SDK Platform 13",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-13",
@@ -25226,7 +25980,7 @@
           }
         ],
         "displayName": "Android SDK Platform 14",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-14",
@@ -25265,7 +26019,7 @@
           }
         ],
         "displayName": "Android SDK Platform 15",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-15",
@@ -25304,7 +26058,7 @@
           }
         ],
         "displayName": "Android SDK Platform 16",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-16",
@@ -25343,7 +26097,7 @@
           }
         ],
         "displayName": "Android SDK Platform 17",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-17",
@@ -25382,7 +26136,7 @@
           }
         ],
         "displayName": "Android SDK Platform 18",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-18",
@@ -25421,7 +26175,7 @@
           }
         ],
         "displayName": "Android SDK Platform 19",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-19",
@@ -25474,7 +26228,7 @@
           }
         ],
         "displayName": "Android SDK Platform 2",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -25514,7 +26268,7 @@
           }
         ],
         "displayName": "Android SDK Platform 20",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-20",
@@ -25553,7 +26307,7 @@
           }
         ],
         "displayName": "Android SDK Platform 21",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-21",
@@ -25592,7 +26346,7 @@
           }
         ],
         "displayName": "Android SDK Platform 22",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-22",
@@ -25631,7 +26385,7 @@
           }
         ],
         "displayName": "Android SDK Platform 23",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-23",
@@ -25670,7 +26424,7 @@
           }
         ],
         "displayName": "Android SDK Platform 24",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-24",
@@ -25709,7 +26463,7 @@
           }
         ],
         "displayName": "Android SDK Platform 25",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-25",
@@ -25748,7 +26502,7 @@
           }
         ],
         "displayName": "Android SDK Platform 26",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-26",
@@ -25787,7 +26541,7 @@
           }
         ],
         "displayName": "Android SDK Platform 27",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-27",
@@ -25826,7 +26580,7 @@
           }
         ],
         "displayName": "Android SDK Platform 28",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-28",
@@ -25865,7 +26619,7 @@
           }
         ],
         "displayName": "Android SDK Platform 29",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-29",
@@ -25918,7 +26672,7 @@
           }
         ],
         "displayName": "Android SDK Platform 3",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -25958,7 +26712,7 @@
           }
         ],
         "displayName": "Android SDK Platform 30",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-30",
@@ -25997,7 +26751,7 @@
           }
         ],
         "displayName": "Android SDK Platform 31",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-31",
@@ -26036,7 +26790,7 @@
           }
         ],
         "displayName": "Android SDK Platform 32",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-32",
@@ -26075,7 +26829,7 @@
           }
         ],
         "displayName": "Android SDK Platform 33",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-33",
@@ -26115,7 +26869,7 @@
           }
         ],
         "displayName": "Android SDK Platform 33-ext5",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-33-ext5",
@@ -26150,7 +26904,7 @@
           }
         ],
         "displayName": "Android SDK Platform 34",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -26196,7 +26950,7 @@
           }
         ],
         "displayName": "Android SDK Platform 34-ext12",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-34-ext12",
@@ -26229,7 +26983,7 @@
           }
         ],
         "displayName": "Android SDK Platform 35",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-35",
@@ -26267,7 +27021,7 @@
           }
         ],
         "displayName": "Android SDK Platform 35-ext15",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-35-ext15",
@@ -26300,7 +27054,7 @@
           }
         ],
         "displayName": "Android SDK Platform 36",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-36",
@@ -26315,6 +27069,39 @@
             "xsi:type": "ns11:platformDetailsType"
           },
           "extension-level:1": "17",
+          "layoutlib:3": {
+            "element-attributes": {
+              "api": "15"
+            }
+          }
+        }
+      },
+      "36x": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "all",
+            "sha1": "33a7af9f531f6ce67b3ec357f619e69aa0a95c8a",
+            "size": 66044874,
+            "url": "https://dl.google.com/android/repository/platform-36-ext18_r01.zip"
+          }
+        ],
+        "displayName": "Android SDK Platform 36-ext19",
+        "last-available-day": 20318,
+        "license": "android-sdk-license",
+        "name": "platforms",
+        "path": "platforms/android-36-ext19",
+        "revision": "36x",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "36x",
+          "base-extension:2": "false",
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "extension-level:1": "19",
           "layoutlib:3": {
             "element-attributes": {
               "api": "15"
@@ -26347,7 +27134,7 @@
           }
         ],
         "displayName": "Android SDK Platform 4",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -26401,7 +27188,7 @@
           }
         ],
         "displayName": "Android SDK Platform 5",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -26455,7 +27242,7 @@
           }
         ],
         "displayName": "Android SDK Platform 6",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -26495,7 +27282,7 @@
           }
         ],
         "displayName": "Android SDK Platform 7",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-7",
@@ -26534,7 +27321,7 @@
           }
         ],
         "displayName": "Android SDK Platform 8",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-8",
@@ -26573,7 +27360,7 @@
           }
         ],
         "displayName": "Android SDK Platform 9",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-9",
@@ -26612,7 +27399,7 @@
           }
         ],
         "displayName": "Android SDK Platform Baklava",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-Baklava",
@@ -26628,6 +27415,40 @@
             "xsi:type": "ns11:platformDetailsType"
           },
           "extension-level:2": "16",
+          "layoutlib:4": {
+            "element-attributes": {
+              "api": "15"
+            }
+          }
+        }
+      },
+      "CANARY": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "all",
+            "sha1": "163262487a541e01d0af42cca7cc20a7d46a461b",
+            "size": 66239501,
+            "url": "https://dl.google.com/android/repository/platform-36.0-CANARY_r02.zip"
+          }
+        ],
+        "displayName": "Android SDK Platform CANARY",
+        "last-available-day": 20318,
+        "license": "android-sdk-preview-license",
+        "name": "platforms",
+        "path": "platforms/android-CANARY",
+        "revision": "CANARY",
+        "revision-details": {
+          "major:0": "2"
+        },
+        "type-details": {
+          "api-level:0": "36.0",
+          "base-extension:3": "true",
+          "codename:1": "CANARY",
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "extension-level:2": "19",
           "layoutlib:4": {
             "element-attributes": {
               "api": "15"
@@ -26677,7 +27498,7 @@
           }
         ],
         "displayName": "Android SDK Platform UpsideDownCake",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -26795,7 +27616,7 @@
           }
         ],
         "displayName": "Layout Inspector image server for API S",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/2",
@@ -26916,7 +27737,7 @@
           }
         ],
         "displayName": "Layout Inspector image server for API 29-30",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/1",
@@ -26962,7 +27783,7 @@
           }
         ],
         "displayName": "Layout Inspector image server for API 31-36",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/3",
@@ -26989,7 +27810,7 @@
           }
         ],
         "displayName": "Sources for Android 14",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "obsolete": "true",
@@ -27019,7 +27840,7 @@
           }
         ],
         "displayName": "Sources for Android 15",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-15",
@@ -27048,7 +27869,7 @@
           }
         ],
         "displayName": "Sources for Android 16",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-16",
@@ -27077,7 +27898,7 @@
           }
         ],
         "displayName": "Sources for Android 17",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-17",
@@ -27106,7 +27927,7 @@
           }
         ],
         "displayName": "Sources for Android 18",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-18",
@@ -27135,7 +27956,7 @@
           }
         ],
         "displayName": "Sources for Android 19",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-19",
@@ -27164,7 +27985,7 @@
           }
         ],
         "displayName": "Sources for Android 20",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-20",
@@ -27193,7 +28014,7 @@
           }
         ],
         "displayName": "Sources for Android 21",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-21",
@@ -27222,7 +28043,7 @@
           }
         ],
         "displayName": "Sources for Android 22",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-22",
@@ -27251,7 +28072,7 @@
           }
         ],
         "displayName": "Sources for Android 23",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-23",
@@ -27280,7 +28101,7 @@
           }
         ],
         "displayName": "Sources for Android 24",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-24",
@@ -27309,7 +28130,7 @@
           }
         ],
         "displayName": "Sources for Android 25",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-25",
@@ -27338,7 +28159,7 @@
           }
         ],
         "displayName": "Sources for Android 26",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-26",
@@ -27367,7 +28188,7 @@
           }
         ],
         "displayName": "Sources for Android 27",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-27",
@@ -27396,7 +28217,7 @@
           }
         ],
         "displayName": "Sources for Android 28",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-28",
@@ -27425,7 +28246,7 @@
           }
         ],
         "displayName": "Sources for Android 29",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-29",
@@ -27454,7 +28275,7 @@
           }
         ],
         "displayName": "Sources for Android 30",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-30",
@@ -27483,7 +28304,7 @@
           }
         ],
         "displayName": "Sources for Android 31",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-31",
@@ -27512,7 +28333,7 @@
           }
         ],
         "displayName": "Sources for Android 32",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-32",
@@ -27541,7 +28362,7 @@
           }
         ],
         "displayName": "Sources for Android 33",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-33",
@@ -27571,7 +28392,7 @@
           }
         ],
         "displayName": "Sources for Android 34",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-34",
@@ -27601,7 +28422,7 @@
           }
         ],
         "displayName": "Sources for Android 35",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-35",
@@ -27631,7 +28452,7 @@
           }
         ],
         "displayName": "Sources for Android 36",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-36",
@@ -27698,7 +28519,7 @@
           }
         },
         "displayName": "Android SDK Tools",
-        "last-available-day": 20237,
+        "last-available-day": 20318,
         "license": "android-sdk-license",
         "name": "tools",
         "obsolete": "true",

--- a/pkgs/development/mobile/androidenv/test-suite.nix
+++ b/pkgs/development/mobile/androidenv/test-suite.nix
@@ -18,7 +18,7 @@ let
 in
 stdenv.mkDerivation {
   name = "androidenv-test-suite";
-  version = "1";
+  version = lib.substring 0 8 (builtins.hashFile "sha256" ./repo.json);
   buildInputs = lib.mapAttrsToList (name: value: value) all-tests;
 
   buildCommand = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Gradually increasing diffs on https://nixpkgs-update-logs.nix-community.org/androidenv.test-suite/ mean the autoupdate wasn't working (they all end in "Package version did not change"). These also shouldn't be built on hydra, easy enough to do by just inheriting meta from existing androidenv packages.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
