### PR TITLE
Modular services: no `pkgs`

### DIFF
--- a/nixos/README-modular-services.md
+++ b/nixos/README-modular-services.md
@@ -51,6 +51,10 @@ A [`_class`](https://nixos.org/manual/nixpkgs/unstable/#module-system-lib-evalMo
 Provide it as the first attribute in the module:
 
 ```nix
+# Non-module dependencies (`importApply`)
+{ writeScript, runtimeShell }:
+
+# Service module
 { lib, config, ... }:
 {
   _class = "service";
@@ -87,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     services = {
       default = {
-        imports = [ ./service.nix ];
+        imports = [ (lib.modules.importApply ./service.nix { inherit pkgs; }) ];
         example.package = finalAttrs.finalPackage;
         # ...
       };

--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -25,6 +25,7 @@ let
     escapeShellArg
     concatMapStringsSep
     sourceFilesBySuffices
+    modules
     ;
 
   common = import ./common.nix;
@@ -129,7 +130,16 @@ let
   '';
 
   portableServiceOptions = buildPackages.nixosOptionsDoc {
-    inherit (evalModules { modules = [ ../../modules/system/service/portable/service.nix ]; }) options;
+    inherit
+      (evalModules {
+        modules = [
+          (modules.importApply ../../modules/system/service/portable/service.nix {
+            pkgs = throw "nixos docs / portableServiceOptions: Do not reference pkgs in docs";
+          })
+        ];
+      })
+      options
+      ;
     inherit revision warningsAreErrors;
     transformOptions =
       opt:

--- a/nixos/doc/manual/development/modular-services.md
+++ b/nixos/doc/manual/development/modular-services.md
@@ -85,7 +85,9 @@ Moving their logic into separate Nix files may still be beneficial for the effic
 
 ## Writing and Reviewing a Modular Service {#modular-service-review}
 
-Refer to the contributor documentation in [`nixos/README-modular-services.md`](https://github.com/NixOS/nixpkgs/blob/master/nixos/README-modular-services.md).
+A typical service module consists of the following:
+
+For more details, refer to the contributor documentation in [`nixos/README-modular-services.md`](https://github.com/NixOS/nixpkgs/blob/master/nixos/README-modular-services.md).
 
 ## Portable Service Options {#modular-service-options-portable}
 

--- a/nixos/modules/system/service/portable/config-data.nix
+++ b/nixos/modules/system/service/portable/config-data.nix
@@ -1,10 +1,13 @@
 # Tests in: ../../../../tests/modular-service-etc/test.nix
+
+# Non-modular context provided by the modular services integration.
+{ pkgs }:
+
 # Configuration data support for portable services
 # This module provides configData for services, enabling configuration reloading
 # without terminating and restarting the service process.
 {
   lib,
-  pkgs,
   ...
 }:
 let

--- a/nixos/modules/system/service/portable/lib.nix
+++ b/nixos/modules/system/service/portable/lib.nix
@@ -1,6 +1,11 @@
 { lib, ... }:
 let
-  inherit (lib) concatLists mapAttrsToList showOption;
+  inherit (lib)
+    concatLists
+    mapAttrsToList
+    showOption
+    types
+    ;
 in
 rec {
   flattenMapServicesConfigToList =
@@ -30,4 +35,43 @@ rec {
       assertion = ass.assertion;
     }) config.assertions
   );
+
+  /**
+    This is the entrypoint for the portable part of modular services.
+
+    It provides the various options that are consumed by service manager implementations.
+
+    # Inputs
+
+    `serviceManagerPkgs`: A Nixpkgs instance which will be used for built-in logic such as converting `configData.<path>.text` to a store path.
+
+    `extraRootModules`: Modules to be loaded into the "root" service submodule, but not into its sub-`services`. That's the modules' own responsibility.
+
+    `extraRootSpecialArgs`: Fixed module arguments that are provided in a similar manner to `extraRootModules`.
+
+    # Output
+
+    An attribute set.
+
+    `serviceSubmodule`: a Module System option type which is a `submodule` with the portable modules and this function's inputs loaded into it.
+  */
+  configure =
+    {
+      serviceManagerPkgs,
+      extraRootModules ? [ ],
+      extraRootSpecialArgs ? { },
+    }:
+    let
+      modules = [
+        (lib.modules.importApply ./service.nix { pkgs = serviceManagerPkgs; })
+      ];
+      serviceSubmodule = types.submoduleWith {
+        class = "service";
+        modules = modules ++ extraRootModules;
+        specialArgs = extraRootSpecialArgs;
+      };
+    in
+    {
+      inherit serviceSubmodule;
+    };
 }

--- a/nixos/modules/system/service/portable/service.nix
+++ b/nixos/modules/system/service/portable/service.nix
@@ -11,7 +11,6 @@ in
   _class = "service";
   imports = [
     ../../../misc/assertions.nix
-    ./config-data.nix
   ];
   options = {
     services = mkOption {

--- a/nixos/modules/system/service/portable/service.nix
+++ b/nixos/modules/system/service/portable/service.nix
@@ -1,3 +1,9 @@
+# Non-module arguments
+# These are separate from the module arguments to avoid implicit dependencies.
+# This makes service modules self-contains, allowing mixing of Nixpkgs versions.
+{ pkgs }:
+
+# The module
 {
   lib,
   ...
@@ -11,13 +17,14 @@ in
   _class = "service";
   imports = [
     ../../../misc/assertions.nix
+    (lib.modules.importApply ./config-data.nix { inherit pkgs; })
   ];
   options = {
     services = mkOption {
       type = types.attrsOf (
         types.submoduleWith {
           modules = [
-            ./service.nix
+            (lib.modules.importApply ./service.nix { inherit pkgs; })
           ];
         }
       );

--- a/nixos/modules/system/service/systemd/service.nix
+++ b/nixos/modules/system/service/systemd/service.nix
@@ -52,8 +52,8 @@ let
 
 in
 {
+  _class = "service";
   imports = [
-    ../portable/service.nix
     (lib.mkAliasOptionModule [ "systemd" "service" ] [ "systemd" "services" "" ])
     (lib.mkAliasOptionModule [ "systemd" "socket" ] [ "systemd" "sockets" "" ])
   ];
@@ -101,6 +101,8 @@ in
           };
         }
       );
+      # Rendered by the portable docs instead.
+      visible = false;
     };
   };
   config = {

--- a/nixos/modules/system/service/systemd/system.nix
+++ b/nixos/modules/system/service/systemd/system.nix
@@ -73,16 +73,16 @@ in
           modules = [
             ./service.nix
             ./config-data-path.nix
+            (lib.modules.importApply ../portable/config-data.nix { inherit pkgs; })
 
-            # TODO: Consider removing pkgs. Service modules can provide their own
-            #       dependencies.
             {
               # Extend portable services option
               options.services = lib.mkOption {
                 type = types.attrsOf (
                   types.submoduleWith {
-                    specialArgs.pkgs = pkgs;
-                    modules = [ ];
+                    modules = [
+                      (lib.modules.importApply ../portable/config-data.nix { inherit pkgs; })
+                    ];
                   }
                 );
               };
@@ -90,9 +90,6 @@ in
           ];
           specialArgs = {
             # perhaps: features."systemd" = { };
-            # TODO: Consider removing pkgs. Service modules can provide their own
-            #       dependencies.
-            inherit pkgs;
             systemdPackage = config.systemd.package;
           };
         }

--- a/nixos/tests/modular-service-etc/python-http-server.nix
+++ b/nixos/tests/modular-service-etc/python-http-server.nix
@@ -3,7 +3,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 let
@@ -16,7 +15,6 @@ in
     python-http-server = {
       package = mkOption {
         type = types.package;
-        default = pkgs.python3;
         description = "Python package to use for the web server";
       };
 
@@ -46,21 +44,9 @@ in
     ];
 
     configData = {
-      # This should probably just be {} if we were to put this module in production.
-      "webroot" = lib.mkDefault {
-        source = pkgs.runCommand "default-webroot" { } ''
-          mkdir -p $out
-          cat > $out/index.html << 'EOF'
-          <!DOCTYPE html>
-          <html>
-          <head><title>Python Web Server</title></head>
-          <body>
-            <h1>Welcome to the Python Web Server</h1>
-            <p>Serving from port ${toString config.python-http-server.port}</p>
-          </body>
-          </html>
-          EOF
-        '';
+      "webroot" = {
+        # Enable only if directory is set to use this path
+        enable = lib.mkDefault (config.python-http-server.directory == config.configData."webroot".path);
       };
     };
   };

--- a/nixos/tests/modular-service-etc/test.nix
+++ b/nixos/tests/modular-service-etc/test.nix
@@ -147,8 +147,9 @@
     print(f"Before switch - webserver PID: {webserver_pid}, api PID: {api_pid}")
 
     # Switch to the specialisation with updated content
-    switch_output = server.succeed("/run/current-system/specialisation/updated/bin/switch-to-configuration test")
-    print(f"Switch output: {switch_output}")
+    # Capture both stdout and stderr, and show stderr in real-time for debugging
+    switch_output = server.succeed("/run/current-system/specialisation/updated/bin/switch-to-configuration test 2>&1 | tee /dev/stderr")
+    print(f"Switch output (stdout+stderr): {switch_output}")
 
     # Verify services are not mentioned in the switch output (indicating they weren't touched)
     assert "webserver.service" not in switch_output, f"webserver.service was mentioned in switch output: {switch_output}"

--- a/nixos/tests/modular-service-etc/test.nix
+++ b/nixos/tests/modular-service-etc/test.nix
@@ -12,18 +12,44 @@
   nodes = {
     server =
       { pkgs, ... }:
+      let
+        # Normally the package services.default attribute combines this, but we
+        # don't have that, because this is not a production service. Should it be?
+        python-http-server = {
+          imports = [ ./python-http-server.nix ];
+          python-http-server.package = pkgs.python3;
+        };
+      in
       {
         system.services.webserver = {
           # The python web server is simple enough that it doesn't need a reload signal.
           # Other services may need to receive a signal in order to re-read what's in `configData`.
-          imports = [ ./python-http-server.nix ];
+          imports = [ python-http-server ];
           python-http-server = {
             port = 8080;
           };
 
+          configData = {
+            "webroot" = {
+              source = pkgs.runCommand "webroot" { } ''
+                mkdir -p $out
+                cat > $out/index.html << 'EOF'
+                <!DOCTYPE html>
+                <html>
+                <head><title>Python Web Server</title></head>
+                <body>
+                  <h1>Welcome to the Python Web Server</h1>
+                  <p>Serving from port 8080</p>
+                </body>
+                </html>
+                EOF
+              '';
+            };
+          };
+
           # Add a sub-service
           services.api = {
-            imports = [ ./python-http-server.nix ];
+            imports = [ python-http-server ];
             python-http-server = {
               port = 8081;
             };

--- a/nixos/tests/php/fpm-modular.nix
+++ b/nixos/tests/php/fpm-modular.nix
@@ -1,3 +1,5 @@
+# Run with:
+#   nix-build -A nixosTests.php.fpm-modular
 { lib, php, ... }:
 {
   name = "php-${php.version}-fpm-modular-nginx-test";

--- a/pkgs/by-name/gh/ghostunnel/package.nix
+++ b/pkgs/by-name/gh/ghostunnel/package.nix
@@ -7,6 +7,8 @@
   ghostunnel,
   apple-sdk_12,
   darwinMinVersionHook,
+  writeScript,
+  runtimeShell,
 }:
 
 buildGoModule rec {
@@ -41,7 +43,11 @@ buildGoModule rec {
   };
 
   passthru.services.default = {
-    imports = [ ./service.nix ];
+    imports = [
+      (lib.modules.importApply ./service.nix {
+        inherit writeScript runtimeShell;
+      })
+    ];
     ghostunnel.package = ghostunnel; # FIXME: finalAttrs.finalPackage
   };
 

--- a/pkgs/by-name/gh/ghostunnel/service.nix
+++ b/pkgs/by-name/gh/ghostunnel/service.nix
@@ -1,8 +1,11 @@
+# Non-module dependencies (`importApply`)
+{ writeScript, runtimeShell }:
+
+# Service module
 {
   lib,
   config,
   options,
-  pkgs,
   ...
 }:
 let
@@ -25,6 +28,7 @@ in
     ghostunnel = {
       package = mkOption {
         description = "Package to use for ghostunnel";
+        defaultText = "The ghostunnel package that provided this module.";
         type = types.package;
       };
 
@@ -191,8 +195,8 @@ in
             cfg.cacert
           ])
           (
-            pkgs.writeScript "load-credentials" ''
-              #!${pkgs.runtimeShell}
+            writeScript "load-credentials" ''
+              #!${runtimeShell}
               exec $@ ${
                 concatStringsSep " " (
                   optional (cfg.keystore != null) "--keystore=$CREDENTIALS_DIRECTORY/keystore"

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -32,6 +32,8 @@ let
       common-updater-scripts,
       curl,
       jq,
+      coreutils,
+      formats,
 
       version,
       phpSrc ? null,
@@ -390,7 +392,11 @@ let
             inherit ztsSupport;
 
             services.default = {
-              imports = [ ./service.nix ];
+              imports = [
+                (lib.modules.importApply ./service.nix {
+                  inherit formats coreutils;
+                })
+              ];
               php-fpm.package = lib.mkDefault finalAttrs.finalPackage;
             };
           };


### PR DESCRIPTION
This PR resolves tech debt from the modular services / portable services implementation.

- Most significantly, this removes the `pkgs` module argument, which can cause conflicts and uncertainty; see the changed README for details.

- Provide a proper entrypoint (`configure`) to help with service manager integration, separating the boundaries a little better



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## Context

- https://github.com/NixOS/nixpkgs/issues/428084

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
