### PR TITLE
[staging-next] python3Packages.fontmake: remove unnecessary patch

### DIFF
--- a/pkgs/development/python-modules/fontmake/default.nix
+++ b/pkgs/development/python-modules/fontmake/default.nix
@@ -27,16 +27,6 @@ buildPythonPackage rec {
     hash = "sha256-cHFxb7lWUj/7ATynoMGQkhArKWCHHLYvQG5IoaXwVBs=";
   };
 
-  patches = [
-    # Update to FontTools 4.55 and glyphsLib 6.9.5
-    # https://github.com/googlefonts/fontmake/pull/1133
-    (fetchpatch2 {
-      url = "https://github.com/googlefonts/fontmake/commit/ca96d25faa67638930ddc7f9bd1ab218a76caf22.patch";
-      includes = [ "tests/test_main.py" ];
-      hash = "sha256-vz+KeWiGCpUdX5HaXDdyyUCbuMkIylB364j6cD7xR1E=";
-    })
-  ];
-
   build-system = [
     setuptools
     setuptools-scm


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/432489

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
