### PR TITLE
weasis: 4.6.2 -> 4.6.3; add support for aarch64-darwin and aarch64-linux

### DIFF
--- a/pkgs/by-name/we/weasis/package.nix
+++ b/pkgs/by-name/we/weasis/package.nix
@@ -13,6 +13,7 @@ let
     attrs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   platform = selectSystem {
     "x86_64-linux" = "linux-x86-64";
+    "aarch64-linux" = "linux-aarch64";
     "aarch64-darwin" = "macosx-aarch64";
   };
 
@@ -85,8 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
       epl20
     ];
     maintainers = [ ];
-    platforms = [
-      "x86_64-linux"
+    platforms = lib.platforms.linux ++ [
       "aarch64-darwin"
     ];
     mainProgram = "Weasis";

--- a/pkgs/by-name/we/weasis/package.nix
+++ b/pkgs/by-name/we/weasis/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchzip,
   jdk24,
+  unzip,
   copyDesktopItems,
   makeDesktopItem,
 }:
@@ -14,6 +15,7 @@ let
   platform = selectSystem {
     "x86_64-linux" = "linux-x86-64";
     "aarch64-linux" = "linux-aarch64";
+    "x86_64-darwin" = "macosx-x86-64";
     "aarch64-darwin" = "macosx-aarch64";
   };
 
@@ -29,7 +31,10 @@ stdenv.mkDerivation (finalAttrs: {
     stripRoot = false;
   };
 
-  nativeBuildInputs = [ copyDesktopItems ];
+  nativeBuildInputs = [
+    copyDesktopItems
+  ]
+  ++ lib.optional stdenv.isDarwin unzip;
 
   desktopItems = [
     (makeDesktopItem {
@@ -86,9 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
       epl20
     ];
     maintainers = [ ];
-    platforms = lib.platforms.linux ++ [
-      "aarch64-darwin"
-    ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     mainProgram = "Weasis";
   };
 })

--- a/pkgs/by-name/we/weasis/package.nix
+++ b/pkgs/by-name/we/weasis/package.nix
@@ -19,12 +19,12 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "weasis";
-  version = "4.6.2";
+  version = "4.6.3";
 
   # Their build instructions indicate to use the packaging script
   src = fetchzip {
     url = "https://github.com/nroduit/Weasis/releases/download/v${finalAttrs.version}/weasis-native.zip";
-    hash = "sha256-7oYrUNj9BBcFh+1CQQ4PJW8ln+fd5Ed9y9tMoixc5Mc=";
+    hash = "sha256-1dvBKxInuk8FpZjo59+LkIuEBTr57wkLaHfvvvT6bOg=";
     stripRoot = false;
   };
 

--- a/pkgs/by-name/we/weasis/package.nix
+++ b/pkgs/by-name/we/weasis/package.nix
@@ -13,6 +13,7 @@ let
     attrs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   platform = selectSystem {
     "x86_64-linux" = "linux-x86-64";
+    "aarch64-darwin" = "macosx-aarch64";
   };
 
 in
@@ -60,12 +61,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   installPhase = ''
     runHook preInstall
-
+  ''
+  + lib.optionalString stdenv.isLinux ''
     mkdir -p $out/share/{applications,pixmaps}
-
     mv weasis-${platform}-jdk${lib.versions.major jdk24.version}-${finalAttrs.version}/Weasis/* $out/
     mv $out/lib/*.png $out/share/pixmaps/
-
+  ''
+  + lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/Applications
+    mv weasis-${platform}-jdk${lib.versions.major jdk24.version}-${finalAttrs.version}/Weasis.app $out/Applications/
+  ''
+  + ''
     runHook postInstall
   '';
 
@@ -79,7 +85,10 @@ stdenv.mkDerivation (finalAttrs: {
       epl20
     ];
     maintainers = [ ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-darwin"
+    ];
     mainProgram = "Weasis";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
