### PR TITLE
signal-desktop-bin: add withAppleEmojis option

### DIFF
--- a/pkgs/by-name/si/signal-desktop-bin/package.nix
+++ b/pkgs/by-name/si/signal-desktop-bin/package.nix
@@ -2,10 +2,11 @@
   stdenv,
   callPackage,
   commandLineArgs ? "",
+  withAppleEmojis ? false,
 }:
 if stdenv.hostPlatform.system == "aarch64-linux" then
-  callPackage ./signal-desktop-aarch64.nix { inherit commandLineArgs; }
+  callPackage ./signal-desktop-aarch64.nix { inherit commandLineArgs withAppleEmojis; }
 else if stdenv.hostPlatform.isDarwin then
   callPackage ./signal-desktop-darwin.nix { }
 else
-  callPackage ./signal-desktop.nix { inherit commandLineArgs; }
+  callPackage ./signal-desktop.nix { inherit commandLineArgs withAppleEmojis; }

--- a/pkgs/by-name/si/signal-desktop-bin/signal-desktop-aarch64.nix
+++ b/pkgs/by-name/si/signal-desktop-bin/signal-desktop-aarch64.nix
@@ -1,5 +1,9 @@
-{ callPackage, commandLineArgs }:
-callPackage ./generic.nix { inherit commandLineArgs; } {
+{
+  callPackage,
+  commandLineArgs,
+  withAppleEmojis,
+}:
+callPackage ./generic.nix { inherit commandLineArgs withAppleEmojis; } {
   pname = "signal-desktop-bin";
   version = "7.64.0";
 

--- a/pkgs/by-name/si/signal-desktop-bin/signal-desktop.nix
+++ b/pkgs/by-name/si/signal-desktop-bin/signal-desktop.nix
@@ -1,5 +1,9 @@
-{ callPackage, commandLineArgs }:
-callPackage ./generic.nix { inherit commandLineArgs; } rec {
+{
+  callPackage,
+  commandLineArgs,
+  withAppleEmojis,
+}:
+callPackage ./generic.nix { inherit commandLineArgs withAppleEmojis; } rec {
   pname = "signal-desktop-bin";
   version = "7.64.0";
 


### PR DESCRIPTION
adds the [withAppleEmojis option from the from source version](https://github.com/NixOS/nixpkgs/blob/226bb7c9df5f953fd7533e199b8d9e5475458a8a/pkgs/by-name/si/signal-desktop/package.nix#L21) to the binary version.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
