### PR TITLE
qt5.qtwebengine: mark vulnerable

### DIFF
--- a/pkgs/applications/misc/subsurface/default.nix
+++ b/pkgs/applications/misc/subsurface/default.nix
@@ -23,7 +23,7 @@
   qtlocation,
   qtsvg,
   qttools,
-  qtwebengine,
+  qtpositioning,
   libXcomposite,
   bluez,
   writeScript,
@@ -142,7 +142,7 @@ stdenv.mkDerivation {
     qtconnectivity
     qtsvg
     qttools
-    qtwebengine
+    qtpositioning
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -26,6 +26,7 @@
   supercolliderPlugins,
   writeText,
   runCommand,
+  withWebengine ? false, # vulnerable, so disabled by default
 }:
 
 mkDerivation rec {
@@ -64,10 +65,10 @@ mkDerivation rec {
     curl
     libXt
     qtbase
-    qtwebengine
     qtwebsockets
     readline
   ]
+  ++ lib.optional withWebengine qtwebengine
   ++ lib.optional (!stdenv.hostPlatform.isDarwin) alsa-lib;
 
   hardeningDisable = [ "stackprotector" ];
@@ -75,6 +76,7 @@ mkDerivation rec {
   cmakeFlags = [
     "-DSC_WII=OFF"
     "-DSC_EL=${if useSCEL then "ON" else "OFF"}"
+    (lib.cmakeBool "SC_USE_QTWEBENGINE" withWebengine)
   ];
 
   passthru = {

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -464,6 +464,43 @@ qtModule (
 
       # This build takes a long time; particularly on slow architectures
       timeout = 24 * 3600;
+
+      knownVulnerabilities = [
+        ''
+          qt5 qtwebengine is unmaintained upstream since april 2025.
+          It is based on chromium 87.0.4280.144, and supposedly patched up to 135.0.7049.95 which is outdated.
+
+          Security issues are frequently discovered in chromium.
+          The following list of CVEs was fixed in the life cycle of chromium 138 and likely also affects qtwebengine:
+          - CVE-2025-8879
+          - CVE-2025-8880
+          - CVE-2025-8901
+          - CVE-2025-8881
+          - CVE-2025-8882
+          - CVE-2025-8576
+          - CVE-2025-8577
+          - CVE-2025-8578
+          - CVE-2025-8579
+          - CVE-2025-8580
+          - CVE-2025-8581
+          - CVE-2025-8582
+          - CVE-2025-8583
+          - CVE-2025-8292
+          - CVE-2025-8010
+          - CVE-2025-8011
+          - CVE-2025-7656
+          - CVE-2025-6558 (known to be exploited in the wild)
+          - CVE-2025-7657
+          - CVE-2025-6554
+          - CVE-2025-6555
+          - CVE-2025-6556
+          - CVE-2025-6557
+
+          The actual list of CVEs affecting qtwebengine is likely much longer,
+          as this list is missing issues fixed in chromium 136/137 and even more
+          issues are continuously discovered and lack upstream fixes in qtwebengine.
+        ''
+      ];
     };
 
   }

--- a/pkgs/development/python-modules/pyside2/default.nix
+++ b/pkgs/development/python-modules/pyside2/default.nix
@@ -8,6 +8,7 @@
   ninja,
   qt5,
   shiboken2,
+  withWebengine ? false, # vulnerable, so omit by default
 }:
 stdenv.mkDerivation rec {
   pname = "pyside2";
@@ -67,13 +68,15 @@ stdenv.mkDerivation rec {
       qtlocation
       qtscript
       qtwebsockets
-      qtwebengine
       qtwebchannel
       qtcharts
       qtsensors
       qtsvg
       qt3d
     ])
+    ++ lib.optionals withWebengine [
+      qt5.qtwebengine
+    ]
     ++ (with python.pkgs; [ setuptools ])
     ++ (lib.optionals (python.pythonOlder "3.9") [
       # see similar issue: 202262


### PR DESCRIPTION
- remove qt5 qtwebengine from some packages (like pyside2) to reduce breaks
- mark qt5.qtwebengine vulnerable, listing some of the CVEs fixed in Chromium since qtwebengine went unmaintained upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
