### PR TITLE
fio-plot: 1.1.16

### DIFF
--- a/pkgs/by-name/fi/fio-plot/package.nix
+++ b/pkgs/by-name/fi/fio-plot/package.nix
@@ -1,5 +1,4 @@
 {
-  fio,
   python3Packages,
 }:
 (python3Packages.toPythonApplication python3Packages.fio_plot).overrideAttrs (old: {

--- a/pkgs/by-name/fi/fio-plot/package.nix
+++ b/pkgs/by-name/fi/fio-plot/package.nix
@@ -1,0 +1,9 @@
+{
+  fio,
+  python3Packages,
+}:
+(python3Packages.toPythonApplication python3Packages.fio_plot).overrideAttrs (old: {
+  meta = old.meta // {
+    mainProgram = "fio-plot";
+  };
+})

--- a/pkgs/development/python-modules/fio_plot/default.nix
+++ b/pkgs/development/python-modules/fio_plot/default.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchpatch2,
+  buildPythonPackage,
+  matplotlib,
+  numpy,
+  pillow,
+  pyan3,
+  pypaBuildHook,
+  rich,
+  setuptools,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "fio_plot";
+  version = "1.1.16";
+
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  src = fetchFromGitHub {
+    owner = "louwrentius";
+    repo = "fio-plot";
+    tag = "v${version}";
+    hash = "sha256-yN0gVm6ZYEIoh91d+0ohJ9yU+VWwYEq3MoG+WgBrs2Q=";
+  };
+
+  patches = map (patch: fetchpatch2 {
+      url = "https://github.com/louwrentius/fio-plot/commit/${patch.rev}.patch?full_index=1";
+      inherit (patch) hash;
+    })
+    [
+      {
+        rev = "420f46508bf861d5279c9b378ca7b08e39a828f6";
+        hash = "sha256-GrKdExbVuvtb+Ru1kGff30WU2RWvSKTu7yl0yk0IZUs=";
+      }
+      {
+        rev = "610fb3b03435fe957f71ddd8f95f51c743e1061d";
+        hash = "sha256-n1vvkwuXWxquQL0t7Ppo+jvgchc42IkkW1Z6hWro5hQ=";
+      }
+      {
+        rev = "6683208c94e8087a1629c4a7204f9dec5dea5ca9";
+        hash = "sha256-pNABP+m1ID1JbKKKXdQQieXx2FHhF7OeOH1limA895A=";
+      }
+      {
+        rev = "ebfdab83df2b9d435834507106e2151ac99d7ff3";
+        hash = "sha256-RXJS1TXHuCU6QuJ4ES4mGdWKwe1NKF9Qr2QQAk/TxbQ=";
+      }
+      {
+        rev = "a53d97d5f094ca6bed841cb7e95563d5ad0e2b53";
+        hash = "sha256-VKtglKfOgZ+v3Zj2dcAMpVk/EzyK21W5RmjjKGQgFgo=";
+      }
+    ];
+
+  dependencies = [
+    matplotlib
+    numpy
+    pillow
+    pyan3
+    rich
+  ];
+
+  nativeBuildInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "fio_plot" ];
+
+  meta = {
+    description = "Create charts from FIO storage benchmark tool output";
+    homepage = "https://github.com/louwrentius/fio-plot";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ johnrichardrinehart ];
+  };
+}

--- a/pkgs/development/python-modules/pyan3/default.nix
+++ b/pkgs/development/python-modules/pyan3/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   jinja2,
   setuptools,
+  pytestCheckHook,
 }:
 
 let
