### PR TITLE
buildRebar3: enable deterministic builds

### DIFF
--- a/pkgs/development/beam-modules/build-rebar3.nix
+++ b/pkgs/development/beam-modules/build-rebar3.nix
@@ -21,6 +21,11 @@
   buildPhase ? null,
   configurePhase ? null,
   meta ? { },
+  erlangCompilerOptions ? [ ],
+  # Deterministic Erlang builds remove full system paths from debug information
+  # among other things to keep builds more reproducible. See their docs for more:
+  # https://www.erlang.org/doc/man/compile
+  erlangDeterministicBuilds ? true,
   ...
 }@attrs:
 
@@ -63,6 +68,12 @@ let
         propagatedBuildInputs = lib.unique beamDeps;
 
         inherit src;
+
+        ERL_COMPILER_OPTIONS =
+          let
+            options = erlangCompilerOptions ++ lib.optionals erlangDeterministicBuilds [ "deterministic" ];
+          in
+          "[${lib.concatStringsSep "," options}]";
 
         # stripping does not have any effect on beam files
         # it is however needed for dependencies with NIFs

--- a/pkgs/development/beam-modules/build-rebar3.nix
+++ b/pkgs/development/beam-modules/build-rebar3.nix
@@ -21,13 +21,10 @@
   buildPhase ? null,
   configurePhase ? null,
   meta ? { },
-  enableDebugInfo ? false,
   ...
 }@attrs:
 
 let
-  debugInfoFlag = lib.optionalString (enableDebugInfo || erlang.debugInfo) "debug-info";
-
   rebar3 = rebar3WithPlugins {
     plugins = buildPlugins;
   };


### PR DESCRIPTION
The motivation is similar to (and implementation taken partly from) https://github.com/NixOS/nixpkgs/pull/271288 --- some rebar3-compiled `.beam` files contain debug information exposing references to `.hrl` files from the Erlang distribution it was compiled with.  This results in unnecessary store references.

See also https://github.com/NixOS/nixpkgs/pull/423588's change to Elixir's `generic-builder.nix` where the same option is used when building to avoid the same issue.

I'll drop a `nixpkgs-review` output in a moment — AFAICT there are some current failures in master.

## Things done

- Built a package that has a rebar3 dependency, and checked the result was free of references to Erlang, on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
