### PR TITLE
peazip: restructure of icon install, addition of 48px icons

### DIFF
--- a/pkgs/by-name/pe/peazip/package.nix
+++ b/pkgs/by-name/pe/peazip/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     # set it to use compression programs from $PATH
-    substituteInPlace dev/peach.pas --replace "  HSYSBIN       = 0;" "  HSYSBIN       = 2;"
+    substituteInPlace dev/peach.pas --replace-fail "  HSYSBIN       = 0;" "  HSYSBIN       = 2;"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pe/peazip/package.nix
+++ b/pkgs/by-name/pe/peazip/package.nix
@@ -96,12 +96,27 @@ stdenv.mkDerivation (finalAttrs: {
     install -D res/share/batch/freedesktop_integration/KDE-servicemenus/KDE3-konqueror/*.desktop -t $out/share/apps/konqueror/servicemenus
 
     # Install desktop entries's icons
-    mkdir -p $out/share/icons/hicolor/256x256/apps
-    ln -s $out/share/peazip/icons/peazip.png -t $out/share/icons/hicolor/256x256/apps/
-    mkdir $out/share/icons/hicolor/256x256/mimetypes
-    ln -s $out/share/peazip/icons/peazip_{7z,zip,cd}.png $out/share/icons/hicolor/256x256/mimetypes/
-    mkdir $out/share/icons/hicolor/256x256/actions
-    ln -s $out/share/peazip/icons/peazip_{add,extract,convert}.png $out/share/icons/hicolor/256x256/actions/
+    for size in {48,256}; do
+      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+      mkdir $out/share/icons/hicolor/"$size"x"$size"/mimetypes
+      mkdir $out/share/icons/hicolor/"$size"x"$size"/actions
+    done
+
+    pushd res/share/batch/freedesktop_integration
+
+    cp peazip.png $out/share/icons/hicolor/256x256/apps/
+    pushd additional-desktop-files
+    cp peazip_{7z,cd,zip}.png $out/share/icons/hicolor/256x256/mimetypes/
+    cp peazip_{add,extract,convert}.png $out/share/icons/hicolor/256x256/actions/
+    popd
+
+    pushd alternative-icons/48px
+    # for some reason the maintainer only made 48px version of *some* icons
+    cp peazip.png $out/share/icons/hicolor/48x48/apps/
+    cp peazip_{add,extract}.png $out/share/icons/hicolor/48x48/actions/
+    popd
+
+    popd
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- the postInstall phase had a bunch of mkdir commands that could've been a for loop. they were not made into a for loop. this is less feasable for the icon copy operations as those are in very specific directories and copy very specific files.
- the 48px icons have been added (fixes #421876)
- substitute's deprecated --replace option has been replaced with --replace-fail (most appropriate in this instance)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
