### PR TITLE
muon: 0.4.0 -> 0.5.0, unbreak on darwin, enable tests

### DIFF
--- a/pkgs/by-name/mu/muon/darwin-clang.patch
+++ b/pkgs/by-name/mu/muon/darwin-clang.patch
@@ -1,0 +1,15 @@
+diff --git a/src/functions/kernel/dependency.c b/src/functions/kernel/dependency.c
+index fbfc86f6..46f9be9d 100644
+--- a/src/functions/kernel/dependency.c
++++ b/src/functions/kernel/dependency.c
+@@ -377,10 +377,6 @@ get_dependency_extraframework(struct workspace *wk, struct dep_lookup_ctx *ctx,
+ 	}
+ 
+ 	struct obj_compiler *comp = get_obj_compiler(wk, compiler);
+-	if (comp->type[toolchain_component_compiler] != compiler_apple_clang) {
+-		L("skipping extraframework dependency lookup: compiler type is not apple clang");
+-		return true;
+-	}
+ 
+ 	if (!comp->fwdirs) {
+ 		obj cmd;

--- a/pkgs/by-name/mu/muon/package.nix
+++ b/pkgs/by-name/mu/muon/package.nix
@@ -2,7 +2,8 @@
   lib,
   stdenv,
   fetchFromSourcehut,
-  fetchurl,
+  fetchFromGitHub,
+  coreutils,
   curl,
   libarchive,
   libpkgconf,
@@ -10,33 +11,51 @@
   python3,
   samurai,
   scdoc,
+  writableTmpDirAsHomeHook,
   zlib,
   embedSamurai ? false,
   buildDocs ? true,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "muon" + lib.optionalString embedSamurai "-embedded-samurai";
-  version = "0.4.0";
+  version = "0.5.0";
 
-  src = fetchFromSourcehut {
-    name = "muon-src";
-    owner = "~lattis";
-    repo = "muon";
-    tag = finalAttrs.version;
-    hash = "sha256-xTdyqK8t741raMhjjJBMbWnAorLMMdZ02TeMXK7O+Yw=";
-  };
+  srcs = [
+    (fetchFromSourcehut {
+      name = "muon-src";
+      owner = "~lattis";
+      repo = "muon";
+      tag = finalAttrs.version;
+      hash = "sha256-bWEYWUD+GK8R3yVnDTnzFWmm4KAuVPI+1yMfCXWcG/A=";
+    })
+    (fetchFromGitHub {
+      name = "meson-tests";
+      repo = "meson-tests";
+      owner = "muon-build";
+      rev = "db92588773a24f67cda2f331b945825ca3a63fa7";
+      hash = "sha256-z4Fc1lr/m2MwIwhXJwoFWpzeNg+udzMxuw5Q/zVvpSM=";
+    })
+  ]
+  ++ lib.optionals buildDocs [
+    (fetchFromGitHub {
+      name = "meson-docs";
+      repo = "meson-docs";
+      owner = "muon-build";
+      rev = "1017b3413601044fb41ad04977445e68a80e8181";
+      hash = "sha256-aFpyJFIqybLNKhm/kyfCjYylj7DE6muI1+OUh4Cq4WY=";
+    })
+  ];
+
+  sourceRoot = "./muon-src";
 
   outputs = [ "out" ] ++ lib.optionals buildDocs [ "man" ];
 
   nativeBuildInputs = [
     pkgconf
+    (python3.withPackages (ps: [ ps.pyyaml ]))
   ]
   ++ lib.optionals (!embedSamurai) [ samurai ]
-  ++ lib.optionals buildDocs [
-    (python3.withPackages (ps: [ ps.pyyaml ]))
-    scdoc
-  ];
+  ++ lib.optionals buildDocs [ scdoc ];
 
   buildInputs = [
     curl
@@ -47,54 +66,43 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  postUnpack =
-    let
-      # URLs manually extracted from subprojects directory
-      meson-docs-wrap = fetchurl {
-        name = "meson-docs-wrap";
-        url = "https://github.com/muon-build/meson-docs/archive/5bc0b250984722389419dccb529124aed7615583.tar.gz";
-        hash = "sha256-5MmmiZfadCuUJ2jy5Rxubwf4twX0jcpr+TPj5ssdSbM=";
-      };
-
-      meson-tests-wrap = fetchurl {
-        name = "meson-tests-wrap";
-        url = "https://github.com/muon-build/meson-tests/archive/591b5a053f9aa15245ccbd1d334cf3f8031b1035.tar.gz";
-        hash = "sha256-6GXfcheZyB/S/xl/j7pj5EAWtsmx4N0fVhLPMJ2wC/w=";
-      };
-    in
-    ''
-      mkdir -p $sourceRoot/subprojects/meson-docs
-      pushd $sourceRoot/subprojects/meson-docs
-      ${lib.optionalString buildDocs "tar xvf ${meson-docs-wrap} --strip-components=1"}
-      popd
-
-      mkdir -p $sourceRoot/subprojects/meson-tests
-      pushd $sourceRoot/subprojects/meson-tests
-      tar xvf ${meson-tests-wrap} --strip-components=1
-      popd
-    '';
+  postUnpack = ''
+    for subproject in ${lib.optionalString buildDocs "meson-docs"} meson-tests; do
+      cp -r "$subproject" "$sourceRoot/subprojects/$subproject"
+      chmod +w -R "$sourceRoot/subprojects/$subproject"
+      rm "$sourceRoot/subprojects/$subproject.wrap"
+    done
+  '';
 
   postPatch = ''
-    patchShebangs bootstrap.sh
-  ''
-  + lib.optionalString buildDocs ''
-    patchShebangs subprojects/meson-docs/docs/genrefman.py
+    find subprojects/meson-tests -name "*.py" -exec chmod +x {} \;
+    patchShebangs .
+
+    substituteInPlace \
+      "subprojects/meson-tests/common/14 configure file/test.py.in" \
+      "subprojects/meson-tests/common/274 customtarget exe for test/generate.py" \
+      "subprojects/meson-tests/native/8 external program shebang parsing/script.int.in" \
+        --replace-fail "/usr/bin/env" "${coreutils}/bin/env"
+
+    substituteInPlace \
+      "subprojects/meson-tests/meson.build" \
+        --replace-fail "['common/66 vcstag', {'python': true}]," ""
   '';
 
-  # tests try to access "~"
-  postConfigure = ''
-    export HOME=$(mktemp -d)
-  '';
+  enableParallelBuilding = true;
 
   buildPhase =
     let
       muonBool = lib.mesonBool;
       muonEnable = lib.mesonEnable;
+      muonOption = lib.mesonOption;
 
       cmdlineForMuon = lib.concatStringsSep " " [
+        (muonOption "prefix" (placeholder "out"))
         (muonBool "static" stdenv.targetPlatform.isStatic)
-        (muonEnable "docs" buildDocs)
+        (muonEnable "meson-docs" buildDocs)
         (muonEnable "samurai" embedSamurai)
+        (muonEnable "tracy" false)
       ];
       cmdlineForSamu = "-j$NIX_BUILD_CORES";
     in
@@ -108,19 +116,24 @@ stdenv.mkDerivation (finalAttrs: {
       ./stage-1/muon-bootstrap setup ${cmdlineForMuon} stage-2
       ${lib.optionalString embedSamurai "./stage-1/muon-bootstrap"} samu ${cmdlineForSamu} -C stage-2
 
-      ./stage-2/muon setup -Dprefix=$out ${cmdlineForMuon} stage-3
+      ./stage-2/muon setup ${cmdlineForMuon} stage-3
       ${lib.optionalString embedSamurai "./stage-2/muon"} samu ${cmdlineForSamu} -C stage-3
 
       runHook postBuild
     '';
 
-  # tests are failing because they don't find Python
-  doCheck = false;
+  # tests only pass when samurai is embedded
+  doCheck = embedSamurai;
+
+  nativeCheckInputs = [
+    # needed for "common/220 fs module"
+    writableTmpDirAsHomeHook
+  ];
 
   checkPhase = ''
     runHook preCheck
 
-    ./stage-3/muon -C stage-3 test
+    ./stage-3/muon -C stage-3 test -d dots -S -j$NIX_BUILD_CORES
 
     runHook postCheck
   '';
@@ -146,4 +159,3 @@ stdenv.mkDerivation (finalAttrs: {
 # TODO LIST:
 # 1. automate sources acquisition (especially wraps)
 # 2. setup hook
-# 3. tests

--- a/pkgs/by-name/mu/muon/package.nix
+++ b/pkgs/by-name/mu/muon/package.nix
@@ -74,6 +74,8 @@ stdenv.mkDerivation (finalAttrs: {
     done
   '';
 
+  patches = [ ./darwin-clang.patch ];
+
   postPatch = ''
     find subprojects/meson-tests -name "*.py" -exec chmod +x {} \;
     patchShebangs .
@@ -133,6 +135,9 @@ stdenv.mkDerivation (finalAttrs: {
   checkPhase = ''
     runHook preCheck
 
+    ${lib.optionalString (
+      stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64
+    ) "NIX_BUILD_CORES=1"}
     ./stage-3/muon -C stage-3 test -d dots -S -j$NIX_BUILD_CORES
 
     runHook postCheck
@@ -152,7 +157,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ ];
     platforms = platforms.unix;
-    broken = stdenv.hostPlatform.isDarwin; # typical `ar failure`
     mainProgram = "muon";
   };
 })

--- a/pkgs/by-name/mu/muon/package.nix
+++ b/pkgs/by-name/mu/muon/package.nix
@@ -1,8 +1,9 @@
 {
   lib,
   stdenv,
-  fetchFromSourcehut,
   fetchFromGitHub,
+  fetchFromSourcehut,
+  callPackage,
   coreutils,
   curl,
   libarchive,
@@ -20,31 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "muon" + lib.optionalString embedSamurai "-embedded-samurai";
   version = "0.5.0";
 
-  srcs = [
-    (fetchFromSourcehut {
-      name = "muon-src";
-      owner = "~lattis";
-      repo = "muon";
-      tag = finalAttrs.version;
-      hash = "sha256-bWEYWUD+GK8R3yVnDTnzFWmm4KAuVPI+1yMfCXWcG/A=";
-    })
-    (fetchFromGitHub {
-      name = "meson-tests";
-      repo = "meson-tests";
-      owner = "muon-build";
-      rev = "db92588773a24f67cda2f331b945825ca3a63fa7";
-      hash = "sha256-z4Fc1lr/m2MwIwhXJwoFWpzeNg+udzMxuw5Q/zVvpSM=";
-    })
-  ]
-  ++ lib.optionals buildDocs [
-    (fetchFromGitHub {
-      name = "meson-docs";
-      repo = "meson-docs";
-      owner = "muon-build";
-      rev = "1017b3413601044fb41ad04977445e68a80e8181";
-      hash = "sha256-aFpyJFIqybLNKhm/kyfCjYylj7DE6muI1+OUh4Cq4WY=";
-    })
-  ];
+  srcs = builtins.attrValues finalAttrs.passthru.srcs;
 
   sourceRoot = "./muon-src";
 
@@ -151,15 +128,39 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  meta = with lib; {
-    homepage = "https://muon.build/";
-    description = "Implementation of Meson build system in C99";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ ];
-    platforms = platforms.unix;
+  passthru.srcs = {
+    muon-src = fetchFromSourcehut {
+      name = "muon-src";
+      owner = "~lattis";
+      repo = "muon";
+      tag = finalAttrs.version;
+      hash = "sha256-bWEYWUD+GK8R3yVnDTnzFWmm4KAuVPI+1yMfCXWcG/A=";
+    };
+    meson-docs = fetchFromGitHub {
+      name = "meson-docs";
+      repo = "meson-docs";
+      owner = "muon-build";
+      rev = "1017b3413601044fb41ad04977445e68a80e8181";
+      hash = "sha256-aFpyJFIqybLNKhm/kyfCjYylj7DE6muI1+OUh4Cq4WY=";
+    };
+    meson-tests = fetchFromGitHub {
+      name = "meson-tests";
+      repo = "meson-tests";
+      owner = "muon-build";
+      rev = "db92588773a24f67cda2f331b945825ca3a63fa7";
+      hash = "sha256-z4Fc1lr/m2MwIwhXJwoFWpzeNg+udzMxuw5Q/zVvpSM=";
+    };
+  };
+  passthru.updateScript = callPackage ./update.nix { };
+
+  meta = {
+    homepage = "https://muon.build";
+    description = "Implementation of the meson build system in C99";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
     mainProgram = "muon";
   };
 })
 # TODO LIST:
-# 1. automate sources acquisition (especially wraps)
-# 2. setup hook
+# 1. setup hook

--- a/pkgs/by-name/mu/muon/update.nix
+++ b/pkgs/by-name/mu/muon/update.nix
@@ -16,20 +16,20 @@ lib.getExe (writeShellApplication {
   ];
 
   text = ''
-    REPO=$(nix-instantiate --raw --eval -E "with import ./. {}; muon.passthru.srcs.muon-src.meta.homepage")
+    REPO=$(nix-instantiate --raw --eval -E "with import ./. {}; muon.srcsAttrs.muon-src.meta.homepage")
     MUON_VERSION=$(list-git-tags --url="$REPO" | tail -1)
 
     update-source-version "muon" \
       "$MUON_VERSION" \
       --version-key=version \
-      --source-key=passthru.srcs.muon-src
+      --source-key=srcsAttrs.muon-src
     update-source-version "muon" \
       "$(curl -s "$REPO/blob/$MUON_VERSION/subprojects/meson-docs.wrap" | grep -oP "revision = \K.+$")" \
-      --version-key=passthru.srcs.meson-docs.rev \
-      --source-key=passthru.srcs.meson-docs
+      --version-key=srcsAttrs.meson-docs.rev \
+      --source-key=srcsAttrs.meson-docs
     update-source-version "muon" \
       "$(curl -s "$REPO/blob/$MUON_VERSION/subprojects/meson-tests.wrap" | grep -oP "revision = \K.+$")" \
-      --version-key=passthru.srcs.meson-tests.rev \
-      --source-key=passthru.srcs.meson-tests
+      --version-key=srcsAttrs.meson-tests.rev \
+      --source-key=srcsAttrs.meson-tests
   '';
 })

--- a/pkgs/by-name/mu/muon/update.nix
+++ b/pkgs/by-name/mu/muon/update.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  writeShellApplication,
+  common-updater-scripts,
+  curl,
+  gnugrep,
+}:
+
+lib.getExe (writeShellApplication {
+  name = "update-muon";
+
+  runtimeInputs = [
+    common-updater-scripts
+    curl
+    gnugrep
+  ];
+
+  text = ''
+    REPO=$(nix-instantiate --raw --eval -E "with import ./. {}; muon.passthru.srcs.muon-src.meta.homepage")
+    MUON_VERSION=$(list-git-tags --url="$REPO" | tail -1)
+
+    update-source-version "muon" \
+      "$MUON_VERSION" \
+      --version-key=version \
+      --source-key=passthru.srcs.muon-src
+    update-source-version "muon" \
+      "$(curl -s "$REPO/blob/$MUON_VERSION/subprojects/meson-docs.wrap" | grep -oP "revision = \K.+$")" \
+      --version-key=passthru.srcs.meson-docs.rev \
+      --source-key=passthru.srcs.meson-docs
+    update-source-version "muon" \
+      "$(curl -s "$REPO/blob/$MUON_VERSION/subprojects/meson-tests.wrap" | grep -oP "revision = \K.+$")" \
+      --version-key=passthru.srcs.meson-tests.rev \
+      --source-key=passthru.srcs.meson-tests
+  '';
+})


### PR DESCRIPTION
Updates muon to 0.5.0 ([changelog](https://docs.muon.build/release_notes.html#-050)). It now includes a meson/muon LSP.

Tests are now passing when building it with embedded samurai. They're run in the package tests, rather than doCheck being enabled by default to keep the required dependencies to a minimum.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
