### PR TITLE
font-alias: switch from fetchurl to fetchFromGitLab

### DIFF
--- a/pkgs/by-name/fo/font-alias/package.nix
+++ b/pkgs/by-name/fo/font-alias/package.nix
@@ -1,30 +1,36 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  writeScript,
+  fetchFromGitLab,
+  gitUpdater,
+  autoreconfHook,
+  font-util,
+  util-macros,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "font-alias";
   version = "1.0.5";
 
-  src = fetchurl {
-    url = "mirror://xorg/individual/font/font-alias-${finalAttrs.version}.tar.xz";
-    hash = "sha256-n4niF7tz4ONjagpJP7+LfJlRVuDFPZoEdtIBtnwta24=";
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    group = "xorg";
+    owner = "font";
+    repo = "alias";
+    tag = "font-alias-${finalAttrs.version}";
+    hash = "sha256-qglRNSt/PgFprpsvOVCeLMA+YagJw8DZMAfFdZ0m0/s=";
   };
 
+  nativeBuildInputs = [
+    autoreconfHook
+    font-util
+    util-macros
+  ];
+
   passthru = {
-    updateScript = writeScript "update-${finalAttrs.pname}" ''
-      #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p common-updater-scripts
-
-      version="$(list-directory-versions --pname ${finalAttrs.pname} \
-        --url https://xorg.freedesktop.org/releases/individual/font/ \
-        | sort -V | tail -n1)"
-
-      update-source-version ${finalAttrs.pname} "$version"
-    '';
+    updateScript = gitUpdater {
+      rev-prefix = "font-alias-";
+    };
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
