### PR TITLE
ryubing: fix filepicker crash

### DIFF
--- a/pkgs/by-name/ry/ryubing/package.nix
+++ b/pkgs/by-name/ry/ryubing/package.nix
@@ -26,6 +26,8 @@
   udev,
   SDL2,
   SDL2_mixer,
+  gtk3,
+  wrapGAppsHook3,
 }:
 
 buildDotnetModule rec {
@@ -40,10 +42,14 @@ buildDotnetModule rec {
     hash = "sha256-6BCDFd0nU96OgI5lqf4fbyNkG4PS5P4raHVbvBAhB5A=";
   };
 
-  nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin [
-    cctools
-    darwin.sigtool
-  ];
+  nativeBuildInputs =
+    lib.optional stdenv.hostPlatform.isLinux [
+      wrapGAppsHook3
+    ]
+    ++ lib.optional stdenv.hostPlatform.isDarwin [
+      cctools
+      darwin.sigtool
+    ];
 
   enableParallelBuilding = false;
 
@@ -70,6 +76,7 @@ buildDotnetModule rec {
     libXext
     libXi
     libXrandr
+    gtk3
 
     # Headless executable
     libGL


### PR DESCRIPTION
Attempting to open the filepicker for adding a game directory crashed the program, including gtk3 and wrapGAppsHook3 fixed it.
Logs from the crash:
```
00:00:10.830 |E| Application : Unhandled exception caught: System.InvalidOperationException: Neither DBus nor GTK are available on the system
   at Avalonia.X11.NativeDialogs.CompositeStorageProvider.EnsureStorageProvider()
   at Avalonia.X11.NativeDialogs.CompositeStorageProvider.OpenFolderPickerAsync(FolderPickerOpenOptions options)
   at Gommon.Extensions.Then[T,TR](Task`1 task, Func`2 continuation)
   at Ryujinx.Ava.Utilities.StorageProviderExtensions.OpenSingleFolderPickerAsync(IStorageProvider storageProvider, FolderPickerOpenOptions openOptions) in /build/source/src/Ryujinx/Utilities/StorageProviderExtensions.cs:line 12
   at Ryujinx.Ava.UI.Views.Settings.SettingsUiView.AddDirButton(TextBox addDirBox, AvaloniaList`1 directories) in /build/source/src/Ryujinx/UI/Views/Settings/SettingsUIView.axaml.cs:line 42
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
