### PR TITLE
rshim-user-space: drop busybox dependency

### DIFF
--- a/pkgs/by-name/rs/rshim-user-space/package.nix
+++ b/pkgs/by-name/rs/rshim-user-space/package.nix
@@ -1,16 +1,23 @@
 {
-  stdenv,
-  lib,
-  fetchFromGitHub,
   autoconf,
   automake,
-  makeBinaryWrapper,
-  pkg-config,
-  pciutils,
-  libusb1,
+  bashNonInteractive,
+  coreutils,
+  fetchFromGitHub,
   fuse,
-  busybox,
+  gawk,
+  gnugrep,
+  gnused,
+  lib,
+  libusb1,
+  makeBinaryWrapper,
+  pciutils,
+  pkg-config,
+  procps,
   pv,
+  stdenv,
+  which,
+  util-linux,
   withBfbInstall ? true,
 }:
 
@@ -58,8 +65,16 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/bfb-install \
       --set PATH ${
         lib.makeBinPath [
-          busybox
+          bashNonInteractive
+          coreutils
+          gawk
+          gnugrep
+          gnused
+          pciutils
+          procps
           pv
+          util-linux
+          which
         ]
       }
   '';


### PR DESCRIPTION
With the current busybox runtime dependency, we ran into issues originated in busybox being more minimal than the full component.

Example:
```sh
[root@nixos:~]# bfb-install -r rshim0 -b installer.bfb
Checking if local host has root access...
lspci: invalid option -- 's'
BusyBox v1.36.1 () multi-call binary.

Usage: lspci [-mk]

List all PCI devices

	-m	Parsable output
	-k	Show driver
Checking if rshim driver is running locally...
```

Fix this by using the "full" dependency versions.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
