### PR TITLE
virtualisation/qemu-vm: expose startVM as virtualiation.runner

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -115,7 +115,7 @@ let
   drivesCmdLine = drives: concatStringsSep "\\\n    " (imap1 driveCmdline drives);
 
   # Shell script to start the VM.
-  startVM = ''
+  runner = hostPkgs.writeScript "run-nixos-vm" ''
     #! ${hostPkgs.runtimeShell}
 
     export PATH=${makeBinPath [ hostPkgs.coreutils ]}''${PATH:+:}$PATH
@@ -1101,6 +1101,17 @@ in
       '';
     };
 
+    virtualisation.runner = mkOption {
+      type = types.package;
+      default = runner;
+      description = ''
+        Shell script that `system.build.vm` executes to start the VM.
+        Exposed read-only to allow i.e. wrapping it in a customized
+        `system.build.vm`.
+      '';
+      readOnly = true;
+    };
+
   };
 
   config = {
@@ -1422,7 +1433,7 @@ in
         ''
           mkdir -p $out/bin
           ln -s ${config.system.build.toplevel} $out/system
-          ln -s ${hostPkgs.writeScript "run-nixos-vm" startVM} $out/bin/run-${config.system.name}-vm
+          ln -s ${cfg.runner} $out/bin/run-${config.system.name}-vm
         '';
 
     # When building a regular system configuration, override whatever


### PR DESCRIPTION
system.build.vm currently embeds `startVM` but does not expose it to the module system. This can make it considerably harder than necessary to customize system.build.vm with i.e. code to create and destroy additional resources on the host system, without vendoring all of startVM.

While introducing a custom system.build attribute might be a solution in some cases, much of the surrounding eco-system assumes VMs to be runnable via system.build.vm. Adhering to that convention allows one to run i.e. NixOS VM tests with a customized system.build.vm.

preVM/postVM attributes akin to pkgs.runInLinuxVM, etc were considered as an alternative, but would either provide suboptimal UX or require more code changes in a anready convoluted NixOS module.

This change should be a noop whenever one does not explicitly set system.build.vm to something other than the default. It supports the later by allowing e.g.:

     system.build.vm = lib.mkForce (
       hostPkgs.writeShellScriptBin "run-${config.system.name}-vm" ''
         ${createVmDisk}
         ${cfg.runner} $@
       ''
     );



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
