### PR TITLE
workflows: use cachix consistently

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
           name: ${{ vars.CACHIX_NAME || 'nixpkgs-ci' }}
           extraPullNames: nixpkgs-ci
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          pushFilter: -source$
+          pushFilter: '(-source$|-nixpkgs-tarball-)'
 
       - run: nix-env --install -f pinned -A nix-build-uncached
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,9 +61,10 @@ jobs:
 
       - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
         with:
-          # This cache is for the nixpkgs repo checks and should not be trusted or used elsewhere.
-          name: nixpkgs-ci
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          # The nixpkgs-ci cache should not be trusted or used outside of Nixpkgs and its forks' CI.
+          name: ${{ vars.CACHIX_NAME || 'nixpkgs-ci' }}
+          extraPullNames: nixpkgs-ci
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - run: nix-env --install -f pinned -A nix-build-uncached
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,7 @@ jobs:
           name: ${{ vars.CACHIX_NAME || 'nixpkgs-ci' }}
           extraPullNames: nixpkgs-ci
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          pushFilter: -source$
 
       - run: nix-env --install -f pinned -A nix-build-uncached
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -116,6 +116,7 @@ jobs:
           name: ${{ vars.CACHIX_NAME || 'nixpkgs-ci' }}
           extraPullNames: nixpkgs-ci
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          pushFilter: -source$
 
       - name: Build codeowners validator
         run: nix-build trusted/ci --arg nixpkgs ./pinned -A codeownersValidator

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -112,9 +112,10 @@ jobs:
 
       - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
         with:
-          # This cache is for the nixpkgs repo checks and should not be trusted or used elsewhere.
-          name: nixpkgs-ci
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          # The nixpkgs-ci cache should not be trusted or used outside of Nixpkgs and its forks' CI.
+          name: ${{ vars.CACHIX_NAME || 'nixpkgs-ci' }}
+          extraPullNames: nixpkgs-ci
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build codeowners validator
         run: nix-build trusted/ci --arg nixpkgs ./pinned -A codeownersValidator

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -16,6 +16,8 @@ on:
         default: false
         type: boolean
     secrets:
+      CACHIX_AUTH_TOKEN:
+        required: true
       OWNER_APP_PRIVATE_KEY:
         required: false
 
@@ -96,6 +98,14 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31
+
+      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
+        with:
+          # The nixpkgs-ci cache should not be trusted or used outside of Nixpkgs and its forks' CI.
+          name: ${{ vars.CACHIX_NAME || 'nixpkgs-ci' }}
+          extraPullNames: nixpkgs-ci
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          pushFilter: '(-source|-single-chunk)$'
 
       - name: Evaluate the ${{ matrix.system }} output paths for all derivation attributes
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,9 @@ on:
       targetSha:
         required: true
         type: string
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: true
 
 permissions: {}
 
@@ -32,6 +35,10 @@ jobs:
           pinnedFrom: untrusted
 
       - uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31
+
+      # TODO: Figure out how to best enable caching for the treefmt job. Cachix won't work well,
+      # because the cache would be invalidated on every commit - treefmt checks every file.
+      # Maybe we can cache treefmt's eval-cache somehow.
 
       - name: Check that files are formatted
         run: |
@@ -65,6 +72,14 @@ jobs:
 
       - uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31
 
+      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
+        with:
+          # The nixpkgs-ci cache should not be trusted or used outside of Nixpkgs and its forks' CI.
+          name: ${{ vars.CACHIX_NAME || 'nixpkgs-ci' }}
+          extraPullNames: nixpkgs-ci
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          pushFilter: -source$
+
       - name: Parse all nix files
         run: |
           # Tests multiple versions at once, let's make sure all of them run, so keep-going.
@@ -87,6 +102,14 @@ jobs:
           target-as-trusted: true
 
       - uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31
