### PR TITLE
Fix build of different packages with gcc-15

### DIFF
--- a/pkgs/by-name/cp/cpio/package.nix
+++ b/pkgs/by-name/cp/cpio/package.nix
@@ -24,6 +24,12 @@ stdenv.mkDerivation rec {
 
   separateDebugInfo = true;
 
+  # The code won't compile in c23 mode.
+  # https://gcc.gnu.org/gcc-15/porting_to.html#c23-fn-decls-without-parameters
+  configureFlags = [
+    "CFLAGS=-std=gnu17"
+  ];
+
   preConfigure = lib.optionalString stdenv.hostPlatform.isCygwin ''
     sed -i gnu/fpending.h -e 's,include <stdio_ext.h>,,'
   '';

--- a/pkgs/by-name/w3/w3m/package.nix
+++ b/pkgs/by-name/w3/w3m/package.nix
@@ -105,6 +105,9 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = [
     "--with-ssl=${openssl.dev}"
     "--with-gc=${boehmgc.dev}"
+    # The code won't compile in c23 mode.
+    # https://gcc.gnu.org/gcc-15/porting_to.html#c23-fn-decls-without-parameters
+    "CFLAGS=-std=gnu17"
   ]
   ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
     "ac_cv_func_setpgrp_void=${if stdenv.hostPlatform.isBSD then "no" else "yes"}"

--- a/pkgs/by-name/wo/woff2/gcc15.patch
+++ b/pkgs/by-name/wo/woff2/gcc15.patch
@@ -1,0 +1,37 @@
+From 08ece7871775c0d7bf4fdff64b961cdc256adf6c Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Fri, 2 Aug 2024 22:12:03 +0100
+Subject: [PATCH] include/woff2/output.h: add missing <stdint.h> include
+
+Without the change `woff2` build fails on upcoming `gcc-15` as:
+
+    In file included from src/woff2_out.cc:9:
+    include/woff2/output.h:73:25: error: expected ')' before '*' token
+       73 |   WOFF2MemoryOut(uint8_t* buf, size_t buf_size);
+          |                 ~       ^
+          |                         )
+    include/woff2/output.h:79:3: error: 'uint8_t' does not name a type
+       79 |   uint8_t* buf_;
+          |   ^~~~~~~
+    include/woff2/output.h:16:1: note: 'uint8_t' is defined in header '<cstdint>';
+      this is probably fixable by adding '#include <cstdint>'
+       15 | #include <string>
+      +++ |+#include <cstdint>
+       16 |
+---
+ include/woff2/output.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/include/woff2/output.h b/include/woff2/output.h
+index dc78ccf..b12d538 100644
+--- a/include/woff2/output.h
++++ b/include/woff2/output.h
+@@ -9,6 +9,8 @@
+ #ifndef WOFF2_WOFF2_OUT_H_
+ #define WOFF2_WOFF2_OUT_H_
+ 
++#include <stdint.h>
++
+ #include <algorithm>
+ #include <cstring>
+ #include <memory>

--- a/pkgs/by-name/wo/woff2/package.nix
+++ b/pkgs/by-name/wo/woff2/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   ];
 
   # Need to explicitly link to brotlicommon
-  patches = lib.optional static ./brotli-static.patch;
+  patches = lib.optional static ./brotli-static.patch ++ [ ./gcc15.patch ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -53,8 +53,13 @@ stdenv.mkDerivation rec {
   # stdenv will take care of overriding bindir, sbindir, etc. such that "out" contains the binaries.
   prefix = builtins.placeholder "lib";
 
-  env = lib.optionalAttrs stdenv.hostPlatform.isStatic {
-    NIX_CFLAGS_COMPILE = "-fcommon";
+  env = {
+    # The release 1.21.3 is not compatible with c23, which changed the meaning of
+    #
+    #     void foo();
+    #
+    # declaration.
+    NIX_CFLAGS_COMPILE = "-std=gnu17" + lib.optionalString stdenv.hostPlatform.isStatic " -fcommon";
   };
 
   configureFlags = [

--- a/pkgs/development/tcl-modules/by-name/ex/expect/package.nix
+++ b/pkgs/development/tcl-modules/by-name/ex/expect/package.nix
@@ -52,7 +52,7 @@ tcl.mkTclDerivation rec {
   strictDeps = true;
 
   env = lib.optionalAttrs stdenv.cc.isGNU {
-    NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+    NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types -std=gnu17";
   };
 
   hardeningDisable = [ "format" ];

--- a/pkgs/servers/gpm/default.nix
+++ b/pkgs/servers/gpm/default.nix
@@ -64,6 +64,9 @@ stdenv.mkDerivation {
     "--sysconfdir=/etc"
     "--localstatedir=/var"
     (if withNcurses then "--with-curses" else "--without-curses")
+    # The code won't compile in c23 mode.
+    # https://gcc.gnu.org/gcc-15/porting_to.html#c23-fn-decls-without-parameters
+    "CFLAGS=-std=gnu17"
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
The most breaking change of C23 (default in gcc-15) is [function declaration without parameters](https://gcc.gnu.org/gcc-15/porting_to.html#c23-fn-decls-without-parameters).

When patching is easy, I do it; when it is hard, I leave it to upstream and just switch back to `-std=gnuc17`.

I didn't contact any of upstreams, I assume they are well-aware of gcc-15 release.

@Ma27 @trofi Please, take a look