### PR TITLE
transito: 0.9.1 -> 0.10.0

### DIFF
--- a/pkgs/by-name/tr/transito/package.nix
+++ b/pkgs/by-name/tr/transito/package.nix
@@ -13,15 +13,15 @@
 
 buildGoModule rec {
   pname = "transito";
-  version = "0.9.1";
+  version = "0.10.0";
 
   src = fetchFromSourcehut {
     owner = "~mil";
     repo = "transito";
     rev = "v${version}";
-    hash = "sha256-5aG/hmpUAN2qYxpqMKLl2WnYgR/sPdtAwLGkFXVyrNs=";
+    hash = "sha256-87U9RdlP260ApkGJB3dLitxAdY3I9nWrukxzRnwuJ2E=";
   };
-  vendorHash = "sha256-7QMO+/f+yc5GfxvDLIXuf+QT2cAmbgI6iQqWmQIkMMA=";
+  vendorHash = "sha256-mgvfrNKvdjLa7O0oTSec8u3eHHU66ZDqpKzNeeyy2J0=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
@@ -66,6 +66,7 @@ buildGoModule rec {
       GTFS data, to name a few: Lisbon, NYC, Brussels, Krakow, and Bourges.
     '';
     homepage = "https://git.sr.ht/~mil/transito";
+    changelog = "https://git.sr.ht/~mil/transito/refs/v${version}";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.McSinyx ];
     mainProgram = "transito";


### PR DESCRIPTION
https://git.sr.ht/~mil/transito/refs/v0.10.0

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `7c1179895554ed6840ee283a95dd8752cd013d53`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>transito</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc