### PR TITLE
tailscale: add philiptaron as maintainer

### DIFF
--- a/pkgs/by-name/ta/tailscale/package.nix
+++ b/pkgs/by-name/ta/tailscale/package.nix
@@ -227,6 +227,7 @@ buildGoModule (finalAttrs: {
       mbaillie
       jk
       mfrw
+      philiptaron
       pyrox0
       ryan4yin
     ];

--- a/pkgs/by-name/ta/tailscale/package.nix
+++ b/pkgs/by-name/ta/tailscale/package.nix
@@ -22,12 +22,9 @@
   tailscale-nginx-auth,
 }:
 
-let
-  version = "1.86.4";
-in
-buildGoModule {
+buildGoModule (finalAttrs: {
   pname = "tailscale";
-  inherit version;
+  version = "1.86.4";
 
   outputs = [
     "out"
@@ -37,7 +34,7 @@ buildGoModule {
   src = fetchFromGitHub {
     owner = "tailscale";
     repo = "tailscale";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-cYj04DtoYKejygz1Euir/6/Eq1M046nzzhqSfpTi0OE=";
   };
 
@@ -70,8 +67,8 @@ buildGoModule {
   ldflags = [
     "-w"
     "-s"
-    "-X tailscale.com/version.longStamp=${version}"
-    "-X tailscale.com/version.shortStamp=${version}"
+    "-X tailscale.com/version.longStamp=${finalAttrs.version}"
+    "-X tailscale.com/version.shortStamp=${finalAttrs.version}"
   ];
 
   tags = [
@@ -223,7 +220,7 @@ buildGoModule {
   meta = {
     homepage = "https://tailscale.com";
     description = "Node agent for Tailscale, a mesh VPN built on WireGuard";
-    changelog = "https://github.com/tailscale/tailscale/releases/tag/v${version}";
+    changelog = "https://tailscale.com/changelog#client";
     license = lib.licenses.bsd3;
     mainProgram = "tailscale";
     maintainers = with lib.maintainers; [
@@ -234,4 +231,4 @@ buildGoModule {
       ryan4yin
     ];
   };
-}
+})


### PR DESCRIPTION
I'm part of the [Tailscale Insiders](https://tailscale.com/blog/tailscale-insiders-update-seattle-meetup-news) team and am passionate about making Tailscale on Nix and NixOS the best it can be.

A separate commit moves the Tailscale package to use `finalAttrs`-style fixed-point construction.

The changelog entry also shifts to the official Tailscale changelog on Tailscale.com.

## Things done

- [x] Validated that no rebuilds were present
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md