### PR TITLE
rtklib-ex: init at 2.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23675,6 +23675,12 @@
     githubId = 158321;
     name = "Stewart Mackenzie";
   };
+  skaphi = {
+    name = "Oskar Philipsson";
+    email = "oskar.philipsson@gmail.com";
+    github = "skaphi";
+    githubId = 41991455;
+  };
   skeuchel = {
     name = "Steven Keuchel";
     email = "steven.keuchel@gmail.com";

--- a/pkgs/by-name/rt/rtklib-ex/package.nix
+++ b/pkgs/by-name/rt/rtklib-ex/package.nix
@@ -1,0 +1,54 @@
+{
+  stdenv,
+  cmake,
+  nix-update-script,
+  blas,
+  lapack,
+  lib,
+  fetchFromGitHub,
+  qt6,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rtklib-ex";
+  version = "2.5.0";
+
+  src = fetchFromGitHub {
+    owner = "rtklibexplorer";
+    repo = "RTKLIB";
+    tag = "v${version}";
+    hash = "sha256-j00VEQvxOiAc3EQX3x2b3RxYkbtvCZ17ugnW6b6ChWU=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    blas
+    lapack
+    qt6.wrapQtAppsHook
+    qt6.qttools
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtserialport
+  ];
+
+  doCheck = true;
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_INSTALL_DATAROOTDIR" "${placeholder "out"}/share")
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Open Source Program Package for GNSS Positioning";
+    homepage = "https://rtkexplorer.com";
+    changelog = "https://github.com/rtklibexplorer/RTKLIB/releases/tag/${src.tag}";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.skaphi ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

First package attempt of rtklib-ex. A collection of utilities and a library for doing RTK GNSS stuff. [homepage](https://rtkexplorer.com/)

I am not using this project a lot anymore because I mostly needed it for my master’s thesis. But I would be happy to try to maintain it in nixpkgs.

This is my first contribution to nixpkgs, so please tell me everything I did wrong :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
