### PR TITLE
cctv-viewer: 0.1.9-unstable-2025-06-13 -> 0.1.9-dev

### DIFF
--- a/pkgs/by-name/cc/cctv-viewer/package.nix
+++ b/pkgs/by-name/cc/cctv-viewer/package.nix
@@ -10,14 +10,14 @@
   libva,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "cctv-viewer";
-  version = "0.1.9-unstable-2025-06-13";
+  version = "0.1.9-dev";
 
   src = fetchFromGitHub {
     owner = "iEvgeny";
     repo = "cctv-viewer";
-    rev = "8a8fff2612ae2123b8be156c954a29706383b480";
+    rev = "v${version}";
     hash = "sha256-Euw9S+iONAEENkFwo169x/+pcyeTXLe8wb70KKjv3bE=";
     fetchSubmodules = true;
   };
@@ -55,7 +55,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "Viewer and mounter for video streams";
+    description = "A simple Qt application for simultaneously viewing multiple video streams. Designed for high performance and low latency. Based on ffmpeg.";
     homepage = "https://cctv-viewer.org";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ teohz ];


### PR DESCRIPTION
This updates the `cctv-viewer` package to use a newly created upstream tag (`0.1.9-dev`) instead of a raw commit hash.

This provides a more stable and permanent reference for the package source, following a recommendation from the initial package review.
The description has been updated to be more descriptive and mirror the official one.
The underlying source code is the same.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.