### PR TITLE
mujoco: clean unused hunks from CMakeLists.txt patch

### DIFF
--- a/pkgs/by-name/mu/mujoco/mujoco-system-deps-dont-fetch.patch
+++ b/pkgs/by-name/mu/mujoco/mujoco-system-deps-dont-fetch.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 3cab120d..abc526b1 100644
+index a4794196..66525432 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -128,7 +128,7 @@ target_link_libraries(
+@@ -140,7 +140,7 @@ target_link_libraries(
            lodepng
            qhullstatic_r
            tinyobjloader
@@ -12,52 +12,19 @@ index 3cab120d..abc526b1 100644
  
  set_target_properties(
 diff --git a/cmake/MujocoDependencies.cmake b/cmake/MujocoDependencies.cmake
-index 78522705..7c64e22a 100644
+index cb17621a..e1bd0e9d 100644
 --- a/cmake/MujocoDependencies.cmake
 +++ b/cmake/MujocoDependencies.cmake
-@@ -93,28 +93,36 @@ set(BUILD_SHARED_LIBS
+@@ -93,8 +93,6 @@ set(BUILD_SHARED_LIBS
  if(NOT TARGET lodepng)
    FetchContent_Declare(
      lodepng
 -    GIT_REPOSITORY https://github.com/lvandeve/lodepng.git
 -    GIT_TAG ${MUJOCO_DEP_VERSION_lodepng}
    )
-+endif()
  
--  FetchContent_GetProperties(lodepng)
--  if(NOT lodepng_POPULATED)
--    FetchContent_Populate(lodepng)
--    # This is not a CMake project.
--    set(LODEPNG_SRCS ${lodepng_SOURCE_DIR}/lodepng.cpp)
--    set(LODEPNG_HEADERS ${lodepng_SOURCE_DIR}/lodepng.h)
--    add_library(lodepng STATIC ${LODEPNG_HEADERS} ${LODEPNG_SRCS})
--    target_compile_options(lodepng PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
--    target_link_options(lodepng PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
--    target_include_directories(lodepng PUBLIC ${lodepng_SOURCE_DIR})
-+if(NOT TARGET lodepng)
-+  if(NOT MUJOCO_USE_SYSTEM_lodepng)
-+    fetchcontent_declare(
-+      lodepng
-+      GIT_REPOSITORY https://github.com/lvandeve/lodepng.git
-+      GIT_TAG ${MUJOCO_DEP_VERSION_lodepng}
-+    )
-+
-+    FetchContent_GetProperties(lodepng)
-+    if(NOT lodepng_POPULATED)
-+      FetchContent_Populate(lodepng)
-+      # This is not a CMake project.
-+      set(LODEPNG_SRCS ${lodepng_SOURCE_DIR}/lodepng.cpp)
-+      set(LODEPNG_HEADERS ${lodepng_SOURCE_DIR}/lodepng.h)
-+      add_library(lodepng STATIC ${LODEPNG_HEADERS} ${LODEPNG_SRCS})
-+      target_compile_options(lodepng PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
-+      target_link_options(lodepng PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
-+      target_include_directories(lodepng PUBLIC ${lodepng_SOURCE_DIR})
-+    endif()
-+  else()
-+    find_package(lodepng REQUIRED)
-   endif()
- endif()
- 
+   FetchContent_GetProperties(lodepng)
+@@ -113,8 +111,6 @@ endif()
  if(NOT TARGET marchingcubecpp)
    FetchContent_Declare(
      marchingcubecpp
@@ -66,19 +33,9 @@ index 78522705..7c64e22a 100644
    )
  
    FetchContent_GetProperties(marchingcubecpp)
-@@ -124,119 +132,157 @@ if(NOT TARGET marchingcubecpp)
-   endif()
- endif()
- 
-+option(MUJOCO_USE_SYSTEM_qhull "Use installed qhull version." OFF)
-+mark_as_advanced(MUJOCO_USE_SYSTEM_qhull)
-+
- set(QHULL_ENABLE_TESTING OFF)
- 
- findorfetch(
+@@ -130,13 +126,9 @@ findorfetch(
    USE_SYSTEM_PACKAGE
--  OFF
-+  ${MUJOCO_USE_SYSTEM_qhull}
+   OFF
    PACKAGE_NAME
 -  qhull
 +  Qhull
@@ -91,46 +48,7 @@ index 78522705..7c64e22a 100644
    TARGETS
    qhull
    EXCLUDE_FROM_ALL
- )
--# MuJoCo includes a file from libqhull_r which is not exported by the qhull include directories.
--# Add it to the target.
--target_include_directories(
--  qhullstatic_r INTERFACE $<BUILD_INTERFACE:${qhull_SOURCE_DIR}/src/libqhull_r>
--)
--target_compile_options(qhullstatic_r PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
--target_link_options(qhullstatic_r PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
-+if(NOT MUJOCO_USE_SYSTEM_qhull)
-+  # MuJoCo includes a file from libqhull_r which is not exported by the qhull include directories.
-+  # Add it to the target.
-+  target_include_directories(
-+    qhullstatic_r INTERFACE $<BUILD_INTERFACE:${qhull_SOURCE_DIR}/src/libqhull_r>
-+  )
-+  target_compile_options(qhullstatic_r PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
-+  target_link_options(qhullstatic_r PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
-+else()
-+  if(NOT TARGET qhullstatic_r)
-+    add_library(qhullstatic_r INTERFACE)
-+    set_target_properties(qhullstatic_r PROPERTIES INTERFACE_LINK_LIBRARIES Qhull::qhull_r)
-+
-+    # Workaround as headers are installed in <prefix>/include/libqhull_r/something.h
-+    # but mujoco include them as #include <something.h>
-+    get_property(qhull_include_dirs TARGET Qhull::qhull_r PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
-+    foreach(qhull_include_dir IN LISTS qhull_include_dirs)
-+      target_include_directories(qhullstatic_r INTERFACE ${qhull_include_dirs}/libqhull_r)
-+    endforeach()
-+    target_include_directories(qhullstatic_r INTERFACE )
-+  endif()
-+endif()
-+
-+option(MUJOCO_USE_SYSTEM_tinyxml2 "Use installed tinyxml2 version." OFF)
-+mark_as_advanced(MUJOCO_USE_SYSTEM_tinyxml2)
- 
- set(tinyxml2_BUILD_TESTING OFF)
- findorfetch(
-   USE_SYSTEM_PACKAGE
--  OFF
-+  ${MUJOCO_USE_SYSTEM_tinyxml2}
-   PACKAGE_NAME
+@@ -157,12 +149,8 @@ findorfetch(
    tinyxml2
    LIBRARY_NAME
    tinyxml2
@@ -143,21 +61,8 @@ index 78522705..7c64e22a 100644
 +  tinyxml2::tinyxml2
    EXCLUDE_FROM_ALL
  )
--target_compile_options(tinyxml2 PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
--target_link_options(tinyxml2 PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
-+if(NOT MUJOCO_USE_SYSTEM_tinyxml2)
-+  target_compile_options(tinyxml2 PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
-+  target_link_options(tinyxml2 PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
-+endif()
-+
-+option(MUJOCO_USE_SYSTEM_tinyobjloader "Use installed tinyobjloader version." OFF)
-+mark_as_advanced(MUJOCO_USE_SYSTEM_tinyobjloader)
- 
- findorfetch(
-   USE_SYSTEM_PACKAGE
--  OFF
-+  ${MUJOCO_USE_SYSTEM_tinyobjloader}
-   PACKAGE_NAME
+ target_compile_options(tinyxml2 PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
+@@ -175,35 +163,32 @@ findorfetch(
    tinyobjloader
    LIBRARY_NAME
    tinyobjloader
@@ -170,17 +75,6 @@ index 78522705..7c64e22a 100644
    EXCLUDE_FROM_ALL
  )
  
-+if(MUJOCO_USE_SYSTEM_tinyobjloader)
-+  # As of tinyobjloader v2.0.0rc10, the tinyobjloader target is named tinyobjloader in the build,
-+  # but tinyobjloader::tinyobjloader when it is installed. To deal with this, if tinyobjloader is
-+  # found in the system, we create an ALIAS
-+  # The following is equivalent to add_library(tinyobjloader ALIAS tinyobjloader::tinyobjloader),
-+  # but compatible with CMake 3.16 . Once the minimum CMake is bumped to CMake 3.18, we can use
-+  # the simpler version
-+  add_library(tinyobjloader INTERFACE IMPORTED)
-+  set_target_properties(tinyobjloader PROPERTIES INTERFACE_LINK_LIBRARIES tinyobjloader::tinyobjloader)
-+endif()
-+
 +option(MUJOCO_USE_SYSTEM_sdflib "Use installed sdflib version." OFF)
 +mark_as_advanced(MUJOCO_USE_SYSTEM_sdflib)
 +
@@ -207,22 +101,14 @@ index 78522705..7c64e22a 100644
  )
 -target_compile_options(SdfLib PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
 -target_link_options(SdfLib PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
-+
 +if(NOT MUJOCO_USE_SYSTEM_sdflib)
 +  target_compile_options(SdfLib PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
 +  target_link_options(SdfLib PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
 +endif()
-+
-+option(MUJOCO_USE_SYSTEM_ccd "Use installed ccd version." OFF)
-+mark_as_advanced(MUJOCO_USE_SYSTEM_ccd)
  
  set(ENABLE_DOUBLE_PRECISION ON)
  set(CCD_HIDE_ALL_SYMBOLS ON)
- findorfetch(
-   USE_SYSTEM_PACKAGE
--  OFF
-+  ${MUJOCO_USE_SYSTEM_ccd}
-   PACKAGE_NAME
+@@ -214,10 +199,6 @@ findorfetch(
    ccd
    LIBRARY_NAME
    ccd
@@ -233,55 +119,7 @@ index 78522705..7c64e22a 100644
    TARGETS
    ccd
    EXCLUDE_FROM_ALL
- )
--target_compile_options(ccd PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
--target_link_options(ccd PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
--
--# libCCD has an unconditional `#define _CRT_SECURE_NO_WARNINGS` on Windows.
--# TODO(stunya): Remove this after https://github.com/danfis/libccd/pull/77 is merged.
--if(WIN32)
--  if(MSVC)
--    # C4005 is the MSVC equivalent of -Wmacro-redefined.
--    target_compile_options(ccd PRIVATE /wd4005)
--  else()
--    target_compile_options(ccd PRIVATE -Wno-macro-redefined)
-+
-+if(NOT MUJOCO_USE_SYSTEM_ccd)
-+  target_compile_options(ccd PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
-+  target_link_options(ccd PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
-+  # This is necessary to ensure that the any library that consumes the ccd
-+  # compiled internally by MuJoCo (as static library) has CCD_EXPORT correctly
-+  # defined as an empty string. For ccd itself, this is ensured by the variable
-+  # CCD_HIDE_ALL_SYMBOLS set to ON before the call to findorfetch
-+  # See https://github.com/danfis/libccd/pull/79
-+  target_compile_definitions(ccd INTERFACE CCD_STATIC_DEFINE)
-+
-+  # libCCD has an unconditional `#define _CRT_SECURE_NO_WARNINGS` on Windows.
-+  # TODO(stunya): Remove this after https://github.com/danfis/libccd/pull/77 is merged.
-+  if(WIN32)
-+    if(MSVC)
-+      # C4005 is the MSVC equivalent of -Wmacro-redefined.
-+      target_compile_options(ccd PRIVATE /wd4005)
-+    else()
-+      target_compile_options(ccd PRIVATE -Wno-macro-redefined)
-+    endif()
-   endif()
- endif()
- 
- if(MUJOCO_BUILD_TESTS)
-+  option(MUJOCO_USE_SYSTEM_abseil "Use installed abseil version." OFF)
-+  mark_as_advanced(MUJOCO_USE_SYSTEM_abseil)
-+
-   set(ABSL_PROPAGATE_CXX_STD ON)
- 
-   # This specific version of Abseil does not have the following variable. We need to work with BUILD_TESTING
-@@ -249,15 +295,11 @@ if(MUJOCO_BUILD_TESTS)
-   set(ABSL_BUILD_TESTING OFF)
-   findorfetch(
-     USE_SYSTEM_PACKAGE
--    OFF
-+    ${MUJOCO_USE_SYSTEM_abseil}
-     PACKAGE_NAME
+@@ -254,10 +235,6 @@ if(MUJOCO_BUILD_TESTS)
      absl
      LIBRARY_NAME
      abseil-cpp
@@ -292,13 +130,7 @@ index 78522705..7c64e22a 100644
      TARGETS
      absl::core_headers
      EXCLUDE_FROM_ALL
-@@ -276,22 +318,20 @@ if(MUJOCO_BUILD_TESTS)
- 
-   findorfetch(
-     USE_SYSTEM_PACKAGE
--    OFF
-+    ${MUJOCO_USE_SYSTEM_gtest}
-     PACKAGE_NAME
+@@ -281,14 +258,9 @@ if(MUJOCO_BUILD_TESTS)
      GTest
      LIBRARY_NAME
      googletest
@@ -315,19 +147,7 @@ index 78522705..7c64e22a 100644
      EXCLUDE_FROM_ALL
    )
  
-+  option(MUJOCO_USE_SYSTEM_benchmark "Use installed benchmark version." OFF)
-+  mark_as_advanced(MUJOCO_USE_SYSTEM_benchmark)
-+
-   set(BENCHMARK_EXTRA_FETCH_ARGS "")
-   if(WIN32 AND NOT MSVC)
-     set(BENCHMARK_EXTRA_FETCH_ARGS
-@@ -310,15 +350,11 @@ if(MUJOCO_BUILD_TESTS)
- 
-   findorfetch(
-     USE_SYSTEM_PACKAGE
--    OFF
-+    ${MUJOCO_USE_SYSTEM_benchmark}
-     PACKAGE_NAME
+@@ -315,10 +287,6 @@ if(MUJOCO_BUILD_TESTS)
      benchmark
      LIBRARY_NAME
      benchmark
@@ -338,22 +158,14 @@ index 78522705..7c64e22a 100644
      TARGETS
      benchmark::benchmark
      benchmark::benchmark_main
-@@ -328,15 +364,18 @@ if(MUJOCO_BUILD_TESTS)
- endif()
+@@ -329,14 +297,12 @@ endif()
  
  if(MUJOCO_TEST_PYTHON_UTIL)
-+  option(MUJOCO_USE_SYSTEM_Eigen3 "Use installed Eigen3 version." OFF)
-+  mark_as_advanced(MUJOCO_USE_SYSTEM_Eigen3)
-+
    add_compile_definitions(EIGEN_MPL2_ONLY)
 -  if(NOT TARGET eigen)
--    # Support new IN_LIST if() operator.
--    set(CMAKE_POLICY_DEFAULT_CMP0057 NEW)
 +  if(NOT TARGET Eigen3::Eigen)
-+    if(NOT MUJOCO_USE_SYSTEM_Eigen3)
-+      # Support new IN_LIST if() operator.
-+      set(CMAKE_POLICY_DEFAULT_CMP0057 NEW)
-+    endif()
+     # Support new IN_LIST if() operator.
+     set(CMAKE_POLICY_DEFAULT_CMP0057 NEW)
  
      FetchContent_Declare(
        Eigen3
@@ -362,26 +174,6 @@ index 78522705..7c64e22a 100644
      )
  
      FetchContent_GetProperties(Eigen3)
-@@ -348,6 +387,19 @@ if(MUJOCO_TEST_PYTHON_UTIL)
-       set_target_properties(
-         Eigen3::Eigen PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${eigen3_SOURCE_DIR}"
-       )
-+
-+      fetchcontent_getproperties(Eigen3)
-+      # if(NOT Eigen3_POPULATED)
-+      #   fetchcontent_populate(Eigen3)
-+
-+      #   # Mark the library as IMPORTED as a workaround for https://gitlab.kitware.com/cmake/cmake/-/issues/15415
-+      #   add_library(Eigen3::Eigen INTERFACE IMPORTED)
-+      #   set_target_properties(
-+      #     Eigen3::Eigen PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${eigen3_SOURCE_DIR}"
-+      #   )
-+      # endif()
-+    else()
-+      find_package(Eigen3 REQUIRED)
-     endif()
-   endif()
- endif()
 diff --git a/plugin/sdf/CMakeLists.txt b/plugin/sdf/CMakeLists.txt
 index 8b834971..25021fa1 100644
 --- a/plugin/sdf/CMakeLists.txt


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Remove unused `MUJOCO_USE_SYSTEM_xxxx` options and related patches from `mujoco-system-deps-dont-fetch.patch`.

This will make easier to adapt the patch for [updating mujoco to 3.3.5](https://github.com/NixOS/nixpkgs/pull/433484).
We will then work towards re-introducing **and actually using** the `MUJOCO_USE_SYSTEM_xxxx` options to leverage `nixpkgs` dependencies.

cc @SomeoneSerge @samuela

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
