### PR TITLE
nixos/public-inbox: fix inboxdir option

### DIFF
--- a/nixos/modules/services/mail/public-inbox.nix
+++ b/nixos/modules/services/mail/public-inbox.nix
@@ -630,7 +630,7 @@ in
               ''
               + concatStrings (
                 mapAttrsToList (name: inbox: ''
-                  if [ ! -e ${stateDir}/inboxes/${escapeShellArg name} ]; then
+                  if [ ! -e ${escapeShellArg inbox.inboxdir} ]; then
                     # public-inbox-init creates an inbox and adds it to a config file.
                     # It tries to atomically write the config file by creating
                     # another file in the same directory, and renaming it.
@@ -643,7 +643,7 @@ in
                       ${escapeShellArgs (
                         [
                           name
-                          "${stateDir}/inboxes/${name}"
+                          inbox.inboxdir
                           inbox.url
                         ]
                         ++ inbox.address
@@ -653,9 +653,9 @@ in
                   fi
 
                   ln -sf ${inbox.description} \
-                    ${stateDir}/inboxes/${escapeShellArg name}/description
+                    ${escapeShellArg inbox.inboxdir}/description
 
-                  export GIT_DIR=${stateDir}/inboxes/${escapeShellArg name}/all.git
+                  export GIT_DIR=${escapeShellArg inbox.inboxdir}/all.git
                   if test -d "$GIT_DIR"; then
                     # Config is inherited by each epoch repository,
                     # so just needs to be set for all.git.


### PR DESCRIPTION
This wasn't consistently used — sometimes the default value was hardcoded.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
