### PR TITLE
vtk: add vtk-dicom module

### DIFF
--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -8,6 +8,7 @@
   newScope,
   stdenv,
   fetchurl,
+  fetchFromGitHub,
   cmake,
   pkg-config,
 
@@ -46,6 +47,7 @@
   libgeotiff,
   laszip_2,
   gdal,
+  gdcm,
   pdal,
   alembic,
   imath,
@@ -136,6 +138,19 @@ stdenv.mkDerivation (finalAttrs: {
     hash = sourceSha256;
   };
 
+  postPatch =
+    let
+      vtk-dicom = fetchFromGitHub {
+        owner = "dgobbi";
+        repo = "vtk-dicom";
+        tag = "v0.8.17";
+        hash = "sha256-1lI2qsV4gymWqjeouEHZ5FRlmlh9vimH7J5rzA+eOds=";
+      };
+    in
+    ''
+      cp --no-preserve=mode -r ${vtk-dicom} ./Remote/vtkDICOM
+    '';
+
   nativeBuildInputs = [
     cmake
     pkg-config # required for finding MySQl
@@ -153,6 +168,7 @@ stdenv.mkDerivation (finalAttrs: {
     libgeotiff
     laszip_2
     gdal
+    (gdcm.override { enableVTK = false; })
     pdal
     alembic
     imath
@@ -289,6 +305,9 @@ stdenv.mkDerivation (finalAttrs: {
     # mpiSupport
     (lib.cmakeBool "VTK_USE_MPI" mpiSupport)
     (vtkBool "VTK_GROUP_ENABLE_MPI" mpiSupport)
+
+    # Remote module options
+    (lib.cmakeBool "USE_GDCM" true) # for vtkDicom
   ];
 
   pythonImportsCheck = [ "vtk" ];


### PR DESCRIPTION
Refresh of #317335 by @kurnevsky which was stale and no longer mergeable after #417613. ~Currently disabled on Darwin as I don't know if it will build or not.~

@qbisi I wasn't sure what the criteria for being included in `passthru.vtkPackages` is but let me know if I should add `gdcm`/`vtk-dicom`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
