### PR TITLE
{bash-completion,util-linux}: fix `mount -t` tab completion

### DIFF
--- a/pkgs/by-name/ba/bash-completion/package.nix
+++ b/pkgs/by-name/ba/bash-completion/package.nix
@@ -22,6 +22,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-M2m9XkGKdfuZCGOSWu1bQgOYrOuzIOxMAwaz6uI/EHo=";
   };
 
+  postPatch = ''
+    # fix `mount -t` tab completion
+    substituteInPlace bash_completion \
+      --replace-fail "/lib/modules" "/run/booted-system/kernel-modules/lib/modules"
+  '';
+
   strictDeps = true;
   nativeBuildInputs = [ autoreconfHook ];
 

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -83,6 +83,10 @@ stdenv.mkDerivation (finalPackage: rec {
 
     substituteInPlace sys-utils/eject.c \
       --replace-fail "/bin/umount" "$bin/bin/umount"
+
+    # fix `mount -t` tab completion
+    substituteInPlace bash-completion/{blkid,mount,umount} \
+      --replace-fail "/lib/modules" "/run/booted-system/kernel-modules/lib/modules"
   ''
   + lib.optionalString shadowSupport ''
     substituteInPlace include/pathnames.h \

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -82,11 +82,11 @@ stdenv.mkDerivation (finalPackage: rec {
     patchShebangs tests/run.sh tools/all_syscalls tools/all_errnos
 
     substituteInPlace sys-utils/eject.c \
-      --replace "/bin/umount" "$bin/bin/umount"
+      --replace-fail "/bin/umount" "$bin/bin/umount"
   ''
   + lib.optionalString shadowSupport ''
     substituteInPlace include/pathnames.h \
-      --replace "/bin/login" "${shadow}/bin/login"
+      --replace-fail "/bin/login" "${shadow}/bin/login"
   ''
   + lib.optionalString stdenv.hostPlatform.isFreeBSD ''
     substituteInPlace lib/c_strtod.c --replace-fail __APPLE__ __FreeBSD__


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (bash-completion)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
