### PR TITLE
slimevr: 0.16.0 -> 0.16.2

### DIFF
--- a/pkgs/by-name/sl/slimevr-server/deps.json
+++ b/pkgs/by-name/sl/slimevr-server/deps.json
@@ -27,17 +27,6 @@
   }
  },
  "https://oss.sonatype.org/content/repositories/snapshots": {
-  "com/fazecast#jSerialComm/2.11.1-20240515.234541-3/SNAPSHOT": {
-   "jar": "sha256-n4A3U5elHQhq9b0YVgvWCuXAHqt0RzxL5e4Fe4iGTkM=",
-   "module": "sha256-xeVUO5f2Imx43EgYUI5vbLXyyEmJh/jT106eLUWtUYg=",
-   "pom": "sha256-y+ZXr7k89vlAHOMZmlTNYl8D0Nki+6CDame/QNX/e2M="
-  },
-  "com/fazecast/jSerialComm/2.11.1-SNAPSHOT/maven-metadata": {
-   "xml": {
-    "groupId": "com.fazecast",
-    "lastUpdated": "20241221185706"
-   }
-  },
   "net/java/dev/jna#jna-platform/5.1.1-20181118.214522-1/SNAPSHOT": {
    "pom": "sha256-STVISbMwC8BymYDxq6UJhC3ZWqO+p7iA7lRW34ZcX6g="
   },
@@ -559,6 +548,11 @@
   },
   "com/fasterxml/jackson/dataformat#jackson-dataformats-text/2.15.1": {
    "pom": "sha256-xLCopnocY3IgeJlhd5bYafE/UerrGsN/wHqcpxPaQjU="
+  },
+  "com/fazecast#jSerialComm/2.11.2": {
+   "jar": "sha256-IG2ScOZI3wMyR+deuECTpek9ePB8U+X+H6n8SmAaxXY=",
+   "module": "sha256-9ogHv84GSzOaAwFlbzbffC8GORkp7GKOyGyOMK7bufw=",
+   "pom": "sha256-jc/TZu3kSH1ZOSy+OvUaN3cUT09dRPinstTcvwBB38I="
   },
   "com/github/jonpeterson#jackson-module-model-versioning/1.2.2": {
    "jar": "sha256-FcepndfH5cTcOLXkhn1TZw1YDYqAXvQ4A7qT8IN2Uc0=",

--- a/pkgs/by-name/sl/slimevr/package.nix
+++ b/pkgs/by-name/sl/slimevr/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   fetchFromGitHub,
-  fetchpatch,
   stdenv,
   replaceVars,
   makeWrapper,
@@ -17,30 +16,31 @@
   webkitgtk_4_1,
   gst_all_1,
   libayatana-appindicator,
+  udevCheckHook,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "slimevr";
-  version = "0.16.0";
+  version = "0.16.2";
 
   src = fetchFromGitHub {
     owner = "SlimeVR";
     repo = "SlimeVR-Server";
-    rev = "v${version}";
-    hash = "sha256-ZYL+aBrADbzSXnhFzxNk8xRrY0WHmHCtVaC6VfXfLJw=";
+    tag = "v${version}";
+    hash = "sha256-g0SDienJX7ZUbypeIAWSwjxgu40AFd3jVALuMhHj6mQ=";
     # solarxr
     fetchSubmodules = true;
   };
 
   buildAndTestSubdir = "gui/src-tauri";
 
-  cargoHash = "sha256-+WrBVL4/XslJSOwuxs4IzqXG9l1/lMSbKil/8OHc9Xw=";
+  cargoHash = "sha256-w2z+EQqkVGLmXQS+AzeJwkGG4ovpz9+ovmLOcUks734=";
 
   pnpmDeps = pnpm_9.fetchDeps {
     pname = "${pname}-pnpm-deps";
     inherit version src;
     fetcherVersion = 1;
-    hash = "sha256-lh5IKdBXuH9GZFUTrzaQFDWCEYj0UJhKwCdPmsiwfCs=";
+    hash = "sha256-b0oCOjxrUQqWmUR6IzTEO75pvJZB7MQD14DNbQm95sA=";
   };
 
   nativeBuildInputs = [
@@ -50,6 +50,7 @@ rustPlatform.buildRustPackage rec {
     pkg-config
     wrapGAppsHook3
     makeWrapper
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -85,17 +86,6 @@ rustPlatform.buildRustPackage rec {
       --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
     substituteInPlace gui/src-tauri/src/tray.rs \
       --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
-
-    # tao < version 0.31 has a GTK crash. Manually apply the fix.
-    pushd $cargoDepsCopy/tao-0.30.*
-    patch -p1 < ${
-      fetchpatch {
-        name = "fix-gtk-crash.patch";
-        url = "https://github.com/tauri-apps/tao/commit/83e35e961f4893790b913ee2efc15ae33fd16fb2.diff";
-        hash = "sha256-FNXWzsg4lO6VbLsqS6NevX8kVj26YtcYdKbbFejq9hM=";
-      }
-    }
-    popd
   '';
 
   # solarxr needs to be installed after compiling its Typescript files. This isn't
@@ -105,11 +95,14 @@ rustPlatform.buildRustPackage rec {
   '';
 
   doCheck = false; # No tests
+  doInstallCheck = true; # Check udev
 
   # Get rid of placeholder slimevr.jar
   postInstall = ''
     rm $out/share/slimevr/slimevr.jar
     rm -d $out/share/slimevr
+
+    install -Dm644 -t $out/lib/udev/rules.d/ gui/src-tauri/69-slimevr-devices.rules
   '';
 
   # `JAVA_HOME`, `JAVA_TOOL_OPTIONS`, and `--launch-from-path` are so the GUI can


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
* Removed tao patch as now SlimeVR uses a newer version of tauri
* Added the now included udev rules in the repo.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
