### PR TITLE
ci/github-script/labels: auto close package request issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/10_package_request.yml
+++ b/.github/ISSUE_TEMPLATE/10_package_request.yml
@@ -16,14 +16,9 @@ body:
           </a>
         </p>
 
-        Thank you for your interest in packaging new software in Nixpkgs.
-        Unfortunately, to mitigate the unsustainable growth of unmaintained packages, **Nixpkgs is no longer accepting package requests** via Issues.
+        Thank you for your interest in packaging new software in Nixpkgs. Unfortunately, to mitigate the unsustainable growth of unmaintained packages, **Nixpkgs is no longer accepting package requests** via Issues.
 
-        As a [volunteer community][community], we are always open to new contributors.
-        If you wish to see this package in Nixpkgs, **we encourage you to [contribute] it yourself, via a Pull Request**.
-        Anyone can [become a package maintainer][maintainers]!
-        You can find language-specific packaging information in the [Nixpkgs Manual][nixpkgs].
-        Should you need any help, please reach out to the community on [Matrix] or [Discourse].
+        As a [volunteer community][community], we are always open to new contributors. If you wish to see this package in Nixpkgs, **we encourage you to [contribute] it yourself**, via a Pull Request. Anyone can [become a package maintainer][maintainers]! You can find language-specific packaging information in the [Nixpkgs Manual][nixpkgs]. Should you need any help, please reach out to the community on [Matrix] or [Discourse].
 
         [community]: https://nixos.org/community
         [contribute]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#quick-start-to-adding-a-package


### PR DESCRIPTION
This allows the labels workflow to support issue management in two ways:
- New package request can potentially created with a `4.workflow: auto-close` label immediately and be closed automatically this way. Plays together with #434609.
- Existing package requests can be bulk-closed by adding this label. This has the advantage of posting the explanatory comment at the same time, which is not possible with regular bulk operations.

Context of this PR is #425040.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
