### PR TITLE
python3Packages.opencc: init at 1.1.9

### DIFF
--- a/pkgs/development/python-modules/opencc/default.nix
+++ b/pkgs/development/python-modules/opencc/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  cmake,
+  setuptools,
+  wheel,
+}:
+
+buildPythonPackage rec {
+  pname = "opencc";
+  version = "1.1.9";
+  format = "setuptools";
+
+  src = fetchPypi {
+    pname = "opencc";
+    inherit version;
+    hash = "sha256-itcig3MpUTAzkPrjOhztqYrJsDNoqPKRLtyTTXQHfko=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    setuptools
+    wheel
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  pythonImportsCheck = [
+    "opencc"
+  ];
+
+  meta = {
+    description = "Python bindings for OpenCC (Conversion between Traditional and Simplified Chinese)";
+    homepage = "https://github.com/BYVoid/OpenCC";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ siraben ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10761,6 +10761,8 @@ self: super: with self; {
 
   opencamlib = callPackage ../development/python-modules/opencamlib { };
 
+  opencc = callPackage ../development/python-modules/opencc { };
+
   opencensus = callPackage ../development/python-modules/opencensus { };
 
   opencensus-context = callPackage ../development/python-modules/opencensus-context { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add OpenCC to Python packages. Allows for conversion between Simplified, Traditional and Shinjitai charsets.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

```
❯ nix shell --impure --expr 'with import ./. {}; python3.withPackages (p: [ p.opencc ])' \
    --command python -c "from opencc import OpenCC; print(OpenCC('s2t').convert('画龙点睛'))"
畫龍點睛
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
