### PR TITLE
lib{ice,sm,xt,xmu,xpm,xaw}: refactor, move to pkgs/by-name and rename from xorg namespace

### DIFF
--- a/pkgs/by-name/li/libice/package.nix
+++ b/pkgs/by-name/li/libice/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  xtrans,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libice";
+  version = "1.1.2";
+
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libICE-${finalAttrs.version}.tar.xz";
+    hash = "sha256-l05O1BQiXrPHFphd+XCfTajSKmeiiQBmvG38ia0phiU=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    xtrans
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libICE \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Inter-Client Exchange Library";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libice";
+    license = lib.licenses.mitOpenGroup;
+    maintainers = [ ];
+    pkgConfigModules = [ "ice" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libsm/package.nix
+++ b/pkgs/by-name/li/libsm/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libice,
+  libuuid,
+  xorgproto,
+  xtrans,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libsm";
+  version = "1.2.6";
+
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libSM-${finalAttrs.version}.tar.xz";
+    hash = "sha256-vnwKvbFcv9KaxiVzwcguh3+dQEetFTIefql9HkPYNb4=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libice
+    libuuid
+    xorgproto
+    xtrans
+  ];
+
+  propagatedBuildInputs = [
+    # needs to be propagated because of header file dependencies
+    libice
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libSM \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "X Session Management Library";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libsm";
+    license = with lib.licenses; [
+      mit
+      mitOpenGroup
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [ "sm" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxaw/package.nix
+++ b/pkgs/by-name/li/libxaw/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxext,
+  libxmu,
+  libxpm,
+  libxt,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxaw";
+  version = "1.0.16";
+
+  outputs = [
+    "out"
+    "dev"
+    "devdoc"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libXaw-${finalAttrs.version}.tar.xz";
+    hash = "sha256-cx1XK1THCPgeGXpq+oAWkY4uBt/TAl4GbKZCpbjDnI8=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxext
+    libxmu
+    libxpm
+    libxt
+  ];
+
+  propagatedBuildInputs = [
+    xorgproto
+    libxt
+    # needs to be propagated because of header file dependencies
+    libxmu
+  ];
+
+  postInstall =
+    # remove dangling symlinks to .so files on static
+    lib.optionalString stdenv.hostPlatform.isStatic "rm $out/lib/*.so*";
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libXaw \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "X Athena Widget Set, based on the X Toolkit Intrinsics (Xt) Library";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxaw";
+    license = with lib.licenses; [
+      mitOpenGroup
+      x11
+      hpndSellVariant
+      hpnd
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [
+      "xaw6"
+      "xaw7"
+    ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxmu/package.nix
+++ b/pkgs/by-name/li/libxmu/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxext,
+  libxt,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxmu";
+  version = "1.2.1";
+
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libXmu-${finalAttrs.version}.tar.xz";
+    hash = "sha256-/LJ3kySKOeX8xbnErsQMwHNLPKdqrD19HCZOf34U6LI=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxext
+    libxt
+  ];
+
+  propagatedBuildInputs = [
+    xorgproto
+    libx11
+    libxt
+  ];
+
+  buildFlags = [ "BITMAP_DEFINES='-DBITMAPDIR=\"/no-such-path\"'" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libXmu \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "X miscellaneous utility routines library";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxmu";
+    license = with lib.licenses; [
+      mitOpenGroup
+      hpnd
+      x11
+      isc
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [
+      "xmu"
+      "xmuu"
+    ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxpm/package.nix
+++ b/pkgs/by-name/li/libxpm/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  gettext,
+  xorgproto,
+  libx11,
+  libxext,
+  libxt,
+  ncompress,
+  gzip,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxpm";
+  version = "3.5.17";
+
+  outputs = [
+    "bin"
+    "dev"
+    "out"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libXpm-${finalAttrs.version}.tar.xz";
+    hash = "sha256-ZLMfgQGefTiMgisLKK+NUcRiK4Px8Mtvo/yV4nEibkM=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    gettext
+  ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxext
+    libxt
+  ];
+
+  propagatedBuildInputs = [
+    libx11
+  ];
+
+  env = {
+    XPM_PATH_COMPRESS = lib.makeBinPath [ ncompress ];
+    XPM_PATH_GZIP = lib.makeBinPath [ gzip ];
+    XPM_PATH_UNCOMPRESS = lib.makeBinPath [ gzip ];
+  };
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libXpm \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "X Pixmap (XPM) image file format library";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxpm";
+    license = with lib.licenses; [
+      x11
+      mit
+    ];
+    mainProgram = "sxpm";
+    maintainers = [ ];
+    pkgConfigModules = [ "xpm" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxt/package.nix
+++ b/pkgs/by-name/li/libxt/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  buildPackages,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libsm,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxt";
+  version = "1.3.1";
+
+  outputDoc = "devdoc";
+  outputs = [
+    "out"
+    "dev"
+    "devdoc"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libXt-${finalAttrs.version}.tar.xz";
+    hash = "sha256-4Kd0szMk9NTAWxmepFBQ+HIGWG2BZV+L7026Q02TEog=";
+  };
+
+  strictDeps = true;
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libsm
+  ];
+
+  propagatedBuildInputs = [
+    xorgproto
+    libx11
+    # needs to be propagated because of header file dependencies
+    libsm
+  ];
+
+  configureFlags =
+    lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "--enable-malloc0returnsnull"
+    ++ lib.optional (stdenv.targetPlatform.useLLVM or false) "ac_cv_path_RAWCPP=cpp";
+
+  env = {
+    CPP = if stdenv.hostPlatform.isDarwin then "clang -E -" else "${stdenv.cc.targetPrefix}cc -E -";
+  };
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libXt \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "X Toolkit Intrinsics library";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxt";
+    license = with lib.licenses; [
+      mit
+      hpndSellVariant
+      hpnd
+      mitOpenGroup
+      x11
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [ "xt" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -23,6 +23,7 @@
   libxdmcp,
   libxext,
   libxfixes,
+  libxmu,
   libxrandr,
   libxrender,
   libxt,
@@ -101,6 +102,7 @@ self: with self; {
   libXdmcp = libxdmcp;
   libXext = libxext;
   libXfixes = libxfixes;
+  libXmu = libxmu;
   libXrandr = libxrandr;
   libXrender = libxrender;
   libXt = libxt;
@@ -2185,49 +2187,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xinerama" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXmu = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libXext,
-      xorgproto,
-      libXt,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXmu";
-      version = "1.2.1";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXmu-1.2.1.tar.xz";
-        sha256 = "1cp82iz7yki63iykvb3alwy4nwy01k2axi5rqpyfafca4j9pgcpw";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        libXext
-        xorgproto
-        libXt
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [
-          "xmu"
-          "xmuu"
-        ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -25,6 +25,7 @@
   libxfixes,
   libxrandr,
   libxrender,
+  libxt,
   libxv,
   lndir,
   luit,
@@ -102,6 +103,7 @@ self: with self; {
   libXfixes = libxfixes;
   libXrandr = libxrandr;
   libXrender = libxrender;
+  libXt = libxt;
   libXv = libxv;
   utilmacros = util-macros;
   xcbproto = xcb-proto;
@@ -2390,46 +2392,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xres" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXt = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libICE,
-      xorgproto,
-      libSM,
-      libX11,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXt";
-      version = "1.3.1";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXt-1.3.1.tar.xz";
-        sha256 = "120jjd6l7fjdxy5myrc1dmc0cwpqa18a97hrbg0d9x146frp99z0";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libICE
-        xorgproto
-        libSM
-        libX11
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xt" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -24,6 +24,7 @@
   libxext,
   libxfixes,
   libxmu,
+  libxpm,
   libxrandr,
   libxrender,
   libxt,
@@ -103,6 +104,7 @@ self: with self; {
   libXext = libxext;
   libXfixes = libxfixes;
   libXmu = libxmu;
+  libXpm = libxpm;
   libXrandr = libxrandr;
   libXrender = libxrender;
   libXt = libxt;
@@ -2227,50 +2229,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xp" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXpm = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libXext,
-      xorgproto,
-      libXt,
-      gettext,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXpm";
-      version = "3.5.17";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXpm-3.5.17.tar.xz";
-        sha256 = "0hvf49qy55gwldpwpw7ihcmn5i2iinpjh2rbha63hzcy060izcv4";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        gettext
-      ];
-      buildInputs = [
-        libX11
-        libXext
-        xorgproto
-        libXt
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xpm" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -11,6 +11,7 @@
   libdmx,
   libfontenc,
   libfs,
+  libice,
   libpciaccess,
   libpthread-stubs,
   libx11,
@@ -89,6 +90,7 @@ self: with self; {
   fontutil = font-util;
   libAppleWM = libapplewm;
   libFS = libfs;
+  libICE = libice;
   libpthreadstubs = libpthread-stubs;
   libX11 = libx11;
   libXau = libxau;
@@ -1736,42 +1738,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libICE = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      xtrans,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libICE";
-      version = "1.1.2";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libICE-1.1.2.tar.xz";
-        sha256 = "09c656nqkz3dpik012d2cwmd5a2dkxqgjpcq2v3v6pi22ka4wklp";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        xtrans
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "ice" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -17,6 +17,7 @@
   libsm,
   libx11,
   libxau,
+  libxaw,
   libxcb,
   libxcvt,
   libxcursor,
@@ -99,6 +100,7 @@ self: with self; {
   libSM = libsm;
   libX11 = libx11;
   libXau = libxau;
+  libXaw = libxaw;
   libXcursor = libxcursor;
   libXdmcp = libxdmcp;
   libXext = libxext;
@@ -1862,53 +1864,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xtrap" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXaw = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libXext,
-      xorgproto,
-      libXmu,
-      libXpm,
-      libXt,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXaw";
-      version = "1.0.16";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXaw-1.0.16.tar.xz";
-        sha256 = "13wwqfwaahm6dh35w0nkvw32x3li2s0glsks34ggh267ahmmf7bk";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        libXext
-        xorgproto
-        libXmu
-        libXpm
-        libXt
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [
-          "xaw6"
-          "xaw7"
-        ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -14,6 +14,7 @@
   libice,
   libpciaccess,
   libpthread-stubs,
+  libsm,
   libx11,
   libxau,
   libxcb,
@@ -92,6 +93,7 @@ self: with self; {
   libFS = libfs;
   libICE = libice;
   libpthreadstubs = libpthread-stubs;
+  libSM = libsm;
   libX11 = libx11;
   libXau = libxau;
   libXcursor = libxcursor;
@@ -1738,44 +1740,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libSM = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libICE,
-      libuuid,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libSM";
-      version = "1.2.6";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libSM-1.2.6.tar.xz";
-        sha256 = "1gimv11iwzd9gqg345dd8x09szw75v4c2wr5qsdd5gswn6yhlz5y";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libICE
-        libuuid
-        xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "sm" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -53,6 +53,8 @@ $pcMap{"xcursor"} = "libXcursor";
 $pcMap{"xdmcp"} = "libXdmcp";
 $pcMap{"xext"} = "libXext";
 $pcMap{"xfixes"} = "libXfixes";
+$pcMap{"xmu"} = "libXmu";
+$pcMap{"xmuu"} = "libXmu";
 $pcMap{"xrandr"} = "libXrandr";
 $pcMap{"xrender"} = "libXrender";
 $pcMap{"xt"} = "libXt";
@@ -319,6 +321,7 @@ print OUT <<EOF;
   libxdmcp,
   libxext,
   libxfixes,
+  libxmu,
   libxrandr,
   libxrender,
   libxt,
@@ -397,6 +400,7 @@ self: with self; {
   libXdmcp = libxdmcp;
   libXext = libxext;
   libXfixes = libxfixes;
+  libXmu = libxmu;
   libXrandr = libxrandr;
   libXrender = libxrender;
   libXt = libxt;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -47,6 +47,8 @@ $pcMap{"sm"} = "libSM";
 $pcMap{"x11"} = "libX11";
 $pcMap{"x11-xcb"} = "libX11";
 $pcMap{"xau"} = "libXau";
+$pcMap{"xaw6"} = "libXaw";
+$pcMap{"xaw7"} = "libXaw";
 $pcMap{"xbitmaps"} = "xbitmaps";
 $pcMap{"xcb-proto"} = "xcbproto";
 $pcMap{"xcursor"} = "libXcursor";
@@ -316,6 +318,7 @@ print OUT <<EOF;
   libsm,
   libx11,
   libxau,
+  libxaw,
   libxcb,
   libxcvt,
   libxcursor,
@@ -398,6 +401,7 @@ self: with self; {
   libSM = libsm;
   libX11 = libx11;
   libXau = libxau;
+  libXaw = libxaw;
   libXcursor = libxcursor;
   libXdmcp = libxdmcp;
   libXext = libxext;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -43,6 +43,7 @@ $pcMap{"ice"} = "libICE";
 $pcMap{"libfs"} = "libFS";
 $pcMap{"pciaccess"} = "libpciaccess";
 $pcMap{"pthread-stubs"} = "libpthreadstubs";
+$pcMap{"sm"} = "libSM";
 $pcMap{"x11"} = "libX11";
 $pcMap{"x11-xcb"} = "libX11";
 $pcMap{"xau"} = "libXau";
@@ -308,6 +309,7 @@ print OUT <<EOF;
   libice,
   libpciaccess,
   libpthread-stubs,
+  libsm,
   libx11,
   libxau,
   libxcb,
@@ -386,6 +388,7 @@ self: with self; {
   libFS = libfs;
   libICE = libice;
   libpthreadstubs = libpthread-stubs;
+  libSM = libsm;
   libX11 = libx11;
   libXau = libxau;
   libXcursor = libxcursor;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -39,6 +39,7 @@ $pcMap{"hwdata"} = "hwdata";
 $pcMap{"dmx"} = "libdmx";
 $pcMap{"fontenc"} = "libfontenc";
 $pcMap{"fontutil"} = "fontutil";
+$pcMap{"ice"} = "libICE";
 $pcMap{"libfs"} = "libFS";
 $pcMap{"pciaccess"} = "libpciaccess";
 $pcMap{"pthread-stubs"} = "libpthreadstubs";
@@ -304,6 +305,7 @@ print OUT <<EOF;
   libdmx,
   libfontenc,
   libfs,
+  libice,
   libpciaccess,
   libpthread-stubs,
   libx11,
@@ -382,6 +384,7 @@ self: with self; {
   fontutil = font-util;
   libAppleWM = libapplewm;
   libFS = libfs;
+  libICE = libice;
   libpthreadstubs = libpthread-stubs;
   libX11 = libx11;
   libXau = libxau;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -55,6 +55,7 @@ $pcMap{"xext"} = "libXext";
 $pcMap{"xfixes"} = "libXfixes";
 $pcMap{"xrandr"} = "libXrandr";
 $pcMap{"xrender"} = "libXrender";
+$pcMap{"xt"} = "libXt";
 $pcMap{"xtrans"} = "xtrans";
 $pcMap{"xv"} = "libXv";
 $pcMap{"\$PIXMAN"} = "pixman";
@@ -320,6 +321,7 @@ print OUT <<EOF;
   libxfixes,
   libxrandr,
   libxrender,
+  libxt,
   libxv,
   lndir,
   luit,
@@ -397,6 +399,7 @@ self: with self; {
   libXfixes = libxfixes;
   libXrandr = libxrandr;
   libXrender = libxrender;
+  libXt = libxt;
   libXv = libxv;
   utilmacros = util-macros;
   xcbproto = xcb-proto;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -55,6 +55,7 @@ $pcMap{"xext"} = "libXext";
 $pcMap{"xfixes"} = "libXfixes";
 $pcMap{"xmu"} = "libXmu";
 $pcMap{"xmuu"} = "libXmu";
+$pcMap{"xpm"} = "libXpm";
 $pcMap{"xrandr"} = "libXrandr";
 $pcMap{"xrender"} = "libXrender";
 $pcMap{"xt"} = "libXt";
@@ -322,6 +323,7 @@ print OUT <<EOF;
   libxext,
   libxfixes,
   libxmu,
+  libxpm,
   libxrandr,
   libxrender,
   libxt,
@@ -401,6 +403,7 @@ self: with self; {
   libXext = libxext;
   libXfixes = libxfixes;
   libXmu = libxmu;
+  libXpm = libxpm;
   libXrandr = libxrandr;
   libXrender = libxrender;
   libXt = libxt;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -288,15 +288,6 @@ self: super:
     configureFlags = attrs.configureFlags or [ ] ++ malloc0ReturnsNullCrossFlag;
   });
 
-  libXmu = super.libXmu.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-      "doc"
-    ];
-    buildFlags = [ "BITMAP_DEFINES='-DBITMAPDIR=\"/no-such-path\"'" ];
-  });
-
   libXres = super.libXres.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -225,15 +225,6 @@ self: super:
     propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [ xorg.libXfixes ];
   });
 
-  libXaw = super.libXaw.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-      "devdoc"
-    ];
-    propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [ xorg.libXmu ];
-  });
-
   libXdamage = super.libXdamage.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -319,18 +319,6 @@ self: super:
     buildFlags = [ "BITMAP_DEFINES='-DBITMAPDIR=\"/no-such-path\"'" ];
   });
 
-  libSM = super.libSM.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-      "doc"
-    ];
-    propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [
-      xorg.libICE
-      xorg.xtrans
-    ];
-  });
-
   libXres = super.libXres.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -320,21 +320,6 @@ self: super:
     ];
   });
 
-  libXpm = super.libXpm.overrideAttrs (attrs: {
-    outputs = [
-      "bin"
-      "dev"
-      "out"
-    ]; # tiny man in $bin
-    patchPhase = "sed -i '/USE_GETTEXT_TRUE/d' sxpm/Makefile.in cxpm/Makefile.in";
-    XPM_PATH_COMPRESS = lib.makeBinPath [ ncompress ];
-    XPM_PATH_GZIP = lib.makeBinPath [ gzip ];
-    XPM_PATH_UNCOMPRESS = lib.makeBinPath [ gzip ];
-    meta = attrs.meta // {
-      mainProgram = "sxpm";
-    };
-  });
-
   libXpresent = super.libXpresent.overrideAttrs (attrs: {
     buildInputs = attrs.buildInputs ++ [
       xorg.libXext

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -217,28 +217,6 @@ self: super:
     };
   });
 
-  # Propagate some build inputs because of header file dependencies.
-  # Note: most of these are in Requires.private, so maybe builder.sh
-  # should propagate them automatically.
-  libXt = super.libXt.overrideAttrs (attrs: {
-    preConfigure = ''
-      sed 's,^as_dummy.*,as_dummy="\$PATH",' -i configure
-    '';
-    configureFlags =
-      attrs.configureFlags or [ ]
-      ++ malloc0ReturnsNullCrossFlag
-      ++ lib.optional (stdenv.targetPlatform.useLLVM or false) "ac_cv_path_RAWCPP=cpp";
-    propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [ xorg.libSM ];
-    depsBuildBuild = [ buildPackages.stdenv.cc ];
-    CPP = if stdenv.hostPlatform.isDarwin then "clang -E -" else "${stdenv.cc.targetPrefix}cc -E -";
-    outputDoc = "devdoc";
-    outputs = [
-      "out"
-      "dev"
-      "devdoc"
-    ];
-  });
-
   libXcomposite = super.libXcomposite.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -239,14 +239,6 @@ self: super:
     ];
   });
 
-  libICE = super.libICE.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-      "doc"
-    ];
-  });
-
   libXcomposite = super.libXcomposite.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -141,7 +141,6 @@ mirror://xorg/individual/font/font-sony-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-sun-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-winitzki-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-xfree86-type1-1.0.5.tar.xz
