### PR TITLE
k3s: simplify airgap images passthru

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -59,6 +59,13 @@
 
 - `ansible-later` has been removed because it was discontinued by the author.
 
+- `k3s` airgap images passthru attributes have changed:
+  - `imagesList` was removed
+  - `airgapImages` was renamed to `airgap-images`
+  - `airgapImagesAmd64` was renamed to `airgap-images-amd64-tar-zst`
+  - `airgapImagesArm64` was renamed to `airgap-images-arm64-tar-zst`
+  - `airgapImagesArm` was renamed to `airgap-images-arm-tar-zst`
+
 - `stalwart-mail` since `0.13.0` "introduces a significant redesign of the MTA’s delivery and queueing subsystem". See [the upgrading announcement for the `0.13.0` release](https://github.com/stalwartlabs/stalwart/blob/89b561b5ca1c5a11f2a768b4a2cfef0f473b7a01/UPGRADING.md#upgrading-from-v012x-and-v011x-to-v013x).
 
 - Greetd and its original greeters (`tuigreet`, `gtkgreet`, `qtgreet`, `regreet`, `wlgreet`) were moved from `greetd` namespace to top level (`greetd.tuigreet` -> `tuigreet`, `greetd.greetd` -> `greetd`, etc). The original attrs are available for compatibility as passthrus of `greetd`, but will emit a warning. They will be removed in future releases.

--- a/nixos/tests/k3s/airgap-images.nix
+++ b/nixos/tests/k3s/airgap-images.nix
@@ -22,21 +22,13 @@ import ../make-test-python.nix (
           "--disable servicelb"
           "--disable traefik"
         ];
-        images = [ k3s.airgapImages ];
+        images = [ k3s.airgap-images ];
       };
     };
 
     testScript = ''
-      import json
-
-      start_all()
       machine.wait_for_unit("k3s")
       machine.wait_until_succeeds("journalctl -r --no-pager -u k3s | grep \"Imported images from /var/lib/rancher/k3s/agent/images/\"")
-      images = json.loads(machine.succeed("crictl img -o json"))
-      image_names = [i["repoTags"][0] for i in images["images"]]
-      with open("${k3s.imagesList}") as expected_images:
-        for line in expected_images:
-          assert line.rstrip() in image_names, f"The image {line.rstrip()} is not present in the airgap images archive"
     '';
   }
 )

--- a/pkgs/applications/networking/cluster/k3s/1_30/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_30/images-versions.json
@@ -1,18 +1,26 @@
 {
-  "airgap-images-amd64": {
+  "airgap-images-amd64-tar-gz": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.14%2Bk3s2/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "f98a57f7b25a4537096fbe9755f96cfd05bfe6fc6315f111c0f44e1abf4aad6d"
+  },
+  "airgap-images-amd64-tar-zst": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.14%2Bk3s2/k3s-airgap-images-amd64.tar.zst",
     "sha256": "9bda99cde833c4e13fb4d35fa46fd57d4b1a2eefc33e00fa352ce686c871c842"
   },
-  "airgap-images-arm": {
+  "airgap-images-arm-tar-gz": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.14%2Bk3s2/k3s-airgap-images-arm.tar.gz",
+    "sha256": "33df3a2b155118198c48e66426a04292a348aa53fef126a3cb8e4fe7aea83ccc"
+  },
+  "airgap-images-arm-tar-zst": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.14%2Bk3s2/k3s-airgap-images-arm.tar.zst",
     "sha256": "d40a78ff14b40547bca6d05db3d7e767b272bb9257628ebd3905d1659bc49bd5"
   },
-  "airgap-images-arm64": {
+  "airgap-images-arm64-tar-gz": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.14%2Bk3s2/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "bba9c2e417ece797a5ae8bf9346bb35dc8ab163828c801a2cb512d6097610b52"
+  },
+  "airgap-images-arm64-tar-zst": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.14%2Bk3s2/k3s-airgap-images-arm64.tar.zst",
     "sha256": "6561f91f14c8419c9d1c20fb9af7948757d87bd91855b376058d9f2e16010452"
-  },
-  "images-list": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.14%2Bk3s2/k3s-images.txt",
-    "sha256": "1f87ad26acac5e553279a64942c0e3eeef5c026cc2f82661d358990848672584"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_31/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_31/images-versions.json
@@ -1,18 +1,26 @@
 {
-  "airgap-images-amd64": {
+  "airgap-images-amd64-tar-gz": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.11%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "fa4f87e7e82c0e613f854eedf8f64d2cdabbd127f3ae84707ed1ca59e2137855"
+  },
+  "airgap-images-amd64-tar-zst": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.11%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
     "sha256": "c98ad7590af33ef7e148920eb809dfd0f8145a623fdd8d32c6efeecab6088412"
   },
