### PR TITLE
librewolf-unwrapped: 141.0.3-1 -> 142.0.1

### DIFF
--- a/pkgs/applications/networking/browsers/librewolf/src.json
+++ b/pkgs/applications/networking/browsers/librewolf/src.json
@@ -1,11 +1,11 @@
 {
-  "packageVersion": "141.0.3-1",
+  "packageVersion": "142.0-1",
   "source": {
-    "rev": "141.0.3-1",
-    "hash": "sha256-0SosHE51IkDyg37fHnlJKn7IbMwr1iSXHr5Wuv2WkPg="
+    "rev": "142.0-1",
+    "hash": "sha256-/bn9xeDxnJCQol/E8rhS8RVhpUj7UN+QScSIzLFnZ/o="
   },
   "firefox": {
-    "version": "141.0.3",
-    "hash": "sha512-tmCwGIQMQaJUc0tIR6eR8an9L3Lb6oJepZcf0LMmmkPx9L4cz0pT94Cba5g5j04EoULlf4iC1lkLq2Nu91AC9g=="
+    "version": "142.0",
+    "hash": "sha512-sMHHZgg6MKkrd9zxalhNn7NBzYEdIcOjTaTNDXFP1q3HO2CAktZgWGl7xFYvqsxEhZFT5J/9624U4Fnlny6iRg=="
   }
 }


### PR DESCRIPTION
firefox upstream release notes: https://www.firefox.com/en-US/firefox/142.0/releasenotes/

Security advisory: https://www.mozilla.org/en-US/security/advisories/mfsa2025-64/

Fixes:
- CVE-2025-9179
- CVE-2025-9180
- CVE-2025-9181
- (CVE-2025-9186 Android-only)
- CVE-2025-9182
- CVE-2025-9183
- CVE-2025-9187
- CVE-2025-9184
- CVE-2025-9185

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