-mirror://xorg/individual/lib/libSM-1.2.6.tar.xz
 mirror://xorg/individual/lib/libWindowsWM-1.0.1.tar.bz2
 mirror://xorg/individual/lib/libXaw-1.0.16.tar.xz
 mirror://xorg/individual/lib/libXcomposite-0.4.6.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -159,7 +159,6 @@ mirror://xorg/individual/lib/libXres-1.2.2.tar.xz
 mirror://xorg/individual/lib/libXScrnSaver-1.2.4.tar.xz
 mirror://xorg/individual/lib/libxshmfence-1.3.3.tar.xz
 mirror://xorg/individual/lib/libXTrap-1.0.1.tar.bz2
-mirror://xorg/individual/lib/libXt-1.3.1.tar.xz
 mirror://xorg/individual/lib/libXtst-1.2.5.tar.xz
 mirror://xorg/individual/lib/libXvMC-1.0.14.tar.xz
 mirror://xorg/individual/lib/libXxf86dga-1.1.6.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -142,7 +142,6 @@ mirror://xorg/individual/font/font-sun-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-winitzki-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-xfree86-type1-1.0.5.tar.xz
 mirror://xorg/individual/lib/libWindowsWM-1.0.1.tar.bz2
-mirror://xorg/individual/lib/libXaw-1.0.16.tar.xz
 mirror://xorg/individual/lib/libXcomposite-0.4.6.tar.xz
 mirror://xorg/individual/lib/libXdamage-1.1.6.tar.xz
 mirror://xorg/individual/lib/libXfont-1.5.4.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -141,7 +141,6 @@ mirror://xorg/individual/font/font-sony-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-sun-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-winitzki-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-xfree86-type1-1.0.5.tar.xz
