### PR TITLE
literata: Init at 3.103

### DIFF
--- a/pkgs/by-name/li/literata/package.nix
+++ b/pkgs/by-name/li/literata/package.nix
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "A serif typeface designed for ebooks and optimized for reading";
+    description = "Serif typeface designed for ebooks and optimized for reading";
     homepage = "https://github.com/googlefonts/literata";
     license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ xavwe ];

--- a/pkgs/by-name/li/literata/package.nix
+++ b/pkgs/by-name/li/literata/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "literata";
+  version = "3.103";
+
+  src = fetchzip {
+    url = "https://github.com/googlefonts/literata/releases/download/${finalAttrs.version}/${finalAttrs.version}.zip";
+    hash = "sha256-XwwvyzwO2uhi1Bay9HtB75j1QfAJR4TMETgy/zyvwZ0=";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/truetype
+    find . -name "*.ttf" -exec cp {} "$out/share/fonts/truetype/" \;
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A serif typeface designed for ebooks and optimized for reading";
+    homepage = "https://github.com/googlefonts/literata";
+    license = lib.licenses.ofl;
+    maintainers = with lib.maintainers; [ xavwe ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
This adds the literata package which is a nice font for long-form reading...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
