### PR TITLE
brogue-ce: add configuration options for terminal/graphics and macOS

### DIFF
--- a/pkgs/by-name/br/brogue-ce/package.nix
+++ b/pkgs/by-name/br/brogue-ce/package.nix
@@ -4,8 +4,13 @@
   fetchFromGitHub,
   makeDesktopItem,
   copyDesktopItems,
+
+  ncurses,
   SDL2,
   SDL2_image,
+
+  terminal ? false,
+  graphics ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -28,12 +33,25 @@ stdenv.mkDerivation (finalAttrs: {
     copyDesktopItems
   ];
 
-  buildInputs = [
-    SDL2
-    SDL2_image
+  buildInputs =
+    (lib.optionals graphics [
+      SDL2
+      SDL2_image
+    ])
+    ++ (lib.optionals terminal [
+      ncurses
+    ]);
+
+  makeFlags = [
+    "DATADIR=$(out)/opt/brogue-ce"
+    "TERMINAL=${if terminal then "YES" else "NO"}"
+    "GRAPHICS=${if graphics then "YES" else "NO"}"
+    "MAC_APP=${if stdenv.isDarwin then "YES" else "NO"}"
   ];
 
-  makeFlags = [ "DATADIR=$(out)/opt/brogue-ce" ];
+  postBuild = lib.optionalString (stdenv.isDarwin && graphics) ''
+    make Brogue.app $makeFlags
+  '';
 
   desktopItems = [
     (makeDesktopItem {
@@ -57,6 +75,11 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm755 linux/brogue-multiuser.sh $out/bin/brogue-ce
     install -Dm 644 bin/assets/icon.png $out/share/icons/hicolor/256x256/apps/brogue-ce.png
     runHook postInstall
+  '';
+
+  postInstall = lib.optionalString (stdenv.isDarwin && graphics) ''
+    mkdir -p $out/Applications
+    mv Brogue.app "$out/Applications/Brogue CE.app"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Exposes configuration options 'terminal' and 'graphics', with defaults (false, true respectively) to match existing behaviour

Moves SDL2 deps behind the 'graphics' flag and adds ncurses dep behind 'terminal' flag.

The respective make flags are applied to build for terminal/graphics.

In addition, brogue-ce is bundled into a macOS application when on darwin and graphics are enabled.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
