### PR TITLE
mdsf: 0.5.1 -> 0.10.4

### DIFF
--- a/pkgs/by-name/md/mdsf/package.nix
+++ b/pkgs/by-name/md/mdsf/package.nix
@@ -7,7 +7,7 @@
 }:
 let
   pname = "mdsf";
-  version = "0.5.1";
+  version = "0.10.4";
 in
 rustPlatform.buildRustPackage {
   inherit pname version;
@@ -16,17 +16,48 @@ rustPlatform.buildRustPackage {
     owner = "hougesen";
     repo = "mdsf";
     tag = "v${version}";
-    hash = "sha256-KHTWE3ENRc/VHrgwAag6DsnEU3c8Nqw15jR5jWlNrk4=";
+    hash = "sha256-NH3DE6ef1HuS5ADVFros+iDQMZVVgG8V9OuFzzkig8g=";
   };
 
-  cargoHash = "sha256-kgqRwYjDc/eV9wv1G6aAhfrGpoYDPCFfqaTm+T2p7uw=";
+  cargoHash = "sha256-dGqFRXezzqOpHA74fnLUGQAI8KgbPmWIL46UP0wza40=";
 
   checkFlags = [
-    "--skip=tests::it_should_add_go_package_if_missing"
-    "--skip=tests::it_should_format_the_code"
-    "--skip=tests::it_should_format_the_codeblocks_that_start_with_whitespace"
-    "--skip=tests::it_should_not_care_if_go_package_is_set"
-    "--skip=tests::it_should_not_modify_outside_blocks"
+    # Failing due to the method under test trying to create a directory & write to the filesystem
+    "--skip=caching::test_cache_entry::it_should_work"
+    # Permissions denied due to the test trying to remove a directory
+    "--skip=commands::prune_cache::test_run::it_should_remove_cache_directory"
+    # Permissions denied due to the test trying to write to a file
+    "--skip=config::test_config::it_should_error_on_broken_config"
+    # The following tests try to create tmp files
+    "--skip=format::accepts_multiple_file_paths"
+    "--skip=format::accepts_multiple_file_paths_with_thread_argument"
+    "--skip=format::accepts_multiple_file_paths_with_thread_argument_zero"
+    "--skip=format::format_with_cache_arg"
+    "--skip=format::formats_broken_input"
+    "--skip=format::formats_broken_input_stdin"
+    "--skip=format::formats_broken_input_with_debug_arg"
+    "--skip=format::on_missing_tool_binary_fail_cli"
+    "--skip=format::on_missing_tool_binary_fail_config"
+    "--skip=format::on_missing_tool_binary_fail_fast_cli"
+    "--skip=format::on_missing_tool_binary_fail_fast_config"
+    "--skip=format::on_missing_tool_binary_ignore_cli"
+    "--skip=format::on_missing_tool_binary_ignore_config"
+    "--skip=format::on_missing_tool_binary_prioritize_cli"
+    "--skip=format::supports_config_path_argument"
+    # Depends on one of gofumpt, gofmt, or crlfmt being available
+    "--skip=test_lib::it_should_add_go_package_if_missing"
+    # The following tests depend on rustfmt being available
+    "--skip=test_lib::it_should_format_the_code"
+    "--skip=test_lib::it_should_format_the_codeblocks_that_start_with_whitespace"
+    "--skip=test_lib::it_should_not_care_if_go_package_is_set"
+    "--skip=test_lib::it_should_not_modify_outside_blocks"
+    # The following tests try to interact with the file system
+    "--skip=verify::accepts_multiple_file_paths_broken"
+    "--skip=verify::accepts_multiple_file_paths_mixed"
+    "--skip=verify::fails_with_broken_input"
+    # The following tests try to interact with stdin
+    "--skip=verify::success_with_formatted_input_stdin"
+    "--skip=verify::supports_log_level_argument"
   ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
@@ -34,7 +65,7 @@ rustPlatform.buildRustPackage {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "Tool for formatting a linting markdown code snippets using language specific tools";
+    description = "Format markdown code blocks using your favorite tools";
     homepage = "https://github.com/hougesen/mdsf";
     changelog = "https://github.com/hougesen/mdsf/releases";
     license = lib.licenses.mit;


### PR DESCRIPTION
Changelog: https://github.com/hougesen/mdsf/blob/v0.10.4/CHANGELOG.md#v0104

Updating mdsf, a formatter for Markdown code blocks. There are a number of failing tests associated with this, most of them either trying to create tmp files or interact with the filesystem in some way, and a few of them depending on external binaries. If there is a better way to handle them, please let me know. Happy to make the appropriate changes.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
