### PR TITLE
vscode-extensions.ms-python.python: per arch derivation

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/ms-python.python/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-python.python/default.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   lib,
   vscode-utils,
   icu,
@@ -11,12 +12,36 @@
   vscode-extension-update-script,
 }:
 
+let
+  supported = {
+    x86_64-linux = {
+      hash = "sha256-AlqZTioxiL0XPRMpWMWw8fIWoDAmU1ybCaDhlaXv6lc=";
+      arch = "linux-x64";
+    };
+    x86_64-darwin = {
+      hash = "sha256-IWj79vUJJXt88kDiCIHVY95aKsHB84vH3iv6GgLOFQo=";
+      arch = "darwin-x64";
+    };
+    aarch64-linux = {
+      hash = "sha256-kTSHvqS50UZ/yTMqJITyFIUZgHn1dMSwX1R3oxmTnYk=";
+      arch = "linux-arm64";
+    };
+    aarch64-darwin = {
+      hash = "sha256-LWA8LqCQrmd83icDYCmUgytPJbCV3ecNobSpWV2R3MA=";
+      arch = "darwin-arm64";
+    };
+  };
+
+  base =
+    supported.${stdenv.hostPlatform.system}
+      or (throw "unsupported platform ${stdenv.hostPlatform.system}");
+
+in
 vscode-utils.buildVscodeMarketplaceExtension rec {
-  mktplcRef = {
+  mktplcRef = base // {
     name = "python";
     publisher = "ms-python";
     version = "2025.12.0";
-    hash = "sha256-IY4xrAFLGe8JCgdx2H3kiQTCh9i5wOykL9hfpztV+44=";
   };
 
   buildInputs = [ icu ];
@@ -52,12 +77,7 @@ vscode-utils.buildVscodeMarketplaceExtension rec {
     homepage = "https://github.com/Microsoft/vscode-python";
     changelog = "https://github.com/microsoft/vscode-python/releases";
     license = lib.licenses.mit;
-    platforms = [
-      "aarch64-linux"
-      "x86_64-linux"
-      "aarch64-darwin"
-      "x86_64-darwin"
-    ];
+    platforms = builtins.attrNames supported;
     maintainers = [
       lib.maintainers.jraygauthier
       lib.maintainers.jfchevrette


### PR DESCRIPTION
There is a compiled executable called `pet`(https://github.com/microsoft/python-environment-tools) inside the extension. The current status quo is that it fetches the `aarch64-linux` executable which of course doesn't work on the other platforms. I could not test darwin but added the hashes anyway.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
