### PR TITLE
creduce: 2.10.0 -> 2.10.0-unstable-2024-06-01

### DIFF
--- a/pkgs/development/tools/misc/creduce/default.nix
+++ b/pkgs/development/tools/misc/creduce/default.nix
@@ -1,8 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  fetchpatch,
+  fetchFromGitHub,
   cmake,
   makeWrapper,
   llvm,
@@ -15,41 +14,23 @@
 
 stdenv.mkDerivation rec {
   pname = "creduce";
-  version = "2.10.0";
+  version = "2.10.0-unstable-2024-06-01";
 
-  src = fetchurl {
-    url = "https://embed.cs.utah.edu/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "2xwPEjln8k1iCwQM69UwAb89zwPkAPeFVqL/LhH+oGM=";
+  src = fetchFromGitHub {
+    owner = "csmith-project";
+    repo = "creduce";
+    rev = "31e855e290970cba0286e5032971509c0e7c0a80";
+    hash = "sha256-RbxFqZegsCxnUaIIA5OfTzx1wflCPeF+enQt90VwMgA=";
   };
 
-  patches = [
-    # Port to LLVM 15
-    (fetchpatch {
-      url = "https://github.com/csmith-project/creduce/commit/e507cca4ccb32585c5692d49b8d907c1051c826c.patch";
-      hash = "sha256-jO5E85AvHcjlErbUhzuQDXwQkhQsXklcTMQfWBd09OU=";
-    })
-    (fetchpatch {
-      url = "https://github.com/csmith-project/creduce/commit/8d56bee3e1d2577fc8afd2ecc03b1323d6873404.patch";
-      hash = "sha256-dRaBaJAYkvMyxKvfriOcg4D+4i6+6orZ85zws1AFx/s=";
-    })
-    # Port to LLVM 16
-    (fetchpatch {
-      url = "https://github.com/csmith-project/creduce/commit/8ab9a69caf13ce24172737e8bfd09de51a1ecb6a.patch";
-      hash = "sha256-gPNXxYHnsyUvXmC0CGtsulH2Fu/EMnDE4GdOYc0UbiQ=";
-    })
-  ];
-
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace "-std=c++11" "-std=c++17"
-  ''
-  # On Linux, c-reduce's preferred way to reason about
-  # the cpu architecture/topology is to use 'lscpu',
-  # so let's make sure it knows where to find it:
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
-    substituteInPlace creduce/creduce_utils.pm --replace \
-      lscpu ${util-linux}/bin/lscpu
-  '';
+  postPatch =
+    # On Linux, c-reduce's preferred way to reason about
+    # the cpu architecture/topology is to use 'lscpu',
+    # so let's make sure it knows where to find it:
+    lib.optionalString stdenv.hostPlatform.isLinux ''
+      substituteInPlace creduce/creduce_utils.pm --replace \
+        lscpu ${util-linux}/bin/lscpu
+    '';
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7011,7 +7011,7 @@ with pkgs;
   credstash = with python3Packages; toPythonApplication credstash;
 
   creduce = callPackage ../development/tools/misc/creduce {
-    inherit (llvmPackages_16) llvm libclang;
+    inherit (llvmPackages_18) llvm libclang;
   };
 
   inherit (nodePackages) csslint;


### PR DESCRIPTION
We were already applying a ton of commits on top of the latest stable release, including fixes for newer LLVM versions. Let’s bump to the latest commit and pick up support for LLVM 18.

There are in‐flight PRs for LLVM 19 and 20:

* <https://github.com/csmith-project/creduce/pull/285>
* <https://github.com/csmith-project/creduce/pull/287>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
