### PR TITLE
libxcb-{util,errors,image,keysyms,render-util,wm}: refactor, move to pkgs/by-name and rename from xorg.xcbutil*

### DIFF
--- a/pkgs/by-name/li/libxcb-errors/package.nix
+++ b/pkgs/by-name/li/libxcb-errors/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  m4,
+  python3,
+  xcbproto,
+  libxcb,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxcb-errors";
+  version = "1.0.1";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/xcb/xcb-util-errors-${finalAttrs.version}.tar.xz";
+    hash = "sha256-VijIe5hCWa2Se6zYpClYMZw2vfSwZYh4A8nYIPuA81c=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    m4
+    python3
+  ];
+
+  buildInputs = [
+    xcbproto
+    libxcb
+  ];
+
+  propagatedBuildInputs = [ libxcb ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname xcb-util-errors \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "XCB utility library that gives human readable names to error, event & request codes";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-errors";
+    license = lib.licenses.x11;
+    maintainers = [ ];
+    pkgConfigModules = [ "xcb-errors" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxcb-image/package.nix
+++ b/pkgs/by-name/li/libxcb-image/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  m4,
+  xorgproto,
+  libxcb,
+  libxcb-util,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxcb-image";
+  version = "0.4.1";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/xcb/xcb-util-image-${finalAttrs.version}.tar.xz";
+    hash = "sha256-zK2O5drbEnH9RyetFNm9d6ZOUFYIdmxOmCZ9mu3kDT0=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    m4
+  ];
+
+  buildInputs = [
+    xorgproto
+    libxcb
+    libxcb-util
+  ];
+
+  propagatedBuildInputs = [ libxcb ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname xcb-util-image \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "XCB port of Xlib's XImage and XShmImage functions.";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-image";
+    license = lib.licenses.x11;
+    maintainers = [ ];
+    pkgConfigModules = [ "xcb-image" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxcb-keysyms/package.nix
+++ b/pkgs/by-name/li/libxcb-keysyms/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libxcb,
+  xorgproto,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxcb-keysyms";
+  version = "0.4.1";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/xcb/xcb-util-keysyms-${finalAttrs.version}.tar.xz";
+    hash = "sha256-fCYKUpRBKu1CnfHaL4r9O9B7fLo/7HcvuhWmE6bVxjg=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libxcb
+    xorgproto
+  ];
+
+  propagatedBuildInputs = [ libxcb ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname xcb-util-keysyms \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Standard X key constants and conversion to/from keycodes";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-keysyms";
+    license = lib.licenses.x11;
+    maintainers = [ ];
+    pkgConfigModules = [ "xcb-keysyms" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxcb-render-util/package.nix
+++ b/pkgs/by-name/li/libxcb-render-util/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libxcb,
+  xorgproto,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxcb-render-util";
+  version = "0.3.10";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/xcb/xcb-util-renderutil-${finalAttrs.version}.tar.xz";
+    hash = "sha256-PhXU8OItjdv7ufXXfbQ+rNejBAKb8lphZsxjyqltBLo=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libxcb
+    xorgproto
+  ];
+
+  propagatedBuildInputs = [ libxcb ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname xcb-util-renderutil \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "XCB convenience functions for the Render extension";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-render-util";
+    license = with lib.licenses; [
+      hpndSellVariant
+      x11
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [ "xcb-renderutil" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxcb-util/package.nix
+++ b/pkgs/by-name/li/libxcb-util/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libxcb,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxcb-util";
+  version = "0.4.1";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/xcb/xcb-util-${finalAttrs.version}.tar.xz";
+    hash = "sha256-Wr47u9jlTw+j7JRSkbfo+oz9PMzENxj4dYQw+UEm5RI=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libxcb ];
+  propagatedBuildInputs = [ libxcb ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname xcb-util \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "XCB utility libraries";
+    longDescription = ''
+      The XCB util modules provides a number of libraries which sit on top of libxcb, the core
+      X protocol library, and some of the extension libraries. These experimental libraries provid
+      convenience functions and interfaces which make the raw X protocol more usable. Some of the
+      libraries also provide client-side code which is not strictly part of the X protocol but which
+      have traditionally been provided by Xlib.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-util";
+    license = lib.licenses.x11;
+    maintainers = [ ];
+    pkgConfigModules = [
+      "xcb-atom"
+      "xcb-aux"
+      "xcb-event"
+      "xcb-util"
+    ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxcb-wm/package.nix
+++ b/pkgs/by-name/li/libxcb-wm/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libxcb,
+  xorgproto,
+  m4,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxcb-wm";
+  version = "0.4.2";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/xcb/xcb-util-wm-${finalAttrs.version}.tar.xz";
+    hash = "sha256-YsNOIdBiZGh/rqftv2NjLJ8E1V5yEUqkpXu5Xk+Iigs=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    m4
+  ];
+
+  buildInputs = [
+    libxcb
+    xorgproto
+  ];
+
+  propagatedBuildInputs = [ libxcb ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname xcb-util-wm \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "XCB client and window-manager helpers for ICCCM & EWMH.";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb-wm";
+    license = lib.licenses.x11;
+    maintainers = [ ];
+    pkgConfigModules = [
+      "xcb-ewmh"
+      "xcb-icccm"
+    ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -17,6 +17,7 @@
   libxau,
   libxcb,
   libxcb-errors,
+  libxcb-image,
   libxcb-util,
   libxcvt,
   libxcursor,
@@ -104,6 +105,7 @@ self: with self; {
   utilmacros = util-macros;
   xcbproto = xcb-proto;
   xcbutilerrors = libxcb-errors;
+  xcbutilimage = libxcb-image;
   xcbutil = libxcb-util;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
@@ -3237,50 +3239,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xcb-cursor" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xcbutilimage = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      gperf,
-      libxcb,
-      xcbutil,
-      xorgproto,
-      m4,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xcb-util-image";
-      version = "0.4.1";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/xcb/xcb-util-image-0.4.1.tar.xz";
-        sha256 = "0g8dwknrlz96k176qxh8ar84x9kpppci9b978zyp24nvvbjqxbfc";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        m4
-      ];
-      buildInputs = [
-        gperf
-        libxcb
-        xcbutil
-        xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xcb-image" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -16,6 +16,7 @@
   libx11,
   libxau,
   libxcb,
+  libxcb-util,
   libxcvt,
   libxcursor,
   libxdmcp,
@@ -101,6 +102,7 @@ self: with self; {
   libXv = libxv;
   utilmacros = util-macros;
   xcbproto = xcb-proto;
+  xcbutil = libxcb-util;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
@@ -3187,53 +3189,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xcbutil = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      gperf,
-      libxcb,
-      xorgproto,
-      m4,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xcb-util";
-      version = "0.4.1";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/xcb/xcb-util-0.4.1.tar.xz";
-        sha256 = "04p54r0zjc44fpw1hdy4rhygv37sx2vr2lllxjihykz5v2xkpgjs";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        m4
-      ];
-      buildInputs = [
-        gperf
-        libxcb
-        xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [
-          "xcb-atom"
-          "xcb-aux"
-          "xcb-event"
-          "xcb-util"
-        ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -18,6 +18,7 @@
   libxcb,
   libxcb-errors,
   libxcb-image,
+  libxcb-keysyms,
   libxcb-util,
   libxcvt,
   libxcursor,
@@ -106,6 +107,7 @@ self: with self; {
   xcbproto = xcb-proto;
   xcbutilerrors = libxcb-errors;
   xcbutilimage = libxcb-image;
+  xcbutilkeysyms = libxcb-keysyms;
   xcbutil = libxcb-util;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
@@ -3239,48 +3241,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xcb-cursor" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xcbutilkeysyms = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      gperf,
-      libxcb,
-      xorgproto,
-      m4,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xcb-util-keysyms";
-      version = "0.4.1";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/xcb/xcb-util-keysyms-0.4.1.tar.xz";
-        sha256 = "0f66snk179hmp8ppgv1zp9y7pl1vzn52znpikm1fsaj1ji90l9kw";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        m4
-      ];
-      buildInputs = [
-        gperf
-        libxcb
-        xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xcb-keysyms" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -16,6 +16,7 @@
   libx11,
   libxau,
   libxcb,
+  libxcb-errors,
   libxcb-util,
   libxcvt,
   libxcursor,
@@ -102,6 +103,7 @@ self: with self; {
   libXv = libxv;
   utilmacros = util-macros;
   xcbproto = xcb-proto;
+  xcbutilerrors = libxcb-errors;
   xcbutil = libxcb-util;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
@@ -3235,52 +3237,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xcb-cursor" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xcbutilerrors = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      gperf,
-      libxcb,
-      xcbproto,
-      xorgproto,
-      m4,
-      python3,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xcb-util-errors";
-      version = "1.0.1";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/xcb/xcb-util-errors-1.0.1.tar.xz";
-        sha256 = "0mzkh3xj1n690dw8hrdhyjykd71ib0ls9n5cgf9asna2k1xwha2n";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        m4
-        python3
-      ];
-      buildInputs = [
-        gperf
-        libxcb
-        xcbproto
-        xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xcb-errors" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -19,6 +19,7 @@
   libxcb-errors,
   libxcb-image,
   libxcb-keysyms,
+  libxcb-render-util,
   libxcb-util,
   libxcvt,
   libxcursor,
@@ -109,6 +110,7 @@ self: with self; {
   xcbutilimage = libxcb-image;
   xcbutilkeysyms = libxcb-keysyms;
   xcbutil = libxcb-util;
+  xcbutilrenderutil = libxcb-render-util;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
@@ -3241,48 +3243,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xcb-cursor" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xcbutilrenderutil = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      gperf,
-      libxcb,
-      xorgproto,
-      m4,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xcb-util-renderutil";
-      version = "0.3.10";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/xcb/xcb-util-renderutil-0.3.10.tar.xz";
-        sha256 = "1fh4dnlwlqyccrhmmwlv082a7mxc7ss7vmzmp7xxp39dwbqd859y";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        m4
-      ];
-      buildInputs = [
-        gperf
-        libxcb
-        xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xcb-renderutil" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -21,6 +21,7 @@
   libxcb-keysyms,
   libxcb-render-util,
   libxcb-util,
+  libxcb-wm,
   libxcvt,
   libxcursor,
   libxdmcp,
@@ -111,6 +112,7 @@ self: with self; {
   xcbutilkeysyms = libxcb-keysyms;
   xcbutil = libxcb-util;
   xcbutilrenderutil = libxcb-render-util;
+  xcbutilwm = libxcb-wm;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
@@ -3243,51 +3245,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xcb-cursor" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xcbutilwm = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      gperf,
-      libxcb,
-      xorgproto,
-      m4,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xcb-util-wm";
-      version = "0.4.2";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/xcb/xcb-util-wm-0.4.2.tar.xz";
-        sha256 = "02wai17mxfbvlnj4l4bjbvah97rccdivzvd7mrznhr32s0hlxhv2";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        m4
-      ];
-      buildInputs = [
-        gperf
-        libxcb
-        xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [
-          "xcb-ewmh"
-          "xcb-icccm"
-        ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -50,6 +50,7 @@ $pcMap{"xcb-atom"} = "xcbutil";
 $pcMap{"xcb-aux"} = "xcbutil";
 $pcMap{"xcb-errors"} = "xcbutilerrors";
 $pcMap{"xcb-event"} = "xcbutil";
+$pcMap{"xcb-image"} = "xcbutilimage";
 $pcMap{"xcb-proto"} = "xcbproto";
 $pcMap{"xcb-util"} = "xcbutil";
 $pcMap{"xcursor"} = "libXcursor";
@@ -315,6 +316,7 @@ print OUT <<EOF;
   libxau,
   libxcb,
   libxcb-errors,
+  libxcb-image,
   libxcb-util,
   libxcvt,
   libxcursor,
@@ -402,6 +404,7 @@ self: with self; {
   utilmacros = util-macros;
   xcbproto = xcb-proto;
   xcbutilerrors = libxcb-errors;
+  xcbutilimage = libxcb-image;
   xcbutil = libxcb-util;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -51,6 +51,7 @@ $pcMap{"xcb-aux"} = "xcbutil";
 $pcMap{"xcb-errors"} = "xcbutilerrors";
 $pcMap{"xcb-event"} = "xcbutil";
 $pcMap{"xcb-image"} = "xcbutilimage";
+$pcMap{"xcb-keysyms"} = "xcbutilkeysyms";
 $pcMap{"xcb-proto"} = "xcbproto";
 $pcMap{"xcb-util"} = "xcbutil";
 $pcMap{"xcursor"} = "libXcursor";
@@ -317,6 +318,7 @@ print OUT <<EOF;
   libxcb,
   libxcb-errors,
   libxcb-image,
+  libxcb-keysyms,
   libxcb-util,
   libxcvt,
   libxcursor,
@@ -405,6 +407,7 @@ self: with self; {
   xcbproto = xcb-proto;
   xcbutilerrors = libxcb-errors;
   xcbutilimage = libxcb-image;
+  xcbutilkeysyms = libxcb-keysyms;
   xcbutil = libxcb-util;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -46,7 +46,11 @@ $pcMap{"x11"} = "libX11";
 $pcMap{"x11-xcb"} = "libX11";
 $pcMap{"xau"} = "libXau";
 $pcMap{"xbitmaps"} = "xbitmaps";
+$pcMap{"xcb-atom"} = "xcbutil";
+$pcMap{"xcb-aux"} = "xcbutil";
+$pcMap{"xcb-event"} = "xcbutil";
 $pcMap{"xcb-proto"} = "xcbproto";
+$pcMap{"xcb-util"} = "xcbutil";
 $pcMap{"xcursor"} = "libXcursor";
 $pcMap{"xdmcp"} = "libXdmcp";
 $pcMap{"xext"} = "libXext";
@@ -309,6 +313,7 @@ print OUT <<EOF;
   libx11,
   libxau,
   libxcb,
+  libxcb-util,
   libxcvt,
   libxcursor,
   libxdmcp,
@@ -394,6 +399,7 @@ self: with self; {
   libXv = libxv;
   utilmacros = util-macros;
   xcbproto = xcb-proto;
+  xcbutil = libxcb-util;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -48,6 +48,7 @@ $pcMap{"xau"} = "libXau";
 $pcMap{"xbitmaps"} = "xbitmaps";
 $pcMap{"xcb-atom"} = "xcbutil";
 $pcMap{"xcb-aux"} = "xcbutil";
+$pcMap{"xcb-errors"} = "xcbutilerrors";
 $pcMap{"xcb-event"} = "xcbutil";
 $pcMap{"xcb-proto"} = "xcbproto";
 $pcMap{"xcb-util"} = "xcbutil";
@@ -313,6 +314,7 @@ print OUT <<EOF;
   libx11,
   libxau,
   libxcb,
+  libxcb-errors,
   libxcb-util,
   libxcvt,
   libxcursor,
@@ -399,6 +401,7 @@ self: with self; {
   libXv = libxv;
   utilmacros = util-macros;
   xcbproto = xcb-proto;
+  xcbutilerrors = libxcb-errors;
   xcbutil = libxcb-util;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -50,6 +50,8 @@ $pcMap{"xcb-atom"} = "xcbutil";
 $pcMap{"xcb-aux"} = "xcbutil";
 $pcMap{"xcb-errors"} = "xcbutilerrors";
 $pcMap{"xcb-event"} = "xcbutil";
+$pcMap{"xcb-ewmh"} = "xcbutilwm";
+$pcMap{"xcb-icccm"} = "xcbutilwm";
 $pcMap{"xcb-image"} = "xcbutilimage";
 $pcMap{"xcb-keysyms"} = "xcbutilkeysyms";
 $pcMap{"xcb-proto"} = "xcbproto";
@@ -322,6 +324,7 @@ print OUT <<EOF;
   libxcb-keysyms,
   libxcb-render-util,
   libxcb-util,
+  libxcb-wm,
   libxcvt,
   libxcursor,
   libxdmcp,
@@ -412,6 +415,7 @@ self: with self; {
   xcbutilkeysyms = libxcb-keysyms;
   xcbutil = libxcb-util;
   xcbutilrenderutil = libxcb-render-util;
+  xcbutilwm = libxcb-wm;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -53,6 +53,7 @@ $pcMap{"xcb-event"} = "xcbutil";
 $pcMap{"xcb-image"} = "xcbutilimage";
 $pcMap{"xcb-keysyms"} = "xcbutilkeysyms";
 $pcMap{"xcb-proto"} = "xcbproto";
+$pcMap{"xcb-renderutil"} = "xcbutilrenderutil";
 $pcMap{"xcb-util"} = "xcbutil";
 $pcMap{"xcursor"} = "libXcursor";
 $pcMap{"xdmcp"} = "libXdmcp";
@@ -319,6 +320,7 @@ print OUT <<EOF;
   libxcb-errors,
   libxcb-image,
   libxcb-keysyms,
+  libxcb-render-util,
   libxcb-util,
   libxcvt,
   libxcursor,
@@ -409,6 +411,7 @@ self: with self; {
   xcbutilimage = libxcb-image;
   xcbutilkeysyms = libxcb-keysyms;
   xcbutil = libxcb-util;
+  xcbutilrenderutil = libxcb-render-util;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -447,13 +447,6 @@ self: super:
     };
   });
 
-  xcbutilwm = super.xcbutilwm.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-    ]; # mainly to get rid of propagating others
-  });
-
   xf86inputevdev = super.xf86inputevdev.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -437,13 +437,6 @@ self: super:
 
   xcalc = addMainProgram super.xcalc { };
 
-  xcbutil = super.xcbutil.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-    ];
-  });
-
   xcbutilerrors = super.xcbutilerrors.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -447,13 +447,6 @@ self: super:
     };
   });
 
-  xcbutilkeysyms = super.xcbutilkeysyms.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-    ]; # mainly to get rid of propagating others
-  });
-
   xcbutilrenderutil = super.xcbutilrenderutil.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -437,13 +437,6 @@ self: super:
 
   xcalc = addMainProgram super.xcalc { };
 
-  xcbutilerrors = super.xcbutilerrors.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-    ]; # mainly to get rid of propagating others
-  });
-
   xcbutilcursor = super.xcbutilcursor.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -447,13 +447,6 @@ self: super:
     };
   });
 
-  xcbutilimage = super.xcbutilimage.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-    ]; # mainly to get rid of propagating others
-  });
-
   xcbutilkeysyms = super.xcbutilkeysyms.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -447,13 +447,6 @@ self: super:
     };
   });
 
