### PR TITLE
trickle: fix build

### DIFF
--- a/pkgs/by-name/tr/trickle/atomicio.patch
+++ b/pkgs/by-name/tr/trickle/atomicio.patch
@@ -1,0 +1,30 @@
+diff --git i/atomicio.c w/atomicio.c
+index 3930a07..81a14a4 100644
+--- i/atomicio.c
++++ w/atomicio.c
+@@ -37,11 +37,7 @@
+  * ensure all of data on socket comes through. f==read || f==write
+  */
+ ssize_t
+-atomicio(f, fd, _s, n)
+-	ssize_t (*f) ();
+-	int fd;
+-	void *_s;
+-	size_t n;
++atomicio(ssize_t (*f)(int, const void *, size_t), int fd, const void *_s, size_t n)
+ {
+ 	char *s = _s;
+ 	ssize_t res, pos = 0;
+diff --git i/util.h w/util.h
+index b00059c..f24d0c3 100644
+--- i/util.h
++++ w/util.h
+@@ -41,7 +41,7 @@
+ #define MAX(a, b) ((a) > (b) ? (a) : (b))
+ #define MIN(a, b) ((a) < (b) ? (a) : (b))
+ 
+-ssize_t    atomicio(ssize_t (*)(), int, void *, size_t);
++ssize_t    atomicio(ssize_t (*f)(int, const void *, size_t), int fd, const void *s, size_t n);
+ char      *get_progname(char *);
+ 
+ 

--- a/pkgs/by-name/tr/trickle/remove-libtrickle.patch
+++ b/pkgs/by-name/tr/trickle/remove-libtrickle.patch
@@ -1,0 +1,17 @@
+diff --git i/Makefile.am w/Makefile.am
+index 9c2bbf3..0b0023e 100644
+--- i/Makefile.am
++++ w/Makefile.am
+@@ -30,12 +30,6 @@ tricklectl_LDADD = @ERRO@ $(LIBOBJS)
+ 
+ AM_CFLAGS = -Wall -Icompat @EVENTINC@
+ 
+-overloaddir = $(libdir)
+-overload_DATA = libtrickle.so
+-
+-libtrickle.so: trickle-overload.c atomicio.c
+-$(overload_DATA):
+-
+ CLEANFILES = *.so
+ 
+ EXTRA_DIST = LICENSE README strlcat.c strlcpy.c err.c Makefile.am.inc	\

--- a/pkgs/by-name/tr/trickle/trickle-gcc14.patch
+++ b/pkgs/by-name/tr/trickle/trickle-gcc14.patch
@@ -1,0 +1,25 @@
+diff --git a/configure.in b/configure.in
+index 6ebf3b2..5c85682 100644
+--- a/configure.in
++++ b/configure.in
+@@ -198,6 +198,7 @@ if test "$HAVEMETHOD" = "no"; then
+         AC_TRY_RUN(
+         #include <dlfcn.h>
+         #include <stdio.h>
++        #include <stdlib.h>
+     
+         int
+         main(int argc, char **argv)
+diff --git a/xdr.c b/xdr.c
+index ed8bf5b..a20bbd9 100644
+--- a/xdr.c
++++ b/xdr.c
+@@ -103,7 +103,7 @@ xdr_msg(XDR *xdrs, struct msg *msg)
+ {
+ 	X(xdr_short(xdrs, &msg->status));
+ 	X(xdr_union(xdrs, (int *)&msg->type, (char *)&msg->data,
+-	      xdr_msg_discrim, _xdr_void));
++	      xdr_msg_discrim, (xdrproc_t)_xdr_void));
+ 
+ 	return (TRUE);
+ }


### PR DESCRIPTION
This fixes the build of trickle by

- updating the revision to HEAD (and switching to GitHub), which contains a few clean ups in the build process, e.g. generated files were removed
- adding patches found on AUR, GitHub issues and my own

This is quite a beast to compile, but basic functionality (i.e. rate limiting) works in my test cases.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
