### PR TITLE
calibre: fix cuda build

### DIFF
--- a/pkgs/by-name/ca/calibre/package.nix
+++ b/pkgs/by-name/ca/calibre/package.nix
@@ -222,6 +222,11 @@ stdenv.mkDerivation (finalAttrs: {
       $ETN 'test_qt'  # we don't include svg or webp support
       $ETN 'test_import_of_all_python_modules'  # explores actual file paths, gets confused
       $ETN 'test_websocket_basic'  # flakey
+      # hangs with cuda enabled, also:
+      # eglInitialize: Failed to get system egl display
+      # Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
+      $ETN 'test_recipe_browser_webengine'
+
       ${lib.optionalString stdenv.hostPlatform.isAarch64 "$ETN 'test_piper'"} # https://github.com/microsoft/onnxruntime/issues/10038
       ${lib.optionalString (!unrarSupport) "$ETN 'test_unrar'"}
     )


### PR DESCRIPTION
Hello :wave:

I'm not sure about how to fix this. It started with a hanging build using cuda support. This [other guy](https://github.com/NixOS/nixpkgs/issues/420293#issuecomment-3069821367) ~find the same~ fixed the problem.

<details>
<summary>
It hangs during `installCheckPhase` in the test `test_recipe_browser_webengine`
</summary>

```
test_recipe_browser_webengine (calibre.scraper.test_fetch_backend.TestFetchBackend.test_recipe_browser_webengine) ... QRhiGles2: Failed to create temporary context
QRhiGles2: Failed to create context
This plugin does not support createPlatformVulkanInstance
QVulkanInstance: Failed to initialize Vulkan
Unable to detect GPU vendor.
[18859:18871:0819/014959.906717:ERROR:bus.cc(407)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
Fontconfig error: Cannot load default config file: No such file: (null)
[18859:18877:0819/014959.950235:ERROR:angle_platform_impl.cc(44)] Display.cpp:1083 (initialize): ANGLE Display::initialize error 12289: Failed to get system egl display
ERR: Display.cpp:1083 (initialize): ANGLE Display::initialize error 12289: Failed to get system egl display
[18859:18877:0819/014959.950263:ERROR:gl_display.cc(497)] EGL Driver message (Critical) eglInitialize: Failed to get system egl display
[18859:18877:0819/014959.950268:ERROR:gl_display.cc(767)] eglInitialize OpenGL failed with error EGL_NOT_INITIALIZED, trying next display type
[18859:18877:0819/014959.950289:ERROR:angle_platform_impl.cc(44)] Display.cpp:1083 (initialize): ANGLE Display::initialize error 12289: Failed to get system egl display
ERR: Display.cpp:1083 (initialize): ANGLE Display::initialize error 12289: Failed to get system egl display
[18859:18877:0819/014959.950299:ERROR:gl_display.cc(497)] EGL Driver message (Critical) eglInitialize: Failed to get system egl display
[18859:18877:0819/014959.950303:ERROR:gl_display.cc(767)] eglInitialize OpenGLES failed with error EGL_NOT_INITIALIZED
[18859:18877:0819/014959.950306:ERROR:gl_display.cc(801)] Initialization of all EGL display types failed.
[18859:18877:0819/014959.950312:ERROR:gl_ozone_egl.cc(26)] GLDisplayEGL::Initialize failed.
[18859:18877:0819/014959.950393:ERROR:angle_platform_impl.cc(44)] Display.cpp:1083 (initialize): ANGLE Display::initialize error 12289: Failed to get system egl display
ERR: Display.cpp:1083 (initialize): ANGLE Display::initialize error 12289: Failed to get system egl display
[18859:18877:0819/014959.950399:ERROR:gl_display.cc(497)] EGL Driver message (Critical) eglInitialize: Failed to get system egl display
[18859:18877:0819/014959.950403:ERROR:gl_display.cc(767)] eglInitialize OpenGL failed with error EGL_NOT_INITIALIZED, trying next display type
[18859:18877:0819/014959.950417:ERROR:angle_platform_impl.cc(44)] Display.cpp:1083 (initialize): ANGLE Display::initialize error 12289: Failed to get system egl display
ERR: Display.cpp:1083 (initialize): ANGLE Display::initialize error 12289: Failed to get system egl display
[18859:18877:0819/014959.950421:ERROR:gl_display.cc(497)] EGL Driver message (Critical) eglInitialize: Failed to get system egl display
[18859:18877:0819/014959.950425:ERROR:gl_display.cc(767)] eglInitialize OpenGLES failed with error EGL_NOT_INITIALIZED
[18859:18877:0819/014959.950428:ERROR:gl_display.cc(801)] Initialization of all EGL display types failed.
[18859:18877:0819/014959.950432:ERROR:gl_ozone_egl.cc(26)] GLDisplayEGL::Initialize failed.
GLOzone not found for unknown
Received signal 6
#0 0x7fffe6e51a85 base::debug::CollectStackTrace()
#1 0x7fffe6e351c6 base::debug::StackTrace::StackTrace()
#2 0x7fffe6e52279 base::debug::(anonymous namespace)::StackDumpSignalHandler()
#3 0x7ffff74419c0 (/nix/store/lmn7lwydprqibdkghw7wgcn21yhllz13-glibc-2.40-66/lib/libc.so.6+0x419bf)
#4 0x7ffff749cf3c __pthread_kill_implementation
#5 0x7ffff744190e __GI_raise
#6 0x7ffff7428942 __GI_abort
#7 0x7ffff16d43b3 qAbort()
#8 0x7ffff1729518 qt_message()
#9 0x7ffff16d59cb QMessageLogger::fatal()
#10 0x7fffe1f41862 QtWebEngineCore::SurfaceFactoryQt::GetGLOzone()
#11 0x7fffe86648cf gl::init::CreateGLContext()
#12 0x7fffe924cadd gpu::GpuChannelManager::GetSharedContextState()
#13 0x7fffe925b752 gpu::SharedImageStub::Initialize()
#14 0x7fffe925ba77 gpu::SharedImageStub::Create()
#15 0x7fffe92411a6 gpu::GpuChannel::CreateSharedImageStub()
#16 0x7fffe9243f1f gpu::GpuChannel::Create()
#17 0x7fffe9248cc0 gpu::GpuChannelManager::EstablishChannel()
#18 0x7fffe959a1a7 viz::GpuServiceImpl::EstablishGpuChannel()
#19 0x7fffe9591429 base::internal::Invoker<>::RunOnce()
#20 0x7fffe6dbf345 base::TaskAnnotator::RunTaskImpl()
#21 0x7fffe6de87e0 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl()
#22 0x7fffe6de998f base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()
#23 0x7fffe6d5d9ec base::MessagePumpDefault::Run()
#24 0x7fffe6de7a3a base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run()
#25 0x7fffe6d98c29 base::RunLoop::Run()
#26 0x7fffe6e0fb9c base::Thread::ThreadMain()
#27 0x7fffe6e2e6e9 base::(anonymous namespace)::ThreadFunc()
#28 0x7ffff749af08 start_thread
#29 0x7ffff75230ac __clone3
  r8: 0000000000000000  r9: 0000000000000000 r10: 0000000000000008 r11: 0000000000000246
 r12: 00007fffb5ffb6c0 r13: 00007fffb5ff93d0 r14: 0000000000000006 r15: 00007fffef16b570
  di: 00000000000049ab  si: 00000000000049bd  bp: 00007fffb5ff92d0  bx: 00000000000049bd
  dx: 0000000000000006  ax: 0000000000000000  cx: 00007ffff749cf3c  sp: 00007fffb5ff9290
  ip: 00007ffff749cf3c efl: 0000000000000246 cgf: 002b000000000033 erf: 0000000000000000
 trp: 0000000000000000 msk: 0000000000000000 cr2: 0000000000000000
[end of stack trace]
```

</details>

My initial thought was to conditionally skip that test depending on cuda support available. But...

<details>
<summary>
If I run a build without cuda the `installCheckPhase` logs other error
</summary>

```
test_recipe_browser_webengine (calibre.scraper.test_fetch_backend.TestFetchBackend.test_recipe_browser_webengine) ... QRhiGles2: Failed to create temporary context
QRhiGles2: Failed to create context
This plugin does not support createPlatformVulkanInstance
QVulkanInstance: Failed to initialize Vulkan
Unable to detect GPU vendor.
[18858:18870:0819/021255.229121:ERROR:bus.cc(407)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
Fontconfig error: Cannot load default config file: No such file: (null)
[18858:18876:0819/021255.231442:ERROR:angle_platform_impl.cc(44)] Display.cpp:1083 (initialize): ANGLE Display::initialize error 12289: Failed to get system egl display
ERR: Display.cpp:1083 (initialize): ANGLE Display::initialize error 12289: Failed to get system egl display
[18858:18876:0819/021255.231461:ERROR:gl_display.cc(497)] EGL Driver message (Critical) eglInitialize: Failed to get system egl display
[18858:18876:0819/021255.231465:ERROR:gl_display.cc(767)] eglInitialize OpenGL failed with error EGL_NOT_INITIALIZED, trying next display type
[18858:18876:0819/021255.231487:ERROR:angle_platform_impl.cc(44)] Display.cpp:1083 (initialize): ANGLE Display::initialize error 12289: Failed to get system egl display
ERR: Display.cpp:1083 (initialize): ANGLE Display::initialize error 12289: Failed to get system egl display
[18858:18876:0819/021255.231492:ERROR:gl_display.cc(497)] EGL Driver message (Critical) eglInitialize: Failed to get system egl display
[18858:18876:0819/021255.231495:ERROR:gl_display.cc(767)] eglInitialize OpenGLES failed with error EGL_NOT_INITIALIZED
[18858:18876:0819/021255.231498:ERROR:gl_display.cc(801)] Initialization of all EGL display types failed.
[18858:18876:0819/021255.231504:ERROR:gl_ozone_egl.cc(26)] GLDisplayEGL::Initialize failed.
[18858:18876:0819/021255.231576:ERROR:angle_platform_impl.cc(44)] Display.cpp:1083 (initialize): ANGLE Display::initialize error 12289: Failed to get system egl display
ERR: Display.cpp:1083 (initialize): ANGLE Display::initialize error 12289: Failed to get system egl display
[18858:18876:0819/021255.231584:ERROR:gl_display.cc(497)] EGL Driver message (Critical) eglInitialize: Failed to get system egl display
[18858:18876:0819/021255.231587:ERROR:gl_display.cc(767)] eglInitialize OpenGL failed with error EGL_NOT_INITIALIZED, trying next display type
[18858:18876:0819/021255.231602:ERROR:angle_platform_impl.cc(44)] Display.cpp:1083 (initialize): ANGLE Display::initialize error 12289: Failed to get system egl display
ERR: Display.cpp:1083 (initialize): ANGLE Display::initialize error 12289: Failed to get system egl display
[18858:18876:0819/021255.231608:ERROR:gl_display.cc(497)] EGL Driver message (Critical) eglInitialize: Failed to get system egl display
[18858:18876:0819/021255.231611:ERROR:gl_display.cc(767)] eglInitialize OpenGLES failed with error EGL_NOT_INITIALIZED
[18858:18876:0819/021255.231616:ERROR:gl_display.cc(801)] Initialization of all EGL display types failed.
[18858:18876:0819/021255.231619:ERROR:gl_ozone_egl.cc(26)] GLDisplayEGL::Initialize failed.
GLOzone not found for unknown
Received signal 6
#0 0x7fffe6e51a85 base::debug::CollectStackTrace()
#1 0x7fffe6e351c6 base::debug::StackTrace::StackTrace()
#2 0x7fffe6e52279 base::debug::(anonymous namespace)::StackDumpSignalHandler()
#3 0x7ffff74419c0 (/nix/store/lmn7lwydprqibdkghw7wgcn21yhllz13-glibc-2.40-66/lib/libc.so.6+0x419bf)
#4 0x7ffff749cf3c __pthread_kill_implementation
#5 0x7ffff744190e __GI_raise
#6 0x7ffff7428942 __GI_abort
#7 0x7ffff16d43b3 qAbort()
#8 0x7ffff1729518 qt_message()
#9 0x7ffff16d59cb QMessageLogger::fatal()
#10 0x7fffe1f41862 QtWebEngineCore::SurfaceFactoryQt::GetGLOzone()
#11 0x7fffe86648cf gl::init::CreateGLContext()
#12 0x7fffe924cadd gpu::GpuChannelManager::GetSharedContextState()
#13 0x7fffe925b752 gpu::SharedImageStub::Initialize()
#14 0x7fffe925ba77 gpu::SharedImageStub::Create()
#15 0x7fffe92411a6 gpu::GpuChannel::CreateSharedImageStub()
#16 0x7fffe9243f1f gpu::GpuChannel::Create()
#17 0x7fffe9248cc0 gpu::GpuChannelManager::EstablishChannel()
#18 0x7fffe959a1a7 viz::GpuServiceImpl::EstablishGpuChannel()
#19 0x7fffe9591429 base::internal::Invoker<>::RunOnce()
#20 0x7fffe6dbf345 base::TaskAnnotator::RunTaskImpl()
#21 0x7fffe6de87e0 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl()
#22 0x7fffe6de998f base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()
#23 0x7fffe6d5d9ec base::MessagePumpDefault::Run()
#24 0x7fffe6de7a3a base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run()
#25 0x7fffe6d98c29 base::RunLoop::Run()
#26 0x7fffe6e0fb9c base::Thread::ThreadMain()
#27 0x7fffe6e2e6e9 base::(anonymous namespace)::ThreadFunc()
#28 0x7ffff749af08 start_thread
#29 0x7ffff75230ac __clone3
  r8: 0000000000000000  r9: 0000000000000000 r10: 0000000000000008 r11: 0000000000000246
 r12: 00007fffbdffb6c0 r13: 00007fffbdff93d0 r14: 0000000000000006 r15: 00007fffef16b570
  di: 00000000000049aa  si: 00000000000049bc  bp: 00007fffbdff92d0  bx: 00000000000049bc
  dx: 0000000000000006  ax: 0000000000000000  cx: 00007ffff749cf3c  sp: 00007fffbdff9290
  ip: 00007ffff749cf3c efl: 0000000000000246 cgf: 002b000000000033 erf: 0000000000000000
 trp: 0000000000000000 msk: 0000000000000000 cr2: 0000000000000000
[end of stack trace]
ok [1.0 s]
```

</details>

So that led me think to just skip that damn test. There's also another fix good old chatGPT suggested, adding some flags before running the tests:

```
export QTWEBENGINE_DISABLE_GPU=1
export QT_QUICK_BACKEND=software
export QT_XCB_GL_INTEGRATION=none
export QTWEBENGINE_CHROMIUM_FLAGS="--disable-gpu --disable-software-rasterizer"
```

That lead to this test output:

```
test_recipe_browser_webengine (calibre.scraper.test_fetch_backend.TestFetchBackend.test_recipe_browser_webengine) ... QRhiGles2: Failed to create temporary context
QRhiGles2: Failed to create context
This plugin does not support createPlatformVulkanInstance
QVulkanInstance: Failed to initialize Vulkan
Unable to detect GPU vendor.
[18859:18871:0819/023630.155002:ERROR:bus.cc(407)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
Fontconfig error: Cannot load default config file: No such file: (null)
ok [1.0 s]
```

For now I'm just skipping the test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
