### PR TITLE
rustPlatform.buildRustPackage: miscelaneous modernization to unify `unpackPhase` and `cargoDeps.unpackPhase`

### DIFF
--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -162,11 +162,6 @@ lib.extendMkDerivation {
 
       patches = cargoPatches ++ patches;
 
-      postUnpack = ''
-        eval "$cargoDepsHook"
-      ''
-      + (args.postUnpack or "");
-
       configurePhase =
         args.configurePhase or ''
           runHook preConfigure

--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -15,6 +15,16 @@
   windows,
 }:
 
+let
+  interpolateString =
+    s:
+    if lib.isList s then
+      lib.concatMapStringsSep " " (s: "${s}") (lib.filter (s: s != null) s)
+    else if s == null then
+      ""
+    else
+      "${s}";
+in
 lib.extendMkDerivation {
   constructDrv = stdenv.mkDerivation;
 
@@ -23,6 +33,7 @@ lib.extendMkDerivation {
     "cargoUpdateHook"
     "cargoLock"
     "useFetchCargoVendor"
+    "RUSTFLAGS"
   ];
 
   extendDrvArgs =
@@ -77,11 +88,19 @@ lib.extendMkDerivation {
     assert lib.warnIf (args ? useFetchCargoVendor)
       "buildRustPackage: `useFetchCargoVendor` is non‐optional and enabled by default as of 25.05, remove it"
       true;
+    {
+      env = {
+        PKG_CONFIG_ALLOW_CROSS = if stdenv.buildPlatform != stdenv.hostPlatform then 1 else 0;
+        RUST_LOG = logLevel;
+        RUSTFLAGS =
+          lib.optionalString (
+            stdenv.hostPlatform.isDarwin && buildType == "debug"
+          ) "-C split-debuginfo=packed "
+          # Workaround the existing RUSTFLAGS specified as a list.
+          + interpolateString (args.RUSTFLAGS or "");
+      }
+      // args.env or { };
 
-    lib.optionalAttrs (stdenv.hostPlatform.isDarwin && buildType == "debug") {
-      RUSTFLAGS = "-C split-debuginfo=packed " + (args.RUSTFLAGS or "");
-    }
-    // {
       cargoDeps =
         if cargoVendorDir != null then
           null
@@ -143,12 +162,8 @@ lib.extendMkDerivation {
 
       patches = cargoPatches ++ patches;
 
-      PKG_CONFIG_ALLOW_CROSS = if stdenv.buildPlatform != stdenv.hostPlatform then 1 else 0;
-
       postUnpack = ''
         eval "$cargoDepsHook"
-
-        export RUST_LOG=${logLevel}
       ''
       + (args.postUnpack or "");
 

--- a/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
@@ -1,6 +1,8 @@
 cargoSetupPostUnpackHook() {
     echo "Executing cargoSetupPostUnpackHook"
 
+    eval "${cargoDepsHook-}"
+
     # Some cargo builds include build hooks that modify their own vendor
     # dependencies. This copies the vendor directory into the build tree and makes
     # it writable. If we're using a tarball, the unpackFile hook already handles


### PR DESCRIPTION
1. Pass all environment variables (including `RUST_LOG`) via `env`
2. Run `cargoDepsHook` (a hook for tweaks before Rust vendor from `cargoDeps` or `cargoVendorDir` gets unpacked) inside `cargoSetupPostUnpackHook` instead of prepending to `postUnpack`.
3. Make it feasible to unify the `postUnpack` of the main derivation and `cargoDeps` in PR #435239

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
