### PR TITLE
postgresqlPackages.pg_hint_plan: updates; support PG18

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
@@ -21,8 +21,8 @@ let
       hash = "sha256-o8Hepf/Mc1ClRTLZ6PBdqU4jSdlz+ijVgl2vJKmIc6M=";
     };
     "14" = {
-      version = "1.4.2";
-      hash = "sha256-nGyKcNY57RdQdZKSaBPk2/YbT0Annz1ZevH0lKswdhA=";
+      version = "1.4.4";
+      hash = "sha256-8rJ4Ck0Axf9zKhOXaJ4EA/M783YZRLuWx+GMGccadVo=";
     };
     "13" = {
       version = "1.3.11";

--- a/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
@@ -9,8 +9,8 @@ let
   sources = {
     # For v18, see https://github.com/ossc-db/pg_hint_plan/issues/224
     "17" = {
-      version = "1.7.0";
-      hash = "sha256-MNQMePDmGxC8OFIJuVJrhfgU566vkng00+tjeGpGKvs=";
+      version = "1.7.1";
+      hash = "sha256-9GKqyrNpi80I4WWIiRN8zeXBm5bkRuzOWrZVfpYOzag=";
     };
     "16" = {
       version = "1.6.2";

--- a/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
@@ -13,8 +13,8 @@ let
       hash = "sha256-MNQMePDmGxC8OFIJuVJrhfgU566vkng00+tjeGpGKvs=";
     };
     "16" = {
-      version = "1.6.0";
-      hash = "sha256-lg7N0QblluTgtNo1tGZjirNJSyQXtcAEs9Jqd3zx0Sg=";
+      version = "1.6.2";
+      hash = "sha256-WMmtnuGOvLwtiEmgHpYURC1k5NmkBiDg+PnQCIZp7Sk=";
     };
     "15" = {
       version = "1.5.3";

--- a/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
@@ -7,7 +7,10 @@
 
 let
   sources = {
-    # For v18, see https://github.com/ossc-db/pg_hint_plan/issues/224
+    "18" = {
+      version = "1.8.0";
+      hash = "sha256-QsDppGN5TE7CSii3mNmwqT/riNNjyRTJk6d6Xcf0JMw=";
+    };
     "17" = {
       version = "1.7.1";
       hash = "sha256-9GKqyrNpi80I4WWIiRN8zeXBm5bkRuzOWrZVfpYOzag=";

--- a/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
@@ -25,8 +25,8 @@ let
       hash = "sha256-nGyKcNY57RdQdZKSaBPk2/YbT0Annz1ZevH0lKswdhA=";
     };
     "13" = {
-      version = "1.3.9";
-      hash = "sha256-KGcHDwk8CgNHPZARfLBfS8r7TRCP9LPjT+m4fNSnnW0=";
+      version = "1.3.11";
+      hash = "sha256-XTxCw1Uj6rVLcXJuHoT3RkEhdKVLGjOdR7rhFI8YJas=";
     };
   };
 

--- a/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
@@ -17,8 +17,8 @@ let
       hash = "sha256-lg7N0QblluTgtNo1tGZjirNJSyQXtcAEs9Jqd3zx0Sg=";
     };
     "15" = {
-      version = "1.5.1";
-      hash = "sha256-o8Hepf/Mc1ClRTLZ6PBdqU4jSdlz+ijVgl2vJKmIc6M=";
+      version = "1.5.3";
+      hash = "sha256-jkU0zt1waPTdFrBLAxYNvlo+RwdhCtKQq7iqAuxthNA=";
     };
     "14" = {
       version = "1.4.4";


### PR DESCRIPTION
Release Notes for 1.8.0:
https://github.com/ossc-db/pg_hint_plan/releases/tag/REL18_1_8_0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