@@ -28,7 +29,7 @@ buildPythonPackage {
   pythonImportsCheck = [ "pyan" ];
 
   meta = {
-    description = "Static call graph generator. The official Python 3 version.";
+    description = "Static call graph generator for Python3";
     homepage = "https://github.com/Technologicat/pyan";
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [ johnrichardrinehart ];

--- a/pkgs/development/python-modules/pyan3/default.nix
+++ b/pkgs/development/python-modules/pyan3/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  jinja2,
+  setuptools,
+}:
+
+let
+  version = "v1.2.0";
+in
+buildPythonPackage {
+  pname = "pyan3";
+  pyproject = true;
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "Technologicat";
+    repo = "pyan";
+    tag = version;
+    hash = "sha256-v+wszUOCib/8962dnNWwtD0saF9NsNSBQ154lovox4w=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeBuildInputs = [ jinja2 ];
+
+  pythonImportsCheck = [ "pyan" ];
+
+  meta = {
+    description = "Static call graph generator. The official Python 3 version.";
+    homepage = "https://github.com/Technologicat/pyan";
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ johnrichardrinehart ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5153,6 +5153,8 @@ self: super: with self; {
 
   finvizfinance = callPackage ../development/python-modules/finvizfinance { };
 
+  fio_plot = callPackage ../development/python-modules/fio_plot { };
+
   fiona = callPackage ../development/python-modules/fiona { };
 
   fipy = callPackage ../development/python-modules/fipy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12433,6 +12433,8 @@ self: super: with self; {
 
   pyaml-env = callPackage ../development/python-modules/pyaml-env { };
 
+  pyan3 = callPackage ../development/python-modules/pyan3 { };
+
   pyannotate = callPackage ../development/python-modules/pyannotate { };
 
   pyannote-audio = callPackage ../development/python-modules/pyannote-audio { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Sorry ahead-of-time if this PR is absolute crap. I have little to no experience with `python` packaging and I have attention issues, so there may be a lot of small things to clean up, here. Thanks for your review.

The goal of this PR is to add `fio-plot` (a package which provides two binaries, `fio-plot` and `bench_fio`), to `legacyPackages`. I've only tested that the binaries build and seem to run on `x86_64-linux`:
```bash
$ ./result/bin/bench_fio                                                                                                                
　
usage: bench_fio [-h] -d TARGET [TARGET ...] -t {device,file,directory,rbd} [-P CEPH_POOL] [-s SIZE] -o OUTPUT [-b BLOCK_SIZE [BLOCK_SIZE ...]]
                 [--iodepth IODEPTH [IODEPTH ...]] [--numjobs NUMJOBS [NUMJOBS ...]] [--runtime RUNTIME] [-p] [--precondition-repeat]
                 [--precondition-template PRECONDITION_TEMPLATE] [-m MODE [MODE ...]] [--rwmixread RWMIXREAD [RWMIXREAD ...]] [-e ENGINE] [--direct DIRECT] [--loops LOOPS]
                 [--time-based] [--entire-device] [--ss SS] [--ss-dur SS_DUR] [--ss-ramp SS_RAMP] [--extra-opts EXTRA_OPTS [EXTRA_OPTS ...]] [--invalidate INVALIDATE]
                 [--quiet] [--loginterval LOGINTERVAL] [--dry-run] [--destructive] [--remote REMOTE] [--remote-checks] [--remote-timeout REMOTE_TIMEOUT] [--create]
                 [--parallel]
bench_fio: error: the following arguments are required: -d/--target, -t/--type, -o/--output
$ ./result/bin/fio-plot 
usage: fio-plot [-h] -i INPUT_DIRECTORY [INPUT_DIRECTORY ...] [-o OUTPUT_FILENAME] -T TITLE [-s SOURCE] (-L | -l | -N | -H | -g | -C) [--disable-grid] [--enable-markers]
                [--subtitle SUBTITLE] [-d IODEPTH [IODEPTH ...]] [-n NUMJOBS [NUMJOBS ...]] [-M [MAXDEPTH]] [-J [MAXJOBS]] [-D [DPI]] [-p [PERCENTILE]]
                -r {read,write,randread,randwrite,randrw,trim,rw,readwrite,randtrim,trimwrite} [-m MAX_Z] [-e MOVING_AVERAGE] [--min-iops MIN_IOPS] [--min-lat MIN_LAT]
                [-t {bw,iops,lat,slat,clat} [{bw,iops,lat,slat,clat} ...]] [-f {read,write} [{read,write} ...]] [--truncate-xaxis TRUNCATE_XAXIS]
                [--xlabel-depth XLABEL_DEPTH] [--xlabel-parent XLABEL_PARENT] [--xlabel-segment-size XLABEL_SEGMENT_SIZE] [--xlabel-single-column] [-w LINE_WIDTH]
                [--group-bars] [--show-cpu] [--show-data] [--show-ss] [--table-lines] [--max-lat MAX_LAT] [--max-clat MAX_CLAT] [--max-slat MAX_SLAT] [--max-iops MAX_IOPS]
                [--max-bw MAX_BW] [--draw-total] [--colors COLORS [COLORS ...]] [--disable-fio-version] [--title-fontsize TITLE_FONTSIZE]
                [--subtitle-fontsize SUBTITLE_FONTSIZE] [--source-fontsize SOURCE_FONTSIZE] [--credit-fontsize CREDIT_FONTSIZE] [--table-fontsize TABLE_FONTSIZE]
                [--include-hosts INCLUDE_HOSTS [INCLUDE_HOSTS ...] | --exclude-hosts EXCLUDE_HOSTS [EXCLUDE_HOSTS ...]]
fio-plot: error: the following arguments are required: -i/--input-directory, -T/--title, -r/--rw
```

Now, in order to provide the application package, I also needed to add the corresponding `python` module package, `fio_plot`. But, `fio_plot` depends on https://github.com/Technologicat/pyan/, which is not in tree, yet.

Also, I was running into weird issues around `bin` files already existing when the `fio_plot` repository _only_ provided its `setup.py`. The world seems to be moving toward `pyproject.toml` so you might notice that I've also bundled in a patch to the source repository which provides a `pyproject.toml`. This file unblocks the build. I'm going to make a corresponding PR to https://github.com/louwrentius/fio-plot/, but I'm not sure if this project is still maintained. I also want to be able to point to this PR in that PR and say "hey, I needed to hack something up in `nixpkgs` because your project packaging is stale". I'm happy to remove this patch later if the source repository includes these changes.

So, rather then break this into 3 separate/stacked PRs, I decided to provide a single PR. I hope that's okay.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
