### PR TITLE
filius,ipfetch,starfetch: fix use of deprecated command options

### DIFF
--- a/pkgs/by-name/fi/filius/package.nix
+++ b/pkgs/by-name/fi/filius/package.nix
@@ -28,7 +28,7 @@ maven.buildMavenPackage rec {
 
   postPatch = ''
     substituteInPlace src/deb/filius.desktop \
-      --replace 'Exec=/usr/share/filius/filius.sh' 'Exec=filius'
+      --replace-fail 'Exec=/usr/share/filius/filius.sh' 'Exec=filius'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ip/ipfetch/package.nix
+++ b/pkgs/by-name/ip/ipfetch/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
   postPatch = ''
     patchShebangs --host ipfetch
     # Not only does `/usr` have to be replaced but also `/flags` needs to be added because with Nix the script is broken without this. The `/flags` is somehow not needed if you install via the install script in the source repository.
-    substituteInPlace ./ipfetch --replace /usr/share/ipfetch $out/usr/share/ipfetch/flags
+    substituteInPlace ./ipfetch --replace-fail /usr/share/ipfetch $out/usr/share/ipfetch/flags
   '';
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/by-name/st/starfetch/package.nix
+++ b/pkgs/by-name/st/starfetch/package.nix
@@ -16,10 +16,10 @@ stdenv.mkDerivation rec {
   };
 
   postPatch = ''
-    substituteInPlace src/starfetch.cpp --replace /usr/local/ $out/
+    substituteInPlace src/starfetch.cpp --replace-fail /usr/local/ $out/
   ''
   + lib.optionalString stdenv.cc.isClang ''
-    substituteInPlace makefile --replace g++ clang++
+    substituteInPlace makefile --replace-warn g++ clang++
   '';
 
   installPhase = ''


### PR DESCRIPTION
- replaced the deprecated option "--replace" of the substitute command with appropriate replacements in packages maintained by annaaurora

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
