### PR TITLE
git: 2.50.1 -> 2.51.0

### DIFF
--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -60,7 +60,7 @@ assert sendEmailSupport -> perlSupport;
 assert svnSupport -> perlSupport;
 
 let
-  version = "2.50.1";
+  version = "2.51.0";
   svn = subversionClient.override { perlBindings = perlSupport; };
   gitwebPerlLibs = with perlPackages; [
     CGI
@@ -89,7 +89,7 @@ stdenv.mkDerivation (finalAttrs: {
         }.tar.xz"
       else
         "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
-    hash = "sha256-fj5sNt7L2PHu3RTULbZnS+A2ccIgSGS++ipBdWxcj8Q=";
+    hash = "sha256-YKfCJRzC5YjVzYe65WcmBhfG3gwi3KnNv8TH0riZC2I=";
   };
 
   outputs = [ "out" ] ++ lib.optional withManual "doc";
@@ -301,12 +301,6 @@ stdenv.mkDerivation (finalAttrs: {
     cp -a contrib $out/share/git/
     mkdir -p $out/share/bash-completion/completions
     ln -s $out/share/git/contrib/completion/git-prompt.sh $out/share/bash-completion/completions/
-    # only readme, developed in another repo
-    rm -r contrib/hooks/multimail
-    mkdir -p $out/share/git-core/contrib
-    cp -a contrib/hooks/ $out/share/git-core/contrib/
-    substituteInPlace $out/share/git-core/contrib/hooks/pre-auto-gc-battery \
-      --replace ' grep' ' ${gnugrep}/bin/grep' \
 
     # grep is a runtime dependency, need to patch so that it's found
     substituteInPlace $out/libexec/git-core/git-sh-setup \

--- a/pkgs/applications/version-management/git/git-send-email-honor-PATH.patch
+++ b/pkgs/applications/version-management/git/git-send-email-honor-PATH.patch
@@ -1,29 +1,25 @@
 diff --git a/Documentation/git-send-email.adoc b/Documentation/git-send-email.adoc
-index 7f223db42d..7e46a07d31 100644
+index 5d13a856a7..5c9978c1e4 100644
 --- a/Documentation/git-send-email.adoc
 +++ b/Documentation/git-send-email.adoc
-@@ -177,7 +177,7 @@ Sending
+@@ -190,7 +190,7 @@ Sending
  	The command will be executed in the shell if necessary.  Default
  	is the value of `sendemail.sendmailCmd`.  If unspecified, and if
- 	--smtp-server is also unspecified, git-send-email will search
--	for `sendmail` in `/usr/sbin`, `/usr/lib` and $PATH.
-+	for `sendmail` in $PATH.
+ 	`--smtp-server` is also unspecified, `git send-email` will search
+-	for `sendmail` in `/usr/sbin`, `/usr/lib` and `$PATH`.
++	for `sendmail` in `$PATH`.
  
  --smtp-encryption=<encryption>::
  	Specify in what way encrypting begins for the SMTP connection.
-@@ -233,9 +233,9 @@ a password is obtained using 'git-credential'.
- --smtp-server=<host>::
+@@ -247,7 +247,7 @@ a password is obtained using linkgit:git-credential[1].
  	If set, specifies the outgoing SMTP server to use (e.g.
  	`smtp.example.com` or a raw IP address).  If unspecified, and if
--	`--sendmail-cmd` is also unspecified, the default is to search
--	for `sendmail` in `/usr/sbin`, `/usr/lib` and $PATH if such a
--	program is available, falling back to `localhost` otherwise.
-+	`--sendmail-cmd` is also unspecified, the default is to search for
-+	`sendmail` in $PATH if such a program is available, falling back to
-+	`localhost` otherwise.
+ 	`--sendmail-cmd` is also unspecified, the default is to search
+-	for `sendmail` in `/usr/sbin`, `/usr/lib` and `$PATH` if such a
++	for `sendmail` in `$PATH` if such a
+ 	program is available, falling back to `localhost` otherwise.
  +
  For backward compatibility, this option can also specify a full pathname
- of a sendmail-like program instead; the program must support the `-i`
 diff --git a/git-send-email.perl b/git-send-email.perl
 index 798d59b84f..69c9cc2a7d 100755
 --- a/git-send-email.perl


### PR DESCRIPTION
Changelog: https://git.kernel.org/pub/scm/git/git.git/tree/Documentation/RelNotes/2.51.0.adoc?h=v2.51.0

This also removes some contrib scripts that are no longer packaged with Git.

Nothing obviously scary or significantly backward-incompatible in the changelog.

I'm working through the to-do list and will tick things off as I get to them.  I don't have access to a Darwin system to test directly, but I regularly build against Darwin over at https://github.com/me-and/nix-git-ci.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built gitMinimal, git, gitSVN and gitFull on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [NixOS tests] in [nixos/tests] (nixosTests.cgit, nixosTests.gitdaemon, nixosTests.buildbot)
    - [x] x86_64-linux
    - [ ] aarch64-linux
  - [Package tests] at `passthru.tests`.
    - [x] x86_64-linux
    - [ ] aarch64-linux
    - [ ] x86_64-darwin
    - [ ] aarch64-darwin
  - Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality (tests.fetchgit)
    - [x] x86_64-linux
    - [x] aarch64-linux
    - [ ] x86_64-darwin
    - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
