### PR TITLE
Revert "python3Packages.buildPythonPackage: default enabledTestPaths = [ "." ]"

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -1285,7 +1285,6 @@ Adding `pytest` is not required, since it is included with `pytestCheckHook`.
 `enabledTestPaths` and `disabledTestPaths`
 
 :   To specify path globs (files or directories) or test items.
-    `enabledTestPaths` defaults to `[ "." ]`.
 
 `enabledTests` and `disabledTests`
 

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -18,12 +18,6 @@
 
 - The minimum version of Nix required to evaluate Nixpkgs has been raised from 2.3 to 2.18.
 
-- `buildPythonPackage` and `buildPythonApplication` now set `enabledTestPaths = [ "." ]` by default if not specified otherwise, and require the specified value to be a non-empty list to simplify overriding.
-
-  When running install-checks with `pytestCheckHook`, such default value resembles `pytest`'s default behaviour of discovering tests in the current working directory.
-
-  To support both version of Nixpkgs before and after this change, set `enabledTestPaths = [ "." ]` manually for packages that don't need custom `enabledTestPaths` specification.
-
 - The `offrss` package was removed due to lack of upstream maintenance since 2012. It's recommended for users to migrate to another RSS reader
 
 - `base16-builder` node package has been removed due to lack of upstream maintenance.

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -431,17 +431,6 @@ let
       # Longer-term we should get rid of `checkPhase` and use `installCheckPhase`.
       installCheckPhase = attrs.checkPhase;
     }
-    // {
-      # `pytest` defaults to discover tests in the current directory if no paths or test items are specified.
-      # Provide an explicit default value to simplify overriding.
-      enabledTestPaths =
-        if attrs ? enabledTestPaths then
-          lib.throwIf (!lib.isList attrs.enabledTestPaths || attrs.enabledTestPaths == [ ])
-            "${lib.getName finalAttrs}: enabledTestPaths must be a non-empty list (default to [ \".\" ])."
-            attrs.enabledTestPaths
-        else
-          [ "." ];
-    }
     //
       lib.mapAttrs
         (
@@ -453,6 +442,7 @@ let
         (
           getOptionalAttrs [
             "enabledTestMarks"
+            "enabledTestPaths"
             "enabledTests"
           ] attrs
         )


### PR DESCRIPTION
Reverts NixOS/nixpkgs#425191

The default `pytest` behavior is not as simple as "current working directory", which potentially causes a lot of packages to fail.

See https://github.com/NixOS/nixpkgs/pull/425191#issuecomment-3200593179.

Fixes #434974