### PR TITLE
gpgme2: init at 2.0.0

### DIFF
--- a/pkgs/by-name/gp/gpgme2/package.nix
+++ b/pkgs/by-name/gp/gpgme2/package.nix
@@ -1,0 +1,116 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoreconfHook,
+  libgpg-error,
+  gnupg,
+  pkg-config,
+  glib,
+  pth,
+  libassuan,
+  which,
+  texinfo,
+  buildPackages,
+  qtbase ? null,
+  # only for passthru.tests
+  libsForQt5,
+  qt6Packages,
+  python3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gpgme";
+  version = "2.0.0";
+
+  outputs = [
+    "out"
+    "dev"
+    "info"
+  ];
+
+  outputBin = "dev"; # gpgme-config; not so sure about gpgme-tool
+
+  src = fetchurl {
+    url = "mirror://gnupg/gpgme/gpgme-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-3fFh08Qf9qP8uvS+bG4wXKTvHMPx7N/ODIwqFnwMw20=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    gnupg
+    pkg-config
+    texinfo
+  ];
+
+  propagatedBuildInputs = [
+    glib
+    libassuan
+    libgpg-error
+    pth
+  ]
+  ++ lib.optionals (qtbase != null) [ qtbase ];
+
+  nativeCheckInputs = [ which ];
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
+  dontWrapQtApps = true;
+
+  configureFlags = [
+    "--enable-fixed-path=${gnupg}/bin"
+    "--with-libgpg-error-prefix=${libgpg-error.dev}"
+    "--with-libassuan-prefix=${libassuan.dev}"
+  ]
+  # Tests will try to communicate with gpg-agent instance via a UNIX socket
+  # which has a path length limit. Nix on darwin is using a build directory
+  # that already has quite a long path and the resulting socket path doesn't
+  # fit in the limit. https://github.com/NixOS/nix/pull/1085
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ "--disable-gpg-test" ];
+
+  env.NIX_CFLAGS_COMPILE = toString (
+    # qgpgme uses Q_ASSERT which retains build inputs at runtime unless
+    # debugging is disabled
+    lib.optional (qtbase != null) "-DQT_NO_DEBUG"
+    # https://www.gnupg.org/documentation/manuals/gpgme/Largefile-Support-_0028LFS_0029.html
+    ++ lib.optional stdenv.hostPlatform.is32bit "-D_FILE_OFFSET_BITS=64"
+  );
+
+  enableParallelBuilding = true;
+
+  # prevent tests from being run during the buildPhase
+  makeFlags = [ "tests=" ];
+
+  doCheck = true;
+
+  checkFlags = [
+    "-C"
+    "tests"
+  ];
+
+  passthru.tests = {
+    python = python3.pkgs.gpgme;
+    qt5 = libsForQt5.qgpgme;
+    qt6 = qt6Packages.qgpgme;
+  };
+
+  meta = with lib; {
+    # fatal error: 'QtCore/qcompare.h' file not found
+    broken = qtbase != null && stdenv.hostPlatform.isDarwin;
+    homepage = "https://gnupg.org/software/gpgme/index.html";
+    changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;f=NEWS;hb=gpgme-${finalAttrs.version}";
+    description = "Library for making GnuPG easier to use";
+    longDescription = ''
+      GnuPG Made Easy (GPGME) is a library designed to make access to GnuPG
+      easier for applications. It provides a High-Level Crypto API for
+      encryption, decryption, signing, signature verification and key
+      management.
+    '';
+    license = with licenses; [
+      lgpl21Plus
+      gpl3Plus
+    ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Copied gpgme to gpgme2 with modifications to use sources for [gpgme 2.0.0](https://github.com/gpg/gpgme/releases/tag/gpgme-2.0.0)

I decided to add gpgme2 rather than update the existing gpgme package in order to have the possibility to migrate existing packages depending on gpgme one by one to gpgme2.

@dotlambda are you okay with continuing to be a maintainer for gpgme2?

Kindly requesting feedback on how to best handle the passthru tests and Qt support.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
