### PR TITLE
minizinc: update gecode to 6.3.0

### DIFF
--- a/pkgs/development/tools/minizinc/default.nix
+++ b/pkgs/development/tools/minizinc/default.nix
@@ -13,6 +13,22 @@
   zlib,
 }:
 
+let
+  gecode_6_3_0 = gecode.overrideAttrs (_: {
+    version = "6.3.0";
+    src = fetchFromGitHub {
+      owner = "gecode";
+      repo = "gecode";
+      rev = "f7f0d7c273d6844698f01cec8229ebe0b66a016a";
+      hash = "sha256-skf2JEtNkRqEwfHb44WjDGedSygxVuqUixskTozi/5k=";
+    };
+    patches = [ ];
+  });
+in
+let
+  gecode = gecode_6_3_0;
+in
+
 stdenv.mkDerivation (finalAttrs: {
   pname = "minizinc";
   version = "2.9.3";
@@ -42,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/share/minizinc/solvers/
     jq \
       '.version = "${gecode.version}"
-       | .mznlib = "${gecode}/share/gecode/mznlib"
+       | .mznlib = "${gecode}/share/minizinc/gecode/"
        | .executable = "${gecode}/bin/fzn-gecode"' \
        ${./gecode.msc} \
        >$out/share/minizinc/solvers/gecode.msc

--- a/pkgs/development/tools/minizinc/simple-test/default.nix
+++ b/pkgs/development/tools/minizinc/simple-test/default.nix
@@ -12,9 +12,10 @@ stdenv.mkDerivation {
   dontInstall = true;
 
   buildCommand = ''
-    minizinc --solver gecode ${./aust.mzn}
-    minizinc --solver cbc ${./loan.mzn} ${./loan1.dzn}
-    touch $out
+    mkdir -p $out
+    minizinc --solver gecode ${./aust.mzn} | tee $out/aust.log
+    minizinc --solver gecode ${./nqueens.mzn} | tee $out/nqueens.log
+    minizinc --solver cbc ${./loan.mzn} ${./loan1.dzn} | tee $out/loan.log
   '';
 
   meta.timeout = 10;

--- a/pkgs/development/tools/minizinc/simple-test/nqueens.mzn
+++ b/pkgs/development/tools/minizinc/simple-test/nqueens.mzn
@@ -1,0 +1,9 @@
+int: n = 8; % The number of queens.
+
+array [1..n] of var 1..n: q;
+
+include "alldifferent.mzn";
+
+constraint alldifferent(q);
+constraint alldifferent(i in 1..n)(q[i] + i);
+constraint alldifferent(i in 1..n)(q[i] - i);


### PR DESCRIPTION
Fixes #383881.

I did not update `gecode` generally because version 6.3.0 has not been released yet.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
