### PR TITLE
softhsm: fix src to use Github

### DIFF
--- a/pkgs/by-name/so/softhsm/package.nix
+++ b/pkgs/by-name/so/softhsm/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   postInstall = "rm -rf $out/var";
 
   meta = with lib; {
-    homepage = "https://www.opendnssec.org/softhsm";
+    homepage = "https://www.softhsm.org/";
     description = "Cryptographic store accessible through a PKCS #11 interface";
     longDescription = "
       SoftHSM provides a software implementation of a generic

--- a/pkgs/by-name/so/softhsm/package.nix
+++ b/pkgs/by-name/so/softhsm/package.nix
@@ -1,9 +1,10 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   botan2,
   sqlite,
+  autoreconfHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -11,10 +12,16 @@ stdenv.mkDerivation rec {
   pname = "softhsm";
   version = "2.6.1";
 
-  src = fetchurl {
-    url = "https://dist.opendnssec.org/source/${pname}-${version}.tar.gz";
-    hash = "sha256-YSSUcwVLzRgRUZ75qYmogKe9zDbTF8nCVFf8YU30dfI=";
+  src = fetchFromGitHub {
+    owner = "softhsm";
+    repo = "SoftHSMv2";
+    rev = "${version}";
+    hash = "sha256-sx0ceVY795JbtKbQGAVFllB9UJfTdgd242d6c+s1tBw=";
   };
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
 
   configureFlags = [
     "--with-crypto-backend=botan"


### PR DESCRIPTION
Softhsm sources are no longer available, switch to GitHub. After changing the sources, I was no longer able to compile softhsm, as no makefile is included in the tag version there. Add autoreconfHook to fix this.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
