### PR TITLE
opensnitch-ui: migrate to python-slugify to fix build

### DIFF
--- a/pkgs/by-name/op/opensnitch-ui/package.nix
+++ b/pkgs/by-name/op/opensnitch-ui/package.nix
@@ -12,6 +12,13 @@ python3Packages.buildPythonApplication {
   inherit (opensnitch) src version;
   sourceRoot = "${opensnitch.src.name}/ui";
 
+  patches = [
+    # https://github.com/evilsocket/opensnitch/pull/1413
+    # unicode-slugify has failing tests and is overall unmaintained and broken.
+    # python-slugify is a preferrable replacement
+    ./use_python_slugify.patch
+  ];
+
   postPatch = ''
     substituteInPlace opensnitch/utils/__init__.py \
       --replace-fail /usr/lib/python3/dist-packages/data ${python3Packages.pyasn}/${python3Packages.python.sitePackages}/pyasn/data
@@ -38,7 +45,7 @@ python3Packages.buildPythonApplication {
     pyinotify
     pyqt5
     qt-material
-    unicode-slugify
+    python-slugify
     unidecode
   ];
 

--- a/pkgs/by-name/op/opensnitch-ui/use_python_slugify.patch
+++ b/pkgs/by-name/op/opensnitch-ui/use_python_slugify.patch
@@ -1,0 +1,11 @@
+diff --git a/requirements.txt b/requirements.txt
+index 66e0de13..68d651b1 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -1,5 +1,5 @@
+ grpcio-tools>=1.10.1
+ pyinotify==0.9.6
+-unicode_slugify==0.1.5
++python-slugify>=7.0.0
+ pyqt5>=5.6
+ protobuf


### PR DESCRIPTION
~~Depends on https://github.com/NixOS/nixpkgs/pull/434692 for `opensnitch-ui` to build successfully. Tested by picking both those PRs onto one branch.~~ rebased to include this fix in the pr branch.

Upstream proposal: https://github.com/evilsocket/opensnitch/pull/1413

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
