### PR TITLE
tree-grepper: init at 2.5.0-unstable-2025-08-18

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -820,6 +820,13 @@ lib.mapAttrs mkLicense (
       redistributable = true;
     };
 
+    hl2_1 = {
+      fullName = "Hippocratic License v2.1";
+      url = "https://firstdonoharm.dev/version/2/1/license/code_of_conduct.txt";
+      free = false;
+      redistributable = true;
+    };
+
     hl3 = {
       fullName = "Hippocratic License v3.0";
       url = "https://firstdonoharm.dev/version/3/0/core.txt";

--- a/pkgs/by-name/tr/tree-grepper/package.nix
+++ b/pkgs/by-name/tr/tree-grepper/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  tree-sitter,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage {
+  pname = "tree-grepper";
+  # no releases since 2022 but active development:
+  # https://github.com/BrianHicks/tree-grepper/issues/688
+  version = "2.5.0-unstable-2025-08-18";
+
+  src = fetchFromGitHub {
+    owner = "BrianHicks";
+    repo = "tree-grepper";
+    rev = "c05ae50bd96e131569f1020c60219720dd8fe29c";
+    hash = "sha256-UTkOzyM78Fawf0PtzBTrTH4yveb4Fy4HMSdm6dVuJjI=";
+  };
+
+  # HACK: There's not dynamic loading support so we have to just build the
+  # grammars in. Someone should fix this upstream.
+  # https://github.com/BrianHicks/tree-grepper/issues/88
+  preBuild = ''
+    ln -sf ${tree-sitter.grammars} vendor
+  '';
+
+  cargoHash = "sha256-Y1fzMQUsQZsfAk+Lmdmgax7xvg94DC+Rf8YK1yCSaaw=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "tree-sitter based AST search tool";
+    maintainers = with lib.maintainers; [ lf- ];
+    license = lib.licenses.hl2_1;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -78,6 +78,7 @@
   tree-sitter-pgn = lib.importJSON ./tree-sitter-pgn.json;
   tree-sitter-php = lib.importJSON ./tree-sitter-php.json;
   tree-sitter-pioasm = lib.importJSON ./tree-sitter-pioasm.json;
+  tree-sitter-powershell = lib.importJSON ./tree-sitter-powershell.json;
   tree-sitter-prisma = lib.importJSON ./tree-sitter-prisma.json;
   tree-sitter-proto = lib.importJSON ./tree-sitter-proto.json;
   tree-sitter-pug = lib.importJSON ./tree-sitter-pug.json;

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-powershell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-powershell.json
@@ -1,0 +1,14 @@
+{
+  "url": "https://github.com/airbus-cert/tree-sitter-powershell",
+  "rev": "96ab1da05cfb55b52ee7000b4be8a4b6fad232f5",
+  "date": "2025-08-01T09:33:53+02:00",
+  "path": "/nix/store/bl9rp6h6jzxnvfh03bppcpngi45vd5zz-tree-sitter-powershell",
+  "sha256": "1nhy412x7l9p06kxihlnjvi6wca3xqb7m1zjkl6vrgn62k91wjwb",
+  "hash": "sha256-i0se0hTGvrwNnfKHehbuQzFu4paWwtinATfR00UgHto=",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "fetchTags": false,
+  "leaveDotGit": false,
+  "rootDir": ""
+}

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -496,6 +496,10 @@ let
       orga = "crystal-lang-tools";
       repo = "tree-sitter-crystal";
     };
+    "tree-sitter-powershell" = {
+      orga = "airbus-cert";
+      repo = "tree-sitter-powershell";
+    };
   };
 
   pinnedGrammars = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/BrianHicks/tree-grepper

What can you do with it? Example: `result/bin/tree-grepper --query nix "$(cat query.scm)"`

```scheme
(
  (source_code
    expression: (function_expression
      formals: (formals
        formal: (formal name: (identifier) @ident)
      )
    )
  )
  (#any-of? @ident "pytestCheckHook" "pytest")
)
```

And thus you have executed a query to find any usages of pytest in a `package.nix`-like context (top level lambda expression) in all of nixpkgs! Pretty cool!!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
