### PR TITLE
syncthingtray: migrate to by-name

### DIFF
--- a/pkgs/by-name/sy/syncthingtray/package.nix
+++ b/pkgs/by-name/sy/syncthingtray/package.nix
@@ -2,21 +2,10 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  qtbase,
-  qtsvg,
-  qtwayland,
-  qtwebengine,
-  qtdeclarative,
-  extra-cmake-modules,
+  kdePackages,
   cpp-utilities,
-  qtutilities,
-  qtforkawesome,
   boost,
-  wrapQtAppsHook,
   cmake,
-  kio,
-  plasma-framework,
-  qttools,
   iconv,
   cppunit,
   syncthing,
@@ -49,37 +38,37 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   buildInputs = [
-    qtbase
-    qtsvg
+    kdePackages.qtbase
+    kdePackages.qtsvg
     cpp-utilities
-    qtutilities
+    kdePackages.qtutilities
     boost
-    qtforkawesome
+    kdePackages.qtforkawesome
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ iconv ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ qtwayland ]
-  ++ lib.optionals webviewSupport [ qtwebengine ]
-  ++ lib.optionals jsSupport [ qtdeclarative ]
-  ++ lib.optionals kioPluginSupport [ kio ]
-  ++ lib.optionals plasmoidSupport [ plasma-framework ];
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ kdePackages.qtwayland ]
+  ++ lib.optionals webviewSupport [ kdePackages.qtwebengine ]
+  ++ lib.optionals jsSupport [ kdePackages.qtdeclarative ]
+  ++ lib.optionals kioPluginSupport [ kdePackages.kio ]
+  ++ lib.optionals plasmoidSupport [ kdePackages.libplasma ];
 
   nativeBuildInputs = [
-    wrapQtAppsHook
+    kdePackages.wrapQtAppsHook
     cmake
-    qttools
+    kdePackages.qttools
     # Although these are test dependencies, we add them anyway so that we test
     # whether the test units compile. On Darwin we don't run the tests but we
     # still build them.
     cppunit
     syncthing
   ]
-  ++ lib.optionals plasmoidSupport [ extra-cmake-modules ];
+  ++ lib.optionals plasmoidSupport [ kdePackages.extra-cmake-modules ];
 
   # syncthing server seems to hang on darwin, causing tests to fail.
   doCheck = !stdenv.hostPlatform.isDarwin;
   preCheck = ''
     export QT_QPA_PLATFORM=offscreen
-    export QT_PLUGIN_PATH="${lib.getBin qtbase}/${qtbase.qtPluginPrefix}"
+    export QT_PLUGIN_PATH="${lib.getBin kdePackages.qtbase}/${kdePackages.qtbase.qtPluginPrefix}"
   '';
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     # put the app bundle into the proper place /Applications instead of /bin
@@ -94,14 +83,14 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
 
   cmakeFlags = [
-    "-DQT_PACKAGE_PREFIX=Qt${lib.versions.major qtbase.version}"
-    "-DKF_PACKAGE_PREFIX=KF${lib.versions.major qtbase.version}"
+    "-DQT_PACKAGE_PREFIX=Qt${lib.versions.major kdePackages.qtbase.version}"
+    "-DKF_PACKAGE_PREFIX=KF${lib.versions.major kdePackages.qtbase.version}"
     "-DBUILD_TESTING=ON"
     # See https://github.com/Martchus/syncthingtray/issues/208
     "-DEXCLUDE_TESTS_FROM_ALL=OFF"
     "-DAUTOSTART_EXEC_PATH=${autostartExecPath}"
     # See https://github.com/Martchus/syncthingtray/issues/42
-    "-DQT_PLUGIN_DIR:STRING=${placeholder "out"}/${qtbase.qtPluginPrefix}"
+    "-DQT_PLUGIN_DIR:STRING=${placeholder "out"}/${kdePackages.qtbase.qtPluginPrefix}"
     "-DBUILD_SHARED_LIBS=ON"
   ]
   ++ lib.optionals (!plasmoidSupport) [ "-DNO_PLASMOID=ON" ]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10984,11 +10984,6 @@ with pkgs;
     syncthing-relay
     ;
 
-  syncthingtray = kdePackages.callPackage ../applications/misc/syncthingtray {
-    # renamed in KF5 -> KF6
-    plasma-framework = kdePackages.libplasma;
-  };
-
   synergyWithoutGUI = synergy.override { withGUI = false; };
 
   tabbed = callPackage ../applications/window-managers/tabbed {


### PR DESCRIPTION
migrate kdePackages to by-name
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
