### PR TITLE
vscode-extensions.ms-python.debugpy: per arch

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/ms-python.debugpy/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-python.debugpy/default.nix
@@ -1,14 +1,39 @@
 {
+  stdenv,
   lib,
   vscode-utils,
 }:
 
+let
+  supported = {
+    x86_64-linux = {
+      hash = "sha256-0Je6GvtL4ZrKML2KtGCIIauwOdbVHd/aw/PT4W8vCnQ=";
+      arch = "linux-x64";
+    };
+    x86_64-darwin = {
+      hash = "sha256-Xj0pqqE9RJ9UlBkePO4z4Rr43s0mLDnK8VDm0AQhSoM=";
+      arch = "darwin-x64";
+    };
+    aarch64-linux = {
+      hash = "sha256-WWn5UIEhP587tbF9zSGit3fzM9HJQ/G3y4MdyxrjPe8=";
+      arch = "linux-arm64";
+    };
+    aarch64-darwin = {
+      hash = "sha256-nKIA7h/1aLPV2jBUMm6Ni6tvjOKvdvFKnBgjX7BxjPo=";
+      arch = "darwin-arm64";
+    };
+  };
+
+  base =
+    supported.${stdenv.hostPlatform.system}
+      or (throw "unsupported platform ${stdenv.hostPlatform.system}");
+
+in
 vscode-utils.buildVscodeMarketplaceExtension {
-  mktplcRef = {
+  mktplcRef = base // {
     name = "debugpy";
     publisher = "ms-python";
     version = "2025.10.0";
-    hash = "sha256-NDCNiKLCU7/2VH43eTyOMBTZ3oxzA7JwCBit9+JHfmY=";
   };
 
   meta = {
@@ -16,6 +41,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=ms-python.debugpy";
     homepage = "https://github.com/Microsoft/vscode-python-debugger";
     license = lib.licenses.mit;
+    platforms = builtins.attrNames supported;
     maintainers = [ lib.maintainers.carlthome ];
   };
 }


### PR DESCRIPTION
Came up in discussion of https://github.com/NixOS/nixpkgs/pull/434672

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
