### PR TITLE
python313Packages.pylibjpeg-rle: init at 2.1.0

### DIFF
--- a/pkgs/development/python-modules/pydicom/default.nix
+++ b/pkgs/development/python-modules/pydicom/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
       pillow
       #pyjpegls # not in nixpkgs
       #pylibjpeg.optional-dependencies.openjpeg # infinite recursion
-      #pylibjpeg.optional-dependencies.rle # not in nixpkgs
+      #pylibjpeg.optional-dependencies.rle # infinite recursion
       pylibjpeg-libjpeg
       gdcm
     ];

--- a/pkgs/development/python-modules/pylibjpeg-rle/default.nix
+++ b/pkgs/development/python-modules/pylibjpeg-rle/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  cargo,
+  rustPlatform,
+  rustc,
+  numpy,
+  pydicom,
+  pylibjpeg-data,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pylibjpeg-rle";
+  version = "2.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pydicom";
+    repo = "pylibjpeg-rle";
+    tag = "v${version}";
+    hash = "sha256-S9QBZEYfM9cwhwycF9TDpHv44z6fXTu3wBr4ZZHxXR8=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit pname version src;
+    hash = "sha256-ZkaDnG7wXQeaefASdsUFxuDKxjLukczyJeUgfG9uIyo=";
+  };
+
+  build-system = [
+    cargo
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+    rustc
+  ];
+
+  dependencies = [
+    numpy
+  ];
+
+  nativeCheckInputs = [
+    pydicom
+    pylibjpeg-data
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    mv rle/tests .
+    rm -r rle
+  '';
+
+  pythonImportsCheck = [
+    "rle"
+    "rle.rle"
+    "rle.utils"
+  ];
+
+  meta = {
+    description = "Fast DICOM RLE plugin for pylibjpeg";
+    homepage = "https://github.com/pydicom/pylibjpeg-rle";
+    changelog = "https://github.com/pydicom/pylibjpeg-rle/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/pylibjpeg/default.nix
+++ b/pkgs/development/python-modules/pylibjpeg/default.nix
@@ -10,6 +10,7 @@
   pylibjpeg-data,
   pylibjpeg-libjpeg,
   pylibjpeg-openjpeg,
+  pylibjpeg-rle,
 }:
 
 buildPythonPackage rec {
@@ -30,11 +31,15 @@ buildPythonPackage rec {
 
   dependencies = [ numpy ];
 
-  optional-dependencies = {
-    libjpeg = [ pylibjpeg-libjpeg ];
-    openjpeg = [ pylibjpeg-openjpeg ];
-    #rle = [ pylibjpeg-rle ]; # not in Nixpkgs
-  };
+  optional-dependencies =
+    let
+      extras = {
+        libjpeg = [ pylibjpeg-libjpeg ];
+        openjpeg = [ pylibjpeg-openjpeg ];
+        rle = [ pylibjpeg-rle ];
+      };
+    in
+    extras // { all = lib.concatLists (lib.attrValues extras); };
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13208,6 +13208,8 @@ self: super: with self; {
 
   pylibjpeg-openjpeg = callPackage ../development/python-modules/pylibjpeg-openjpeg { };
 
+  pylibjpeg-rle = callPackage ../development/python-modules/pylibjpeg-rle { };
+
   pyliblo3 = callPackage ../development/python-modules/pyliblo3 { };
 
   pylibmc = callPackage ../development/python-modules/pylibmc { };


### PR DESCRIPTION
Init python313Packages.pylibjpeg-rle, a [fast DICOM RLE plugin for pylibjpeg](https://github.com/pydicom/pylibjpeg-rle), previously missing as an optional dependency of pylibjpeg.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
