### PR TITLE
lue: init at 0.3.1

### DIFF
--- a/pkgs/by-name/lu/lue/package.nix
+++ b/pkgs/by-name/lu/lue/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  ffmpeg,
+  nix-update-script,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "lue";
+  version = "0.3.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "superstarryeyes";
+    repo = "lue";
+    tag = "v${version}";
+    hash = "sha256-D1y7nu3WIsnShy2ruyF06iVusD8leuaAUi0M8I1hVqQ=";
+  };
+
+  build-system = with python3.pkgs; [
+    setuptools
+    wheel
+  ];
+
+  dependencies = with python3.pkgs; [
+    edge-tts
+    markdown
+    platformdirs
+    pymupdf
+    python-docx
+    rich
+    striprtf
+  ];
+
+  optional-dependencies = with python3.pkgs; {
+    kokoro = [
+      huggingface-hub
+      kokoro
+      soundfile
+    ];
+  };
+
+  pythonImportsCheck = [ "lue" ];
+
+  makeWrapperArgs = [ "--prefix PATH :${lib.makeBinPath [ ffmpeg ]}" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal eBook Reader with Text-to-Speech";
+    homepage = "https://github.com/superstarryeyes/lue";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "lue";
+  };
+}

--- a/pkgs/development/python-modules/edge-tts/default.nix
+++ b/pkgs/development/python-modules/edge-tts/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  wheel,
+  aiohttp,
+  certifi,
+  tabulate,
+  typing-extensions,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "edge-tts";
+  version = "7.2.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "rany2";
+    repo = "edge-tts";
+    tag = version;
+    hash = "sha256-JnwfvSa60oEbSEyD6q88Ey6IyGOwVWO0T75VrUKZmos=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  dependencies = [
+    aiohttp
+    certifi
+    tabulate
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "edge_tts" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Microsoft Edge text-to-speech service WITHOUT Edge, Windows and API keys";
+    longDescription = ''
+      `edge-tts` is a Python module that allows you to use Microsoft
+      Edge's online text-to-speech service from within your Python
+      code or using the provided `edge-tts` or `edge-playback`
+      command.
+    '';
+    homepage = "https://github.com/rany2/edge-tts";
+    license = with lib.licenses; [
+      mit # `src/edge_tts/srt_composer.py` only
+      lgpl3Plus # All remaining files
+    ];
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "edge-tts";
+  };
+}

--- a/pkgs/development/python-modules/python-docx/default.nix
+++ b/pkgs/development/python-modules/python-docx/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "python-docx";
-  version = "1.1.2";
+  version = "1.2.0";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "python-openxml";
     repo = "python-docx";
     tag = "v${version}";
-    hash = "sha256-isxMtq5j5J02GcHMzOJdJw+ZokLoxA6fG1xsN21Irbc=";
+    hash = "sha256-5x2VmMiY5fZiXoswCDcs89olL0vbpGzmJZThrNS/SmI=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4673,6 +4673,8 @@ self: super: with self; {
 
   edalize = callPackage ../development/python-modules/edalize { };
 
+  edge-tts = callPackage ../development/python-modules/edge-tts { };
+
   editables = callPackage ../development/python-modules/editables { };
 
   editdistance = callPackage ../development/python-modules/editdistance { };


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