-  "airgap-images-arm": {
+  "airgap-images-arm-tar-gz": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.11%2Bk3s1/k3s-airgap-images-arm.tar.gz",
+    "sha256": "0b6009407069fdd684d9627c5fa4bdb31ea4644172f1f429a2cce15d2c18631d"
+  },
+  "airgap-images-arm-tar-zst": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.11%2Bk3s1/k3s-airgap-images-arm.tar.zst",
     "sha256": "c1bd7557836538592dbd59f798e7a4b91d7aef74c8f9f71631060c96a5288dd6"
   },
-  "airgap-images-arm64": {
+  "airgap-images-arm64-tar-gz": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.11%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "6fa41db4ee001c1db8a404dd38f17f2426f27f688f9f7a2a76f4ef336f51c886"
+  },
+  "airgap-images-arm64-tar-zst": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.11%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
     "sha256": "97f0db38f57a2dc63167795620ba34a89348d874ecc91fbf3d8d962dc1392e47"
-  },
-  "images-list": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.11%2Bk3s1/k3s-images.txt",
-    "sha256": "1f87ad26acac5e553279a64942c0e3eeef5c026cc2f82661d358990848672584"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_32/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_32/images-versions.json
@@ -1,18 +1,26 @@
 {
-  "airgap-images-amd64": {
+  "airgap-images-amd64-tar-gz": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.7%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "f6a8720aa9bb03d0c8a97a93e994557292f1efba1fa6648cd8a07830622ce748"
+  },
+  "airgap-images-amd64-tar-zst": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.7%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
     "sha256": "965f5767c08cffc96bf0967813e7c3fec4c41309e9952a480f0a50865bebd039"
   },
-  "airgap-images-arm": {
+  "airgap-images-arm-tar-gz": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.7%2Bk3s1/k3s-airgap-images-arm.tar.gz",
+    "sha256": "9aa6f9f33e58e04fb9d8f9cd5c51dd01c6092d7b5434f84341b2f74bc8de783e"
+  },
+  "airgap-images-arm-tar-zst": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.7%2Bk3s1/k3s-airgap-images-arm.tar.zst",
     "sha256": "57ab9c306cc96f8dd925bc788c80e49c2d13ee7a222a12235fb525529ad25ac0"
   },
-  "airgap-images-arm64": {
+  "airgap-images-arm64-tar-gz": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.7%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "9633b71655ed0f4af556c148f9bf7753221b3c9b42a8d902391187789302adca"
+  },
+  "airgap-images-arm64-tar-zst": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.7%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
     "sha256": "1aa05a55492ba0872fa8a0ff518d6e947869bea32dc2b8e5223bdcf53450c7f9"
-  },
-  "images-list": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.7%2Bk3s1/k3s-images.txt",
-    "sha256": "e786e9a6f0331a92a2257a12995028761bfee1b5bfaac866025b64162e69bfe0"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_33/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_33/images-versions.json
@@ -1,18 +1,26 @@
 {
-  "airgap-images-amd64": {
+  "airgap-images-amd64-tar-gz": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.3%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "64690dc963f6cbff8adb175a1bc41e6bf207734a9a214362544a36361a2d8350"
+  },
+  "airgap-images-amd64-tar-zst": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.3%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
     "sha256": "51b6ddeafa465e542f0707272736100916886dd49abcb1420ee52878dd3638a9"
   },
-  "airgap-images-arm": {
+  "airgap-images-arm-tar-gz": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.3%2Bk3s1/k3s-airgap-images-arm.tar.gz",
+    "sha256": "878d17722dd98e7d88de93a83606e0c9b0d7587c7e4a043559b5236a353fb224"
+  },
+  "airgap-images-arm-tar-zst": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.3%2Bk3s1/k3s-airgap-images-arm.tar.zst",
     "sha256": "339dd2b33b40f03bf95ee2e5dcb8e543ab6852e156cb8aaebe3885717a2966b5"
   },
-  "airgap-images-arm64": {
+  "airgap-images-arm64-tar-gz": {
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.3%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "e4ab063deb50241e60218a3a30ce090a5817daa0f38dacd10651e27b2be28b9e"
+  },
+  "airgap-images-arm64-tar-zst": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.3%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
     "sha256": "c12ec7b122f34eb1f89310b05e66b500a2f49522d7cd4ceb3475a675cab6ebc6"
-  },
-  "images-list": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.3%2Bk3s1/k3s-images.txt",
-    "sha256": "e786e9a6f0331a92a2257a12995028761bfee1b5bfaac866025b64162e69bfe0"
   }
 }


### PR DESCRIPTION
As we had some trouble with this in the last release:

This reduces the filtering and renaming of airgap images archives to make the update script and builder more resilient to upstream changes. Additionally, it reduces the code of the k3s builder.

The names of the passthru attributes are now closer to the upstream asset names, so users are required to rename the attributes, as written in the release notes incompatibilities section.

Since the update script does not filter assets, k3s now passthrus all airgap images archives that are released upstream. The update script had all information anyway, so this has no negative side effects. 

@NixOS/k3s 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
