### PR TITLE
shaderc: use correct dependency revisions

### DIFF
--- a/pkgs/development/compilers/shaderc/default.nix
+++ b/pkgs/development/compilers/shaderc/default.nix
@@ -12,56 +12,30 @@
 # spirv-tools used by vulkan-loader. Exact revisions are taken from
 # the DEPS file in the shaderc repository.
 let
-  # this is the git tag of the google/shaderc repo
-  version = "2025.2";
-
-  src = fetchFromGitHub {
-    owner = "google";
-    repo = "shaderc";
-    rev = "v${version}";
-    hash = "sha256-u3gmH2lrkwBTZg9j4jInQceXK4MUWhKZPSPsN98mEkk=";
-  };
-
-  # Read the DEPS file
-  depsContent = builtins.readFile "${src}/DEPS";
-
-  # Function to extract a specific revision hash from DEPS file
-  getDepsRevision =
-    revisionKey:
-    let
-      lines = lib.splitString "\n" depsContent;
-      # Find the line containing the revision key
-      revisionLine = lib.findFirst (line: builtins.match ".*'${revisionKey}'.*" line != null) null lines;
-
-      # find the commit hash inside the DEPS file
-      match = builtins.match ".*'${revisionKey}':[[:space:]]*'([^']+)'.*" revisionLine;
-
-      revstring = builtins.elemAt match 0;
-    in
-    revstring;
-
+  # dependency revs taken from here:
+  # From https://github.com/google/shaderc/blob/v2025.2/DEPS:
   glslang = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "glslang";
-    rev = getDepsRevision "glslang_revision";
+    rev = "697683e6b8871420d7d942b1a2fe233242ab5608";
     hash = "sha256-+iX5TOPFwAWrzRKd4gikzYIWfzSdmRCukY6WsKNJCzE=";
   };
   spirv-tools = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Tools";
-    rev = getDepsRevision "spirv_tools_revision";
+    rev = "a62abcb402009b9ca5975e6167c09f237f630e0e";
     hash = "sha256-nGyEOREua/W2mdb8DhmqXW0gDThnXnIlhnURAUhCO2g=";
   };
   spirv-headers = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Headers";
-    rev = getDepsRevision "spirv_headers_revision";
+    rev = "aa6cef192b8e693916eb713e7a9ccadf06062ceb";
     hash = "sha256-bUgt7m3vJYoozxgrA5hVTRcbPg3OAzht0e+MgTH7q9k=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "shaderc";
-  inherit version src;
+  version = "2025.2";
 
   outputs = [
     "out"
@@ -70,6 +44,13 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
     "static"
   ];
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "shaderc";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-u3gmH2lrkwBTZg9j4jInQceXK4MUWhKZPSPsN98mEkk=";
+  };
 
   postPatch = ''
     cp -r --no-preserve=mode ${glslang} third_party/glslang


### PR DESCRIPTION
The shaderc package has incorrect dependency pinned, leading to multiple issues. Notably, it causes build failures for ggml-vulkan (a dependency of llama.cpp and whisper.cpp).

It seems like the current, incorrect dependencies for shaderc were set in this PR: https://github.com/NixOS/nixpkgs/pull/401421

I fixed this by pulling the correct git revisions from shaderc's DEPS file.

I had originally implemented this by parsing the DEPS file from google/shaderc, before realizing that IFD isn't allowed in nixpkgs. If anyone has ideas for improvements, I'm happy to hear them.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
