### PR TITLE
debian-devscripts: Add missing IO::String Perl dependency for uscan

### DIFF
--- a/pkgs/by-name/de/debian-devscripts/package.nix
+++ b/pkgs/by-name/de/debian-devscripts/package.nix
@@ -91,6 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
     IPCRun
     FileDirList
     FileTouch
+    IOString
   ]);
 
   preConfigure = ''


### PR DESCRIPTION
https://salsa.debian.org/debian/devscripts/-/commit/3786d357c46d641acdfd17620c6cc022b71142d1

```console
$ git clone https://repo.or.cz/r/git/debian.git/ git
$ cd git
$ uscan
Can't locate IO/String.pm in @INC (you may need to install the IO::String module) (@INC entries checked: /nix/store/hzhz3180npnwgglqk7h1vqkvhy00y8wg-debian-devscripts-2.25.17/share/devscripts /nix/store/6ivpf1crj9p6707icbbk011n11ch7l3p-dpkg-1.22.21/lib/perl5/site_perl /nix/store/49rng2j1jbdr3jvgci5x6pv15lam6ysx-perl-5.40.0/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/49rng2j1jbdr3jvgci5x6pv15lam6ysx-perl-5.40.0/lib/perl5/site_perl/5.40.0 /nix/store/49rng2j1jbdr3jvgci5x6pv15lam6ysx-perl-5.40.0/lib/perl5/site_perl /nix/store/jx2lyzw5x6nn4zd6n2i1gz5w9a6s1gpf-perl5.40.0-Crypt-SSLeay-0.73_06/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/jx2lyzw5x6nn4zd6n2i1gz5w9a6s1gpf-perl5.40.0-Crypt-SSLeay-0.73_06/lib/perl5/site_perl/5.40.0 /nix/store/jx2lyzw5x6nn4zd6n2i1gz5w9a6s1gpf-perl5.40.0-Crypt-SSLeay-0.73_06/lib/perl5/site_perl /nix/store/by7w1vwv3q3a8hirhfs5x0xim7hjfdfn-perl5.40.0-Bytes-Random-Secure-0.29/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/by7w1vwv3q3a8hirhfs5x0xim7hjfdfn-perl5.40.0-Bytes-Random-Secure-0.29/lib/perl5/site_perl/5.40.0 /nix/store/by7w1vwv3q3a8hirhfs5x0xim7hjfdfn-perl5.40.0-Bytes-Random-Secure-0.29/lib/perl5/site_perl /nix/store/32mdngrd7svg144rxf75r0f9xkx4fh80-perl5.40.0-Crypt-Random-Seed-0.03/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/32mdngrd7svg144rxf75r0f9xkx4fh80-perl5.40.0-Crypt-Random-Seed-0.03/lib/perl5/site_perl/5.40.0 /nix/store/32mdngrd7svg144rxf75r0f9xkx4fh80-perl5.40.0-Crypt-Random-Seed-0.03/lib/perl5/site_perl /nix/store/z1cxvmpf074snx5w46k05kg26sgfq41p-perl5.40.0-Crypt-Random-TESHA2-0.01/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/z1cxvmpf074snx5w46k05kg26sgfq41p-perl5.40.0-Crypt-Random-TESHA2-0.01/lib/perl5/site_perl/5.40.0 /nix/store/z1cxvmpf074snx5w46k05kg26sgfq41p-perl5.40.0-Crypt-Random-TESHA2-0.01/lib/perl5/site_perl /nix/store/2r71j8ldn4mb41y50q3l5qinhs3rw7ya-perl5.40.0-Math-Random-ISAAC-1.004/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/2r71j8ldn4mb41y50q3l5qinhs3rw7ya-perl5.40.0-Math-Random-ISAAC-1.004/lib/perl5/site_perl/5.40.0 /nix/store/2r71j8ldn4mb41y50q3l5qinhs3rw7ya-perl5.40.0-Math-Random-ISAAC-1.004/lib/perl5/site_perl /nix/store/01b5lr8j4w373w7psg8s16g6hrhmycny-perl5.40.0-LWP-Protocol-https-6.11/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/01b5lr8j4w373w7psg8s16g6hrhmycny-perl5.40.0-LWP-Protocol-https-6.11/lib/perl5/site_perl/5.40.0 /nix/store/01b5lr8j4w373w7psg8s16g6hrhmycny-perl5.40.0-LWP-Protocol-https-6.11/lib/perl5/site_perl /nix/store/qvrxzfsayd6h8jy2r41k2b7a6knfyj29-perl5.40.0-IO-Socket-SSL-2.083/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/qvrxzfsayd6h8jy2r41k2b7a6knfyj29-perl5.40.0-IO-Socket-SSL-2.083/lib/perl5/site_perl/5.40.0 /nix/store/qvrxzfsayd6h8jy2r41k2b7a6knfyj29-perl5.40.0-IO-Socket-SSL-2.083/lib/perl5/site_perl /nix/store/j0hsmsw5582lc98vx6sfyqx1jl8qdcqh-perl5.40.0-Mozilla-CA-20230821/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/j0hsmsw5582lc98vx6sfyqx1jl8qdcqh-perl5.40.0-Mozilla-CA-20230821/lib/perl5/site_perl/5.40.0 /nix/store/j0hsmsw5582lc98vx6sfyqx1jl8qdcqh-perl5.40.0-Mozilla-CA-20230821/lib/perl5/site_perl /nix/store/ksmsk09q1psi22q1j0ngsrfc4gmpdf48-perl5.40.0-Net-SSLeay-1.92/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/ksmsk09q1psi22q1j0ngsrfc4gmpdf48-perl5.40.0-Net-SSLeay-1.92/lib/perl5/site_perl/5.40.0 /nix/store/ksmsk09q1psi22q1j0ngsrfc4gmpdf48-perl5.40.0-Net-SSLeay-1.92/lib/perl5/site_perl /nix/store/rc3w51l7jmz5ha9vy55c63x7pc63i7al-perl5.40.0-libwww-perl-6.72/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/rc3w51l7jmz5ha9vy55c63x7pc63i7al-perl5.40.0-libwww-perl-6.72/lib/perl5/site_perl/5.40.0 /nix/store/rc3w51l7jmz5ha9vy55c63x7pc63i7al-perl5.40.0-libwww-perl-6.72/lib/perl5/site_perl /nix/store/44hcv3r700fpz5blawas0f6chb900d7v-perl5.40.0-File-Listing-6.16/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/44hcv3r700fpz5blawas0f6chb900d7v-perl5.40.0-File-Listing-6.16/lib/perl5/site_perl/5.40.0 /nix/store/44hcv3r700fpz5blawas0f6chb900d7v-perl5.40.0-File-Listing-6.16/lib/perl5/site_perl /nix/store/1k2d80n48kahj4ma3h7kqn0rg464ahfx-perl5.40.0-HTTP-Date-6.06/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/1k2d80n48kahj4ma3h7kqn0rg464ahfx-perl5.40.0-HTTP-Date-6.06/lib/perl5/site_perl/5.40.0 /nix/store/1k2d80n48kahj4ma3h7kqn0rg464ahfx-perl5.40.0-HTTP-Date-6.06/lib/perl5/site_perl /nix/store/y9qam21v364bvi3qwn8v3x9spsq2xc91-perl5.40.0-TimeDate-2.33/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/y9qam21v364bvi3qwn8v3x9spsq2xc91-perl5.40.0-TimeDate-2.33/lib/perl5/site_perl/5.40.0 /nix/store/y9qam21v364bvi3qwn8v3x9spsq2xc91-perl5.40.0-TimeDate-2.33/lib/perl5/site_perl /nix/store/zsrlh9hphzp8kynbqy2c0i5sa4ks1z51-perl5.40.0-HTML-Parser-3.81/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/zsrlh9hphzp8kynbqy2c0i5sa4ks1z51-perl5.40.0-HTML-Parser-3.81/lib/perl5/site_perl/5.40.0 /nix/store/zsrlh9hphzp8kynbqy2c0i5sa4ks1z51-perl5.40.0-HTML-Parser-3.81/lib/perl5/site_perl /nix/store/nb2gikpamcqz0i62k81cpa51w6f6fqk8-perl5.40.0-HTML-Tagset-3.20/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/nb2gikpamcqz0i62k81cpa51w6f6fqk8-perl5.40.0-HTML-Tagset-3.20/lib/perl5/site_perl/5.40.0 /nix/store/nb2gikpamcqz0i62k81cpa51w6f6fqk8-perl5.40.0-HTML-Tagset-3.20/lib/perl5/site_perl /nix/store/dbaln80k4vywv7drq3mbxcqcvxzn53vj-perl5.40.0-HTTP-Message-6.45/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/dbaln80k4vywv7drq3mbxcqcvxzn53vj-perl5.40.0-HTTP-Message-6.45/lib/perl5/site_perl/5.40.0 /nix/store/dbaln80k4vywv7drq3mbxcqcvxzn53vj-perl5.40.0-HTTP-Message-6.45/lib/perl5/site_perl /nix/store/scz952w251fzscnc4laadq25aqp9k37q-perl5.40.0-Clone-0.46/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/scz952w251fzscnc4laadq25aqp9k37q-perl5.40.0-Clone-0.46/lib/perl5/site_perl/5.40.0 /nix/store/scz952w251fzscnc4laadq25aqp9k37q-perl5.40.0-Clone-0.46/lib/perl5/site_perl /nix/store/v85w54lnlsd48sn1d0ndx2ccjrif515w-perl5.40.0-Encode-Locale-1.05/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/v85w54lnlsd48sn1d0ndx2ccjrif515w-perl5.40.0-Encode-Locale-1.05/lib/perl5/site_perl/5.40.0 /nix/store/v85w54lnlsd48sn1d0ndx2ccjrif515w-perl5.40.0-Encode-Locale-1.05/lib/perl5/site_perl /nix/store/jxqknkbhms9w4dc7pa14sxy48jyyigl5-perl5.40.0-IO-HTML-1.004/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/jxqknkbhms9w4dc7pa14sxy48jyyigl5-perl5.40.0-IO-HTML-1.004/lib/perl5/site_perl/5.40.0 /nix/store/jxqknkbhms9w4dc7pa14sxy48jyyigl5-perl5.40.0-IO-HTML-1.004/lib/perl5/site_perl /nix/store/kjmnq9l3mmn255bpdhby3zy0lyns4j6d-perl5.40.0-LWP-MediaTypes-6.04/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/kjmnq9l3mmn255bpdhby3zy0lyns4j6d-perl5.40.0-LWP-MediaTypes-6.04/lib/perl5/site_perl/5.40.0 /nix/store/kjmnq9l3mmn255bpdhby3zy0lyns4j6d-perl5.40.0-LWP-MediaTypes-6.04/lib/perl5/site_perl /nix/store/n0c89q37hzzff3l4wdp2fn068c5ygmyx-perl5.40.0-URI-5.21/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/n0c89q37hzzff3l4wdp2fn068c5ygmyx-perl5.40.0-URI-5.21/lib/perl5/site_perl/5.40.0 /nix/store/n0c89q37hzzff3l4wdp2fn068c5ygmyx-perl5.40.0-URI-5.21/lib/perl5/site_perl /nix/store/413cl055d3mn09kpxxyp0r9xkcnnrd8j-perl5.40.0-HTTP-Cookies-6.10/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/413cl055d3mn09kpxxyp0r9xkcnnrd8j-perl5.40.0-HTTP-Cookies-6.10/lib/perl5/site_perl/5.40.0 /nix/store/413cl055d3mn09kpxxyp0r9xkcnnrd8j-perl5.40.0-HTTP-Cookies-6.10/lib/perl5/site_perl /nix/store/g8laallc9lbmr7l16kv1d98hm5pcaamn-perl5.40.0-HTTP-CookieJar-0.014/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/g8laallc9lbmr7l16kv1d98hm5pcaamn-perl5.40.0-HTTP-CookieJar-0.014/lib/perl5/site_perl/5.40.0 /nix/store/g8laallc9lbmr7l16kv1d98hm5pcaamn-perl5.40.0-HTTP-CookieJar-0.014/lib/perl5/site_perl /nix/store/yhv1r44mf9vdlr5kpszgr76yj2h5p43n-perl5.40.0-HTTP-Negotiate-6.01/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/yhv1r44mf9vdlr5kpszgr76yj2h5p43n-perl5.40.0-HTTP-Negotiate-6.01/lib/perl5/site_perl/5.40.0 /nix/store/yhv1r44mf9vdlr5kpszgr76yj2h5p43n-perl5.40.0-HTTP-Negotiate-6.01/lib/perl5/site_perl /nix/store/ak0ba7k7fn47shvz7zvbig1zlrq3p33k-perl5.40.0-Net-HTTP-6.23/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/ak0ba7k7fn47shvz7zvbig1zlrq3p33k-perl5.40.0-Net-HTTP-6.23/lib/perl5/site_perl/5.40.0 /nix/store/ak0ba7k7fn47shvz7zvbig1zlrq3p33k-perl5.40.0-Net-HTTP-6.23/lib/perl5/site_perl /nix/store/nb2ghxgm8mihs9ig6rd7yhi31cxwsgrc-perl5.40.0-Try-Tiny-0.31/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/nb2ghxgm8mihs9ig6rd7yhi31cxwsgrc-perl5.40.0-Try-Tiny-0.31/lib/perl5/site_perl/5.40.0 /nix/store/nb2ghxgm8mihs9ig6rd7yhi31cxwsgrc-perl5.40.0-Try-Tiny-0.31/lib/perl5/site_perl /nix/store/l1nkixb7faysc7pcdgs30b68xzzyahgi-perl5.40.0-WWW-RobotRules-6.02/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/l1nkixb7faysc7pcdgs30b68xzzyahgi-perl5.40.0-WWW-RobotRules-6.02/lib/perl5/site_perl/5.40.0 /nix/store/l1nkixb7faysc7pcdgs30b68xzzyahgi-perl5.40.0-WWW-RobotRules-6.02/lib/perl5/site_perl /nix/store/hkj5kki2jc7ajkalymrshxnyna60lwai-perl5.40.0-DB_File-1.859/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/hkj5kki2jc7ajkalymrshxnyna60lwai-perl5.40.0-DB_File-1.859/lib/perl5/site_perl/5.40.0 /nix/store/hkj5kki2jc7ajkalymrshxnyna60lwai-perl5.40.0-DB_File-1.859/lib/perl5/site_perl /nix/store/xaxvac37llwfi58rwk58z53l0jxcf5rj-perl5.40.0-File-DesktopEntry-0.22/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/xaxvac37llwfi58rwk58z53l0jxcf5rj-perl5.40.0-File-DesktopEntry-0.22/lib/perl5/site_perl/5.40.0 /nix/store/xaxvac37llwfi58rwk58z53l0jxcf5rj-perl5.40.0-File-DesktopEntry-0.22/lib/perl5/site_perl /nix/store/p88p2n8kj06grj1ia5ycxkdl4pqvv89a-perl5.40.0-File-BaseDir-0.09/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/p88p2n8kj06grj1ia5ycxkdl4pqvv89a-perl5.40.0-File-BaseDir-0.09/lib/perl5/site_perl/5.40.0 /nix/store/p88p2n8kj06grj1ia5ycxkdl4pqvv89a-perl5.40.0-File-BaseDir-0.09/lib/perl5/site_perl /nix/store/p5i3y7v38570hhg61vzrflmxi4lpjpvf-perl5.40.0-IPC-System-Simple-1.30/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/p5i3y7v38570hhg61vzrflmxi4lpjpvf-perl5.40.0-IPC-System-Simple-1.30/lib/perl5/site_perl/5.40.0 /nix/store/p5i3y7v38570hhg61vzrflmxi4lpjpvf-perl5.40.0-IPC-System-Simple-1.30/lib/perl5/site_perl /nix/store/gbai7lqkg5n08kpprnhajb2n2f953frd-perl5.40.0-Parse-DebControl-2.005/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/gbai7lqkg5n08kpprnhajb2n2f953frd-perl5.40.0-Parse-DebControl-2.005/lib/perl5/site_perl/5.40.0 /nix/store/gbai7lqkg5n08kpprnhajb2n2f953frd-perl5.40.0-Parse-DebControl-2.005/lib/perl5/site_perl /nix/store/w7dwg0dksmmyg3y843kl46hbkpjfnlwr-perl5.40.0-IO-Stringy-2.113/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/w7dwg0dksmmyg3y843kl46hbkpjfnlwr-perl5.40.0-IO-Stringy-2.113/lib/perl5/site_perl/5.40.0 /nix/store/w7dwg0dksmmyg3y843kl46hbkpjfnlwr-perl5.40.0-IO-Stringy-2.113/lib/perl5/site_perl /nix/store/n9499h823i059nvjbvifr9r86sh3scra-perl5.40.0-Moo-2.005005/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/n9499h823i059nvjbvifr9r86sh3scra-perl5.40.0-Moo-2.005005/lib/perl5/site_perl/5.40.0 /nix/store/n9499h823i059nvjbvifr9r86sh3scra-perl5.40.0-Moo-2.005005/lib/perl5/site_perl /nix/store/d889acxjfgghv21dxi0xbzm3n6an4ivh-perl5.40.0-Class-Method-Modifiers-2.15/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/d889acxjfgghv21dxi0xbzm3n6an4ivh-perl5.40.0-Class-Method-Modifiers-2.15/lib/perl5/site_perl/5.40.0 /nix/store/d889acxjfgghv21dxi0xbzm3n6an4ivh-perl5.40.0-Class-Method-Modifiers-2.15/lib/perl5/site_perl /nix/store/ifnf2bsjlgs7g3zb5i10wphhj8j04vmm-perl5.40.0-Module-Runtime-0.016/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/ifnf2bsjlgs7g3zb5i10wphhj8j04vmm-perl5.40.0-Module-Runtime-0.016/lib/perl5/site_perl/5.40.0 /nix/store/ifnf2bsjlgs7g3zb5i10wphhj8j04vmm-perl5.40.0-Module-Runtime-0.016/lib/perl5/site_perl /nix/store/p6xi614pj8rk02csc5scmij5mlb1ryzl-perl5.40.0-Role-Tiny-2.002004/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/p6xi614pj8rk02csc5scmij5mlb1ryzl-perl5.40.0-Role-Tiny-2.002004/lib/perl5/site_perl/5.40.0 /nix/store/p6xi614pj8rk02csc5scmij5mlb1ryzl-perl5.40.0-Role-Tiny-2.002004/lib/perl5/site_perl /nix/store/mw3mzq6lp60kxp1bdv2nhhk4g770dd44-perl5.40.0-Sub-Quote-2.006008/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/mw3mzq6lp60kxp1bdv2nhhk4g770dd44-perl5.40.0-Sub-Quote-2.006008/lib/perl5/site_perl/5.40.0 /nix/store/mw3mzq6lp60kxp1bdv2nhhk4g770dd44-perl5.40.0-Sub-Quote-2.006008/lib/perl5/site_perl /nix/store/abd4b89zhz8isn3k284n83jfql792sd3-perl5.40.0-File-HomeDir-1.006/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/abd4b89zhz8isn3k284n83jfql792sd3-perl5.40.0-File-HomeDir-1.006/lib/perl5/site_perl/5.40.0 /nix/store/abd4b89zhz8isn3k284n83jfql792sd3-perl5.40.0-File-HomeDir-1.006/lib/perl5/site_perl /nix/store/svwly9mcwdpngh20pfm578kldf6iiz41-perl5.40.0-File-Which-1.27/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/svwly9mcwdpngh20pfm578kldf6iiz41-perl5.40.0-File-Which-1.27/lib/perl5/site_perl/5.40.0 /nix/store/svwly9mcwdpngh20pfm578kldf6iiz41-perl5.40.0-File-Which-1.27/lib/perl5/site_perl /nix/store/1jppkc4xj15i6q6g1mnirrpyjwrqsv0r-perl5.40.0-IPC-Run-20231003.0/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/1jppkc4xj15i6q6g1mnirrpyjwrqsv0r-perl5.40.0-IPC-Run-20231003.0/lib/perl5/site_perl/5.40.0 /nix/store/1jppkc4xj15i6q6g1mnirrpyjwrqsv0r-perl5.40.0-IPC-Run-20231003.0/lib/perl5/site_perl /nix/store/v55w6wy9x2k2g2kvwa9bppqqhz7x8l0j-perl5.40.0-IO-Tty-1.20/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/v55w6wy9x2k2g2kvwa9bppqqhz7x8l0j-perl5.40.0-IO-Tty-1.20/lib/perl5/site_perl/5.40.0 /nix/store/v55w6wy9x2k2g2kvwa9bppqqhz7x8l0j-perl5.40.0-IO-Tty-1.20/lib/perl5/site_perl /nix/store/aqgsxja32f7h7qgfsjdy5r9rr523sry0-perl5.40.0-File-DirList-0.05/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/aqgsxja32f7h7qgfsjdy5r9rr523sry0-perl5.40.0-File-DirList-0.05/lib/perl5/site_perl/5.40.0 /nix/store/aqgsxja32f7h7qgfsjdy5r9rr523sry0-perl5.40.0-File-DirList-0.05/lib/perl5/site_perl /nix/store/r6ard53jwvi3y3c2j6h035fn1yjcd4m2-perl5.40.0-File-Touch-0.12/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/r6ard53jwvi3y3c2j6h035fn1yjcd4m2-perl5.40.0-File-Touch-0.12/lib/perl5/site_perl/5.40.0 /nix/store/r6ard53jwvi3y3c2j6h035fn1yjcd4m2-perl5.40.0-File-Touch-0.12/lib/perl5/site_perl /nix/store/6ivpf1crj9p6707icbbk011n11ch7l3p-dpkg-1.22.21 /nix/store/49rng2j1jbdr3jvgci5x6pv15lam6ysx-perl-5.40.0/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/49rng2j1jbdr3jvgci5x6pv15lam6ysx-perl-5.40.0/lib/perl5/site_perl/5.40.0 /nix/store/49rng2j1jbdr3jvgci5x6pv15lam6ysx-perl-5.40.0/lib/perl5/5.40.0/x86_64-linux-thread-multi /nix/store/49rng2j1jbdr3jvgci5x6pv15lam6ysx-perl-5.40.0/lib/perl5/5.40.0) at /nix/store/hzhz3180npnwgglqk7h1vqkvhy00y8wg-debian-devscripts-2.25.17/share/devscripts/Devscripts/Uscan/Version4.pm line 7.
BEGIN failed--compilation aborted at /nix/store/hzhz3180npnwgglqk7h1vqkvhy00y8wg-debian-devscripts-2.25.17/share/devscripts/Devscripts/Uscan/Version4.pm line 7.
Compilation failed in require at /nix/store/hzhz3180npnwgglqk7h1vqkvhy00y8wg-debian-devscripts-2.25.17/share/devscripts/Devscripts/Uscan/WatchFile.pm line 235.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
