### PR TITLE
emacs: allow withXwidgets when on darwin with NS

### DIFF
--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -96,10 +96,8 @@
   withX ? !(stdenv.hostPlatform.isDarwin || noGui || withPgtk),
   withXinput2 ? withX,
   withXwidgets ?
-    !stdenv.hostPlatform.isDarwin
-    && !noGui
-    && (withGTK3 || withPgtk)
-    && (lib.versionOlder version "30"), # XXX: upstream bug 66068 precludes newer versions of webkit2gtk (https://lists.gnu.org/archive/html/bug-gnu-emacs/2024-09/msg00695.html)
+    (stdenv.hostPlatform.isDarwin && withNS)
+    || (!noGui && (withGTK3 || withPgtk) && (lib.versionOlder version "30")), # XXX: upstream bug 66068 precludes newer versions of webkit2gtk (https://lists.gnu.org/archive/html/bug-gnu-emacs/2024-09/msg00695.html)
   withSmallJaDic ? false,
   withCompressInstall ? true,
 
@@ -129,7 +127,7 @@ assert withGpm -> stdenv.hostPlatform.isLinux;
 assert withImageMagick -> (withX || withNS);
 assert withNS -> stdenv.hostPlatform.isDarwin && !(withX || variant == "macport");
 assert withPgtk -> withGTK3 && !withX;
-assert withXwidgets -> !noGui && (withGTK3 || withPgtk);
+assert withXwidgets -> (stdenv.isDarwin && withNS) || (!noGui && (withGTK3 || withPgtk));
 
 let
   libGccJitLibraryPaths = [
@@ -348,7 +346,7 @@ mkDerivation (finalAttrs: {
   ++ lib.optionals withXinput2 [
     libXi
   ]
-  ++ lib.optionals withXwidgets [
+  ++ lib.optionals (withXwidgets && stdenv.isLinux) [
     webkitgtk_4_0
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [


### PR DESCRIPTION
This:
1. Modifies the default value of withXwidgets, so that it is true on darwin with NS
2. Modifies the assertion to allow Xwidgets on darwin with NS
3. Only includes webkitgtk when on Linux (macOS bundles WebKit.framework)

There are two possible issues I could see arising from this PR.
1. The default value of Xwidgets is changed on Darwin, to bundling it by default.
- I don't foresee this really being an issue as it just adds a darwin dependency rather than pulling in a bunch of nix dependenies
2. Using Xwidgets on Darwin is now dependent on a system library.
- I don't know what the state of "pure" building of Darwin apps is, whether we can depend on not nix- but system-managed libraries, so this may be a deal breaker.

Lastly, when I rebuilt under `nixpkgs-review`, it rebuilt 65 packages, of which 6 failed: `framac`, `lbdb`, `macvim`, `mu`, `mu.mu4e`, and `vimacs`. Tested separately, `framac`, `macvim`, and `vimacs` failed to build from a vanilla nixpkgs checkout so I don't think this PR affected them, but `lbdb`, `mu`, and `mu.mu4e` ran fine. Their build logs failed for some test reasons? I don't know if this is a blocking issue for the PR, sorry if it is.

I really just want Xwidgets on darwin, I can maintain this separately if this is unfit for nixpkgs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