-  xcbutilrenderutil = super.xcbutilrenderutil.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-    ]; # mainly to get rid of propagating others
-  });
-
   xcbutilwm = super.xcbutilwm.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/xcb/xcb-util-keysyms-0.4.1.tar.xz
 mirror://xorg/individual/xcb/xcb-util-renderutil-0.3.10.tar.xz
 mirror://xorg/individual/xcb/xcb-util-wm-0.4.2.tar.xz
 mirror://xorg/individual/app/appres-1.0.7.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/xcb/xcb-util-image-0.4.1.tar.xz
 mirror://xorg/individual/xcb/xcb-util-keysyms-0.4.1.tar.xz
 mirror://xorg/individual/xcb/xcb-util-renderutil-0.3.10.tar.xz
 mirror://xorg/individual/xcb/xcb-util-wm-0.4.2.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/xcb/xcb-util-renderutil-0.3.10.tar.xz
 mirror://xorg/individual/xcb/xcb-util-wm-0.4.2.tar.xz
 mirror://xorg/individual/app/appres-1.0.7.tar.xz
 mirror://xorg/individual/app/bitmap-1.1.1.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/xcb/xcb-util-errors-1.0.1.tar.xz
 mirror://xorg/individual/xcb/xcb-util-image-0.4.1.tar.xz
 mirror://xorg/individual/xcb/xcb-util-keysyms-0.4.1.tar.xz
 mirror://xorg/individual/xcb/xcb-util-renderutil-0.3.10.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/xcb/xcb-util-0.4.1.tar.xz
 mirror://xorg/individual/xcb/xcb-util-errors-1.0.1.tar.xz
 mirror://xorg/individual/xcb/xcb-util-image-0.4.1.tar.xz
 mirror://xorg/individual/xcb/xcb-util-keysyms-0.4.1.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/xcb/xcb-util-wm-0.4.2.tar.xz
 mirror://xorg/individual/app/appres-1.0.7.tar.xz
 mirror://xorg/individual/app/bitmap-1.1.1.tar.xz
 mirror://xorg/individual/app/editres-1.0.9.tar.xz


