### PR TITLE
{titanion,torus-trooper,tumiki-fighters}: use LDC

### DIFF
--- a/pkgs/by-name/ti/titanion/package.nix
+++ b/pkgs/by-name/ti/titanion/package.nix
@@ -4,7 +4,7 @@
   fetchpatch,
   fetchurl,
   unzip,
-  gdc,
+  ldc,
   libGL,
   libGLU,
   SDL,
@@ -17,7 +17,7 @@ let
     patchname: hash:
     fetchpatch {
       name = "${patchname}.patch";
-      url = "https://sources.debian.org/data/main/t/titanion/0.3.dfsg1-7/debian/patches/${patchname}";
+      url = "https://sources.debian.org/data/main/t/titanion/0.3.dfsg1-8/debian/patches/${patchname}";
       inherit hash;
     };
 
@@ -43,6 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     (debianPatch "makefile.patch" "sha256-g0jDPmc0SWXkTLhiczeTse/WGCtgMUsbyPNZzwK3U+o=")
     (debianPatch "dlang_v2.patch" "sha256-tfTAAKlPFSjbfAK1EjeB3unj9tbMlNaajJ+VVSMMiYw=")
     (debianPatch "gdc-8.patch" "sha256-BxkPfSEymq7TDA+yjJHaYsjtGr0Tuu1/sWLwRBAMga4=")
+    (debianPatch "gcc12.patch" "sha256-Kqmb6hRn6lAHLJMoZ5nGCmHcqfbTUIDq5ahALI2f4a4=")
   ];
 
   postPatch = ''
@@ -52,11 +53,16 @@ stdenv.mkDerivation (finalAttrs: {
       substituteInPlace $f \
         --replace "/usr/" "$out/"
     done
+    # GDC → DMD/LDC flag compatibility
+    substituteInPlace Makefile \
+      --replace-fail "-o " -of= \
+      --replace-fail -Wdeprecated "" \
+      --replace-fail -l -L-l
   '';
 
   nativeBuildInputs = [
     unzip
-    gdc
+    ldc
   ];
 
   buildInputs = [
@@ -66,6 +72,8 @@ stdenv.mkDerivation (finalAttrs: {
     SDL_mixer
     bulletml
   ];
+
+  makeFlags = [ "GDC=ldc2" ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/to/torus-trooper/package.nix
+++ b/pkgs/by-name/to/torus-trooper/package.nix
@@ -4,7 +4,7 @@
   fetchpatch,
   fetchurl,
   unzip,
-  gdc,
+  ldc,
   libGL,
   libGLU,
   SDL,
@@ -17,7 +17,7 @@ let
     patchname: hash:
     fetchpatch {
       name = "${patchname}.patch";
-      url = "https://sources.debian.org/data/main/t/torus-trooper/0.22.dfsg1-12/debian/patches/${patchname}.patch";
+      url = "https://sources.debian.org/data/main/t/torus-trooper/0.22.dfsg1-14/debian/patches/${patchname}.patch";
       sha256 = hash;
     };
 
@@ -48,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     (debianPatch "libbulletml0v5-segfault" "0pad2daz60hswkhkdpssxaqc9p9ca0sw1nraqzr453x0zdwwq0hn")
     (debianPatch "std.math.fabs" "18xnnqlj20bxv2h9fa8dn4rmxwi3k6y3g50kwvh8i8p3b4hgag3r")
     (debianPatch "gdc-8" "10z702y75c48hjcnvv8m7f3ka52cj3r3jqafdbby85nb0p2lbssx")
+    (debianPatch "gcc12" "sha256-8zNwhteRW3xWFsdoTOLIPPZn2cqCE1mS7UDYP1DzSQQ=")
   ];
 
   postPatch = ''
@@ -55,11 +56,16 @@ stdenv.mkDerivation (finalAttrs: {
       substituteInPlace $f \
         --replace "/usr/" "$out/"
     done
+    # GDC → DMD/LDC flag compatibility
+    substituteInPlace Makefile \
+      --replace-fail "-o " -of= \
+      --replace-fail -Wno-deprecated "" \
+      --replace-fail -l -L-l
   '';
 
   nativeBuildInputs = [
     unzip
-    gdc
+    ldc
   ];
 
   buildInputs = [
@@ -69,6 +75,8 @@ stdenv.mkDerivation (finalAttrs: {
     SDL_mixer
     bulletml
   ];
+
+  makeFlags = [ "GDC=ldc2" ];
 
   installPhase = ''
     install -Dm755 torus-trooper $out/bin/torus-trooper

--- a/pkgs/by-name/tu/tumiki-fighters/package.nix
+++ b/pkgs/by-name/tu/tumiki-fighters/package.nix
@@ -4,7 +4,7 @@
   fetchpatch,
   fetchurl,
   unzip,
-  gdc,
+  ldc,
   libGL,
   SDL,
   SDL_mixer,
@@ -16,7 +16,7 @@ let
     patchname: hash:
     fetchpatch {
       name = "${patchname}.patch";
-      url = "https://sources.debian.org/data/main/t/tumiki-fighters/0.2.dfsg1-9/debian/patches/${patchname}.patch";
+      url = "https://sources.debian.org/data/main/t/tumiki-fighters/0.2.dfsg1-10/debian/patches/${patchname}.patch";
       sha256 = hash;
     };
 
@@ -42,6 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     (debianPatch "window-resizing" "1dm79d0yisa8zs5fr89y3wq2kzd3khcaxs0la8lhncvkqbd4smx8")
     (debianPatch "dlang_v2" "1isnvbl3bjnpyphji8k3fl0yd1z4869h0lai143vpwgj6518lpg4")
     (debianPatch "gdc-8" "1md0zwmv50jnak5g9d93bglv9v4z41blinjii6kv3vmgjnajapzj")
+    (debianPatch "gcc12" "sha256-3ZFsI2Q4zCT591qCOu2iT2edE52DfO2pUySnMMBhNIQ=")
   ];
 
   postPatch = ''
@@ -57,11 +58,16 @@ stdenv.mkDerivation (finalAttrs: {
       substituteInPlace $f \
         --replace "/usr/" "$out/"
     done
+    # GDC → DMD/LDC flag compatibility
+    substituteInPlace Makefile \
+      --replace-fail "-o " -of= \
+      --replace-fail -Wno-deprecated "" \
+      --replace-fail -l -L-l
   '';
 
   nativeBuildInputs = [
     unzip
-    gdc
+    ldc
   ];
 
   buildInputs = [
@@ -70,6 +76,8 @@ stdenv.mkDerivation (finalAttrs: {
     SDL_mixer
     bulletml
   ];
+
+  makeFlags = [ "GDC=ldc2" ];
 
   installPhase = ''
     install -Dm755 tumiki-fighters $out/bin/tumiki-fighters


### PR DESCRIPTION
GDC is going to be dropped in #435019.

I used LDC instead of DMD because it claims better platform support and faster binaries.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