+
+      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
+        with:
+          # The nixpkgs-ci cache should not be trusted or used outside of Nixpkgs and its forks' CI.
+          name: ${{ vars.CACHIX_NAME || 'nixpkgs-ci' }}
+          extraPullNames: nixpkgs-ci
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          pushFilter: -source$
 
       - name: Running nixpkgs-vet
         env:

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -9,6 +9,8 @@ jobs:
   lint:
     name: Lint
     uses: ./.github/workflows/lint.yml
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
       mergedSha: ${{ github.event.merge_group.head_sha }}
       targetSha: ${{ github.event.merge_group.base_sha }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -100,6 +100,8 @@ jobs:
     name: Lint
     needs: [prepare]
     uses: ./.github/workflows/lint.yml
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
       targetSha: ${{ needs.prepare.outputs.targetSha }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -114,6 +114,7 @@ jobs:
       # compare
       statuses: write
     secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
       OWNER_APP_PRIVATE_KEY: ${{ secrets.OWNER_APP_PRIVATE_KEY }}
     with:
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -43,6 +43,8 @@ jobs:
       issues: write
       pull-requests: write
       statuses: write
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
       mergedSha: ${{ github.sha }}
       systems: ${{ needs.prepare.outputs.systems }}

--- a/ci/nixpkgs-vet.nix
+++ b/ci/nixpkgs-vet.nix
@@ -16,6 +16,9 @@ let
       fileset = (gitTracked path);
       root = path;
     };
+
+  filteredBase = filtered base;
+  filteredHead = filtered head;
 in
 runCommand "nixpkgs-vet"
   {
@@ -27,11 +30,11 @@ runCommand "nixpkgs-vet"
   ''
     export NIX_STATE_DIR=$(mktemp -d)
 
-    nixpkgs-vet --base ${filtered base} ${filtered head}
+    nixpkgs-vet --base ${filteredBase} ${filteredHead}
 
     # TODO: Upstream into nixpkgs-vet, see:
     # https://github.com/NixOS/nixpkgs-vet/issues/164
-    badFiles=$(find ${filtered head}/pkgs -type f -name '*.nix' -print | xargs grep -l '^[^#]*<nixpkgs/' || true)
+    badFiles=$(find ${filteredHead}/pkgs -type f -name '*.nix' -print | xargs grep -l '^[^#]*<nixpkgs/' || true)
     if [[ -n $badFiles ]]; then
       echo "Nixpkgs is not allowed to use <nixpkgs> to refer to itself."
       echo "The offending files:"
@@ -41,7 +44,7 @@ runCommand "nixpkgs-vet"
 
     # TODO: Upstream into nixpkgs-vet, see:
     # https://github.com/NixOS/nixpkgs-vet/issues/166
-    conflictingPaths=$(find ${filtered head} | awk '{ print $1 " " tolower($1) }' | sort -k2 | uniq -D -f 1 | cut -d ' ' -f 1)
+    conflictingPaths=$(find ${filteredHead} | awk '{ print $1 " " tolower($1) }' | sort -k2 | uniq -D -f 1 | cut -d ' ' -f 1)
     if [[ -n $conflictingPaths ]]; then
       echo "Files in nixpkgs must not vary only by case."
       echo "The offending paths:"

--- a/ci/nixpkgs-vet.nix
+++ b/ci/nixpkgs-vet.nix
@@ -13,7 +13,10 @@ let
     with lib.fileset;
     path:
     toSource {
-      fileset = (gitTracked path);
+      fileset = difference (gitTracked path) (unions [
+        (path + /.github)
+        (path + /ci)
+      ]);
       root = path;
     };
 


### PR DESCRIPTION
This uses the `nixpkgs-ci` cachix cache in most of the CI jobs. This mostly has an effect when iterating on CI in a fork, where the target branch (and thus the merge commit) is not moving at all. It can also have a benefit when pushing to PRs targeting slower moving branches (release branches or even stable staging, which doesn't receive many commits at all). If lucky, you might also benefit from this caching if fixing a commit message or squashing commits immediately after CI has run on your PR and the target branch hasn't advanced, yet.

It also allows setting up a cachix cache in a fork, which is important to be able to test changes related to that. I am currently doing that, trying to replace some of the artifact download stuff for Eval with cachix instead (not part of this PR).

This should also make the nixpkgs-vet job a few seconds faster in general.

## Things done

- [x] Tested in my fork.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
