### PR TITLE
mvnBuild: deprecate phases

### DIFF
--- a/pkgs/build-support/release/maven-build.nix
+++ b/pkgs/build-support/release/maven-build.nix
@@ -24,9 +24,8 @@ in
 stdenv.mkDerivation (
   {
     inherit name src;
-    phases = "setupPhase unpackPhase patchPhase mvnCompile ${lib.optionalString doTestCompile "mvnTestCompile mvnTestJar"} ${lib.optionalString doTest "mvnTest"} ${lib.optionalString doJavadoc "mvnJavadoc"} ${lib.optionalString doCheckstyle "mvnCheckstyle"} mvnJar mvnAssembly mvnRelease finalPhase";
 
-    setupPhase = ''
+    preUnpack = ''
       runHook preSetupPhase
 
       mkdir -p $out/nix-support
@@ -37,70 +36,58 @@ stdenv.mkDerivation (
       runHook postSetupPhase
     '';
 
-    mvnCompile = ''
+    buildPhase = ''
       mvn compile ${mvnFlags}
     '';
 
-    mvnTestCompile = ''
-      mvn test-compile ${mvnFlags}
-    '';
+    checkPhase =
+      lib.optionalString doTestCompile ''
+        mvn test-compile ${mvnFlags}
+        mvn jar:test-jar ${mvnFlags}
+      ''
+      + lib.optionalString doTest ''
+        mvn test ${mvnFlags}
 
-    mvnTestJar = ''
-      mvn jar:test-jar ${mvnFlags}
-    '';
+        if [ -d target/site/cobertura ] ; then
+          echo "report coverage $out/site/cobertura" >> $out/nix-support/hydra-build-products
+        fi
 
-    mvnTest = ''
-      mvn test ${mvnFlags}
+        if [ -d target/surefire-reports ] ; then
+          mvn surefire-report:report-only
+          echo "report coverage $out/site/surefire-report.html" >> $out/nix-support/hydra-build-products
+        fi
+      '';
 
-      if [ -d target/site/cobertura ] ; then
-        echo "report coverage $out/site/cobertura" >> $out/nix-support/hydra-build-products
-      fi
+    installPhase =
+      lib.optionalString doJavadoc ''
+        mvn javadoc:javadoc ${mvnFlags}
+        echo "report javadoc $out/site/apidocs" >> $out/nix-support/hydra-build-products
+      ''
+      + lib.optionalString doCheckstyle ''
+        mvn checkstyle:checkstyle ${mvnFlags}
+        echo "report checkstyle $out/site/checkstyle.html" >> $out/nix-support/hydra-build-products
+      ''
+      + ''
+        mvn jar:jar ${mvnFlags}
+        mvn assembly:assembly -Dmaven.test.skip=true ${mvnFlags}
 
-      if [ -d target/surefire-reports ] ; then
-        mvn surefire-report:report-only
-        echo "report coverage $out/site/surefire-report.html" >> $out/nix-support/hydra-build-products
-      fi
-    '';
+        mkdir -p $out/release
+        zip=$(ls target/*.zip | head -1)
+        releaseName=$(basename $zip .zip)
+        releaseName="$releaseName-r${toString src.rev or "0"}"
+        cp $zip $out/release/$releaseName.zip
 
-    mvnJavadoc = ''
-      mvn javadoc:javadoc ${mvnFlags}
-      echo "report javadoc $out/site/apidocs" >> $out/nix-support/hydra-build-products
-    '';
+        echo "$releaseName" > $out/nix-support/hydra-release-name
 
-    mvnCheckstyle = ''
-      mvn checkstyle:checkstyle ${mvnFlags}
-      echo "report checkstyle $out/site/checkstyle.html" >> $out/nix-support/hydra-build-products
-    '';
+        ${lib.optionalString doRelease ''
+          echo "file zip $out/release/$releaseName.zip" >> $out/nix-support/hydra-build-products
+        ''}
 
-    mvnJar = ''
-      mvn jar:jar ${mvnFlags}
-    '';
-
-    mvnAssembly = ''
-      mvn assembly:assembly -Dmaven.test.skip=true ${mvnFlags}
-    '';
-
-    mvnRelease = ''
-      mkdir -p $out/release
-
-      zip=$(ls target/*.zip| head -1)
-      releaseName=$(basename $zip .zip)
-      releaseName="$releaseName-r${toString src.rev or "0"}"
-      cp $zip $out/release/$releaseName.zip
-
-      echo "$releaseName" > $out/nix-support/hydra-release-name
-
-      ${lib.optionalString doRelease ''
-        echo "file zip $out/release/$releaseName.zip" >> $out/nix-support/hydra-build-products
-      ''}
-    '';
-
-    finalPhase = ''
-      if [ -d target/site ] ; then
-        cp -R target/site $out/
-        echo "report site $out/site" >> $out/nix-support/hydra-build-products
-      fi
-    '';
+        if [ -d target/site ] ; then
+          cp -R target/site $out/
+          echo "report site $out/site" >> $out/nix-support/hydra-build-products
+        fi
+      '';
   }
   // args
 )


### PR DESCRIPTION
part of #28910

I am not sure about the consequences, because i can not find any usage of the code within this repo.
The only thing i found was: https://github.com/search?q=mvnBuild%20language%3ANix%20&type=code

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
