### PR TITLE
python3Packages.mypy: propagate pathspec; python3Packages.charset-normalizer: 3.4.2 -> 3.4.3

### DIFF
--- a/pkgs/development/python-modules/charset-normalizer/default.nix
+++ b/pkgs/development/python-modules/charset-normalizer/default.nix
@@ -5,7 +5,6 @@
   fetchFromGitHub,
   mypy,
   pytestCheckHook,
-  pythonOlder,
   requests,
   setuptools,
   setuptools-scm,
@@ -13,16 +12,14 @@
 
 buildPythonPackage rec {
   pname = "charset-normalizer";
-  version = "3.4.2";
+  version = "3.4.3";
   pyproject = true;
 
-  disabled = pythonOlder "3.5";
-
   src = fetchFromGitHub {
-    owner = "Ousret";
+    owner = "jawah";
     repo = "charset_normalizer";
     tag = version;
-    hash = "sha256-PkFmNEMdp9duDCqMTKooOLAOCqHf3IjrGlr8jKYT2WE=";
+    hash = "sha256-ZEHxBErjjvofqe3rkkgiEuEJcoluwo+2nZrLfrsHn5Q=";
   };
 
   build-system = [
@@ -45,7 +42,7 @@ buildPythonPackage rec {
     description = "Python module for encoding and language detection";
     mainProgram = "normalizer";
     homepage = "https://charset-normalizer.readthedocs.io/";
-    changelog = "https://github.com/Ousret/charset_normalizer/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/jawah/charset_normalizer/blob/${src.tag}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
   pyproject = true;
 
   # relies on several CPython internals
-  disabled = pythonOlder "3.8" || isPyPy;
+  disabled = isPyPy;
 
   src = fetchFromGitHub {
     owner = "python";
@@ -71,6 +71,7 @@ buildPythonPackage rec {
 
   dependencies = [
     mypy-extensions
+    pathspec
     typing-extensions
   ]
   ++ lib.optionals (pythonOlder "3.11") [ tomli ];
@@ -144,6 +145,7 @@ buildPythonPackage rec {
     description = "Optional static typing for Python";
     homepage = "https://www.mypy-lang.org";
     changelog = "https://github.com/python/mypy/blob/${src.rev}/CHANGELOG.md";
+    downloadPage = "https://github.com/python/mypy";
     license = lib.licenses.mit;
     mainProgram = "mypy";
     maintainers = with lib.maintainers; [ lnl7 ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Follow-up to https://github.com/NixOS/nixpkgs/pull/434240#issuecomment-3202088515

This was a misjudgement during the update, where pathspec was only added
as a build-time dependency.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
