### PR TITLE
appimageTools.defaultFhsEnvArgs: move libsecret to targetPkgs

### DIFF
--- a/pkgs/build-support/appimage/default.nix
+++ b/pkgs/build-support/appimage/default.nix
@@ -128,6 +128,10 @@ rec {
         krb5
         gsettings-desktop-schemas
         hicolor-icon-theme # dont show a gtk warning about hicolor not being installed
+
+        # libraries not on the upstream include list, but nevertheless expected
+        # by at least one appimage
+        libsecret # For bitwarden, appimage is x86_64 only
       ];
 
     # list of libraries expected in an appimage environment:
@@ -244,8 +248,6 @@ rec {
         at-spi2-core
         pciutils # for FreeCAD
         pipewire # immersed-vr wayland support
-
-        libsecret # For bitwarden
         libmpg123 # Slippi launcher
         brotli # TwitchDropsMiner
       ];


### PR DESCRIPTION
The bitwarden appimage is x86_64 only and does not need i686 libsecret, which currently also fails to build. This makes building appimage-run a lot lighter, as it no longer requires building i686 spidermonkey.

This causes a rebuild of 151 packages on x86_64, which all seem to build fine ~~so I haven't been able to test it locally~~ (aarch64 is only 28). This is still less than the 500 needed to be a "mass rebuild" so I've left it targeting master.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
