### PR TITLE
Get julia working on aarch64-darwin (redux)

### DIFF
--- a/pkgs/development/compilers/julia/default.nix
+++ b/pkgs/development/compilers/julia/default.nix
@@ -1,4 +1,9 @@
-{ callPackage, fetchpatch2 }:
+{
+  callPackage,
+  fetchpatch2,
+  lib,
+  stdenv,
+}:
 
 let
   juliaWithPackages = callPackage ../../julia-modules { };
@@ -57,6 +62,16 @@ in
       hash = "sha256-YYQ7lkf9BtOymU8yd6ZN4ctaWlKX2TC4yOO8DpN0ACQ=";
       patches = [
         ./patches/1.9/0002-skip-failing-and-flaky-tests.patch
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        # Backport a fix to cli/trampolines/trampolines_aarch64.S
+        # https://github.com/JuliaLang/julia/pull/54634
+        (fetchpatch2 {
+          url = "https://github.com/JuliaLang/julia/commit/c954935b9050b462c2763e78327e75bf6d389d75.patch";
+          hash = "sha256-YXfVlq9H8H0GL2tv52e10KHoI9fIO3szK1zNe/zYqaQ=";
+        })
+
+        ./patches/1.9/0001-patch-options-for-codesign.patch
       ];
     }) { }
   );

--- a/pkgs/development/compilers/julia/generic.nix
+++ b/pkgs/development/compilers/julia/generic.nix
@@ -5,20 +5,24 @@
 }:
 
 {
-  lib,
-  stdenv,
-  fetchurl,
-  which,
-  python3,
-  gfortran,
+  buildPackages,
   cacert,
   cmake,
-  perl,
+  curl,
+  darwin,
+  fetchurl,
+  gfortran,
   gnum4,
-  openssl,
+  lib,
   libxml2,
+  openssl,
+  perl,
+  python3,
+  stdenv,
+  unzip,
+  which,
+  xcbuild,
   zlib,
-  buildPackages,
 }:
 
 stdenv.mkDerivation rec {
@@ -34,13 +38,20 @@ stdenv.mkDerivation rec {
   strictDeps = true;
 
   nativeBuildInputs = [
-    which
-    python3
-    gfortran
     cmake
-    perl
+    gfortran
     gnum4
     openssl
+    perl
+    python3
+    which
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    curl
+    darwin.DarwinTools
+    darwin.sigtool
+    unzip
+    xcbuild
   ];
 
   buildInputs = [
@@ -72,17 +83,37 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals stdenv.hostPlatform.isAarch64 [
     "JULIA_CPU_TARGET=generic;cortex-a57;thunderx2t99;carmel,clone_all;apple-m1,base(3);neoverse-512tvb,base(3)"
+    "USE_BINARYBUILDER=${if stdenv.hostPlatform.isDarwin then "1" else "0"}"
   ];
 
   # remove forbidden reference to $TMPDIR
-  preFixup = ''
+  preFixup = lib.optionalString stdenv.hostPlatform.isElf ''
     for file in libcurl.so libgmpxx.so libmpfr.so; do
       patchelf --shrink-rpath --allowed-rpath-prefixes ${builtins.storeDir} "$out/lib/julia/$file"
     done
   '';
 
+  # Code signing on version 1.9 is done as part of the build process, although
+  # we need a patch because darwin.sigtool has a more limited set of arguments
+  # than the modern macOS codesign utility.
+  #
+  # For the later versions, patching the same way doesn't seem to work, so we
+  # re-sign in the postFixup.
+  postFixup =
+    lib.optionalString (lib.versionAtLeast version "1.10" && stdenv.hostPlatform.isDarwin)
+      ''
+        codesign -s - --force --entitlements ./contrib/mac/app/Entitlements.plist $out/bin/julia
+
+        # We also need to re-sign the dylibs. Julia will be killed by macOS when you try to
+        # start it without this line. This will output errors for some of the dylibs.
+        find $out -name "*.dylib" -exec codesign -s - --force {} \;
+      '';
+
   # tests are flaky for aarch64-linux on hydra
-  doInstallCheck = if (lib.versionOlder version "1.10") then !stdenv.hostPlatform.isAarch64 else true;
+  # some tests not working on aarch64-darwin for unrelated reasons
+  doInstallCheck =
+    stdenv.hostPlatform.isLinux
+    && (lib.versionAtLeast version "1.10" || !stdenv.hostPlatform.isAarch64);
 
   installCheckTarget = "testall";
 
@@ -98,10 +129,10 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   env = lib.optionalAttrs (lib.versionOlder version "1.11" || stdenv.hostPlatform.isAarch64) {
-    NIX_CFLAGS_COMPILE = toString [
+    NIX_CFLAGS_COMPILE = toString ([
       "-Wno-error=implicit-function-declaration"
       "-Wno-error=incompatible-pointer-types"
-    ];
+    ]);
   };
 
   meta = with lib; {
@@ -117,6 +148,7 @@ stdenv.mkDerivation rec {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
+      "aarch64-darwin"
     ];
   };
 }

--- a/pkgs/development/compilers/julia/patches/1.9/0001-patch-options-for-codesign.patch
+++ b/pkgs/development/compilers/julia/patches/1.9/0001-patch-options-for-codesign.patch
@@ -1,0 +1,22 @@
+From e6fd20b34a4674f851302424e4ca90e6edf11d67 Mon Sep 17 00:00:00 2001
+From: MilesCranmer <miles.cranmer@gmail.com>
+Date: Sun, 9 Jun 2024 23:57:23 +0100
+Subject: [PATCH] patch options for codesign
+
+---
+ contrib/codesign.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/contrib/codesign.sh b/contrib/codesign.sh
+index 03866c4bb1..4d3e5a9ccc 100755
+--- a/contrib/codesign.sh
++++ b/contrib/codesign.sh
+@@ -34,5 +34,5 @@ fi
+ echo "Codesigning with identity ${MACOS_CODESIGN_IDENTITY}"
+ for f in ${MACHO_FILES}; do
+     echo "Codesigning ${f}..."
+-    codesign -s "${MACOS_CODESIGN_IDENTITY}" --option=runtime ${ENTITLEMENTS} -vvv --timestamp --deep --force "${f}"
++    codesign -s "${MACOS_CODESIGN_IDENTITY}" ${ENTITLEMENTS} --force "${f}"
+ done
+--
+2.39.0

--- a/pkgs/development/julia-modules/default.nix
+++ b/pkgs/development/julia-modules/default.nix
@@ -7,6 +7,7 @@
   makeWrapper,
   python3,
   runCommand,
+  writableTmpDirAsHomeHook,
   writeTextFile,
 
   # Artifacts dependencies
@@ -221,6 +222,10 @@ let
               pyyaml
             ]
           ))
+        ];
+
+        nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+          writableTmpDirAsHomeHook
         ];
       }
       ''


### PR DESCRIPTION
This PR carries on the work from #317900 to get Julia building on `aarch64-darwin`. Thanks @MilesCranmer!

This also gets `julia.withPackages` to work on `aarch64-darwin`. I ran the tests to build and import the top 100 most popular Julia packages, and it succeeded with 100% success for both Julia 1.10 and 1.11 (EDIT: and now 1.9!).

~~Julia 1.9 isn't building successfully at the moment, I'm not sure why.~~

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
