### PR TITLE
mame: remove `coreaudio_sound.cpp` patch (upstreamed)

### DIFF
--- a/pkgs/applications/emulators/mame/default.nix
+++ b/pkgs/applications/emulators/mame/default.nix
@@ -7,7 +7,6 @@
   SDL2_ttf,
   copyDesktopItems,
   expat,
-  fetchpatch,
   fetchurl,
   flac,
   fontconfig,
@@ -117,16 +116,6 @@ stdenv.mkDerivation rec {
     # that you run MAME changing to install directory, so we add absolute paths
     # here
     ./001-use-absolute-paths.diff
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # coreaudio_sound.cpp compares __MAC_OS_X_VERSION_MIN_REQUIRED to 1200
-    # instead of 120000, causing it to try to use a constant that isn't
-    # actually defined yet when targeting macOS 11 like Nixpkgs does.
-    # Backport mamedev/mame#13890 until the next time we update MAME.
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/mamedev/mame/pull/13890.patch";
-      hash = "sha256-Fqpw4fHEMns4tSSIjc1p36ss+J9Tc/O0cnN3HI/ratM=";
-    })
   ];
 
   # Since the bug described in https://github.com/NixOS/nixpkgs/issues/135438,


### PR DESCRIPTION
This patch is no longer needed after the most recent update (#431692), and is breaking macOS/Darwin builds ([`x86-64`](https://hydra.nixos.org/build/305124760), [`aarch64`](https://hydra.nixos.org/build/305124762)).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
