### PR TITLE
python312Packages.mlx-lm: supply missing `lm-eval`

### DIFF
--- a/pkgs/development/python-modules/lm-eval/default.nix
+++ b/pkgs/development/python-modules/lm-eval/default.nix
@@ -23,6 +23,7 @@
   pandas,
   peft,
   pybind11,
+  pythonAtLeast,
   pytablewriter,
   pytestCheckHook,
   requests,
@@ -46,15 +47,19 @@
 
 buildPythonPackage rec {
   pname = "lm-eval";
-  version = "0.4.8";
+  version = "0.4.9.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "EleutherAI";
     repo = "lm-evaluation-harness";
     tag = "v${version}";
-    hash = "sha256-F8oy6XTovqiU7FQyuubRsiblSdvfZg9RPIyzRw2GH18=";
+    hash = "sha256-N5NRRabjWxPchwOIkjqYTCKInCmVSY6T5cAmdxNbCkU=";
   };
+
+  # Uses __future__
+  # https://github.com/EleutherAI/lm-evaluation-harness/issues/3245
+  disabled = pythonAtLeast "3.13";
 
   build-system = [
     setuptools-scm
@@ -136,15 +141,14 @@ buildPythonPackage rec {
 
   disabledTestPaths = [
     # attempts to download models
-    "tests/models/test_huggingface.py"
+    "tests/models"
+    "tests/scripts/test_zeno_visualize.py"
     "tests/test_evaluator.py"
     "tests/test_include_path.py"
     "tests/test_prompt.py"
     "tests/test_task_manager.py"
     "tests/test_tasks.py"
-
-    # optimum-intel is not available
-    "tests/models/test_openvino.py"
+    "tests/test_unitxt_tasks.py"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/mlx-lm/default.nix
+++ b/pkgs/development/python-modules/mlx-lm/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   setuptools,
   jinja2,
+  lm-eval,
   mlx,
   numpy,
   protobuf,
@@ -40,9 +41,10 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    writableTmpDirAsHomeHook
+    lm-eval
     pytestCheckHook
     sentencepiece
+    writableTmpDirAsHomeHook
   ];
 
   pythonImportsCheck = [
@@ -61,7 +63,9 @@ buildPythonPackage rec {
     "tests/test_prompt_cache.py::TestPromptCache::test_cache_to_quantized"
     "tests/test_prompt_cache.py::TestPromptCache::test_cache_with_generate"
     "tests/test_prompt_cache.py::TestPromptCache::test_trim_cache_with_generate"
+
     # RuntimeError: [metal_kernel] No GPU back-end.
+    "tests/test_losses.py"
     "tests/test_models.py::TestModels::test_bitnet"
   ];
 


### PR DESCRIPTION
1. `python312Packages.mlx-lm` stopped building after the 0.26.3 update due to a missing check input. Added the missing input `lm-eval`
2. `python3Packages.lm-eval` had also stopped building. Fixed the build, updated, limited to python <= 3.12 due to the use of `__future__`, and filed a bug upstream. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
