### PR TITLE
python312Packages.viser: 1.0.3 -> 1.0.4

### DIFF
--- a/pkgs/development/python-modules/viser/default.nix
+++ b/pkgs/development/python-modules/viser/default.nix
@@ -26,7 +26,7 @@
   scipy,
   tqdm,
   trimesh,
-  tyro,
+  typing-extensions,
   websockets,
   yourdfpy,
 
@@ -43,6 +43,7 @@
   # pyliblzfse,
   robot-descriptions,
   torch,
+  tyro,
 
   # nativeCheckInputs
   pytestCheckHook,
@@ -50,14 +51,14 @@
 
 buildPythonPackage rec {
   pname = "viser";
-  version = "1.0.3";
+  version = "1.0.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nerfstudio-project";
     repo = "viser";
     tag = "v${version}";
-    hash = "sha256-zufWYq4HvkmbSawTq8G7TheWNpspRL/dptyLuGnUQ2U=";
+    hash = "sha256-AS5D6pco6wzQ414yxvv0K9FB3tfP1BvqigRLJJXDduU=";
   };
 
   postPatch = ''
@@ -108,7 +109,7 @@ buildPythonPackage rec {
     scipy
     tqdm
     trimesh
-    tyro
+    typing-extensions
     websockets
     yourdfpy
   ];
@@ -130,6 +131,7 @@ buildPythonPackage rec {
       # pyliblzfse
       robot-descriptions
       torch
+      tyro
     ];
   };
 


### PR DESCRIPTION
Diff: https://github.com/nerfstudio-project/viser/compare/v1.0.0...v1.0.4

Changelog: https://github.com/nerfstudio-project/viser/releases/tag/v1.0.4


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
