### PR TITLE
ante: unstable-2023-12-18 -> 0-unstable-2025-07-12

### DIFF
--- a/pkgs/by-name/an/ante/package.nix
+++ b/pkgs/by-name/an/ante/package.nix
@@ -1,54 +1,70 @@
 {
+  stdenv,
   fetchFromGitHub,
   lib,
+  zlib,
   libffi,
   libxml2,
-  llvmPackages_16,
+  llvmPackages_18,
   ncurses,
+  darwin,
   rustPlatform,
 }:
 
 rustPlatform.buildRustPackage {
   pname = "ante";
-  version = "unstable-2023-12-18";
+  version = "0-unstable-2025-07-12";
   src = fetchFromGitHub {
     owner = "jfecher";
     repo = "ante";
-    rev = "e38231ffa51b84a2ca53b4b0439d1ca5e0dea32a";
-    hash = "sha256-UKEoOm+Jc0YUwO74Tn038MLeX/c3d2z8I0cTBVfX61U=";
+    rev = "e1f68f00937ae39badcc42a48c0078b608f294bf";
+    fetchSubmodules = true;
+    hash = "sha256-mbjV7S705bSseA/P31jiJiktpUEQ8hS+M4kcs2AM1/Y=";
   };
 
-  cargoHash = "sha256-uOOSxRoc59XzJT5oVO2NOYC0BwrNq4X6Jd/gQz0ZBp8=";
+  cargoHash = "sha256-cRF1JFqWpGGQO3fIGcatVY1pp65CvNeM/6LFYDJxdpM=";
 
-  /*
-     https://crates.io/crates/llvm-sys#llvm-compatibility
-     llvm-sys requires a specific version of llvmPackages,
-     that is not the same as the one included by default with rustPlatform.
-  */
-  nativeBuildInputs = [ llvmPackages_16.llvm ];
+  strictDeps = true;
+
+  nativeBuildInputs = [ llvmPackages_18.llvm ];
   buildInputs = [
+    zlib
     libffi
     libxml2
     ncurses
   ];
 
   postPatch = ''
-    substituteInPlace tests/golden_tests.rs --replace \
+    substituteInPlace tests/golden_tests.rs --replace-fail \
       'target/debug' "target/$(rustc -vV | sed -n 's|host: ||p')/release"
+
+    substituteInPlace src/util/mod.rs \
+      --replace-fail '"gcc"' '"${lib.getExe llvmPackages_18.clang}"'
   '';
   preBuild =
     let
-      major = lib.versions.major llvmPackages_16.llvm.version;
-      minor = lib.versions.minor llvmPackages_16.llvm.version;
+      major = lib.versions.major llvmPackages_18.llvm.version;
+      minor = lib.versions.minor llvmPackages_18.llvm.version;
       llvm-sys-ver = "${major}${builtins.substring 0 1 minor}";
     in
     ''
       # On some architectures llvm-sys is not using the package listed inside nativeBuildInputs
-      export LLVM_SYS_${llvm-sys-ver}_PREFIX=${llvmPackages_16.llvm.dev}
+      export LLVM_SYS_${llvm-sys-ver}_PREFIX=${llvmPackages_18.llvm.dev}
       export ANTE_STDLIB_DIR=$out/lib
       mkdir -p $ANTE_STDLIB_DIR
       cp -r $src/stdlib/* $ANTE_STDLIB_DIR
     '';
+  # Ante uses the default LLVM target which, because we currently
+  # don’t include a Darwin version in the target, seemingly defaults
+  # to the host macOS version, which makes `ld(1)` warn about the
+  # mismatching deployment targets, which breaks the tests.
+  #
+  # TODO: Remove this once it stops being necessary.
+  preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    export MACOSX_DEPLOYMENT_TARGET=$(
+      ${lib.getExe' darwin.DarwinTools "sw_vers"} -productVersion
+    )
+  '';
 
   meta = with lib; {
     homepage = "https://antelang.org/";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
