### PR TITLE
ibus: Fix cross `No package 'wayland-scanner' found`

### DIFF
--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -196,6 +196,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxkbcommon
     wayland
     wayland-protocols
+    wayland-scanner # For cross, build uses $PKG_CONFIG to look for wayland-scanner
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
The autoconf `PKG_CHECK_MODULES` macro and so on aren't made with cross
in mind, so there isn't an easy way to change them to use
`PKG_CONFIG_FOR_BUILD`.

`"PKG_CONFIG_WAYLAND_SCANNER_WAYLAND_SCANNER=${lib.getBin buildPackages.wayland-scanner}/bin/wayland-scanner"` in `configureFlags` isn't necessary

`wayland-scanner` is still required in `nativeBuildInputs`, otherwise
there's an error `No rule to make target '/input-method-unstable-v1.xml', needed by 'input-method-unstable-v1-protocol.c'.  Stop.`


Alternative

```
  postAutoreconf = ''
    # Fixes cross "No package 'wayland-scanner' found"
    substituteInPlace configure \
      --replace-fail '$PKG_CONFIG --exists --print-errors "wayland-scanner' '$PKG_CONFIG_FOR_BUILD --exists --print-errors "wayland-scanner' \
      --replace-fail 'pkg_cv_WAYLAND_SCANNER_CFLAGS=`$PKG_CONFIG --cflags "wayland-scanner' 'pkg_cv_WAYLAND_SCANNER_CFLAGS=`$PKG_CONFIG_FOR_BUILD --cflags "wayland-scanner' \
      --replace-fail '$PKG_CONFIG --exists --print-errors \"wayland-scanner' '$PKG_CONFIG_FOR_BUILD --exists --print-errors \"wayland-scanner' \
      --replace-fail '$PKG_CONFIG --libs "wayland-scanner' '$PKG_CONFIG_FOR_BUILD --libs "wayland-scanner' \
      --replace-fail '$PKG_CONFIG --variable=wayland_scanner wayland-scanner' '$PKG_CONFIG_FOR_BUILD --variable=wayland_scanner wayland-scanner' \
      --replace-fail '$PKG_CONFIG --variable=pkgdatadir wayland-scanner' '$PKG_CONFIG_FOR_BUILD --variable=pkgdatadir wayland-scanner'
  '';
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
