### PR TITLE
gpgmepp: init at 2.0.0

### DIFF
--- a/pkgs/by-name/gp/gpgmepp/package.nix
+++ b/pkgs/by-name/gp/gpgmepp/package.nix
@@ -1,0 +1,44 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  cmake,
+  gpgme2,
+  libgpg-error,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gpgmepp";
+  version = "2.0.0";
+
+  src = fetchurl {
+    url = "mirror://gnupg/gpgmepp/gpgmepp-${finalAttrs.version}.tar.xz";
+    hash = "sha256-1HlgScBnCKJvMJb3SO8JU0fho8HlcFYXAf6VLD9WU4I=";
+  };
+
+  postPatch = ''
+    # For details see https://github.com/NixOS/nixpkgs/issues/144170
+    substituteInPlace src/gpgmepp.pc.in \
+      --replace-fail "\''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@" "@CMAKE_INSTALL_FULL_INCLUDEDIR@" \
+      --replace-fail "\''${exec_prefix}/@CMAKE_INSTALL_LIBDIR@" "@CMAKE_INSTALL_FULL_LIBDIR@"
+  '';
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    gpgme2
+    libgpg-error
+  ];
+
+  meta = {
+    description = "C++ bindings for GPGME";
+    homepage = "https://gnupg.org/software/gpgme/index.html";
+    changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgmepp.git;f=NEWS;hb=gpgmepp-${finalAttrs.version}";
+    license = with lib.licenses; [
+      lgpl21
+      gpl2
+    ];
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

**N.B.** This PR depends on #434815 

@dotlambda are you willing to become maintainer for gpgmepp 2.0.0? These C++ bindings for gpgme were previously contained within gpgme, but have been externalised with gpgme version 2.0.0.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
