### PR TITLE
nixos/logind: migrate to settings option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -202,6 +202,8 @@
   - `systemd.watchdog.kexecTime` was renamed to `systemd.settings.Manager.KExecWatchdogSec`
   - `systemd.enableCgroupAccounting` was removed. Cgroup accounting now needs to be disabled directly using `systemd.settings.Manager.*Accounting`.
 
+- `services.logind.extraConfig` was converted to RFC42-style `services.logind.settings.Login`.
+
 - `services.ntpd-rs` now performs configuration validation.
 
 - Immich now has support for [VectorChord](https://github.com/tensorchord/VectorChord) when using the PostgreSQL configuration provided by `services.immich.database.enable`, which replaces `pgvecto-rs`. VectorChord support can be toggled with the option `services.immich.database.enableVectorChord`. Additionally, `pgvecto-rs` support is now disabled from NixOS 25.11 onwards using the option `services.immich.database.enableVectors`. This option will be removed fully in the future once Immich drops support for `pgvecto-rs` fully. See [Immich migration instructions](#module-services-immich-vectorchord-migration)

--- a/nixos/modules/system/boot/systemd/logind.nix
+++ b/nixos/modules/system/boot/systemd/logind.nix
@@ -5,164 +5,39 @@
   utils,
   ...
 }:
-let
-  cfg = config.services.logind;
-
-  logindHandlerType = lib.types.enum [
-    "ignore"
-    "poweroff"
-    "reboot"
-    "halt"
-    "kexec"
-    "suspend"
-    "hibernate"
-    "hybrid-sleep"
-    "suspend-then-hibernate"
-    "sleep"
-    "lock"
-  ];
-in
 {
   options.services.logind = {
-    extraConfig = lib.mkOption {
-      default = "";
-      type = lib.types.lines;
-      example = "IdleAction=lock";
+    settings.Login = lib.mkOption {
       description = ''
-        Extra config options for systemd-logind.
-        See {manpage}`logind.conf(5)`
-        for available options.
+        Settings option for systemd-logind.
+        See {manpage}`logind.conf(5)` for available options.
       '';
-    };
+      type = lib.types.submodule {
+        freeformType = lib.types.attrsOf utils.systemdUtils.unitOptions.unitOption;
+        options.KillUserProcesses = lib.mkOption {
+          default = false;
+          type = lib.types.bool;
+          description = ''
+            Specifies whether the processes of a user should be killed
+            when the user logs out.  If true, the scope unit corresponding
+            to the session and all processes inside that scope will be
+            terminated.  If false, the scope is "abandoned"
+            (see {manpage}`systemd.scope(5)`),
+            and processes are not killed.
 
-    killUserProcesses = lib.mkOption {
-      default = false;
-      type = lib.types.bool;
-      description = ''
-        Specifies whether the processes of a user should be killed
-        when the user logs out.  If true, the scope unit corresponding
-        to the session and all processes inside that scope will be
-        terminated.  If false, the scope is "abandoned"
-        (see {manpage}`systemd.scope(5)`),
-        and processes are not killed.
+            See {manpage}`logind.conf(5)` for more details.
 
-        See {manpage}`logind.conf(5)`
-        for more details.
-      '';
-    };
-
-    powerKey = lib.mkOption {
-      default = "poweroff";
-      example = "ignore";
-      type = logindHandlerType;
-
-      description = ''
-        Specifies what to do when the power key is pressed.
-      '';
-    };
-
-    powerKeyLongPress = lib.mkOption {
-      default = "ignore";
-      example = "reboot";
-      type = logindHandlerType;
-
-      description = ''
-        Specifies what to do when the power key is long-pressed.
-      '';
-    };
-
-    rebootKey = lib.mkOption {
-      default = "reboot";
-      example = "ignore";
-      type = logindHandlerType;
-
-      description = ''
-        Specifies what to do when the reboot key is pressed.
-      '';
-    };
-
-    rebootKeyLongPress = lib.mkOption {
-      default = "poweroff";
-      example = "ignore";
-      type = logindHandlerType;
-
-      description = ''
-        Specifies what to do when the reboot key is long-pressed.
-      '';
-    };
-
-    suspendKey = lib.mkOption {
-      default = "suspend";
-      example = "ignore";
-      type = logindHandlerType;
-
-      description = ''
-        Specifies what to do when the suspend key is pressed.
-      '';
-    };
-
-    suspendKeyLongPress = lib.mkOption {
-      default = "hibernate";
-      example = "ignore";
-      type = logindHandlerType;
-
-      description = ''
-        Specifies what to do when the suspend key is long-pressed.
-      '';
-    };
-
-    hibernateKey = lib.mkOption {
-      default = "hibernate";
-      example = "ignore";
-      type = logindHandlerType;
-
-      description = ''
-        Specifies what to do when the hibernate key is pressed.
-      '';
-    };
-
-    hibernateKeyLongPress = lib.mkOption {
-      default = "ignore";
-      example = "suspend";
-      type = logindHandlerType;
-
-      description = ''
-        Specifies what to do when the hibernate key is long-pressed.
-      '';
-    };
-
-    lidSwitch = lib.mkOption {
-      default = "suspend";
-      example = "ignore";
-      type = logindHandlerType;
-
-      description = ''
-        Specifies what to do when the laptop lid is closed.
-      '';
-    };
-
-    lidSwitchExternalPower = lib.mkOption {
-      default = cfg.lidSwitch;
-      defaultText = lib.literalExpression "services.logind.lidSwitch";
-      example = "ignore";
-      type = logindHandlerType;
-
-      description = ''
-        Specifies what to do when the laptop lid is closed
-        and the system is on external power. By default use
-        the same action as specified in services.logind.lidSwitch.
-      '';
-    };
-
-    lidSwitchDocked = lib.mkOption {
-      default = "ignore";
-      example = "suspend";
-      type = logindHandlerType;
-
-      description = ''
-        Specifies what to do when the laptop lid is closed
-        and another screen is added.
-      '';
+            Defaulted to false in nixpkgs because many tools that rely on
+            persistent user processes—like `tmux`, `screen`, `mosh`, `VNC`,
+            `nohup`, and more — would break by the systemd-default behavior.
+          '';
+        };
+      };
+      default = { };
+      example = {
+        KillUserProcesses = false;
+        HandleLidSwitch = "ignore";
+      };
     };
   };
 
@@ -187,24 +62,10 @@ in
       "user-runtime-dir@.service"
     ];
 
-    environment.etc = {
-      "systemd/logind.conf".text = ''
-        [Login]
-        KillUserProcesses=${if cfg.killUserProcesses then "yes" else "no"}
-        HandlePowerKey=${cfg.powerKey}
-        HandlePowerKeyLongPress=${cfg.powerKeyLongPress}
-        HandleRebootKey=${cfg.rebootKey}
-        HandleRebootKeyLongPress=${cfg.rebootKeyLongPress}
-        HandleSuspendKey=${cfg.suspendKey}
-        HandleSuspendKeyLongPress=${cfg.suspendKeyLongPress}
-        HandleHibernateKey=${cfg.hibernateKey}
-        HandleHibernateKeyLongPress=${cfg.hibernateKeyLongPress}
-        HandleLidSwitch=${cfg.lidSwitch}
-        HandleLidSwitchExternalPower=${cfg.lidSwitchExternalPower}
-        HandleLidSwitchDocked=${cfg.lidSwitchDocked}
-        ${cfg.extraConfig}
-      '';
-    };
+    environment.etc."systemd/logind.conf".text = ''
+      [Login]
+      ${utils.systemdUtils.lib.attrsToSection config.services.logind.settings.Login}
+    '';
 
     # Restarting systemd-logind breaks X11
     # - upstream commit: https://cgit.freedesktop.org/xorg/xserver/commit/?id=dc48bd653c7e101
@@ -218,4 +79,33 @@ in
     systemd.services."user-runtime-dir@".stopIfChanged = false;
     systemd.services."user-runtime-dir@".restartIfChanged = false;
   };
