### PR TITLE
lue: init at 0.1.0

### DIFF
--- a/pkgs/by-name/lu/lue/package.nix
+++ b/pkgs/by-name/lu/lue/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "lue";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "superstarryeyes";
+    repo = "lue";
+    tag = "v${version}";
+    hash = "sha256-YricCgY/Zi14Xh1fiNrLKy+Cn/R1gO3wnvnqVK75Ths=";
+  };
+
+  build-system = with python3.pkgs; [
+    setuptools
+    wheel
+  ];
+
+  dependencies = with python3.pkgs; [
+    edge-tts
+    markdown
+    platformdirs
+    pymupdf
+    python-docx
+    rich
+    striprtf
+  ];
+
+  optional-dependencies = with python3.pkgs; {
+    kokoro = [
+      huggingface-hub
+      kokoro
+      soundfile
+    ];
+  };
+
+  pythonImportsCheck = [ "lue" ];
+
+  meta = {
+    description = "Terminal eBook Reader with Text-to-Speech";
+    homepage = "https://github.com/superstarryeyes/lue";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "lue";
+  };
+}

--- a/pkgs/development/python-modules/edge-tts/default.nix
+++ b/pkgs/development/python-modules/edge-tts/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  wheel,
+  aiohttp,
+  certifi,
+  tabulate,
+  typing-extensions,
+}:
+
+buildPythonPackage rec {
+  pname = "edge-tts";
+  version = "7.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "rany2";
+    repo = "edge-tts";
+    tag = version;
+    hash = "sha256-HnMMh3N9mUF8ALRpgx1wjrF2RL2ntRyVOOz4RcJyRMI=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    certifi
+    tabulate
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "edge_tts" ];
+
+  meta = {
+    description = "Microsoft Edge text-to-speech service WITHOUT Edge, Windows or API keys";
+    longDescription = ''
+      `edge-tts` is a Python module that allows you to use Microsoft
+      Edge's online text-to-speech service from within your Python
+      code or using the provided `edge-tts` or `edge-playback`
+      command.
+    '';
+    homepage = "https://github.com/rany2/edge-tts";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "edge-tts";
+  };
+}

--- a/pkgs/development/python-modules/markdown/default.nix
+++ b/pkgs/development/python-modules/markdown/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "markdown";
-  version = "3.8";
+  version = "3.8.2";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "Python-Markdown";
     repo = "markdown";
     tag = version;
-    hash = "sha256-H1xvDM2ShiPbfcpW+XGrxCxtaRFVaquuMuGg1RhjeNA=";
+    hash = "sha256-L5OTjllMUrpsKZbK+EHcqlua/6I4onJvRC3povbHgfY=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pymupdf/default.nix
+++ b/pkgs/development/python-modules/pymupdf/default.nix
@@ -46,7 +46,7 @@ let
 in
 buildPythonPackage rec {
   pname = "pymupdf";
-  version = "1.26.1";
+  version = "1.26.3";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     owner = "pymupdf";
     repo = "PyMuPDF";
     tag = version;
-    hash = "sha256-Z+TO4MaLFmgNSRMTltY77bHnA5RHc4Ii45sDjJsFZto=";
+    hash = "sha256-djTbALLvdX2jOTGgoyUIBhiqJ6KzM+Dkb4M7d2eVoPM=";
   };
 
   # swig is not wrapped as Python package

--- a/pkgs/development/python-modules/python-docx/default.nix
+++ b/pkgs/development/python-modules/python-docx/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "python-docx";
-  version = "1.1.2";
+  version = "1.2.0";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "python-openxml";
     repo = "python-docx";
     tag = "v${version}";
-    hash = "sha256-isxMtq5j5J02GcHMzOJdJw+ZokLoxA6fG1xsN21Irbc=";
+    hash = "sha256-5x2VmMiY5fZiXoswCDcs89olL0vbpGzmJZThrNS/SmI=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/rich/default.nix
+++ b/pkgs/development/python-modules/rich/default.nix
@@ -29,7 +29,7 @@
 
 buildPythonPackage rec {
   pname = "rich";
-  version = "14.0.0";
+  version = "14.1.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     owner = "Textualize";
     repo = "rich";
     tag = "v${version}";
-    hash = "sha256-gnKzb4lw4zgepTfJahHnpw2/vcg8o1kv8KfeVDSHcQI=";
+    hash = "sha256-44L3eVf/gI0FlOlxzJ7/+A1jN6ILkeVEelaru1Io20U=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4549,6 +4549,8 @@ self: super: with self; {
 
   edalize = callPackage ../development/python-modules/edalize { };
 
+  edge-tts = callPackage ../development/python-modules/edge-tts { };
+
   editables = callPackage ../development/python-modules/editables { };
 
   editdistance = callPackage ../development/python-modules/editdistance { };


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
