### PR TITLE
hydrasect: init at 2025-08-27

### DIFF
--- a/pkgs/by-name/hy/hydrasect/package.nix
+++ b/pkgs/by-name/hy/hydrasect/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "hydrasect";
+  version = "0.1.0-unstable-2025-08-27";
+
+  src = fetchFromGitHub {
+    owner = "blitz";
+    repo = "hydrasect";
+    rev = "88161c6d8dce16bf832599cf8ab544bbe5857c00";
+    hash = "sha256-Na7MlT+OXHZBtCKqJ0IzK4k3XfvQhsY+lnUJFG66YDU=";
+  };
+
+  cargoHash = "sha256-muqG74Ze6aUURPutuKlXvq5ayglJ7TGAzeji89lsoLk=";
+
+  meta = {
+    description = "Tool that makes bisecting nixpkgs pleasant";
+    homepage = "https://github.com/blitz/hydrasect";
+    license = lib.licenses.eupl12;
+    maintainers = with lib.maintainers; [ kiara ];
+    mainProgram = "hydrasect";
+  };
+}


### PR DESCRIPTION
adds [hydrasect](https://github.com/blitz/hydrasect).

/cc @blitz.

(would close the (already closed) #323985.)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