+
+  imports =
+    let
+      settingsRename =
+        old: new:
+        lib.mkRenamedOptionModule
+          [ "services" "logind" old ]
+          [ "services" "logind" "settings" "Login" new ];
+    in
+    [
+      (lib.mkRemovedOptionModule [
+        "services"
+        "logind"
+        "extraConfig"
+      ] "Use services.logind.settings.Login instead.")
+
+      (settingsRename "killUserProcesses" "KillUserProcesses")
+      (settingsRename "powerKey" "HandlePowerKey")
+      (settingsRename "powerKeyLongPress" "HandlePowerKeyLongPress")
+      (settingsRename "rebootKey" "HandleRebootKey")
+      (settingsRename "rebootKeyLongPress" "HandleRebootKeyLongPress")
+      (settingsRename "suspendKey" "HandleSuspendKey")
+      (settingsRename "suspendKeyLongPress" "HandleSuspendKeyLongPress")
+      (settingsRename "hibernateKey" "HandleHibernateKey")
+      (settingsRename "hibernateKeyLongPress" "HandleHibernateKeyLongPress")
+      (settingsRename "lidSwitch" "HandleLidSwitch")
+      (settingsRename "lidSwitchExternalPower" "HandleLidSwitchExternalPower")
+      (settingsRename "lidSwitchDocked" "HandleLidSwitchDocked")
+    ];
 }


### PR DESCRIPTION
add `services.logind.settings`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
