### PR TITLE
yaziPlugins.recycle-bin: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9741,6 +9741,11 @@
     githubId = 28863828;
     name = "guserav";
   };
+  guttermonk = {
+    github = "guttermonk";
+    githubId = 4753752;
+    name = "guttermonk";
+  };
   guyonvarch = {
     github = "guyonvarch";
     githubId = 6768842;

--- a/pkgs/by-name/ya/yazi/plugins/recycle-bin/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/recycle-bin/default.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkYaziPlugin,
+}:
+mkYaziPlugin {
+  pname = "recycle-bin.yazi";
+  version = "1.0.0-unstable-2025-08-20";
+
+  src = fetchFromGitHub {
+    owner = "uhs-robert";
+    repo = "recycle-bin.yazi";
+    rev = "3f36069567b4602f841f2377c5f182f9a2480dea";
+    hash = "sha256-1z92wbadcnljj019b1r89l38zyd0nnpm22m269502drbj65grlkz";
+  };
+
+  meta = {
+    description = "A Recycle Bin for Yazi with browse, restore, and cleanup capabilities";
+    homepage = "https://github.com/uhs-robert/recycle-bin.yazi";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/ya/yazi/plugins/recycle-bin/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/recycle-bin/default.nix
@@ -10,15 +10,15 @@ mkYaziPlugin {
   src = fetchFromGitHub {
     owner = "uhs-robert";
     repo = "recycle-bin.yazi";
-    rev = "3f36069567b4602f841f2377c5f182f9a2480dea";
-    hash = "sha256-1z92wbadcnljj019b1r89l38zyd0nnpm22m269502drbj65grlkz";
+    rev = "52f6fe08f5f42cbae56d8c46abc368560e1e2d6e";
+    hash = "sha256-krZAbL7JRRvJbT+23C6fw8Zbav+8I+bvIFAYrpeNuhw=";
   };
 
   meta = {
-    description = "A Recycle Bin for Yazi with browse, restore, and cleanup capabilities";
+    description = "Recycle Bin for Yazi with browse, restore, and cleanup capabilities";
     homepage = "https://github.com/uhs-robert/recycle-bin.yazi";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ guttermonk ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
Added yazi recycle-bin plugin to nixpkgs: https://github.com/uhs-robert/recycle-bin.yazi/releases/tag/v1.0.0


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
