### PR TITLE
emacsPackages.eaf-git: init at 0-unstable-2025-07-10

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -19,6 +19,10 @@ lib.packagesFromDirectoryRecursive {
     inherit (pkgs) aria2;
   };
 
+  eaf-git = callPackage ./manual-packages/eaf-git {
+    inherit (pkgs) ripgrep;
+  };
+
   elpaca = callPackage ./manual-packages/elpaca { inherit (pkgs) git; };
 
   emacs-application-framework = callPackage ./manual-packages/emacs-application-framework {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-git/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-git/default.nix
@@ -1,0 +1,83 @@
+{
+  # Basic
+  lib,
+  melpaBuild,
+  fetchFromGitHub,
+  # Dependencies
+  delta,
+  ripgrep,
+  # Java Script dependency
+  nodejs,
+  fetchNpmDeps,
+  npmHooks,
+  # Updater
+  nix-update-script,
+}:
+
+melpaBuild (finalAttrs: {
+
+  pname = "eaf-git";
+  version = "0-unstable-2025-07-10";
+
+  src = fetchFromGitHub {
+    owner = "emacs-eaf";
+    repo = "eaf-git";
+    rev = "24c3887075630a21d0a53ddb95b01ef70694f03a";
+    hash = "sha256-ggxgwMTk46WDLKxrNkzX3pSO/yLoLTJVH08T4o70fEM=";
+  };
+
+  env.npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-npm-deps";
+    inherit (finalAttrs) src;
+    hash = "sha256-kbFnPZlFqoE1Q/KKVW5ZI4HPPWsIjXA/jne2jw7BeEc=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    npmHooks.npmConfigHook
+  ];
+
+  postBuild = ''
+    npm run build
+  '';
+
+  files = ''
+    ("*.el"
+     "*.py"
+     "*.js"
+     "src")
+  '';
+
+  postInstall = ''
+    LISPDIR=$out/share/emacs/site-lisp/elpa/${finalAttrs.ename}-${finalAttrs.melpaVersion}
+    touch node_modules/.nosearch
+    cp -r node_modules $LISPDIR/
+    cp -r dist $LISPDIR/
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+    eafPythonDeps =
+      ps: with ps; [
+        charset-normalizer
+        giturlparse
+        pygit2
+        pygments
+        unidiff
+      ];
+    eafOtherDeps = [
+      delta
+      ripgrep
+    ];
+  };
+
+  meta = {
+    description = "Git client for the EAF";
+    homepage = "https://github.com/emacs-eaf/eaf-git";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      thattemperature
+    ];
+  };
+
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
