### PR TITLE
qt-material: modernize, fix

### DIFF
--- a/pkgs/development/python-modules/qt-material/default.nix
+++ b/pkgs/development/python-modules/qt-material/default.nix
@@ -1,28 +1,34 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   jinja2,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "qt-material";
   version = "2.17";
-  format = "setuptools";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-tQCgwfXvj0aozwN9GqW9+epOthgYC2MyU5373QZHrQ0=";
+  src = fetchFromGitHub {
+    owner = "dunderlab";
+    repo = "qt-material";
+    tag = "v${version}";
+    hash = "sha256-ilrPA8SoVCo6FgwxWQ4sOjqURCFDQJLlTTkCZzTZQKI=";
   };
 
-  propagatedBuildInputs = [ jinja2 ];
+  build-system = [ setuptools ];
+
+  dependencies = [ jinja2 ];
 
   pythonImportsCheck = [ "qt_material" ];
 
-  meta = with lib; {
+  meta = {
+    changelog = "https://github.com/dunderlab/qt-material/releases/tag/${src.tag}";
     description = "Material inspired stylesheet for PySide2, PySide6, PyQt5 and PyQt6";
-    homepage = "https://github.com/UN-GCPDS/qt-material";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ _999eagle ];
+    homepage = "https://github.com/dunderlab/qt-material";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ _999eagle ];
   };
 }


### PR DESCRIPTION
- pypi as source failed to fetch, so use github fetcher
- pypi links to https://github.com/dunderlab/qt-material as the package homepage
- qt-material switched to a pyproject build
- adjust dependencies/build-system to accomodate

Hydra log of fetch fail: https://hydra.nixos.org/build/304743714/nixlog/15

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
