### PR TITLE
[Backport release-25.05] tor-browser: 14.5.5 -> 14.5.6

### DIFF
--- a/pkgs/by-name/to/tor-browser/package.nix
+++ b/pkgs/by-name/to/tor-browser/package.nix
@@ -109,7 +109,7 @@ lib.warnIf (useHardenedMalloc != null)
         ++ lib.optionals mediaSupport [ ffmpeg ]
       );
 
-      version = "14.5.5";
+      version = "14.5.6";
 
       sources = {
         x86_64-linux = fetchurl {
@@ -119,7 +119,7 @@ lib.warnIf (useHardenedMalloc != null)
             "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
             "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
           ];
-          hash = "sha256-rJGhgSSktaeH7KSOtf1KjJbrl/m4sdz+9UdjUN9ovz0=";
+          hash = "sha256-GRLCWCCPixclqdk4UijfHqyDAJjx4eiMM7IwePSCZMI=";
         };
 
         i686-linux = fetchurl {
@@ -129,7 +129,7 @@ lib.warnIf (useHardenedMalloc != null)
             "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
             "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
           ];
-          hash = "sha256-mvlx817/vLi4QyA0aSPyAuWSBfMLjfkFG9Zse9rmSzw=";
+          hash = "sha256-dhRPuMwtxzgA8DJdwct9oNjEOftFSS9Z9wP908wcwIw=";
         };
       };
 

--- a/pkgs/by-name/to/tor-browser/package.nix
+++ b/pkgs/by-name/to/tor-browser/package.nix
@@ -353,28 +353,29 @@ lib.warnIf (useHardenedMalloc != null)
         };
       };
 
-      meta = with lib; {
+      meta = {
         description = "Privacy-focused browser routing traffic through the Tor network";
         mainProgram = "tor-browser";
         homepage = "https://www.torproject.org/";
         changelog = "https://gitweb.torproject.org/builders/tor-browser-build.git/plain/projects/tor-browser/Bundle-Data/Docs/ChangeLog.txt?h=maint-${version}";
-        platforms = attrNames sources;
-        maintainers = with maintainers; [
+        platforms = lib.attrNames sources;
+        maintainers = with lib.maintainers; [
+          c4patino
           felschr
-          panicgh
-          joachifm
           hax404
+          joachifm
+          panicgh
         ];
         # MPL2.0+, GPL+, &c.  While it's not entirely clear whether
         # the compound is "libre" in a strict sense (some components place certain
         # restrictions on redistribution), it's free enough for our purposes.
-        license = with licenses; [
+        license = with lib.licenses; [
           mpl20
           lgpl21Plus
           lgpl3Plus
           free
         ];
-        sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+        sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
       };
     }
   )


### PR DESCRIPTION
Manual backport of #435144 as per https://github.com/NixOS/nixpkgs/pull/435144#issuecomment-3207250882

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
