### PR TITLE
nixos/i18n/input-method: Fix cross

### DIFF
--- a/nixos/modules/i18n/input-method/default.nix
+++ b/nixos/modules/i18n/input-method/default.nix
@@ -22,13 +22,12 @@ let
         preferLocalBuild = true;
         allowSubstitutes = false;
         buildInputs = [
-          pkgs.gtk2
           cfg.package
         ];
       }
       ''
         mkdir -p $out/etc/gtk-2.0/
-        GTK_PATH=${cfg.package}/lib/gtk-2.0/ gtk-query-immodules-2.0 > $out/etc/gtk-2.0/immodules.cache
+        GTK_PATH=${cfg.package}/lib/gtk-2.0/ ${pkgs.stdenv.hostPlatform.emulator pkgs.buildPackages} ${lib.getExe' pkgs.gtk2.dev "gtk-query-immodules-2.0"} > $out/etc/gtk-2.0/immodules.cache
       '';
 
   gtk3_cache =
@@ -37,13 +36,12 @@ let
         preferLocalBuild = true;
         allowSubstitutes = false;
         buildInputs = [
-          pkgs.gtk3
           cfg.package
         ];
       }
       ''
         mkdir -p $out/etc/gtk-3.0/
-        GTK_PATH=${cfg.package}/lib/gtk-3.0/ gtk-query-immodules-3.0 > $out/etc/gtk-3.0/immodules.cache
+        GTK_PATH=${cfg.package}/lib/gtk-3.0/ ${pkgs.stdenv.hostPlatform.emulator pkgs.buildPackages} ${lib.getExe' pkgs.gtk3.dev "gtk-query-immodules-3.0"} > $out/etc/gtk-3.0/immodules.cache
       '';
 
 in
@@ -107,8 +105,12 @@ in
     environment.systemPackages = [
       cfg.package
     ]
-    ++ lib.optional cfg.enableGtk2 gtk2_cache
-    ++ lib.optional cfg.enableGtk3 gtk3_cache;
+    ++ lib.optional (
+      cfg.enableGtk2 && (pkgs.stdenv.hostPlatform.emulatorAvailable pkgs.buildPackages)
+    ) gtk2_cache
+    ++ lib.optional (
+      cfg.enableGtk3 && (pkgs.stdenv.hostPlatform.emulatorAvailable pkgs.buildPackages)
+    ) gtk3_cache;
   };
 
   meta = {


### PR DESCRIPTION
If the gtk2 and gtk3 are moved to `nativeBuildInputs` then this happens
```
Cannot load module /nix/store/sn268l2xkdvkvagq1r35xy9071zns4hx-ibus-with-plugins-1.5.32/lib/gtk-3.0/3.0.0/immodules/im-ibus.so: /nix/store/sn268l2xkdvkvagq1r35xy9071zns4hx-ibus-with-plugins-1.5.32/lib/gtk-3.0/3.0.0/immodules/im-ibus.so: cannot open shared object file: No such file or directory
> /nix/store/sn268l2xkdvkvagq1r35xy9071zns4hx-ibus-with-plugins-1.5.32/lib/gtk-3.0/3.0.0/immodules/im-ibus.so does not export GTK+ IM module API: /nix/store/sn268l2xkdvkvagq1r35xy9071zns4hx-ibus-with-plugins-1.5.32/lib/gtk-3.0/3.0.0/immodules/im-ibus.so: cannot open shared object file: No such file or directory
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
