### PR TITLE
nirius: init at 0.4.3

### DIFF
--- a/pkgs/by-name/ni/nirius/package.nix
+++ b/pkgs/by-name/ni/nirius/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchFromSourcehut,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nirius";
+  version = "0.4.3";
+
+  src = fetchFromSourcehut {
+    owner = "~tsdh";
+    repo = "nirius";
+    rev = "nirius-${version}";
+    hash = "sha256-JAoKuM+A9AO1erhpWIYKq8lWjRAYjDKqxf1r/Fu2IAM=";
+  };
+
+  cargoHash = "sha256-btau5IVJ4PWK65eU1F7cmUzF4MOj8FEc4p8KhHg03QQ=";
+
+  meta = {
+    description = "Utility commands for the niri wayland compositor";
+    mainProgram = "nirius";
+    homepage = "https://git.sr.ht/~tsdh/nirius";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ tylerjl ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
[nirius](https://git.sr.ht/~tsdh/nirius) is a sibling daemon to niri that facilitates a few extra capabilities. It's primary use is as a userland daemon, so the intent here is to eventually get a module into home-manager, but we can define the package in `nixpkgs` upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
