### PR TITLE
spacetimedb: provide GIT_HASH at compile time for codegen in 1.3.0

### DIFF
--- a/pkgs/by-name/sp/spacetimedb/package.nix
+++ b/pkgs/by-name/sp/spacetimedb/package.nix
@@ -19,7 +19,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "clockworklabs";
     repo = "spacetimedb";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KslKsTVhc4xz1XMkkk40tqVZnLoL9UuSPvFHvdZ5vrI=";
+    hash = "sha256-3wuHR/dibB/JdDBxNLdch5Mlqbq/xnm3nWojyaTY9wE=";
+    # required for build.rs to set GIT_HASH for compile time
+    leaveDotGit = true;
   };
 
   cargoHash = "sha256-DpGKSWCXSp7fvA1OdZ4YZnanvmKlnxBGsyhEThNwkGo=";


### PR DESCRIPTION
SpacetimeDB now uses `GIT_HASH` (provided at compile time) in `1.3.0` (see https://github.com/clockworklabs/SpacetimeDB/pull/2673)

Before this fix, generated code comments look like:
```
// This was generated using spacetimedb cli version 1.3.0 (commit ).
```

After this fix:
```
// This was generated using spacetimedb cli version 1.3.0 (commit e107144998a2ca83ae87f905ff8a6eb5a50ff504).
```

`spacetime --version` before fix:
```
spacetime Path: /nix/store/8xw2hnrl0f7481a7fybak781rd3mqg6h-spacetimedb-1.3.0/bin/spacetime
Commit: 
spacetimedb tool version 1.3.0; spacetimedb-lib version 1.3.0;
```

`spacetime --version` after fix:
```
spacetime Path: /nix/store/65z5g0vi9slzqxlzdv4df2c7plnpfa7h-spacetimedb-1.3.0/bin/spacetime
Commit: e107144998a2ca83ae87f905ff8a6eb5a50ff504
spacetimedb tool version 1.3.0; spacetimedb-lib version 1.3.0;
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