-mirror://xorg/individual/lib/libICE-1.1.2.tar.xz
 mirror://xorg/individual/lib/libSM-1.2.6.tar.xz
 mirror://xorg/individual/lib/libWindowsWM-1.0.1.tar.bz2
 mirror://xorg/individual/lib/libXaw-1.0.16.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -152,7 +152,6 @@ mirror://xorg/individual/lib/libXi-1.8.2.tar.xz
 mirror://xorg/individual/lib/libXinerama-1.1.5.tar.xz
 mirror://xorg/individual/lib/libxkbfile-1.1.3.tar.xz
 mirror://xorg/individual/lib/libXp-1.0.4.tar.xz
-mirror://xorg/individual/lib/libXpm-3.5.17.tar.xz
 mirror://xorg/individual/lib/libXpresent-1.0.1.tar.xz
 mirror://xorg/individual/lib/libXres-1.2.2.tar.xz
 mirror://xorg/individual/lib/libXScrnSaver-1.2.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -151,7 +151,6 @@ mirror://xorg/individual/lib/libXft-2.3.9.tar.xz
 mirror://xorg/individual/lib/libXi-1.8.2.tar.xz
 mirror://xorg/individual/lib/libXinerama-1.1.5.tar.xz
 mirror://xorg/individual/lib/libxkbfile-1.1.3.tar.xz
