### PR TITLE
rofi-nerdy: init at 0.0.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27707,6 +27707,12 @@
     githubId = 474343;
     name = "Xavier Zwirtz";
   };
+  xavwe = {
+    email = "git@xavwe.dev";
+    github = "xavwe";
+    githubId = 125409009;
+    name = "Xaver Wenhart";
+  };
   XBagon = {
     name = "XBagon";
     email = "xbagon@outlook.de";

--- a/pkgs/by-name/ro/rofi-nerdy/package.nix
+++ b/pkgs/by-name/ro/rofi-nerdy/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  glib,
+  cairo,
+  pango,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rofi-nerdy";
+  version = "0.0.8";
+
+  src = fetchFromGitHub {
+    owner = "Rolv-Apneseth";
+    repo = "rofi-nerdy";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RiQ8bP7Q1ItZfCO94R95aTenqVOD45ohfUdmtDn0r9k=";
+  };
+
+  cargoHash = "sha256-NvS38uTqlBTUmRg2z0Faa5bTlRC/DTXQU3MCcSmPerA=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    glib
+    cairo
+    pango
+  ];
+
+  meta = {
+    description = "Nerd font icon selector plugin for rofi";
+    homepage = "https://github.com/Rolv-Apneseth/rofi-nerdy";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ xavwe ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Nerd font icon selector plugin for rofi
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
