### PR TITLE
lanraragi: 0.9.41 -> 0.9.50

### DIFF
--- a/nixos/tests/lanraragi.nix
+++ b/nixos/tests/lanraragi.nix
@@ -7,11 +7,17 @@
     machine1 =
       { pkgs, ... }:
       {
+        # needed for the cache
+        virtualisation.memorySize = 4096;
+
         services.lanraragi.enable = true;
       };
     machine2 =
       { pkgs, ... }:
       {
+        # needed for the cache
+        virtualisation.memorySize = 4096;
+
         services.lanraragi = {
           enable = true;
           passwordFile = pkgs.writeText "lrr-test-pass" ''

--- a/pkgs/by-name/la/lanraragi/bail-if-cpanm-fails.patch
+++ b/pkgs/by-name/la/lanraragi/bail-if-cpanm-fails.patch
@@ -1,0 +1,15 @@
+diff --git a/tools/install.pl b/tools/install.pl
+index fa99f5beb..b369b3b3e 100755
+--- a/tools/install.pl
++++ b/tools/install.pl
+@@ -242,7 +242,9 @@ sub install_package {
+ 
+     if ($@) {
+         say("$package not installed! Trying to install now using cpanm$cpanopt");
+-        system("cpanm --notest $package $cpanopt");
++        if ( system("cpanm --notest $package $cpanopt") != 0 ) {
++            die "Something went wrong while installing $package - Bailing out.";
++        }
+     } else {
+         say("$package package installed, proceeding...");
+     }

--- a/pkgs/by-name/la/lanraragi/fix-paths.patch
+++ b/pkgs/by-name/la/lanraragi/fix-paths.patch
@@ -1,17 +1,17 @@
 diff --git a/lib/LANraragi.pm b/lib/LANraragi.pm
-index e6b833c4..4b90e4c5 100644
+index 1342d66..600ccbe 100644
 --- a/lib/LANraragi.pm
 +++ b/lib/LANraragi.pm
-@@ -21,6 +21,8 @@ use LANraragi::Utils::Minion;
- use LANraragi::Model::Search;
- use LANraragi::Model::Config;
+@@ -25,6 +25,8 @@ use LANraragi::Model::Config;
+ 
+ use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
  
 +use FindBin;
 +
  # This method will run once at server start
  sub startup {
      my $self = shift;
-@@ -30,7 +32,7 @@ sub startup {
+@@ -34,7 +36,7 @@ sub startup {
      say "ｷﾀ━━━━━━(ﾟ∀ﾟ)━━━━━━!!!!!";
  
      # Load package.json to get version/vername/description
@@ -21,18 +21,18 @@ index e6b833c4..4b90e4c5 100644
      my $version = $packagejson->{version};
      my $vername = $packagejson->{version_name};
 diff --git a/lib/LANraragi/Model/Archive.pm b/lib/LANraragi/Model/Archive.pm
-index 73e824dd..8bcea29c 100644
+index 425f935..9483012 100644
 --- a/lib/LANraragi/Model/Archive.pm
 +++ b/lib/LANraragi/Model/Archive.pm
-@@ -13,6 +13,7 @@ use Time::HiRes qw(usleep);
+@@ -14,6 +14,7 @@ use File::Path  qw(remove_tree);
  use File::Basename;
  use File::Copy "cp";
  use File::Path qw(make_path);
 +use FindBin;
  
- use LANraragi::Utils::Generic qw(remove_spaces remove_newlines render_api_response);
- use LANraragi::Utils::TempFolder qw(get_temp);
-@@ -126,7 +127,7 @@ sub serve_thumbnail {
+ use LANraragi::Utils::Generic    qw(render_api_response);
+ use LANraragi::Utils::String     qw(trim trim_CRLF);
+@@ -222,7 +223,7 @@ sub serve_thumbnail {
          } else {
  
              # If the thumbnail doesn't exist, serve the default thumbnail.
@@ -40,30 +40,30 @@ index 73e824dd..8bcea29c 100644
 +            $self->render_file( filepath => "$FindBin::Bin/../public/img/noThumb.png" );
          }
          return;
- 
+     } else {
 diff --git a/lib/LANraragi/Utils/Generic.pm b/lib/LANraragi/Utils/Generic.pm
-index 14736893..4352f023 100644
+index 1b1ffbd..c0f87d6 100644
 --- a/lib/LANraragi/Utils/Generic.pm
 +++ b/lib/LANraragi/Utils/Generic.pm
-@@ -17,6 +17,8 @@ use Sys::CpuAffinity;
- use LANraragi::Utils::TempFolder qw(get_temp);
- use LANraragi::Utils::Logging qw(get_logger);
+@@ -28,6 +28,8 @@ BEGIN {
+     }
+ }
  
 +use FindBin;
 +
  # Generic Utility Functions.
  use Exporter 'import';
- our @EXPORT_OK =
-@@ -161,7 +163,7 @@ sub start_shinobu {
+ our @EXPORT_OK = qw(is_image is_archive render_api_response get_tag_with_namespace shasum_str start_shinobu
+@@ -149,7 +151,7 @@ sub start_shinobu {
      my $mojo = shift;
+     if ( IS_UNIX ) {
+         my $proc = Proc::Simple->new();
+-        $proc->start( $^X, "./lib/Shinobu.pm" );
++        $proc->start( $^X, "$FindBin::Bin/../lib/Shinobu.pm" );
+         $proc->kill_on_destroy(0);
  
-     my $proc = Proc::Simple->new();
--    $proc->start( $^X, "./lib/Shinobu.pm" );
-+    $proc->start( $^X, "$FindBin::Bin/../lib/Shinobu.pm" );
-     $proc->kill_on_destroy(0);
- 
-     $mojo->LRR_LOGGER->debug( "Shinobu Worker new PID is " . $proc->pid );
-@@ -201,7 +203,7 @@ sub get_css_list {
+         $mojo->LRR_LOGGER->debug( "Shinobu Worker new PID is " . $proc->pid );
+@@ -198,7 +200,7 @@ sub get_css_list {
  
      #Get all the available CSS sheets.
      my @css;
@@ -72,11 +72,50 @@ index 14736893..4352f023 100644
      while ( my $file = readdir($dir) ) {
          if ( $file =~ /.+\.css/ ) { push( @css, $file ); }
      }
+diff --git a/lib/LANraragi/Utils/I18N.pm b/lib/LANraragi/Utils/I18N.pm
+index b917c2c..bee242e 100644
+--- a/lib/LANraragi/Utils/I18N.pm
++++ b/lib/LANraragi/Utils/I18N.pm
+@@ -5,19 +5,22 @@ use warnings;
+ use utf8;
+ use base 'Locale::Maketext';
+ 
++# Technically, we could just not use FindBin::Bin, but then the search process
++# would go through a lot of unnecessary effort to finally find the translations
++use FindBin;
+ use Locale::Maketext::Lexicon {
+-    en      => [ Gettext => "../../locales/template/en.po" ],
+-    es      => [ Gettext => "../../locales/template/es.po" ],
+-    zh      => [ Gettext => "../../locales/template/zh.po" ],
+-    "zh-cn" => [ Gettext => "../../locales/template/zh.po" ],
+-    fr      => [ Gettext => "../../locales/template/fr.po" ],
+-    id      => [ Gettext => "../../locales/template/id.po" ],
+-    ko      => [ Gettext => "../../locales/template/ko.po" ],
+-    no      => [ Gettext => "../../locales/template/nb_NO.po" ],
+-    nb      => [ Gettext => "../../locales/template/nb_NO.po" ],
+-    pt      => [ Gettext => "../../locales/template/pt.po" ],
+-    "zh-tw" => [ Gettext => "../../locales/template/zh_Hant.po" ],
+-    vi      => [ Gettext => "../../locales/template/vi.po" ],
++    en      => [ Gettext => "$FindBin::Bin/../locales/template/en.po" ],
++    es      => [ Gettext => "$FindBin::Bin/../locales/template/es.po" ],
++    zh      => [ Gettext => "$FindBin::Bin/../locales/template/zh.po" ],
++    "zh-cn" => [ Gettext => "$FindBin::Bin/../locales/template/zh.po" ],
++    fr      => [ Gettext => "$FindBin::Bin/../locales/template/fr.po" ],
++    id      => [ Gettext => "$FindBin::Bin/../locales/template/id.po" ],
++    ko      => [ Gettext => "$FindBin::Bin/../locales/template/ko.po" ],
++    no      => [ Gettext => "$FindBin::Bin/../locales/template/nb_NO.po" ],
++    nb      => [ Gettext => "$FindBin::Bin/../locales/template/nb_NO.po" ],
++    pt      => [ Gettext => "$FindBin::Bin/../locales/template/pt.po" ],
++    "zh-tw" => [ Gettext => "$FindBin::Bin/../locales/template/zh_Hant.po" ],
++    vi      => [ Gettext => "$FindBin::Bin/../locales/template/vi.po" ],
+     _auto   => 0,
+ };
+ 
 diff --git a/lib/LANraragi/Utils/Logging.pm b/lib/LANraragi/Utils/Logging.pm
-index ee29c507..6bdfc1bd 100644
+index 7acbd01..b73ce3e 100644
 --- a/lib/LANraragi/Utils/Logging.pm
 +++ b/lib/LANraragi/Utils/Logging.pm
-@@ -18,7 +18,7 @@ our @EXPORT_OK = qw(get_logger get_plugin_logger get_logdir get_lines_from_file)
+@@ -19,7 +19,7 @@ our @EXPORT_OK = qw(get_logger get_plugin_logger get_logdir get_lines_from_file)
  # Get the Log folder.
  sub get_logdir {
  
@@ -86,7 +125,7 @@ index ee29c507..6bdfc1bd 100644
      # Folder location can be overriden by LRR_LOG_DIRECTORY
      if ( $ENV{LRR_LOG_DIRECTORY} ) {
 diff --git a/lib/LANraragi/Utils/TempFolder.pm b/lib/LANraragi/Utils/TempFolder.pm
-index a5ab8a83..64a56255 100644
+index a5ab8a8..64a5625 100644
 --- a/lib/LANraragi/Utils/TempFolder.pm
 +++ b/lib/LANraragi/Utils/TempFolder.pm
 @@ -13,7 +13,7 @@ our @EXPORT_OK = qw(get_temp);
@@ -98,4 +137,3 @@ index a5ab8a83..64a56255 100644
  
      # Folder location can be overriden by LRR_TEMP_DIRECTORY
      if ( $ENV{LRR_TEMP_DIRECTORY} ) {
-

--- a/pkgs/by-name/la/lanraragi/install.patch
+++ b/pkgs/by-name/la/lanraragi/install.patch
@@ -1,16 +1,8 @@
 diff --git a/tools/install.pl b/tools/install.pl
-index 9e155f0..a63de58 100644
+index 0931979..50745d7 100644
 --- a/tools/install.pl
 +++ b/tools/install.pl
-@@ -9,6 +9,7 @@ use Config;
- 
- use feature    qw(say);
- use File::Path qw(make_path);
-+use File::Copy qw(copy);
- 
- #Vendor dependencies
- my @vendor_css = (
-@@ -90,33 +91,6 @@ if ( $ENV{HOMEBREW_FORMULA_PREFIX} ) {
+@@ -92,36 +92,6 @@ if ( $ENV{HOMEBREW_FORMULA_PREFIX} ) {
      $cpanopt = " -l " . $ENV{HOMEBREW_FORMULA_PREFIX} . "/libexec";
  }
  
@@ -23,11 +15,14 @@ index 9e155f0..a63de58 100644
 -
 -say("\r\nWill now check if all LRR software dependencies are met. \r\n");
 -
--#Check for Redis
--say("Checking for Redis...");
--can_run('redis-server')
--  or die 'NOT FOUND! Please install a Redis server before proceeding.';
--say("OK!");
+-#Fails on win even if redis is in the path
+-if ( IS_UNIX ) {
+-    #Check for Redis
+-    say("Checking for Redis...");
+-    can_run('redis-server')
+-      or die 'NOT FOUND! Please install a Redis server before proceeding.';
+-    say("OK!");
+-}
 -
 -#Check for GhostScript
 -say("Checking for GhostScript...");
@@ -44,25 +39,7 @@ index 9e155f0..a63de58 100644
  #Check for PerlMagick
  say("Checking for ImageMagick/PerlMagick...");
  my $imgk;
-@@ -136,37 +110,11 @@ if ($@) {
-     say("OK!");
- }
- 
--#Build & Install CPAN Dependencies
--if ( $back || $full ) {
--    say("\r\nInstalling Perl modules... This might take a while.\r\n");
--
--    if ( $Config{"osname"} ne "darwin" ) {
--        say("Installing Linux::Inotify2 for non-macOS systems... (This will do nothing if the package is there already)");
--
--        install_package( "Linux::Inotify2", $cpanopt );
--    }
--
--    if ( system( "cpanm --installdeps ./tools/. --notest" . $cpanopt ) != 0 ) {
--        die "Something went wrong while installing Perl modules - Bailing out.";
--    }
--}
--
+@@ -170,13 +140,6 @@ if ( $back || $full ) {
  #Clientside Dependencies with Provisioning
  if ( $front || $full ) {
  
@@ -75,30 +52,4 @@ index 9e155f0..a63de58 100644
 -
      say("\r\nProvisioning...\r\n");
  
--    #Load File::Copy
--    install_package( "File::Copy", $cpanopt );
--    File::Copy->import("copy");
--
-     make_path getcwd . "/public/css/vendor";
-     make_path getcwd . "/public/css/webfonts";
-     make_path getcwd . "/public/js/vendor";
-@@ -213,19 +161,3 @@ sub cp_node_module {
- 
- }
- 
--sub install_package {
--
--    my $package = $_[0];
--    my $cpanopt = $_[1];
--
--    ## no critic
--    eval "require $package";    #Run-time evals are needed here to check if the package has been properly installed.
--    ## use critic
--
--    if ($@) {
--        say("$package not installed! Trying to install now using cpanm$cpanopt");
--        system("cpanm $package $cpanopt");
--    } else {
--        say("$package package installed, proceeding...");
--    }
--}
+     #Load File::Copy

--- a/pkgs/by-name/la/lanraragi/package.nix
+++ b/pkgs/by-name/la/lanraragi/package.nix
@@ -11,22 +11,33 @@
 
 buildNpmPackage rec {
   pname = "lanraragi";
-  version = "0.9.41";
+  version = "0.9.50";
 
   src = fetchFromGitHub {
     owner = "Difegue";
     repo = "LANraragi";
     tag = "v.${version}";
-    hash = "sha256-HF2g8rrcV6f6ZTKmveS/yjil/mBxpvRUFyauv5f+qQ8=";
+    hash = "sha256-WwAY74sFPFJNfrTcGfXEZE8svuOxoCXR70SFyHb2Y40=";
   };
 
   patches = [
+    # https://github.com/Difegue/LANraragi/pull/1340
+    # Note: the PR was reverted upstream because it broke on windows
+    ./bail-if-cpanm-fails.patch
+
+    # Skip running `npm ci` and unnecessary build-time checks
     ./install.patch
+
+    # Don't assume that the cwd is $out/share/lanraragi
+    # Put logs and temp files into the cwd by default, instead of into $out/share/lanraragi
     ./fix-paths.patch
-    ./expose-password-hashing.patch # Used by the NixOS module
+
+    # Expose the password hashing logic that can be used by the NixOS module
+    # to set the admin password
+    ./expose-password-hashing.patch
   ];
 
-  npmDepsHash = "sha256-RAjZGuK0C6R22fVFq82GPQoD1HpRs3MYMluUAV5ZEc8=";
+  npmDepsHash = "sha256-+vS/uoEmJJM3G9jwdwQTlhV0VkjAhhVd60x+PcYyWSw=";
 
   nativeBuildInputs = [
     perl
@@ -36,25 +47,27 @@ buildNpmPackage rec {
 
   buildInputs =
     with perl.pkgs;
+    # deps listed in `tools/cpanfile`:
     [
       perl
-      ImageMagick
       locallib
       Redis
       Encode
       ArchiveLibarchiveExtract
       ArchiveLibarchivePeek
+      ArchiveZip
+      # Digest::SHA (part of perl)
       ListMoreUtils
-      NetDNSNative
       SortNaturally
       AuthenPassphrase
       FileReadBackwards
+      # URI::Escape (part of URI)
       URI
-      LogfileRotate
+      # IPC::Cmd (part of perl)
+      # Compress::Zlib (part of perl)
       Mojolicious
       MojoliciousPluginTemplateToolkit
       MojoliciousPluginRenderFile
-      MojoliciousPluginStatus
       IOSocketSocks
       IOSocketSSL
       CpanelJSONXS
@@ -62,26 +75,35 @@ buildNpmPackage rec {
       MinionBackendRedis
       ProcSimple
       ParallelLoops
+      MCE # (has MCE::Loop)
+      MCEShared
       SysCpuAffinity
       FileChangeNotify
       ModulePluggable
       TimeLocal
       YAMLPP
       StringSimilarity
-      CHI
-      CacheFastMmap
+      # Locale::Maketext (part of perl)
       LocaleMaketextLexicon
+      CHI
+      # CHI::Driver::FastMmap (part of CHI)
+      CacheFastMmap
     ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [ LinuxInotify2 ];
+    # deps listed in `tools/install.pm`:
+    ++ [
+      ImageMagick
+      NetDNSNative
+      MojoliciousPluginStatus
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      LinuxInotify2
+    ];
 
   buildPhase = ''
     runHook preBuild
 
-    # Check if every perl dependency was installed
-    cpanm --installdeps ./tools --notest
-
     perl ./tools/install.pl install-full
-    rm -r node_modules public/js/vendor/*.map public/css/vendor/*.map
+    rm public/js/vendor/*.map public/css/vendor/*.map
 
     runHook postBuild
   '';
@@ -89,6 +111,8 @@ buildNpmPackage rec {
   doCheck = true;
 
   nativeCheckInputs = with perl.pkgs; [
+    # App::Prove (part of perl)
+    # Test::Harness (part of perl)
     TestMockObject
     TestTrap
     TestDeep
@@ -108,7 +132,7 @@ buildNpmPackage rec {
 
     mkdir -p $out/share/lanraragi
     chmod +x script/launcher.pl
-    cp -r lib public script templates package.json lrr.conf $out/share/lanraragi
+    cp -r lib public script locales templates package.json lrr.conf $out/share/lanraragi
 
     makeWrapper $out/share/lanraragi/script/launcher.pl $out/bin/lanraragi \
       --prefix PERL5LIB : $PERL5LIB \

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -19713,6 +19713,24 @@ with self;
     };
   };
 
+  MCEShared = buildPerlPackage {
+    pname = "MCE-Shared";
+    version = "1.893";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MA/MARIOROY/MCE-Shared-1.893.tar.gz";
+      hash = "sha256-+kxIet+w2zyPK2qidNM9j4J/ojTGMbs689lPpKPJRi8=";
+    };
+    propagatedBuildInputs = [ MCE ];
+    meta = {
+      description = "MCE extension for sharing data supporting threads and processes";
+      homepage = "https://github.com/marioroy/mce-shared";
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
+    };
+  };
+
   LogLog4perl = buildPerlPackage {
     pname = "Log-Log4perl";
     version = "1.57";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -2913,10 +2913,10 @@ with self;
 
   CacheFastMmap = buildPerlPackage {
     pname = "Cache-FastMmap";
-    version = "1.57";
+    version = "1.60";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROBM/Cache-FastMmap-1.57.tar.gz";
-      hash = "sha256-4Es6KNmJ7bj7lur6zcK4f57MuE8EfrLifLJqp9CMx7g=";
+      url = "mirror://cpan/authors/id/R/RO/ROBM/Cache-FastMmap-1.60.tar.gz";
+      hash = "sha256-my07Cu8JXSxZs1akSClQ0MOiLoTm5puXu5bcwe3GQv8=";
     };
     buildInputs = [ TestDeep ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -19698,10 +19698,10 @@ with self;
 
   MCE = buildPerlPackage {
     pname = "MCE";
-    version = "1.889";
+    version = "1.901";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARIOROY/MCE-1.889.tar.gz";
-      hash = "sha256-22FT5HTQRvwlMFC/U8VAAthM1Mp30hwrnfVv7rgJu+0=";
+      url = "mirror://cpan/authors/id/M/MA/MARIOROY/MCE-1.901.tar.gz";
+      hash = "sha256-3RRrHpmFPjPBzbtowgJK7nQGeseDlNUbgdH6so9Q0TU=";
     };
     meta = {
       description = "Many-Core Engine for Perl providing parallel processing capabilities";


### PR DESCRIPTION
## Description of changes
- updated to [0.9.50](https://github.com/Difegue/LANraragi/releases/tag/v.0.9.50)
- maintain patches, add locales and a "bail" patch
- altered dependencies
     - removed Logrotate [relevant upstream commit](https://github.com/Difegue/LANraragi/commit/41ec096c10cdc3089e468fc007c76807a2e36c48)
     - changed ParallelLoops to MCEShared [relevant upstream commit](https://github.com/Difegue/LANraragi/commit/30999af5ca1a625ff2a65497d40f412b8549a51d) 
     - updated relevant perl packages
     - better organisation of perl depedencies

I do want to note that it's currently a draft as I'm interested in adding proper plugin and theme support. That would either involve patching the source to allow a package override or adding to the [services.lanraragi](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/web-apps/lanraragi.nix) module
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