-mirror://xorg/individual/lib/libXmu-1.2.1.tar.xz
 mirror://xorg/individual/lib/libXp-1.0.4.tar.xz
 mirror://xorg/individual/lib/libXpm-3.5.17.tar.xz
 mirror://xorg/individual/lib/libXpresent-1.0.1.tar.xz


### PR DESCRIPTION
my plan is to migrate all packages from xorg to pkgs/by-name
this is the start of iteration 7, due to #415036 and #415049 being merged
it shouldn't conflict with any of the other open xorg migration prs
this pr moves several core libraries that many xorg packages depend on

<details>
<summary>this is the script i use to get the packages that don't depend on other xorg packages:</summary>

```nix
let
  inherit (import <nixpkgs> { }) lib;

  done = import ./pkgs/servers/x11/xorg/default.nix |> lib.functionArgs |> lib.attrNames;

  pkgs =
    (import ./default.nix { }).xorg
    |> lib.filterAttrs (
      n: v:
      lib.isAttrs v
      && v ? pname
      && !lib.elem n done
      && !lib.elem n (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem v.pname done
      && !lib.elem v.pname (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem (lib.toLower n) done
      && !lib.elem (lib.toLower n) (map (lib.replaceStrings [ "-" ] [ "" ]) done)
    );

  pnames = lib.mapAttrsToList (_: v: v.pname) pkgs;

  filteredPkgs =
    pkgs
    |> lib.filterAttrs (
      n: v:
      true
      && !v.meta.unfree
      && !v.meta.broken
      && !v.meta.unsupported
      && !lib.hasPrefix "font" n
      && !lib.hasPrefix "xf86" n
    );
in
filteredPkgs
# get deps
|> lib.mapAttrs (
  _: v:
  v.buildInputs ++ v.nativeBuildInputs ++ v.propagatedBuildInputs ++ v.propagatedNativeBuildInputs
)
# filter deps for xorg packages
|> lib.mapAttrs (_: v: lib.filter (x: x ? pname && lib.elem x.pname pnames) v)
# map deps to list and count
|> lib.mapAttrsToList (
  name: value: {
    inherit name;
    deps = map (x: x.pname or "error") value |> lib.unique;
    count = lib.length value;
  }
)
# sort
|> lib.sort (
  x: y: x.count < y.count || (x.count == y.count && (lib.toLower x.name) > (lib.toLower y.name))
)
|> lib.reverseList
# represent as string
|> map (x: "${toString x.count} - ${toString x.name}: ${lib.concatStringsSep " " x.deps}")
```

you can call it like this to get a nice output:

```sh
nix eval --json --file ./xorg-nodepends.nix | jq .[] --raw-output
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] x86_64-linux static 
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - only help and version output
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
  - [x] ran passthru.updateScript
  - [x] ran nixpkgs-hammer
  - [x] ran nix-check-deps 
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
