### PR TITLE
gh-f: cleanup

### DIFF
--- a/pkgs/by-name/gh/gh-f/package.nix
+++ b/pkgs/by-name/gh/gh-f/package.nix
@@ -2,7 +2,7 @@
   lib,
   fetchFromGitHub,
   stdenvNoCC,
-  makeWrapper,
+  makeBinaryWrapper,
   gh,
   fzf,
   coreutils,
@@ -10,48 +10,55 @@
   gnused,
   withBat ? false,
   bat,
+  nix-update-script,
 }:
-let
-  binPath = lib.makeBinPath (
-    [
-      gh
-      fzf
-      coreutils
-      gawk
-      gnused
-    ]
-    ++ lib.optional withBat bat
-  );
-in
-stdenvNoCC.mkDerivation rec {
+
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "gh-f";
   version = "1.4.1";
 
   src = fetchFromGitHub {
     owner = "gennaro-tedesco";
     repo = "gh-f";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Jf7sDn/iRB/Lwz21fGLRduvt9/9cs5FFMhazULgj1ik=";
   };
 
-  nativeBuildInputs = [
-    makeWrapper
-  ];
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  propagatedUserEnvPkgs = [
+    gh
+    fzf
+    coreutils
+    gawk
+    gnused
+  ]
+  ++ lib.optional withBat bat;
 
   installPhase = ''
+    runHook preInstall
+
     install -D -m755 "gh-f" "$out/bin/gh-f"
+
+    runHook postInstall
   '';
 
   postFixup = ''
-    wrapProgram "$out/bin/gh-f" --prefix PATH : "${binPath}"
+    wrapProgram "$out/bin/gh-f" \
+      --suffix PATH : ${lib.makeBinPath finalAttrs.propagatedUserEnvPkgs}
   '';
 
-  meta = with lib; {
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
     homepage = "https://github.com/gennaro-tedesco/gh-f";
     description = "GitHub CLI ultimate FZF extension";
-    maintainers = with maintainers; [ loicreynier ];
-    license = licenses.unlicense;
+    license = lib.licenses.unlicense;
     mainProgram = "gh-f";
-    platforms = platforms.all;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [
+      loicreynier
+      yiyu
+    ];
   };
-}
+})


### PR DESCRIPTION
Ensure dependencies are in the environment and add `nix-update-script`

cc @loicreynier

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