### PR DESCRIPTION
my plan is to migrate all packages from xorg to pkgs/by-name
this part of iteration 7, possible due to #415036 and #415049 being merged
it shouldn't conflict with any of the other open xorg migration prs
this pr moves almost all xcbutil* and renames them to the actual repo names in the freedesktop gitlab
the new names also make sense since these are all libraries
the only xcbutil i couldn't move is libxcb-cursor/xcbutilcursor because it is at a completely different position in tarballs.list conflicting with another pr :(

<details>
<summary>this is the script i use to get the packages that don't depend on other xorg packages:</summary>

```nix
let
  inherit (import <nixpkgs> { }) lib;

  done = import ./pkgs/servers/x11/xorg/default.nix |> lib.functionArgs |> lib.attrNames;

  pkgs =
    (import ./default.nix { }).xorg
    |> lib.filterAttrs (
      n: v:
      lib.isAttrs v
      && v ? pname
      && !lib.elem n done
      && !lib.elem n (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem v.pname done
      && !lib.elem v.pname (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem (lib.toLower n) done
      && !lib.elem (lib.toLower n) (map (lib.replaceStrings [ "-" ] [ "" ]) done)
    );

  pnames = lib.mapAttrsToList (_: v: v.pname) pkgs;

  filteredPkgs =
    pkgs
    |> lib.filterAttrs (
      n: v:
      true
      && !v.meta.unfree
      && !v.meta.broken
      && !v.meta.unsupported
      && !lib.hasPrefix "font" n
      && !lib.hasPrefix "xf86" n
    );
in
filteredPkgs
# get deps
|> lib.mapAttrs (
  _: v:
  v.buildInputs ++ v.nativeBuildInputs ++ v.propagatedBuildInputs ++ v.propagatedNativeBuildInputs
)
# filter deps for xorg packages
|> lib.mapAttrs (_: v: lib.filter (x: x ? pname && lib.elem x.pname pnames) v)
# map deps to list and count
|> lib.mapAttrsToList (
  name: value: {
    inherit name;
    deps = map (x: x.pname or "error") value |> lib.unique;
    count = lib.length value;
  }
)
# sort
|> lib.sort (
  x: y: x.count < y.count || (x.count == y.count && (lib.toLower x.name) > (lib.toLower y.name))
)
|> lib.reverseList
# represent as string
|> map (x: "${toString x.count} - ${toString x.name}: ${lib.concatStringsSep " " x.deps}")
```

you can call it like this to get a nice output:

```sh
nix eval --json --file ./xorg-nodepends.nix | jq .[] --raw-output
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] x86_64-linux static 
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
  - [x] ran passthru.updateScript
  - [x] ran nixpkgs-hammer
  - [x] ran nix-check-deps 
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
