### PR TITLE
or-tools: re-enable tests on x86_64-linux

### DIFF
--- a/pkgs/by-name/or/or-tools/package.nix
+++ b/pkgs/by-name/or/or-tools/package.nix
@@ -7,6 +7,8 @@
   ensureNewerSourcesForZipFilesHook,
   fetchFromGitHub,
   fetchpatch,
+  gtest,
+  gbenchmark,
   glpk,
   highs,
   lib,
@@ -54,6 +56,11 @@ stdenv.mkDerivation (finalAttrs: {
       name = "0001-Fix-up-broken-CMake-rules-for-bundled-pybind-stuff.patch";
       url = "https://build.opensuse.org/public/source/science/google-or-tools/0001-Fix-up-broken-CMake-rules-for-bundled-pybind-stuff.patch?rev=19";
       hash = "sha256-r38ZbRkEW1ZvJb0Uf56c0+HcnfouZZJeEYlIK7quSjQ=";
+    })
+    (fetchpatch {
+      name = "math_opt-only-run-SCIP-tests-if-enabled.patch";
+      url = "https://github.com/google/or-tools/commit/b5a2f8ac40dd4bfa4359c35570733171454ec72b.patch";
+      hash = "sha256-h96zJkqTtwfBd+m7Lm9r/ks/n8uvY4iSPgxMZe8vtXI=";
     })
   ];
 
@@ -108,6 +115,8 @@ stdenv.mkDerivation (finalAttrs: {
     cbc
     eigen
     glpk
+    gbenchmark
+    gtest
     highs
     python3.pkgs.absl-py
     python3.pkgs.pybind11
@@ -131,11 +140,15 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   nativeCheckInputs = [
     python3.pkgs.matplotlib
+    python3.pkgs.pandas
+    python3.pkgs.pytest
+    python3.pkgs.scipy
+    python3.pkgs.svgwrite
     python3.pkgs.virtualenv
   ];
 
-  # some tests fail on linux and hang on darwin
-  doCheck = false;
+  # some tests fail on aarch64-linux and hang on darwin
+  doCheck = stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform.isLinux;
 
   preCheck = ''
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD/lib


### PR DESCRIPTION
This needs https://github.com/google/or-tools/pull/4745 to skip SCIP tests if built without SCIP (which we currently do).

The tests currently still fail on aarch64-linux
(https://github.com/google/or-tools/issues/4746), so we only enable for x86_64-linux. It can be re-tested with a more recent version once or-tools is updated.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
