### PR TITLE
yaziPlugins: update on 2025-08-19

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/lazygit/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/lazygit/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "lazygit.yazi";
-  version = "0-unstable-2025-03-31";
+  version = "0-unstable-2025-08-06";
 
   src = fetchFromGitHub {
     owner = "Lil-Dank";
     repo = "lazygit.yazi";
-    rev = "7a08a0988c2b7481d3f267f3bdc58080e6047e7d";
-    hash = "sha256-OJJPgpSaUHYz8a9opVLCds+VZsK1B6T+pSRJyVgYNy8=";
+    rev = "8f37dc5795f165021098b17d797c7b8f510aeca9";
+    hash = "sha256-rR7SMTtQYrvQjhkzulDaNH/LAA77UnXkcZ50WwBX2Uw=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mediainfo.yazi";
-  version = "25.5.31-unstable-2025-07-19";
+  version = "25.5.31-unstable-2025-08-06";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "mediainfo.yazi";
-    rev = "f89605ce7ca33181ee6770e641d80ec4673093e0";
-    hash = "sha256-NloChkZWKo9JL636d+G7vgEY/HX24udngYftw/Ydzk4=";
+    rev = "0e2ae47cfb2b7c7a32d714c753b1cebbaa75d127";
+    hash = "sha256-CHigaujMHd1BuYyyxzI5B4ZYQhuH2YZptVVJToq39sY=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mount/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mount/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mount.yazi";
-  version = "25.5.31-unstable-2025-07-02";
+  version = "25.5.31-unstable-2025-08-11";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "e5f00e2716fd177b0ca0d313f1a6e64f01c12760";
-    hash = "sha256-DLcmzCmITybWrYuBpTyswtoGUimpagkyeVUWmbKjarY=";
+    rev = "e95c7b384e7b0a9793fe1471f0f8f7810ef2a7ed";
+    hash = "sha256-TUS+yXxBOt6tL/zz10k4ezot8IgVg0/2BbS8wPs9KcE=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/restore/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/restore/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "restore.yazi";
-  version = "25.5.31-unstable-2025-07-11";
+  version = "25.5.31-unstable-2025-08-12";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "restore.yazi";
-    rev = "84f1921806c49b7b20af26cbe57cb4fd286142e2";
-    hash = "sha256-pEQZ/2Z4XVYlfzqtCz51bIgE9KzkDF/qyX8vThhlWGI=";
+    rev = "2a2ba2fbaee72f88054a43723becf66c3cfb892e";
+    hash = "sha256-FqvQuKNH3jjXQ/7N7MsUsOoh9DTreZTjpdQ4lrr2iLk=";
   };
 
   meta = {


### PR DESCRIPTION
- lazygit: 0-unstable-2025-03-31 → 0-unstable-2025-08-06
- mediainfo: 25.5.31-unstable-2025-07-19 → 25.5.31-unstable-2025-08-06
- mount: 25.5.31-unstable-2025-07-02 → 25.5.31-unstable-2025-08-11
- restore: 25.5.31-unstable-2025-07-11 → 25.5.31-unstable-2025-08-12

https://github.com/NixOS/nixpkgs/pull/435142 reminded me I haven't done this in a bit. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
