### PR TITLE
lazyhetzner: init at 0.0.4

### DIFF
--- a/pkgs/by-name/la/lazyhetzner/package.nix
+++ b/pkgs/by-name/la/lazyhetzner/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "lazyhetzner";
+  version = "0.0.4";
+
+  src = fetchFromGitHub {
+    owner = "grammeaway";
+    repo = "lazyhetzner";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MPPe4Epr77aqAFOeDGj4lTAauR489hVqGz8uiIqdyW8=";
+
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse HEAD > $out/COMMIT
+      date -u -d "@$(git log -1 --pretty=%ct)" "+%Y-%m-%dT%H:%M:%SZ" > $out/SOURCE_DATE_EPOCH
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+
+  vendorHash = "sha256-g+HWDhMNrPUsszmosClthEHS60Cp7zjt+50Jt9zqfTE=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/grammeaway/lazyhetzner/cmd.version=v${finalAttrs.version}"
+  ];
+
+  preBuild = ''
+    ldflags+=" -X github.com/grammeaway/lazyhetzner/cmd.commit=$(cat COMMIT)"
+    ldflags+=" -X github.com/grammeaway/lazyhetzner/cmd.date=$(cat SOURCE_DATE_EPOCH)"
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "TUI for managing Hetzner Cloud resources";
+    homepage = "https://github.com/grammeaway/lazyhetzner";
+    changelog = "https://github.com/grammeaway/lazyhetzner/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ ryand56 ];
+    mainProgram = "lazyhetzner";
+  };
+})


### PR DESCRIPTION
Adds [lazyhetzner](https://github.com/grammeaway/lazyhetzner), a way to manage your Hetzner Cloud resources from the TUI.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
