### PR TITLE
kotlin-lsp: init at 0.253.10629

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19297,6 +19297,12 @@
     githubId = 645664;
     name = "Philippe Hürlimann";
   };
+  p-louis = {
+    email = "patrick.louis@mailbox.org";
+    github = "p-louis";
+    githubId = 20523289;
+    name = "Patrick Louis";
+  };
   p-rintz = {
     email = "nix@rintz.net";
     github = "p-rintz";

--- a/pkgs/by-name/ko/kotlin-lsp/package.nix
+++ b/pkgs/by-name/ko/kotlin-lsp/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  openjdk,
+  gradle,
+  makeWrapper,
+  maven,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "kotlin-lsp";
+  version = "0.253.10629";
+  src = fetchzip {
+    stripRoot = false;
+    url = "https://download-cdn.jetbrains.com/kotlin-lsp/${version}/kotlin-${version}.zip";
+    hash = "sha256-LCLGo3Q8/4TYI7z50UdXAbtPNgzFYtmUY/kzo2JCln0=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/lib
+    mkdir -p $out/native
+    mkdir -p $out/bin
+    cp -r lib/* $out/lib
+    ls -la
+    cp -r native/* $out/native
+    chmod +x kotlin-lsp.sh
+    cp "kotlin-lsp.sh" "$out/kotlin-lsp.sh"
+    ln -s $out/kotlin-lsp.sh $out/bin/kotlin-lsp
+  '';
+
+  nativeBuildInputs = [
+    gradle
+    makeWrapper
+  ];
+  buildInputs = [
+    openjdk
+    gradle
+  ];
+
+  postFixup = ''
+    wrapProgram "$out/bin/kotlin-lsp" --set JAVA_HOME ${openjdk} --prefix PATH : ${
+      lib.strings.makeBinPath [
+        openjdk
+        maven
+      ]
+    }
+  '';
+
+  meta = {
+    description = "Kotlin LSP";
+    longDescription = ''
+      Official LSP implementation for Kotlin code completion, linting and more
+      for any editor/IDE'';
+    maintainers = with lib.maintainers; [ p-louis ];
+    homepage = "https://github.com/Kotlin/kotlin-lsp";
+    changelog = "https://github.com/Kotlin/kotlin-lsp/blob/main/RELEASES.md";
+    license = lib.licenses.als20;
+    platforms = lib.platforms.unix;
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+    mainProgram = "kotlin-lsp";
+  };
+}

--- a/pkgs/by-name/ko/kotlin-lsp/package.nix
+++ b/pkgs/by-name/ko/kotlin-lsp/package.nix
@@ -2,63 +2,95 @@
   lib,
   stdenv,
   fetchzip,
-  openjdk,
-  gradle,
-  makeWrapper,
-  maven,
+  autoPatchelfHook,
+  wayland,
+  libgcc,
+  libx11,
+  libxi,
+  freetype,
+  alsa-lib,
+  libxrender,
+  libxtst,
+  zlib,
 }:
+let
+  system = stdenv.hostPlatform.system;
+  platformSuffix =
+    {
+      "x86_64-linux" = "linux-x64";
+      "aarch64-linux" = "linux-aarch64";
+      "x86_64-darwin" = "macos-x64";
+      "aarch64-darwin" = "macos-aarch64";
+    }
+    .${system};
 
+  hash =
+    {
+      "x86_64-linux" = "sha256-EweSqy30NJuxvlJup78O+e+JOkzvUdb6DshqAy1j9jE=";
+      "aarch64-linux" = "sha256-MhHEYHBctaDH9JVkN/guDCG1if9Bip1aP3n+JkvHCvA=";
+      "x86_64-darwin" = "sha256-zMuUcahT1IiCT1NTrMCIzUNM0U6U3zaBkJtbGrzF7I8=";
+      "aarch64-darwin" = "sha256-zwlzVt3KYN0OXKr6sI9XSijXSbTImomSTGRGa+3zCK8=";
+    }
+    .${system};
+in
 stdenv.mkDerivation rec {
   pname = "kotlin-lsp";
-  version = "0.253.10629";
+  version = "261.13587.0";
+
   src = fetchzip {
+    inherit hash;
     stripRoot = false;
-    url = "https://download-cdn.jetbrains.com/kotlin-lsp/${version}/kotlin-${version}.zip";
-    hash = "sha256-LCLGo3Q8/4TYI7z50UdXAbtPNgzFYtmUY/kzo2JCln0=";
+    url = "https://download-cdn.jetbrains.com/kotlin-lsp/${version}/kotlin-lsp-${version}-${platformSuffix}.zip";
   };
 
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
+    freetype
+    libgcc.lib
+    libx11
+    libxi
+    libxrender
+    libxtst
+    wayland
+    zlib
+  ];
+
+  dontConfigure = true;
   dontBuild = true;
 
   installPhase = ''
-    mkdir -p $out/lib
-    mkdir -p $out/native
-    mkdir -p $out/bin
-    cp -r lib/* $out/lib
-    ls -la
-    cp -r native/* $out/native
-    chmod +x kotlin-lsp.sh
-    cp "kotlin-lsp.sh" "$out/kotlin-lsp.sh"
-    ln -s $out/kotlin-lsp.sh $out/bin/kotlin-lsp
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib/kotlin-lsp
+    cp -r * $out/lib/kotlin-lsp
+    chmod +x $out/lib/kotlin-lsp/jre/bin/java
+    chmod +x $out/lib/kotlin-lsp/kotlin-lsp.sh
+    ln -s $out/lib/kotlin-lsp/kotlin-lsp.sh $out/bin/kotlin-lsp
+
+    runHook postInstall
   '';
 
-  nativeBuildInputs = [
-    gradle
-    makeWrapper
-  ];
-  buildInputs = [
-    openjdk
-    gradle
-  ];
-
-  postFixup = ''
-    wrapProgram "$out/bin/kotlin-lsp" --set JAVA_HOME ${openjdk} --prefix PATH : ${
-      lib.strings.makeBinPath [
-        openjdk
-        maven
-      ]
-    }
+  postInstall = ''
+    substituteInPlace $out/lib/kotlin-lsp/kotlin-lsp.sh \
+      --replace 'chmod +x "$LOCAL_JRE_PATH/bin/java"' '# chmod removed for NixOS'
   '';
 
   meta = {
-    description = "Kotlin LSP";
-    longDescription = ''
-      Official LSP implementation for Kotlin code completion, linting and more
-      for any editor/IDE'';
+    description = "LSP implementation for Kotlin code completion, linting";
     maintainers = with lib.maintainers; [ p-louis ];
     homepage = "https://github.com/Kotlin/kotlin-lsp";
-    changelog = "https://github.com/Kotlin/kotlin-lsp/blob/main/RELEASES.md";
-    license = lib.licenses.als20;
-    platforms = lib.platforms.unix;
+    changelog = "https://github.com/Kotlin/kotlin-lsp/blob/kotlin-lsp/v${version}/RELEASES.md";
+    license = lib.licenses.asl20;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
     sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
     mainProgram = "kotlin-lsp";
   };


### PR DESCRIPTION
This PR adds the kotlin-lsp package in the latest available version at the time of writing this.

Considering this is the official LSP implementation it will supersede `kotlin-language-server` in the long run.

Release notes:
https://github.com/Kotlin/kotlin-lsp/releases/tag/kotlin-lsp%2Fv0.253.10629

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
