### PR TITLE
zoom-us: 6.5.9.* -> 6.5.10.*

### DIFF
--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -58,25 +58,25 @@ let
   # Zoom versions are released at different times per platform and often with different versions.
   # We write them on three lines like this (rather than using {}) so that the updater script can
   # find where to edit them.
-  versions.aarch64-darwin = "6.5.9.61929";
-  versions.x86_64-darwin = "6.5.9.61929";
+  versions.aarch64-darwin = "6.5.10.62715";
+  versions.x86_64-darwin = "6.5.10.62715";
 
   # This is the fallback version so that evaluation can produce a meaningful result.
-  versions.x86_64-linux = "6.5.9.3723";
+  versions.x86_64-linux = "6.5.10.3973";
 
   srcs = {
     aarch64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
       name = "zoomusInstallerFull.pkg";
-      hash = "sha256-2V4Cad7/YcI5rSuUu8GI1GCEgio/rG/ZRpedNKqoGvc=";
+      hash = "sha256-O7h+4mfoUSoFd8c7K+C9W6L46PgJvDKj1qb+DG0leco=";
     };
     x86_64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
-      hash = "sha256-RO+kIHvmvCj9bun2BeCzAm9XMYQOobYyVKqA5ruG0I8=";
+      hash = "sha256-S1pyrguOjEGW87HM+K1B/FI55WJp7Xu8cXvdpRA0sJ8=";
     };
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
-      hash = "sha256-OOa4zRRekXEWLl+BH3bPtCQzRaQAo742C9EqPTZnDR8=";
+      hash = "sha256-OXuhVpWAyfQYdEnjF7I6gOJeDCS1GlSonN5cdvvtJL0=";
     };
   };
 
@@ -209,6 +209,7 @@ let
       pkgs.xorg.libXtst
       pkgs.xorg.libxcb
       pkgs.xorg.libxshmfence
+      pkgs.xorg.xcbutilcursor
       pkgs.xorg.xcbutilimage
       pkgs.xorg.xcbutilkeysyms
       pkgs.xorg.xcbutilrenderutil


### PR DESCRIPTION
Resolves #434913 by updating `zoom-us` to the latest version.  This version won't start unless `xorg.xcbutilcursor` is available, which is therefore added by this pull request.

Notifying co-maintainers @philiptaron @ryan4yin

Notifying update requester (cf. https://github.com/NixOS/nixpkgs/issues/434913) @spifory

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

### More

Tested with Plasma5/X11/Pulseaudio on a NixOS 25.05 machine (unchecked means "not tested"):

- [x] sidebar loads (albeit empty on my installation, cf. https://github.com/NixOS/nixpkgs/issues/344931 )
- [x] audio is "detected" by zoom: microphone VU-meter shows amplitude
- [x] audio is produced: "Test speaker" generates audible ting-a-ling
- [x] other participant's audio in video conference is audible
- [x] other participants can hear me
- [x] sending camera picture in video conference works
- [x] participant's camera video is received in video conference
- [x] screen sharing sends screen to other participants
- [ ] participant's shared screen is displayed
- [x] "Participants" dialog box is shown (cf. https://github.com/NixOS/nixpkgs/issues/116355 )
- [x] settings dialog is shown/useable  (cf. https://github.com/NixOS/nixpkgs/pull/410244 )
- [x] SSO works: Zoom starts Firefox, then Firefox calls back to Zoom after login, as usual
- [x] reading team chat messages works as expected
- [x] writing team chat messages works
- [ ] sidebar shows content
- [ ] Pipewire
- [ ] Wayland
- [ ] xdg-desktop-portal (cf. https://github.com/NixOS/nixpkgs/issues/359533 )
- [ ] Darwin

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `87cfadee130e489a95b2ee3ccd72369b606080ca`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>zoom-us</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
