### PR TITLE
networkminer: fix desktop file

### DIFF
--- a/pkgs/by-name/ne/networkminer/package.nix
+++ b/pkgs/by-name/ne/networkminer/package.nix
@@ -39,6 +39,9 @@ buildDotnetModule rec {
     # Embedded base64-encoded app icon in resx fails to parse. Delete it
     sed -zi 's|<data name="$this.Icon".*</data>||g' NetworkMiner/NamedPipeForm.resx
     sed -zi 's|<data name="$this.Icon".*</data>||g' NetworkMiner/UpdateCheck.resx
+
+    # Remove the UTF-8 BOM from the desktop file.
+    dos2unix -r NetworkMiner/NetworkMiner.desktop
   '';
 
   nugetDeps = ./deps.json;


### PR DESCRIPTION
The NetworkMiner.desktop file of the official NetworkMiner package contains three corrupted bytes. With this fix they are removed, making the desktop file work as intended.

Edit: the "corrupted" bytes are a UTF Byter Order Mark. In order for the .desktop file to be recognised, they have to be removed.

Before: 
```
00000000: efbb bf5b 4465 736b 746f 7020 456e 7472  ...[Desktop Entr
00000010: 795d 0a4e 616d 653d 4e65 7477 6f72 6b4d  y].Name=NetworkM
00000020: 696e 6572 0a43 6f6d 6d65 6e74 3d45 7874  iner.Comment=Ext
```

After (with the fix):
```
00000000: 5b44 6573 6b74 6f70 2045 6e74 7279 5d0a  [Desktop Entry].
00000010: 4e61 6d65 3d4e 6574 776f 726b 4d69 6e65  Name=NetworkMine
00000020: 720a 436f 6d6d 656e 743d 4578 7472 6163  r.Comment=Extrac
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
