### PR TITLE
calibrePlugins.epubmerge: init at 3.2.0

### DIFF
--- a/pkgs/by-name/ca/calibre/plugins/default.nix
+++ b/pkgs/by-name/ca/calibre/plugins/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  callPackage,
+  fetchurl,
+  stdenvNoCC,
+}:
+let
+  root = ./.;
+
+  mkCalibrePlugin =
+    args@{
+      pname,
+      version,
+      url ? null,
+      src ? null,
+      sha256 ? null,
+      hash ? null,
+      meta ? { },
+      installPhase ? null,
+      ...
+    }:
+    let
+      # If src is not provided, create it from url and hash/sha256
+      pluginSrc =
+        if src != null then
+          src
+        else
+          fetchurl ({ inherit url; } // (if hash != null then { inherit hash; } else { inherit sha256; }));
+    in
+    stdenvNoCC.mkDerivation (
+      args
+      // {
+        inherit pname version;
+        src = pluginSrc;
+
+        dontUnpack = true;
+
+        installPhase =
+          if installPhase != null then
+            installPhase
+          else
+            ''
+              runHook preInstall
+
+              mkdir $out
+              cp $src $out/${pname}.zip
+
+              runHook postInstall
+            '';
+
+        meta = meta // {
+          description = meta.description or "Calibre plugin";
+          platforms = meta.platforms or lib.platforms.all;
+          homepage = meta.homepage or null;
+        };
+      }
+    );
+
+  call = name: callPackage (root + "/${name}") { inherit mkCalibrePlugin; };
+in
+lib.pipe root [
+  builtins.readDir
+  (lib.filterAttrs (_: type: type == "directory"))
+  (builtins.mapAttrs (name: _: call name))
+]
+// {
+  inherit mkCalibrePlugin;
+}

--- a/pkgs/by-name/ca/calibre/plugins/epubmerge/default.nix
+++ b/pkgs/by-name/ca/calibre/plugins/epubmerge/default.nix
@@ -1,0 +1,15 @@
+{ mkCalibrePlugin, lib }:
+
+mkCalibrePlugin rec {
+  pname = "epubmerge";
+  version = "3.2.0";
+  url = "https://github.com/JimmXinu/EpubMerge/releases/download/v${version}/EpubMerge.zip";
+  sha256 = "sha256-GH6JE7bnnytdOocNtSnh5ENV5cEr7vM6BRyJC8uTijU=";
+
+  meta = {
+    description = "A Calibre plugin to merge multiple EPUB files into a single volume";
+    homepage = "https://github.com/JimmXinu/EpubMerge";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ xavwe ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12879,6 +12879,8 @@ with pkgs;
 
   yaziPlugins = recurseIntoAttrs (callPackage ../by-name/ya/yazi/plugins { });
 
+  calibrePlugins = recurseIntoAttrs (callPackage ../by-name/ca/calibre/plugins { });
+
   libpostalWithData = callPackage ../by-name/li/libpostal/package.nix {
     withData = true;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds the calibre plugin epubmerge for https://github.com/nix-community/home-manager/issues/6171.
I’m still fairly new to Nixpkgs, so I would very much appreciate any feedback or suggestions for improvement.
I tried to make it as simple as possible to add other calibre plugins in the future.

Closes https://github.com/NixOS/nixpkgs/issues/35457

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
