### PR TITLE
trayscale: fix version number display

### DIFF
--- a/pkgs/by-name/tr/trayscale/package.nix
+++ b/pkgs/by-name/tr/trayscale/package.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X=deedles.dev/trayscale/internal/version.version=${version}"
+    "-X=deedles.dev/trayscale/internal/metadata.version=${version}"
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Without this change, it displays `(devel)` in the version number

## nixos-25.05(0.16.0)

<img width="520" height="420" alt="Screenshot From 2025-08-20 16-35-44" src="https://github.com/user-attachments/assets/bec98007-821d-458c-8b23-09267316352e" />

## nixos-unstable(0.18.3)

<img width="520" height="420" alt="Screenshot From 2025-08-20 16-16-54" src="https://github.com/user-attachments/assets/bb8cde59-68d3-453a-a91f-f9114321ed76" />

## After this change(`nix build` and running `./bin/.trayscale-wrapped`)

I guess the app icon will be fixed if running with nix run. I'll test it after few hours/days ago(This package takes long time to build) 

<img width="520" height="420" alt="image" src="https://github.com/user-attachments/assets/19781de0-c42d-4a32-b714-4a0d961ae476" />

ref: https://github.com/DeedleFake/trayscale/commit/9948effb47c5e604e166d08799148656df24f729
follow: https://github.com/NixOS/nixpkgs/pull/410423

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc: @sikmir 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

