### PR TITLE
emacs: bump elisp packages

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
@@ -440,10 +440,10 @@
     elpaBuild {
       pname = "async";
       ename = "async";
-      version = "1.9.9.0.20250325.50900";
+      version = "1.9.9.0.20250826.51747";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/async-1.9.9.0.20250325.50900.tar";
-        sha256 = "094wj61sh7v8qamysmrpdclm93p8w33nq9vs9j2c1jpjskd5m3jh";
+        url = "https://elpa.gnu.org/devel/async-1.9.9.0.20250826.51747.tar";
+        sha256 = "1a05lli45vls1qdy7bvgb0vb1drm3q8dlbn67hzyszscknrrnjal";
       };
       packageRequires = [ ];
       meta = {
@@ -461,10 +461,10 @@
     elpaBuild {
       pname = "auctex";
       ename = "auctex";
-      version = "14.0.9.0.20250627.121203";
+      version = "14.1.0.0.20250808.215752";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auctex-14.0.9.0.20250627.121203.tar";
-        sha256 = "1a5jfd7nmmmrgm8a319gv6f7356rpp9ccm5680qssx95pg67paax";
+        url = "https://elpa.gnu.org/devel/auctex-14.1.0.0.20250808.215752.tar";
+        sha256 = "1li0njqva88asr5flf1xiy4wibdxnkynp813fy38vqi3v9ckg96c";
       };
       packageRequires = [ ];
       meta = {
@@ -577,27 +577,6 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/auto-correct.html";
-        license = lib.licenses.free;
-      };
-    }
-  ) { };
-  auto-header = callPackage (
-    {
-      elpaBuild,
-      fetchurl,
-      lib,
-    }:
-    elpaBuild {
-      pname = "auto-header";
-      ename = "auto-header";
-      version = "0.1.2.0.20230407.82136";
-      src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auto-header-0.1.2.0.20230407.82136.tar";
-        sha256 = "1dm5nqcvbya9fyj45q6k8ni507prs3ij2q5rhdl9m8vwkq6gf72w";
-      };
-      packageRequires = [ ];
-      meta = {
-        homepage = "https://elpa.gnu.org/devel/auto-header.html";
         license = lib.licenses.free;
       };
     }
@@ -740,10 +719,10 @@
     elpaBuild {
       pname = "beframe";
       ename = "beframe";
-      version = "1.4.0.0.20250628.65448";
+      version = "1.4.0.0.20250808.63627";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/beframe-1.4.0.0.20250628.65448.tar";
-        sha256 = "1py8q76jfkvmvqsf15vpdaznlzqj464m8wwslkjyr25hysrgh6cl";
+        url = "https://elpa.gnu.org/devel/beframe-1.4.0.0.20250808.63627.tar";
+        sha256 = "1pk37b1n7ng58ymajcq29ass1wgrpg0q48vrr22l7lwrpl6jcfx8";
       };
       packageRequires = [ ];
       meta = {
@@ -761,10 +740,10 @@
     elpaBuild {
       pname = "bicep-ts-mode";
       ename = "bicep-ts-mode";
-      version = "0.1.4.0.20250320.94622";
+      version = "0.1.4.0.20250811.165718";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/bicep-ts-mode-0.1.4.0.20250320.94622.tar";
-        sha256 = "1psvm6g2mklyqfa349ikx78l3hfkw3xr9314schc7j73m9mlbj44";
+        url = "https://elpa.gnu.org/devel/bicep-ts-mode-0.1.4.0.20250811.165718.tar";
+        sha256 = "006m3qmad18x3h4jdhxf8nx43krk34sj636ccxlxild5lncqdf8a";
       };
       packageRequires = [ ];
       meta = {
@@ -1014,10 +993,10 @@
     elpaBuild {
       pname = "bufferlo";
       ename = "bufferlo";
-      version = "1.1.0.20250503.201002";
+      version = "1.1.0.20250818.175416";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/bufferlo-1.1.0.20250503.201002.tar";
-        sha256 = "05bpgfyizzc6364c7jv8l2d8z78ighmswxn2hxgzwsvbyhnfmxpr";
+        url = "https://elpa.gnu.org/devel/bufferlo-1.1.0.20250818.175416.tar";
+        sha256 = "109fvfi5bvj75sr7gxqv72maj42y7wj73xrq2542w9gkjm41ayg7";
       };
       packageRequires = [ ];
       meta = {
@@ -1105,10 +1084,10 @@
     elpaBuild {
       pname = "cape";
       ename = "cape";
-      version = "2.1.0.20250617.112523";
+      version = "2.1.0.20250807.213828";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cape-2.1.0.20250617.112523.tar";
-        sha256 = "1vr9rsa6lb8hcdpwlnczvrcf2ncpnnlcwclhqq3r9nbcfpbyvlmm";
+        url = "https://elpa.gnu.org/devel/cape-2.1.0.20250807.213828.tar";
+        sha256 = "1vlxp4fh3ch2148kmv9fx54pj3m4963pywr9z2mws59mbffyh6qv";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1274,10 +1253,10 @@
     elpaBuild {
       pname = "cobol-mode";
       ename = "cobol-mode";
-      version = "1.1.0.20250527.194517";
+      version = "1.1.0.20250810.203242";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cobol-mode-1.1.0.20250527.194517.tar";
-        sha256 = "057n1ck9pn9mkh3kkzw5ps2iwjfy9fbyr9cviccfh46avlfkyqq0";
+        url = "https://elpa.gnu.org/devel/cobol-mode-1.1.0.20250810.203242.tar";
+        sha256 = "16hkkrg551jsapnraf4vl19r53yl4ll3wdr49yxyy9qkiqvv2l25";
       };
       packageRequires = [ ];
       meta = {
@@ -1318,10 +1297,10 @@
     elpaBuild {
       pname = "colorful-mode";
       ename = "colorful-mode";
-      version = "1.2.4.0.20250621.201608";
+      version = "1.2.4.0.20250825.181603";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/colorful-mode-1.2.4.0.20250621.201608.tar";
-        sha256 = "1lfgg7y8l37474966n76b5h3jl1dah73bfg27mscz8i24344p0nh";
+        url = "https://elpa.gnu.org/devel/colorful-mode-1.2.4.0.20250825.181603.tar";
+        sha256 = "01f5m6cs0mpw1qb7fg6bkwip7f7h5cdic6ficdzj4gfn8b6q6vh7";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1386,10 +1365,10 @@
     elpaBuild {
       pname = "company";
       ename = "company";
-      version = "1.0.2.0.20250522.193744";
+      version = "1.0.2.0.20250805.152556";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20250522.193744.tar";
-        sha256 = "1h74h8rh3ya89ajfhkym879ll6v5qsvww4rjv0r1kn0yhhn79c3j";
+        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20250805.152556.tar";
+        sha256 = "15c22xk1m3m071yvagw89vijb46qsys7a3kvq7h61nnxw4za5x9n";
       };
       packageRequires = [ ];
       meta = {
@@ -1460,10 +1439,10 @@
     elpaBuild {
       pname = "company-statistics";
       ename = "company-statistics";
-      version = "0.2.3.0.20170210.193350";
+      version = "0.2.3.0.20250805.152437";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/company-statistics-0.2.3.0.20170210.193350.tar";
-        sha256 = "0fwvaadfr5jlx3021kfjbij9692c2v3l600v2rwqijc563phdfg3";
+        url = "https://elpa.gnu.org/devel/company-statistics-0.2.3.0.20250805.152437.tar";
+        sha256 = "0r23dakpkakwv294snzfq7s6g56m48d0j9ncnmkyhs37vg51x21x";
       };
       packageRequires = [ company ];
       meta = {
@@ -1546,10 +1525,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "2.6.0.20250702.84636";
+      version = "2.7.0.20250821.173915";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-2.6.0.20250702.84636.tar";
-        sha256 = "0k0av4i9ww7kwg7igllsak6wrbl3nj2d4r4kggh8dn77z4b19x81";
+        url = "https://elpa.gnu.org/devel/consult-2.7.0.20250821.173915.tar";
+        sha256 = "18a831akjfipb42f1d158m9l40z17469f5crmlaqsp3384j9qk7h";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1569,10 +1548,10 @@
     elpaBuild {
       pname = "consult-denote";
       ename = "consult-denote";
-      version = "0.3.1.0.20250606.75450";
+      version = "0.3.1.0.20250805.41616";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-denote-0.3.1.0.20250606.75450.tar";
-        sha256 = "01dbnll9al7046kkbmfqwvgdp7bwhxgq552lzc4igqxm8kbb99gc";
+        url = "https://elpa.gnu.org/devel/consult-denote-0.3.1.0.20250805.41616.tar";
+        sha256 = "1ryyjcxlqbkqiivbiazkj7pxqac9sn3kyczz103z9pmvf3g3wc1r";
       };
       packageRequires = [
         consult
@@ -1659,10 +1638,10 @@
     elpaBuild {
       pname = "corfu";
       ename = "corfu";
-      version = "2.3.0.20250617.112559";
+      version = "2.3.0.20250804.224308";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/corfu-2.3.0.20250617.112559.tar";
-        sha256 = "110zk8s1dg4g447yfa2c8jb3gvfi1jfjz6kjn5mfgl0zz1llmhn1";
+        url = "https://elpa.gnu.org/devel/corfu-2.3.0.20250804.224308.tar";
+        sha256 = "0vbn7lg0706s8hjizzwda6wm105pkhfmc825y3a64imi1brz17dw";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1876,10 +1855,10 @@
     elpaBuild {
       pname = "cursory";
       ename = "cursory";
-      version = "1.1.0.0.20250127.85433";
+      version = "1.2.0.0.20250722.60609";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cursory-1.1.0.0.20250127.85433.tar";
-        sha256 = "02lhik1s120zbrilwf8c4hwi4hh5jp36h02728kc9kwxvlf34r69";
+        url = "https://elpa.gnu.org/devel/cursory-1.2.0.0.20250722.60609.tar";
+        sha256 = "140g6vi060ns4dippvq8z2j6ydsb54ygdk0scvg7igk2j0zndg35";
       };
       packageRequires = [ ];
       meta = {
@@ -1940,10 +1919,10 @@
     elpaBuild {
       pname = "dape";
       ename = "dape";
-      version = "0.24.1.0.20250619.215347";
+      version = "0.24.1.0.20250825.172742";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dape-0.24.1.0.20250619.215347.tar";
-        sha256 = "0sn4v04rzyj0azb7mfm9dz3afr4jmi3irpacfj7cgbm25dsj5hxk";
+        url = "https://elpa.gnu.org/devel/dape-0.24.1.0.20250825.172742.tar";
+        sha256 = "14dnib8w7lv2w7a0ha0q5yq3rkmndq71xkszbp1fjljfdy0m7p06";
       };
       packageRequires = [ jsonrpc ];
       meta = {
@@ -1983,10 +1962,10 @@
     elpaBuild {
       pname = "dash";
       ename = "dash";
-      version = "2.20.0.0.20250312.130713";
+      version = "2.20.0.0.20250814.95131";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dash-2.20.0.0.20250312.130713.tar";
-        sha256 = "0kdmc5axls8lhpbzzvab3c49kdagh3630jyrd0xmrdwf4pxim7ns";
+        url = "https://elpa.gnu.org/devel/dash-2.20.0.0.20250814.95131.tar";
+        sha256 = "06xrjbqbsr5ywd7pqi2gn2w9aavg3yr0vf0i8h40s5nhls683r41";
       };
       packageRequires = [ ];
       meta = {
@@ -2027,10 +2006,10 @@
     elpaBuild {
       pname = "debbugs";
       ename = "debbugs";
-      version = "0.44.0.20250505.144705";
+      version = "0.44.0.20250826.75956";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/debbugs-0.44.0.20250505.144705.tar";
-        sha256 = "104nk2svlyp7gsr4fpa7q25yi89j29m3c6ydb0zdspbrggw2zfka";
+        url = "https://elpa.gnu.org/devel/debbugs-0.44.0.20250826.75956.tar";
+        sha256 = "0lmagkv1wq2w8llmbf1vxbaw79i0byqvrbbl56fdjib1fz35aakv";
       };
       packageRequires = [ soap-client ];
       meta = {
@@ -2074,10 +2053,10 @@
     elpaBuild {
       pname = "denote";
       ename = "denote";
-      version = "4.0.0.0.20250708.74730";
+      version = "4.0.0.0.20250819.183753";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-4.0.0.0.20250708.74730.tar";
-        sha256 = "0f0czcsc5ql8g09lnjjcw3cg1yyzj5agm9aw5rmvxp7q70pwfw2s";
+        url = "https://elpa.gnu.org/devel/denote-4.0.0.0.20250819.183753.tar";
+        sha256 = "1jikp1d5kai3v1vw2zbd0l6m7990ymw2asdz9887ky3wzhz6ia0c";
       };
       packageRequires = [ ];
       meta = {
@@ -2096,10 +2075,10 @@
     elpaBuild {
       pname = "denote-journal";
       ename = "denote-journal";
-      version = "0.1.1.0.20250702.194716";
+      version = "0.1.1.0.20250826.41610";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-journal-0.1.1.0.20250702.194716.tar";
-        sha256 = "0qkgh5d6qky04blvbqwpw2231aj1gmj84m485m6zijlvbkcn9cy9";
+        url = "https://elpa.gnu.org/devel/denote-journal-0.1.1.0.20250826.41610.tar";
+        sha256 = "0c17447h15c9s61rrww6kp45lhrz2an18hb6nkx7ryzy0lqdvss9";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2118,10 +2097,10 @@
     elpaBuild {
       pname = "denote-markdown";
       ename = "denote-markdown";
-      version = "0.1.1.0.20250419.74350";
+      version = "0.1.1.0.20250719.40600";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-markdown-0.1.1.0.20250419.74350.tar";
-        sha256 = "0q3fc8zyaspd6z0zan40rsjfpgvja72bp0qm93pyr69q6iijshh8";
+        url = "https://elpa.gnu.org/devel/denote-markdown-0.1.1.0.20250719.40600.tar";
+        sha256 = "1ck90jkhl7bm018hgpyl1g8f33jyaj5dk12b7khjx6a949ypx4nk";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2162,10 +2141,10 @@
     elpaBuild {
       pname = "denote-org";
       ename = "denote-org";
-      version = "0.1.1.0.20250521.104352";
+      version = "0.1.1.0.20250823.62813";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-org-0.1.1.0.20250521.104352.tar";
-        sha256 = "037jbn4j454y5lki6lchx36cma89gysbn0jy74nfnsv9f30gvz9h";
+        url = "https://elpa.gnu.org/devel/denote-org-0.1.1.0.20250823.62813.tar";
+        sha256 = "0rn70j1nsjlxf6dia24lj49i6gkb0cvfagdzbyzm8gqnb4l0gyzz";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2206,10 +2185,10 @@
     elpaBuild {
       pname = "denote-sequence";
       ename = "denote-sequence";
-      version = "0.1.1.0.20250707.134142";
+      version = "0.1.1.0.20250822.171436";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-sequence-0.1.1.0.20250707.134142.tar";
-        sha256 = "0iyv6cv4520sj1wgpr3zn4v86r8xjd9273y5nnc7ijsdfdjj26qz";
+        url = "https://elpa.gnu.org/devel/denote-sequence-0.1.1.0.20250822.171436.tar";
+        sha256 = "07jn2s5wjra5xl9vr9lr6fllfbgj36d2q90l0yyyn9clcpkv1mgy";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2318,10 +2297,10 @@
     elpaBuild {
       pname = "dicom";
       ename = "dicom";
-      version = "0.6.0.20250617.112606";
+      version = "0.6.0.20250804.224351";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dicom-0.6.0.20250617.112606.tar";
-        sha256 = "152ny6k4bfydysbl534yky175ji65146x70glzy18xn40ay4pz5k";
+        url = "https://elpa.gnu.org/devel/dicom-0.6.0.20250804.224351.tar";
+        sha256 = "1prlld2r6cc38gdkkbgh6pnbxq8z64xrn77x18l0rvj9fi0x6lk0";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2368,10 +2347,10 @@
     elpaBuild {
       pname = "diff-hl";
       ename = "diff-hl";
-      version = "1.10.0.0.20250627.223032";
+      version = "1.10.0.0.20250731.22728";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20250627.223032.tar";
-        sha256 = "101yzzclgagvfjzw3r9483vv27h6fbvniwnlycrri9agxv6n6qxm";
+        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20250731.22728.tar";
+        sha256 = "09acwwc86iw8awvl7yc505vspvydwfb778g3fcvs9mx39mqcx9md";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -2495,10 +2474,10 @@
     elpaBuild {
       pname = "dired-preview";
       ename = "dired-preview";
-      version = "0.5.2.0.20250507.81237";
+      version = "0.6.0.0.20250720.94036";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dired-preview-0.5.2.0.20250507.81237.tar";
-        sha256 = "12f510r8f6z9qp679dipyv1damincr2q6bbi4vcn17ylwhaqdp6s";
+        url = "https://elpa.gnu.org/devel/dired-preview-0.6.0.0.20250720.94036.tar";
+        sha256 = "09cvi5kcdzghm1l657jnfsvdnfnkfnl76m9vnai49z53a66iivkc";
       };
       packageRequires = [ ];
       meta = {
@@ -2664,10 +2643,10 @@
     elpaBuild {
       pname = "doric-themes";
       ename = "doric-themes";
-      version = "0.2.0.0.20250705.145026";
+      version = "0.3.0.0.20250823.65805";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/doric-themes-0.2.0.0.20250705.145026.tar";
-        sha256 = "0w7zibcgcyn1vbhxy4xd7hbp3rd79aag9jl9hv75cln4zd0d99fp";
+        url = "https://elpa.gnu.org/devel/doric-themes-0.3.0.0.20250823.65805.tar";
+        sha256 = "1iy73srwflia95x7kzjb35dp99p608a5yb5vs3z0qzasmm6b4axy";
       };
       packageRequires = [ ];
       meta = {
@@ -2887,10 +2866,10 @@
     elpaBuild {
       pname = "ef-themes";
       ename = "ef-themes";
-      version = "1.10.0.0.20250704.54909";
+      version = "1.10.0.0.20250808.64044";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ef-themes-1.10.0.0.20250704.54909.tar";
-        sha256 = "108rn50zqjlkzj1g99n6q4kabqd053f80yx2qk96wr35mvqifvvj";
+        url = "https://elpa.gnu.org/devel/ef-themes-1.10.0.0.20250808.64044.tar";
+        sha256 = "0g0f4kjlc1wl29g5qy1j59dxkm20a1wkbhvr5r07wav2a0is1rlr";
       };
       packageRequires = [ ];
       meta = {
@@ -2915,10 +2894,10 @@
     elpaBuild {
       pname = "eglot";
       ename = "eglot";
-      version = "1.18.0.20250625.170717";
+      version = "1.18.0.20250819.161828";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eglot-1.18.0.20250625.170717.tar";
-        sha256 = "0zjdrdl2bb2fx83kzz3d8q8kfyba7mv1zfmrzpm0ha6s4kckpq0v";
+        url = "https://elpa.gnu.org/devel/eglot-1.18.0.20250819.161828.tar";
+        sha256 = "0b7jh9xvi1cfyrmvhbgpb3vpvyv2306zvcyi6j4vwj08wlr9ln49";
       };
       packageRequires = [
         eldoc
@@ -2991,10 +2970,10 @@
     elpaBuild {
       pname = "eldoc";
       ename = "eldoc";
-      version = "1.15.0.0.20250329.105231";
+      version = "1.16.0.0.20250709.192845";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eldoc-1.15.0.0.20250329.105231.tar";
-        sha256 = "0jzsa6m4k2wg7frlbc6mn0g3lwlhbgrhg10ik2yp3fcdav5nfkq1";
+        url = "https://elpa.gnu.org/devel/eldoc-1.16.0.0.20250709.192845.tar";
+        sha256 = "1n35mlpl1r2kxvp6z0ah3zykgjlam9pq2mxbap0iamhmvrp27537";
       };
       packageRequires = [ ];
       meta = {
@@ -3088,10 +3067,10 @@
     elpaBuild {
       pname = "ellama";
       ename = "ellama";
-      version = "1.8.1.0.20250526.173209";
+      version = "1.8.2.0.20250801.174017";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ellama-1.8.1.0.20250526.173209.tar";
-        sha256 = "1h3ypfrp4jxgamrc6y75rzsj1iq7n03ng2zg8ab3n0lf8xz5x61k";
+        url = "https://elpa.gnu.org/devel/ellama-1.8.2.0.20250801.174017.tar";
+        sha256 = "0drgpw3q5lm4x8fkf7nymv08vkjizbybmh1k66p1fy6sxxbjyfz9";
       };
       packageRequires = [
         compat
@@ -3136,10 +3115,10 @@
     elpaBuild {
       pname = "embark";
       ename = "embark";
-      version = "1.1.0.20250707.134730";
+      version = "1.1.0.20250825.75213";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/embark-1.1.0.20250707.134730.tar";
-        sha256 = "165wyrp252bdf2qqpiq5gqs41rn6pnz0s9fdxzz0rf5sajhmmajj";
+        url = "https://elpa.gnu.org/devel/embark-1.1.0.20250825.75213.tar";
+        sha256 = "0x5zg5rlhx4vlhijsjb1mjxmbc3g6mk4qf5s98ma71wprvfx3c8y";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3160,10 +3139,10 @@
     elpaBuild {
       pname = "embark-consult";
       ename = "embark-consult";
-      version = "1.1.0.20250707.134730";
+      version = "1.1.0.20250825.75213";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/embark-consult-1.1.0.20250707.134730.tar";
-        sha256 = "11557bz8xhwmyg6qgjw9rr6c6d5l08haiyqai4k0zglbdnn8rd3b";
+        url = "https://elpa.gnu.org/devel/embark-consult-1.1.0.20250825.75213.tar";
+        sha256 = "0ypm3z99kd8kiszih55ysh7jhcf711s7qqyg3m8byli6wff4h40x";
       };
       packageRequires = [
         compat
@@ -3224,10 +3203,10 @@
     elpaBuild {
       pname = "emms";
       ename = "emms";
-      version = "22.0.20250609.224757";
+      version = "23.0.20250731.114728";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/emms-22.0.20250609.224757.tar";
-        sha256 = "1ghvwrjyzyfc80wxxvmlmhxdwzkbw6xxrk2h1hj23yc3q5hbfyi4";
+        url = "https://elpa.gnu.org/devel/emms-23.0.20250731.114728.tar";
+        sha256 = "0dxqq6c1w6v7qgsbsznqkwf518dy0a3zaxs31j5ldyz6b2ylfsrh";
       };
       packageRequires = [
         cl-lib
@@ -3313,10 +3292,10 @@
     elpaBuild {
       pname = "erc";
       ename = "erc";
-      version = "5.6.1snapshot0.20250416.173013";
+      version = "5.6.1snapshot0.20250825.211748";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/erc-5.6.1snapshot0.20250416.173013.tar";
-        sha256 = "0ii5wh8cg8v0ip57x059hx408bg09d80wz6sm4p5p17nj7klnpm0";
+        url = "https://elpa.gnu.org/devel/erc-5.6.1snapshot0.20250825.211748.tar";
+        sha256 = "09fs9p1fjjzzripdnzmp3z0r1j6b0cl3wga4v8rlrkz7s0sikbpv";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3360,10 +3339,10 @@
     elpaBuild {
       pname = "ess";
       ename = "ess";
-      version = "25.1.0.0.20250606.83117";
+      version = "25.1.0.0.20250729.82713";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ess-25.1.0.0.20250606.83117.tar";
-        sha256 = "1mr16s1pxfw7nfv9fjgwygy0s173z99gl9spcjn9jpdm7ydg9nzl";
+        url = "https://elpa.gnu.org/devel/ess-25.1.0.0.20250729.82713.tar";
+        sha256 = "1c6pk6dxzqi4xx06a0yirrzrpvrqsdf3pidbkw08m6ddjg75qrcp";
       };
       packageRequires = [ ];
       meta = {
@@ -3453,10 +3432,10 @@
     elpaBuild {
       pname = "external-completion";
       ename = "external-completion";
-      version = "0.1.0.20250329.135944";
+      version = "0.1.0.20250806.111358";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/external-completion-0.1.0.20250329.135944.tar";
-        sha256 = "00hgqksypn9mr6acbyf2xxzg84z6cfrmldzv3ssg9j5zxg0pf4n4";
+        url = "https://elpa.gnu.org/devel/external-completion-0.1.0.20250806.111358.tar";
+        sha256 = "15r86524q9645xcdhb0ciygfrcnjy9sfihk50i39wqzv9nnp4dhq";
       };
       packageRequires = [ ];
       meta = {
@@ -3476,10 +3455,10 @@
     elpaBuild {
       pname = "exwm";
       ename = "exwm";
-      version = "0.34.0.20250627.135417";
+      version = "0.34.0.20250728.33017";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/exwm-0.34.0.20250627.135417.tar";
-        sha256 = "021ws9brxwzx25hdkm20c53qcgbzxx86jv1yaqvi4w21pc31079y";
+        url = "https://elpa.gnu.org/devel/exwm-0.34.0.20250728.33017.tar";
+        sha256 = "07xhfbi7qlp9csqdbcz70w9xfr97ylgzh7f819lzxliqlxzcmw9s";
       };
       packageRequires = [
         compat
@@ -3509,27 +3488,6 @@
       packageRequires = [ cl-lib ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/f90-interface-browser.html";
-        license = lib.licenses.free;
-      };
-    }
-  ) { };
-  face-shift = callPackage (
-    {
-      elpaBuild,
-      fetchurl,
-      lib,
-    }:
-    elpaBuild {
-      pname = "face-shift";
-      ename = "face-shift";
-      version = "0.2.1.0.20230426.73945";
-      src = fetchurl {
-        url = "https://elpa.gnu.org/devel/face-shift-0.2.1.0.20230426.73945.tar";
-        sha256 = "0gl9k7g3wsc045dx9mp9ypk084r4j3mhf2a4xn08lzz8z8i9k2rz";
-      };
-      packageRequires = [ ];
-      meta = {
-        homepage = "https://elpa.gnu.org/devel/face-shift.html";
         license = lib.licenses.free;
       };
     }
@@ -3631,10 +3589,10 @@
     elpaBuild {
       pname = "flymake";
       ename = "flymake";
-      version = "1.4.1.0.20250531.142308";
+      version = "1.4.1.0.20250823.114435";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/flymake-1.4.1.0.20250531.142308.tar";
-        sha256 = "00h774wxsx8rgmlyph7b4w9d8k4mi67vfx6dnx45zgkicdkrp70h";
+        url = "https://elpa.gnu.org/devel/flymake-1.4.1.0.20250823.114435.tar";
+        sha256 = "0xw00vq7p4vwxfcp9jlkajgpplipgs18hh522ld1mmg87likm0zq";
       };
       packageRequires = [
         eldoc
@@ -3719,10 +3677,10 @@
     elpaBuild {
       pname = "fontaine";
       ename = "fontaine";
-      version = "3.0.1.0.20250415.152114";
+      version = "3.0.1.0.20250710.40159";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/fontaine-3.0.1.0.20250415.152114.tar";
-        sha256 = "1cnx5ch9s18lmwslrzi1652xv964zpigcijwf7jpmvxj0cfi0g9b";
+        url = "https://elpa.gnu.org/devel/fontaine-3.0.1.0.20250710.40159.tar";
+        sha256 = "0sb35y50ja6k2fagxaibbi85xq8q3g25k5ci9pwgi355s24yzq77";
       };
       packageRequires = [ ];
       meta = {
@@ -4189,10 +4147,10 @@
     elpaBuild {
       pname = "greader";
       ename = "greader";
-      version = "0.12.7.0.20250623.220009";
+      version = "0.12.7.0.20250722.52020";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/greader-0.12.7.0.20250623.220009.tar";
-        sha256 = "1j8w628wypiq2wc5sl15qi9vv8w1qfbl9iv9zixq0kwmdzqgi8nd";
+        url = "https://elpa.gnu.org/devel/greader-0.12.7.0.20250722.52020.tar";
+        sha256 = "0zgwih2mz53igjqw4ifk7qa82dbvxiz5hfyydz4nlh6x18ysg825";
       };
       packageRequires = [
         compat
@@ -4451,10 +4409,10 @@
     elpaBuild {
       pname = "hyperbole";
       ename = "hyperbole";
-      version = "9.0.2pre0.20250707.10907";
+      version = "9.0.2pre0.20250819.124153";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20250707.10907.tar";
-        sha256 = "0x5zznxmywgdh7pkp5s1j83qbasfkcszrzr4xyc06862rfvcyq4a";
+        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20250819.124153.tar";
+        sha256 = "09798m66pv8f528djsqwcqqm3aa1y2a6nncm18n64ld9zppy82xc";
       };
       packageRequires = [ ];
       meta = {
@@ -4515,10 +4473,10 @@
     elpaBuild {
       pname = "indent-bars";
       ename = "indent-bars";
-      version = "0.9.1.0.20250708.125252";
+      version = "0.9.2.0.20250719.204514";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/indent-bars-0.9.1.0.20250708.125252.tar";
-        sha256 = "1g2hg0cwch0a8dmknjq0kdakccl5qfd7y9igii4g46x0s865z06r";
+        url = "https://elpa.gnu.org/devel/indent-bars-0.9.2.0.20250719.204514.tar";
+        sha256 = "0dvbgzkqdnbk65gsk1mh7cn06w6n5qmdpm4mmswkx57g479j68ni";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4587,6 +4545,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/isearch-mb.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  iso-date = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "iso-date";
+      ename = "iso-date";
+      version = "1.2.0.0.20250822.220102";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/iso-date-1.2.0.0.20250822.220102.tar";
+        sha256 = "00x25a6rfck3dmsxir62j6zp433jl1mamk7w5vgnd69s883x95vp";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/iso-date.html";
         license = lib.licenses.free;
       };
     }
@@ -4828,10 +4807,10 @@
     elpaBuild {
       pname = "jinx";
       ename = "jinx";
-      version = "2.2.0.20250619.145315";
+      version = "2.3.0.20250804.224330";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jinx-2.2.0.20250619.145315.tar";
-        sha256 = "1rcaxcsh85da3xcy4wdj3y0pwj63v518idw1aw0xl0yswxnqhkr2";
+        url = "https://elpa.gnu.org/devel/jinx-2.3.0.20250804.224330.tar";
+        sha256 = "08lbppgqgnqvmzvbwc1z9zan0d6fsf0jacdifqcinlr6s7qlnrci";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5021,10 +5000,10 @@
     elpaBuild {
       pname = "kubed";
       ename = "kubed";
-      version = "0.5.0.0.20250628.101732";
+      version = "0.5.0.0.20250822.121413";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/kubed-0.5.0.0.20250628.101732.tar";
-        sha256 = "1x5f65yqwx7cs6clg8q9yw8fbq81zv3l0y9jz3r7f76310cqd0zw";
+        url = "https://elpa.gnu.org/devel/kubed-0.5.0.0.20250822.121413.tar";
+        sha256 = "1mnf64pghsdkx63i2bax7rdwdq6ribrd1krl5ri4p3gfkpsy1r56";
       };
       packageRequires = [ ];
       meta = {
@@ -5204,10 +5183,10 @@
     elpaBuild {
       pname = "lin";
       ename = "lin";
-      version = "1.1.0.0.20240913.71045";
+      version = "1.1.0.0.20250728.43733";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/lin-1.1.0.0.20240913.71045.tar";
-        sha256 = "1sba8z5qq14rz0a9fa8mi48agkkylcc64ngp3v97lhg9imich8iy";
+        url = "https://elpa.gnu.org/devel/lin-1.1.0.0.20250728.43733.tar";
+        sha256 = "0ki0wlkmzmv1byi3gvdrbjhiy3qjb3qka908m5svgwjdxcf6zi7m";
       };
       packageRequires = [ ];
       meta = {
@@ -5280,10 +5259,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.27.0.0.20250702.171702";
+      version = "0.27.1.0.20250809.223521";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/llm-0.27.0.0.20250702.171702.tar";
-        sha256 = "0mwzbjl83fz2hpzlicnaxnypaxs6cw27cw9756jiwkn6s5vd259p";
+        url = "https://elpa.gnu.org/devel/llm-0.27.1.0.20250809.223521.tar";
+        sha256 = "0ynsbvz9csg7mnd5f8ycwknghyqf7zvvlf4qcs7za84mgjnya5la";
       };
       packageRequires = [
         compat
@@ -5498,10 +5477,10 @@
     elpaBuild {
       pname = "map";
       ename = "map";
-      version = "3.3.1.0.20250329.135944";
+      version = "3.3.1.0.20250819.91151";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/map-3.3.1.0.20250329.135944.tar";
-        sha256 = "0gsc71i87dx4a9hhs6vp6b8d4nq6lh7d8zqm8nlwdrkqyv0m57bd";
+        url = "https://elpa.gnu.org/devel/map-3.3.1.0.20250819.91151.tar";
+        sha256 = "0axrs58ji1q74q2b9yfq5kb8sjhz9lbjqgmqb9cv78hy28pjvq7y";
       };
       packageRequires = [ ];
       meta = {
@@ -5520,10 +5499,10 @@
     elpaBuild {
       pname = "marginalia";
       ename = "marginalia";
-      version = "2.1.0.20250702.61734";
+      version = "2.2.0.20250824.83436";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/marginalia-2.1.0.20250702.61734.tar";
-        sha256 = "14i37m535n0465dqmjsdy9pxmv852ljyw48d36kfyh38daa0mrpd";
+        url = "https://elpa.gnu.org/devel/marginalia-2.2.0.20250824.83436.tar";
+        sha256 = "0x6lpwpx64xlbm2p0jzykgpjd4cnablyjirz3h907sf1amnwhkqf";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5647,10 +5626,10 @@
     elpaBuild {
       pname = "mct";
       ename = "mct";
-      version = "1.1.0.0.20250707.74133";
+      version = "1.1.0.0.20250724.62824";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/mct-1.1.0.0.20250707.74133.tar";
-        sha256 = "1nykajgdcl6ash7fpzrsmr8v1qgfq6z3vfpzkacczjgm31hd64vg";
+        url = "https://elpa.gnu.org/devel/mct-1.1.0.0.20250724.62824.tar";
+        sha256 = "0gvznkbcd8igj9bkz249zc9qwzy07qayil38a2d7b25b2mfbchsq";
       };
       packageRequires = [ ];
       meta = {
@@ -5819,10 +5798,10 @@
     elpaBuild {
       pname = "minuet";
       ename = "minuet";
-      version = "0.5.4.0.20250619.15440";
+      version = "0.6.0.0.20250819.191029";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/minuet-0.5.4.0.20250619.15440.tar";
-        sha256 = "19cr17cjfwsi6xdxqc65i2k2ps6q322756aizr0af99lwngvkzvr";
+        url = "https://elpa.gnu.org/devel/minuet-0.6.0.0.20250819.191029.tar";
+        sha256 = "1hq7slvzp1n89v5w4vm0vhlsday3zmq47pl7xkn5b70xa396ynqd";
       };
       packageRequires = [
         dash
@@ -5865,10 +5844,10 @@
     elpaBuild {
       pname = "modus-themes";
       ename = "modus-themes";
-      version = "4.8.0.0.20250707.171448";
+      version = "4.8.1.0.20250718.41026";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/modus-themes-4.8.0.0.20250707.171448.tar";
-        sha256 = "0fkmrfxbdmpkbc6b4g52jgl4cjyadlxq33jnq24d96iib962qkvc";
+        url = "https://elpa.gnu.org/devel/modus-themes-4.8.1.0.20250718.41026.tar";
+        sha256 = "0j0nz06mh0k927l2w46zij4vilg5r3zxvkza171aarnz3x01lvfr";
       };
       packageRequires = [ ];
       meta = {
@@ -6102,10 +6081,10 @@
     elpaBuild {
       pname = "nano-theme";
       ename = "nano-theme";
-      version = "0.3.4.0.20240624.80231";
+      version = "0.3.4.0.20250820.51020";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/nano-theme-0.3.4.0.20240624.80231.tar";
-        sha256 = "1h2sifcl26av1lzzmngb2svl23hchjnzd8aaszkxxwh34wg1cgnk";
+        url = "https://elpa.gnu.org/devel/nano-theme-0.3.4.0.20250820.51020.tar";
+        sha256 = "1dia2jpl2mxamhr3hw7z9q9963psagnzhl5qqbag3a1d9bnn1bwa";
       };
       packageRequires = [ ];
       meta = {
@@ -6207,10 +6186,10 @@
     elpaBuild {
       pname = "notmuch-indicator";
       ename = "notmuch-indicator";
-      version = "1.2.0.0.20241025.81216";
+      version = "1.2.0.0.20250729.50820";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/notmuch-indicator-1.2.0.0.20241025.81216.tar";
-        sha256 = "1n29yddv4pbiwjfpa0ra3gvalhvcr5pxbzaqrg14z2grgqwbi4rh";
+        url = "https://elpa.gnu.org/devel/notmuch-indicator-1.2.0.0.20250729.50820.tar";
+        sha256 = "0wfkrpw1v0h5zjhd47q9m36nbr9ykhqmvzv0bx4rps1k7mbxvv8x";
       };
       packageRequires = [ ];
       meta = {
@@ -6263,24 +6242,19 @@
   ) { };
   oauth2 = callPackage (
     {
-      cl-lib ? null,
       elpaBuild,
       fetchurl,
       lib,
-      nadvice,
     }:
     elpaBuild {
       pname = "oauth2";
       ename = "oauth2";
-      version = "0.17.0.20240830.100757";
+      version = "0.17.0.20250810.115209";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/oauth2-0.17.0.20240830.100757.tar";
-        sha256 = "0y602ffm77d6f97hml9g6b1c3f2f7gfwzw5zw54iy4nl4fc7xk09";
+        url = "https://elpa.gnu.org/devel/oauth2-0.17.0.20250810.115209.tar";
+        sha256 = "1vzis99y0lwm8zfy0qbhzwwh4qj6r02m2l6jwmzy0n9m63964pij";
       };
-      packageRequires = [
-        cl-lib
-        nadvice
-      ];
+      packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/oauth2.html";
         license = lib.licenses.free;
@@ -6394,27 +6368,6 @@
       };
     }
   ) { };
-  openpgp = callPackage (
-    {
-      elpaBuild,
-      fetchurl,
-      lib,
-    }:
-    elpaBuild {
-      pname = "openpgp";
-      ename = "openpgp";
-      version = "1.0.2.0.20240726.81226";
-      src = fetchurl {
-        url = "https://elpa.gnu.org/devel/openpgp-1.0.2.0.20240726.81226.tar";
-        sha256 = "0yxvzc0jbkgx9hvd57cicmw38bm178w0ahqqa6fvxn55i4ssgmjs";
-      };
-      packageRequires = [ ];
-      meta = {
-        homepage = "https://elpa.gnu.org/devel/openpgp.html";
-        license = lib.licenses.free;
-      };
-    }
-  ) { };
   orderless = callPackage (
     {
       compat,
@@ -6425,10 +6378,10 @@
     elpaBuild {
       pname = "orderless";
       ename = "orderless";
-      version = "1.4.0.20250705.202309";
+      version = "1.5.0.20250728.24301";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/orderless-1.4.0.20250705.202309.tar";
-        sha256 = "15c7rangdl36m2zjr6rjjlma33yrjhg6is21agsz452zrpj8mp0f";
+        url = "https://elpa.gnu.org/devel/orderless-1.5.0.20250728.24301.tar";
+        sha256 = "082inppxd4ab2n1mq4dn7pnv2077kwp5bg1d6ic0x63dz8yiqww9";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6446,10 +6399,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "9.8pre0.20250628.182216";
+      version = "9.8pre0.20250817.94001";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-9.8pre0.20250628.182216.tar";
-        sha256 = "1sl64n8izkr9q31175ivmqvjhpisqfdva9iv3njbkyx6dvjam849";
+        url = "https://elpa.gnu.org/devel/org-9.8pre0.20250817.94001.tar";
+        sha256 = "0g4mi27zfpm3pss1hpmj66y22yhwqa583imjdxbrxxv1b9fn3z0l";
       };
       packageRequires = [ ];
       meta = {
@@ -6468,10 +6421,10 @@
     elpaBuild {
       pname = "org-contacts";
       ename = "org-contacts";
-      version = "1.1.0.20250619.32158";
+      version = "1.1.0.20250820.180336";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-contacts-1.1.0.20250619.32158.tar";
-        sha256 = "1lkf67m4c19mgj0pni07y3nvdncwy1xis7ax08m5kbq16i21ay3s";
+        url = "https://elpa.gnu.org/devel/org-contacts-1.1.0.20250820.180336.tar";
+        sha256 = "0s7wlh9a5fsbmp76lrxvcs4gz7xg6qky2d6q0ixbpb6pq6arxx4i";
       };
       packageRequires = [ org ];
       meta = {
@@ -6517,10 +6470,10 @@
     elpaBuild {
       pname = "org-gnosis";
       ename = "org-gnosis";
-      version = "0.0.9.0.20250226.154732";
+      version = "0.1.1.0.20250804.81757";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-gnosis-0.0.9.0.20250226.154732.tar";
-        sha256 = "1yk5fp4l3q1ycgbgmgn9biy3na22ssvx15j76k6almx50cgcngyp";
+        url = "https://elpa.gnu.org/devel/org-gnosis-0.1.1.0.20250804.81757.tar";
+        sha256 = "16lw8pv8n9aamn5f8q2gk8ljzpcgwzlhsgiclw45bn98cy0cqb1d";
       };
       packageRequires = [
         compat
@@ -6565,10 +6518,10 @@
     elpaBuild {
       pname = "org-modern";
       ename = "org-modern";
-      version = "1.9.0.20250617.112650";
+      version = "1.9.0.20250804.224509";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-modern-1.9.0.20250617.112650.tar";
-        sha256 = "0pqv10bw7k4n9yq6rpxkfaa8ld9kz5gp9xrw2wg06zz63v1c5ydw";
+        url = "https://elpa.gnu.org/devel/org-modern-1.9.0.20250804.224509.tar";
+        sha256 = "10rffsxn989yqqawdg36ymz3i1k82z1hwp4l49gy37szcrpmc5ps";
       };
       packageRequires = [
         compat
@@ -6745,10 +6698,10 @@
     elpaBuild {
       pname = "osm";
       ename = "osm";
-      version = "1.7.0.20250617.112655";
+      version = "1.7.0.20250804.224343";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/osm-1.7.0.20250617.112655.tar";
-        sha256 = "1pcii0bks4isjnfdi5k3jlx707g1nfv2sgmmr58h7hsvkc7y6k45";
+        url = "https://elpa.gnu.org/devel/osm-1.7.0.20250804.224343.tar";
+        sha256 = "1iqpfzn6rcswkn8sgskwyqya07q21xs0c1s3xrlfxrskybrh1rpd";
       };
       packageRequires = [ compat ];
       meta = {
@@ -7343,10 +7296,10 @@
     elpaBuild {
       pname = "project";
       ename = "project";
-      version = "0.11.1.0.20250702.24624";
+      version = "0.11.1.0.20250824.2348";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/project-0.11.1.0.20250702.24624.tar";
-        sha256 = "1xsdnr7gljjc89x1819r4h2i3ip3bsb7qrpknrdjqy6bzrdigpji";
+        url = "https://elpa.gnu.org/devel/project-0.11.1.0.20250824.2348.tar";
+        sha256 = "0rd684rv45snxn14h6z9dm2ffridygpcmphraszy953rn8syr7xx";
       };
       packageRequires = [ xref ];
       meta = {
@@ -7406,10 +7359,10 @@
     elpaBuild {
       pname = "pulsar";
       ename = "pulsar";
-      version = "1.2.0.0.20241228.104712";
+      version = "1.2.0.0.20250729.33601";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/pulsar-1.2.0.0.20241228.104712.tar";
-        sha256 = "02625fbs1l0c1lr0gy2v3rjmb65bmvil6svx1bf9wx4l1aqhfyjz";
+        url = "https://elpa.gnu.org/devel/pulsar-1.2.0.0.20250729.33601.tar";
+        sha256 = "12k9nijvsfr29c6mhw026a13z2q3gs2idaymivlkywakipzrsdzz";
       };
       packageRequires = [ ];
       meta = {
@@ -7479,10 +7432,10 @@
     elpaBuild {
       pname = "python";
       ename = "python";
-      version = "0.30.0.20250625.165705";
+      version = "0.30.0.20250807.130628";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/python-0.30.0.20250625.165705.tar";
-        sha256 = "0rpn51f0hb088jsvril0w7igbbxd9cjf07z6cn97p50a4xw77i70";
+        url = "https://elpa.gnu.org/devel/python-0.30.0.20250807.130628.tar";
+        sha256 = "0p6r82k9vbwdb3kdbxfh9a4a088fdssa7wz3rdxz61c0jqvia2bw";
       };
       packageRequires = [
         compat
@@ -7598,6 +7551,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/rcirc-color.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  rcirc-mentions = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "rcirc-mentions";
+      ename = "rcirc-mentions";
+      version = "1.0.3.0.20250822.43114";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/rcirc-mentions-1.0.3.0.20250822.43114.tar";
+        sha256 = "064k7r6digaljdi156m49wcasf7k37rj195lxbarh18qavragqv7";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/rcirc-mentions.html";
         license = lib.licenses.free;
       };
     }
@@ -7910,10 +7884,10 @@
     elpaBuild {
       pname = "relint";
       ename = "relint";
-      version = "2.1.0.20250224.150638";
+      version = "2.1.0.20250814.100832";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/relint-2.1.0.20250224.150638.tar";
-        sha256 = "06fn5lm4w7ypjrndlc8kl2lvvipiv4ik9hh8rvaa5h0vhkw1y947";
+        url = "https://elpa.gnu.org/devel/relint-2.1.0.20250814.100832.tar";
+        sha256 = "10xj341zrf6plvz5816w0bimfz2dc2kfc6qs59yxcyk3j33bs5jd";
       };
       packageRequires = [ xr ];
       meta = {
@@ -8277,10 +8251,10 @@
     elpaBuild {
       pname = "show-font";
       ename = "show-font";
-      version = "0.3.0.0.20250426.112415";
+      version = "0.3.1.0.20250826.74910";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/show-font-0.3.0.0.20250426.112415.tar";
-        sha256 = "0ygk5qq98rmbyjnh58c5rpdszrpwvpn9vr55s6lpp94lwl1yhkwq";
+        url = "https://elpa.gnu.org/devel/show-font-0.3.1.0.20250826.74910.tar";
+        sha256 = "0m5g2qkcs97liqk98x3qnsimkg7bp6fysxpvinmkah66gq0lx5b7";
       };
       packageRequires = [ ];
       meta = {
@@ -8554,10 +8528,10 @@
     elpaBuild {
       pname = "spacious-padding";
       ename = "spacious-padding";
-      version = "0.7.0.0.20250618.104647";
+      version = "0.7.0.0.20250719.40007";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/spacious-padding-0.7.0.0.20250618.104647.tar";
-        sha256 = "0g9zikr4kqkk155kpxiyg79dsjbf4755263msjhnr3088vj4c6sv";
+        url = "https://elpa.gnu.org/devel/spacious-padding-0.7.0.0.20250719.40007.tar";
+        sha256 = "0zdfzk1v3niq2rxm0v52086jyijjj0vvcr7071r8780a41jr3yqm";
       };
       packageRequires = [ ];
       meta = {
@@ -8750,10 +8724,10 @@
     elpaBuild {
       pname = "standard-themes";
       ename = "standard-themes";
-      version = "2.2.0.0.20250704.55025";
+      version = "2.2.0.0.20250803.41715";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/standard-themes-2.2.0.0.20250704.55025.tar";
-        sha256 = "14g3dvrkcv5niz70iw942aj2nrcj75azn265w7sinsf1jsny6xi1";
+        url = "https://elpa.gnu.org/devel/standard-themes-2.2.0.0.20250803.41715.tar";
+        sha256 = "1mykgalrlgr154g4hdslvdfd3jajzv8dkgg2w5rjy2lihnslcds5";
       };
       packageRequires = [ ];
       meta = {
@@ -8792,10 +8766,10 @@
     elpaBuild {
       pname = "substitute";
       ename = "substitute";
-      version = "0.3.1.0.20250124.63904";
+      version = "0.3.1.0.20250710.41803";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/substitute-0.3.1.0.20250124.63904.tar";
-        sha256 = "0303zy8xz422fhm6ijk1lvfxj409jmf4pvqlnslb0km0mg11z44w";
+        url = "https://elpa.gnu.org/devel/substitute-0.3.1.0.20250710.41803.tar";
+        sha256 = "1b4cs2kmg6vp946m6vrwhp0rqps737xzndkx7cnhxqmg315whn39";
       };
       packageRequires = [ ];
       meta = {
@@ -8856,10 +8830,10 @@
     elpaBuild {
       pname = "svg-lib";
       ename = "svg-lib";
-      version = "0.3.0.20240219.161327";
+      version = "0.3.0.20250822.125859";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/svg-lib-0.3.0.20240219.161327.tar";
-        sha256 = "1qycnhjinmn1smajsniz34kv7jkl4gycjhsl6mxxjhq0432cw2fc";
+        url = "https://elpa.gnu.org/devel/svg-lib-0.3.0.20250822.125859.tar";
+        sha256 = "14ilvsml7j9xi9fkqhdxab6nmy979741fwxq72xpfl3j9ivymsrn";
       };
       packageRequires = [ ];
       meta = {
@@ -8943,10 +8917,10 @@
     elpaBuild {
       pname = "sxhkdrc-mode";
       ename = "sxhkdrc-mode";
-      version = "1.1.0.0.20241224.141418";
+      version = "1.2.0.0.20250814.70257";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/sxhkdrc-mode-1.1.0.0.20241224.141418.tar";
-        sha256 = "0z1q837vpjhhbr8gi5fiwnc25bvyfgsfxa4rlq2l527d8vrn1mpl";
+        url = "https://elpa.gnu.org/devel/sxhkdrc-mode-1.2.0.0.20250814.70257.tar";
+        sha256 = "1zjkhhpsiq5wdp2lyq98zrxj52c5h6kr4vn9dfimgkx3z3z8dcgl";
       };
       packageRequires = [ ];
       meta = {
@@ -9123,10 +9097,10 @@
     elpaBuild {
       pname = "tempel";
       ename = "tempel";
-      version = "1.5.0.20250620.115731";
+      version = "1.5.0.20250823.200409";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tempel-1.5.0.20250620.115731.tar";
-        sha256 = "0rhgwzl9zlxjgg8vc7qlgavfpa40qhrwljpdvn2nfybhc1r28rvg";
+        url = "https://elpa.gnu.org/devel/tempel-1.5.0.20250823.200409.tar";
+        sha256 = "0rsaq2b0k37q03kq7rknfg26ma87j1m89n2l1s9s7pg9kvjqyrkk";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9187,10 +9161,10 @@
     elpaBuild {
       pname = "tex-parens";
       ename = "tex-parens";
-      version = "0.7.0.20250322.84812";
+      version = "0.7.0.20250709.53958";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tex-parens-0.7.0.20250322.84812.tar";
-        sha256 = "0q8nv125k863vmgclrbh7v4548pnccwmidgl645wjv89198dh5v0";
+        url = "https://elpa.gnu.org/devel/tex-parens-0.7.0.20250709.53958.tar";
+        sha256 = "0mbcgc17cy8imk7dzh9krwd62dy2h7fj5pzvfr1wggdczrs2zva8";
       };
       packageRequires = [ ];
       meta = {
@@ -9272,10 +9246,10 @@
     elpaBuild {
       pname = "tmr";
       ename = "tmr";
-      version = "1.1.0.0.20250616.63541";
+      version = "1.1.0.0.20250823.55117";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tmr-1.1.0.0.20250616.63541.tar";
-        sha256 = "0lizpxy6v1947y5cvg1qqb3whmmvay5mv6q3k1gf7hpgfmfz3xs0";
+        url = "https://elpa.gnu.org/devel/tmr-1.1.0.0.20250823.55117.tar";
+        sha256 = "16mp83rl6sfgxqncgz1qw68alh1xj57yqc4yy1z7cxjg5p4vbbj6";
       };
       packageRequires = [ ];
       meta = {
@@ -9361,10 +9335,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.8.0.0.20250629.74034";
+      version = "2.8.0.1.0.20250730.65308";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tramp-2.8.0.0.20250629.74034.tar";
-        sha256 = "0h9vxgwvm5nzjpa8hnq3bxinjsc1f3chql68y3qi0x7ll77g1r2v";
+        url = "https://elpa.gnu.org/devel/tramp-2.8.0.1.0.20250730.65308.tar";
+        sha256 = "1yzd022xgx5x81k19pam97lw0sr75xz4pns681h77q5yhwz4r3yr";
       };
       packageRequires = [ ];
       meta = {
@@ -9447,10 +9421,10 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.9.3.0.20250701.122332";
+      version = "0.9.4.0.20250801.114942";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/transient-0.9.3.0.20250701.122332.tar";
-        sha256 = "1h8iv5ccmc2j3my97rsbn0b12rp8w0jrhvkkhz6w9pvp0braxlh6";
+        url = "https://elpa.gnu.org/devel/transient-0.9.4.0.20250801.114942.tar";
+        sha256 = "10ly70n16v6hrhgjvhihpzv9hpq4zdx3lrq8ywjprdcp9ir5bx0r";
       };
       packageRequires = [
         compat
@@ -9553,27 +9527,6 @@
       };
     }
   ) { };
-  typo = callPackage (
-    {
-      elpaBuild,
-      fetchurl,
-      lib,
-    }:
-    elpaBuild {
-      pname = "typo";
-      ename = "typo";
-      version = "1.0.1.0.20230730.150555";
-      src = fetchurl {
-        url = "https://elpa.gnu.org/devel/typo-1.0.1.0.20230730.150555.tar";
-        sha256 = "0cjn2lh0949kc6c9fxknzg2fyb4p3iwic2a9md5yxpdl42j24fvw";
-      };
-      packageRequires = [ ];
-      meta = {
-        homepage = "https://elpa.gnu.org/devel/typo.html";
-        license = lib.licenses.free;
-      };
-    }
-  ) { };
   ulisp-repl = callPackage (
     {
       elpaBuild,
@@ -9670,10 +9623,10 @@
     elpaBuild {
       pname = "urgrep";
       ename = "urgrep";
-      version = "0.5.3snapshot0.20250701.205050";
+      version = "0.6.0snapshot0.20250709.114307";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/urgrep-0.5.3snapshot0.20250701.205050.tar";
-        sha256 = "0anv784nnm0z6bnq5l59kdv4w0qy1q6kwxg3ahnq83ls3nl7sqpy";
+        url = "https://elpa.gnu.org/devel/urgrep-0.6.0snapshot0.20250709.114307.tar";
+        sha256 = "149q30izqnv462k4rvghb5g3mh6p3zznh2sqdzi4msk2mbpgggny";
       };
       packageRequires = [
         compat
@@ -9892,10 +9845,10 @@
     elpaBuild {
       pname = "vc-jj";
       ename = "vc-jj";
-      version = "0.3.0.20250707.95759";
+      version = "0.3.0.20250825.81224";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vc-jj-0.3.0.20250707.95759.tar";
-        sha256 = "0rblsz2ga0csc86mq276hqfxrc7dj3gnh1xlk0sfqbqyc39yx293";
+        url = "https://elpa.gnu.org/devel/vc-jj-0.3.0.20250825.81224.tar";
+        sha256 = "1f3xclsgglk93b2h7nc6gclydg578ffzc7zqxlbgbxbri5kmb0a9";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9968,6 +9921,32 @@
       };
     }
   ) { };
+  vecdb = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+      pg,
+      plz,
+    }:
+    elpaBuild {
+      pname = "vecdb";
+      ename = "vecdb";
+      version = "0.2.0.20250724.14151";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/vecdb-0.2.0.20250724.14151.tar";
+        sha256 = "09l02c9vldx4bk6cn69rnfg9kafxfif7nmsv538jhhxzf5q31z43";
+      };
+      packageRequires = [
+        pg
+        plz
+      ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/vecdb.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   verilog-mode = callPackage (
     {
       elpaBuild,
@@ -9999,10 +9978,10 @@
     elpaBuild {
       pname = "vertico";
       ename = "vertico";
-      version = "2.4.0.20250702.140354";
+      version = "2.4.0.20250824.101737";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vertico-2.4.0.20250702.140354.tar";
-        sha256 = "0xr2kc9b82xng17m7lavjddaj4sy6ngq3dbzlffssrh6v5bn3lii";
+        url = "https://elpa.gnu.org/devel/vertico-2.4.0.20250824.101737.tar";
+        sha256 = "0xkad13qk8aibmd1j40lv1l30bifav2pfmh07cy6j548nb7y5d8j";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10497,10 +10476,10 @@
     elpaBuild {
       pname = "xelb";
       ename = "xelb";
-      version = "0.21.0.20250706.151817";
+      version = "0.21.0.20250724.152124";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xelb-0.21.0.20250706.151817.tar";
-        sha256 = "0lg5iwxa9h2m2bfzm2crvsv2lar86hligvynvrxdkcig07hg6qkh";
+        url = "https://elpa.gnu.org/devel/xelb-0.21.0.20250724.152124.tar";
+        sha256 = "1j9s7kqngz1vy9v7j4bbj7mbqi4ljwqz12gkix56ql92yxycw941";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10544,10 +10523,10 @@
     elpaBuild {
       pname = "xr";
       ename = "xr";
-      version = "2.1.0.20250224.150416";
+      version = "2.1.0.20250814.100809";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xr-2.1.0.20250224.150416.tar";
-        sha256 = "0ndfsnma1h3h6kbaymaa7cckdsk92zbi822zarliwvwg9qf1qmnw";
+        url = "https://elpa.gnu.org/devel/xr-2.1.0.20250814.100809.tar";
+        sha256 = "0dnpwvc6bbvi3w25q38xwpcfplwx0dsfsgxjqzjyxm17zijmgnfp";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -440,10 +440,10 @@
     elpaBuild {
       pname = "auctex";
       ename = "auctex";
-      version = "14.0.9";
+      version = "14.1.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/auctex-14.0.9.tar";
-        sha256 = "1mhzrqln0fjj9nn04dhgzpcyv2wzysz4l85wmp4fw620jksf8j7n";
+        url = "https://elpa.gnu.org/packages/auctex-14.1.0.tar";
+        sha256 = "0cb5f86p7yxqx27wck2a3wgsxrzhv5rrgn88wpias1w7v2lbsw2j";
       };
       packageRequires = [ ];
       meta = {
@@ -556,27 +556,6 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/auto-correct.html";
-        license = lib.licenses.free;
-      };
-    }
-  ) { };
-  auto-header = callPackage (
-    {
-      elpaBuild,
-      fetchurl,
-      lib,
-    }:
-    elpaBuild {
-      pname = "auto-header";
-      ename = "auto-header";
-      version = "0.1.2";
-      src = fetchurl {
-        url = "https://elpa.gnu.org/packages/auto-header-0.1.2.tar";
-        sha256 = "0p22bpdy29i7ff8rzjh1qzvj4d8igl36gs1981kmds4qz23qn447";
-      };
-      packageRequires = [ ];
-      meta = {
-        homepage = "https://elpa.gnu.org/packages/auto-header.html";
         license = lib.licenses.free;
       };
     }
@@ -1526,10 +1505,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "2.6";
+      version = "2.7";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/consult-2.6.tar";
-        sha256 = "1afji70i64w027r265ry8s21v4fic087lmfch7qvwdcjzj165pl4";
+        url = "https://elpa.gnu.org/packages/consult-2.7.tar";
+        sha256 = "1r4rjq537j1yr73apr8ga86kzs5h0xk4s0xf9983pq9spgd0wrpi";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1856,10 +1835,10 @@
     elpaBuild {
       pname = "cursory";
       ename = "cursory";
-      version = "1.1.0";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/cursory-1.1.0.tar";
-        sha256 = "1n2d7nxg4m4i303vmsz0cxv9p5q6630y6x2g7mq51wbc7g0zdrhc";
+        url = "https://elpa.gnu.org/packages/cursory-1.2.0.tar";
+        sha256 = "0019syaj02lxm4c4bdfqfq6g5izkgwwfgz82fj1grxk904kdi4fs";
       };
       packageRequires = [ ];
       meta = {
@@ -2449,10 +2428,10 @@
     elpaBuild {
       pname = "dired-preview";
       ename = "dired-preview";
-      version = "0.5.2";
+      version = "0.6.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/dired-preview-0.5.2.tar";
-        sha256 = "1zipwb9ydyx6cscpf8p7vf2fl03rd7diivdvq9h73pbz754m0bq9";
+        url = "https://elpa.gnu.org/packages/dired-preview-0.6.0.tar";
+        sha256 = "1nlibx8jwyvb5n58sx8bg6vcazhnlj5dydmf36v7hzy0h4i460i0";
       };
       packageRequires = [ ];
       meta = {
@@ -2618,10 +2597,10 @@
     elpaBuild {
       pname = "doric-themes";
       ename = "doric-themes";
-      version = "0.2.0";
+      version = "0.3.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/doric-themes-0.2.0.tar";
-        sha256 = "1h4v5aqsigr9vk3rirsgpfw0py8cp5y7dpvx8ph2ia7wk8nw8zz3";
+        url = "https://elpa.gnu.org/packages/doric-themes-0.3.0.tar";
+        sha256 = "1i2wrg3j2gpwyb3y1fb8wwmzl0hk5dw8i1160vcffpwmbf3mppza";
       };
       packageRequires = [ ];
       meta = {
@@ -2949,10 +2928,10 @@
     elpaBuild {
       pname = "eldoc";
       ename = "eldoc";
-      version = "1.15.0";
+      version = "1.16.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/eldoc-1.15.0.tar";
-        sha256 = "05fgk3y2rp0xrm3x0xmf9fm72l442y7ydxxg3xk006d9cq06h8kz";
+        url = "https://elpa.gnu.org/packages/eldoc-1.16.0.tar";
+        sha256 = "08dnvfyz6qkjx3fcggp628qacbxvac1agl7kgbkg6kiq4axwmifb";
       };
       packageRequires = [ ];
       meta = {
@@ -3046,10 +3025,10 @@
     elpaBuild {
       pname = "ellama";
       ename = "ellama";
-      version = "1.8.1";
+      version = "1.8.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ellama-1.8.1.tar";
-        sha256 = "19n8zcgls4jiz7hacj564gb9y0sxdli2yl4j4d35c44pq52g2y6v";
+        url = "https://elpa.gnu.org/packages/ellama-1.8.2.tar";
+        sha256 = "0gkkm3hfxwn2x12vbbrp3nydkzs91abd90cf8qmwaxgdl6fvlg4d";
       };
       packageRequires = [
         compat
@@ -3182,10 +3161,10 @@
     elpaBuild {
       pname = "emms";
       ename = "emms";
-      version = "22";
+      version = "23";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/emms-22.tar";
-        sha256 = "0jn8si9m8pxd7ni543p8z697297i9dva319dw141zwpbxqhmyvpi";
+        url = "https://elpa.gnu.org/packages/emms-23.tar";
+        sha256 = "08s04cqk9p0srcxffvpdf67fajv130sfyah6yd13mj7am9r1ak9d";
       };
       packageRequires = [
         cl-lib
@@ -3466,27 +3445,6 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/f90-interface-browser.html";
-        license = lib.licenses.free;
-      };
-    }
-  ) { };
-  face-shift = callPackage (
-    {
-      elpaBuild,
-      fetchurl,
-      lib,
-    }:
-    elpaBuild {
-      pname = "face-shift";
-      ename = "face-shift";
-      version = "0.2.1";
-      src = fetchurl {
-        url = "https://elpa.gnu.org/packages/face-shift-0.2.1.tar";
-        sha256 = "14sbafkxr7kmv6sd5rw7d7hcsh0hhx92wkh6arfbchxad8jzimr6";
-      };
-      packageRequires = [ ];
-      meta = {
-        homepage = "https://elpa.gnu.org/packages/face-shift.html";
         license = lib.licenses.free;
       };
     }
@@ -4475,10 +4433,10 @@
     elpaBuild {
       pname = "indent-bars";
       ename = "indent-bars";
-      version = "0.9.1";
+      version = "0.9.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/indent-bars-0.9.1.tar";
-        sha256 = "1jb0jhfin728ld703y392gy99is7jywqak3z2xrrvpmn9q17q8vs";
+        url = "https://elpa.gnu.org/packages/indent-bars-0.9.2.tar";
+        sha256 = "030haxxla7m6p2zks9g50dj8rr8grm67n2ig7zd3k20h1yrfm6q0";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4547,6 +4505,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/isearch-mb.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  iso-date = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "iso-date";
+      ename = "iso-date";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/iso-date-1.2.0.tar";
+        sha256 = "132v583glz0faxyizysbsg7bm3hhhwav2769xqq3x86y0k5399c5";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/iso-date.html";
         license = lib.licenses.free;
       };
     }
@@ -4788,10 +4767,10 @@
     elpaBuild {
       pname = "jinx";
       ename = "jinx";
-      version = "2.2";
+      version = "2.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/jinx-2.2.tar";
-        sha256 = "17f7p7q21f0l8zzr2z05y6mzrh6pw036cnp1375hbssnpsrh3wc1";
+        url = "https://elpa.gnu.org/packages/jinx-2.3.tar";
+        sha256 = "0sm6yrh70qy6w7v1ljr02rfj10kyixnghk1aigizc4rgpr4b8azp";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5240,10 +5219,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.27.0";
+      version = "0.27.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/llm-0.27.0.tar";
-        sha256 = "1vxhlkq05im6h1jjg4bs077iw0qw8spg2lz3n3k783zanfrifzi6";
+        url = "https://elpa.gnu.org/packages/llm-0.27.1.tar";
+        sha256 = "0qdzkjm9cihhcj5ains8m952hwkjfy4glr6yzrs5dws3bl3yqqbh";
       };
       packageRequires = [
         compat
@@ -5478,10 +5457,10 @@
     elpaBuild {
       pname = "marginalia";
       ename = "marginalia";
-      version = "2.1";
+      version = "2.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/marginalia-2.1.tar";
-        sha256 = "0yg2v8pjccfdrlyabn8kih3hf7dkksirgc9g7a83m2zbkrbhimms";
+        url = "https://elpa.gnu.org/packages/marginalia-2.2.tar";
+        sha256 = "16h0zdzjip10ryalanygfkz4i2bf21vr6f4348l5cgx0mnx10cvx";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5777,10 +5756,10 @@
     elpaBuild {
       pname = "minuet";
       ename = "minuet";
-      version = "0.5.4";
+      version = "0.6.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/minuet-0.5.4.tar";
-        sha256 = "01mw4sqb7rp9zpxjm590a9qvxiyawwhjyq3k568gv30pj3a9lrxp";
+        url = "https://elpa.gnu.org/packages/minuet-0.6.0.tar";
+        sha256 = "1vpq6jsmw93hssla13dkf2ff13sv11fbjaq7wmrybnc4vnyfkycz";
       };
       packageRequires = [
         dash
@@ -5823,10 +5802,10 @@
     elpaBuild {
       pname = "modus-themes";
       ename = "modus-themes";
-      version = "4.8.0";
+      version = "4.8.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/modus-themes-4.8.0.tar";
-        sha256 = "15d8ld7gf3c15i409pmp8pnv3b9bgy0r5xbb1bicga7knyqqaj6c";
+        url = "https://elpa.gnu.org/packages/modus-themes-4.8.1.tar";
+        sha256 = "1xax6pfq8xlybwid3sgzm82az4p1blm217qp1bvy0fjf5qcand5i";
       };
       packageRequires = [ ];
       meta = {
@@ -6349,27 +6328,6 @@
       };
     }
   ) { };
-  openpgp = callPackage (
-    {
-      elpaBuild,
-      fetchurl,
-      lib,
-    }:
-    elpaBuild {
-      pname = "openpgp";
-      ename = "openpgp";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://elpa.gnu.org/packages/openpgp-1.0.2.tar";
-        sha256 = "1gaq6hf9mwk52zjqw3d0wrj9l8mgzrbrk7nzywap4psnriq0vs0j";
-      };
-      packageRequires = [ ];
-      meta = {
-        homepage = "https://elpa.gnu.org/packages/openpgp.html";
-        license = lib.licenses.free;
-      };
-    }
-  ) { };
   orderless = callPackage (
     {
       compat,
@@ -6380,10 +6338,10 @@
     elpaBuild {
       pname = "orderless";
       ename = "orderless";
-      version = "1.4";
+      version = "1.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/orderless-1.4.tar";
-        sha256 = "151df7azrhyxaa768bp6mxmc44mmc4h1x180s2a9ns4b3lsfczrv";
+        url = "https://elpa.gnu.org/packages/orderless-1.5.tar";
+        sha256 = "188mksjaazf1rxvyqrcybya4a53j6c1xwvcbfh8s1sgv0jqxlv8z";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6401,10 +6359,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "9.7.31";
+      version = "9.7.34";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-9.7.31.tar";
-        sha256 = "13fxckj4pw4cwjqgz4fbw680jfypfqq8rc4hir26halsxz8lvi2m";
+        url = "https://elpa.gnu.org/packages/org-9.7.34.tar";
+        sha256 = "0jd9bhymcjxkf04vygl32mnqvbsgjqqp48axv3pm2s614vw23qsp";
       };
       packageRequires = [ ];
       meta = {
@@ -6472,10 +6430,10 @@
     elpaBuild {
       pname = "org-gnosis";
       ename = "org-gnosis";
-      version = "0.0.9";
+      version = "0.1.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-gnosis-0.0.9.tar";
-        sha256 = "1p0qpvxwjvbmzf8npsyirpgi7ykd7ai14m758zp1rlwz03qyx2m4";
+        url = "https://elpa.gnu.org/packages/org-gnosis-0.1.1.tar";
+        sha256 = "0165bv6ky7zg9km7h63qzqg7rxnjdcpks4xyv0l2sidgmzimdyg5";
       };
       packageRequires = [
         compat
@@ -7513,6 +7471,27 @@
       };
     }
   ) { };
+  rcirc-mentions = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "rcirc-mentions";
+      ename = "rcirc-mentions";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/rcirc-mentions-1.0.3.tar";
+        sha256 = "1dk651cm30kigbg8ns26k5fmr42ha9w6yx27j1iiwrxyifsxyb12";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/rcirc-mentions.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   rcirc-menu = callPackage (
     {
       elpaBuild,
@@ -8167,10 +8146,10 @@
     elpaBuild {
       pname = "show-font";
       ename = "show-font";
-      version = "0.3.0";
+      version = "0.3.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/show-font-0.3.0.tar";
-        sha256 = "1xrpzrb1i3593fawqy6bgfjn0fixgpnkq0kad14fk8qibh9iwb0x";
+        url = "https://elpa.gnu.org/packages/show-font-0.3.1.tar";
+        sha256 = "1ahlv8khf5vcmxvprz6swk3sw3i1rbbv45jp1c46mkhdg6bkmc7m";
       };
       packageRequires = [ ];
       meta = {
@@ -8812,10 +8791,10 @@
     elpaBuild {
       pname = "sxhkdrc-mode";
       ename = "sxhkdrc-mode";
-      version = "1.1.0";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/sxhkdrc-mode-1.1.0.tar";
-        sha256 = "00mzhxrlcbswsv3jysgqniq02inakz7j5a2hx2w83is5rbmb9bhc";
+        url = "https://elpa.gnu.org/packages/sxhkdrc-mode-1.2.0.tar";
+        sha256 = "0a4r06cxgqkvx2vv94icy096kg5v1qf637gmgwrgg0i4w49hk5jk";
       };
       packageRequires = [ ];
       meta = {
@@ -9205,10 +9184,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.8.0";
+      version = "2.8.0.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tramp-2.8.0.tar";
-        sha256 = "1sfrxd10q80j0f27dwxc594s6rflnnq97lgl45kgvwfwfwffwvn7";
+        url = "https://elpa.gnu.org/packages/tramp-2.8.0.1.tar";
+        sha256 = "1g7srsdyqldqx0hn8yv5x94dawfbqdbkbsi1l9ax06g3kn360sd7";
       };
       packageRequires = [ ];
       meta = {
@@ -9291,10 +9270,10 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.9.3";
+      version = "0.9.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/transient-0.9.3.tar";
-        sha256 = "0rbh2m2lpcn5xvaw1wn0rzc3xyq6pgja9k1a5601sl4pbs60cx4d";
+        url = "https://elpa.gnu.org/packages/transient-0.9.4.tar";
+        sha256 = "191d04n8y9brkfsbp205h29wmrlzk7adsff4jrhq9y4ml78az7n9";
       };
       packageRequires = [
         compat
@@ -9393,27 +9372,6 @@
       packageRequires = [ seq ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/triples.html";
-        license = lib.licenses.free;
-      };
-    }
-  ) { };
-  typo = callPackage (
-    {
-      elpaBuild,
-      fetchurl,
-      lib,
-    }:
-    elpaBuild {
-      pname = "typo";
-      ename = "typo";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://elpa.gnu.org/packages/typo-1.0.1.tar";
-        sha256 = "1w4m2admlgmx7d661l70rryyxbaahfvrvhxc1b9sq41nx88bmgn1";
-      };
-      packageRequires = [ ];
-      meta = {
-        homepage = "https://elpa.gnu.org/packages/typo.html";
         license = lib.licenses.free;
       };
     }
@@ -9807,6 +9765,32 @@
       packageRequires = [ hydra ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/vdiff.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  vecdb = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+      pg,
+      plz,
+    }:
+    elpaBuild {
+      pname = "vecdb";
+      ename = "vecdb";
+      version = "0.2";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/vecdb-0.2.tar";
+        sha256 = "10p5nhk4v4j05k9cz9br5ninycpp7spgby9mrr9z8bsy2g0j0il2";
+      };
+      packageRequires = [
+        pg
+        plz
+      ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/vecdb.html";
         license = lib.licenses.free;
       };
     }

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
@@ -54,10 +54,10 @@
     elpaBuild {
       pname = "aidermacs";
       ename = "aidermacs";
-      version = "1.5.0.20250707.183212";
+      version = "1.5.0.20250818.124701";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/aidermacs-1.5.0.20250707.183212.tar";
-        sha256 = "11skkh7abmdf9jndl9qpk5bd8g3as1j5rmpx5p4mvzl3hsd8nhf4";
+        url = "https://elpa.nongnu.org/nongnu-devel/aidermacs-1.5.0.20250818.124701.tar";
+        sha256 = "0y32fj69y0vvk3gcf7lrpwcmqk7y55gxrpl59l1wc9rwq42rsv90";
       };
       packageRequires = [
         compat
@@ -184,10 +184,10 @@
     elpaBuild {
       pname = "apache-mode";
       ename = "apache-mode";
-      version = "2.2.0.0.20250422.172352";
+      version = "2.2.0.0.20250811.194318";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/apache-mode-2.2.0.0.20250422.172352.tar";
-        sha256 = "1gqjb98d1wihfryacdyjivsxidydilb6glgivf39l8ca2xk44dbg";
+        url = "https://elpa.nongnu.org/nongnu-devel/apache-mode-2.2.0.0.20250811.194318.tar";
+        sha256 = "16hpfjy2998i289gd95f61fj95g798z99kwlv3mh8a57sj1da0fz";
       };
       packageRequires = [ ];
       meta = {
@@ -205,10 +205,10 @@
     elpaBuild {
       pname = "apropospriate-theme";
       ename = "apropospriate-theme";
-      version = "0.2.0.0.20241215.141144";
+      version = "0.2.0.0.20250724.72226";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/apropospriate-theme-0.2.0.0.20241215.141144.tar";
-        sha256 = "0hr961s3s9n9an63yxkxkryas0vr0cw9g07ir8igyan6b8b2didb";
+        url = "https://elpa.nongnu.org/nongnu-devel/apropospriate-theme-0.2.0.0.20250724.72226.tar";
+        sha256 = "10z6ifrfg0dxjjvk8lhw7a2w041wbfvfik9jvz8m7sl6k6pl8bsi";
       };
       packageRequires = [ ];
       meta = {
@@ -312,10 +312,10 @@
     elpaBuild {
       pname = "bash-completion";
       ename = "bash-completion";
-      version = "3.2.1snapshot0.20250626.204257";
+      version = "3.2.1snapshot0.20250721.202603";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/bash-completion-3.2.1snapshot0.20250626.204257.tar";
-        sha256 = "19ajv804fl520pk5wqni066dpklbc6i16wbkvm5d7hiwzybfpg44";
+        url = "https://elpa.nongnu.org/nongnu-devel/bash-completion-3.2.1snapshot0.20250721.202603.tar";
+        sha256 = "0vx9d3216n3p39fkch1z3kmsbszqcdhf1j4wiqp15y034j2g5gk1";
       };
       packageRequires = [ ];
       meta = {
@@ -481,10 +481,10 @@
     elpaBuild {
       pname = "buttercup";
       ename = "buttercup";
-      version = "1.37.0.20250216.231504";
+      version = "1.38.0.20250801.138";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/buttercup-1.37.0.20250216.231504.tar";
-        sha256 = "01x2b82kbb2pcn2m75yfrfcjc1dg6qcqyc1d6abnhwvgdxfxv7yf";
+        url = "https://elpa.nongnu.org/nongnu-devel/buttercup-1.38.0.20250801.138.tar";
+        sha256 = "1hcwlymmhbcrgz501gjx7d337x1cy4gzz6nbg0xq4yjxp0l0pq5c";
       };
       packageRequires = [ ];
       meta = {
@@ -572,10 +572,10 @@
     elpaBuild {
       pname = "cider";
       ename = "cider";
-      version = "1.19.0snapshot0.20250704.84003";
+      version = "1.20.0snapshot0.20250806.194437";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.19.0snapshot0.20250704.84003.tar";
-        sha256 = "0m86kc0x6hd0q9zl785vzbzpvsjr461cshsp158xihjpp4jsa92q";
+        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.20.0snapshot0.20250806.194437.tar";
+        sha256 = "1z7v7f8pal8z4pgr6qzmh1g8ir1rdwshx2hifzngkp33lqmvd15x";
       };
       packageRequires = [
         clojure-mode
@@ -622,10 +622,10 @@
     elpaBuild {
       pname = "clojure-ts-mode";
       ename = "clojure-ts-mode";
-      version = "0.6.0snapshot0.20250705.130718";
+      version = "0.6.0snapshot0.20250815.44110";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/clojure-ts-mode-0.6.0snapshot0.20250705.130718.tar";
-        sha256 = "1f58y6v2rgz4srn26zdy6c8i2qxn79asxg8l35yqdnrh8l7f5609";
+        url = "https://elpa.nongnu.org/nongnu-devel/clojure-ts-mode-0.6.0snapshot0.20250815.44110.tar";
+        sha256 = "1nn9bg4lpv5vxwvmxhlfbkk4zdg8sk52lk6mhpx5679jbgc8kx7q";
       };
       packageRequires = [ ];
       meta = {
@@ -666,10 +666,10 @@
     elpaBuild {
       pname = "consult-flycheck";
       ename = "consult-flycheck";
-      version = "1.0.0.20250617.112549";
+      version = "1.0.0.20250804.224423";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/consult-flycheck-1.0.0.20250617.112549.tar";
-        sha256 = "0i7p48sm95810a7a2yjjpz0s5m7a4hab44pwsnl27ap0qs6y7xcz";
+        url = "https://elpa.nongnu.org/nongnu-devel/consult-flycheck-1.0.0.20250804.224423.tar";
+        sha256 = "1xjin3rf75l8id6yc5h4whqwsaarvmhy5fjm7adl4xikq6i2cbm4";
       };
       packageRequires = [
         consult
@@ -823,10 +823,10 @@
     elpaBuild {
       pname = "dart-mode";
       ename = "dart-mode";
-      version = "1.0.7.0.20250422.170214";
+      version = "1.0.7.0.20250811.110356";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/dart-mode-1.0.7.0.20250422.170214.tar";
-        sha256 = "1q0znwlbg9adgp2nis1mzyxn281ddh3jyjwqan7mr116qxjsrxcv";
+        url = "https://elpa.nongnu.org/nongnu-devel/dart-mode-1.0.7.0.20250811.110356.tar";
+        sha256 = "0xispkk8chgahkw4pgn70scx0nnsrlnvvskrgfisr9ih5rlbhvi1";
       };
       packageRequires = [ ];
       meta = {
@@ -1122,10 +1122,10 @@
     elpaBuild {
       pname = "editorconfig";
       ename = "editorconfig";
-      version = "0.11.0.0.20250426.231051";
+      version = "0.11.0.0.20250808.184702";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/editorconfig-0.11.0.0.20250426.231051.tar";
-        sha256 = "18l7z7qzwyb93pmlmwvp3lbka0i23afs95ql5j5wa9y0nggyxhnp";
+        url = "https://elpa.nongnu.org/nongnu-devel/editorconfig-0.11.0.0.20250808.184702.tar";
+        sha256 = "1j2zspg9i7r0rnjy79c7032cd3nxir9r1j7img0bwwc1sv7az32y";
       };
       packageRequires = [ ];
       meta = {
@@ -1227,10 +1227,10 @@
     elpaBuild {
       pname = "emacsql";
       ename = "emacsql";
-      version = "4.3.1.0.20250601.100932";
+      version = "4.3.1.0.20250811.210334";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/emacsql-4.3.1.0.20250601.100932.tar";
-        sha256 = "1kjzbz003r93315f1v92kzifdjnmi91dia242g14hkc3kwahzagg";
+        url = "https://elpa.nongnu.org/nongnu-devel/emacsql-4.3.1.0.20250811.210334.tar";
+        sha256 = "1c76h1l5d2yjyy4xxk65scmivfp5qshngjy653fcqh8zhn4as6vx";
       };
       packageRequires = [ ];
       meta = {
@@ -1272,10 +1272,10 @@
     elpaBuild {
       pname = "evil";
       ename = "evil";
-      version = "1.15.0.0.20250318.181600";
+      version = "1.15.0.0.20250812.102316";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/evil-1.15.0.0.20250318.181600.tar";
-        sha256 = "0qbz4gpiychd57370kpj73zcqdjl1gap80zjs4896smyj1pbr9c4";
+        url = "https://elpa.nongnu.org/nongnu-devel/evil-1.15.0.0.20250812.102316.tar";
+        sha256 = "05wx37b8vnjxx4swcpzmi0lf3g2b82dswd9j49xcphmqc0br4a6x";
       };
       packageRequires = [
         cl-lib
@@ -1542,10 +1542,10 @@
     elpaBuild {
       pname = "evil-numbers";
       ename = "evil-numbers";
-      version = "0.7.0.20241208.52322";
+      version = "0.7.0.20250823.61659";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/evil-numbers-0.7.0.20241208.52322.tar";
-        sha256 = "1a5lw59lfavfqnaxay4c4j7246q4i3w53ra9gc44qr94432nd1q9";
+        url = "https://elpa.nongnu.org/nongnu-devel/evil-numbers-0.7.0.20250823.61659.tar";
+        sha256 = "0snfxd5nkaliz7l33vdflk0sj683klcwa1gzc758rc32byzwmhd6";
       };
       packageRequires = [ evil ];
       meta = {
@@ -1723,10 +1723,10 @@
     elpaBuild {
       pname = "flycheck";
       ename = "flycheck";
-      version = "35.0.0.20250527.90754";
+      version = "35.0.0.20250814.121325";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/flycheck-35.0.0.20250527.90754.tar";
-        sha256 = "05d9fbd4hv57jcfsjphdzlmnl4wrfawy7q006sca33wljscpyqr1";
+        url = "https://elpa.nongnu.org/nongnu-devel/flycheck-35.0.0.20250814.121325.tar";
+        sha256 = "1w2hzzdz4bb982dj1632lg1fhi69hxy2244nmc5g19qk799cvgwc";
       };
       packageRequires = [ ];
       meta = {
@@ -1802,6 +1802,27 @@
       ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/flymake-popon.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  flymake-pyrefly = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "flymake-pyrefly";
+      ename = "flymake-pyrefly";
+      version = "0.1.6.0.20250805.190746";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/flymake-pyrefly-0.1.6.0.20250805.190746.tar";
+        sha256 = "10r5f7zqnwwcp5ds9bh6d3hlfkp0wa614iknw7dgzhbg83v2c6r8";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/flymake-pyrefly.html";
         license = lib.licenses.free;
       };
     }
@@ -1903,10 +1924,10 @@
     elpaBuild {
       pname = "geiser";
       ename = "geiser";
-      version = "0.31.1.0.20250119.142455";
+      version = "0.32.0.20250810.134607";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/geiser-0.31.1.0.20250119.142455.tar";
-        sha256 = "0aiaszjbf3fykkhiy2d79wcxwg7bpg9m9s47kcyfcqlkcphrpbz9";
+        url = "https://elpa.nongnu.org/nongnu-devel/geiser-0.32.0.20250810.134607.tar";
+        sha256 = "0gwwdnpfhn37xk8dmw3izxr4w0ky37yv7va64m90ibzblrbgvfcf";
       };
       packageRequires = [ project ];
       meta = {
@@ -1969,10 +1990,10 @@
     elpaBuild {
       pname = "geiser-chicken";
       ename = "geiser-chicken";
-      version = "0.17.0.20241204.144210";
+      version = "0.17.0.20250803.172103";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/geiser-chicken-0.17.0.20241204.144210.tar";
-        sha256 = "0lss1nz7kdbpmky96r10gvsbnjxxnqlymz0d0579ggvf9hi1cj66";
+        url = "https://elpa.nongnu.org/nongnu-devel/geiser-chicken-0.17.0.20250803.172103.tar";
+        sha256 = "0zhwlyhykm7ys0nv6fc9qhrmnbsmr8lbprfzj6zm4h1k173n30r4";
       };
       packageRequires = [ geiser ];
       meta = {
@@ -2204,10 +2225,10 @@
     elpaBuild {
       pname = "gnosis";
       ename = "gnosis";
-      version = "0.5.3.0.20250702.65148";
+      version = "0.5.5.0.20250815.134629";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gnosis-0.5.3.0.20250702.65148.tar";
-        sha256 = "0kgwvyy28q76bbkf3az2c0lc212cq94yblskdpgxlz4zzvjdrdwj";
+        url = "https://elpa.nongnu.org/nongnu-devel/gnosis-0.5.5.0.20250815.134629.tar";
+        sha256 = "0ricm6spfgybd5z6k6si868rb00s34ci9cmbdlh439q6n1w0i3j3";
       };
       packageRequires = [
         compat
@@ -2273,10 +2294,10 @@
     elpaBuild {
       pname = "gnuplot";
       ename = "gnuplot";
-      version = "0.11.0.20250613.122323";
+      version = "0.11.0.20250724.153116";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gnuplot-0.11.0.20250613.122323.tar";
-        sha256 = "0mc5v1f8m6bv4lcdci2sk99xzfhb7597jniywb2n1bhwzz0mp7vj";
+        url = "https://elpa.nongnu.org/nongnu-devel/gnuplot-0.11.0.20250724.153116.tar";
+        sha256 = "0fynfi8yzvmn63awmq0hikf2qwch6l5d1crbc4xzgdz5a132w8c7";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2380,10 +2401,10 @@
     elpaBuild {
       pname = "gptel";
       ename = "gptel";
-      version = "0.9.8.5.0.20250705.205718";
+      version = "0.9.8.5.0.20250823.231025";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.8.5.0.20250705.205718.tar";
-        sha256 = "1682337hiak8bdjrrik5blclarhapkkad3mkr3nnxm6mwm7izb2a";
+        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.8.5.0.20250823.231025.tar";
+        sha256 = "0lrydk1lby15iz4z9h1w23mhi4h6vfm6xdcan72qphg9d33xc33y";
       };
       packageRequires = [
         compat
@@ -2490,10 +2511,10 @@
     elpaBuild {
       pname = "haml-mode";
       ename = "haml-mode";
-      version = "3.2.1.0.20231110.173413";
+      version = "3.2.1.0.20250714.144103";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/haml-mode-3.2.1.0.20231110.173413.tar";
-        sha256 = "0fb5mi0cqwi8186j8cqbzy1zhragj6kwxw779rkhx410vcarl4zi";
+        url = "https://elpa.nongnu.org/nongnu-devel/haml-mode-3.2.1.0.20250714.144103.tar";
+        sha256 = "0sawdjl7kgqqcn01kgcr7wyf875ix4hlqizaryg9akvgl8869nq2";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -2511,10 +2532,10 @@
     elpaBuild {
       pname = "haskell-mode";
       ename = "haskell-mode";
-      version = "17.5.0.20250630.193117";
+      version = "17.5.0.20250812.135807";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/haskell-mode-17.5.0.20250630.193117.tar";
-        sha256 = "17z0fv7qrsncfiaqydvhmacc6g51f8g7k465gas7ffxq0504icr2";
+        url = "https://elpa.nongnu.org/nongnu-devel/haskell-mode-17.5.0.20250812.135807.tar";
+        sha256 = "17nbn2dl75v3bvzk4c1yag27ji2mrlhfpc3js0kldcz999sxn52w";
       };
       packageRequires = [ ];
       meta = {
@@ -2577,10 +2598,10 @@
     elpaBuild {
       pname = "helm";
       ename = "helm";
-      version = "4.0.4.0.20250707.55928";
+      version = "4.0.5.0.20250823.30001";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.4.0.20250707.55928.tar";
-        sha256 = "0x5yskncxgk3g94mfkkchpdwfp8l9jv4rp1dnjiwa73cikhl4z85";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.5.0.20250823.30001.tar";
+        sha256 = "180qb00slqj3iswdns8lhb6fj04qrypfxskzsdlmrbywn7g7gprz";
       };
       packageRequires = [
         helm-core
@@ -2602,10 +2623,10 @@
     elpaBuild {
       pname = "helm-core";
       ename = "helm-core";
-      version = "4.0.4.0.20250707.55928";
+      version = "4.0.5.0.20250823.30001";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.4.0.20250707.55928.tar";
-        sha256 = "1hyg0wqmjwklfyv4yjx30vj2pfaky72kgbcgaw9nyka64d4ayhhj";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.5.0.20250823.30001.tar";
+        sha256 = "183z699pn0bdy4qfygnfmi0qaik5pmly8cl16b5zm39qabph4nrs";
       };
       packageRequires = [ async ];
       meta = {
@@ -2707,10 +2728,10 @@
     elpaBuild {
       pname = "htmlize";
       ename = "htmlize";
-      version = "1.58.0.20250704.192840";
+      version = "1.59.0.20250724.170327";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/htmlize-1.58.0.20250704.192840.tar";
-        sha256 = "06gp2wgkcv971a3lkw5bq9yal3i2w1a5qzlf4yyy5gvhbh69h3bh";
+        url = "https://elpa.nongnu.org/nongnu-devel/htmlize-1.59.0.20250724.170327.tar";
+        sha256 = "16ysry86hyvgjpdws8h96zs02djvclj6cbdmif6vpsywn3q01mzn";
       };
       packageRequires = [ ];
       meta = {
@@ -2813,10 +2834,10 @@
     elpaBuild {
       pname = "idris-mode";
       ename = "idris-mode";
-      version = "1.1.0.0.20250424.90824";
+      version = "1.1.0.0.20250825.75833";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/idris-mode-1.1.0.0.20250424.90824.tar";
-        sha256 = "0zs0z9p7c1xbsy0fw0q03x9z42d5ac37k4f2aljir0c62r5mckxl";
+        url = "https://elpa.nongnu.org/nongnu-devel/idris-mode-1.1.0.0.20250825.75833.tar";
+        sha256 = "0ifxj3na8i0xhrkkh5j5xlassjxjv9snaybkaqd8ah5khj4y8cq9";
       };
       packageRequires = [
         cl-lib
@@ -3076,10 +3097,10 @@
     elpaBuild {
       pname = "llama";
       ename = "llama";
-      version = "1.0.0.0.20250701.152904";
+      version = "1.0.0.0.20250812.133610";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/llama-1.0.0.0.20250701.152904.tar";
-        sha256 = "14c56w4n61kb5sd8m7898aw7fp28h56p74v0h84xbm0z1ylisvig";
+        url = "https://elpa.nongnu.org/nongnu-devel/llama-1.0.0.0.20250812.133610.tar";
+        sha256 = "0ybk2b9nq9sm88376j3ighbzhkklvlga78zl4rim8llafk8yjsi9";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3129,10 +3150,10 @@
     elpaBuild {
       pname = "loopy";
       ename = "loopy";
-      version = "0.14.0.0.20250706.11705";
+      version = "0.14.0.0.20250810.194832";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/loopy-0.14.0.0.20250706.11705.tar";
-        sha256 = "0h42k1i38rsp90k5a1l46x2l5n7fp6pwmg4snaw3wl796nsqwh7w";
+        url = "https://elpa.nongnu.org/nongnu-devel/loopy-0.14.0.0.20250810.194832.tar";
+        sha256 = "0s07913f6y63vwrm4zpb4k1wx6sl75vpmfawczyzxgldkjjslnpq";
       };
       packageRequires = [
         compat
@@ -3311,10 +3332,10 @@
     elpaBuild {
       pname = "markdown-mode";
       ename = "markdown-mode";
-      version = "2.8alpha0.20250624.63145";
+      version = "2.8alpha0.20250812.42301";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/markdown-mode-2.8alpha0.20250624.63145.tar";
-        sha256 = "0pkc9cqsxnyr0i1bzyp7bnxbf7skdjad77h150yvx14g8hvyhpdn";
+        url = "https://elpa.nongnu.org/nongnu-devel/markdown-mode-2.8alpha0.20250812.42301.tar";
+        sha256 = "1ckl1ykijnahld1fwd6mp04j1hwdq1acdbi9wrnwzizizrfisbjp";
       };
       packageRequires = [ ];
       meta = {
@@ -3334,10 +3355,10 @@
     elpaBuild {
       pname = "mastodon";
       ename = "mastodon";
-      version = "2.0.1.0.20250602.141655";
+      version = "2.0.2.0.20250801.103236";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/mastodon-2.0.1.0.20250602.141655.tar";
-        sha256 = "0dzddf45f2h6790pwgi7hychv36adhanigbwvfivpvg9wxvrm3fi";
+        url = "https://elpa.nongnu.org/nongnu-devel/mastodon-2.0.2.0.20250801.103236.tar";
+        sha256 = "0wgx53vlg2ifajmr298a3hrz8fy08sgdx909jfbm44kbf4myhm2m";
       };
       packageRequires = [
         persist
@@ -3409,10 +3430,10 @@
     elpaBuild {
       pname = "meow";
       ename = "meow";
-      version = "1.5.0.0.20250404.143236";
+      version = "1.5.0.0.20250803.54141";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/meow-1.5.0.0.20250404.143236.tar";
-        sha256 = "098ca9ypmm5q2wviarqbcabz971ngf53lv8k1idnsvw8n34a0h83";
+        url = "https://elpa.nongnu.org/nongnu-devel/meow-1.5.0.0.20250803.54141.tar";
+        sha256 = "1yjr5bc90f93vwwnb1gj8ni1i0h8mh5sl51vafyh24dnd49rw9c3";
       };
       packageRequires = [ ];
       meta = {
@@ -3855,10 +3876,10 @@
     elpaBuild {
       pname = "orgit";
       ename = "orgit";
-      version = "2.0.3.0.20250601.105749";
+      version = "2.0.3.0.20250823.203621";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/orgit-2.0.3.0.20250601.105749.tar";
-        sha256 = "1dk63z953ph91llmh98xi1dfsbfkgp1q2mpn6m7l9wydv98y82w9";
+        url = "https://elpa.nongnu.org/nongnu-devel/orgit-2.0.3.0.20250823.203621.tar";
+        sha256 = "0zdblah0hz8lcmvgq035djl79np57bb01ynm2kksflnpz6bsmhsk";
       };
       packageRequires = [
         compat
@@ -3902,10 +3923,10 @@
     elpaBuild {
       pname = "package-lint";
       ename = "package-lint";
-      version = "0.26.0.20250630.143113";
+      version = "0.26.0.20250819.130417";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/package-lint-0.26.0.20250630.143113.tar";
-        sha256 = "1jr9r5g86z23vs5aw3wmj4ny8mb5a4yqirvmflkd4vv0f00qylyc";
+        url = "https://elpa.nongnu.org/nongnu-devel/package-lint-0.26.0.20250819.130417.tar";
+        sha256 = "0fsjd3sry469xrpkfabid2bh7f3p50ddhwj6c9vabg9fad3yykyd";
       };
       packageRequires = [ let-alist ];
       meta = {
@@ -3945,10 +3966,10 @@
     elpaBuild {
       pname = "page-break-lines";
       ename = "page-break-lines";
-      version = "0.15.0.20250218.160727";
+      version = "0.15.0.20250812.113016";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/page-break-lines-0.15.0.20250218.160727.tar";
-        sha256 = "0w6kcvqckjn4x6m5za73s4snn4pwpn0syf1mzjkqrzrx00sjcq3z";
+        url = "https://elpa.nongnu.org/nongnu-devel/page-break-lines-0.15.0.20250812.113016.tar";
+        sha256 = "08v3pdy4p4qw8dcss4246r7lajcabs37ah4vngyniip331qnf8ja";
       };
       packageRequires = [ ];
       meta = {
@@ -4093,6 +4114,28 @@
       };
     }
   ) { };
+  pg = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+      peg,
+    }:
+    elpaBuild {
+      pname = "pg";
+      ename = "pg";
+      version = "0.58.0.20250823.202123";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/pg-0.58.0.20250823.202123.tar";
+        sha256 = "0ddi6025ydm9dzacnnkiry72pc3lwdjb0gljslar15cl9ks2bi0x";
+      };
+      packageRequires = [ peg ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/pg.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   php-mode = callPackage (
     {
       elpaBuild,
@@ -4144,10 +4187,10 @@
     elpaBuild {
       pname = "popup";
       ename = "popup";
-      version = "0.5.9.0.20250422.161227";
+      version = "0.5.9.0.20250812.70240";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/popup-0.5.9.0.20250422.161227.tar";
-        sha256 = "0rj578i7l0hcmb3apch5ld05habq1iw3f3fazlax0n6r85g6phmy";
+        url = "https://elpa.nongnu.org/nongnu-devel/popup-0.5.9.0.20250812.70240.tar";
+        sha256 = "1csszznlk47jxzbsw2rayf0mwnxk4r2abc95sb7nzf30bibgwymg";
       };
       packageRequires = [ ];
       meta = {
@@ -4165,10 +4208,10 @@
     elpaBuild {
       pname = "projectile";
       ename = "projectile";
-      version = "2.9.1.0.20250704.90814";
+      version = "2.9.1.0.20250716.140530";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/projectile-2.9.1.0.20250704.90814.tar";
-        sha256 = "00prn27p6hip55p9srsgbaq3gf6dmg6s8iglqd3v1pqz3hggjjcr";
+        url = "https://elpa.nongnu.org/nongnu-devel/projectile-2.9.1.0.20250716.140530.tar";
+        sha256 = "0y4vk9jb1knblzfaj28rvqkpgqwp58lhbgwab8p0nnnfjh269y4z";
       };
       packageRequires = [ ];
       meta = {
@@ -4186,10 +4229,10 @@
     elpaBuild {
       pname = "proof-general";
       ename = "proof-general";
-      version = "4.6snapshot0.20250623.210821";
+      version = "4.6snapshot0.20250811.112700";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/proof-general-4.6snapshot0.20250623.210821.tar";
-        sha256 = "0km27ky5ljzdw09c0idw72nxyl6qm15ci61vhfs2jrmqh1ncv645";
+        url = "https://elpa.nongnu.org/nongnu-devel/proof-general-4.6snapshot0.20250811.112700.tar";
+        sha256 = "1gwdwq8lb22b03fq8a046dqyy4kgdbaf7lhiah64pndhl8649xhq";
       };
       packageRequires = [ ];
       meta = {
@@ -4230,10 +4273,10 @@
     elpaBuild {
       pname = "racket-mode";
       ename = "racket-mode";
-      version = "1.0.20250707.155225";
+      version = "1.0.20250711.83643";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/racket-mode-1.0.20250707.155225.tar";
-        sha256 = "0wzg57y7yx5aqwlildi314ay8vf0gwxfpxdadjswjjc1zfifq6yy";
+        url = "https://elpa.nongnu.org/nongnu-devel/racket-mode-1.0.20250711.83643.tar";
+        sha256 = "0fz97vmiwlqbgvbzp0zaa5jy5pbpdbhzg16db1rg01f101x5368h";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4335,10 +4378,10 @@
     elpaBuild {
       pname = "reformatter";
       ename = "reformatter";
-      version = "0.8.0.20250324.192239";
+      version = "0.8.0.20250812.113040";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/reformatter-0.8.0.20250324.192239.tar";
-        sha256 = "0kg01an6pf9laaqqdh4h09y508k94l85xjqb038dg9whv2bf0h3a";
+        url = "https://elpa.nongnu.org/nongnu-devel/reformatter-0.8.0.20250812.113040.tar";
+        sha256 = "1x8n1i974cnmjccz4142nr4p8yic9szfpsmnxm9gg4mnvrlnjzwv";
       };
       packageRequires = [ ];
       meta = {
@@ -4440,10 +4483,10 @@
     elpaBuild {
       pname = "rust-mode";
       ename = "rust-mode";
-      version = "1.0.6.0.20250705.144445";
+      version = "1.0.6.0.20250816.40724";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/rust-mode-1.0.6.0.20250705.144445.tar";
-        sha256 = "1misimvimmzdb3g23yjax0wl41cys7fghg5yhks56x0169q11mh3";
+        url = "https://elpa.nongnu.org/nongnu-devel/rust-mode-1.0.6.0.20250816.40724.tar";
+        sha256 = "1w45rp9ppw8sr2pprzfy2bglmd2x47frhz5kfmf07ch3prdbynp7";
       };
       packageRequires = [ ];
       meta = {
@@ -4488,10 +4531,10 @@
     elpaBuild {
       pname = "scad-mode";
       ename = "scad-mode";
-      version = "96.0.0.20250128.214002";
+      version = "97.0.0.20250728.23846";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/scad-mode-96.0.0.20250128.214002.tar";
-        sha256 = "1ivx4yaz13505w4k6p3q25pg5xwgrbyygfgwzc22vqdv498rg102";
+        url = "https://elpa.nongnu.org/nongnu-devel/scad-mode-97.0.0.20250728.23846.tar";
+        sha256 = "1jvhzhvs0zfx3ygzrm9ixw10wmdv0fy9s3g236kbdrlkc94lddrc";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4551,10 +4594,10 @@
     elpaBuild {
       pname = "scroll-on-jump";
       ename = "scroll-on-jump";
-      version = "0.2.0.20250706.112423";
+      version = "0.2.0.20250712.131709";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/scroll-on-jump-0.2.0.20250706.112423.tar";
-        sha256 = "0v2y99ihpmhcdabvmnglvvf4vmmfpp1nplb99bh6i3r6n0i58n4j";
+        url = "https://elpa.nongnu.org/nongnu-devel/scroll-on-jump-0.2.0.20250712.131709.tar";
+        sha256 = "1x38322dlcfjyj1jy1gmyvc6wwp6idnc802mjc3a4g3yzqjb64iq";
       };
       packageRequires = [ ];
       meta = {
@@ -4615,10 +4658,10 @@
     elpaBuild {
       pname = "slime";
       ename = "slime";
-      version = "2.31snapshot0.20250706.142233";
+      version = "2.31snapshot0.20250817.234725";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.31snapshot0.20250706.142233.tar";
-        sha256 = "1vn1vm0fh2acq522j30kngkgnvxy9gdh0v26w0vdi6mv21531cdd";
+        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.31snapshot0.20250817.234725.tar";
+        sha256 = "12jaqyly9y0yvamvm26qgzcx3pqrais581dd50jc4vkfs2s2x0ig";
       };
       packageRequires = [ macrostep ];
       meta = {
@@ -4721,10 +4764,10 @@
     elpaBuild {
       pname = "spell-fu";
       ename = "spell-fu";
-      version = "0.3.0.20241011.20613";
+      version = "0.3.0.20250712.131907";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/spell-fu-0.3.0.20241011.20613.tar";
-        sha256 = "1v9qzc7hqq0scs9vsgp88pp8hihxlsa8mcq5hmcz4g3p1ffhc1lb";
+        url = "https://elpa.nongnu.org/nongnu-devel/spell-fu-0.3.0.20250712.131907.tar";
+        sha256 = "1v9ahhwapqg4a7v82ipx2rcfk9ibrbrsapqk3b3md552j4fdrwzp";
       };
       packageRequires = [ ];
       meta = {
@@ -5111,10 +5154,10 @@
     elpaBuild {
       pname = "treesit-fold";
       ename = "treesit-fold";
-      version = "0.2.1.0.20250602.41006";
+      version = "0.2.1.0.20250816.45809";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/treesit-fold-0.2.1.0.20250602.41006.tar";
-        sha256 = "17lwdj39j7fx16q7949f0yfr8wkbpwg3iy48k33lsrhmd6wj1fw7";
+        url = "https://elpa.nongnu.org/nongnu-devel/treesit-fold-0.2.1.0.20250816.45809.tar";
+        sha256 = "03j1lcrsx14qm4m7k6h56aka7r94gzp7c97jpm404fwnn9zdrib8";
       };
       packageRequires = [ ];
       meta = {
@@ -5196,10 +5239,10 @@
     elpaBuild {
       pname = "typst-ts-mode";
       ename = "typst-ts-mode";
-      version = "0.12.1.0.20250708.85145";
+      version = "0.12.2.0.20250807.11325";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/typst-ts-mode-0.12.1.0.20250708.85145.tar";
-        sha256 = "00z3kw7bi435iw0rwndm8xhx730zv5zsydqnk2mqjmhxj56iv1fw";
+        url = "https://elpa.nongnu.org/nongnu-devel/typst-ts-mode-0.12.2.0.20250807.11325.tar";
+        sha256 = "1j28vzijhn7aqr3h8pjslixbz38j97zgvx3f86myi2ag5l8k615g";
       };
       packageRequires = [ ];
       meta = {
@@ -5369,10 +5412,10 @@
     elpaBuild {
       pname = "web-mode";
       ename = "web-mode";
-      version = "17.3.21.0.20250619.133456";
+      version = "17.3.21.0.20250714.65721";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/web-mode-17.3.21.0.20250619.133456.tar";
-        sha256 = "163ix98pqwd4qkzsikh588gd2airy7pb144v5jmdpnfxpmir6721";
+        url = "https://elpa.nongnu.org/nongnu-devel/web-mode-17.3.21.0.20250714.65721.tar";
+        sha256 = "0v4jcv0lcm4gds8m086f79wpbd0d64i0y1cf8z5rvrx8psf93wpc";
       };
       packageRequires = [ ];
       meta = {
@@ -5480,10 +5523,10 @@
     elpaBuild {
       pname = "with-editor";
       ename = "with-editor";
-      version = "3.4.4.0.20250531.223012";
+      version = "3.4.5.0.20250811.205345";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/with-editor-3.4.4.0.20250531.223012.tar";
-        sha256 = "19qqvsr28qncfwhm2zvn6h74ymwgr3jfcr9qkbnc3kixsmjp4ps7";
+        url = "https://elpa.nongnu.org/nongnu-devel/with-editor-3.4.5.0.20250811.205345.tar";
+        sha256 = "0y4gm4dw0nwcq7m2n68ysk4sqrr2bbn4m8skgl6m66iag9av58j0";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5590,10 +5633,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "27.0.20250707145105.0.20250707.153146";
+      version = "28.4.20250825201039.0.20250825.201812";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-27.0.20250707145105.0.20250707.153146.tar";
-        sha256 = "1vz9ccksqsk3l6a99b79vlgcshhv536bsdk1znccswgwx2nfmyij";
+        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-28.4.20250825201039.0.20250825.201812.tar";
+        sha256 = "12z8ygjsyw1faa3b2j9s0fsnkil5rzik35k3k4dwyvzvdrmm8m5n";
       };
       packageRequires = [ ];
       meta = {
@@ -5633,10 +5676,10 @@
     elpaBuild {
       pname = "xml-rpc";
       ename = "xml-rpc";
-      version = "1.6.17.0.20231009.103222";
+      version = "1.6.17.0.20250812.100619";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/xml-rpc-1.6.17.0.20231009.103222.tar";
-        sha256 = "19invp04068pzyjbbbscc7vlqh76r8n3f9d4mxacbvi5bhvrc2p0";
+        url = "https://elpa.nongnu.org/nongnu-devel/xml-rpc-1.6.17.0.20250812.100619.tar";
+        sha256 = "0l4amp36zazwgnm7gvlyqfqjycj3c9vbdr1hdhf8jxyrikr9p12a";
       };
       packageRequires = [ ];
       meta = {
@@ -5676,10 +5719,10 @@
     elpaBuild {
       pname = "yasnippet-snippets";
       ename = "yasnippet-snippets";
-      version = "1.0.0.20250612.151830";
+      version = "1.0.0.20250808.81958";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/yasnippet-snippets-1.0.0.20250612.151830.tar";
-        sha256 = "0gr1pch82gb1b32j562aqz76wc88ricar27i59fvyr1gaqjdlxdi";
+        url = "https://elpa.nongnu.org/nongnu-devel/yasnippet-snippets-1.0.0.20250808.81958.tar";
+        sha256 = "067jidwz1xn13fxcnwdrh0bnr93bndwjs1yznn483xdw9fcgyz05";
       };
       packageRequires = [ yasnippet ];
       meta = {
@@ -5719,10 +5762,10 @@
     elpaBuild {
       pname = "zig-mode";
       ename = "zig-mode";
-      version = "0.0.8.0.20250618.122718";
+      version = "0.0.8.0.20250812.82048";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/zig-mode-0.0.8.0.20250618.122718.tar";
-        sha256 = "0c0w6n55qvc8za1miwg26n49lddh3cya6dlxkl5m498bx08mdljf";
+        url = "https://elpa.nongnu.org/nongnu-devel/zig-mode-0.0.8.0.20250812.82048.tar";
+        sha256 = "0wdcd7v40zgzh5zh5y17vzkwh028grzq93w65hhr42qq2g85rqy8";
       };
       packageRequires = [ reformatter ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
@@ -481,10 +481,10 @@
     elpaBuild {
       pname = "buttercup";
       ename = "buttercup";
-      version = "1.37";
+      version = "1.38";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/buttercup-1.37.tar";
-        sha256 = "1r6q2ngqc0bnkkajhv5n9hw7njhmzf22192chl974vqm7x2vzn7v";
+        url = "https://elpa.nongnu.org/nongnu/buttercup-1.38.tar";
+        sha256 = "08lqi9qs7f79i44w4nvv15n23dmmka17j3dpj5s3kn0pk1gkv11j";
       };
       packageRequires = [ ];
       meta = {
@@ -572,10 +572,10 @@
     elpaBuild {
       pname = "cider";
       ename = "cider";
-      version = "1.18.0";
+      version = "1.19.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/cider-1.18.0.tar";
-        sha256 = "15k2klm84x0jsglbc398fg9y83xkw6dbcn1jkg0zpw886j32dhxr";
+        url = "https://elpa.nongnu.org/nongnu/cider-1.19.0.tar";
+        sha256 = "04jz9cjdrx7i8p8zb7yavapz2yl8nlv7jczvmph2bpyxff2fimcf";
       };
       packageRequires = [
         clojure-mode
@@ -1824,6 +1824,27 @@
       };
     }
   ) { };
+  flymake-pyrefly = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "flymake-pyrefly";
+      ename = "flymake-pyrefly";
+      version = "0.1.6";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/flymake-pyrefly-0.1.6.tar";
+        sha256 = "06z8hkivi2k24yk8bqkgcm52al5jfz82kwjhzbc3j0aaickmacnm";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/flymake-pyrefly.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   focus = callPackage (
     {
       cl-lib ? null,
@@ -1920,10 +1941,10 @@
     elpaBuild {
       pname = "geiser";
       ename = "geiser";
-      version = "0.31.1";
+      version = "0.32";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/geiser-0.31.1.tar";
-        sha256 = "14d8syc51fkagc5isb8pym7mq5bw6ng83qxv1g5dnnj7nydl0gcr";
+        url = "https://elpa.nongnu.org/nongnu/geiser-0.32.tar";
+        sha256 = "1mija2lp2fqhzi9bifl0ipkjhj3gx89qz41mk0phb5y5cws6nar1";
       };
       packageRequires = [ project ];
       meta = {
@@ -2221,10 +2242,10 @@
     elpaBuild {
       pname = "gnosis";
       ename = "gnosis";
-      version = "0.5.3";
+      version = "0.5.5";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/gnosis-0.5.3.tar";
-        sha256 = "1dzijdw0c23k6r9l1p3n1a54k4ymk48ckpcz47z9q4i7d7vj8q3m";
+        url = "https://elpa.nongnu.org/nongnu/gnosis-0.5.5.tar";
+        sha256 = "0na35233h87yk8h300g4vcfc5w4ckd09y8y7hwj7n3y725wi964h";
       };
       packageRequires = [
         compat
@@ -2593,10 +2614,10 @@
     elpaBuild {
       pname = "helm";
       ename = "helm";
-      version = "4.0.4";
+      version = "4.0.5";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/helm-4.0.4.tar";
-        sha256 = "1vlqn6v15ms9y1fwk8rip6my1x5ac3pkqxjnqvajv2csc4la1yh2";
+        url = "https://elpa.nongnu.org/nongnu/helm-4.0.5.tar";
+        sha256 = "1dbkpyq42f4gl9mc4aqjwdddmn800pga8dpvzky3qpns0q7i1d6g";
       };
       packageRequires = [
         helm-core
@@ -2618,10 +2639,10 @@
     elpaBuild {
       pname = "helm-core";
       ename = "helm-core";
-      version = "4.0.4";
+      version = "4.0.5";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/helm-core-4.0.4.tar";
-        sha256 = "1zfwpasfrdh4hap9zs0jv7d0gkw06i3nzs80jkdizjp9vmjxc7sq";
+        url = "https://elpa.nongnu.org/nongnu/helm-core-4.0.5.tar";
+        sha256 = "0l0z0lq78fha77g1a7iz4zlmidw0c3ri6b4kwrc3jm8cn218q87v";
       };
       packageRequires = [ async ];
       meta = {
@@ -2723,10 +2744,10 @@
     elpaBuild {
       pname = "htmlize";
       ename = "htmlize";
-      version = "1.58";
+      version = "1.59";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/htmlize-1.58.tar";
-        sha256 = "1vd7pq8rrxnc5x2nc6qjjkh3hyk89m7g8zdijpw463d4v6wrrfpx";
+        url = "https://elpa.nongnu.org/nongnu/htmlize-1.59.tar";
+        sha256 = "0ng3gngv4y67ncr7a0zl7mj22c4772mkqf3dazspmp3jfqdyq9sr";
       };
       packageRequires = [ ];
       meta = {
@@ -3350,10 +3371,10 @@
     elpaBuild {
       pname = "mastodon";
       ename = "mastodon";
-      version = "2.0.1";
+      version = "2.0.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/mastodon-2.0.1.tar";
-        sha256 = "1jqrb7a7zsz85sp9nzf2rds02waiams87n6mnhwkl7ar8wnycnxy";
+        url = "https://elpa.nongnu.org/nongnu/mastodon-2.0.2.tar";
+        sha256 = "146ds0wzw7l1irn5had926y5irqa1j5cld5s0pfmvyh18zjzn9bg";
       };
       packageRequires = [
         persist
@@ -4116,6 +4137,28 @@
       };
     }
   ) { };
+  pg = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+      peg,
+    }:
+    elpaBuild {
+      pname = "pg";
+      ename = "pg";
+      version = "0.58";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/pg-0.58.tar";
+        sha256 = "1h5arpkm9gchn3igv6zzrip0pc9qb0ib0gfsj59svarxa3nvmssn";
+      };
+      packageRequires = [ peg ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/pg.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   php-mode = callPackage (
     {
       elpaBuild,
@@ -4253,10 +4296,10 @@
     elpaBuild {
       pname = "racket-mode";
       ename = "racket-mode";
-      version = "1.0.20250707.155225";
+      version = "1.0.20250711.83643";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/racket-mode-1.0.20250707.155225.tar";
-        sha256 = "1r4hshyja0hx6xa6krn62m9xxrk4ilasc1i5ghl6qyfr2sppj7bb";
+        url = "https://elpa.nongnu.org/nongnu/racket-mode-1.0.20250711.83643.tar";
+        sha256 = "0qcsk00f0wfcz2h2kqckhb7yw66gw1cpcygmjri5bhnis1irzkki";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4507,10 +4550,10 @@
     elpaBuild {
       pname = "scad-mode";
       ename = "scad-mode";
-      version = "96.0";
+      version = "97.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/scad-mode-96.0.tar";
-        sha256 = "0l5r88srzzxy143kjghyfcm0n7vbm79qxy0mgxfd66i8gmvw85m4";
+        url = "https://elpa.nongnu.org/nongnu/scad-mode-97.0.tar";
+        sha256 = "0javyq4jqjx3anci18d8fdfz10pm1kfh9nfyw7v9flkvsxhala65";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5236,10 +5279,10 @@
     elpaBuild {
       pname = "typst-ts-mode";
       ename = "typst-ts-mode";
-      version = "0.12.1";
+      version = "0.12.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/typst-ts-mode-0.12.1.tar";
-        sha256 = "02wzmpgm8in6b0pc1mqdwh3hqgkg9l73wdykk3d520pph2ni8496";
+        url = "https://elpa.nongnu.org/nongnu/typst-ts-mode-0.12.2.tar";
+        sha256 = "170q09ma08cksyg9bapfhid28f0xi46ssdv7bzdyiy3gc4x61i4b";
       };
       packageRequires = [ ];
       meta = {
@@ -5494,10 +5537,10 @@
     elpaBuild {
       pname = "with-editor";
       ename = "with-editor";
-      version = "3.4.4";
+      version = "3.4.5";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/with-editor-3.4.4.tar";
-        sha256 = "02sb265fmh99apvz3v4hr788w3h0shnlcr917ygp9hn8byjkajm6";
+        url = "https://elpa.nongnu.org/nongnu/with-editor-3.4.5.tar";
+        sha256 = "1bwrn24kqc612ddjl9rpvwkdb1igsqrlmmf1fnad1zza8d09s5iz";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5604,10 +5647,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "27.0.20250707145105";
+      version = "28.4.20250825201039";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-27.0.20250707145105.tar";
-        sha256 = "0257md3qjr4h6dpmk893d85vbf47x550qvd52z7pzx7n0v751yiz";
+        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-28.4.20250825201039.tar";
+        sha256 = "19vdcmimk3f8g14bjmk0wvlm0jq50r36gnc39ilxlbm84ybyrpl6";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -1615,9 +1615,9 @@
  },
  {
   "ename": "actionscript-mode",
-  "commit": "2c11e74f2156f109b713380cebf83022d7159d4a",
-  "sha256": "1dkiay9jmizvslji5kzab4dxm1dq0jm8ps7sjq6710g7a5aqdvwq",
-  "fetcher": "github",
+  "commit": "8a5639b0ce2f035d9564d7c5558713fc35c29276",
+  "sha256": "0kx5jv2qm5a8mb7a3i3x8j3ffb6ld24rh3wndhx7mf96apy8v6ab",
+  "fetcher": "codeberg",
   "repo": "austinhaas/actionscript-mode",
   "unstable": {
    "version": [
@@ -1802,11 +1802,11 @@
   "repo": "thierryvolpiatto/addressbook-bookmark",
   "unstable": {
    "version": [
-    20250603,
-    618
+    20250803,
+    408
    ],
-   "commit": "c95cdf6b71c04dcab687cbcc40d5c0d61cb2cd59",
-   "sha256": "1gjv1111q5rfinf81y5lx5846p7vr1d8xmd3kx7wvdgkyvz1crmh"
+   "commit": "09936ea4dd490ffcc4d63a89a4eb4c321b587703",
+   "sha256": "1872yba5xjh3qsaq4zn4k9wnw213rsj75f6mj2qmmzdpr85sja38"
   },
   "stable": {
    "version": [
@@ -1825,11 +1825,11 @@
   "repo": "louabill/ado-mode",
   "unstable": {
    "version": [
-    20241216,
-    2039
+    20250719,
+    1831
    ],
-   "commit": "d688bf8889e6ff893558984d3cdb7d4335908a3f",
-   "sha256": "1wksibdw7lamgzvrpn35lix2xknbj1w9xx16pa61kp51sjp7yapc"
+   "commit": "d03e2aab90cce83485b095297921ba0e24f43c69",
+   "sha256": "1x0nm6ij0j6bb1vjlg05zhz35bv1lr98pjlnzvk1h6k98l9rrih7"
   },
   "stable": {
    "version": [
@@ -2041,20 +2041,20 @@
   "repo": "anticomputer/age.el",
   "unstable": {
    "version": [
-    20250228,
-    521
+    20250806,
+    1723
    ],
-   "commit": "05ad63306bdac3a58f3a3b23adfd94c8d573f9f2",
-   "sha256": "014zdv86qsi48yyy6z40ix514ssixw39jd34sj5wsxbngm03w14l"
+   "commit": "e99165ef5274bc4512b8d77ba2ac208c59b5d456",
+   "sha256": "09rfk9aijjgacff7n8d1cmsg7yb6cc3fppjxzs07dm9vcakcdvbh"
   },
   "stable": {
    "version": [
     0,
     1,
-    7
+    9
    ],
-   "commit": "05ad63306bdac3a58f3a3b23adfd94c8d573f9f2",
-   "sha256": "014zdv86qsi48yyy6z40ix514ssixw39jd34sj5wsxbngm03w14l"
+   "commit": "e99165ef5274bc4512b8d77ba2ac208c59b5d456",
+   "sha256": "09rfk9aijjgacff7n8d1cmsg7yb6cc3fppjxzs07dm9vcakcdvbh"
   }
  },
  {
@@ -2223,8 +2223,8 @@
   "repo": "tninja/aider.el",
   "unstable": {
    "version": [
-    20250707,
-    1757
+    20250826,
+    400
    ],
    "deps": [
     "magit",
@@ -2232,14 +2232,14 @@
     "s",
     "transient"
    ],
-   "commit": "dfe64d0361024631e1d2c3565ce1b4638994b854",
-   "sha256": "0gczwm9yjwfx6iadl2ip2pyppnf9azna2ny5q1yngrsqnap07w7p"
+   "commit": "f7d467fe6497d8cd8a3b4267f5f4bc93e5c669ef",
+   "sha256": "17s0q7wl5psnrx4j832kir34vwfpphjfi6s3jjgpsp649gwqnpgq"
   },
   "stable": {
    "version": [
     0,
     13,
-    0
+    1
    ],
    "deps": [
     "magit",
@@ -2247,8 +2247,8 @@
     "s",
     "transient"
    ],
-   "commit": "e11be58103c03b49f6dce4d89a4068017fdfa95c",
-   "sha256": "0bqw48zxs31w5sajd4mchgz656w6qmmkgld86hb5x0b6mjaa8cp9"
+   "commit": "19adf3246aac61fca6ec11b5c8967e52fd7a7f63",
+   "sha256": "19y8s0gmfxp4m5508jkmw8wmb9z9xsrjm55r5bja2kl6c1i6xx57"
   }
  },
  {
@@ -2259,16 +2259,16 @@
   "repo": "MatthewZMD/aidermacs",
   "unstable": {
    "version": [
-    20250707,
-    1832
+    20250817,
+    701
    ],
    "deps": [
     "compat",
     "markdown-mode",
     "transient"
    ],
-   "commit": "5084913506b8b243c732a77b6de4768f18edcff3",
-   "sha256": "0p24acxdskc9khkk79aj216fn2sdwlbwsnw7q0jvsdxfi1ryymbj"
+   "commit": "cdee470ee5aa5c81364799fa46f9dbd5ef588663",
+   "sha256": "04zhi6k9ljxs7g61s825bzkwdnwx68bz78m43vf2njbdl0x6dph7"
   },
   "stable": {
    "version": [
@@ -2575,16 +2575,16 @@
   "repo": "jwiegley/alert",
   "unstable": {
    "version": [
-    20250615,
-    1845
+    20250823,
+    650
    ],
    "deps": [
     "cl-lib",
     "gntp",
     "log4e"
    ],
-   "commit": "d17ad05ade019fd3560c78f8ed57a352034797e8",
-   "sha256": "0lplkbhncmp4vyyx6vwqbr4rwq157l7vy53kqm4p7y8x1s3kyprf"
+   "commit": "79f6936ab4d85227530959811143429347a6971b",
+   "sha256": "06d51grlrc7cnjcgiwb7cjpfxdb3i3vxaicimghb0wp5l4rcbxm1"
   },
   "stable": {
    "version": [
@@ -3378,11 +3378,11 @@
   "repo": "anki-editor/anki-editor",
   "unstable": {
    "version": [
-    20250606,
-    524
+    20250723,
+    920
    ],
-   "commit": "55fd1c39038fa8c6ba800e0de160147543a697a7",
-   "sha256": "1pk00nvmh4vib8raxnnhl94ia25vfd4fhpc8b24jq9km3kklx7db"
+   "commit": "0a889b50922af6b1fb5086ceaa344b3201e8547e",
+   "sha256": "1xrp8pjaq278k7rfw8r91yn18zv247qwk91zk3wyrvhazjf6vr17"
   }
  },
  {
@@ -3532,11 +3532,11 @@
   "repo": "agda/agda",
   "unstable": {
    "version": [
-    20250328,
-    1043
+    20250805,
+    1029
    ],
-   "commit": "ad8ea74ccefd3507006a7ea9a7d9ff5b7a973603",
-   "sha256": "0qiqw69h9vpvwisqngkfdpfqibi5w5ddhxhwvbrv0ah2n29saswr"
+   "commit": "213db6e50bb89c1b0b2832eab4c6caafb137eb6d",
+   "sha256": "0kp5343cigdrax9596pvj1zi6pmnrjy0jrq7kwxi5brhn06a62gq"
   },
   "stable": {
    "version": [
@@ -3911,11 +3911,11 @@
   "repo": "radian-software/apheleia",
   "unstable": {
    "version": [
-    20250611,
-    2251
+    20250807,
+    2320
    ],
-   "commit": "f3308f53d3fd15b808abc583fa4c50a197f0d1e9",
-   "sha256": "049gkaxg91s4cc85j2jm4hyhamg3r5x13pymyd5zcray2z6r6698"
+   "commit": "f1d36031fc162f541f77d4f6c6c0fd6197aba077",
+   "sha256": "02l36zd37lrdxvv82j1hq7wn07nddw6569ni60y5pbcg22fzsbq6"
   },
   "stable": {
    "version": [
@@ -3987,11 +3987,11 @@
   "repo": "Greybeard-Entertainment/app-monochrome",
   "unstable": {
    "version": [
-    20241110,
-    1142
+    20250710,
+    2315
    ],
-   "commit": "6fedc38316ecf9529bd700cfb691cd1248a31c77",
-   "sha256": "133jvvjmc8q8hqrz53cf308ajxc77iqn7mqfzvrflkm3j785c8iv"
+   "commit": "bd8bfee0b64bf10543f4cefaf40bb5dcd4cf123b",
+   "sha256": "0rhg40h7czsvvd051v9ymwxw137r5bz0zsgy6zsg81zj0c4b8db7"
   }
  },
  {
@@ -4064,11 +4064,11 @@
   "repo": "waymondo/apropospriate-theme",
   "unstable": {
    "version": [
-    20241215,
-    1911
+    20250724,
+    1422
    ],
-   "commit": "1e8daa3e21e44a2fbc138db6fb38a915b4288479",
-   "sha256": "1spmmhasky247bn5x6am2n8zpqay4llvqqpl3ibi4crrwncvxipl"
+   "commit": "4457fb40db9893fe92f4afcd9420c37c503701f0",
+   "sha256": "1wq0hm05v22r7ksxlyxklm4pldbybd4608ilvpc2gmhckbig0b61"
   },
   "stable": {
    "version": [
@@ -4408,6 +4408,30 @@
   }
  },
  {
+  "ename": "asdf-vm",
+  "commit": "03c944c74671e1871628d890a7251449282269b3",
+  "sha256": "0grdq1rjwqjrilnyww5mixsw8yg159vzl3rykk520dw2v5bfdbv9",
+  "fetcher": "github",
+  "repo": "zellio/emacs-asdf-vm",
+  "unstable": {
+   "version": [
+    20250710,
+    1053
+   ],
+   "commit": "f6dbb4b6560cd7e5bb05006e9fc416c5c323b567",
+   "sha256": "1l7ck69z6digbrybzggmb0q4myhlv9pwc71x8l5scjb4sv5ch1qq"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "commit": "f6dbb4b6560cd7e5bb05006e9fc416c5c323b567",
+   "sha256": "1l7ck69z6digbrybzggmb0q4myhlv9pwc71x8l5scjb4sv5ch1qq"
+  }
+ },
+ {
   "ename": "asilea",
   "commit": "858e673c66e876d80f41d47d307c944d7bdb147d",
   "sha256": "1lb8nr6r6yy06m4pxg8w9ja4zv8k5xwhl95v2wv95y1qwhgnwg3j",
@@ -4516,10 +4540,10 @@
  },
  {
   "ename": "ast-grep",
-  "commit": "0a2c5915b8e1fe52783101cbf7c708d803d08193",
-  "sha256": "1zhm9k0jdkqbcm95rrl9ljrhpwh5an7czx0nmdhgal2xl3wkyghl",
+  "commit": "b5c322b1e2d9212e617b81c0eaf75ffacf41102b",
+  "sha256": "1gfl6asv8sbgcn321bgzv5wwl6b6fwsawj2hkk7i499r1y5vkp7n",
   "fetcher": "github",
-  "repo": "sunskyxh/ast-grep.el",
+  "repo": "SunskyXH/ast-grep.el",
   "unstable": {
    "version": [
     20250703,
@@ -4618,11 +4642,11 @@
   "repo": "jwiegley/emacs-async",
   "unstable": {
    "version": [
-    20250325,
-    509
+    20250826,
+    517
    ],
-   "commit": "bb3f31966ed65a76abe6fa4f80a960a2917f554e",
-   "sha256": "0qlfhilaa97kmcycms1ch5gqcn6i56xrkmm69x6175d2lq36lpq1"
+   "commit": "59f6ee68eb9bed8de12d71ca78a11dd8effbc2aa",
+   "sha256": "1ja7i4yfan83dan6vvpzywca6yh4ip9an76xhcb2s30270wmvnrk"
   },
   "stable": {
    "version": [
@@ -5269,11 +5293,11 @@
   "repo": "emacscollective/auto-compile",
   "unstable": {
    "version": [
-    20250531,
-    2214
+    20250815,
+    2130
    ],
-   "commit": "b9e5df6f6d3f57263d6b22f2401f776380a37778",
-   "sha256": "1ndqm7b2mnrsb0rqigghzjqvk39gj8pjg4nhz8bapvrywb5s5zjk"
+   "commit": "a11a3f717b0951b4ea1f2e1be5719fd496a07204",
+   "sha256": "0i4z0vgyd19bwjw3p37784rhny4n3svfja4zcw9dczp538a4b4wg"
   },
   "stable": {
    "version": [
@@ -5583,20 +5607,20 @@
   "repo": "LionyxML/auto-dark-emacs",
   "unstable": {
    "version": [
-    20240927,
-    1255
+    20250823,
+    106
    ],
-   "commit": "117e20cddf171bcc288dac32907eb5d856951268",
-   "sha256": "0cp4hcac2kya3m8cc8xfrv01cg06vi70zgp4m6q39cw2i9dnlnch"
+   "commit": "8d3f559c832be55857b1bbe4388feb8037a842e4",
+   "sha256": "0d9wsc2lbx7icpgg0rfwyp8iqkg99q1mpwczc5b2qawmpf1bdaj4"
   },
   "stable": {
    "version": [
     0,
     13,
-    2
+    6
    ],
-   "commit": "117e20cddf171bcc288dac32907eb5d856951268",
-   "sha256": "0cp4hcac2kya3m8cc8xfrv01cg06vi70zgp4m6q39cw2i9dnlnch"
+   "commit": "8d3f559c832be55857b1bbe4388feb8037a842e4",
+   "sha256": "0d9wsc2lbx7icpgg0rfwyp8iqkg99q1mpwczc5b2qawmpf1bdaj4"
   }
  },
  {
@@ -6090,6 +6114,21 @@
   }
  },
  {
+  "ename": "automoji",
+  "commit": "cc0dd270be8ba97cb37cd195e7dd769457e57cb7",
+  "sha256": "001p67wifdwxdn76kzp704vpccn4wfhawcbwni5zhjdpaml4vqj7",
+  "fetcher": "github",
+  "repo": "Dev380/automoji-el",
+  "unstable": {
+   "version": [
+    20250814,
+    2054
+   ],
+   "commit": "725e6915f9976bd7fd87a4daa7dc9f1968bcfe23",
+   "sha256": "1xr4ansaqlzzq1ihw4j3mcka1gjrrmwpc6pprwq9hin3c0aba209"
+  }
+ },
+ {
   "ename": "autoscratch",
   "commit": "3a7d9122d09bb952c1ae34cf0104cb82a0f6e2b5",
   "sha256": "01h33w3w9isjwz1mcr87zflhgnc14f8655la0h9bf3033jnbi5g8",
@@ -6235,14 +6274,14 @@
   "repo": "nameiwillforget/avy-act",
   "unstable": {
    "version": [
-    20250420,
-    1805
+    20250727,
+    1603
    ],
    "deps": [
     "avy"
    ],
-   "commit": "b50b6ee3435ed63eea1a6ffff39ecd121ae4d091",
-   "sha256": "06xqmkv3nah7cw4kzfgz79w1xwqnlh881c517xlibsx9s58zcn2k"
+   "commit": "6e60b4bac5501e29e12daccea15594755c847295",
+   "sha256": "1kkchn6qq318a2a1i80inckxh10ziqg6w6pvjlhh3y2gslq93yxj"
   }
  },
  {
@@ -6419,6 +6458,25 @@
    ],
    "commit": "12e8e0b49878099bda5d3e4915cc3c738c87b95c",
    "sha256": "03vw6y4bjfip4ryr265hkkwm66rl3m7gwird7hgrqzilmb9sahia"
+  }
+ },
+ {
+  "ename": "awqat",
+  "commit": "d8f9f02378807e0303455793a1237d38c784ad7f",
+  "sha256": "1pq55ykidnp1c18dpsp33aa5l9qlcp4igzks2klx84wx488n4f84",
+  "fetcher": "github",
+  "repo": "zkry/awqat",
+  "unstable": {
+   "version": [
+    20250727,
+    1902
+   ],
+   "deps": [
+    "alert",
+    "s"
+   ],
+   "commit": "52754b230c5796eb9c8aaeda87083855c4235f32",
+   "sha256": "1r2q2amn3qry6k7z1wyyfmabb6kq5ggr8068apwpb1vc4jgc5prn"
   }
  },
  {
@@ -6905,11 +6963,11 @@
   "repo": "tinted-theming/base16-emacs",
   "unstable": {
    "version": [
-    20250629,
-    145
+    20250810,
+    148
    ],
-   "commit": "244ae9a10f3bd4e9f09705da434989cd3831ddf6",
-   "sha256": "180mb2syky61azq0p16n8b64b4m06ga8wjmiqmxdqli7k39pv87l"
+   "commit": "196f6b9f7c58cb439ed7b0d59c76b1ad737569e0",
+   "sha256": "06yl4x94j1mgiqiadnd22hxyq3yfi1skbbh2f80bpfla27bb1p1y"
   },
   "stable": {
    "version": [
@@ -6951,11 +7009,11 @@
   "repo": "szermatt/emacs-bash-completion",
   "unstable": {
    "version": [
-    20250626,
-    2042
+    20250721,
+    2026
    ],
-   "commit": "520503455d0ad762faa75b88501cccc71786343d",
-   "sha256": "0qvz8jard3dr9abln6288v6s4mcn4rf8bd6glna5rqlr5r7swh21"
+   "commit": "762f28fefba487e15d626691310f3194804eb71a",
+   "sha256": "1kf542389phlrjly5cjhhkv5534cc6lp93468aiaqnx2maaa982a"
   },
   "stable": {
    "version": [
@@ -7524,11 +7582,11 @@
   "repo": "Beluga-lang/Beluga",
   "unstable": {
    "version": [
-    20250519,
-    2027
+    20250823,
+    858
    ],
-   "commit": "8bf5054bc10e0d56f6ae8552f366da2f6d43b188",
-   "sha256": "0zmbkipla44m4hd6bdxr8fpfrd14n99hlv5dd60z6c0zlnk6q4s2"
+   "commit": "bdc1897d7070c341b1fa317288a79005b7f5b8c2",
+   "sha256": "0yvzd09pdnxs00dy0s2045l98sdnb47bcx7qy604rriyl024zrah"
   }
  },
  {
@@ -7802,19 +7860,19 @@
   "repo": "kristjoc/bible-gateway",
   "unstable": {
    "version": [
-    20250605,
-    905
+    20250724,
+    853
    ],
-   "commit": "c30789af353e37569e3dae7c910f3684320f8d8e",
-   "sha256": "018ahpad299a7yf7wp2ljc4w0b9rr557avq9zr0vk5zsggfnm37l"
+   "commit": "5f86dd2768950c213f03292e9ee7d2ee652c18fc",
+   "sha256": "1sbc5hd4n3whgi0m1jdvkl4xj4awspq1wjwi6z4m8hyf9mbsj3gd"
   },
   "stable": {
    "version": [
     1,
-    0
+    1
    ],
-   "commit": "c30789af353e37569e3dae7c910f3684320f8d8e",
-   "sha256": "018ahpad299a7yf7wp2ljc4w0b9rr557avq9zr0vk5zsggfnm37l"
+   "commit": "5f86dd2768950c213f03292e9ee7d2ee652c18fc",
+   "sha256": "1sbc5hd4n3whgi0m1jdvkl4xj4awspq1wjwi6z4m8hyf9mbsj3gd"
   }
  },
  {
@@ -7825,14 +7883,14 @@
   "repo": "cpitclaudel/biblio.el",
   "unstable": {
    "version": [
-    20250409,
-    2132
+    20250812,
+    1408
    ],
    "deps": [
     "biblio-core"
    ],
-   "commit": "0314982c0ca03d0f8e0ddbe9fc20588c35021098",
-   "sha256": "1m637bnafbmifx2mr7xbijyv5v0dqnx6id6v58gwkyjran2lg4h7"
+   "commit": "bb9d6b4b962fb2a4e965d27888268b66d868766b",
+   "sha256": "1xjv4qzqc6bgpr5qay6wk58sxmlbv95fnkcan8r7m9rwbd9bn8nx"
   },
   "stable": {
    "version": [
@@ -8109,16 +8167,30 @@
   "repo": "lorniu/bilibili.el",
   "unstable": {
    "version": [
-    20250527,
-    850
+    20250727,
+    348
    ],
    "deps": [
     "mpvi",
     "org",
     "pdd"
    ],
-   "commit": "ccc8cabe4b6d724782edccbf6cf09af5371b26fb",
-   "sha256": "0jqbgc642mw5ahkpd6yzq13lqdp4d4qwzbfapxz4ln1lzkcjda0l"
+   "commit": "f650983c9c29ea5fe4574dac3b3fd2a62ae49520",
+   "sha256": "1bqnk1sxvb6py98phvg7szd7qysfrmw7ccbl4cw3kn2ppl8ahk3d"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "deps": [
+    "mpvi",
+    "org",
+    "pdd"
+   ],
+   "commit": "f650983c9c29ea5fe4574dac3b3fd2a62ae49520",
+   "sha256": "1bqnk1sxvb6py98phvg7szd7qysfrmw7ccbl4cw3kn2ppl8ahk3d"
   }
  },
  {
@@ -9193,15 +9265,15 @@
   "repo": "emacscollective/borg",
   "unstable": {
    "version": [
-    20250601,
-    1047
+    20250812,
+    1354
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "bcec39d4f78b6f2145172d390ffd39f4e5bc74fe",
-   "sha256": "0c1irizwpwqicrhprq84mr7lwvagddl2iiy18hpljaf8jqq9ajpv"
+   "commit": "cedcf302193a64f58f78e85924b36624dc61eafd",
+   "sha256": "07rrz2yqapdvx353kfgp8y4611kxsbj2r37j9cq1l5kw0a30sqzl"
   },
   "stable": {
    "version": [
@@ -9362,6 +9434,21 @@
    ],
    "commit": "7c04ca9009e72b48da307b41d6814df1e383609a",
    "sha256": "0bah6xpmb86rgjd3irnalpdqsb6wbf5izq6h1di5hh9axk55acsr"
+  }
+ },
+ {
+  "ename": "bracket-face",
+  "commit": "890e94376ea0b6ada2c49a0a3e11b2a59aab7caa",
+  "sha256": "1j9iczccp494yqviqawphhndzyz6hsd21fqvsj7cd20balgz2g3g",
+  "fetcher": "github",
+  "repo": "tarsius/paren-face",
+  "unstable": {
+   "version": [
+    20250822,
+    1936
+   ],
+   "commit": "88cbcf779d3c382cf785a540a2134a663b753d7b",
+   "sha256": "0rxrcnpsar1550ihfr6a8qf0cx1p5va14cdx70ykqzfpvcbg5rdw"
   }
  },
  {
@@ -9527,11 +9614,11 @@
   "repo": "killdash9/broadcast.el",
   "unstable": {
    "version": [
-    20151205,
-    212
+    20250804,
+    1815
    ],
-   "commit": "f6f9cd2e0e3f8c31d6b8e7446c27eb0e50b25f16",
-   "sha256": "0w6b9rxdciy1365kgf6fh3vgrjr8xd5ar6xcn0g4h56f2zg9hdmj"
+   "commit": "c6fff897c14f0aac9c44a7d8ca3f70782e4c38d0",
+   "sha256": "1ac4c2w4d5c20wdjhw9y1vgj4ynxi6yl2z0lfgjhiv8sgwdgh3hg"
   }
  },
  {
@@ -9972,11 +10059,11 @@
   "repo": "jamescherti/buffer-terminator.el",
   "unstable": {
    "version": [
-    20250627,
-    1241
+    20250822,
+    1932
    ],
-   "commit": "bcd7955c6de0fc3dca995656c4ab59ce3384800b",
-   "sha256": "0agg80dqm9bidsp9b9hgrpx7fw13q81spbc7x6wy9xmd1kwwvcvg"
+   "commit": "a5f4a6a00ebb0af979c8b122c3a0122a9dedc070",
+   "sha256": "1s4xqzs895cgwqk8m33d9imq87wc39qm8c1rp5652nzi8h5iv2xw"
   },
   "stable": {
    "version": [
@@ -10089,20 +10176,20 @@
   "repo": "jamescherti/bufferfile.el",
   "unstable": {
    "version": [
-    20250624,
-    1554
+    20250805,
+    1623
    ],
-   "commit": "8b5aa56907d10394672909be6d88a59a29a89d14",
-   "sha256": "0xf09b6lm7rjvm21pihgmcznkjv7aa9bgz9zz8f9ksb8y7115zgd"
+   "commit": "775e258d7480daebb06073ada76eebc4c979f509",
+   "sha256": "1j2n3738mqfr2g3hy4swcdzlzj50dmawq2n06ln1s03giq54p05k"
   },
   "stable": {
    "version": [
     1,
     0,
-    5
+    6
    ],
-   "commit": "39689ccff11fc592b6c83d8b05dcffc02a269df6",
-   "sha256": "0v00dbr6npnrb57n95sax9ii9qs82qfz88p22qam1hwaiaqw8lgg"
+   "commit": "5a78bf05443d60d651aaadcb8855d84b39bab182",
+   "sha256": "157hs1wigczs7l674j3aml7hlng806kafdryix939v9xrv58z8lx"
   }
  },
  {
@@ -10453,38 +10540,6 @@
   }
  },
  {
-  "ename": "butler",
-  "commit": "c86e3f5083e59568afac69eed9aa8c1a0bd76e2e",
-  "sha256": "1jv74l9jy55qpwf5np9nlj6a1wqsm3xirm7wm89d1h2mbsfcr0mq",
-  "fetcher": "github",
-  "repo": "AshtonKem/Butler",
-  "unstable": {
-   "version": [
-    20210928,
-    230
-   ],
-   "deps": [
-    "deferred",
-    "json"
-   ],
-   "commit": "10943ccdf2030187b2f7bd97337d78acb7fd31c9",
-   "sha256": "028c5mqhxpq007s7c6rha47zzyj6nsf49mnh99b0mfg9d95s4057"
-  },
-  "stable": {
-   "version": [
-    0,
-    2,
-    6
-   ],
-   "deps": [
-    "deferred",
-    "json"
-   ],
-   "commit": "454cb9d3980b9ac555f3f77e4e48056de07f051b",
-   "sha256": "1wsk5isza8xqr84w6haal95ssifz6j2lrr5phbsdc90jb9hicbff"
-  }
- },
- {
   "ename": "buttercup",
   "commit": "d4b187cb5b3cc5b546bfa6b94b6792e6363242d1",
   "sha256": "1grrrdk5pl9l1jvnwzl8g0102gipvxb5qn6k2nmv28jpl57v8dkb",
@@ -10492,19 +10547,19 @@
   "repo": "jorgenschaefer/emacs-buttercup",
   "unstable": {
    "version": [
-    20250216,
-    2315
+    20250801,
+    1
    ],
-   "commit": "c467c659b2c5b7029e20909331e072d7301af1d5",
-   "sha256": "0gkw1lmy8ynralrs4xwqsd06ww09xk5yqjdgw4r5c0zhp5dxn4ky"
+   "commit": "cc5a2ab7c7f18aaaf525fac61fe59bae5ad018dd",
+   "sha256": "09n8skr5wi8bs7x81d5bi6z89dd8s1zi9a5f4r2qadaz69slncxq"
   },
   "stable": {
    "version": [
     1,
-    37
+    38
    ],
-   "commit": "c467c659b2c5b7029e20909331e072d7301af1d5",
-   "sha256": "0gkw1lmy8ynralrs4xwqsd06ww09xk5yqjdgw4r5c0zhp5dxn4ky"
+   "commit": "cc5a2ab7c7f18aaaf525fac61fe59bae5ad018dd",
+   "sha256": "09n8skr5wi8bs7x81d5bi6z89dd8s1zi9a5f4r2qadaz69slncxq"
   }
  },
  {
@@ -11037,8 +11092,8 @@
   "repo": "chenyanming/calibredb.el",
   "unstable": {
    "version": [
-    20250705,
-    225
+    20250725,
+    1429
    ],
    "deps": [
     "dash",
@@ -11048,8 +11103,8 @@
     "s",
     "transient"
    ],
-   "commit": "bbc9d573d5536be5b3530f27539c607f9b030b80",
-   "sha256": "1c6idn8l6894g55kp7bmvrdrhi10mndn24ym95sbv1zqajib653m"
+   "commit": "320c28254c6f8d4c35ea5d4c7f91210a7a1a9bee",
+   "sha256": "0ahzif99wb935sbivgqy2ra9c6ff1r1p2p6m47cmslhsycb09y2y"
   },
   "stable": {
    "version": [
@@ -11239,14 +11294,14 @@
   "repo": "minad/cape",
   "unstable": {
    "version": [
-    20250521,
-    645
+    20250807,
+    2138
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c9191ee9e13e86a7b40c3d25c8bf7907c085a1cf",
-   "sha256": "0jdlk2i4mksp7dh71hvz93125z9y1vrfq78jiazzmwyimnawq5zh"
+   "commit": "97641dcd1ebca1007badd26b2fb9269b86934c22",
+   "sha256": "1w7pym65a2p63fiv5fqmsvxx6nbxr96a1inldzpjqq5qndgaksgw"
   },
   "stable": {
    "version": [
@@ -11561,32 +11616,32 @@
  },
  {
   "ename": "casual",
-  "commit": "b89f2ab853d0dd1c684591d5f05c12de8d3785e4",
-  "sha256": "0s2nagcj1v9mw77ag60fdxhivrraxs3gk7i1xnj2d48gwjksai18",
+  "commit": "6b66a8e6d1f18ac170ad06cdf23db2eb9e64d9c9",
+  "sha256": "1hnh609iwlvjl1zr794yi9navw3yzbb53qmwy526q08masbjccix",
   "fetcher": "github",
   "repo": "kickingvegas/casual",
   "unstable": {
    "version": [
-    20250709,
-    1922
+    20250817,
+    2347
    ],
    "deps": [
     "transient"
    ],
-   "commit": "a587b65b5e04003410610c1d264cf5f7d6bdf32a",
-   "sha256": "0vdgm2c3rbda1zhjmwd52kp3srd1wgqrzzl3iaz7rp2g271bwih0"
+   "commit": "5e004a06eef3b66865b785bca51512cdb89ff6a9",
+   "sha256": "0dlhb04l0i71ivsz9mgrphx9mk6qldbihpvkijpqs01h5q2swd83"
   },
   "stable": {
    "version": [
     2,
-    7,
-    1
+    8,
+    4
    ],
    "deps": [
     "transient"
    ],
-   "commit": "a587b65b5e04003410610c1d264cf5f7d6bdf32a",
-   "sha256": "0vdgm2c3rbda1zhjmwd52kp3srd1wgqrzzl3iaz7rp2g271bwih0"
+   "commit": "5e004a06eef3b66865b785bca51512cdb89ff6a9",
+   "sha256": "0dlhb04l0i71ivsz9mgrphx9mk6qldbihpvkijpqs01h5q2swd83"
   }
  },
  {
@@ -11719,11 +11774,11 @@
   "repo": "catppuccin/emacs",
   "unstable": {
    "version": [
-    20250622,
-    712
+    20250715,
+    754
    ],
-   "commit": "26766bbc61d59a94088aaa4cccbb9d39b5a8b5b8",
-   "sha256": "058g2ajw7h4y7dnh22ij70xrlhpj334prdzjfpvy3216b8kswbfh"
+   "commit": "d070e926504b81dd9b8cdbf90604b5268e7e17b5",
+   "sha256": "0xcqmyr5nq4zb7q5qkplrsp126h7rhgxxj2plsn3qmggryhdrdr2"
   },
   "stable": {
    "version": [
@@ -11832,15 +11887,15 @@
   "repo": "emacs-lsp/emacs-ccls",
   "unstable": {
    "version": [
-    20250301,
-    131
+    20250825,
+    531
    ],
    "deps": [
     "dash",
     "lsp-mode"
    ],
-   "commit": "28c7930c89c48a8f8e0ff5a62734f587f54e52be",
-   "sha256": "19x4y73va3gvxjl6j783vdzrcfa9fc4qv6lk91qqs3i9g3avahc3"
+   "commit": "80981d751198b59a7960a5437cb42a4d9974f254",
+   "sha256": "02crd43hxk2b8pdwnihp3lchb1wbba0whj3jwhg4yzxn32zlgw1y"
   }
  },
  {
@@ -12208,16 +12263,16 @@
   "repo": "worr/cfn-mode",
   "unstable": {
    "version": [
-    20250706,
-    805
+    20250817,
+    807
    ],
    "deps": [
     "f",
     "s",
     "yaml-mode"
    ],
-   "commit": "4982e0c346e29365352cc69225371a0ff6f86243",
-   "sha256": "0cry80is2yhc95b0nph280f9lbcqp06gf2dl7r7jz0yi3l6k681d"
+   "commit": "7a1d5825d5d875c1f816ab233c977fd9cc8726dc",
+   "sha256": "06gjgpp8yrblglz8rxq80459zw37i6w0x53kc0nrkf85xwqwird1"
   },
   "stable": {
    "version": [
@@ -12273,21 +12328,21 @@
   "repo": "Alexander-Miller/cfrs",
   "unstable": {
    "version": [
-    20220129,
-    1149
+    20250729,
+    1422
    ],
    "deps": [
     "dash",
     "posframe",
     "s"
    ],
-   "commit": "f3a21f237b2a54e6b9f8a420a9da42b4f0a63121",
-   "sha256": "1vf5zm82sx3m1yvq73km8ajapv6rnz41b1jrsif7kh0ijh9vk3qi"
+   "commit": "981bddb3fb9fd9c58aed182e352975bd10ad74c8",
+   "sha256": "1bnfchv62zk9rapmiff6jcip9w6pp1x48l8qp26z9yb8clnvlz24"
   },
   "stable": {
    "version": [
     1,
-    6,
+    7,
     0
    ],
    "deps": [
@@ -12295,8 +12350,8 @@
     "posframe",
     "s"
    ],
-   "commit": "f3a21f237b2a54e6b9f8a420a9da42b4f0a63121",
-   "sha256": "1vf5zm82sx3m1yvq73km8ajapv6rnz41b1jrsif7kh0ijh9vk3qi"
+   "commit": "981bddb3fb9fd9c58aed182e352975bd10ad74c8",
+   "sha256": "1bnfchv62zk9rapmiff6jcip9w6pp1x48l8qp26z9yb8clnvlz24"
   }
  },
  {
@@ -12481,26 +12536,28 @@
   "repo": "xenodium/chatgpt-shell",
   "unstable": {
    "version": [
-    20250702,
-    1851
+    20250825,
+    1527
    ],
    "deps": [
-    "shell-maker"
+    "shell-maker",
+    "transient"
    ],
-   "commit": "d5a6c91d80de7bbf9958fc6782bcdd0a852d8963",
-   "sha256": "00bgq4sbrsw3d7ab2c4j6mcxy7gysvnk5il83rq4a7h7vmqwg98y"
+   "commit": "cda5d96d9b01b28cff527ff1134a2df5e9a2731a",
+   "sha256": "04lx5qlw5srbr2rhd0w3z6ikvwcbzsyz623k4rw6yr4ps82dfgyp"
   },
   "stable": {
    "version": [
     2,
-    22,
-    1
+    26,
+    2
    ],
    "deps": [
-    "shell-maker"
+    "shell-maker",
+    "transient"
    ],
-   "commit": "052973946b8cf556ff36e3a360628175c50fce5d",
-   "sha256": "1scm9xi6zn26xiks2x1vxjfqsj6hg8d1nq9q2495z9jjk2j62h0i"
+   "commit": "9bf591aa58f5bce7d3b01c505f5608e31820950f",
+   "sha256": "1irwv2fcyj0nf086p29pgyyk1pdbq6c8pczxacfsax0xjmxzyzpx"
   }
  },
  {
@@ -12919,14 +12976,14 @@
   "repo": "breatheoutbreathein/chordpro-mode.el",
   "unstable": {
    "version": [
-    20250410,
-    707
+    20250814,
+    301
    ],
    "deps": [
     "compat"
    ],
-   "commit": "9c559886e343fa37ba1524221eb3356adab1b6c7",
-   "sha256": "1pynhqrrvbkad0bp1n84pak60qzsrknjysvl8rpnm7mqinwgxlj7"
+   "commit": "ae6db74f2078e4ee3d6262ac1344df9c1ab87527",
+   "sha256": "03aqw9385f5xdhphhm352n66yi2fmah6n43wrnr850d3mq5485g0"
   },
   "stable": {
    "version": [
@@ -13166,8 +13223,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20250702,
-    1103
+    20250806,
+    1944
    ],
    "deps": [
     "clojure-mode",
@@ -13178,13 +13235,13 @@
     "spinner",
     "transient"
    ],
-   "commit": "66edadb64f80de472f7ac47427db200c3df02060",
-   "sha256": "1hyzdxa3k30868br3ffqj1w1nxyp0l7zn90mspkljzc4kg9c11ap"
+   "commit": "ff44b5b6f5ecb4bc3407fdc07eb54a3e8dc663fd",
+   "sha256": "05sa88kp3pg53harnxk83z54q0qs61icq9xf9871hyxb317hrlqk"
   },
   "stable": {
    "version": [
     1,
-    18,
+    19,
     0
    ],
    "deps": [
@@ -13196,8 +13253,8 @@
     "spinner",
     "transient"
    ],
-   "commit": "6d2d09318423f373bdbd546e97dc3e32b21c10e4",
-   "sha256": "0rcrc5cy0ph56wrpn4mz7wmanndfff032il1di64i3d9y746c0da"
+   "commit": "b5a6ffc97e3c76957721f71280ea5f49fd29d7a3",
+   "sha256": "0limw27arkc8bn0zzj0jzhdsax78qm1lz5jfgy8zgf971llhf5qc"
   }
  },
  {
@@ -13400,14 +13457,14 @@
   "repo": "emacs-circe/circe",
   "unstable": {
    "version": [
-    20250421,
-    1753
+    20250713,
+    1752
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "9d9f63fd7cf8812797eb0ef77d7969e7387a9eb9",
-   "sha256": "12vq5p3bmqp4gh4s40s8sbz8hs2zczkcl4zfnn7ybr5sc36g1zax"
+   "commit": "a0aada8cbb381228c80d98b81ebdec30012c512e",
+   "sha256": "055143h804dh58j5xa9q9l0vhb41fbpfaxg3lwz0iilgjazs5xx7"
   },
   "stable": {
    "version": [
@@ -13593,16 +13650,16 @@
   "repo": "krisbalintona/citar-org-node",
   "unstable": {
    "version": [
-    20250527,
-    2252
+    20250727,
+    650
    ],
    "deps": [
     "citar",
     "ht",
     "org-node"
    ],
-   "commit": "edc3e7e7abfd8dc5ad029df79d28b0c317ff8ac7",
-   "sha256": "1qjhz09p55w36rr59jr38pwphsszb227ymcmbssx815h0n6g2n86"
+   "commit": "b6f8e9db9bbff7675299bc3babb62db7e73bdc60",
+   "sha256": "1nliz0lyknvp4amn2r48hrwmhnc62inz6qzjsaqdsy6mpn3qg0jr"
   },
   "stable": {
    "version": [
@@ -13659,8 +13716,8 @@
   "repo": "andras-simonyi/citeproc-el",
   "unstable": {
    "version": [
-    20250525,
-    1011
+    20250819,
+    1700
    ],
    "deps": [
     "compat",
@@ -13672,8 +13729,8 @@
     "s",
     "string-inflection"
    ],
-   "commit": "e3bf1f80bcd64edf4afef564c0d94d38aa567d61",
-   "sha256": "1158cqchq5zprxwbf1ayjh0i0wl907jkcdj97f3skrbdj9rx4pcn"
+   "commit": "f5217b9fdbcb41a0381ecf92108390fc843090dd",
+   "sha256": "1z3admj8xf73azk4hd8yp75ldwla5zl0n4a4syndk6wqn18vgc7f"
   },
   "stable": {
    "version": [
@@ -13880,6 +13937,42 @@
   }
  },
  {
+  "ename": "claude-code",
+  "commit": "ad463328e858a1df77d95da55cfde40ccae31cc9",
+  "sha256": "1q7q64ydp38kmg8sxj7rsgn528fw2jz0m1m5yzfvvvc9sbjzy4m1",
+  "fetcher": "github",
+  "repo": "yuya373/claude-code-emacs",
+  "unstable": {
+   "version": [
+    20250723,
+    1154
+   ],
+   "deps": [
+    "markdown-mode",
+    "projectile",
+    "transient",
+    "vterm"
+   ],
+   "commit": "f62dfe4c570c92fceaf628c5749b240a5fd9330d",
+   "sha256": "1z2xq2qmy92nzsgrr2xfjljww5rgzj41yzpipsvqzg1ws6rvd1zs"
+  },
+  "stable": {
+   "version": [
+    0,
+    6,
+    0
+   ],
+   "deps": [
+    "markdown-mode",
+    "projectile",
+    "transient",
+    "vterm"
+   ],
+   "commit": "f62dfe4c570c92fceaf628c5749b240a5fd9330d",
+   "sha256": "1z2xq2qmy92nzsgrr2xfjljww5rgzj41yzpipsvqzg1ws6rvd1zs"
+  }
+ },
+ {
   "ename": "claude-shell",
   "commit": "a40f86ecc9a185f065a720318ff69afc10d92535",
   "sha256": "0lqw9qra8zdafwnyfm164h2nzh6ys5ndbf75s4dnwjpg5lxv135y",
@@ -13905,15 +13998,15 @@
   "repo": "mzacho/claudia",
   "unstable": {
    "version": [
-    20250309,
-    2334
+    20250824,
+    1704
    ],
    "deps": [
     "markdown-mode",
     "uuidgen"
    ],
-   "commit": "d33d36a2682682a8f85bcdff3f4fe668c83c2cba",
-   "sha256": "1q79hz71vjjzhfghfqr9r7rhx18f70zxy34l52562v4p91qx5y8w"
+   "commit": "f5a3398d588a83372169a277d3dd3ed467ff799b",
+   "sha256": "1gd3xskakmhyd366vj7i7022k2y4pllxvm01n60grqyihjavv4ka"
   }
  },
  {
@@ -14687,11 +14780,11 @@
   "repo": "clojure-emacs/clojure-ts-mode",
   "unstable": {
    "version": [
-    20250705,
-    1307
+    20250815,
+    441
    ],
-   "commit": "603660f42df141016f7011fbf303250733df42c8",
-   "sha256": "07m4fgdhfkz744hnbzgyqbhn6c9fjdrk6xd5dw49qga85vygplc3"
+   "commit": "32490c80fad7d27367b08d967e8184f75b4ca19e",
+   "sha256": "0zn6ajk7fkd6w7306bd3l4v7zqjj58czinqdk5bdjbgbapnh9rs7"
   },
   "stable": {
    "version": [
@@ -14746,15 +14839,15 @@
   "repo": "magit/closql",
   "unstable": {
    "version": [
-    20250601,
-    1010
+    20250815,
+    1802
    ],
    "deps": [
     "compat",
     "emacsql"
    ],
-   "commit": "05a2b048fd4e5c90aa971479cb9e71cf9aeba2bf",
-   "sha256": "0qk9g2f966iy534k0rbkgbz120psk3hvvw7hn720ym22rlbf214b"
+   "commit": "08194fb97deb3a83863da7731cb316aa62058f22",
+   "sha256": "0yj3sbcwdk6g4fivma6zdqkvj5wsagx2kid05jgj7zpiyq3wgqgv"
   },
   "stable": {
    "version": [
@@ -14940,20 +15033,20 @@
   "url": "https://gitlab.kitware.com/cmake/cmake.git",
   "unstable": {
    "version": [
-    20250304,
-    1338
+    20250805,
+    1455
    ],
-   "commit": "bf8f4d4639407e01bb7e827eb7b6d1fc44fabb52",
-   "sha256": "1ds3d9bf1732zcbiv9l29zm9hmwhcqhkfr1p9jbxb6mm3q719afh"
+   "commit": "2a2c2e0b2658f7c07e00fcf649882fd5578c2fc1",
+   "sha256": "05apsrvsnc4qjh230ym9mdmip8lv209947rw743h4kxch02pxld2"
   },
   "stable": {
    "version": [
     4,
-    0,
-    3
+    1,
+    0
    ],
-   "commit": "79e82f371ca8f00696fb0b838521cb0f72bb7786",
-   "sha256": "08yw3qpk784942zs4nllviw2a2q2ag3x0a0vl09r3vng708k3z66"
+   "commit": "2a2c2e0b2658f7c07e00fcf649882fd5578c2fc1",
+   "sha256": "05apsrvsnc4qjh230ym9mdmip8lv209947rw743h4kxch02pxld2"
   }
  },
  {
@@ -15458,14 +15551,14 @@
   "repo": "ankurdave/color-identifiers-mode",
   "unstable": {
    "version": [
-    20250612,
-    1046
+    20250709,
+    134
    ],
    "deps": [
     "dash"
    ],
-   "commit": "8813aa7337d80462d5a8907cbce373c1592a4ed9",
-   "sha256": "1f7x3klxwaryafaabbrzm879y5h2yjhknxf46hz8l9l48l2sizvd"
+   "commit": "162e56caa183c16f252b3e0a9dc816e5baaaea28",
+   "sha256": "1dx9rqvh7vgq8jygl5h1206jnn7s4w7b1gpqx1fvyafb4zyi06k4"
   },
   "stable": {
    "version": [
@@ -15770,14 +15863,14 @@
   "repo": "NicholasBHubbard/comint-histories",
   "unstable": {
    "version": [
-    20250319,
-    1602
+    20250825,
+    1935
    ],
    "deps": [
     "f"
    ],
-   "commit": "100173efba855e66e0a9596135f88820501125b9",
-   "sha256": "1kl7wlppy1d6g62xynp5jlj0cdjv13yq453ib2h7yxmma3xb3n6r"
+   "commit": "85a91700216524aec0e4c92c123faabff27e69e8",
+   "sha256": "1bsd51j3aclw8nlv10q57c30zf0fix28v5iilz92ci7iaf6j79yj"
   }
  },
  {
@@ -16062,20 +16155,20 @@
   "repo": "mekeor/communinfo",
   "unstable": {
    "version": [
-    20241126,
-    2028
+    20250726,
+    2115
    ],
-   "commit": "294aadda671ca53b802394e3bbb39a984a48bb2f",
-   "sha256": "1zxdk4ffy8589m9v5nx99gbsbaaibnb19r85fqyrfq0qlr42hici"
+   "commit": "feda0794ba63e407089c7f134e52a92f58d070b8",
+   "sha256": "16nrlkdpzsg0xb9ybl9hqayldfx4cqc5g8317ah8n02vv8w4jby4"
   },
   "stable": {
    "version": [
     0,
     1,
-    2
+    4
    ],
-   "commit": "2e1481c2441725f1938d8b11848e954906d118b8",
-   "sha256": "01vf2fz8s02ph3ppnx4sprk7cl7m3ifd5qfbz5d777swhar0wdsl"
+   "commit": "179b6a7bd75837f12d496949b0e7a09373c2ad80",
+   "sha256": "02myabw9mb8q86hnb8ngvd179xxim0x7818f2pi3lw19lfbgic75"
   }
  },
  {
@@ -16086,11 +16179,11 @@
   "repo": "company-mode/company-mode",
   "unstable": {
    "version": [
-    20250426,
-    1319
+    20250805,
+    1525
    ],
-   "commit": "41f07c7d401c1374a76f3004a3448d3d36bdf347",
-   "sha256": "16x0ssni2fxahdv292v3zqik12y3zvpqjkdbzsdgpb6z2p0j9ja0"
+   "commit": "ca045bc54411f274779057d94a1807efe7f8d2a6",
+   "sha256": "10lazdsydnnxrndp925sh3zah9nn38sbq4dhr4h0pkhr884wk69j"
   },
   "stable": {
    "version": [
@@ -16311,8 +16404,8 @@
   "repo": "cpitclaudel/company-coq",
   "unstable": {
    "version": [
-    20250625,
-    922
+    20250806,
+    1134
    ],
    "deps": [
     "cl-lib",
@@ -16321,8 +16414,8 @@
     "dash",
     "yasnippet"
    ],
-   "commit": "9a872fe98cbf20a688ff35165f7f6a1b3f5b8380",
-   "sha256": "0rar1hamg3nna3ivq39sa55nxm8xyxca1m4k0lz17851g65nyrrz"
+   "commit": "78ed04ce39e925232a556d2077718cc7b215469c",
+   "sha256": "02c4771ds6hm6hr12z5pw0lir43gjgba87wzrnda9gh5vbvflyc4"
   },
   "stable": {
    "version": [
@@ -16619,15 +16712,15 @@
   "repo": "pkryger/company-forge.el",
   "unstable": {
    "version": [
-    20250702,
-    1534
+    20250815,
+    1339
    ],
    "deps": [
     "company",
     "forge"
    ],
-   "commit": "a31ae799ed8e0c83380d6b2e9a112b76053e4ce9",
-   "sha256": "0bfyn7algjb5ys7jfln160zdx6dva9j2wq9fd6b1br8bqvaaf3v3"
+   "commit": "7361b40a814cc61e543db6462e58e701ac1afca7",
+   "sha256": "1p2adrpjki0j0ggq254xkzgqzyzqv5f3sd5c1zxxpy91lhnnv51v"
   }
  },
  {
@@ -17321,28 +17414,28 @@
   "repo": "radian-software/prescient.el",
   "unstable": {
    "version": [
-    20240803,
-    2320
+    20250816,
+    19
    ],
    "deps": [
     "company",
     "prescient"
    ],
-   "commit": "2b8a8b41228bddb2e11eb1c200e98a9edd04797c",
-   "sha256": "0qz3xv38vazxqsl7lan7fshj3gmb0qagkrvl5xzwqhdg0rir981j"
+   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
+   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
   },
   "stable": {
    "version": [
     6,
     3,
-    1
+    2
    ],
    "deps": [
     "company",
     "prescient"
    ],
-   "commit": "2b8a8b41228bddb2e11eb1c200e98a9edd04797c",
-   "sha256": "0qz3xv38vazxqsl7lan7fshj3gmb0qagkrvl5xzwqhdg0rir981j"
+   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
+   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
   }
  },
  {
@@ -17511,15 +17604,15 @@
   "repo": "Andersbakken/rtags",
   "unstable": {
    "version": [
-    20250218,
-    2303
+    20250804,
+    1613
    ],
    "deps": [
     "company",
     "rtags"
    ],
-   "commit": "94269d3558e5db8bab381379dc347bdc7f7ded68",
-   "sha256": "12iv0h14brybqlld5b7z8yicpm3y0wcmmswx9pv261izp7dr41xc"
+   "commit": "d46dfed0e0f175937658ee642b39db05e2ee1477",
+   "sha256": "12rsfw8rlf18q61h7lq4krsx37vvm6vvzz2whxhs05bjps6h9qjx"
   },
   "stable": {
    "version": [
@@ -17695,14 +17788,14 @@
   "repo": "company-mode/company-statistics",
   "unstable": {
    "version": [
-    20170210,
-    1933
+    20250805,
+    1524
    ],
    "deps": [
     "company"
    ],
-   "commit": "e62157d43b2c874d2edbd547c3bdfb05d0a7ae5c",
-   "sha256": "12mwviz1mwx4ywks2lkmybbgh1wny67wkzlq5y3ml8gvyc288n3i"
+   "commit": "120e982f47e01945c044e0762ba376741c41b76c",
+   "sha256": "0iv9jgznz6y6wm8jyk74w5i7wxcanszaifyfck348irfyk8y3bik"
   },
   "stable": {
    "version": [
@@ -17983,20 +18076,20 @@
   "repo": "jamescherti/compile-angel.el",
   "unstable": {
    "version": [
-    20250704,
-    2211
+    20250825,
+    1926
    ],
-   "commit": "4f26258dfce13288c21b7dbe218d670b4099e6a2",
-   "sha256": "0k9mdqgwwd8g57id3y4g6n4jml1l7q7ivmcs8yfdfz70mjz4lj8s"
+   "commit": "298d9fbe552972ed9a678fc41ed9a2452a313a29",
+   "sha256": "0214k5vhf141wg6jbjirrzmx67kdrgs6qrvgphr5brasa85n2ydg"
   },
   "stable": {
    "version": [
     1,
     1,
-    1
+    2
    ],
-   "commit": "d8b0a801828772563e409ecc06d4e20d4522b6a1",
-   "sha256": "0sgzssrvqlg3lw0gra53sskic3krx9ipbq6h1ym6bnhxz9r29c22"
+   "commit": "c8475c2445913765ed5b9928045e62345ee866c6",
+   "sha256": "1bkws8303qligshrlndj7dh6m3s3qpj5smfgy5bv7f7lnbn0ps1l"
   }
  },
  {
@@ -18273,6 +18366,30 @@
   }
  },
  {
+  "ename": "cond-let",
+  "commit": "761d528d7a7c1d5a75432e2faafb0439ba650212",
+  "sha256": "07pwhydnfj8amq85va7zkig2f977fm2zx7vg0f2if5isnnhcz3yi",
+  "fetcher": "github",
+  "repo": "tarsius/cond-let",
+  "unstable": {
+   "version": [
+    20250823,
+    1715
+   ],
+   "commit": "7d3d9c6b28fadaa48f2015df4169c666dd9986dd",
+   "sha256": "11zar4q6364dykbga3akhfdvcmm1dxnc570nlnryc5irnsv80nbx"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "commit": "8cb8733112d00ad8d24cb1f2f7a7845448c31819",
+   "sha256": "07csd39xb5816y7944v4bcl0hv3pm8vnfqwcc84g7ijpwpip8rfc"
+  }
+ },
+ {
   "ename": "conda",
   "commit": "fcf762e34837975f5440a1d81a7f09699778123e",
   "sha256": "1hi292h6ccl7vkvyxcwwcdxw8q2brv3hy0mnlikzj2qy5pbnfg4y",
@@ -18280,8 +18397,8 @@
   "repo": "necaris/conda.el",
   "unstable": {
    "version": [
-    20241005,
-    2057
+    20250719,
+    140
    ],
    "deps": [
     "dash",
@@ -18289,8 +18406,8 @@
     "pythonic",
     "s"
    ],
-   "commit": "05de0c8f0cf336d90c044446aaa066ee13001b83",
-   "sha256": "038ay0crl693g6ag7q54ckhgcwl6x4d3pik4mriqrjfaq0cp6f1b"
+   "commit": "8a1a934a2de576d4158b1b12329be4f5be931a4a",
+   "sha256": "1gfsxlcv4rzihf9w65n10lagn4q5wvpg29lqs4xdn8lvgc7wycvp"
   },
   "stable": {
    "version": [
@@ -18465,19 +18582,19 @@
   "repo": "tralph3/conner",
   "unstable": {
    "version": [
-    20240828,
-    123
+    20250726,
+    1900
    ],
-   "commit": "93caf208e8e7f6b0627e5eb162f1488311d16b4c",
-   "sha256": "18rn5gbbscyy6558lxgja83x3jyhj9acnz79zc16a4x8jc994qjc"
+   "commit": "c87ada981743184ad21cd41def1405520651d626",
+   "sha256": "1jlxa20rppylgrn2g8hx61b5jx6af6mq878zgxhb4z93xyc33fwg"
   },
   "stable": {
    "version": [
     0,
-    4
+    5
    ],
-   "commit": "05de24bdac7c424d88eabd7cd0307f9b8bcc2aa3",
-   "sha256": "1s2dnbmfic0v2i9inp95a7psrwiajrpjc99b59rxaqqk5qwpf8hm"
+   "commit": "c87ada981743184ad21cd41def1405520651d626",
+   "sha256": "1jlxa20rppylgrn2g8hx61b5jx6af6mq878zgxhb4z93xyc33fwg"
   }
  },
  {
@@ -18503,25 +18620,25 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20250702,
-    846
+    20250821,
+    1739
    ],
    "deps": [
     "compat"
    ],
-   "commit": "d32cccdcb5559b503306291fa9f52df19594d687",
-   "sha256": "0kh16gclc6jdp1wv19sblg511irz5hfyy42c4shyl547im1cayar"
+   "commit": "c8bbb3f1e2fbbdcca773498e2db168c0929c3434",
+   "sha256": "1in3qiqlfzcwib34dd01v6a5y5h84p2nr94bn7gi32mw9p9b3z8m"
   },
   "stable": {
    "version": [
     2,
-    6
+    7
    ],
    "deps": [
     "compat"
    ],
-   "commit": "4314c45d84d9e00d45d2b611562d8fe2e4ddcf48",
-   "sha256": "18vnf1dca47d9rbs00gkhjxank34dxw6mbv165dgb3nq3hpzxgmw"
+   "commit": "770c43117aad6add1ca8532207618b7e90aec1fe",
+   "sha256": "1vgvs1ymssh5gv7xwnv9bksmgr3i5zqzqhyxz5x8ygj6fxfv2f12"
   }
  },
  {
@@ -18756,15 +18873,15 @@
   "repo": "minad/consult-flycheck",
   "unstable": {
    "version": [
-    20250101,
-    914
+    20250724,
+    1511
    ],
    "deps": [
     "consult",
     "flycheck"
    ],
-   "commit": "3bc2141daf8cfad7e4d2e2f78b15d45033f707a5",
-   "sha256": "0x0jbk0pyw2djwskn0f9nsqyyjh8j3g588vh500x4p1bnca4afvc"
+   "commit": "86dcb0bf2897be0f2b915ade96b1915ab23c3ee9",
+   "sha256": "01vidxcmh8zxw8bixp4bwnmrsblrpq72k3pmhjpdd9d9vvg2jg3x"
   },
   "stable": {
    "version": [
@@ -18805,30 +18922,30 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250531,
-    1028
+    20250730,
+    2355
    ],
    "deps": [
     "consult",
     "markdown-mode",
-    "ox-gfm"
+    "ox-gfm",
+    "yaml"
    ],
-   "commit": "d640f86a6d8e419d27cc4cd67cbb526c617fcf18",
-   "sha256": "03274q4nfsass46amklkhda6vsfhb2y6idrm0rz5a1qcs6c5qz3s"
+   "commit": "f76011cafdfb5ab3cff5c93865e4db21713d67cb",
+   "sha256": "11f5bikazp32yap76vqmp6ij0wnvg9hkp4bia31f3gba4hpf6ys2"
   },
   "stable": {
    "version": [
     2,
-    5,
-    1
+    6
    ],
    "deps": [
     "consult",
     "markdown-mode",
     "ox-gfm"
    ],
-   "commit": "d640f86a6d8e419d27cc4cd67cbb526c617fcf18",
-   "sha256": "03274q4nfsass46amklkhda6vsfhb2y6idrm0rz5a1qcs6c5qz3s"
+   "commit": "82834b0b2e21903f15cbb6427d1fd12c30e16b88",
+   "sha256": "09yriq68kcm4x0haig1vxlsnrbx2b1y7y2ws6k8fnds3ja175cy2"
   }
  },
  {
@@ -18839,30 +18956,29 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250531,
-    1028
+    20250714,
+    2249
    ],
    "deps": [
     "consult",
     "consult-gh",
     "embark-consult"
    ],
-   "commit": "d640f86a6d8e419d27cc4cd67cbb526c617fcf18",
-   "sha256": "03274q4nfsass46amklkhda6vsfhb2y6idrm0rz5a1qcs6c5qz3s"
+   "commit": "82834b0b2e21903f15cbb6427d1fd12c30e16b88",
+   "sha256": "09yriq68kcm4x0haig1vxlsnrbx2b1y7y2ws6k8fnds3ja175cy2"
   },
   "stable": {
    "version": [
     2,
-    5,
-    1
+    6
    ],
    "deps": [
     "consult",
     "consult-gh",
     "embark-consult"
    ],
-   "commit": "d640f86a6d8e419d27cc4cd67cbb526c617fcf18",
-   "sha256": "03274q4nfsass46amklkhda6vsfhb2y6idrm0rz5a1qcs6c5qz3s"
+   "commit": "82834b0b2e21903f15cbb6427d1fd12c30e16b88",
+   "sha256": "09yriq68kcm4x0haig1vxlsnrbx2b1y7y2ws6k8fnds3ja175cy2"
   }
  },
  {
@@ -18873,30 +18989,29 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250531,
-    1028
+    20250714,
+    2249
    ],
    "deps": [
     "consult",
     "consult-gh",
     "forge"
    ],
-   "commit": "d640f86a6d8e419d27cc4cd67cbb526c617fcf18",
-   "sha256": "03274q4nfsass46amklkhda6vsfhb2y6idrm0rz5a1qcs6c5qz3s"
+   "commit": "82834b0b2e21903f15cbb6427d1fd12c30e16b88",
+   "sha256": "09yriq68kcm4x0haig1vxlsnrbx2b1y7y2ws6k8fnds3ja175cy2"
   },
   "stable": {
    "version": [
     2,
-    5,
-    1
+    6
    ],
    "deps": [
     "consult",
     "consult-gh",
     "forge"
    ],
-   "commit": "d640f86a6d8e419d27cc4cd67cbb526c617fcf18",
-   "sha256": "03274q4nfsass46amklkhda6vsfhb2y6idrm0rz5a1qcs6c5qz3s"
+   "commit": "82834b0b2e21903f15cbb6427d1fd12c30e16b88",
+   "sha256": "09yriq68kcm4x0haig1vxlsnrbx2b1y7y2ws6k8fnds3ja175cy2"
   }
  },
  {
@@ -18907,30 +19022,29 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250531,
-    1028
+    20250714,
+    2249
    ],
    "deps": [
     "consult",
     "consult-gh",
     "pr-review"
    ],
-   "commit": "d640f86a6d8e419d27cc4cd67cbb526c617fcf18",
-   "sha256": "03274q4nfsass46amklkhda6vsfhb2y6idrm0rz5a1qcs6c5qz3s"
+   "commit": "82834b0b2e21903f15cbb6427d1fd12c30e16b88",
+   "sha256": "09yriq68kcm4x0haig1vxlsnrbx2b1y7y2ws6k8fnds3ja175cy2"
   },
   "stable": {
    "version": [
     2,
-    5,
-    1
+    6
    ],
    "deps": [
     "consult",
     "consult-gh",
     "pr-review"
    ],
-   "commit": "d640f86a6d8e419d27cc4cd67cbb526c617fcf18",
-   "sha256": "03274q4nfsass46amklkhda6vsfhb2y6idrm0rz5a1qcs6c5qz3s"
+   "commit": "82834b0b2e21903f15cbb6427d1fd12c30e16b88",
+   "sha256": "09yriq68kcm4x0haig1vxlsnrbx2b1y7y2ws6k8fnds3ja175cy2"
   }
  },
  {
@@ -19012,6 +19126,26 @@
   }
  },
  {
+  "ename": "consult-hn",
+  "commit": "a9ad989fa3ee38fea7f52d16259cba44a1d7aed5",
+  "sha256": "0c8cb644mycd3cvxli7x7djifln244f8rr1f40frrzilw6c55v76",
+  "fetcher": "github",
+  "repo": "agzam/consult-hn",
+  "unstable": {
+   "version": [
+    20250716,
+    104
+   ],
+   "deps": [
+    "consult",
+    "transient",
+    "ts"
+   ],
+   "commit": "7e02d69296b880dd0cfbdaed45c0365d6daca647",
+   "sha256": "1wiwgpbnl0p00p9zp43c7i90z7yspsamfxlxcwdxf2pj07svhd5k"
+  }
+ },
+ {
   "ename": "consult-ls-git",
   "commit": "af90413953b4b6a4d6c1b9919835703035b565d7",
   "sha256": "0vrvcjyjq3f4zs2jdyfk82xhr4n8yw5mxhrsmmd0ljhcqp6zxbmf",
@@ -19090,28 +19224,28 @@
   "repo": "jao/consult-notmuch",
   "unstable": {
    "version": [
-    20250205,
-    1714
+    20250815,
+    1739
    ],
    "deps": [
     "consult",
     "notmuch"
    ],
-   "commit": "17d2a4ea8c180acd4fb805dcc1b17d9c6a1a4044",
-   "sha256": "1kgi3y1lkp1jd784ncyysr5yimyq6bjpvgx9wxfca14ylb8my37a"
+   "commit": "abc0318c9971b4288cc96f6f934ad6d36e63d9f9",
+   "sha256": "1yx33bzj251igsagdphlxa84wb07ynlz4rf1nplpk19m5lfkj54c"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     0
    ],
    "deps": [
     "consult",
     "notmuch"
    ],
-   "commit": "17d2a4ea8c180acd4fb805dcc1b17d9c6a1a4044",
-   "sha256": "1kgi3y1lkp1jd784ncyysr5yimyq6bjpvgx9wxfca14ylb8my37a"
+   "commit": "abc0318c9971b4288cc96f6f934ad6d36e63d9f9",
+   "sha256": "1yx33bzj251igsagdphlxa84wb07ynlz4rf1nplpk19m5lfkj54c"
   }
  },
  {
@@ -19141,15 +19275,15 @@
   "repo": "Qkessler/consult-project-extra",
   "unstable": {
    "version": [
-    20231221,
-    1857
+    20250729,
+    1123
    ],
    "deps": [
     "consult",
     "project"
    ],
-   "commit": "982e8008d69ea6733a2a7548e245d645c0fefb3f",
-   "sha256": "0zfmfypq781v4vw0zd5z9kqa1f47wiq2hhgmg5yljrgmgnl7j53y"
+   "commit": "0cdcf7fc04711417ee1e05e9aec21488732438fe",
+   "sha256": "0zmj2ld0qm7kk4f8q646k11ivswgrn7yvhlhyxlmpazhi892qmp6"
   },
   "stable": {
    "version": [
@@ -19301,26 +19435,26 @@
   "repo": "chmouel/consult-vc-modified-files",
   "unstable": {
    "version": [
-    20250307,
-    905
+    20250724,
+    2218
    ],
    "deps": [
     "consult"
    ],
-   "commit": "99d98f6220685aaa42ab1a9d4baf34560095645b",
-   "sha256": "1wyz6w92gldxp9bxrq8f8s27pb9jdslaadhra9gn7wg2ql6s8idk"
+   "commit": "06837dc61a3b8f38dec0ad62b33293fc50ca03d2",
+   "sha256": "1bc4pl4bkxz8mj3bij0zn3b6sws49c10a77mgs0mkz9c7n2f6hkd"
   },
   "stable": {
    "version": [
     0,
-    1,
+    3,
     0
    ],
    "deps": [
     "consult"
    ],
-   "commit": "e73aa635cfe454e62bbaca0fd8bbdc0a30946ee6",
-   "sha256": "07v2lw5r7s1p5s7iviw4l1pa7da96f0q642max77wmlay29v70k5"
+   "commit": "06837dc61a3b8f38dec0ad62b33293fc50ca03d2",
+   "sha256": "1bc4pl4bkxz8mj3bij0zn3b6sws49c10a77mgs0mkz9c7n2f6hkd"
   }
  },
  {
@@ -19536,20 +19670,21 @@
   "repo": "chep/copilot-chat.el",
   "unstable": {
    "version": [
-    20250702,
-    934
+    20250825,
+    810
    ],
    "deps": [
     "aio",
     "markdown-mode",
+    "mcp",
     "org",
     "polymode",
     "request",
     "shell-maker",
     "transient"
    ],
-   "commit": "434ac0c08f0aff04251a2e2ae37262e8d360ab67",
-   "sha256": "10ilz877srhhrcmhjwjchc6z2z6y0rfvsxvww67gbshqvz0r5iai"
+   "commit": "86ce56c00babbad06641ead5dfa9264bb00908bc",
+   "sha256": "0mm29m8sjvkmmdcka44zsp7ydd4wcsbchwkwgp5c541bpcgsbdpx"
   },
   "stable": {
    "version": [
@@ -19778,28 +19913,28 @@
   "repo": "radian-software/prescient.el",
   "unstable": {
    "version": [
-    20240803,
-    2320
+    20250816,
+    19
    ],
    "deps": [
     "corfu",
     "prescient"
    ],
-   "commit": "2b8a8b41228bddb2e11eb1c200e98a9edd04797c",
-   "sha256": "0qz3xv38vazxqsl7lan7fshj3gmb0qagkrvl5xzwqhdg0rir981j"
+   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
+   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
   },
   "stable": {
    "version": [
     6,
     3,
-    1
+    2
    ],
    "deps": [
     "corfu",
     "prescient"
    ],
-   "commit": "2b8a8b41228bddb2e11eb1c200e98a9edd04797c",
-   "sha256": "0qz3xv38vazxqsl7lan7fshj3gmb0qagkrvl5xzwqhdg0rir981j"
+   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
+   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
   }
  },
  {
@@ -20830,26 +20965,26 @@
   "repo": "emacsfodder/emacs-theme-creamsody",
   "unstable": {
    "version": [
-    20240619,
-    731
+    20250724,
+    52
    ],
    "deps": [
     "autothemer"
    ],
-   "commit": "10acf5c5d3e1108fc1e7a4ab487aa2ac79720f42",
-   "sha256": "0s07lvzrr12faxf5wpyg9s44g2v8w6vm4f59mam4xl6v8nq6pfdh"
+   "commit": "98d55dcb2480889dee416c9fa0c6baf8c6af9844",
+   "sha256": "1kxpl6y5c796733yz6x3nxd8wz349h5fg9hda552l5pnqxgk4qxd"
   },
   "stable": {
    "version": [
     1,
     0,
-    9
+    12
    ],
    "deps": [
     "autothemer"
    ],
-   "commit": "5f4fce9de6920cd2788bf6baf3a3da110f09bffd",
-   "sha256": "0qk76dk3g5whnx49qwahh32di7x9adw6d7gj4rr03d10zlvwsssb"
+   "commit": "98d55dcb2480889dee416c9fa0c6baf8c6af9844",
+   "sha256": "1kxpl6y5c796733yz6x3nxd8wz349h5fg9hda552l5pnqxgk4qxd"
   }
  },
  {
@@ -20948,9 +21083,9 @@
  },
  {
   "ename": "cricbuzz",
-  "commit": "855ea20024b606314f8590129259747cac0bcc97",
-  "sha256": "18nmr7rpbylqgfx5q3ps38wx9q1ndj06msgyjyc8lqpipbsz0pip",
-  "fetcher": "github",
+  "commit": "06f8868ff6e2966b8482cd100271e1d1afc2ce79",
+  "sha256": "04g0nrj6m4gaxn6idms3nh4sgqsy14zh6bvy3jlsilk401gsqimn",
+  "fetcher": "sourcehut",
   "repo": "lepisma/cricbuzz.el",
   "unstable": {
    "version": [
@@ -22191,14 +22326,14 @@
   "repo": "xenodium/dall-e-shell",
   "unstable": {
    "version": [
-    20250331,
-    1641
+    20250821,
+    1033
    ],
    "deps": [
     "shell-maker"
    ],
-   "commit": "efec43ab3338e59f12165110e6c6c957345f6257",
-   "sha256": "1fab097pgqc9by9dhjmsgn3grp905h7pivnz46w9s52pa1pvbrmv"
+   "commit": "428125f9fa8578703a9ca85d173b2cc9a3eb16b9",
+   "sha256": "0mhaa7b2ghyjkca3377a9129zfjxyg0m1inqlvqmsj812bvn90q8"
   },
   "stable": {
    "version": [
@@ -22589,11 +22724,11 @@
   "repo": "nameiwillforget/d-emacs",
   "unstable": {
    "version": [
-    20250627,
-    1245
+    20250816,
+    2150
    ],
-   "commit": "99a3251cef48e9e85dda797f1897f4fe655ad1eb",
-   "sha256": "0d9ivn6nps8vyyn7msbdq6cafam1r1i1aancdfvyjlnqar65n37j"
+   "commit": "f2fb095ee01f2464dcfda2155b60c68dc7d06d41",
+   "sha256": "04qpf2fx2jpbs6qs90aiwcnq8fal1mn2h6ml9bxc8ddyg1s5ldgr"
   }
  },
  {
@@ -23393,11 +23528,11 @@
   "repo": "ideasman42/emacs-default-font-presets",
   "unstable": {
    "version": [
-    20250611,
-    330
+    20250731,
+    454
    ],
-   "commit": "5f664dfc2765cbe0495c29f97712ed140aff8903",
-   "sha256": "011bbsjf59ximk0sc94cwig792f7igrrnan9x4i31ckkj5bh6fml"
+   "commit": "d604cea39e3fbf47fe3b96bf910d83ad6d61ca43",
+   "sha256": "0zsa610j961g0jjbxkjhy6v75hn5xd29wgs29q95djv1cwb1gp12"
   }
  },
  {
@@ -24018,11 +24153,11 @@
   "repo": "DamienCassou/desktop-environment",
   "unstable": {
    "version": [
-    20230903,
-    1229
+    20250821,
+    1428
    ],
-   "commit": "bc1153aa619b12456304cca642424a0d8d2eb416",
-   "sha256": "0bslgm9rz7whk0ll21028dsl22wbd289cdc95qj8hhlk8m4hlp2h"
+   "commit": "1f16fa0fcc1b5b33773a8e334a60133a046e9fc7",
+   "sha256": "0fxhwi45787w484lvahw3xlsyzxf2m0x0wbz8924xr15fif06c90"
   },
   "stable": {
    "version": [
@@ -24431,14 +24566,14 @@
   "repo": "dgutov/diff-hl",
   "unstable": {
    "version": [
-    20250613,
-    2144
+    20250731,
+    209
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "830b05253ba8f35b80448e5de2201aecb6943840",
-   "sha256": "06g14mj493pxvb80yjw3739n4jnd5r4aldxvwy95m9ign8y00p13"
+   "commit": "f3408d5004627e685b5a4a3a454a9a92ef182432",
+   "sha256": "01g1718222hnlfd7jimvw0qhllmqv5k0vvcd9fffj5is4qzj7c9g"
   },
   "stable": {
    "version": [
@@ -24554,16 +24689,16 @@
   "repo": "pkryger/difftastic.el",
   "unstable": {
    "version": [
-    20250702,
-    1543
+    20250801,
+    1425
    ],
    "deps": [
     "compat",
     "magit",
     "transient"
    ],
-   "commit": "c4ab6b322b19f5ad06514a46b35a64f169e41f91",
-   "sha256": "1vncgv8jn7qncnraa1skcvs5z7w2v7g63a982li57yk7rgfhqcfv"
+   "commit": "d149a37c93d492a29073451cf07c86fc42b335fe",
+   "sha256": "14d8ayckwm0n5xsdbbbqa0kv2iffvzg58kaaj029fspscvgwv2ix"
   }
  },
  {
@@ -24597,20 +24732,20 @@
   "repo": "retroj/digistar-mode",
   "unstable": {
    "version": [
-    20250429,
-    1455
+    20250710,
+    1554
    ],
-   "commit": "54b38bd570cd52348065b61360d1194a779a5af6",
-   "sha256": "0y5939bql53mgdjyxjgfkbzj8k9g01rjqs2fbz5wg7rc1rzh15vr"
+   "commit": "09063c4f05129be3c4b595a318edabf6ad05393a",
+   "sha256": "1mbf7rlxx4sy3sr1wrllzivp4g4n2m0m3m41pkcvgwbvjvas3xvr"
   },
   "stable": {
    "version": [
     0,
     9,
-    17
+    18
    ],
-   "commit": "fe3f90116c00e3c2f5d17b84c292d418b44dde6e",
-   "sha256": "0jl934fa0ihsd1in6nl9h7lq32240zabyvnaff00zlmr37x1ypzj"
+   "commit": "09063c4f05129be3c4b595a318edabf6ad05393a",
+   "sha256": "1mbf7rlxx4sy3sr1wrllzivp4g4n2m0m3m41pkcvgwbvjvas3xvr"
   }
  },
  {
@@ -24730,26 +24865,26 @@
   "repo": "tarsius/dim-autoload",
   "unstable": {
    "version": [
-    20250531,
-    2216
+    20250801,
+    945
    ],
    "deps": [
     "compat"
    ],
-   "commit": "52b87938ea61c78f21647b0ae185e13ba3653513",
-   "sha256": "10pwdhn80z0spiscmzsa060qmzlvsdnl8ynb5b7sb225shgr1sjn"
+   "commit": "31ba7cf40f5da6b6157c71917599cf718fd68936",
+   "sha256": "0gkpmssr4f5wz6qxapyz66j5wixg4jxs4dslk85nqlhhlpn2vnsc"
   },
   "stable": {
    "version": [
     2,
-    0,
-    8
+    1,
+    0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "52b87938ea61c78f21647b0ae185e13ba3653513",
-   "sha256": "10pwdhn80z0spiscmzsa060qmzlvsdnl8ynb5b7sb225shgr1sjn"
+   "commit": "31ba7cf40f5da6b6157c71917599cf718fd68936",
+   "sha256": "0gkpmssr4f5wz6qxapyz66j5wixg4jxs4dslk85nqlhhlpn2vnsc"
   }
  },
  {
@@ -25027,14 +25162,14 @@
   "repo": "amno1/dired-auto-readme",
   "unstable": {
    "version": [
-    20241010,
-    1014
+    20250726,
+    1928
    ],
    "deps": [
     "markdown-mode"
    ],
-   "commit": "4a57b4adfaeeadcf24bc73d3e90256e53aa2e93d",
-   "sha256": "063ji4bjr9fvqk14swxc2jx1ig7fndz7rjqlvqiz1q4y9rhpazaq"
+   "commit": "d1cced1a5cf26ff50a8c1585b6e6813a3ddb8395",
+   "sha256": "0az7aglhpxpzv01r6gi83gpkw39zfwk37jw2lfbchhm6rh8d3cid"
   }
  },
  {
@@ -25122,11 +25257,11 @@
   "repo": "juan-leon/dired-efap",
   "unstable": {
    "version": [
-    20220421,
-    1535
+    20250726,
+    1400
    ],
-   "commit": "360b369cb19998c6730ee1debfbec3edb7f349a9",
-   "sha256": "07yfks2gj15fw0arrf0nyh5ip8kjc46fyrgpdcviwr6lk739c3jk"
+   "commit": "34afe56327e26b90634e054e3b38e69c82f833bd",
+   "sha256": "1g1magmr15294kil3qlxps2rnj7r5xskhh3aj1ypfyz4ygcnyjls"
   },
   "stable": {
    "version": [
@@ -25849,14 +25984,14 @@
   "repo": "Boruch-Baum/emacs-diredc",
   "unstable": {
    "version": [
-    20250615,
-    1518
+    20250806,
+    44
    ],
    "deps": [
     "key-assist"
    ],
-   "commit": "3e2599df299dd65e184af8725ce3c634e37d7540",
-   "sha256": "01na9d7ag0zm6bn119f5n2raz799vg3xjmw1g24fcisrrnzagiaq"
+   "commit": "0f534d81871889bfd5cfff9202351ad1768f4d38",
+   "sha256": "1fxc5adwnm1pwq910ck7q8ri2xnn99727xhpy6l4vy3247bj5dmg"
   },
   "stable": {
    "version": [
@@ -26343,14 +26478,14 @@
   "repo": "aurtzy/disproject",
   "unstable": {
    "version": [
-    20250622,
-    133
+    20250822,
+    2145
    ],
    "deps": [
     "transient"
    ],
-   "commit": "ed818cd90042581e2b893b38af5dfca2b64dd0a0",
-   "sha256": "06pm09ssm73qvsi7q1h31c51dp3ny22x8a9k71br63r0l069s29l"
+   "commit": "5ab01bdfd3732db4aafe934da3665abf57a036f4",
+   "sha256": "00brlzg8s33gh0hi5i0w8y6gwax7ds0v3l51ww38csvyha5jgbw2"
   },
   "stable": {
    "version": [
@@ -26836,6 +26971,21 @@
   }
  },
  {
+  "ename": "dock",
+  "commit": "6e2893fa31c1c4332d9d09319d7defca354f0f8d",
+  "sha256": "1yk7pfjhc8zwrjz2468nl7f61hmyfyrjz81s7lzv00njb13ahg95",
+  "fetcher": "github",
+  "repo": "hron/dock.el",
+  "unstable": {
+   "version": [
+    20250720,
+    1954
+   ],
+   "commit": "8397c69d33444fa48ec24944e1886386801a27a1",
+   "sha256": "1pwv51w9i932hql1dr2ccxshs3l61ywhm3rmdg1jkrckwdn9mxy7"
+  }
+ },
+ {
   "ename": "docker",
   "commit": "6c74bf8a41c17bc733636f9e7c05f3858d17936b",
   "sha256": "10x05vli7lg1w3fdbkrl34y4mwbhp2c7nqdwnbdy53i81jisw2lk",
@@ -26843,8 +26993,8 @@
   "repo": "Silex/docker.el",
   "unstable": {
    "version": [
-    20250411,
-    709
+    20250715,
+    835
    ],
    "deps": [
     "aio",
@@ -26853,8 +27003,8 @@
     "tablist",
     "transient"
    ],
-   "commit": "75a5716e26cbab2147df68dd885c28950c89f854",
-   "sha256": "0fvq6rlqjq7q0b91342m203f3r5903yx5fg8krckba2m6lcl2krb"
+   "commit": "91233a7c559d87c47de6193a64913732756f0799",
+   "sha256": "10dfxqslvdmzni9ifjcqx6kd5r0h991h204x2zm2ng9nv0hs4sg4"
   },
   "stable": {
    "version": [
@@ -27244,16 +27394,16 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20250704,
-    1558
+    20250729,
+    216
    ],
    "deps": [
     "compat",
     "nerd-icons",
     "shrink-path"
    ],
-   "commit": "14b09e0b20f0e210be54167b12c3b5a201eb0327",
-   "sha256": "093faiamd6lk2abk5n61i86drawqb00v319yg9vv95an6silcmmg"
+   "commit": "cb703c217e8eb4d6f853da7fca9f1be91d985642",
+   "sha256": "1hmdnv3a0zp60ngfpgcy0vwldj8f0r30pcqjm9ywv2a3ik5vgnwi"
   },
   "stable": {
    "version": [
@@ -27278,23 +27428,26 @@
   "repo": "elken/doom-modeline-now-playing",
   "unstable": {
    "version": [
-    20250710,
-    1417
+    20250810,
+    1114
    ],
    "deps": [
-     "doom-modeline"
+    "doom-modeline"
    ],
-   "commit": "684bfde0b88a2cb31dd824216608ecbc2eb00c8b",
-   "sha256": "0ky4fhybl9181x4dw5siv459vryvv8gm8zv7y2pksgrsh2ya9r1i"
+   "commit": "bb6f7111ac703962d3acdb1a42b499e7037699da",
+   "sha256": "03wx7xkshw4ycpqgfn0ihzwwz88jcr0lis9hybyzdpjymq4aq1mc"
   },
   "stable": {
    "version": [
     1,
     0,
-    0
+    1
    ],
-   "commit": "bde17eb2d65cea890c18c516096d1580a812d366",
-   "sha256": "0qd0zls0d2fvy3vxp7ihaw02zrfq2xa69vqbq463yrwdzdx16z7d"
+   "deps": [
+    "doom-modeline"
+   ],
+   "commit": "c851f2642a3f8603355b86a1d86affb46fd05a4d",
+   "sha256": "167c3k07qwph23jxx2cd7lqx8s5c90q79h5pbpcz0zdfns1gbpcm"
   }
  },
  {
@@ -27532,14 +27685,14 @@
   "url": "https://salsa.debian.org/emacsen-team/dpkg-dev-el.git",
   "unstable": {
    "version": [
-    20250408,
-    635
+    20250826,
+    835
    ],
    "deps": [
     "debian-el"
    ],
-   "commit": "14a47e96b4f0e20ab9008bac6dc554d07335cbd6",
-   "sha256": "1gm7f1lh6rrqp21p3pzarqdpw0j1bpi39rl1aaydr163k4akh0yy"
+   "commit": "9b0fc3d97ee5e859ec13d6ba5df67c31d5693c2a",
+   "sha256": "1dmf2iqf343s8slhgnwyfs1qb6nc5jwa5igqmlbh3kb6jdjqp5gp"
   },
   "stable": {
    "version": [
@@ -27902,19 +28055,19 @@
   "repo": "jscheid/dtrt-indent",
   "unstable": {
    "version": [
-    20250409,
-    1325
+    20250716,
+    2128
    ],
-   "commit": "015b26d6d6af9465c1dc48ef721db119ecd78437",
-   "sha256": "0lf0q4v5rg9bkw0zxbs9ijblwrgxmc8dqnkags1as1yqp6q1lkb7"
+   "commit": "9108979357e8c9a1015baa5d37c0b596e2dda11b",
+   "sha256": "1fk88rjv8shdpmnbhc4fy52anf18w7xl9z2fi6bnpjawi9hn9c94"
   },
   "stable": {
    "version": [
     1,
-    24
+    25
    ],
-   "commit": "015b26d6d6af9465c1dc48ef721db119ecd78437",
-   "sha256": "0lf0q4v5rg9bkw0zxbs9ijblwrgxmc8dqnkags1as1yqp6q1lkb7"
+   "commit": "9108979357e8c9a1015baa5d37c0b596e2dda11b",
+   "sha256": "1fk88rjv8shdpmnbhc4fy52anf18w7xl9z2fi6bnpjawi9hn9c94"
   }
  },
  {
@@ -27984,16 +28137,16 @@
   "repo": "jacktasia/dumb-jump",
   "unstable": {
    "version": [
-    20250516,
-    1032
+    20250822,
+    2314
    ],
    "deps": [
     "dash",
     "popup",
     "s"
    ],
-   "commit": "42f97dea503367bf45c53a69de959177b06b0f59",
-   "sha256": "1gjl34q1qmdajl5lvsyhjzxciq1gyafspvm5zg5g0haqb2hdnr99"
+   "commit": "a9a7e1711ee100747877528bb3531b947233a99e",
+   "sha256": "0wyv9kcyh5fx3997n0d57wdnkrz56ybc2d7i651357a80c802c4i"
   },
   "stable": {
    "version": [
@@ -28061,11 +28214,11 @@
   "stable": {
    "version": [
     3,
-    19,
+    20,
     1
    ],
-   "commit": "76c0c3941798f81dcc13a305d7abb120c191f5fa",
-   "sha256": "01ys792jnld5yihhyirwkk4jlqm59bk0vrqjvvk5xjn8pp26vryq"
+   "commit": "84b524ad0b337a95e44a7c307b1c237d20075272",
+   "sha256": "1v5jkirw0js6bmcl79f4i9dqwa83k2sqixq7ay6mq89g9a49qalx"
   }
  },
  {
@@ -28382,11 +28535,11 @@
   "repo": "countvajhula/dynaring",
   "unstable": {
    "version": [
-    20241126,
-    252
+    20250617,
+    43
    ],
-   "commit": "42333fcb734f675cab5d25d1b9d142d502914388",
-   "sha256": "1i17i0rigxm8isri5ygb1pk695ywlfmgkpgmbgqyzw5zmb9w4gm1"
+   "commit": "a02e2aa5b4964c9715e9f0634a7c60698fc6d2c9",
+   "sha256": "0am496m8k6dvyfzh3ri7152fkx2bgfr6v2g05g8ldim2cpgqm6cz"
   },
   "stable": {
    "version": [
@@ -28732,11 +28885,11 @@
   "repo": "emacs-eask/eask",
   "unstable": {
    "version": [
-    20250707,
-    1919
+    20250801,
+    1115
    ],
-   "commit": "53bc76d3d5452f7d08b9e24188421751b54fff83",
-   "sha256": "0v73bfwcpnm2llp9pqpqc50vihrifabdwjdb1x1qq6ph4nsnwdzv"
+   "commit": "6125fc4782a388a387f787108850074db5381ab5",
+   "sha256": "1gbijxcfcqfgy8aas612xnyhyps28nivcb79ma1k5j7ybb6d3za5"
   },
   "stable": {
    "version": [
@@ -29021,11 +29174,11 @@
   "repo": "jamescherti/easysession.el",
   "unstable": {
    "version": [
-    20250613,
-    1708
+    20250825,
+    59
    ],
-   "commit": "b28881254c639f5e6a34e4ab46ba1d84e2a8d225",
-   "sha256": "1g658l2vpk09j6mc0q6z1z2lqv1gcr0xvkxf7i1g3101ck72ynrz"
+   "commit": "e4aff5d98219dc0abac426fe9301cc0a4d737c5d",
+   "sha256": "17bn3h0sng6b2qjndw4ijh9z241ms1y94vk7khk91jwzizyxdnz7"
   },
   "stable": {
    "version": [
@@ -29110,28 +29263,28 @@
   "repo": "joostkremers/ebib",
   "unstable": {
    "version": [
-    20250607,
-    740
+    20250805,
+    1747
    ],
    "deps": [
     "compat",
     "parsebib"
    ],
-   "commit": "01a6b41c1e1034ee094b38d1b072500c5ae3ef67",
-   "sha256": "1ir7f95g2h3yw29l33siilziv1a481y0xkmbdn8ajk9zp9395agp"
+   "commit": "248e9274804a656a13abc50214963586113a2158",
+   "sha256": "1bfkmfwadj9dg9dfnqj9nrcj6qqv9wnnfn34gl33526k77lmfhxm"
   },
   "stable": {
    "version": [
     2,
-    50,
+    51,
     1
    ],
    "deps": [
     "compat",
     "parsebib"
    ],
-   "commit": "ef4acb957c7580b4c34ad6fa9a7209df5839af3d",
-   "sha256": "01wkvnfs81aj85nc9zcb60q9cg5sja98x1cip79mks5srbs1nf71"
+   "commit": "248e9274804a656a13abc50214963586113a2158",
+   "sha256": "1bfkmfwadj9dg9dfnqj9nrcj6qqv9wnnfn34gl33526k77lmfhxm"
   }
  },
  {
@@ -29208,8 +29361,8 @@
   "repo": "editor-code-assistant/eca-emacs",
   "unstable": {
    "version": [
-    20250706,
-    2133
+    20250826,
+    353
    ],
    "deps": [
     "compat",
@@ -29217,16 +29370,31 @@
     "f",
     "markdown-mode"
    ],
-   "commit": "912adf956e4bbeef30e47403c57a6d21502251e3",
-   "sha256": "06my4mzl0zapvj15xdqc3g7c4rc257d4jhd4ib94478735hh9mzb"
+   "commit": "c74568ad2a7d1360542adec36125fa6f330908cb",
+   "sha256": "146dw38ihcqwavzir4pjsxll29xxv92pw5ijgnqhs5ds83skckp9"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    1
+   ],
+   "deps": [
+    "compat",
+    "dash",
+    "f",
+    "markdown-mode"
+   ],
+   "commit": "c0a144c0c8c4019ccb30c750930d2d359513d4df",
+   "sha256": "1w70wyh6a1r3km3mli5cqk27ih801spdd5przjpa2m2xvwh6mcra"
   }
  },
  {
   "ename": "ecb",
-  "commit": "a6ff6bbfa11f08647bf17afe75bfb4dcafd86683",
-  "sha256": "1vb66hangxa8p7khjxsk6if2n8hagl0zk6k20lr4qm41r8bl7iqf",
+  "commit": "d13240ac4002fdb2580a7d5ea9058e52d3509917",
+  "sha256": "103vqgngvl7f8mc5g8nzkncfraljkx6l7kiinqw5xbjljdip7xvy",
   "fetcher": "github",
-  "repo": "ecb-home/ecb",
+  "repo": "Atomlogik/ecb",
   "unstable": {
    "version": [
     20170728,
@@ -29667,11 +29835,11 @@
   "repo": "editorconfig/editorconfig-emacs",
   "unstable": {
    "version": [
-    20250219,
-    1528
+    20250809,
+    139
    ],
-   "commit": "1a9942746cf5b10daae8962f380b5f2a459086f3",
-   "sha256": "0l875294xqzaz2qv14jcqqx39jd08ibz0npfjg6rvnggzdm2f2jv"
+   "commit": "0c2d853aff146fa3dad4fa6a0a2c05a4b6bc47e6",
+   "sha256": "1wirij6izii6xmjsvas0fis7lvyv93pxs041kycmm04qdqn1rnrv"
   },
   "stable": {
    "version": [
@@ -30437,28 +30605,28 @@
   "repo": "ahyatt/ekg",
   "unstable": {
    "version": [
-    20250524,
-    2305
+    20250813,
+    22
    ],
    "deps": [
     "llm",
     "triples"
    ],
-   "commit": "8c48c05ff174786f68e781a564dc0dd0d1dd136a",
-   "sha256": "0f0kaxzpyzvk1p4vxclap7ld8i2majc3anax6kxyd93a3zk6zjj8"
+   "commit": "f2c52383fe58802807436994709a6f453354690a",
+   "sha256": "0qlg1lksj6cy9fj0ag4c5vr0561j8p52si5hbm571xh40f4pjays"
   },
   "stable": {
    "version": [
     0,
-    7,
-    1
+    8,
+    0
    ],
    "deps": [
     "llm",
     "triples"
    ],
-   "commit": "3000fa56aa97fffa42b203037e2db6f4fe56bb7d",
-   "sha256": "19n3ffjydnkj9qrhvyhljih446inah1fggxw5q6168pxzpz6p8yk"
+   "commit": "f2c52383fe58802807436994709a6f453354690a",
+   "sha256": "0qlg1lksj6cy9fj0ag4c5vr0561j8p52si5hbm571xh40f4pjays"
   }
  },
  {
@@ -30672,19 +30840,20 @@
   "repo": "radian-software/el-patch",
   "unstable": {
    "version": [
-    20250623,
-    1754
+    20250816,
+    21
    ],
-   "commit": "654deaba847a761496f9baeb6f95031c187c019f",
-   "sha256": "18nmrvzqnmzzs05gqhhmp0m8fa5rb09pa2418n5fwsjv0swcqdp8"
+   "commit": "5adb7097d0ff3d9e004a8bb07c0b25f7ee20ba8a",
+   "sha256": "0s8bh7cjdr0gg5jqbrf44abrxzfh7vkjyz02w2dc9hpdjkm75zg5"
   },
   "stable": {
    "version": [
     3,
+    1,
     1
    ],
-   "commit": "92803e7ea6e07cd56667ed7ea0dfacfc1f37f6d9",
-   "sha256": "0x2x3ci5i428wgagbwjh9qp2zlflkzlrkbpi6qa4fv7dq3vgkrv2"
+   "commit": "5adb7097d0ff3d9e004a8bb07c0b25f7ee20ba8a",
+   "sha256": "0s8bh7cjdr0gg5jqbrf44abrxzfh7vkjyz02w2dc9hpdjkm75zg5"
   }
  },
  {
@@ -30714,15 +30883,15 @@
   "repo": "zetagon/el-secretario",
   "unstable": {
    "version": [
-    20250407,
-    1946
+    20250709,
+    1937
    ],
    "deps": [
     "el-secretario",
     "elfeed"
    ],
-   "commit": "0c728c3bdd1d19356c192ba333a945d732bd16b8",
-   "sha256": "075dvn7mr0wxbbghkz3lhw777wfgp4ppzkjcp46dwcpqmdgy2h4i"
+   "commit": "77bfa47532cfa06ad6d1627dbc61e60996b064e4",
+   "sha256": "19480cbic1j1qff6i42z0gk550bhxw2nc22nyrl2iagzfw4mzhzl"
   }
  },
  {
@@ -31066,20 +31235,20 @@
   "repo": "casouri/eldoc-box",
   "unstable": {
    "version": [
-    20250510,
-    1854
+    20250729,
+    132
    ],
-   "commit": "fb1ae42c37c5f3bb80b441b2fdfada914891a714",
-   "sha256": "0id77zab8q7pll9akdb0l1akvpl25zc61qyz3lx9wvavg59aby3w"
+   "commit": "8c5104f06700b774b8af76d77a440e334fbc03e9",
+   "sha256": "0hk716pym15crmnviwikwrdqzhs74widjlz5zrp5107klqgxicwn"
   },
   "stable": {
    "version": [
     1,
-    13,
-    2
+    14,
+    1
    ],
-   "commit": "1b9274be8973e3685f5ffe19f2089f42b4072298",
-   "sha256": "1136rgi7qy5kmciqrz88lxvk01fdcpry2srsvv3h2rfqwmiccpl0"
+   "commit": "8c5104f06700b774b8af76d77a440e334fbc03e9",
+   "sha256": "0hk716pym15crmnviwikwrdqzhs74widjlz5zrp5107klqgxicwn"
   }
  },
  {
@@ -31250,6 +31419,30 @@
    ],
    "commit": "92f77b05fec80c5440a8b800b33345dabca13872",
    "sha256": "1f1z672z21yd2zwldrb95v739kgsgiq5ckh2ffskqcrh1k5dya8j"
+  }
+ },
+ {
+  "ename": "electric-list-directory",
+  "commit": "b3c1b497d03b4b9ec3d2e385fdfbf185d38d42d6",
+  "sha256": "18nn7gkwfqc29vjwr65n6a20rywv36bja0x033a1wyjqxvvylax9",
+  "fetcher": "github",
+  "repo": "kshartman/electric-directory-list",
+  "unstable": {
+   "version": [
+    20250821,
+    520
+   ],
+   "commit": "2e0d4342146f1c033a1dba54e814961649810a5f",
+   "sha256": "12jgsn7ywi9wchmgkvl3b1f2502vj4670738glfmivdi9hnlrb4n"
+  },
+  "stable": {
+   "version": [
+    1,
+    4,
+    1
+   ],
+   "commit": "2e0d4342146f1c033a1dba54e814961649810a5f",
+   "sha256": "12jgsn7ywi9wchmgkvl3b1f2502vj4670738glfmivdi9hnlrb4n"
   }
  },
  {
@@ -31639,21 +31832,21 @@
  },
  {
   "ename": "elfeed-tube",
-  "commit": "d3e742cf4b9901f6372679b917cff64e067c8fda",
-  "sha256": "1yimx812wfvcng26k433pc4i3n78qzzmir2z6kpg2y1dn4v3yr72",
+  "commit": "61982d0b2bbc1f02b8a71979e339bfdf3348994c",
+  "sha256": "0rl4ah8qbc1b9y0gis6ykcnkqq5fmwhp2zzqsf2rhvyq6kzj2r9a",
   "fetcher": "github",
   "repo": "karthink/elfeed-tube",
   "unstable": {
    "version": [
-    20250321,
-    1717
+    20250815,
+    629
    ],
    "deps": [
     "aio",
     "elfeed"
    ],
-   "commit": "79d5a08d76ea3ae96d7def9a5e2ede2e3562462a",
-   "sha256": "0pzxama7qyj9i4x74im5r875b7vv1zrkgfncf5j1qxixj96jzfna"
+   "commit": "99e55ac428dc50bff271575cffddc5060f22087d",
+   "sha256": "1ml7inrj6bk3f4l08a4yhj8cvi7ywbqh96qjgw9rmksa8dsdfc99"
   },
   "stable": {
    "version": [
@@ -31676,15 +31869,15 @@
   "repo": "karthink/elfeed-tube",
   "unstable": {
    "version": [
-    20230607,
-    717
+    20250815,
+    629
    ],
    "deps": [
     "elfeed-tube",
     "mpv"
    ],
-   "commit": "6d5a24cfd0655068afd364cded5521a4550a8adb",
-   "sha256": "0si3i8k23q7sbd0407n0yxvb848b4cjndpfgmvgqvcmlhi9cpb9q"
+   "commit": "99e55ac428dc50bff271575cffddc5060f22087d",
+   "sha256": "1ml7inrj6bk3f4l08a4yhj8cvi7ywbqh96qjgw9rmksa8dsdfc99"
   },
   "stable": {
    "version": [
@@ -31836,29 +32029,29 @@
   "repo": "Wilfred/elisp-def",
   "unstable": {
    "version": [
-    20230901,
-    2308
+    20250818,
+    2223
    ],
    "deps": [
     "dash",
     "f",
     "s"
    ],
-   "commit": "1ad4baccbf3d0d13e7607d332ae6bc60a5dd7360",
-   "sha256": "0k1r4fyai53p7y5vqwqjxdiqlnmrrxqaxglc22j54kdic8j1lbl7"
+   "commit": "61a5f64498c9c8de8e9aab84a22775162f336144",
+   "sha256": "1ssx7hczihd42p5ak5yrb4isbhv7w8i0vipsindrgg56qsys3wrb"
   },
   "stable": {
    "version": [
     1,
-    1
+    2
    ],
    "deps": [
     "dash",
     "f",
     "s"
    ],
-   "commit": "e374dfa1724c7ee34376305a94c5a31a052f4e3b",
-   "sha256": "1zd79yh8d5k2izkvd06splmw8b9pkqjnanzpmszngy83rnqzpyy0"
+   "commit": "37260b2edd738f27d7d256cd9383888d24d84a3d",
+   "sha256": "1j685c6rdjjldix2kg9gs535296496gz72d4bzs6qn35hxk55lwf"
   }
  },
  {
@@ -31926,14 +32119,26 @@
   "repo": "laurynas-biveinis/elisp-dev-mcp",
   "unstable": {
    "version": [
-    20250618,
-    611
+    20250722,
+    1502
    ],
    "deps": [
     "mcp-server-lib"
    ],
-   "commit": "7d0965f0642ca2e8d14153eef31bcdf5ba8acb75",
-   "sha256": "0vmjcdphdx315qqmgwpas0jv83g16vx4l2p1apam87fy1npyixw9"
+   "commit": "45ae39151b66b9bfaa6382b01820a7762ab23ade",
+   "sha256": "09pp594b19svzwq9f748mqfcp9prvppbdmld43sd6g78w92y8dzx"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "deps": [
+    "mcp-server-lib"
+   ],
+   "commit": "45ae39151b66b9bfaa6382b01820a7762ab23ade",
+   "sha256": "09pp594b19svzwq9f748mqfcp9prvppbdmld43sd6g78w92y8dzx"
   }
  },
  {
@@ -32153,8 +32358,8 @@
   "repo": "s-kostyaev/ellama",
   "unstable": {
    "version": [
-    20250526,
-    1732
+    20250801,
+    1740
    ],
    "deps": [
     "compat",
@@ -32162,14 +32367,14 @@
     "plz",
     "transient"
    ],
-   "commit": "8281a9847b1a35df5433d93a8e7569bbe7ef1215",
-   "sha256": "1abvrxa3np8aqkhfq8g7k7flavc5p70q2za1q9lsp5my1amnjy6p"
+   "commit": "018c2151d1f231a3e3a15a5e99cf39157d758ee4",
+   "sha256": "0ik9sw4fh0caj85601an609wkfvmwdmj2g3rbm620mnd3202kwdy"
   },
   "stable": {
    "version": [
     1,
     8,
-    1
+    2
    ],
    "deps": [
     "compat",
@@ -32177,8 +32382,8 @@
     "plz",
     "transient"
    ],
-   "commit": "3b8cb569409ccbef7e9e955aefcd550c4be3e607",
-   "sha256": "1019vwrm95ck2gi29mvwd7sy753zgwa3addw2x0qbhvb3r53620v"
+   "commit": "018c2151d1f231a3e3a15a5e99cf39157d758ee4",
+   "sha256": "0ik9sw4fh0caj85601an609wkfvmwdmj2g3rbm620mnd3202kwdy"
   }
  },
  {
@@ -32660,8 +32865,8 @@
   "repo": "emacs-elsa/Elsa",
   "unstable": {
    "version": [
-    20250316,
-    29
+    20250717,
+    1205
    ],
    "deps": [
     "ansi",
@@ -32673,8 +32878,8 @@
     "lsp-mode",
     "trinary"
    ],
-   "commit": "4ce89b0cf313143cd6b7614f4f50aa8179354df6",
-   "sha256": "173933cg5bpqshy9f7kyh4y4mzj6k6i5rnfvrq8r073pcclx71c2"
+   "commit": "4a4a180a7e6837ac359c0094e40da339e1300765",
+   "sha256": "05lvinckwnn95hn9rjx96lrhcb900m42vpk0vyycpm05a0rzcc0n"
   }
  },
  {
@@ -32917,16 +33122,16 @@
   "repo": "emacscollective/elx",
   "unstable": {
    "version": [
-    20250701,
-    1217
+    20250807,
+    1142
    ],
    "deps": [
     "compat",
     "llama",
     "seq"
    ],
-   "commit": "fec8743eea83ed716ffac7659142ddfdd23d9e39",
-   "sha256": "16qmfwpl7bs8mrgmlii8jkkwzckmrm220w0z008bcjpc1wn9l5l7"
+   "commit": "2b965671ad1d7f5391e48169393492e314e487e8",
+   "sha256": "1lyzv2361h467jhv8928jzg8kg61zfg4ibxp2zr9r88chxgvqml1"
   },
   "stable": {
    "version": [
@@ -32996,20 +33201,20 @@
   "repo": "knu/emacsc",
   "unstable": {
    "version": [
-    20241206,
-    557
+    20250710,
+    1637
    ],
-   "commit": "810f5e8b97e3046bdc7b0195067335b8eecb0bcb",
-   "sha256": "0wc7f6sgwykkmm8awyim9iv5pzjn4vmgmh4kjph4d4hv6n651mdh"
+   "commit": "c0d51eea7c5cbef4ea49350dff8c721227635be6",
+   "sha256": "17k8xpcfir09wbhi7a98k4mcf7bfyrvgb8p6im3yjgmn8il94g4a"
   },
   "stable": {
    "version": [
     1,
     6,
-    20241206
+    20250711
    ],
-   "commit": "810f5e8b97e3046bdc7b0195067335b8eecb0bcb",
-   "sha256": "0wc7f6sgwykkmm8awyim9iv5pzjn4vmgmh4kjph4d4hv6n651mdh"
+   "commit": "c0d51eea7c5cbef4ea49350dff8c721227635be6",
+   "sha256": "17k8xpcfir09wbhi7a98k4mcf7bfyrvgb8p6im3yjgmn8il94g4a"
   }
  },
  {
@@ -33155,14 +33360,14 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20250707,
-    1947
+    20250825,
+    1352
    ],
    "deps": [
     "compat"
    ],
-   "commit": "89c7610fa7988b6c93029f87afa4ba6b7768bf81",
-   "sha256": "1iqghcrwn1wfz867l3cd9qvcsh3hg5fgicbsyvxll7fpbg9gw8v5"
+   "commit": "1371a1e33e3a3d96557beb28dccf1fa762f6ae22",
+   "sha256": "1si8c5p3pqn4295zrpb8gdglzrhz6zc1xlyh7lny1nkvcqvrx2vc"
   },
   "stable": {
    "version": [
@@ -33344,6 +33549,24 @@
   }
  },
  {
+  "ename": "emc",
+  "commit": "40878b3770b743e4b1414790b3c60886b909448e",
+  "sha256": "13sbcc7xwgnj8x2ls8hkz3zgnb3p7fb6rqxr55gxibp0wyjx7y9p",
+  "fetcher": "github",
+  "repo": "marcoxa/emc",
+  "unstable": {
+   "version": [
+    20250609,
+    606
+   ],
+   "deps": [
+    "delight"
+   ],
+   "commit": "78bbc27964571567cef5e2e78d852d0e46f600e7",
+   "sha256": "06qpfx8kcipqss42kn31a4drryd333sm7yzf7s41h3n7b31mq0f6"
+  }
+ },
+ {
   "ename": "emidje",
   "commit": "5d64b3b42b4b9acd3e9d84921df287f3217db83e",
   "sha256": "1p2aa4wl2465gm7ljgr5lbvxfgx0g1w1170zdv3596hi07mccabs",
@@ -33408,28 +33631,28 @@
   "url": "https://git.savannah.gnu.org/git/emms.git",
   "unstable": {
    "version": [
-    20250610,
-    247
+    20250731,
+    1547
    ],
    "deps": [
     "cl-lib",
     "nadvice",
     "seq"
    ],
-   "commit": "e5f46561c3c140d774354f91d1e95c60039a1934",
-   "sha256": "0rrvs21p1gs7v2h2pr06adzw8s04rjsgjd5z4xycvq91s2mdnp9k"
+   "commit": "e3824b81b11ac71b9bb0993a3a3d3647b923a377",
+   "sha256": "04dviyvpwwpxdx3fmm0kasz1wcralwazfsnqb5gn5hadg0j70kmg"
   },
   "stable": {
    "version": [
-    22
+    23
    ],
    "deps": [
     "cl-lib",
     "nadvice",
     "seq"
    ],
-   "commit": "338462506d7de508f7f74a01d15753f9113cd3cb",
-   "sha256": "0s89r9fr79kv864zydqgkv2fdwxa0n84w5b40v87rj5hlya0kx6v"
+   "commit": "09f829b04804af37d00280e31a0e0257bcd2329e",
+   "sha256": "0d1cjfva0ddpg1s884ybxv7gwgxg8qqnyd8m6z9yyrkizn445gsy"
   }
  },
  {
@@ -33819,15 +34042,15 @@
   "repo": "isamert/empv.el",
   "unstable": {
    "version": [
-    20250629,
-    901
+    20250824,
+    2051
    ],
    "deps": [
     "compat",
     "s"
    ],
-   "commit": "2bb45a6a3119d2816af351ff097506c6f2801dd6",
-   "sha256": "153r4xbsa4a14sd6gdpa820qkmk82yd102v3zmm20b63akxbpmxf"
+   "commit": "e2000ef35eb4954109199408e947b57538c206e3",
+   "sha256": "03a9xyzdq9ym1aqzfrqjl4g7ycsba4nqlaa63qmxc2flvyky9hj8"
   },
   "stable": {
    "version": [
@@ -34184,15 +34407,15 @@
   "repo": "purcell/envrc",
   "unstable": {
    "version": [
-    20250602,
-    1734
+    20250728,
+    1241
    ],
    "deps": [
     "inheritenv",
     "seq"
    ],
-   "commit": "cb5f6d2a4217c1e2cc963072aaa5ecfe257ab378",
-   "sha256": "07krgk0px9756ihzc2z37xvky6919rpyp6w474mzjfkilqcp6z4a"
+   "commit": "189bafea47c3110ec897c1c5bc1558fbcc407b85",
+   "sha256": "0ddp1b5ql7rlcdv1mrcdjwm5lz9flxsfd44ffjjf2wmijym9p9pl"
   },
   "stable": {
    "version": [
@@ -34364,16 +34587,16 @@
   "repo": "emacscollective/epkg-marginalia",
   "unstable": {
    "version": [
-    20250601,
-    1049
+    20250823,
+    1655
    ],
    "deps": [
     "compat",
     "epkg",
     "marginalia"
    ],
-   "commit": "d9e58d467c40bf71794f8eee758a83ab0e1933db",
-   "sha256": "1hymzfc2qydjhdhdisd3ba1bqajl7vpn4acdwk9xykip02bnxsfa"
+   "commit": "b62b1d5da52cc31b34ffd563e8a6b97cfa9e4d01",
+   "sha256": "0rcbjlsxpfm7b2y0cprbzf63gli7sn8rgfj72f8bnngqdmyz6zcz"
   },
   "stable": {
    "version": [
@@ -34483,6 +34706,21 @@
    ],
    "commit": "068218d2cf2138cb2e8fc29b57e773a0097a7e8b",
    "sha256": "110b8gn47m5kafmvxr8q9zzrj0pdn6ikw9xsx4z1rc58i02jy307"
+  }
+ },
+ {
+  "ename": "eprolog",
+  "commit": "ad76dd31c95e4069f319064392deea32588f0010",
+  "sha256": "1gndqkaw9z0mli0sxsii2hpjridwcg1g1mbpbsrjgs0rlnv9vh0q",
+  "fetcher": "github",
+  "repo": "tani/eprolog",
+  "unstable": {
+   "version": [
+    20250826,
+    238
+   ],
+   "commit": "69e34857d0434fdae6ac19d2ad0ce0d030259bb9",
+   "sha256": "12v7lyzj5lcqxakhw8xg07w55yp1skdr0ivp3kn9mgp979i7f2wj"
   }
  },
  {
@@ -35071,20 +35309,20 @@
   "repo": "erlang/otp",
   "unstable": {
    "version": [
-    20250613,
-    1454
+    20250717,
+    731
    ],
-   "commit": "d9454dbccbaaad4b8796095c8e653b71b066dfaf",
-   "sha256": "1giajqrz1h8mi3n59q6d56djl3d5hvdm9b5yk98v9bx3x2nw6q3r"
+   "commit": "d04f6a0b261cf23e316e48e2febe14b30c592dc5",
+   "sha256": "0hqljgbhw7yx9hbpd2k0sdvr1psp4aq56wn3d8qa1q0pqpn6zqp3"
   },
   "stable": {
    "version": [
     28,
     0,
-    1
+    2
    ],
-   "commit": "d9454dbccbaaad4b8796095c8e653b71b066dfaf",
-   "sha256": "1giajqrz1h8mi3n59q6d56djl3d5hvdm9b5yk98v9bx3x2nw6q3r"
+   "commit": "d04f6a0b261cf23e316e48e2febe14b30c592dc5",
+   "sha256": "0hqljgbhw7yx9hbpd2k0sdvr1psp4aq56wn3d8qa1q0pqpn6zqp3"
   }
  },
  {
@@ -36177,11 +36415,11 @@
   "repo": "emacs-ess/ESS",
   "unstable": {
    "version": [
-    20250606,
-    831
+    20250725,
+    847
    ],
-   "commit": "cd85d1e1f0e897b409a948a3a4afdaffe032812e",
-   "sha256": "18mx9137wk104s6h1ad384l9lbmz0fh4djjpxjfl2zhxwsjr562k"
+   "commit": "b8341e9a4e343ca6bf8b5038359a204a09b454c5",
+   "sha256": "1y180i5bkmzla6rp53674a59wbfz2f4ikbwqi50ca6vh81v6i877"
   },
   "stable": {
    "version": [
@@ -36622,16 +36860,16 @@
   "repo": "iory/euslisp-mode",
   "unstable": {
    "version": [
-    20170830,
-    1929
+    20250823,
+    1454
    ],
    "deps": [
     "exec-path-from-shell",
-    "helm-ag",
+    "helm",
     "s"
    ],
-   "commit": "db62a2d148482317794727982576494596365a55",
-   "sha256": "187ij4s7mzppgmh0ifny70mw8w31nq86rhsrmnflz26iywnkp8x2"
+   "commit": "bf74f683f3b0e127bf2c0e8082fe097e897cd572",
+   "sha256": "1yx9g546a7nrjbcpdkvf5qlz8y57h82zmpgnp8njj7m92xh7b57w"
   }
  },
  {
@@ -36881,16 +37119,16 @@
   "repo": "emacs-evil/evil",
   "unstable": {
    "version": [
-    20250318,
-    1816
+    20250812,
+    1023
    ],
    "deps": [
     "cl-lib",
     "goto-chg",
     "nadvice"
    ],
-   "commit": "682e87fce99f39ea3155f11f87ee56b6e4593304",
-   "sha256": "17djjfpxnl7a3wmyh0c708w07y05b4d87ii17rnkk9p4w4zimvay"
+   "commit": "334a636621577e77f834bca0c6ecdcec67c6ff1e",
+   "sha256": "1a10912xzq6wixyf9n0fh05ngavd9cg6m1rb3n2b1ivlnpzv21pv"
   },
   "stable": {
    "version": [
@@ -37083,15 +37321,15 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20250707,
-    1829
+    20250821,
+    203
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "d74647169703362433b1f55420623f145880b898",
-   "sha256": "1p0l4yrkjk4j21a0d608sdjp81xllpy6snq9s5awd0cwcsr04z6j"
+   "commit": "faed16f485bf15c95f4544fbb249b5f07c0007fc",
+   "sha256": "0r56ixnfraazmbicy38hjy1i2cljz5y8and5nnc5s2vzan52zsz8"
   },
   "stable": {
    "version": [
@@ -37513,14 +37751,14 @@
   "repo": "achyudh/evil-keypad",
   "unstable": {
    "version": [
-    20250602,
-    2127
+    20250731,
+    552
    ],
    "deps": [
     "evil"
    ],
-   "commit": "b51f3cb8072656be97424cca02c0c48fcc22dccd",
-   "sha256": "100yjraw8smjhc90rdr2x0wbq89ymgwjnvwcfhqsvnr3iwv5lr38"
+   "commit": "f384b88180154f86bf70adf5f018faed6c68a509",
+   "sha256": "1n8bi6va7p56090z7r9444in72gqjgc65pnc5hg1qi361p6w76rc"
   },
   "stable": {
    "version": [
@@ -38708,11 +38946,11 @@
   "repo": "meain/evil-textobj-tree-sitter",
   "unstable": {
    "version": [
-    20250629,
-    1239
+    20250724,
+    607
    ],
-   "commit": "61d4e04fbaf239653b38c6e50cf580845f43a5fc",
-   "sha256": "1wx3g96k4dcznzq5mysjhkj67a6jpjdjss8bvx8g1dnfvv9xh4dg"
+   "commit": "4ca5dffbd3f81361c85203bde44328ad2128d33a",
+   "sha256": "1j00ajpffkd0zzq9xszp0s21zw82ps2jfa00zb2ipg7v2vafkgqj"
   },
   "stable": {
    "version": [
@@ -39164,6 +39402,21 @@
   }
  },
  {
+  "ename": "exec-in-buffer",
+  "commit": "0d0677f5b7a41155d65e0acc002f73c6588eadfb",
+  "sha256": "0l26kg89w1gp9aqyrbdwnwjz8ibdp4gvcr9mv0y8i2x8m7cifx2q",
+  "fetcher": "github",
+  "repo": "arteen1000/exec-in-buffer",
+  "unstable": {
+   "version": [
+    20250629,
+    324
+   ],
+   "commit": "57ddaf95d46714ec1382f83ba952480b4cd0b73d",
+   "sha256": "1flhdpycy4w6pyflpgr3vyaldzcb8k0h4bl93dai8fwgldw08vcw"
+  }
+ },
+ {
   "ename": "exec-path-from-shell",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "014bfcs7znds4if1njyq4s5zrfnr6b3wj6722b4l5r58gh9mlrr5",
@@ -39494,8 +39747,8 @@
   "repo": "ananthakumaran/exunit.el",
   "unstable": {
    "version": [
-    20250325,
-    256
+    20250824,
+    318
    ],
    "deps": [
     "f",
@@ -39503,8 +39756,8 @@
     "s",
     "transient"
    ],
-   "commit": "8de56e3fd50832e5f0435bba8eb13c7292cb1ee1",
-   "sha256": "0i3ghgr7diyckp29zqjsg0rq6amap7iki1jy5gkz3fri99w4l2n6"
+   "commit": "9a7cfc3d7893cba3b2955be7399a2158bbed4d8b",
+   "sha256": "0k22j5hda2wczvnszgm3iy4kxl1cxkrvqgsjc9awaazpzmylgmd6"
   }
  },
  {
@@ -40446,14 +40699,14 @@
   "repo": "martianh/fedi.el",
   "unstable": {
    "version": [
-    20250408,
-    738
+    20250812,
+    645
    ],
    "deps": [
     "markdown-mode"
    ],
-   "commit": "e53f4d61cab19a4037f8594daaa247db4ca6c116",
-   "sha256": "02z5nhv1hr9713b2blfymrb8hckss5ghhr07mjz572a8xdy3rqq8"
+   "commit": "a9df02f835899d0a587d236b1fa4d16e53af9039",
+   "sha256": "0jdlhl3gjyk6alkkyhx3svqkwmfkddsh0qga6wwcc2irlv0gryad"
   },
   "stable": {
    "version": [
@@ -40543,11 +40796,11 @@
   "repo": "technomancy/fennel-mode",
   "unstable": {
    "version": [
-    20250518,
-    1250
+    20250725,
+    200
    ],
-   "commit": "2f61376ad6c92acbb264a37678609c213a6cecfe",
-   "sha256": "0kqp32yppbln2506scx757vji9zgk5iabhl5xycyc60i8shrxb8z"
+   "commit": "a1ad6354b7c66bfa43f5bf117cf4e41bc33da64c",
+   "sha256": "1n27gv470cj5l4r34bgnib3wjwlprh32iv6xlg3ghlwk3hflpda4"
   },
   "stable": {
    "version": [
@@ -41645,15 +41898,15 @@
   "repo": "plandes/flex-compile",
   "unstable": {
    "version": [
-    20250411,
-    2337
+    20250820,
+    1557
    ],
    "deps": [
     "buffer-manage",
     "dash"
    ],
-   "commit": "00c23361b73f3b3c1656a205ec31943d40867cff",
-   "sha256": "12g69mcjrvippgvyhjk2z9zc4377sri1kj1v4h6y2fgggkd6gmg7"
+   "commit": "982b20bf03df82cbd462d119f1101ce542d887c3",
+   "sha256": "17q8bhnwi87zb67mzwdhdibnvypzfyc00iba98zy45fhlbs2l0zg"
   },
   "stable": {
    "version": [
@@ -43425,14 +43678,14 @@
   "repo": "flycheck/flycheck-inline",
   "unstable": {
    "version": [
-    20250101,
-    1908
+    20250724,
+    650
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "0fece8283ceb7cb941f506b9f1e3f416a1c5aeda",
-   "sha256": "19i578jdvcxy23ww0588y2z29hkivp30zxk2bvlcd7nxrhzanpas"
+   "commit": "8af846984375c9bf5786cc57f7ce00bc6a6a4555",
+   "sha256": "0nqx2qss0b87ryp4s5bfqll1p257rr1b297yw5n8h0qkmka8jq7q"
   }
  },
  {
@@ -45271,14 +45524,14 @@
   "repo": "purcell/flymake-flycheck",
   "unstable": {
    "version": [
-    20230826,
-    749
+    20250812,
+    1141
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "cc50a97ee1384d260c56aca257a1dbf770084330",
-   "sha256": "05and3jmmfsdi1lhqg7lpsph5rn2p1jj036blrd762ipqb4s90v4"
+   "commit": "79092d7e53277d7fe961f73b69e2d174ea3c6210",
+   "sha256": "118s1akwqx1xxcrnmj6rvqzbrh3bxqzm4mjmfnkx1vcasqfcgma7"
   },
   "stable": {
    "version": [
@@ -47091,15 +47344,15 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20250703,
-    1603
+    20250824,
+    742
    ],
    "deps": [
     "closql",
     "compat",
+    "cond-let",
     "emacsql",
     "ghub",
-    "let-alist",
     "llama",
     "magit",
     "markdown-mode",
@@ -47107,8 +47360,8 @@
     "transient",
     "yaml"
    ],
-   "commit": "c39791ae9dbf99a78fe86d1d1036d9c9b02cbe92",
-   "sha256": "1ry5v51104gj64gw2izs0z20lfimxnq0mm78shj81izg1zwgcxwq"
+   "commit": "2fb110bd9a3e272056886b5538d72024c2d41282",
+   "sha256": "13nrgkvggl0wikizc7yv35niqygp05klfzj2xjyc66rz7f1ggimj"
   },
   "stable": {
    "version": [
@@ -47141,15 +47394,15 @@
   "repo": "rogs/forge-llm",
   "unstable": {
    "version": [
-    20250403,
-    1333
+    20250731,
+    117
    ],
    "deps": [
     "forge",
     "llm"
    ],
-   "commit": "62c925deffcddd30256d6827040fb9faf13119d3",
-   "sha256": "003m9c05d29m17yzpyms4vf2kw9rjh393hkipjcyvxpdigxzb3nm"
+   "commit": "ebd59266fd68bfd55a8115efc65817ba3e31c235",
+   "sha256": "1fd0805vk5k912q911kd5p3xrakznbq0qqjqvmm67y6krack38bj"
   }
  },
  {
@@ -47377,20 +47630,20 @@
   "repo": "gmlarumbe/fpga",
   "unstable": {
    "version": [
-    20250318,
-    1348
+    20250724,
+    1527
    ],
-   "commit": "23969f10928a070a86869f5287df0ebae081e113",
-   "sha256": "1l73h0yhkgg005zznqx6wg0xjn3nl286nqijfh1bpwx6i97yajs0"
+   "commit": "f31ced6ae7c037f01c1c384e07cd0ffa6de22e5a",
+   "sha256": "07fgpmc88i6gz3vh3wr60hwhczrxxxi33173ncvhnz93j80zf8vm"
   },
   "stable": {
    "version": [
     0,
-    2,
+    3,
     0
    ],
-   "commit": "9cf7b25ab7364f4e690e86b364cc3279cdffc25e",
-   "sha256": "04cxmh455vxfswxk8h460g7dcfr3ww1gnijxlbrkn7m0j1cysz5f"
+   "commit": "9f014c09d132f60fe5fe76356acf78affa2e2bdc",
+   "sha256": "107vmjwk74iwp2xlpkx3f2q8a9bbygl15p09sfj0h4k9jzl4ia9m"
   }
  },
  {
@@ -47531,14 +47784,14 @@
   "repo": "tarsius/frameshot",
   "unstable": {
    "version": [
-    20250531,
-    2216
+    20250815,
+    1806
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c1a3bb14ebd302db14b0530acfa08fef9f69ac2c",
-   "sha256": "1hq80igrnr8p9z1a9ml681487lkfbr1wa549h4lq62cv91z5mrf5"
+   "commit": "c9a630aea2713a7111e4423426d868383ab7073f",
+   "sha256": "1qpiyq85jkvmn784r7k6x1jnpsg9nic3zc1awkp4lm80c2dn707c"
   },
   "stable": {
    "version": [
@@ -47865,11 +48118,11 @@
   "repo": "pdo/frimacs",
   "unstable": {
    "version": [
-    20250125,
-    1556
+    20250809,
+    723
    ],
-   "commit": "8585ab33b109c977f3f05bea49ca8ff148df878a",
-   "sha256": "07x9x0zz3k0vb20m9bxy3fhs5d69ipv4ply3d8jswk95xxcyd024"
+   "commit": "8f94c8389c559dee33ae271d97e4efa2fffbc47c",
+   "sha256": "012vx1v7mfp91isrlj49sm7ilyl5n7dgxrdr7l9v2v6zxcvdrkvr"
   }
  },
  {
@@ -48031,11 +48284,11 @@
   "repo": "open-spaced-repetition/lisp-fsrs",
   "unstable": {
    "version": [
-    20250608,
-    644
+    20250712,
+    511
    ],
-   "commit": "b2c9b8e928b030b80ae7278701eed2bf0c53a79d",
-   "sha256": "1rp40hbbd3y08j7mpghc2hpzljmd1lgbf20ww4ma5dy46r940gvk"
+   "commit": "7c70543ba4d3ac11d973a3595964f156c416146f",
+   "sha256": "1cwq2sl6s1bmhw3kcanz6qkppv76lw4ddanw9mvbs9rj4vxh7mhv"
   }
  },
  {
@@ -48242,15 +48495,15 @@
   "repo": "jojojames/fussy",
   "unstable": {
    "version": [
-    20241208,
-    2139
+    20250820,
+    104
    ],
    "deps": [
     "compat",
     "flx"
    ],
-   "commit": "309614c3acbdca9d0a50827e94c2ac8cda11f420",
-   "sha256": "10vdzvd8pry732mf7vhn3v3dhnnd4pngcvcm1smlimmc4pg0hhw7"
+   "commit": "163ded34be3e9230702201d0abe1e7b85e815c2d",
+   "sha256": "0gkgkg298qnk9yf1d9la5cnl3mrxvs41hxlgys5v36c4pg7v9yzp"
   },
   "stable": {
    "version": [
@@ -48750,26 +49003,25 @@
   "repo": "emacs-geiser/geiser",
   "unstable": {
    "version": [
-    20250119,
-    1424
+    20250810,
+    1346
    ],
    "deps": [
     "project"
    ],
-   "commit": "c1c27072a46a959fa28f963c5e381e219916f85a",
-   "sha256": "0i8pghyfza3mwfb4gc8lr6wya3s4z8k3264wnrxb9v7m1m5bal3w"
+   "commit": "c8b862f00e208f2c09bf2a2b2436af0a466a2531",
+   "sha256": "12dyy2fdsd0ymm3l415lb37ij2146c271xski533dh9vmmqmzvna"
   },
   "stable": {
    "version": [
     0,
-    31,
-    1
+    32
    ],
    "deps": [
     "project"
    ],
-   "commit": "c034c129cfa7442881f13ae146c87785b367cff5",
-   "sha256": "194k1bj4ncl9w68s0dkm9ya853hxbm9lxwsckqsmaj57jz7hw46f"
+   "commit": "9e76f336b91151315642de9bcbed0ffe83b69db7",
+   "sha256": "09dqwxa2h471xcyk5zncxzaz19gf8d5r83yhi425blf2r1ir7b34"
   }
  },
  {
@@ -48838,14 +49090,14 @@
   "repo": "emacs-geiser/chicken",
   "unstable": {
    "version": [
-    20241204,
-    1442
+    20250803,
+    1721
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "5f2c1bb446af6ae4aec9c8d74d4ecb34031706fd",
-   "sha256": "0bzax5fsmjxzinp6rhwrbqbass0pja89khl4adbdp8mafqp46jpk"
+   "commit": "8342bad8ce1c79fee3563cd95ee27a8b062f6a9e",
+   "sha256": "1ayhbyjpm860h8gsc9vhinsvcf60g7v97lj3njsajafm4jhkhgjg"
   },
   "stable": {
    "version": [
@@ -49595,17 +49847,16 @@
   "repo": "magit/ghub",
   "unstable": {
    "version": [
-    20250705,
-    1211
+    20250823,
+    2101
    ],
    "deps": [
     "compat",
-    "let-alist",
     "llama",
     "treepy"
    ],
-   "commit": "855706740689a5d5c821be1210f661a262b7a46d",
-   "sha256": "0ny75m9bwfwm5zczhjh9yp3kynqm0qi7bhq6kxy5gv7gxarzdz2g"
+   "commit": "8d6f6e5d949f0afdd56c61f6f88936b68e976786",
+   "sha256": "05rb3i74wvf34w27pxcpspianj7mxlgqiqa73xbv3rzc9g8hbiy0"
   },
   "stable": {
    "version": [
@@ -50268,11 +50519,11 @@
   "repo": "sshaw/git-link",
   "unstable": {
    "version": [
-    20250708,
-    1249
+    20250812,
+    1427
    ],
-   "commit": "e012173ba207cb4b10ce5fefe0a9ef836fcfc2c4",
-   "sha256": "09g7xcy24kyg80zp0vin0yi20hswcbkaad12pip4cbcysnw55wz3"
+   "commit": "e4cfed05d110a6af07543d069f12e1894f553c2e",
+   "sha256": "0zg3vkj1zgcyci7ql47qqraz44vv59qjpclg7d08q1wj770ilmn3"
   },
   "stable": {
    "version": [
@@ -51481,8 +51732,8 @@
   "url": "https://git.thanosapollo.org/gnosis",
   "unstable": {
    "version": [
-    20250702,
-    651
+    20250815,
+    1346
    ],
    "deps": [
     "compat",
@@ -51490,14 +51741,14 @@
     "org-gnosis",
     "transient"
    ],
-   "commit": "4b87d58574d1b8cb2eb7bf7fe571efa758838c03",
-   "sha256": "11zw5lw32c6zzgl2h1rmklhmqw35xv07ymdddwa1wc2xf9a7mb3p"
+   "commit": "2a3119cf2998a6a625e27846c09b281b3239e722",
+   "sha256": "0wys6wnnkh5p5x44lswkmzign284zhpj3bs8a0af1xfq84bdi1bk"
   },
   "stable": {
    "version": [
     0,
     5,
-    3
+    4
    ],
    "deps": [
     "compat",
@@ -51505,8 +51756,8 @@
     "org-gnosis",
     "transient"
    ],
-   "commit": "4b87d58574d1b8cb2eb7bf7fe571efa758838c03",
-   "sha256": "11zw5lw32c6zzgl2h1rmklhmqw35xv07ymdddwa1wc2xf9a7mb3p"
+   "commit": "c302df0656f0a6fce69cc2e90c543514a896c75a",
+   "sha256": "1agb0aqgr3zs27bfwz3sknlg17knl9sxjp3vkakmaqgjrrr8jwdh"
   }
  },
  {
@@ -51570,14 +51821,14 @@
   "repo": "emacs-gnuplot/gnuplot",
   "unstable": {
    "version": [
-    20250613,
-    1223
+    20250724,
+    1531
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f10d42221856e86c57dd5cc7400c078c021ba710",
-   "sha256": "17kh2mpbm5rir4bfrl2hmf8hic6v09z13y6svbf22fm0nkfvic1p"
+   "commit": "43e9674b869475b1c2a32f045c167673eb2faae0",
+   "sha256": "1l613l11l0w27z7qihv3ch5z8993rbajz61n2in83sk2xx53z1sf"
   },
   "stable": {
    "version": [
@@ -52410,33 +52661,6 @@
   }
  },
  {
-  "ename": "go-translate",
-  "commit": "26092d1830f6a0f46916b0d07afe467ce76e257c",
-  "sha256": "0ls7fy89936jn8kqwyii9214h258ds64fjmfc61mdcqsbg9r07s4",
-  "fetcher": "github",
-  "repo": "lorniu/go-translate",
-  "unstable": {
-   "version": [
-    20250630,
-    1545
-   ],
-   "deps": [
-    "pdd"
-   ],
-   "commit": "7c99960aec50719d7f95caa3e8fdd381ca5fd22b",
-   "sha256": "1j59l5a37f4a84yrr30vvsz38m5nrppi5jhywyxmyywm4hhxx2wr"
-  },
-  "stable": {
-   "version": [
-    3,
-    0,
-    9
-   ],
-   "commit": "9ffbcddb5dbc3be37afc7d5f16206512004f6ef0",
-   "sha256": "1j5knkb8h0wpr6pzvrb6kvisjkm4kkd7jzad6h566sn0si2x9y5g"
-  }
- },
- {
   "ename": "gobgen",
   "commit": "8c9fed22bb8dbfb359e4fdb0d802ed4b5781f50d",
   "sha256": "0fb0q9x7wj8gs1iyr87q1vpxmfa2d43zy6cgxpzmv2wc26x96vi7",
@@ -52459,20 +52683,20 @@
   "repo": "emacsorphanage/god-mode",
   "unstable": {
    "version": [
-    20240812,
-    1014
+    20250820,
+    259
    ],
-   "commit": "55490fffd42ae7d4671ce409214a3fcd0868d791",
-   "sha256": "1mi74kzdqdlrhjisj1fg2zjbr0d9kc0fl00mss1r3wyjl1bjac2f"
+   "commit": "e6eef24dbf739d819a6651e854ec732ac3f386e6",
+   "sha256": "1b39lq1l7xa2i4l5ciry3pjaxgzs0xawadb5kbcfhqhd4xlgb04g"
   },
   "stable": {
    "version": [
     2,
-    18,
+    19,
     0
    ],
-   "commit": "c7754eaadaeabae2df94e23317b4a04d19b3f9e0",
-   "sha256": "1njln47w25ix9w0xjv02110ngr8d8ma3w7db0x4xcxhihbl65zly"
+   "commit": "e6eef24dbf739d819a6651e854ec732ac3f386e6",
+   "sha256": "1b39lq1l7xa2i4l5ciry3pjaxgzs0xawadb5kbcfhqhd4xlgb04g"
   }
  },
  {
@@ -53085,7 +53309,7 @@
   "stable": {
    "version": [
     0,
-    51,
+    52,
     0
    ],
    "deps": [
@@ -53094,8 +53318,8 @@
     "magit-popup",
     "s"
    ],
-   "commit": "50196949631d35948bcd81e34ae33e9118886e41",
-   "sha256": "0yb8nbjdd85xl5c8br7x8kgb8gyvkcyy83fv8hrj4bkzd58kflmb"
+   "commit": "e53c30d0f0f3cdb97160b0263cda0126c070693a",
+   "sha256": "0n2yga2biipqh23bz1p7bz7cwz35wd055qwpjh5gr904sy3i7pqr"
   }
  },
  {
@@ -53178,11 +53402,11 @@
   "repo": "stuhlmueller/gpt.el",
   "unstable": {
    "version": [
-    20250623,
-    352
+    20250807,
+    2036
    ],
-   "commit": "17de2035a9299729391b6e42d47bf4f67907906e",
-   "sha256": "0dgp0qz017b69amgph4jxqg289wwk4fqqfj0h84yphiijcwngcf0"
+   "commit": "4c9f9eb6279381a9b9f4863f7ac35f15f07fd2cf",
+   "sha256": "1c7q3vq0lixlp2bf4w1mgxhrhfxl5hxi17hw0hy19cnyy37sqis2"
   }
  },
  {
@@ -53249,15 +53473,15 @@
   "repo": "karthink/gptel",
   "unstable": {
    "version": [
-    20250706,
-    357
+    20250824,
+    610
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "e9d92423d138e6f217a494ac4b28fe68d349233a",
-   "sha256": "1n2jlc8q454qi3jd3ki27265jn0r84njmq46pyivm1dp4i9j8nss"
+   "commit": "7bb353a582d11ce210bb0a5b77c53de564c28e67",
+   "sha256": "0zqbrdadpnrrcv33c3p9drg6rch66br9czqg4kjjynl4bf2gx6g5"
   },
   "stable": {
    "version": [
@@ -53282,14 +53506,14 @@
   "repo": "dolmens/gptel-aibo",
   "unstable": {
    "version": [
-    20250605,
-    859
+    20250709,
+    851
    ],
    "deps": [
     "gptel"
    ],
-   "commit": "36a5b96332c88e7157023e41f6dafc5b5e84dccb",
-   "sha256": "1wgx440076jrf40w0imlqwif7jhlm5my4ngz7lx7yngi7ic75ndf"
+   "commit": "f55b5170b9dfc3023110ec8cad66e6f352ea9d8a",
+   "sha256": "0h76nppnlg7f8nzzgw0kz2a7w1y6xrf2cly7cbicgnbpm57ll1yl"
   }
  },
  {
@@ -53300,26 +53524,26 @@
   "repo": "lakkiy/gptel-commit",
   "unstable": {
    "version": [
-    20250630,
-    1324
+    20250726,
+    1448
    ],
    "deps": [
     "gptel"
    ],
-   "commit": "9caf217c9864c3f4cf819c2c48d35628ac729427",
-   "sha256": "0ipccfms95319hxrjd042zgmkwhqwm53jgyxh6jrnkxn7c5rrjpg"
+   "commit": "2b1063a01ab894ae5661bfffeb97331ad0cf2e3b",
+   "sha256": "1lc459dhjhhhh2dzvfmvnjdjmn0z1998wn6n6927llways61wvz5"
   },
   "stable": {
    "version": [
     0,
-    1,
-    1
+    2,
+    0
    ],
    "deps": [
     "gptel"
    ],
-   "commit": "1bd5d85bb0beffce0bb27ac136949f4341f0932b",
-   "sha256": "1f2y2bd1pkjzyf9yd04yjg1baqmr3mqmfx5bw9xva1hyrqwbz6k3"
+   "commit": "4ca046eca5e57b42c0886062e10c02611234e186",
+   "sha256": "1ig9z5kv3jypv8bmvhlcy2pbpf7zyx7jj7x4cmdkng3sja4078r0"
   }
  },
  {
@@ -53749,11 +53973,11 @@
   "repo": "ppareit/graphviz-dot-mode",
   "unstable": {
    "version": [
-    20250708,
-    1125
+    20250715,
+    1358
    ],
-   "commit": "1840165b60df7409cfccacbe5365843309d51aaa",
-   "sha256": "0brx74hv7qasbshf65srk64fq89jk9zavg7xax0h0ia3l4j5xakg"
+   "commit": "2c7ba85d19cbed4984d0cab31aa33800ffa89f78",
+   "sha256": "0vw5dc4z9pfp6a2m431sszlfvspf5zykb924bbx90awmxfz1h2fx"
   },
   "stable": {
    "version": [
@@ -53842,15 +54066,15 @@
   "repo": "michelangelo-rodriguez/greader",
   "unstable": {
    "version": [
-    20250623,
-    2200
+    20250722,
+    520
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "320a62803350d776bc3295bad792a898fee40fa4",
-   "sha256": "0wnqbxi0dkbr4ihwdyv1xbxiic2gzq46lwxy838fmv602wx70f9y"
+   "commit": "bc7702a53db6aae35187b83e23b1f56342a16252",
+   "sha256": "0nqg9xy0qfg92ycfrxhwnd6mv6zv6aqh2z1pvk0a6klxy9bb179n"
   }
  },
  {
@@ -54014,11 +54238,11 @@
   "repo": "seagle0128/grip-mode",
   "unstable": {
    "version": [
-    20250426,
-    602
+    20250731,
+    213
    ],
-   "commit": "96a927dce69d7607b981d7754cf8b415ebf9d6a8",
-   "sha256": "17srcnhb1hb2ck0gkjni5adxz3hnjwwh3ajmmbp35h9kjl0b2fh8"
+   "commit": "c965a344ab950c6b4ef788c7b9e8792a95a139d1",
+   "sha256": "0dbqcbsd891r7i267wvjswxn5x8qvc5379if0j91xvgznmzfwllv"
   },
   "stable": {
    "version": [
@@ -54332,6 +54556,36 @@
    ],
    "commit": "c8bff61b10cd33de9d6f5fd84e4b27f48c772304",
    "sha256": "0lw1psy1258vbvnl4j918hkzwqa65g94azbq84fvf2lgv4lbvgln"
+  }
+ },
+ {
+  "ename": "gt",
+  "commit": "ac908b232a412b1e59851deb1852dabed91bc5e6",
+  "sha256": "02nlhj7g5symqhm2nndjhydi9vnmbzsvrnar22zvv88kx6byjkr9",
+  "fetcher": "github",
+  "repo": "lorniu/gt.el",
+  "unstable": {
+   "version": [
+    20250727,
+    230
+   ],
+   "deps": [
+    "pdd"
+   ],
+   "commit": "f9febd8583ea482f72139e02f440f3972502f5a2",
+   "sha256": "1z9rvk9ksva2xpwgb7bgw9zy0lv9sr7sq77f6dpm9fkdwzpj38mi"
+  },
+  "stable": {
+   "version": [
+    3,
+    2,
+    1
+   ],
+   "deps": [
+    "pdd"
+   ],
+   "commit": "f9febd8583ea482f72139e02f440f3972502f5a2",
+   "sha256": "1z9rvk9ksva2xpwgb7bgw9zy0lv9sr7sq77f6dpm9fkdwzpj38mi"
   }
  },
  {
@@ -54669,14 +54923,14 @@
   "repo": "abrochard/emacs-habitica",
   "unstable": {
    "version": [
-    20250622,
-    2058
+    20250715,
+    1113
    ],
    "deps": [
     "org"
    ],
-   "commit": "ed123a2adf82f5e5ecb119a0a55c860f17906aad",
-   "sha256": "0zb09j2qwyg363c15668n7ay2carm44sq402ww8d484dsfhxpj93"
+   "commit": "de82cd5a1283ae4035602a86b2c92dd23d467ccf",
+   "sha256": "0k43hyf0gl7fb7566zv91pzrx3c2scbliivyavpfyymzkvdvrrls"
   }
  },
  {
@@ -54895,14 +55149,14 @@
   "repo": "nex3/haml-mode",
   "unstable": {
    "version": [
-    20230608,
-    1833
+    20250714,
+    1441
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "fe83c65c1f002f7c36480b758727c1afbad9a1b2",
-   "sha256": "1flq3j9jn8ra4n604w1rj0xdxr69d4c96zlhlrg1a2h12glbw66x"
+   "commit": "3bb4a96535eb5c81dbe6a43bfa8d67a778d449c0",
+   "sha256": "1svnggkqi7kk2pspgqb6ciqkiypg09gvph9q48mili17xfx44ll7"
   },
   "stable": {
    "version": [
@@ -55620,20 +55874,20 @@
   "repo": "mgmarlow/helix-mode",
   "unstable": {
    "version": [
-    20250630,
-    1623
+    20250731,
+    1425
    ],
-   "commit": "b3f8c18b5cff37571f9d6bc02e47c8da62296d85",
-   "sha256": "1zr79zavc4g7912ayiaih25c2q05qb6wnnr7hlmym6r7bcrfnypm"
+   "commit": "32e01acddc582ae9eb27eabda974ce12996a9bb8",
+   "sha256": "12frkqmv0qbs4rqxdazki6xvhdb6ykr4xsrzk8ljlj19dniawhd8"
   },
   "stable": {
    "version": [
     0,
-    7,
+    8,
     0
    ],
-   "commit": "4b247cc6a5b8e774a5fb306b2d2c612c3d338146",
-   "sha256": "0n6zpn8b902xfk98fxqk0mh1n187qsgp3fk3zv6p0c9v8gqycaiz"
+   "commit": "32e01acddc582ae9eb27eabda974ce12996a9bb8",
+   "sha256": "12frkqmv0qbs4rqxdazki6xvhdb6ykr4xsrzk8ljlj19dniawhd8"
   }
  },
  {
@@ -55659,28 +55913,28 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20250707,
-    559
+    20250823,
+    300
    ],
    "deps": [
     "helm-core",
     "wfnames"
    ],
-   "commit": "3e9e33bf0312443439854b49b478cb773472ab89",
-   "sha256": "1wgdv52bpk2pxphcqs9dc34c69xi2kcn5mx5zgc5jncidz7h2c2w"
+   "commit": "be88ccd4d16340a64280cbca2e7fd2839721fb0a",
+   "sha256": "080bv3mhf407i7lmaffswxnc80wz78kfp0ijylgmv7hsxxp80hc3"
   },
   "stable": {
    "version": [
     4,
     0,
-    4
+    5
    ],
    "deps": [
     "helm-core",
     "wfnames"
    ],
-   "commit": "6befd6e60f756936062fed6d4b905e508aa141fc",
-   "sha256": "0bj8sp0c6ll3kj9ac4js8lv441p8h9310bkg5rwvxz3gpvlw55ys"
+   "commit": "01ae48a989cdc8665692d5a18c5a386ba0a646ed",
+   "sha256": "1prdbck7m9qlb18v33dkkyba30ld9y1d414xzvfn1avnl3icnm32"
   }
  },
  {
@@ -56470,26 +56724,26 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20250705,
-    1413
+    20250821,
+    349
    ],
    "deps": [
     "async"
    ],
-   "commit": "edfbe48205db5a03c7d0dbdd623702c9a3117ab7",
-   "sha256": "1zlbsg7jarqxs8z5nfdclqysz88vxnxq70200ay7v56ip48zwsif"
+   "commit": "4773888c5b5d65fb469be4ec789a9dfd795cb028",
+   "sha256": "0brhlssa5hzsviknhynqllmh8fk0p07vma7i1xmgqkam7skvnpag"
   },
   "stable": {
    "version": [
     4,
     0,
-    4
+    5
    ],
    "deps": [
     "async"
    ],
-   "commit": "6befd6e60f756936062fed6d4b905e508aa141fc",
-   "sha256": "0bj8sp0c6ll3kj9ac4js8lv441p8h9310bkg5rwvxz3gpvlw55ys"
+   "commit": "01ae48a989cdc8665692d5a18c5a386ba0a646ed",
+   "sha256": "1prdbck7m9qlb18v33dkkyba30ld9y1d414xzvfn1avnl3icnm32"
   }
  },
  {
@@ -57179,26 +57433,26 @@
   "repo": "masutaka/emacs-helm-ghq",
   "unstable": {
    "version": [
-    20210724,
-    744
+    20250725,
+    601
    ],
    "deps": [
     "helm"
    ],
-   "commit": "7b47ac91e42762f2ecbbceeaadc05b86c9fe5f14",
-   "sha256": "0a4piipqnsj0rnwmqz3vj674ljmy1bl33qr9hv959pw5b3jzqfh0"
+   "commit": "d321d7801f8ac1af885551a5be6d39e1562e7ee2",
+   "sha256": "0hjiicrzlgqa1623di72ss85wzbgpvs017myfk1084q8rfmx9xjj"
   },
   "stable": {
    "version": [
     1,
-    8,
-    1
+    10,
+    0
    ],
    "deps": [
     "helm"
    ],
-   "commit": "7b47ac91e42762f2ecbbceeaadc05b86c9fe5f14",
-   "sha256": "0a4piipqnsj0rnwmqz3vj674ljmy1bl33qr9hv959pw5b3jzqfh0"
+   "commit": "d321d7801f8ac1af885551a5be6d39e1562e7ee2",
+   "sha256": "0hjiicrzlgqa1623di72ss85wzbgpvs017myfk1084q8rfmx9xjj"
   }
  },
  {
@@ -57426,26 +57680,26 @@
   "repo": "masutaka/emacs-helm-hatena-bookmark",
   "unstable": {
    "version": [
-    20210724,
-    732
+    20250728,
+    421
    ],
    "deps": [
     "helm"
    ],
-   "commit": "a6a2b37370ac84ca2cae5ef65b2b144a010b1584",
-   "sha256": "0zwngldnh6ys9m7v0fc4nwk1bcrwqvip08114vn4dcv8kl3lnxvv"
+   "commit": "9692659fefcb4e1a6519a0072a8bf6d766419f6b",
+   "sha256": "17l3xwkks7zc2lcvx8xd86nsd8x491lpbn4lsc1j6nfvfmdjdanf"
   },
   "stable": {
    "version": [
     2,
-    4,
-    4
+    5,
+    2
    ],
    "deps": [
     "helm"
    ],
-   "commit": "a6a2b37370ac84ca2cae5ef65b2b144a010b1584",
-   "sha256": "0zwngldnh6ys9m7v0fc4nwk1bcrwqvip08114vn4dcv8kl3lnxvv"
+   "commit": "15ff145a7f8cc3f0a0fa555e404f8b7a55cd2b25",
+   "sha256": "1s714simdwyrljmksdpb5xyvqbjsikkfwh80ajfsmxx8hkccf6n2"
   }
  },
  {
@@ -57811,14 +58065,14 @@
   "repo": "emacs-helm/helm-ls-git",
   "unstable": {
    "version": [
-    20250615,
-    1418
+    20250629,
+    1321
    ],
    "deps": [
     "helm"
    ],
-   "commit": "ca44995c570f855a41730e912fdc8f3b429558f7",
-   "sha256": "1ylacawwqzvzdjv8z8h4b4nf9p70jdzi1mfafddb6k7m7iqcncrl"
+   "commit": "04680c2d605283b53b81facf002daaa6ccb5d700",
+   "sha256": "1y5a3vm372i9wz5phq9fsf27bryddw189k23aqrpvkyzf4bjizba"
   },
   "stable": {
    "version": [
@@ -57890,16 +58144,16 @@
   "repo": "emacs-lsp/helm-lsp",
   "unstable": {
    "version": [
-    20241118,
-    1931
+    20250812,
+    1134
    ],
    "deps": [
     "dash",
     "helm",
     "lsp-mode"
    ],
-   "commit": "e740efb2abbc0ffd43f6dbcdb4527bc55723b842",
-   "sha256": "0cmxdd3fgyiixg81zmxa0j68slhkq8rg5z840cx4dbb3j9w06yd1"
+   "commit": "d9d1a60f5020196b71fa89e5db3dcd12d00b7d02",
+   "sha256": "1g212mkzfm3pb1ynn3m141sz7w0ih9ssdz36a97l3wk4g14p9ric"
   },
   "stable": {
    "version": [
@@ -58618,30 +58872,28 @@
   "repo": "bbatsov/helm-projectile",
   "unstable": {
    "version": [
-    20250218,
-    1525
+    20250814,
+    1150
    ],
    "deps": [
-    "cl-lib",
     "helm",
     "projectile"
    ],
-   "commit": "041076e35a6663302a91a0fa672f847c7d64bf29",
-   "sha256": "1yhdc6h72crnlp46hbvs20c0fc9r1x7896z7rbp1z0i0hphsrs86"
+   "commit": "41bc1c1973a1528f9ae974701d42e3deccce5cbe",
+   "sha256": "094aky23kzwhw9qa4cfyaa6w1146jywcg7f0dgwy0lf1wwrir91l"
   },
   "stable": {
    "version": [
     1,
-    0,
-    0
+    3,
+    2
    ],
    "deps": [
-    "cl-lib",
     "helm",
     "projectile"
    ],
-   "commit": "5eb861b77d8e6697733def65288039df5be81a0e",
-   "sha256": "05gpg90gg03yalmv9fw1y9k21i2l617iipvs0p9n80aln8nrzs8g"
+   "commit": "53acfb64914bfcdb27a745827705493ef6345b52",
+   "sha256": "0rbp5d7v4vy3s21yys9bqip78w43jfhdv65y891al13r3886b2hs"
   }
  },
  {
@@ -58791,6 +59043,38 @@
    ],
    "commit": "723c2a27f3843570ec1039e3c526953e48b4ed40",
    "sha256": "1gpy6jc932p4yiyglnwylriw3jk2f4bs7rrxbwc0z9xzjzzn4qnz"
+  }
+ },
+ {
+  "ename": "helm-raindrop",
+  "commit": "85d707c0c665a619e956e5dec09e6ed6e7f9c20c",
+  "sha256": "0r9w409zj2474mbmfc1cy61q7g47iwnk5gxl1r1lh32asx16l8hl",
+  "fetcher": "github",
+  "repo": "masutaka/emacs-helm-raindrop",
+  "unstable": {
+   "version": [
+    20250806,
+    1220
+   ],
+   "deps": [
+    "helm",
+    "request"
+   ],
+   "commit": "6c080b1acf51ada473a7252cca7e0a5d812be4b0",
+   "sha256": "1gzfyrj1lv58zlbh6bxaz7csbq6v80h9n7f8bamhsnzn2mdlafia"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "deps": [
+    "helm",
+    "request"
+   ],
+   "commit": "6c080b1acf51ada473a7252cca7e0a5d812be4b0",
+   "sha256": "1gzfyrj1lv58zlbh6bxaz7csbq6v80h9n7f8bamhsnzn2mdlafia"
   }
  },
  {
@@ -58995,15 +59279,15 @@
   "repo": "Andersbakken/rtags",
   "unstable": {
    "version": [
-    20250218,
-    2303
+    20250801,
+    1647
    ],
    "deps": [
     "helm",
     "rtags"
    ],
-   "commit": "94269d3558e5db8bab381379dc347bdc7f7ded68",
-   "sha256": "12iv0h14brybqlld5b7z8yicpm3y0wcmmswx9pv261izp7dr41xc"
+   "commit": "dd6b20f7e57a30f32a8ccbb6c22038383dba746b",
+   "sha256": "15rkzvh4i4s2sm1zrclqqs4dnmiik9rcf59jq382ah0afh96mh3b"
   },
   "stable": {
    "version": [
@@ -59128,17 +59412,15 @@
   "repo": "emacs-helm/helm-searcher",
   "unstable": {
    "version": [
-    20250101,
-    844
+    20250814,
+    923
    ],
    "deps": [
-    "f",
     "helm",
-    "s",
     "searcher"
    ],
-   "commit": "a87a6dfcafbe488e166ae0eb8e3e4ca7d9a3a25f",
-   "sha256": "0n7ipkwdg5zsbk7jff8kqsm4792mia03x5ncjj4bk5vz00p5db5c"
+   "commit": "8d1b99900d1c01892678c45e48e1959d454532ee",
+   "sha256": "0zl3vpma8id58nk0945z7j1h56vwswxy6zi9cibyrz8j3ghcbb9a"
   },
   "stable": {
    "version": [
@@ -59504,14 +59786,14 @@
   "repo": "bdc34/helm-taskswitch",
   "unstable": {
    "version": [
-    20221019,
-    1542
+    20250805,
+    2318
    ],
    "deps": [
     "helm"
    ],
-   "commit": "6e8b62702376c1d30ab52a419dd72cb2a40fd76e",
-   "sha256": "0vpkhpqq4v16ax2cqy2j75ycwq15cc3k128b4jw31bk93225faaf"
+   "commit": "11e84316b9db96b19bf1d4038e85bbc26017f302",
+   "sha256": "0hvnm5qw8v88drpzv4m5d6fdndsrdsms0pp11p2q8llk33bimcqd"
   },
   "stable": {
    "version": [
@@ -60638,11 +60920,11 @@
   "repo": "meain/hima-theme",
   "unstable": {
    "version": [
-    20241001,
-    1341
+    20250807,
+    650
    ],
-   "commit": "f136e283feb413d4bda4904edf7a5a58a3a0749b",
-   "sha256": "18vilb5sm3cylzm387hfg9k1304gg8rvziav5c6lb3y2f7a0dj7z"
+   "commit": "637367be2b87a57b0dcc12dc9dd30a854d3281b4",
+   "sha256": "1cymsnr9z1dhqh5843xxbglv0mva0cv0sla8jygvvrakydjglpqh"
   }
  },
  {
@@ -61021,26 +61303,26 @@
   "repo": "tarsius/hl-todo",
   "unstable": {
    "version": [
-    20250531,
-    2218
+    20250801,
+    947
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7ed8bbcadb5229d648b194e0e4c4d261825aa91b",
-   "sha256": "14x53z0mf43igvsiafi0bbmljy5nwzib95amrr5qm69jj5k9n082"
+   "commit": "b8be53068b3469572d66cfedc540f4130901a3da",
+   "sha256": "0ih6hm364kiqxma9f5y3pm5bz9gq7s0nywb2prizlay43bkdg5rv"
   },
   "stable": {
    "version": [
     3,
     8,
-    4
+    5
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7ed8bbcadb5229d648b194e0e4c4d261825aa91b",
-   "sha256": "14x53z0mf43igvsiafi0bbmljy5nwzib95amrr5qm69jj5k9n082"
+   "commit": "b8be53068b3469572d66cfedc540f4130901a3da",
+   "sha256": "0ih6hm364kiqxma9f5y3pm5bz9gq7s0nywb2prizlay43bkdg5rv"
   }
  },
  {
@@ -61296,6 +61578,21 @@
   }
  },
  {
+  "ename": "hotdesk",
+  "commit": "cb5c2ccb07b89edd062fc4304119c947863ded05",
+  "sha256": "1825ppnsxc6vbyzyra1jyrgf89nddqnji0pgh967dq49w46pmfh7",
+  "fetcher": "github",
+  "repo": "j-hotlink/hotdesk",
+  "unstable": {
+   "version": [
+    20250825,
+    2217
+   ],
+   "commit": "5fa4c4b1a05fbf9737eeedc7d46ce8f374c92471",
+   "sha256": "0djq1ig5sk18d86syfxgm6wv2lm3p7fsxrvavjrr2piv2v984za3"
+  }
+ },
+ {
   "ename": "hotfuzz",
   "commit": "8dfb52c062e2195ba51b5670114980bf108aee8b",
   "sha256": "04w3cw5h741dsx5xlqkdisw6kr6l7939x1vf2kns2k143qdcjxqf",
@@ -61423,26 +61720,26 @@
   "repo": "kaorahi/howm",
   "unstable": {
    "version": [
-    20250620,
-    1052
+    20250805,
+    1210
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "89b370b2f10653ec3f8ce09bf6fa3de581bb047d",
-   "sha256": "1n9i6j6b9fnkdjbkvrvfrrmcvk6rkxz8kiirlwayyi1i1x6kxy4q"
+   "commit": "15ef80bc6ed46447027b59769be16108a0fc4a9e",
+   "sha256": "1dmjcbwcghyppqrg383pkric5mjhrz95f7wlm8lxq8k6zkynm1hp"
   },
   "stable": {
    "version": [
     1,
     5,
-    4
+    5
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "53bbfe3b9e4677ac58dd838399da93e2b03db356",
-   "sha256": "1r309zqy7555mrdx51cdhsa8vbyvk71jhx19wqhzmg88ka0fizvc"
+   "commit": "15ef80bc6ed46447027b59769be16108a0fc4a9e",
+   "sha256": "1dmjcbwcghyppqrg383pkric5mjhrz95f7wlm8lxq8k6zkynm1hp"
   }
  },
  {
@@ -61599,19 +61896,19 @@
   "repo": "emacsorphanage/htmlize",
   "unstable": {
    "version": [
-    20250704,
-    1928
+    20250724,
+    1703
    ],
-   "commit": "bf759aa3b2c4099a4252dccdc1db361fbb13a520",
-   "sha256": "1zxx2cns3haxff4862g01llhcn9scck3k9jrcqkjixgy9fynk6pw"
+   "commit": "c9a8196a59973fabb3763b28069af9a4822a5260",
+   "sha256": "084fm91hs9bd46814l9rf6986rxmjyaqxrqpb5jng7pffq41zsnz"
   },
   "stable": {
    "version": [
     1,
-    58
+    59
    ],
-   "commit": "5d2751c4ca101fa0884ce8662f5566736f8257fe",
-   "sha256": "0xkp4sscrz6mpk96vhc59xp94ynfdyalq8npr1g8f6s32xavsga4"
+   "commit": "a24ed5a939a32c625b034b0b6d7f46340c100394",
+   "sha256": "1kdria0h5pmrgdrrxrhf2wlxsmk4drq0byj7mnx4h73sd2ynhhr7"
   }
  },
  {
@@ -62050,11 +62347,11 @@
   "url": "https://git.savannah.gnu.org/git/hyperbole.git",
   "unstable": {
    "version": [
-    20250707,
-    509
+    20250819,
+    1241
    ],
-   "commit": "0adae2bbea101423fe555377dd33214f0b5adc74",
-   "sha256": "1j7qc3skhhkym53bx96wl0wgqyfzapsyzvfky96699phfvbbdz2s"
+   "commit": "818553046b39f3485d1f9f3636153c3151fd430a",
+   "sha256": "1pvyvxhbibmzrs51f068a9rqx90ll6mi2ag060m6gibhapqgaai1"
   },
   "stable": {
    "version": [
@@ -63162,15 +63459,15 @@
   "repo": "idris-hackers/idris-mode",
   "unstable": {
    "version": [
-    20250424,
-    908
+    20250825,
+    758
    ],
    "deps": [
     "cl-lib",
     "prop-menu"
    ],
-   "commit": "ccf32ed0b509f2173672297f6659b4459446064f",
-   "sha256": "0m3mpksyw9w3kfzq8yw8i1x9fyh2jcrj6dss6995nzb00zhqhzfa"
+   "commit": "da5c22f43622112de9e54d8ef9d3ee324d6973f9",
+   "sha256": "11693qh2wp14dwzrkz672m1mz67j7k44saxvpcm91a815m6kpxv5"
   },
   "stable": {
    "version": [
@@ -64191,20 +64488,20 @@
   "repo": "J3RN/inf-elixir",
   "unstable": {
    "version": [
-    20230611,
-    1945
+    20231229,
+    1939
    ],
-   "commit": "77ac6af83eb4b816c62f58a0298b1bae0c3d69fd",
-   "sha256": "0vp7x11ggygq1xlzs4zqqy7x0qvyvy7349grczfv78awqzigdhqb"
+   "commit": "857210b83f3c6a68673222c1271c40cb0b5641bc",
+   "sha256": "1sdi37d8s9i767n8yvqq1prwbgnzmxg3phkbvdjjk9gnii2llns1"
   },
   "stable": {
    "version": [
     2,
-    2,
+    3,
     0
    ],
-   "commit": "5b45f5bd346446d87c629794b3c3e586c3eefd9c",
-   "sha256": "19h3wxwv4yws2hw03pqw4574dvmywy36zr3rby6bd71sx8ljdbkl"
+   "commit": "857210b83f3c6a68673222c1271c40cb0b5641bc",
+   "sha256": "1sdi37d8s9i767n8yvqq1prwbgnzmxg3phkbvdjjk9gnii2llns1"
   }
  },
  {
@@ -65232,25 +65529,26 @@
   "repo": "emarsden/ipp-el",
   "unstable": {
    "version": [
-    20230714,
-    1021
+    20250720,
+    2029
    ],
    "deps": [
-    "cl-lib"
+    "cl-lib",
+    "plz"
    ],
-   "commit": "2b9359ca49acc558fe15622f63e2d31843cdc1f5",
-   "sha256": "12gywh219l1vqcr691qnjrjam9hj6j7fx9x0vmfykcxwxb9krzm8"
+   "commit": "f1d4e4bdbc81de28ada2472e2a73fd9e96791b1d",
+   "sha256": "0dkdxbfp0cnhgk26fidv17c6j8cmhgv6yih129rpbqkzj73p4wax"
   },
   "stable": {
    "version": [
     0,
-    7
+    8
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "4203ecdbf49443412d5a1fb16f6d7ad19f519577",
-   "sha256": "0danh181734g43sdqckxhby3s30i9cb75rn27rf4xh7ls1dilncw"
+   "commit": "cb26728c32ab78ae926791388a864f528eb7c800",
+   "sha256": "10b9dsy5xvllf3aii7j9vfkn6fb939qy20908423dzvaxfnlzr7l"
   }
  },
  {
@@ -66311,28 +66609,28 @@
   "repo": "radian-software/prescient.el",
   "unstable": {
    "version": [
-    20240803,
-    2320
+    20250816,
+    19
    ],
    "deps": [
     "ivy",
     "prescient"
    ],
-   "commit": "2b8a8b41228bddb2e11eb1c200e98a9edd04797c",
-   "sha256": "0qz3xv38vazxqsl7lan7fshj3gmb0qagkrvl5xzwqhdg0rir981j"
+   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
+   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
   },
   "stable": {
    "version": [
     6,
     3,
-    1
+    2
    ],
    "deps": [
     "ivy",
     "prescient"
    ],
-   "commit": "2b8a8b41228bddb2e11eb1c200e98a9edd04797c",
-   "sha256": "0qz3xv38vazxqsl7lan7fshj3gmb0qagkrvl5xzwqhdg0rir981j"
+   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
+   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
   }
  },
  {
@@ -66404,15 +66702,15 @@
   "repo": "Andersbakken/rtags",
   "unstable": {
    "version": [
-    20250218,
-    2303
+    20250801,
+    1647
    ],
    "deps": [
     "ivy",
     "rtags"
    ],
-   "commit": "94269d3558e5db8bab381379dc347bdc7f7ded68",
-   "sha256": "12iv0h14brybqlld5b7z8yicpm3y0wcmmswx9pv261izp7dr41xc"
+   "commit": "dd6b20f7e57a30f32a8ccbb6c22038383dba746b",
+   "sha256": "15rkzvh4i4s2sm1zrclqqs4dnmiik9rcf59jq382ah0afh96mh3b"
   },
   "stable": {
    "version": [
@@ -67482,25 +67780,25 @@
   "repo": "minad/jinx",
   "unstable": {
    "version": [
-    20250619,
-    1453
+    20250802,
+    207
    ],
    "deps": [
     "compat"
    ],
-   "commit": "e4a94a48adfc03afbb8cfb2a2cf76fd7ad1f0e7b",
-   "sha256": "0x3ywxjfz0s47pl5mgbf89g528jymj0w5h36f54chgrg2vh93xbn"
+   "commit": "4c18ce95ced42639f8ef8c47a264c8c37b8b6caa",
+   "sha256": "13kldga8bk4dydc6xvnqdbg69r2wp8aiahlvsg4q4lbakw7mqg0x"
   },
   "stable": {
    "version": [
     2,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "1e143deb27ff9906bf93bd17bbf07e244cc7ca58",
-   "sha256": "1cindzj43vnhmfxn2kx2920fv2pgmrl2p7qv4gsbbb6cqnm8c3zx"
+   "commit": "214d98c18c01897eab108a880b18aa3b64632a03",
+   "sha256": "17pmj9dzyih4m06n7g357a0a8p6v8b216g33r5pcbqz8g0k40djw"
   }
  },
  {
@@ -67511,8 +67809,8 @@
   "repo": "unmonoqueteclea/jira.el",
   "unstable": {
    "version": [
-    20250708,
-    1454
+    20250824,
+    1519
    ],
    "deps": [
     "magit-section",
@@ -67520,14 +67818,14 @@
     "tablist",
     "transient"
    ],
-   "commit": "422f57129a304ea33c79cabe0bc4055c6fe03ecc",
-   "sha256": "0pblk8npy18wi3d06wqv8w6larn8avipkhvmmn97ss3vpn17z19l"
+   "commit": "98bc0cc66ede34793c535a8afd526f42e32b0753",
+   "sha256": "1dsjwr5swrlyjiac9vnxn9dpndqq00pq25mafpzy152wpvnpv3h1"
   },
   "stable": {
    "version": [
     2,
-    1,
-    0
+    7,
+    2
    ],
    "deps": [
     "magit-section",
@@ -67535,8 +67833,8 @@
     "tablist",
     "transient"
    ],
-   "commit": "422f57129a304ea33c79cabe0bc4055c6fe03ecc",
-   "sha256": "0pblk8npy18wi3d06wqv8w6larn8avipkhvmmn97ss3vpn17z19l"
+   "commit": "98bc0cc66ede34793c535a8afd526f42e32b0753",
+   "sha256": "1dsjwr5swrlyjiac9vnxn9dpndqq00pq25mafpzy152wpvnpv3h1"
   }
  },
  {
@@ -67917,10 +68215,10 @@
   "repo": "redguardtoo/js-comint",
   "unstable": {
    "version": [
-    20241205,
-    2321
+    20250807,
+    352
    ],
-   "commit": "68908b5d232738bdc25c4cae502067ef2255a2fd",
+   "commit": "41015e29c8f51f7a927b453d97e14bc0cd7054de",
    "sha256": "1lcj8bp16vp7sp6phx5hhg8k6q2ilrbcrhlfzgszsvz3g2jinlzs"
   },
   "stable": {
@@ -67994,11 +68292,11 @@
   "repo": "ovistoica/js-pkg-mode",
   "unstable": {
    "version": [
-    20241211,
-    744
+    20250803,
+    534
    ],
-   "commit": "d2a609a6cfa0a00d6a96e53e124542e464ccc192",
-   "sha256": "0rminl6an89dy805vhbmnbwdy6afr1cdsgwkss84spamdja9h924"
+   "commit": "4ada384f7f83e227b829223576f02ba51ba06fd1",
+   "sha256": "0lh0faxsmkcr3w9h2fbpvckpm4ab2ja4wq7q1cr6sfnxdj1w84zd"
   }
  },
  {
@@ -68017,6 +68315,21 @@
    ],
    "commit": "9f509043f01fa59bff4daf31b2e95d63f8deab4a",
    "sha256": "00icd76y7sp3cby6n1mkxma4h6aqkrq6cqsnbqrpsgq99qqy30my"
+  }
+ },
+ {
+  "ename": "js-ts-defs",
+  "commit": "1e1bb64f9ded8d0765bddec9511e7e85de575d92",
+  "sha256": "0fg5c0lnnhp5v1chkjrmq8j355yx98gjdwnyr7c1pn56k2sdp7vv",
+  "fetcher": "github",
+  "repo": "jacksonrayhamilton/js-ts-defs",
+  "unstable": {
+   "version": [
+    20250713,
+    2216
+   ],
+   "commit": "ad1fe01406d58b3d13fd62ba8b76198cd18575a7",
+   "sha256": "0p1kqv9gy7fvgigpq69wmcf0n1n9nycafdg1spfyi8k16ai4hgpr"
   }
  },
  {
@@ -68335,14 +68648,14 @@
   "repo": "taku0/json-par",
   "unstable": {
    "version": [
-    20240608,
-    737
+    20250713,
+    755
    ],
    "deps": [
     "json-mode"
    ],
-   "commit": "7b346b0f0db62d65f382ce48a9b2ecd9e180b0d7",
-   "sha256": "1rppp5yi3v3jf90di9jsil18fl00l4qlgandzb3bdrv0j9z2lfqc"
+   "commit": "f81ba61c2fe49b571be890708f3418165b3bbb74",
+   "sha256": "1s0fc9vzf34zpg7jznbkwvpr3qk2w1ls9fvlmsq0cvx43fiw1yr7"
   },
   "stable": {
    "version": [
@@ -68719,14 +69032,14 @@
   "repo": "tpapp/julia-repl",
   "unstable": {
    "version": [
-    20250702,
-    821
+    20250719,
+    1449
    ],
    "deps": [
     "s"
    ],
-   "commit": "cb511c6a9c8cd42f1bb22e76f3bf5f87a489d2ff",
-   "sha256": "1n340kqa75f6ncmczgjgddciiy3fi5h8khvwi2f40fqv4ahdi0kl"
+   "commit": "681efc14a72ece3390137b01c4ee67f317cd8324",
+   "sha256": "1f5wkxjc556vv3fvn0b9vz1kqlgn4438ya3d8cl6if11i6p7gvbg"
   },
   "stable": {
    "version": [
@@ -69448,11 +69761,11 @@
   "repo": "Fabiokleis/kanagawa-emacs",
   "unstable": {
    "version": [
-    20250521,
-    1706
+    20250719,
+    2252
    ],
-   "commit": "84e82ddb6ea13c84a06e8314583d1aa3f6ba2308",
-   "sha256": "18sxkwkwqj8abla9c36pzcbkmqky9maz9p9szjh6xj01is9gh39i"
+   "commit": "fa426fb20966c9fde9cbf70e16172472756db492",
+   "sha256": "1dmz9hw2q783kz93icxhy5ak8bmz4ynfcn7y1rsk1n237w3hzgzm"
   }
  },
  {
@@ -69527,15 +69840,15 @@
   "repo": "ogdenwebb/emacs-kaolin-themes",
   "unstable": {
    "version": [
-    20250616,
-    1431
+    20250820,
+    1822
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "4b64a70625c1640d369392e9a79cdfd534b8e4be",
-   "sha256": "00cav4pj69m1kv46y8lcgrb71jfjw6s5sqnnllp0fq5hqdxnmcw1"
+   "commit": "119b6a5d1f909ee5d3bb140cfdbefe151e0da2df",
+   "sha256": "0fx4wxp6ysqh42czlngbvwhnpnis0kl5kryvj0p3xpmjzv46z46f"
   },
   "stable": {
    "version": [
@@ -70294,28 +70607,28 @@
   "repo": "khoj-ai/khoj",
   "unstable": {
    "version": [
-    20250706,
-    1950
+    20250823,
+    1912
    ],
    "deps": [
     "dash",
     "transient"
    ],
-   "commit": "9a215141f00e75e09386825f49cbf643155d9c9a",
-   "sha256": "1v0sk45s7sfqdlzl1r5pgzkyxbh5sabifqiwpjkadjl35c0w2id5"
+   "commit": "00c5aec614316f1356f450f388dee101a1a4960c",
+   "sha256": "0jka8ic1rqgz2g5s0yz2kfbk65j0djai90fv5058k8q67b03hm6k"
   },
   "stable": {
    "version": [
     1,
     42,
-    9
+    10
    ],
    "deps": [
     "dash",
     "transient"
    ],
-   "commit": "0a34a83d45f9f2b8f96c414ca93284d2f5d428df",
-   "sha256": "14f51774fickblidjl1s8mdqc4zknb20by6f525q9h7vckn55qy2"
+   "commit": "a6fe2d2fbdae2032eed488a27e7317dcff036555",
+   "sha256": "0pk5b6vrh9zcck2lzdlifisahj394wrafrqk2gb82z9zyk5mnxvk"
   }
  },
  {
@@ -70549,14 +70862,14 @@
   "repo": "mew/kixtart-mode",
   "unstable": {
    "version": [
-    20250310,
-    2020
+    20250806,
+    1656
    ],
    "deps": [
     "eldoc"
    ],
-   "commit": "8a02eb6cbd99815b33352796a2a756a5d75edcae",
-   "sha256": "056g26j74cdjmmdz80cyd12fwmqnmsrg6jj94w8wfa1l8aksp9gb"
+   "commit": "ddf0c3b207e5695fbc80fe45374db29f5ea18211",
+   "sha256": "078asawps4ydpzpcxv1a26yjbm6401k0xsisbbl85s5spv67a244"
   },
   "stable": {
    "version": [
@@ -70950,8 +71263,8 @@
   "repo": "abrochard/kubel",
   "unstable": {
    "version": [
-    20250507,
-    1654
+    20250713,
+    1542
    ],
    "deps": [
     "dash",
@@ -70959,8 +71272,8 @@
     "transient",
     "yaml-mode"
    ],
-   "commit": "61ec610b817c9ef59b2f25a242b71dee3f2e068a",
-   "sha256": "0h0k9zz6dvdbg2h96zkjn3gl6k9fk7fddjac81vbs7g8gyj5pfjd"
+   "commit": "9218d91b1085a4cdb240377c335142909df6a9e3",
+   "sha256": "08ijjmpyj58wpwc7js3a5gxxsdzm4vlkb9m2smy1xnllzqh0ikm9"
   },
   "stable": {
    "version": [
@@ -71241,38 +71554,36 @@
   "repo": "isamert/lab.el",
   "unstable": {
    "version": [
-    20250213,
-    1900
+    20250722,
+    1903
    ],
    "deps": [
     "async-await",
     "compat",
     "f",
-    "memoize",
     "promise",
     "request",
     "s"
    ],
-   "commit": "7c92f7934face10b696da45c2459f085a40eb867",
-   "sha256": "1x5l4l486615w77ac4dh95af9x8yhivd5z557c2j053avx2728c4"
+   "commit": "85f66f35f3dbd6d21828aa42647204ed8d70aebb",
+   "sha256": "1xdgkhz1b7x5pwgkn4ykzc436g80m6rjq88zs6y79mcllh6w925n"
   },
   "stable": {
    "version": [
     2,
-    2,
-    2
+    4,
+    0
    ],
    "deps": [
     "async-await",
     "compat",
     "f",
-    "memoize",
     "promise",
     "request",
     "s"
    ],
-   "commit": "17614c9becbb4d52075ccb5bac66ea51895e9e3a",
-   "sha256": "0wfjbk679r8qj5lng8wg3d3b6ss9w5979chihzk62z5lbn5g9pf6"
+   "commit": "5c95bd829cfd9ad610bcbbc0d3f8ef8bee4e152c",
+   "sha256": "1hv56dpbi2p5fxd5gc2n3qf2cynym7zkb4kjsn83r43wv8v54l4s"
   }
  },
  {
@@ -71361,21 +71672,21 @@
   "repo": "Deducteam/lambdapi",
   "unstable": {
    "version": [
-    20250707,
-    1800
+    20250716,
+    1143
    ],
    "deps": [
     "eglot",
     "highlight",
     "math-symbol-lists"
    ],
-   "commit": "0739f007f42e6b9327979d83c1207f71bdc22e9a",
-   "sha256": "0cz2zx5naifypd168pwiiz3dhxqcg2cf2xyk6h0a2nms3l46mnnh"
+   "commit": "f73c64dbeebf850ecc3384d64f0dbf93a1ea6acd",
+   "sha256": "1rk6rmks1818rgl1jmvcs1j8ydm5sqbwlgmb9rp9jj4kx9njxs1a"
   },
   "stable": {
    "version": [
-    2,
-    6,
+    3,
+    0,
     0
    ],
    "deps": [
@@ -71383,8 +71694,8 @@
     "highlight",
     "math-symbol-lists"
    ],
-   "commit": "29be5f84a19e46fd5f1482f1b7e84eddaf9fd49c",
-   "sha256": "0yn1fh4jm1wqalf3snpfapbgimi82xgj7mr4drg9d2if71hbl4y0"
+   "commit": "f73c64dbeebf850ecc3384d64f0dbf93a1ea6acd",
+   "sha256": "1rk6rmks1818rgl1jmvcs1j8ydm5sqbwlgmb9rp9jj4kx9njxs1a"
   }
  },
  {
@@ -72046,14 +72357,14 @@
   "repo": "AnselmC/le-gpt.el",
   "unstable": {
    "version": [
-    20250630,
-    244
+    20250814,
+    230
    ],
    "deps": [
     "markdown-mode"
    ],
-   "commit": "3ae0bacaae68ee6bd6c1e2d73ea312c2224b4e21",
-   "sha256": "0wmczjd69lljap83rh5x8z9alln1fag5664wlm6lmrf002mrcg7z"
+   "commit": "79662c6a8846a6c667ab6d3521c70050e01b9538",
+   "sha256": "1msa3xxy6dymyar9kiw0ibqyxg7f1z66vn89ck8vz5wll95jgj3x"
   }
  },
  {
@@ -72333,11 +72644,11 @@
   "repo": "ledger/ledger-mode",
   "unstable": {
    "version": [
-    20250317,
-    529
+    20250821,
+    1439
    ],
-   "commit": "d9b664820176bf294fbca5ee99c91920862cf37d",
-   "sha256": "1nvnx28b6xwwqfpswr0hiszc38znr5x56q9aplgnf8n3p3mvash5"
+   "commit": "e9bb645e8f05cf7ad0819b0450db7e84c9ed3f41",
+   "sha256": "0kghc44drp69fiw7gzsjzwqzhxcgqxl57jynk7fhycqf1sbw8i1x"
   },
   "stable": {
    "version": [
@@ -72421,27 +72732,27 @@
   "repo": "martianh/lem.el",
   "unstable": {
    "version": [
-    20241228,
-    1420
+    20250806,
+    924
    ],
    "deps": [
     "fedi",
     "markdown-mode"
    ],
-   "commit": "64ba2554f2742a05f8208434d23e2dcb2c476c41",
-   "sha256": "15xrs2hygx236driipb1fm2k4ky86ybnv104z178pyvfm6dndnjj"
+   "commit": "a0f4fa89fe73dfe7412f5d25d6e0619abf8cff14",
+   "sha256": "181cibmv6da4rjr6p3nqpza6i7v4scc4qndznhyjb9nhbf3gsil4"
   },
   "stable": {
    "version": [
     0,
-    22
+    24
    ],
    "deps": [
     "fedi",
     "markdown-mode"
    ],
-   "commit": "0e7372d4ce133aff7d0a2b79d1f66e5e1e9efc07",
-   "sha256": "12g16gq9qawhlj92jgxr2l7xcc0ikvmwsygjcr3qyxy0bawynzr8"
+   "commit": "a0f4fa89fe73dfe7412f5d25d6e0619abf8cff14",
+   "sha256": "181cibmv6da4rjr6p3nqpza6i7v4scc4qndznhyjb9nhbf3gsil4"
   }
  },
  {
@@ -73742,15 +74053,15 @@
   "repo": "sulami/literate-calc-mode.el",
   "unstable": {
    "version": [
-    20240823,
-    335
+    20250809,
+    1227
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "4fe134d60cf725d8e2ab0cde9b9db963e70abcae",
-   "sha256": "1vxfdc7hdq85sy3xpqnvlhjsbsgllin5gqh4v6b073rza81mb8yi"
+   "commit": "bdfdb6e526cdcf987ecded3bd9032990e5be1236",
+   "sha256": "16wdgin2jzpr5p1q5v54ppigxia6z7v5kncg3yabzf86x1ljw6wk"
   }
  },
  {
@@ -74040,14 +74351,14 @@
   "repo": "tarsius/llama",
   "unstable": {
    "version": [
-    20250701,
-    1529
+    20250808,
+    1023
    ],
    "deps": [
     "compat"
    ],
-   "commit": "0cc2daffded18eea7f00a318cfa3e216977ffe50",
-   "sha256": "0yp1k70pgi45k8gb7xn229g1dzmwnijabvzxgrwacp02n7v1piyh"
+   "commit": "bf586c02ddf5cf2eb0bab468b99436018887bbec",
+   "sha256": "0lxpxbw10hmcc211l8w0rxl23j0y3naklwmj611a1d1ksx1s4skc"
   },
   "stable": {
    "version": [
@@ -74191,6 +74502,25 @@
   }
  },
  {
+  "ename": "lobsters",
+  "commit": "16b214185e847a8c19091fc77b4828b122035f29",
+  "sha256": "05gj4k9h06n85r7w7qyxsk99p1lc7hw2gmf4m5a1r8y5fhy0vhnn",
+  "fetcher": "github",
+  "repo": "tanrax/lobsters.el",
+  "unstable": {
+   "version": [
+    20250817,
+    1829
+   ],
+   "deps": [
+    "request",
+    "visual-fill-column"
+   ],
+   "commit": "9d4bd2c67ca324ea402897cb629312add53279c3",
+   "sha256": "08vjn3ay3g215fc4dzlnhygf70gacliz83xizgc3p6k2fyv4y491"
+  }
+ },
+ {
   "ename": "loc-changes",
   "commit": "a5ce68d573d19f26ecfd190f8e6cd1f384ca3e8a",
   "sha256": "1akgij61b2ixpkchrriabwvx68cg4v5r5w9ncjrjh91hskjprfxh",
@@ -74251,20 +74581,20 @@
   "repo": "csmclaren/loco",
   "unstable": {
    "version": [
-    20240718,
-    125
+    20250822,
+    1459
    ],
-   "commit": "fc590068204ae27eef0addfe89071bff2cfe117c",
-   "sha256": "1ds9bvz6rq7vkw3vgl77arawkcf854sb5a57c77h849mgypj43wz"
+   "commit": "b0955516ed13a288a9c2671050c1e25bd64e1b91",
+   "sha256": "0asznx04w7m0iq6npfwvbkd6xrmw4bfb7sxr4ijzwnbj5i2xbdcm"
   },
   "stable": {
    "version": [
     0,
-    1,
-    15
+    2,
+    3
    ],
-   "commit": "fc590068204ae27eef0addfe89071bff2cfe117c",
-   "sha256": "1ds9bvz6rq7vkw3vgl77arawkcf854sb5a57c77h849mgypj43wz"
+   "commit": "b0955516ed13a288a9c2671050c1e25bd64e1b91",
+   "sha256": "0asznx04w7m0iq6npfwvbkd6xrmw4bfb7sxr4ijzwnbj5i2xbdcm"
   }
  },
  {
@@ -74664,8 +74994,8 @@
   "repo": "okamsn/loopy",
   "unstable": {
    "version": [
-    20250706,
-    117
+    20250810,
+    1948
    ],
    "deps": [
     "compat",
@@ -74673,8 +75003,8 @@
     "seq",
     "stream"
    ],
-   "commit": "30ca70a9d4bc4201c57bd6fbc87c14b1c0f416f7",
-   "sha256": "0bfipy9s73d2bvm8zrrypbhi3pm24yanf0jy81jcasbdqsrr1ala"
+   "commit": "3c6beb610fded397088d616c1cc3cf6c90c8e568",
+   "sha256": "0z6y81p81nj7ryc95imyd5z54zxsgpj1i5w0c2lli69yjjbyzb5r"
   },
   "stable": {
    "version": [
@@ -74906,15 +75236,15 @@
   "repo": "emacs-lsp/lsp-focus",
   "unstable": {
    "version": [
-    20241119,
-    1451
+    20250825,
+    539
    ],
    "deps": [
     "focus",
     "lsp-mode"
    ],
-   "commit": "3420d82c6c8635b4184ebacd50e0902deeeb9845",
-   "sha256": "13vn09i2jna2vh55ql02nni3ys81v5n1540yxj1mw3mwgfv5icnc"
+   "commit": "4621d310e780e384cbe93d5680fa9ec5d03e2c73",
+   "sha256": "09yzcfv9gpifsy5ckvmacj7fg0fz1pnnjdzghj4i28x738g7ixxb"
   },
   "stable": {
    "version": [
@@ -75012,16 +75342,16 @@
   "repo": "emacs-lsp/lsp-ivy",
   "unstable": {
    "version": [
-    20241119,
-    1452
+    20250825,
+    512
    ],
    "deps": [
     "dash",
     "ivy",
     "lsp-mode"
    ],
-   "commit": "553276f3c8a6bc15859a9be666b0a50af65e9bc6",
-   "sha256": "10yij9ml3wwvk4z9hglpjydviwkc18czvv81s7hj99yarvn3ldg6"
+   "commit": "2927cbc776477e23d4a1062568d55793eed33c51",
+   "sha256": "12l160q4wi9wc17n1r4pdmp42hwyqrmzc3xcfki6pivmqdaark45"
   },
   "stable": {
    "version": [
@@ -75045,8 +75375,8 @@
   "repo": "emacs-lsp/lsp-java",
   "unstable": {
    "version": [
-    20250228,
-    2147
+    20250712,
+    2133
    ],
    "deps": [
     "dap-mode",
@@ -75058,8 +75388,8 @@
     "request",
     "treemacs"
    ],
-   "commit": "6cfff8761e9f23889c002984f61e4ae04979eaf5",
-   "sha256": "15y8brajnp6y4ii8dylgrfyq7n9a7jd80m3jjk2g9ra04mqzfhw5"
+   "commit": "9230a0007c79a661028c142f35c7b8d1f9f55453",
+   "sha256": "098mzvn56r4zc0944bzwwnb57p3lv0z94m2kl7s8l629vk5qlkph"
   },
   "stable": {
    "version": [
@@ -75278,8 +75608,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20250708,
-    39
+    20250822,
+    625
    ],
    "deps": [
     "dash",
@@ -75290,8 +75620,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "147233313576c844e2bf56640827b0d0e5c2ee6c",
-   "sha256": "14317wgi0mrxbcrlgrfqyf80lh86n7x6bv07b43cxl3k4c4fqk0l"
+   "commit": "c0cafd07ea7e0a2d82fcd0680eb36da10356d700",
+   "sha256": "0v7xvldx0px9jnlncbk3g76dwl464m1fzhrhjsbjdpzz4ay7p5pj"
   },
   "stable": {
    "version": [
@@ -75320,8 +75650,8 @@
   "repo": "emacs-lsp/lsp-mssql",
   "unstable": {
    "version": [
-    20250301,
-    131
+    20250825,
+    542
    ],
    "deps": [
     "dash",
@@ -75330,8 +75660,8 @@
     "lsp-mode",
     "lsp-treemacs"
    ],
-   "commit": "60a1548be01c2d6570d662a50f0d09cb20680df7",
-   "sha256": "12h2llkhjs7256xz9h4b3rd39jbsg14bixj65f4nsgj0ll564nfg"
+   "commit": "93d3adc9dc61156745ab1f7dc147af6070fdd25b",
+   "sha256": "0l85nqmdkr8132dqw8hf7dy2ds6bvcbdh936qsxp78di46ywcb7f"
   }
  },
  {
@@ -75342,15 +75672,15 @@
   "repo": "emacs-lsp/lsp-origami",
   "unstable": {
    "version": [
-    20230815,
-    704
+    20250825,
+    521
    ],
    "deps": [
     "lsp-mode",
     "origami"
    ],
-   "commit": "86aa06517910141c3d5054eea5f7723461fce6a6",
-   "sha256": "1nvz60iwdh5wkcflyk53lfwsd2yjniribvw95x9968sf9icf2dqw"
+   "commit": "b52f42b7932dd968b398e7cfd2ca29051b1a50b4",
+   "sha256": "0gpvdhipwz70p6pmrsy6z1f8zbpfazmrvp5anymywm9g8gq212pr"
   },
   "stable": {
    "version": [
@@ -75474,15 +75804,15 @@
   "repo": "jjlee/lsp-rescript",
   "unstable": {
    "version": [
-    20220314,
-    1957
+    20250808,
+    1449
    ],
    "deps": [
     "lsp-mode",
     "rescript-mode"
    ],
-   "commit": "7baf9adf10234cf964feefae99050268e9bc5681",
-   "sha256": "09jh4q3i0b71srfpsr4w0jk5rn9rz359v8k1pk80636g7448k8gl"
+   "commit": "3c13e3ffe2ece7b08f49c72e8a6e6156041f4c8b",
+   "sha256": "0f053vfad8vqch5xvh1d8cbwh992j41nhahwxjlfc8h0ili2d35a"
   }
  },
  {
@@ -75525,14 +75855,14 @@
   "repo": "shader-ls/lsp-shader",
   "unstable": {
    "version": [
-    20250101,
-    926
+    20250722,
+    2024
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "802e1a3414f90c5ab37a18716198936cc39e4994",
-   "sha256": "0z4j9f1j5qjpyy03n68cs8z5lbdvci3jagmp0l1bbs9rm4zw4fgy"
+   "commit": "13d696b8d8ab5ca319cc5e4ae4a1045eae2a2413",
+   "sha256": "0xrnnj5vllpc82y19a2wij78vqsqrnn5piwalnf2vv6pg9fsa28k"
   },
   "stable": {
    "version": [
@@ -75589,14 +75919,14 @@
   "repo": "emacs-lsp/lsp-sourcekit",
   "unstable": {
    "version": [
-    20250301,
-    131
+    20250825,
+    538
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "3bd9750e7ec97706c0455f41ea4e5cff3391dba8",
-   "sha256": "04hbvldgz4rxpkanzq2kywi8camq4vy50i6sraq6pyx4qbq0nabi"
+   "commit": "30918cd1aeeda5cfbc0fd615f97cf1bf388d8f2d",
+   "sha256": "1d5iq4rhcpa0crwi67ibzmahg6zzlwpm48dkvgbckqa8si589g88"
   }
  },
  {
@@ -75674,16 +76004,16 @@
   "repo": "emacs-lsp/lsp-ui",
   "unstable": {
    "version": [
-    20250228,
-    2155
+    20250804,
+    2109
    ],
    "deps": [
     "dash",
     "lsp-mode",
     "markdown-mode"
    ],
-   "commit": "09d40806429fadc01a12d9a1841b49430f58adb5",
-   "sha256": "136pb5nggfixa681k43f5ii4k9mhg6wfi3af9qm1wa63yly8cphq"
+   "commit": "dcce464bc5d171daebf19009fdfbbc959bf2e7cf",
+   "sha256": "04hszygj88mp3qhvi25x0hl3jfqflw45f4cy95npi96zamlmj203"
   },
   "stable": {
    "version": [
@@ -76237,21 +76567,21 @@
   "repo": "reinierkof/magik-company",
   "unstable": {
    "version": [
-    20250618,
-    1240
+    20250822,
+    1442
    ],
    "deps": [
     "company",
     "magik-mode",
     "yasnippet"
    ],
-   "commit": "6ff5ab12d97afee960fb1556db623c3278d77812",
-   "sha256": "1dfihmhcglyjvy5fbwn8gjfbcwqyrs4wz7c19faka8qyz51n1bnb"
+   "commit": "db00024a7212dc6af674a9ce27c1a15a29d484e8",
+   "sha256": "0g09bgxjd4cbd01b56g54j3x2qxpzs9klp9w9qwp698fy2lhirmm"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     0
    ],
    "deps": [
@@ -76259,8 +76589,8 @@
     "magik-mode",
     "yasnippet"
    ],
-   "commit": "dccabc933d4cb2cad1807d7ec643e1536da70d53",
-   "sha256": "0f679s3addachrnyfhq493f9aff8m8pmn6vxnxv4m3fvwyrzrxy5"
+   "commit": "db00024a7212dc6af674a9ce27c1a15a29d484e8",
+   "sha256": "0g09bgxjd4cbd01b56g54j3x2qxpzs9klp9w9qwp698fy2lhirmm"
   }
  },
  {
@@ -76271,27 +76601,28 @@
   "repo": "roadrunner1776/magik",
   "unstable": {
    "version": [
-    20250705,
-    2053
+    20250821,
+    1048
    ],
    "deps": [
     "compat",
     "yasnippet"
    ],
-   "commit": "3b835448c05fb786e605fd28081ee2bd20bc36a4",
-   "sha256": "1hc8bg03366ql81jqsx449is7wnghcakr3mzm53r4j7mp0p6s5dj"
+   "commit": "4f2db98631de71f9078a001e6efba7c048acd2f1",
+   "sha256": "0s525p67v81s9a8fws3v836vsv2myxmxgrcmzzzkz7nkhqkm7wd1"
   },
   "stable": {
    "version": [
     0,
-    4,
-    0
+    5,
+    5
    ],
    "deps": [
-    "compat"
+    "compat",
+    "yasnippet"
    ],
-   "commit": "dacb19bff41b464ee209d7a2bb5bbf8589e9a37e",
-   "sha256": "1ps9nmirqchhvp6v9xzxv2cjp4i9fnqn06lmz93bwcmzk2akm95q"
+   "commit": "0ccfffef530802698447ce4f549477e724ab8710",
+   "sha256": "0vfjbf4vm4r2cc0bd3yc5rw6mn8c5169nirw0ixrzp6w70h0b903"
   }
  },
  {
@@ -76302,19 +76633,20 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20250704,
-    2300
+    20250826,
+    651
    ],
    "deps": [
     "compat",
+    "cond-let",
     "llama",
     "magit-section",
     "seq",
     "transient",
     "with-editor"
    ],
-   "commit": "5b820a1d1e94649e0f218362286d520d9f29ac2c",
-   "sha256": "0y5151flgsxb1cv123kkj4v74xs5s6sh7ycq00gqc7bm0n09lcdb"
+   "commit": "a47b5098c812b7a7932df802378cb754e3ad8639",
+   "sha256": "0nzsz3x0hnxg4y1wf3pag3dmrihpb6zbdpb7wkcas5mcxm55pnrr"
   },
   "stable": {
    "version": [
@@ -76490,15 +76822,15 @@
   "repo": "emacsorphanage/magit-gerrit",
   "unstable": {
    "version": [
-    20250110,
-    1248
+    20250825,
+    722
    ],
    "deps": [
     "magit",
     "transient"
    ],
-   "commit": "07307dbdff9ec8042457dbeed21281c336fba104",
-   "sha256": "175vw3khs3bcm4ry98bcpd8dw7n1y8al01z4p5xcrlrzfp21cn0y"
+   "commit": "37a4774c3cc401f849d57aaa2c105ca401f9983c",
+   "sha256": "0pbh0w49jhvmgz6liravkn0ajdgzdapb13gpd8j6r4i6mw3n0v2a"
   },
   "stable": {
    "version": [
@@ -76845,6 +77177,24 @@
   }
  },
  {
+  "ename": "magit-prime",
+  "commit": "53b6cf4121e5235d77c878ea04ad2a46617220a2",
+  "sha256": "0g20cgwwfafnkhgm4bqak8gp58159wkdqk6hn9pb0823glmm4nn7",
+  "fetcher": "github",
+  "repo": "Azkae/magit-prime",
+  "unstable": {
+   "version": [
+    20250803,
+    1914
+   ],
+   "deps": [
+    "magit"
+   ],
+   "commit": "ebd58f95a564d69baa21a456471a2584673df78d",
+   "sha256": "04iww0vwcxf2fs3qj54bafvz6a5ny1d91j3nmqgbjmlggsdx2dc7"
+  }
+ },
+ {
   "ename": "magit-rbr",
   "commit": "10427817a1fc2fa8aaf11897719cbb851d9e4b15",
   "sha256": "086vb7xrgyrazc3a7bpyhy219szvrvl59l8wlqakimx0mav7qipr",
@@ -76890,16 +77240,17 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20250704,
-    2300
+    20250826,
+    651
    ],
    "deps": [
     "compat",
+    "cond-let",
     "llama",
     "seq"
    ],
-   "commit": "5b820a1d1e94649e0f218362286d520d9f29ac2c",
-   "sha256": "0y5151flgsxb1cv123kkj4v74xs5s6sh7ycq00gqc7bm0n09lcdb"
+   "commit": "a47b5098c812b7a7932df802378cb754e3ad8639",
+   "sha256": "0nzsz3x0hnxg4y1wf3pag3dmrihpb6zbdpb7wkcas5mcxm55pnrr"
   },
   "stable": {
    "version": [
@@ -77518,11 +77869,11 @@
   "repo": "choppsv1/emacs-mandm-theme",
   "unstable": {
    "version": [
-    20250103,
-    814
+    20250726,
+    1920
    ],
-   "commit": "f6475ef40fa9b78de6530610e83cb36ff8ed5d1a",
-   "sha256": "0fjra40wc4b2ai4jd6zg5jsnpyfyfdyj74i3gz2asnqy99c2ryil"
+   "commit": "5b8ccb687b56ce143d3f60f59a681e6ca2e90956",
+   "sha256": "03mjn7dkh246w92aiw1f63wmkckjkk0kbvcp8xg8ha1wdgwq2cl0"
   }
  },
  {
@@ -77689,25 +78040,25 @@
   "repo": "minad/marginalia",
   "unstable": {
    "version": [
-    20250702,
-    617
+    20250824,
+    834
    ],
    "deps": [
     "compat"
    ],
-   "commit": "aa8e48b86f66739a86fb2e180103f8f9682004be",
-   "sha256": "1hy1p4xpchsg6kircs94fbls50c6iw39w3sckvpr3ajgg8zmzkbj"
+   "commit": "30e6813c8142ef8cb45e6f9bdd23ead1c80b9b2e",
+   "sha256": "0j80bbjy4axljlqa2rfjdf66bghmmsibrmvscx1bx62jcqjia4gj"
   },
   "stable": {
    "version": [
     2,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "151ac0abd70da0fc4cae753e2ac156bbaa10d317",
-   "sha256": "0h7qn2lrw0y789j4z4i9cycfnzqd6w6a2sg50qhdjiirn5i8s2kk"
+   "commit": "6e3412ce57b9c87c2d66bc8814aa1a3fdb2e929f",
+   "sha256": "1grn94v5pidb9wk2vgxx5n3fmhcgx9i14lrwm5clvsvncysy7zhg"
   }
  },
  {
@@ -77831,11 +78182,11 @@
   "repo": "jrblevin/markdown-mode",
   "unstable": {
    "version": [
-    20250624,
-    631
+    20250812,
+    423
    ],
-   "commit": "7c51a2167c5a1330e0ab52fe5b2d03c1ead122ca",
-   "sha256": "0lbrd9hi1r17y2zmm2r5wly5vy5ydr76v9jlpmlvc7d5bkwh00ph"
+   "commit": "d51c469133d220823cc6ab50ff8e8743ed6e42fb",
+   "sha256": "1cp4mqv8jnvwb0ph0f7wnxdv9ryrfl2wyljhixb1simwalkpn98f"
   },
   "stable": {
    "version": [
@@ -77939,16 +78290,16 @@
   "repo": "ardumont/markdown-toc",
   "unstable": {
    "version": [
-    20241226,
-    1737
+    20250812,
+    237
    ],
    "deps": [
     "dash",
     "markdown-mode",
     "s"
    ],
-   "commit": "d2fb4cbd95e558042307d706f9f47f93687c9fcc",
-   "sha256": "13xzcmrhaf0zjbb4ngzqvvwm43h1z9md34n79kl2wrdhmgh7ifd7"
+   "commit": "3835390ac44c5dc712d4caae5661995f0639262e",
+   "sha256": "02i385xaz6r260sch3ra1xl88z7d6c6fly985nn3x97fqpas1b47"
   },
   "stable": {
    "version": [
@@ -77997,17 +78348,17 @@
  },
  {
   "ename": "markless",
-  "commit": "a3c6e6adb1a63534275f9d3d3d0fe0f5e85c549b",
-  "sha256": "1nd7np60h0k1p9pwp3dn8068584h7r7lhfl9j7yn2jrf2r51806h",
-  "fetcher": "github",
-  "repo": "Shirakumo/markless.el",
+  "commit": "a4f322c6f24555058fb7204f9656e343b26f073a",
+  "sha256": "0g5hg753xlqv3zks4h8wima7q90whd84war1xw74ssjlhchpv76l",
+  "fetcher": "codeberg",
+  "repo": "shirakumo/markless.el",
   "unstable": {
    "version": [
-    20240218,
-    1639
+    20250811,
+    1924
    ],
-   "commit": "686dcf2592a042ebb4e01cbf60d4d8840dd74eaa",
-   "sha256": "07fg80zpyblp35m0i6bph372abzjfrh8vxqpyc0ik49vrwh0za1p"
+   "commit": "f8bd797f4d5962fec1dcf9807fba8cf0be17b2f9",
+   "sha256": "1slf0zlw07yp8fl1yiz3ipqk6ajad44kwkb52i53pi98vhlj0y3a"
   }
  },
  {
@@ -78191,28 +78542,28 @@
   "repo": "martianh/mastodon.el",
   "unstable": {
    "version": [
-    20250602,
-    1416
+    20250801,
+    1032
    ],
    "deps": [
     "persist",
     "tp"
    ],
-   "commit": "f6247f0c9b8c15b19e8ddca2f600ceb2cf48beb9",
-   "sha256": "1dvj51x17msyl5baa7sicshkndnbag0zcrakvm9w22gmqjhjimy5"
+   "commit": "3e05dc0952c9d34d918e629a80492462adb7aa15",
+   "sha256": "13rx2r3kwr30p3p1px66ay5djvcn1503jqvkaaf9h6g97jfbj6bm"
   },
   "stable": {
    "version": [
     2,
     0,
-    1
+    2
    ],
    "deps": [
     "persist",
     "tp"
    ],
-   "commit": "f6247f0c9b8c15b19e8ddca2f600ceb2cf48beb9",
-   "sha256": "1dvj51x17msyl5baa7sicshkndnbag0zcrakvm9w22gmqjhjimy5"
+   "commit": "2959ec90ed5813be3efd3b1942815d911c41a416",
+   "sha256": "0msg2nkvcz5v67c6m0z91g5442nl1i3drg3gwfsajj0sh9m4f5mr"
   }
  },
  {
@@ -78604,14 +78955,14 @@
   "repo": "lizqwerscott/mcp.el",
   "unstable": {
    "version": [
-    20250708,
-    1119
+    20250727,
+    749
    ],
    "deps": [
     "jsonrpc"
    ],
-   "commit": "2fcda27b15395fe1ed55d15a88e6187a69af09e9",
-   "sha256": "0q4ycgb4dx4p0v449vncmb4j0nklpy14wasz4x7pkyq6yhsx8lmz"
+   "commit": "4708c5849ce4ddb632016eca662a7405bfa642d4",
+   "sha256": "11x3jscm4iggyy926aidiv95lrbcncngbvivsybvzjvbhdxhb65h"
   }
  },
  {
@@ -78622,11 +78973,20 @@
   "repo": "laurynas-biveinis/mcp-server-lib.el",
   "unstable": {
    "version": [
-    20250626,
-    331
+    20250728,
+    457
    ],
-   "commit": "ad181dd49162c8a4bb5064f081a60baa9fe7852e",
-   "sha256": "07jxkm43q4jc4vz9dr04m22cy7b0332jxqcad0v6lan801bbxj52"
+   "commit": "062a3078122171fffd1c1fc8ec64b114acd1cba2",
+   "sha256": "10xv6fap9605lns1nzbagdj2lby3si9d16nq5smcbrwfzx4a910j"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "commit": "502f79d22fe565050adf7a6879a3f903708405f4",
+   "sha256": "1877rmb8qq5rwxlxx341rdkn1lc64dys9plqavjajng6n4jlf2hd"
   }
  },
  {
@@ -78758,20 +79118,20 @@
   "repo": "hexmode/mediawiki-el",
   "unstable": {
    "version": [
-    20220923,
-    1336
+    20250805,
+    316
    ],
-   "commit": "c28cf78d4fe4969df3af8dcc2adaf71c4212e5ad",
-   "sha256": "0l08k4g6nx2n8pb1iwdhxsbr0szb6xinq94084z8f9jnridlhbwh"
+   "commit": "2f116ce0931f7966fefe75a1fca5552d6552ddb1",
+   "sha256": "1g0z8q2231760bxc5m6yp0r9isdcjdf3f9vkbm940avcwv9l2khv"
   },
   "stable": {
    "version": [
     2,
-    3,
-    1
+    4,
+    7
    ],
-   "commit": "5178a1a1dbe37a144d9c82622eb683bd3c61bef1",
-   "sha256": "1d05jw2sa19rgzskvavh21bfmbh07yza1drfbgypsvay3nkjfd2z"
+   "commit": "2f116ce0931f7966fefe75a1fca5552d6552ddb1",
+   "sha256": "1g0z8q2231760bxc5m6yp0r9isdcjdf3f9vkbm940avcwv9l2khv"
   }
  },
  {
@@ -78977,11 +79337,11 @@
   "repo": "meow-edit/meow",
   "unstable": {
    "version": [
-    20250404,
-    1432
+    20250722,
+    2059
    ],
-   "commit": "e5817f3b5ef82cbcf8a729af205191dc6b142282",
-   "sha256": "15nic2v054256696r4phfrfgbpa9vyjf2z2shdvx6zp10nkc936x"
+   "commit": "3309d64c436209649a5106fa3a3dd019de4d3a64",
+   "sha256": "00mgx7jcb8cvsajww271syklyrrjc7wn9hdmqn3n9jxi46381428"
   },
   "stable": {
    "version": [
@@ -79194,11 +79554,11 @@
   "repo": "abrochard/mermaid-mode",
   "unstable": {
    "version": [
-    20241213,
-    1913
+    20250718,
+    1858
    ],
-   "commit": "e74d4da7612c7a88e07f9dd3369e3b9fd36f396c",
-   "sha256": "0dqg3fyhyxn29b0fw7zr3ykhb5lpqlffhpfcbrk08h8h29mg7jvd"
+   "commit": "9535d513b41ed11bcd91f644815e2db6430c1560",
+   "sha256": "174xlsm316rpxm8sbxfnyhvy1bjkl0qbx71s1mfcyda737y3dsbl"
   }
  },
  {
@@ -79209,11 +79569,11 @@
   "repo": "JonathanHope/mermaid-ts-mode",
   "unstable": {
    "version": [
-    20231001,
-    1704
+    20250803,
+    205
    ],
-   "commit": "3f3a537d249b44e939d6a0d65a6c316761ff8c41",
-   "sha256": "08081a15wzwxljf68mznygjk6v2x5k4v9grx97cjr8ymcjbqnbcj"
+   "commit": "973e442cbed980cf51afc256c90ef133c4d02141",
+   "sha256": "15w453br7ksarhrbin64sjdm3ln20f12p07lkqq7a4vj5g7dihh2"
   }
  },
  {
@@ -79432,14 +79792,14 @@
   "repo": "org2blog/org2blog",
   "unstable": {
    "version": [
-    20250207,
-    2147
+    20250721,
+    2333
    ],
    "deps": [
     "xml-rpc"
    ],
-   "commit": "2310990794c80de8c01bba8c8a7ad5b012c0705d",
-   "sha256": "0b9h9wjazqrd0wjjf4fpwxgg9gpfcm8pab83ymmm1m9x7cdq4ps8"
+   "commit": "a47847c4231800335786e624025cb58760a4746e",
+   "sha256": "1mx2kb3v97dkdnfl778wfkfjwb4s2x9vgnnpnvfki4zmf2d7w81h"
   },
   "stable": {
    "version": [
@@ -79492,11 +79852,11 @@
   "repo": "kazu-yamamoto/Mew",
   "unstable": {
    "version": [
-    20250708,
-    204
+    20250815,
+    36
    ],
-   "commit": "2392ee9b869029a9900587011fe541abe08a2fd5",
-   "sha256": "13ajr51yk2hcfiq532cayb0kvpdb3psf877cxl6qwx0pgaf1qm57"
+   "commit": "a162361aab27e63a886ceff21349425d6da24c86",
+   "sha256": "0bggaf64bzmi336z7ai5xr0zxywfwv7ck3nlw3s5fwdfgr5l7py0"
   },
   "stable": {
    "version": [
@@ -79530,8 +79890,8 @@
   "repo": "danielsz/meyvn-el",
   "unstable": {
    "version": [
-    20240905,
-    43
+    20250815,
+    2140
    ],
    "deps": [
     "cider",
@@ -79542,8 +79902,8 @@
     "projectile",
     "s"
    ],
-   "commit": "8d00ada6daa5617fa60f76e0be2cf2f5d1babcf9",
-   "sha256": "0ncilsn0ih01w6hjdn529jkapiv4nnkway07j2b5fndkrlgk2ry4"
+   "commit": "5380626e327b7a48531c4a652bab4896ba179312",
+   "sha256": "0gnjal5ikz2g5ac7h1lx8hwkix0j18l6sg26ydn6wdhix2yjdfmq"
   },
   "stable": {
    "version": [
@@ -79804,14 +80164,14 @@
   "repo": "countvajhula/mindstream",
   "unstable": {
    "version": [
-    20250330,
-    201
+    20250821,
+    2237
    ],
    "deps": [
     "magit"
    ],
-   "commit": "5ebd1846e67cb7cb8480511825cf76269aa32d00",
-   "sha256": "10j10wga3yimg9rgn35h1rj04ziyyk8z97ap0xzjq27w1np5d1md"
+   "commit": "f76934cdda1c5aa3cf6e64c7ffab350ee97bc22d",
+   "sha256": "1rpclgn126dw1h86cx7zh181sc03ixa7pd9hzjhiw1p03kd0l45p"
   },
   "stable": {
    "version": [
@@ -80120,20 +80480,20 @@
  },
  {
   "ename": "minitest",
-  "commit": "41b2e55c0fe48267dc4f55924c782c6f934d8ca4",
-  "sha256": "0x6nd4kkhiw8hh79r69861pf41j8p1y39kzf2rl61zlmyjz9zpmw",
-  "fetcher": "github",
-  "repo": "arthurnn/minitest-emacs",
+  "commit": "3a2e88b34d43f51cde46af301aaa4f06467e3fbc",
+  "sha256": "0zcvj3lfgj7fy7plf4h9yh012s1nngwdf7c5yy9yxiwbgqjninaz",
+  "fetcher": "sourcehut",
+  "repo": "shoshin/minitest-emacs",
   "unstable": {
    "version": [
-    20231222,
-    1521
+    20250803,
+    49
    ],
    "deps": [
     "dash"
    ],
-   "commit": "5999c45c047212cee15a2be67e78787776a79c35",
-   "sha256": "0xzc95r9j36jmgvwqb5l8jf6390w4nji423jrzg7xv0a6l47y4br"
+   "commit": "d278e94fb1874c584699e1d6fa1b34224c1f8550",
+   "sha256": "1snkk3fqhaaaxbhlshfvmpq1bs2bcbgmamm7fncgaz5kkv3d0x0n"
   },
   "stable": {
    "version": [
@@ -80240,28 +80600,28 @@
   "repo": "milanglacier/minuet-ai.el",
   "unstable": {
    "version": [
-    20250619,
-    554
+    20250819,
+    2310
    ],
    "deps": [
     "dash",
     "plz"
    ],
-   "commit": "8dc40b5e6b92e6c54a664afcb917caa954673e90",
-   "sha256": "0ggcqpcx2cbz66ixjnd1zi9wminksx4k2h2pciv8nihmj01hx0di"
+   "commit": "3d0a2aca430313bd6c311c6530ec8d43f9a68937",
+   "sha256": "06d1g3ahb8ar2mr68flb99z2nkbnhyaqiv1skp20j24bgk1sz01l"
   },
   "stable": {
    "version": [
     0,
-    5,
-    4
+    6,
+    0
    ],
    "deps": [
     "dash",
     "plz"
    ],
-   "commit": "8e4075713885f7ec7253936e3e74c7860ce7f77f",
-   "sha256": "0r8316spbcmv9nsqhmw5df3cwghbra4ncck0dzihjn9agss7zj27"
+   "commit": "a6f4daf27e5816dc9cddf744a844a007084a93ac",
+   "sha256": "15zhdzbk2nsn0gxawpzg9vlsqmddbhnv7jg896kjhsf1if12bvmi"
   }
  },
  {
@@ -80311,15 +80671,15 @@
   "repo": "eki3z/mise.el",
   "unstable": {
    "version": [
-    20250706,
-    357
+    20250804,
+    517
    ],
    "deps": [
     "inheritenv",
     "llama"
    ],
-   "commit": "af4796442b99f6f3b58c52790d0cd32bb250b540",
-   "sha256": "10b7nsnkaxcf6dfhnw9h0h6z3hbv4892wa0ycl1rc27nl2lk0cvr"
+   "commit": "9c7e891ddbe5726fd26943f4abed9fee800aac18",
+   "sha256": "0as4r1z6shn4i9gvvwri20vw2v4jxn33ss6mv8xv8jhxdg64rys9"
   },
   "stable": {
    "version": [
@@ -80343,11 +80703,11 @@
   "repo": "szermatt/mistty",
   "unstable": {
    "version": [
-    20250708,
-    1715
+    20250716,
+    1914
    ],
-   "commit": "1418f8f356e3af54ffa434225445b70746a8c786",
-   "sha256": "0dg14vi4c97azs59adxirp84ppjr2s8mn92z6vbhdyvlrk1619f1"
+   "commit": "bfb17611cff6c845270050a0756a38489cdf4ed6",
+   "sha256": "16pxd68g37d1knnw4i2y7dii3h95prfradl6y04jbz5hpjsq9122"
   },
   "stable": {
    "version": [
@@ -80798,14 +81158,14 @@
   "repo": "tarsius/mode-line-debug",
   "unstable": {
    "version": [
-    20250531,
-    2220
+    20250815,
+    1335
    ],
    "deps": [
     "compat"
    ],
-   "commit": "0cb356097366e25dc9a4c95811a8a21a40b9de56",
-   "sha256": "17q8pxb8x90ghqha70r7mkdr540a6mw6l1j1dcvy9bw51hyfk5rx"
+   "commit": "a3f9adf892908dac0fcb2a000934d824c599ab67",
+   "sha256": "02qg29sz07ywjbf8q9d29n6n7j0f8kl5psnb23d2md3f2czg49pv"
   },
   "stable": {
    "version": [
@@ -80996,20 +81356,20 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20250707,
-    1714
+    20250718,
+    410
    ],
-   "commit": "6639604271fc5bef2dcdd2b0af2d9bcb2259f8b6",
-   "sha256": "0kdw2q1i8f6b0slvfjrmk9frn00y5v4sa44kbb5fw53wlaxkbhbc"
+   "commit": "f4e67c80c94fcae23f87517902a10eccc8ad99d6",
+   "sha256": "16k99i1rvw7x5hp4sgvhz2crmim8g8bzj8hkiqrfgzmb8hjr7hsm"
   },
   "stable": {
    "version": [
     4,
     8,
-    0
+    1
    ],
-   "commit": "b7aa3ae780975b6dda98a75197a6ff89876bb7b7",
-   "sha256": "1nwb5jb58pg3fskc98qvxjv3ikfiwbzdkgxwpmvw13bhhwcmc408"
+   "commit": "2f19a515110f7fcc407fcc32b9cdfdb26a853eb5",
+   "sha256": "1ivgs7hqgw8ndx76qzqmdg35ga4bwqcph7z0khqsy8xzg5qr299g"
   }
  },
  {
@@ -81187,11 +81547,11 @@
   "repo": "ideasman42/emacs-mono-complete",
   "unstable": {
    "version": [
-    20250611,
-    321
+    20250821,
+    509
    ],
-   "commit": "3e4b84606f2c5c4563c4491ca63f88baf5b0f465",
-   "sha256": "03maki7gdwywdj76s4x810ci2562ijpsxv6i25jfz1pydzx8fa97"
+   "commit": "341f7a5871e8416ee9ebc1527893ecbe7ae6a3c3",
+   "sha256": "0pz44126czm3bajgj7jdbz0vwdgnj142g81whnknlp4d4wbdxzhk"
   }
  },
  {
@@ -81358,14 +81718,14 @@
   "repo": "tarsius/moody",
   "unstable": {
    "version": [
-    20250701,
-    1218
+    20250815,
+    1811
    ],
    "deps": [
     "compat"
    ],
-   "commit": "404400af5415a35b5639dd1bfbc192751e85d737",
-   "sha256": "1m92yac6h4kzswwmjxc3qjhbqcmrgv6243h5zdpqbqrgkc9wmjp6"
+   "commit": "f20101353fb89db8266107b82d3d82d2eead8ed5",
+   "sha256": "1rz2jai5gjs2n7ny6an9d8hbvgkdmvjikk8qvlj0fnx4ysxlar6f"
   },
   "stable": {
    "version": [
@@ -81388,11 +81748,11 @@
   "repo": "takaxp/moom",
   "unstable": {
    "version": [
-    20250620,
-    1635
+    20250817,
+    1347
    ],
-   "commit": "32c9ebafe80b51677605ffc1c37f555fdf5738c8",
-   "sha256": "132zyaln89vvcaq1jmdgf0cn8v8vc01kjnyyn14m18pms4dz3wnw"
+   "commit": "2683e801d3c7be537ddf8b6af5154c0b86fafeb6",
+   "sha256": "15q7qzm400qa7psv6vr2ady1b0f5bxk32qfyl55glfkx26vxp41x"
   },
   "stable": {
    "version": [
@@ -82073,14 +82433,26 @@
   "repo": "lorniu/mpvi",
   "unstable": {
    "version": [
-    20250702,
-    632
+    20250825,
+    1331
    ],
    "deps": [
     "emms"
    ],
-   "commit": "fe03352032dd7bb5b9b3818086091b13353138f1",
-   "sha256": "0y67vmkhq5nadv8bkm8xl658hh8i9x7hyq4wxmwg4dl1ak0l49jg"
+   "commit": "c8f8ca22f156456a231e7c6195c5d7da167ef23d",
+   "sha256": "06mji6gw2hs3zqwf7ik1d4wvdbcw3m50ff0rc7mnj5z8hijf74xr"
+  },
+  "stable": {
+   "version": [
+    1,
+    3,
+    0
+   ],
+   "deps": [
+    "emms"
+   ],
+   "commit": "f423ffb7116ff4ab2c1f0207cb38f4ec2bc9660a",
+   "sha256": "13knfdlnam5ahmghdavvjvdk7pjbna5hfj9cxr7dg0lz1zzmv4ya"
   }
  },
  {
@@ -82470,8 +82842,8 @@
   "repo": "mihaiolteanu/mugur",
   "unstable": {
    "version": [
-    20241028,
-    828
+    20250730,
+    1328
    ],
    "deps": [
     "anaphora",
@@ -82479,8 +82851,8 @@
     "dash",
     "s"
    ],
-   "commit": "757e06ba7a062a12e5976a5ce2a47f23eaa454af",
-   "sha256": "1hfbib09a224dysh9synwqzdj3rrgcl2az9zm05xcnlbxcnhgjv4"
+   "commit": "ee43cd1ab5ae687882b7d5f3eb05b0e34c3fc0a0",
+   "sha256": "1nb23izva319iq3vm3crx0k4jblfa4z6mziaglcgprac4bfydqgr"
   },
   "stable": {
    "version": [
@@ -83918,11 +84290,11 @@
   "repo": "rainstormstudio/nerd-icons.el",
   "unstable": {
    "version": [
-    20250621,
-    1548
+    20250815,
+    814
    ],
-   "commit": "4476b4cabe63f5efafa3c0a8b370db4f6a92e90c",
-   "sha256": "1d345y4z9j2m065j03kd6zb8hcr139mqzvpvxmg1147hrb9w25hn"
+   "commit": "e98b14248fec120cc23c5f3a5aa1128d98156c2c",
+   "sha256": "0162hhvm9cqcxxaj3g918p06kcbhzk2iyy1hckdvagsg7sb24cjn"
   },
   "stable": {
    "version": [
@@ -83942,15 +84314,15 @@
   "repo": "rainstormstudio/nerd-icons-completion",
   "unstable": {
    "version": [
-    20250509,
-    1949
+    20250811,
+    751
    ],
    "deps": [
     "compat",
     "nerd-icons"
    ],
-   "commit": "e15e21a263bad06424982c11e8d68ffe1372a4e7",
-   "sha256": "08ianr8dwxal6dw674ngnaiw6k5kwvsfldmzxhj0fwsqg7ah90l3"
+   "commit": "5625ef374d428e69f96c2f95858c8bc4db6f7679",
+   "sha256": "1mxrdwxs0wxfnm308af9jsgmk6qk91hday7dz4v2k87mljmfgrnn"
   }
  },
  {
@@ -83961,26 +84333,26 @@
   "repo": "LuigiPiucco/nerd-icons-corfu",
   "unstable": {
    "version": [
-    20250319,
-    2322
+    20250729,
+    1544
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "55b17ee20a5011c6a9be8beed6a9daf644815b5a",
-   "sha256": "0h2iphhsag77f14nj95fhkz7yv2ql94acj0c835x2ypkprqrs86w"
+   "commit": "f821e953b1a3dc9b381bc53486aabf366bf11cb1",
+   "sha256": "036p45wqwrqhn5xv5sn3gsm2mb79gj6fk24zpkfa7wrv45qqgb21"
   },
   "stable": {
    "version": [
+    1,
     0,
-    5,
-    1
+    0
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "55b17ee20a5011c6a9be8beed6a9daf644815b5a",
-   "sha256": "0h2iphhsag77f14nj95fhkz7yv2ql94acj0c835x2ypkprqrs86w"
+   "commit": "f821e953b1a3dc9b381bc53486aabf366bf11cb1",
+   "sha256": "036p45wqwrqhn5xv5sn3gsm2mb79gj6fk24zpkfa7wrv45qqgb21"
   }
  },
  {
@@ -83991,14 +84363,14 @@
   "repo": "rainstormstudio/nerd-icons-dired",
   "unstable": {
    "version": [
-    20250506,
-    1729
+    20250727,
+    1932
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "69b5d3176b7bb08ac1f477cf7c5a491b9b0b5b54",
-   "sha256": "1q6zyx2m4h9fnirphrw933w9hrz7s5gk0sqgazgyg57szd99bzc2"
+   "commit": "5df0dd57022d0b3f565e05c5d9b3a8a723236676",
+   "sha256": "1zp41j9ly1b8b82kc0lai98l9m98fvy5xsvzsmv77jff333zam25"
   }
  },
  {
@@ -84576,6 +84948,24 @@
   }
  },
  {
+  "ename": "ninetyfive",
+  "commit": "10c81234ec893a747379c266d566cc26733bfde7",
+  "sha256": "0a5m6v3iailj1camdi7z5iljj33fsgn9w73rbagxkhkhpy47q7y7",
+  "fetcher": "github",
+  "repo": "ninetyfive-gg/ninetyfive.el",
+  "unstable": {
+   "version": [
+    20250819,
+    2039
+   ],
+   "deps": [
+    "websocket"
+   ],
+   "commit": "6c3b47e4a53ce18e62e7a24f01988ac370d3dfe4",
+   "sha256": "0s2049jga3q28kbd4qrl0rka8d0cn6ii2sk1539wcqp7ickpf4w7"
+  }
+ },
+ {
   "ename": "ninja-mode",
   "commit": "7c157fd47c9b7783c8bef103eaa42d0f5a626026",
   "sha256": "1xsx71znz85afr73a3nz2ks85bak6fa7kanp48k2bmigy3r4b6j5",
@@ -84751,11 +85141,11 @@
   "repo": "nix-community/nix-ts-mode",
   "unstable": {
    "version": [
-    20240930,
-    651
+    20250819,
+    1504
    ],
-   "commit": "9419d014cada54d34e5004e24a31462e8597fd28",
-   "sha256": "192j4ypqkqnk37bsi9dv0z1mss2pmhmk9x654afyh1mgag30klwb"
+   "commit": "414b18a8a7c9335a1d67c87acc57d5ef2a06a30e",
+   "sha256": "0bv0lwgdhd1xj8cb7ql8pydinqafpnqc1v13cj4mi139ahz991cs"
   },
   "stable": {
    "version": [
@@ -84775,11 +85165,11 @@
   "repo": "jwiegley/nix-update-el",
   "unstable": {
    "version": [
-    20241123,
-    2159
+    20250817,
+    1556
    ],
-   "commit": "77022ccd918d665acbb519b243e7e3dc5eae1c47",
-   "sha256": "18p4wf3f149n27d1divkzd39y1iy75ig2986flzfd06l8x1d2fa3"
+   "commit": "d67f4f7ba8c8ec43144600f5f970c5fd958fc2f7",
+   "sha256": "151mfjfg16v2xp327cmq3wwdzbmjyv68w26z7br5wvqqkfwn8pi0"
   }
  },
  {
@@ -85026,26 +85416,26 @@
   "repo": "emacscollective/no-littering",
   "unstable": {
    "version": [
-    20250701,
-    1219
+    20250812,
+    1334
    ],
    "deps": [
     "compat"
    ],
-   "commit": "57a7b63fe467eb89b716fdd1729d47f0b789727b",
-   "sha256": "1kpr982w1syr65jdjg72ivqgdhk133a1rx2jwwnwc9rph2xmmwkk"
+   "commit": "5930b1c6de1b54890c25b1d862071e9274f1b2db",
+   "sha256": "1jcyjchy6w2a57q22mcadf5rbsw58nmhf5z7i3q137z4m5z8mh05"
   },
   "stable": {
    "version": [
     1,
     7,
-    8
+    9
    ],
    "deps": [
     "compat"
    ],
-   "commit": "57a7b63fe467eb89b716fdd1729d47f0b789727b",
-   "sha256": "1kpr982w1syr65jdjg72ivqgdhk133a1rx2jwwnwc9rph2xmmwkk"
+   "commit": "f12c3d9e44c4be099c226114ac95586f4d50df05",
+   "sha256": "1kjdx3g9vpb6yywalrmq475s4mgxy82dvl5iinhdj3rl3zdhjkzh"
   }
  },
  {
@@ -86394,20 +86784,20 @@
   "repo": "will-abb/aws-athena-babel",
   "unstable": {
    "version": [
-    20250709,
-    12
+    20250713,
+    2235
    ],
-   "commit": "9ae4c947f070f0c6ad3ae28e7c78c306b39154cb",
-   "sha256": "15llx7z1p5w625q8kk4q4ry5p142if4mqv6j9mbljz9zya7y0l43"
+   "commit": "654e20311635c6b371030c0442f5d27105e94f07",
+   "sha256": "1dqfcs6cqkz14cxf3pbrp2nrvnyvg6lmj2bkxydzdg8ycfncxzf8"
   },
   "stable": {
    "version": [
     2,
     1,
-    2
+    3
    ],
-   "commit": "33679e231335e88ddf8b05a5a5809829d2d1faf8",
-   "sha256": "0hg8gajh46p593k0prqf6i01z0wm9vkcnmi3v5za38rd5yg6361w"
+   "commit": "9ae4c947f070f0c6ad3ae28e7c78c306b39154cb",
+   "sha256": "15llx7z1p5w625q8kk4q4ry5p142if4mqv6j9mbljz9zya7y0l43"
   }
  },
  {
@@ -87516,14 +87906,14 @@
   "repo": "alf/ob-restclient.el",
   "unstable": {
    "version": [
-    20231228,
-    1403
+    20250806,
+    2153
    ],
    "deps": [
     "restclient"
    ],
-   "commit": "8183f8af08838854cf145ca4855b373f3e7c44b0",
-   "sha256": "1llgr2sw2466y4ihrnrrdv68hkvhgdyd17gsl5rlzjv41x5iqmc7"
+   "commit": "94dd9cd98ff50717135ed5089afb378616faf11a",
+   "sha256": "1znj8v0wh1hl4fijza665fqnbarsjc0draiph4ifg3dwxskhg3d3"
   }
  },
  {
@@ -88044,11 +88434,11 @@
   "repo": "tarides/ocaml-eglot",
   "unstable": {
    "version": [
-    20250428,
-    129
+    20250716,
+    1427
    ],
-   "commit": "90efa3dc9fdef671e142f641a7f9d9556c0215f9",
-   "sha256": "0hk38rc7qf7v4ga155br5v3d6p5ki974fdqn63f293h880iknsz4"
+   "commit": "2d64c6460571bcfccc5ada74d6d7ac449d20f325",
+   "sha256": "15d03sqf8mhskrfj6x38n8v3za7qnxzqhjdxkza42fx231w2h4nc"
   },
   "stable": {
    "version": [
@@ -88298,26 +88688,26 @@
   "repo": "oer/oer-reveal",
   "unstable": {
    "version": [
-    20250623,
-    1056
+    20250826,
+    1503
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "3d2b94ecc9489c85a8bac09a3bdb690b0df1a9c6",
-   "sha256": "1r6rwiz53jd29w52spg8hslkmc105vpm5wscn01y2sc1m2njs058"
+   "commit": "20456112467fa6c962b242d1d6d4ddcc66488bd3",
+   "sha256": "16fmsczxzl19042i3qr48x3cynh9dj8kj9xglliq6a67nyz8c548"
   },
   "stable": {
    "version": [
     4,
-    32,
+    33,
     0
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "e942059cdaf5ef36fcc7f1473c7261f9bb9bb740",
-   "sha256": "1lxmj4w9nqrh7i45jh528wjplbr4zs36d4ryjck1ankszgqvz02x"
+   "commit": "b115947c3d22b5db39bfed9a43a0bdee112be146",
+   "sha256": "1qgxxydml9bibqiq5sqd4rjvmc8qdvrc136nlngqaan13bxkhfi8"
   }
  },
  {
@@ -88358,6 +88748,21 @@
    ],
    "commit": "6d586cb108c642bc166c64df113e03193f4d1495",
    "sha256": "0xjm365zd6jiv3aqa2cknb7b813d6pq854qj73hkffkp6dm0yxih"
+  }
+ },
+ {
+  "ename": "ol-bible",
+  "commit": "df5147d749e3ddf8b1471b2b15e470ec7a10d96d",
+  "sha256": "1lpvm2smpnwi3gycci7zl44fr8pxyk827m1zcqk692yza5rc7lfk",
+  "fetcher": "sourcehut",
+  "repo": "swflint/ol-bible",
+  "unstable": {
+   "version": [
+    20250819,
+    1543
+   ],
+   "commit": "b67ff8c45d51af9fa71aa44bacb4a872f6b750c6",
+   "sha256": "0ipx60r8vpjqyan40qv78xg3rbra84yf87bqndz87f6n3h52pc6g"
   }
  },
  {
@@ -88498,20 +88903,20 @@
   "repo": "captainflasmr/ollama-buddy",
   "unstable": {
    "version": [
-    20250621,
-    851
+    20250723,
+    759
    ],
-   "commit": "2c2d4723a83b9a243d6f4f5ab81161cfd16bb4e0",
-   "sha256": "107ddm7sn83kjilwkrzak2dnsivzn1vjipaynnra3vyqdj5yhrx5"
+   "commit": "829bfc32aa3cb28b6f2b60f151cfe1b0b2f761f0",
+   "sha256": "17jrpmj5wnafwsbvwrdfds9c92nflcf5sipd37ci4gsjckd83wvq"
   },
   "stable": {
    "version": [
+    1,
     0,
-    2,
     0
    ],
-   "commit": "4b5f89f765b8e8465d51efe6062b9242122de189",
-   "sha256": "0mq74zb3jr0i3p9p4qicm31yym0wmq3i846ayg9qb4vdf94amz4l"
+   "commit": "829bfc32aa3cb28b6f2b60f151cfe1b0b2f761f0",
+   "sha256": "17jrpmj5wnafwsbvwrdfds9c92nflcf5sipd37ci4gsjckd83wvq"
   }
  },
  {
@@ -88811,15 +89216,15 @@
   "repo": "tonyaldon/one.el",
   "unstable": {
    "version": [
-    20231205,
-    1423
+    20250824,
+    1102
    ],
    "deps": [
     "htmlize",
     "jack"
    ],
-   "commit": "fa52cf0144f89eabee06f598b021a37087c69670",
-   "sha256": "1qk7xcca7inkwmdwcai4j43pb2nr8s89c4s0hjmc1bp3grryqrqj"
+   "commit": "0960d56c5a28820e28ba35fce9b204af0dcb558d",
+   "sha256": "09fmw9n970gw9nmbaxlc9v3mzigd81ch1q74kjhny6gaz418a64a"
   },
   "stable": {
    "version": [
@@ -89233,25 +89638,25 @@
   "repo": "oantolin/orderless",
   "unstable": {
    "version": [
-    20250705,
-    2023
+    20250728,
+    243
    ],
    "deps": [
     "compat"
    ],
-   "commit": "082a487f79ca5e960046a31599a5f97dac79a858",
-   "sha256": "112y64hq8zbwj1a0w7i7nl2kbrsyhipdwylfhsd0fb4z28j570sw"
+   "commit": "31812d9252c6cfa7eae8fa04cd40c8b2081e9936",
+   "sha256": "0cgklam29vsfrl70n3cqv1dxbsnpzjylfxabfs9v1yz02q27nggv"
   },
   "stable": {
    "version": [
     1,
-    4
+    5
    ],
    "deps": [
     "compat"
    ],
-   "commit": "254f2412489bbbf62700f9d3d5f18e537841dcc3",
-   "sha256": "1la91fk322n600h4wnavx7a6rdc44mz4v4gg1fb3cpwjsw746sl8"
+   "commit": "31812d9252c6cfa7eae8fa04cd40c8b2081e9936",
+   "sha256": "0cgklam29vsfrl70n3cqv1dxbsnpzjylfxabfs9v1yz02q27nggv"
   }
  },
  {
@@ -89310,6 +89715,25 @@
    ],
    "commit": "9cbbda79e2fe964ded3f39cf7a2e74f1be3d6b9a",
    "sha256": "1xckin2d6s40kgr2293g72ipc57f8gp6y63303kmqcv3qm8q13ca"
+  }
+ },
+ {
+  "ename": "org-agenda-dock",
+  "commit": "3d34ba744444cb8c777968fcb2e94e7affa96413",
+  "sha256": "002pxsjlsfchvmmsf07mvm8jgmqva86b16kxsmv8r0zy1804m144",
+  "fetcher": "github",
+  "repo": "hron/org-agenda-dock",
+  "unstable": {
+   "version": [
+    20250809,
+    703
+   ],
+   "deps": [
+    "dock",
+    "org"
+   ],
+   "commit": "1a0d37f471b6a8f5e9320b6bc97c5932ff83743b",
+   "sha256": "02p3fasfdvckp1r1bbcbs73p666bj6bf466qy2ayqcngfnjn5ch3"
   }
  },
  {
@@ -89545,11 +89969,20 @@
   "repo": "bkaestner/org-arbeitszeit",
   "unstable": {
    "version": [
-    20220816,
-    1447
+    20250724,
+    1857
    ],
-   "commit": "2598fb45a182d22e6d7579d55139db80e8af0b02",
-   "sha256": "1vz1grgpw4gpwzlybfvfchxj15bv9j375zx0z55zd3vv9l316lfa"
+   "commit": "7f8c50e1dea3595bbf3e79f5a5737f7336478a92",
+   "sha256": "0krxainwpn7bnnvbrrhivmh302i9dyfixs6l5wb7xw7qpjgwqzc8"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    5
+   ],
+   "commit": "7f8c50e1dea3595bbf3e79f5a5737f7336478a92",
+   "sha256": "0krxainwpn7bnnvbrrhivmh302i9dyfixs6l5wb7xw7qpjgwqzc8"
   }
  },
  {
@@ -89783,11 +90216,11 @@
   "repo": "jonnay/org-beautify-theme",
   "unstable": {
    "version": [
-    20170908,
-    2218
+    20250730,
+    2044
    ],
-   "commit": "df6a1114fda313e1689363e196c8284fbe2a2738",
-   "sha256": "1lkz7736swimad12khwbbqc4gxjydgr1k45p4mx03s25pv1w920y"
+   "commit": "5301f8cfab127f4219aad83e52787898f0710d4f",
+   "sha256": "0xp2yvbnflxs6abwic0nzlxxgaj78hfyij9jgmyn92fc8g7i2v6n"
   },
   "stable": {
    "version": [
@@ -89859,14 +90292,14 @@
   "url": "https://repo.or.cz/org-bookmarks.git",
   "unstable": {
    "version": [
-    20250619,
-    104
+    20250813,
+    918
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "965f5aab0586fe57ebbd978d4d0ef247dc8f7576",
-   "sha256": "17q0jicl63i1npmfb3cy95j2xn8bmjc4j7z74359bcj5xx5dqwh1"
+   "commit": "32c0790c7f116d1346e8727374baacd4254c2c27",
+   "sha256": "1xxzdmaal2pyj4a7kv5ai7qp1ql84d9wm47chp339rw476d3xm1w"
   },
   "stable": {
    "version": [
@@ -90112,14 +90545,14 @@
   "repo": "Chobbes/org-chef",
   "unstable": {
    "version": [
-    20250608,
-    130
+    20250714,
+    107
    ],
    "deps": [
     "org"
    ],
-   "commit": "6a6bccfd857d3fc03aa79e0a09fed5733af2c5c3",
-   "sha256": "1mr1ws1mcn8qsgb7sl2yfflngqcmmsr0a3nkxn3nm8072846wnqa"
+   "commit": "9f749324f7e8c51a2da8516820268c83e825c6c7",
+   "sha256": "0ii763fhfrd47ivkndml09ivn5s21vy35a182xasb42bji8mmqv8"
   }
  },
  {
@@ -90355,14 +90788,14 @@
   "url": "https://repo.or.cz/org-contacts.git",
   "unstable": {
    "version": [
-    20250619,
-    321
+    20250820,
+    1803
    ],
    "deps": [
     "org"
    ],
-   "commit": "3a592c71b5352f36d3584b393841b4c6a2adb638",
-   "sha256": "1yb16fppvcp4pllckkwakh01a8vj6mv510prz90x9q608yg1wcvh"
+   "commit": "532dcbf680dcd8f1b314a19628b71d381c38aee2",
+   "sha256": "05alncn93blpyy317797l182znczrjsb5wnhvn5lg4s5v3fmi3nw"
   }
  },
  {
@@ -90628,27 +91061,6 @@
   }
  },
  {
-  "ename": "org-drill-table",
-  "commit": "3347da186765877826b224e1f5d1b585ebd3692c",
-  "sha256": "1gb5b4hj4xr8nv8bxfar145i38zcic6c34gk98wpshvwzvb43r69",
-  "fetcher": "github",
-  "repo": "chrisbarrett/org-drill-table",
-  "unstable": {
-   "version": [
-    20180115,
-    1009
-   ],
-   "deps": [
-    "cl-lib",
-    "dash",
-    "org",
-    "s"
-   ],
-   "commit": "e4c4c1b0a17f51cb8de67eafe06a6bffc754f525",
-   "sha256": "1nzn890z30l062flbnww9f3nq7wm5x5146rh76az8h7jm6vigvca"
-  }
- },
- {
   "ename": "org-dropbox",
   "commit": "cd613fbe42c41b125a25dfa0206666446dc5fa40",
   "sha256": "0qfvdz13ncqn7qaz03lwabzsnk62z6wqzlxlvdqv5xyllcy9m6ln",
@@ -90889,11 +91301,19 @@
   "repo": "lorniu/org-expose-emphasis-markers",
   "unstable": {
    "version": [
-    20250520,
-    205
+    20250726,
+    28
    ],
-   "commit": "eff78856b3ba3382d3dae46eabae02f0dd210213",
-   "sha256": "17szxnpp7b0f8rqfrg6pfcw288kfsj11s19x77bxbkzpnfxbj0pf"
+   "commit": "5ca3994f2e13b342e0b9d353b66b892e34c7b784",
+   "sha256": "1sn90262rcrqmmwy45dz8vdd10sv7d5m2dmzz79f5lj6kh90h5zw"
+  },
+  "stable": {
+   "version": [
+    0,
+    21
+   ],
+   "commit": "ba81ff4866326dae63b5eecf2643abb444de32a3",
+   "sha256": "1596r4ix0yas2qwrf38kj14dxdrns0m5622kxvapg7kin67kbifk"
   }
  },
  {
@@ -91167,15 +91587,15 @@
   "repo": "dmitrym0/org-hyperscheduler",
   "unstable": {
    "version": [
-    20220704,
-    2140
+    20250716,
+    1801
    ],
    "deps": [
     "log4e",
     "websocket"
    ],
-   "commit": "b7f33e7bf19b7ce7c81dbac4de765a854ee7f52f",
-   "sha256": "0h7r8rxb4aldr31awl8w7fk82nghh5g8ayz9yspyqr3ix4q4n8z7"
+   "commit": "f40e3df279452dc0cb8506de3bfb6acbf2df79c1",
+   "sha256": "105454550nqczg4rd19k97i1gjy6210w541h31zywky4j616dapw"
   },
   "stable": {
    "version": [
@@ -91248,8 +91668,8 @@
  },
  {
   "ename": "org-incoming",
-  "commit": "1f63ea5ac2c7ce864172effa33ea8387095f23f4",
-  "sha256": "05cxa22vj8rm4xy57scwcgkrypjbc0c5zh9127c35pmqzab3wbad",
+  "commit": "abd059db58d08c881df15cc8c89fca90252771fe",
+  "sha256": "0fcrh4q5726zw4q33qh667qh0hbq9z21qchsfs0asmmj4rbmznzj",
   "fetcher": "github",
   "repo": "tinloaf/org-incoming",
   "unstable": {
@@ -91497,16 +91917,16 @@
   "repo": "ahungry/org-jira",
   "unstable": {
    "version": [
-    20250424,
-    41
+    20250802,
+    302
    ],
    "deps": [
     "cl-lib",
     "dash",
     "request"
    ],
-   "commit": "dfdc26ab8bfb54f4419d3eb52a17be5361d74b87",
-   "sha256": "1k2h7f2i9r73rxl4lnd0i9x3z63l54fg9dnav68f15f9pqmnh209"
+   "commit": "c7259fa13b8eb99a988b06cdaf3a04f9109904de",
+   "sha256": "0r4chf0gchhwarrr7rnhf0fpgczqgjmcirlw6cdc87x8lyx7as13"
   },
   "stable": {
    "version": [
@@ -91576,16 +91996,16 @@
   "repo": "SqrtMinusOne/org-journal-tags",
   "unstable": {
    "version": [
-    20241229,
-    1923
+    20250824,
+    823
    ],
    "deps": [
     "magit-section",
     "org-journal",
     "transient"
    ],
-   "commit": "f9959a4de148094e01e9f0b6232f61c6ff320eaa",
-   "sha256": "03glaxna9k4hnlw8grxm100w44p6blndnl3hngw2i8h8fly1bb4n"
+   "commit": "e815fe09e05a53482b86470c774422c2d49e2754",
+   "sha256": "05ylc3fibqs8lgfvq9qimqm2nsy99p0cvysvxlaiw8xawqi1c8k9"
   },
   "stable": {
    "version": [
@@ -91704,15 +92124,15 @@
   "url": "https://repo.or.cz/org-link-beautify.git",
   "unstable": {
    "version": [
-    20250606,
-    129
+    20250821,
+    537
    ],
    "deps": [
     "nerd-icons",
     "qrencode"
    ],
-   "commit": "ce90824b7e5a7ef44568e64cef0848a51a955c64",
-   "sha256": "18kgskfvwakvxq12h77f6n1yxsvgilwm3qlnhfazvfcflhs56bk6"
+   "commit": "01d015a3b5935cfd69a6a4fafaf30fd3c5d80643",
+   "sha256": "0hp0h2mqgc0ayr5cgdzmjs440ivz84jr887vw79wh07ga025qydq"
   },
   "stable": {
    "version": [
@@ -91873,28 +92293,28 @@
   "repo": "meedstrom/org-mem",
   "unstable": {
    "version": [
-    20250621,
-    2137
+    20250715,
+    1048
    ],
    "deps": [
     "el-job",
     "llama"
    ],
-   "commit": "3ef1012cd7730d47d44fd19084a906f82d739778",
-   "sha256": "0r7yv40p6svvcznr6lzfffmj0dypnbsyxj0xvx1p72f75krn0vxh"
+   "commit": "a99cd068737caf5d9d6c1ea7444f8a6b3c2e57a7",
+   "sha256": "1nm1avc0hbvhr43vkfw3jssiqyckd7ba6jw0qhvgcvk49df393wf"
   },
   "stable": {
    "version": [
     0,
-    17,
-    2
+    18,
+    1
    ],
    "deps": [
     "el-job",
     "llama"
    ],
-   "commit": "6048fc50c1899fd3764d15d216592d2798edc8f5",
-   "sha256": "12aqv1lay6g6vz02s0zqw4620agm0r3s5j87w16gvbawi240x096"
+   "commit": "a99cd068737caf5d9d6c1ea7444f8a6b3c2e57a7",
+   "sha256": "1nm1avc0hbvhr43vkfw3jssiqyckd7ba6jw0qhvgcvk49df393wf"
   }
  },
  {
@@ -92236,30 +92656,30 @@
   "repo": "meedstrom/org-node",
   "unstable": {
    "version": [
-    20250704,
-    1816
+    20250718,
+    1701
    ],
    "deps": [
     "llama",
     "magit-section",
     "org-mem"
    ],
-   "commit": "090bac4bccbddbc18aa360c9c3dc724fc43dc789",
-   "sha256": "0q918yz6fkgg3l8qqgzvz8cgdrkxk644iljlibb8lv43dk1d8bvq"
+   "commit": "c032a0bc238dd8df5a71868cd5c736e258dd9918",
+   "sha256": "1xlxf12g16abizfb0y86kfcyq62v8z538dawmy8sxc0232d41iy7"
   },
   "stable": {
    "version": [
     3,
     7,
-    2
+    4
    ],
    "deps": [
     "llama",
     "magit-section",
     "org-mem"
    ],
-   "commit": "090bac4bccbddbc18aa360c9c3dc724fc43dc789",
-   "sha256": "0q918yz6fkgg3l8qqgzvz8cgdrkxk644iljlibb8lv43dk1d8bvq"
+   "commit": "b5a07fcfb793ffc75dfab04962807b42d7d0b38e",
+   "sha256": "1cxzdyiqan4881m7fpzxym1gkplqlyagl3bj1pwa7a5bswhld40y"
   }
  },
  {
@@ -92323,15 +92743,15 @@
   "repo": "org-noter/org-noter",
   "unstable": {
    "version": [
-    20240918,
-    1703
+    20250730,
+    30
    ],
    "deps": [
     "cl-lib",
     "org"
    ],
-   "commit": "691efc3ed4a2828d791a148e53851365c2eb380f",
-   "sha256": "1fdvl818bmg530nk779jsp0v0xa07sr6y1xzd8x5m8pch13829vc"
+   "commit": "aafa08a49c4c3311d9b17864629aceeff02d33da",
+   "sha256": "12874pcl0rivlhj8jw3ih88gpgz179mr60hacw3dxf7h2ksylwch"
   },
   "stable": {
    "version": [
@@ -92538,16 +92958,16 @@
   "repo": "fuxialexander/org-pdftools",
   "unstable": {
    "version": [
-    20250630,
-    1734
+    20250714,
+    1631
    ],
    "deps": [
     "org",
     "org-noter",
     "pdf-tools"
    ],
-   "commit": "20d1ffd2b047c05a4bdf6735e51d2d7852d8f7bf",
-   "sha256": "1hvy8c64r2c73cy9dxd39wnzmhvsks2al3xdhfbrzi0a11jlvm1s"
+   "commit": "2b3357828a4c2dfba8f87c906d64035d8bf221f2",
+   "sha256": "1skyb7ph9i309bx13nwbc065k8r260qhqd67nh4anqd4nyb2xklp"
   }
  },
  {
@@ -92948,15 +93368,15 @@
   "repo": "oer/org-re-reveal",
   "unstable": {
    "version": [
-    20250606,
-    1856
+    20250821,
+    1332
    ],
    "deps": [
     "htmlize",
     "org"
    ],
-   "commit": "da7e1feba964cd5542515c1ca354a407e70bd06a",
-   "sha256": "1xq650vcyh4z4qlsgx96wf7xdlh06hvz93i1icybm8vi1lmm2nm3"
+   "commit": "ca0d49878760d7d6a044857f7be2f2ee91e166e5",
+   "sha256": "07hi41mi1bgf0mldh6rxhji8hddqk6b1gk92p2832wiv1v408687"
   },
   "stable": {
    "version": [
@@ -93127,8 +93547,8 @@
   "repo": "jkitchin/org-ref",
   "unstable": {
    "version": [
-    20250301,
-    1918
+    20250823,
+    1744
    ],
    "deps": [
     "avy",
@@ -93144,8 +93564,8 @@
     "request",
     "s"
    ],
-   "commit": "edbb80863ef63ef52ef04fce3239e063843f8d30",
-   "sha256": "1i55p4gyh6k83qyc5ka9gbikk969rwyavyy3w528wplngjfn5772"
+   "commit": "6a22c20f863b997497b618507adbcc8cb10a9f86",
+   "sha256": "0915v798xvybac3p53gwwf34v8p728s1s5msp29mw8j9n8zzcfbm"
   },
   "stable": {
    "version": [
@@ -93360,8 +93780,8 @@
   "repo": "ahmed-shariff/org-roam-ql",
   "unstable": {
    "version": [
-    20250702,
-    142
+    20250722,
+    1724
    ],
    "deps": [
     "dash",
@@ -93371,8 +93791,8 @@
     "s",
     "transient"
    ],
-   "commit": "24eac25bf666ec2f361a116d1711fe62c1f463c8",
-   "sha256": "0r1b2hk2lnm8csm58lqzdc3n41y5pfmsqg7kp9ifgqvxask6a8dv"
+   "commit": "9fb452eed0dc4ac8641d8629e4fa9f9fd0bdf6da",
+   "sha256": "01rjfjd88fpa20nivdinfnnbq5cm0s9madi7xgwqd09x04mqxsw5"
   },
   "stable": {
    "version": [
@@ -93701,8 +94121,8 @@
   "repo": "alhassy/org-special-block-extras",
   "unstable": {
    "version": [
-    20241227,
-    124
+    20250715,
+    1754
    ],
    "deps": [
     "dad-joke",
@@ -93713,8 +94133,8 @@
     "s",
     "seq"
    ],
-   "commit": "92443a7a346c60fd00e05464f9af7763a055e4ca",
-   "sha256": "158s48xznd1kfbrchqjlcm05jcbv1gcwmhzypq0klf0w4pbrhipy"
+   "commit": "1a236c783958782a4027e29dafc1efe488f443f1",
+   "sha256": "1km4dr78j9wy3w1hpvcm9kgrvgfvp975rzgy4pb1phgqx0xq89l4"
   },
   "stable": {
    "version": [
@@ -93764,6 +94184,25 @@
    ],
    "commit": "80bea9996de7fa8bc7ff891a91cfaff91111dcd8",
    "sha256": "0vfjj0854csra816040ihhlrsnxlaqnw3aqc18448ga7wbirrxs5"
+  }
+ },
+ {
+  "ename": "org-srs",
+  "commit": "57f34f093f9b3bff4ab088444828fee88d5a3fd4",
+  "sha256": "0i5ckxp3hg29l2g3cj07fjhhx2w0k65ghwcfi39p5imbyjsmjhxz",
+  "fetcher": "github",
+  "repo": "bohonghuang/org-srs",
+  "unstable": {
+   "version": [
+    20250818,
+    1726
+   ],
+   "deps": [
+    "fsrs",
+    "org"
+   ],
+   "commit": "51856d234b8683c3502b5366d0eee512061bce04",
+   "sha256": "1jlva1a5llrsxscg1qfab1a5s3bf6dxkcllhm9d5dgsycb644jyg"
   }
  },
  {
@@ -94038,6 +94477,21 @@
    ],
    "commit": "33b9966c33ecbc3e27cca67c2f2cdea04364d74e",
    "sha256": "1qx3kd02sxs9k7adlvdlbmyhkc5kr7ni5lw4gxjw3nphnc536bkb"
+  }
+ },
+ {
+  "ename": "org-table-highlight",
+  "commit": "3d1a4d411706b67c67bb1d15a31f7b75d83aed3a",
+  "sha256": "175176f415g9w8m569m8vdw0y712gyn38ppfks18i9gw0j41wb2j",
+  "fetcher": "github",
+  "repo": "llcc/org-table-highlight",
+  "unstable": {
+   "version": [
+    20250727,
+    544
+   ],
+   "commit": "bf2ed6ce251ff7b660526f082515e0589d74c2ed",
+   "sha256": "0basfq9y96sh5941i1ls7x0y6nvg6djbpg2b7n4kqx8z4vgcibqj"
   }
  },
  {
@@ -94618,20 +95072,20 @@
   "repo": "pinoaffe/org-vcard",
   "unstable": {
    "version": [
-    20250710,
-    1155
+    20250823,
+    1318
    ],
-   "commit": "92efba59824244defd4165ad0d65d53c882db209",
-   "sha256": "1s7ba46jmdi2j68yvvxc1rcmpq158wsqx04gc3anlb0m4agfjma1"
+   "commit": "d160870fa80b08007ea1a0f6bf1cc35f9ba6db1d",
+   "sha256": "1dbsiihs5rmnk35xqymabjrxprn5jrjf4wjrslb0kvz5ig4vphxq"
   },
   "stable": {
    "version": [
     0,
-    2,
+    3,
     0
    ],
-   "commit": "a6ab82ab28fa78f7c985d3ea9c9fafdd17f7ea8b",
-   "sha256": "14l3xqahqmnfl3sskqcr33xpcsic8dm9cr9wmbv5la3xv14n10k7"
+   "commit": "d160870fa80b08007ea1a0f6bf1cc35f9ba6db1d",
+   "sha256": "1dbsiihs5rmnk35xqymabjrxprn5jrjf4wjrslb0kvz5ig4vphxq"
   }
  },
  {
@@ -94764,40 +95218,6 @@
   }
  },
  {
-  "ename": "org-wild-notifier",
-  "commit": "114552a24f73f13b253e3db4885039b680f6ef33",
-  "sha256": "1lmpa614jnkpmfg3m1d2wjn9w0zig3gwd02n3dyjn23n71fiyhkp",
-  "fetcher": "github",
-  "repo": "akhramov/org-wild-notifier.el",
-  "unstable": {
-   "version": [
-    20240325,
-    744
-   ],
-   "deps": [
-    "alert",
-    "async",
-    "dash"
-   ],
-   "commit": "4c1679c12ebe0e4a97494d0673a5484f9e4d0ba6",
-   "sha256": "0d7zrawh4im8iyp2z32p4g8fbyznfq4liaxhavq89z8pliiv9zny"
-  },
-  "stable": {
-   "version": [
-    0,
-    5,
-    0
-   ],
-   "deps": [
-    "alert",
-    "async",
-    "dash"
-   ],
-   "commit": "aa0f2d8ea282dea714ae67f3f5a0471488e6e396",
-   "sha256": "00xssqg0mvh5ma2053719bcchbrl7mmj8wzhbrjk34cl4lx9p9fb"
-  }
- },
- {
   "ename": "org-working-set",
   "commit": "8df6c37b8d5b7f4a296e57ad1fd758cb99aff718",
   "sha256": "0dkwgci0s6znc25hcvj3a3djarwmwdjyx2lgfrf6sgbqd5l30s8l",
@@ -94906,8 +95326,8 @@
   "repo": "org2blog/org2blog",
   "unstable": {
    "version": [
-    20250204,
-    1933
+    20250722,
+    223
    ],
    "deps": [
     "htmlize",
@@ -94916,8 +95336,8 @@
     "writegood-mode",
     "xml-rpc"
    ],
-   "commit": "f0b4d73e0aa531f508d979ba2365880f064700f9",
-   "sha256": "136i9xrnx0xr6bpa51yjhrr28r9zmi2q22442w9cc1xahwd8b7ia"
+   "commit": "d0168606e60df2267b451dfe92975ad3f5c7919c",
+   "sha256": "1idz1jcxccicl6r45a6zbgjkhdc7p0pg1w1bp67yk10dhm2gvpsy"
   },
   "stable": {
    "version": [
@@ -95229,30 +95649,30 @@
   "repo": "tarsius/orglink",
   "unstable": {
    "version": [
-    20250531,
-    2228
+    20250801,
+    948
    ],
    "deps": [
     "compat",
     "org",
     "seq"
    ],
-   "commit": "1df4181ae33dc470ba0cbfa0f8f9efd2a6fec6d9",
-   "sha256": "0xcylj4nfs8jdi8qf6ymf7404zmr8l0lcbdwzj3xri3v0ki6q9v2"
+   "commit": "7dedd3b361b8bd031429e66f45daf83ee35e82d2",
+   "sha256": "0any5ff30v6qaf687hrga8x20wlpkf6ggqmnjdvxal0csnrnijbg"
   },
   "stable": {
    "version": [
     1,
     2,
-    6
+    7
    ],
    "deps": [
     "compat",
     "org",
     "seq"
    ],
-   "commit": "1df4181ae33dc470ba0cbfa0f8f9efd2a6fec6d9",
-   "sha256": "0xcylj4nfs8jdi8qf6ymf7404zmr8l0lcbdwzj3xri3v0ki6q9v2"
+   "commit": "7dedd3b361b8bd031429e66f45daf83ee35e82d2",
+   "sha256": "0any5ff30v6qaf687hrga8x20wlpkf6ggqmnjdvxal0csnrnijbg"
   }
  },
  {
@@ -95384,11 +95804,11 @@
   "repo": "tbanel/orgaggregate",
   "unstable": {
    "version": [
-    20250708,
-    1111
+    20250824,
+    1449
    ],
-   "commit": "ad7caf71e0360e310dab405235be0820412dee3d",
-   "sha256": "0hbfgv720nh0ks1bayv4zn7x7kr363byaql7xc8aln4fkvv91iai"
+   "commit": "12bcbbe37c883329ad773020fafe90063142abd1",
+   "sha256": "0j20xwxd9jk0xqx2a5khn8pkbjagp1vj17jjrw5l7iw9h9kpkwdv"
   }
  },
  {
@@ -95429,11 +95849,11 @@
   "repo": "tbanel/orgtbljoin",
   "unstable": {
    "version": [
-    20250607,
-    833
+    20250723,
+    1118
    ],
-   "commit": "90ad97d0cf3371ae99290f8c4b0ebb6542fcde7c",
-   "sha256": "122scil58zsa9g11iyp18m3k5x7y96r3vxnq09b9iq7rln5knlaq"
+   "commit": "d434bd138726e77f34a0e77d5de8416d6322b9f4",
+   "sha256": "17mka8m6m9v4wmx87mzn4wx1j2yagl59f96clx3vq0fks555sxfr"
   }
  },
  {
@@ -95865,26 +96285,26 @@
   "repo": "abougouffa/one-tab-per-project",
   "unstable": {
    "version": [
-    20250704,
-    2352
+    20250728,
+    801
    ],
    "deps": [
     "compat"
    ],
-   "commit": "1744f6d3754b3adf02e69bf4f58c93e7a16ab048",
-   "sha256": "0fnbvsfypa3yx883nd87yrrbscibsaa966zb78m5705kl4s22nfq"
+   "commit": "62b6ea6fed5fcc644ff9e3b9cb6cb64d3557814a",
+   "sha256": "1wgcklrf10lkfik5qicim66f95l3f3j667b9mjdmkffjf0gy6rgb"
   },
   "stable": {
    "version": [
     3,
     3,
-    4
+    5
    ],
    "deps": [
     "compat"
    ],
-   "commit": "3d7495d921202a374745b5353994ff3481c1c819",
-   "sha256": "09f2f11q6vz3nl8qacbzlxzlh2nmrf94vrrqal9cmg3b582a9knd"
+   "commit": "33ac081b88dd8318a0bb69a973eef9bbbc3eb5e6",
+   "sha256": "1jfj1q54b62l7xhjvmajrwz1ps547v5z174w9d44yph9b3jqllww"
   }
  },
  {
@@ -95908,6 +96328,30 @@
   }
  },
  {
+  "ename": "outli",
+  "commit": "4410dbcc7f297bb5ef3df69c226b92b258f2f94f",
+  "sha256": "17h7qw4qg8n74zh2xl8256lkpsqjym2qzr9fclsijk31mw135r2j",
+  "fetcher": "github",
+  "repo": "jdtsmith/outli",
+  "unstable": {
+   "version": [
+    20250403,
+    12
+   ],
+   "commit": "1c2cf24aca7a6c9bc920974bd5cf70badab018de",
+   "sha256": "01q37gbfc0mal3ha2x5a1axdcd2c0d55imav4w0cfzs3sm48azvs"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    3
+   ],
+   "commit": "1c2cf24aca7a6c9bc920974bd5cf70badab018de",
+   "sha256": "01q37gbfc0mal3ha2x5a1axdcd2c0d55imav4w0cfzs3sm48azvs"
+  }
+ },
+ {
   "ename": "outline-indent",
   "commit": "330f86638778f4f104808bddc3e4d09d2ab18372",
   "sha256": "1lfz87hhfqrva2g4hbsc9n8783zbvq6m1w6jf6ll9wi3v32lva0z",
@@ -95915,20 +96359,20 @@
   "repo": "jamescherti/outline-indent.el",
   "unstable": {
    "version": [
-    20250704,
-    1609
+    20250823,
+    40
    ],
-   "commit": "11483c97c83aad5f626cc3cf385a1f9effc8a356",
-   "sha256": "15v14sbab8f6r0fbmmr3nbx8kbxhi78n8b4azl36xn8g2nj9s9v2"
+   "commit": "f588cf965e5dea1102f38aebb9f06baec99254dc",
+   "sha256": "0iapy4wyadds6b5f5187priv3vpvp6gqw3yn9fpx443qwdvxygfw"
   },
   "stable": {
    "version": [
     1,
     1,
-    1
+    2
    ],
-   "commit": "5b8792c0949f4298c00e1791cf6097614bf9b339",
-   "sha256": "1rndanc9gy62g3r0m4n56ad7nlb6smmm9fnfsv6mis69dxxbbk37"
+   "commit": "49c12a5a3f31fe35003a49e0d7ef0d17ba6abaa9",
+   "sha256": "0ppwsipg4birwk9m0i4x2d9rq023iws6nqs1i1lf2iialyhnr313"
   }
  },
  {
@@ -95954,26 +96398,26 @@
   "repo": "tarsius/outline-minor-faces",
   "unstable": {
    "version": [
-    20250601,
-    1003
+    20250823,
+    1716
    ],
    "deps": [
     "compat"
    ],
-   "commit": "cb06d2db125ba65fb8c4eb7e5dc6cc6bf3b6dc7e",
-   "sha256": "1mgqcldi426g5ikdc05wvxrr9g97wwm6xhz5qbjcg6rp0zk2wfm1"
+   "commit": "52a674c70923c08cf81ce97a706513ebec55efe6",
+   "sha256": "0x1hm7w6w07rdb12gjcsw416p2bhk7wf4pk720ygl1x3hnrkih9y"
   },
   "stable": {
    "version": [
     1,
     1,
-    3
+    4
    ],
    "deps": [
     "compat"
    ],
-   "commit": "cb06d2db125ba65fb8c4eb7e5dc6cc6bf3b6dc7e",
-   "sha256": "1mgqcldi426g5ikdc05wvxrr9g97wwm6xhz5qbjcg6rp0zk2wfm1"
+   "commit": "a82db0dfe97cf5948d86a5c40d5e38c1ad710f69",
+   "sha256": "1l4dymnzp97qnd92pr8hd29fi9iyq2v26qlcbnnhbn32znk53r53"
   }
  },
  {
@@ -96140,8 +96584,8 @@
   "repo": "vale981/overleaf.el",
   "unstable": {
    "version": [
-    20250627,
-    1227
+    20250728,
+    2103
    ],
    "deps": [
     "plz",
@@ -96149,14 +96593,14 @@
     "webdriver",
     "websocket"
    ],
-   "commit": "e94c4d8d04760656497a8d774e568c30ca157510",
-   "sha256": "0mgzc8wagg255hq0pzdd6lqq7phxgcbw46qvcw13p101ayyk56fb"
+   "commit": "515e45df1bec11e1c0cd2dc4810c48f8ad0685cb",
+   "sha256": "08mzrcjm74xfxpj3bjlfr3w1079xpkbp1wgyvgrdiz9zh5i2b352"
   },
   "stable": {
    "version": [
     1,
     1,
-    3
+    4
    ],
    "deps": [
     "plz",
@@ -96164,8 +96608,8 @@
     "webdriver",
     "websocket"
    ],
-   "commit": "c9e7fbb51a2d22d24172f4500a5e83f15616b006",
-   "sha256": "08w9ca3mrpzx9apxv7ii6c0i4gnnbx51izplsmnfn78pxzy9cp13"
+   "commit": "515e45df1bec11e1c0cd2dc4810c48f8ad0685cb",
+   "sha256": "08mzrcjm74xfxpj3bjlfr3w1079xpkbp1wgyvgrdiz9zh5i2b352"
   }
  },
  {
@@ -96527,14 +96971,14 @@
   "repo": "kaushalmodi/ox-hugo",
   "unstable": {
    "version": [
-    20250212,
-    310
+    20250814,
+    1439
    ],
    "deps": [
     "tomelr"
    ],
-   "commit": "a7641fc810c5e15142a3cede3a439a3189929bf5",
-   "sha256": "0anmnq56r8wnmc41qx3nmzlf9k5y9hi4ql51r0178d8kmfkh87x8"
+   "commit": "6499e35bb04bec2629e51305ffb8a30ae988f92a",
+   "sha256": "1pvglqqq6jnwqq64m9sxfmjprfg5sb8ds4l97qz109wnrhhazgj5"
   },
   "stable": {
    "version": [
@@ -96624,15 +97068,15 @@
   "repo": "jlumpe/ox-json",
   "unstable": {
    "version": [
-    20240106,
-    2116
+    20250825,
+    125
    ],
    "deps": [
     "org",
     "s"
    ],
-   "commit": "57a43e3b3e400d219b80008c51373796b844c6b8",
-   "sha256": "12fxflyh92awjwfj5gwp8frrbjc63kj7ajlwbsmzgpnp9rr43fpx"
+   "commit": "0f7c63b9bbbf6c8b2547e46adc7f34289869105f",
+   "sha256": "1xlqd4rb5br3illbxg7k0rbspxfns2sr5wn7w9k546sb6lg5p4i2"
   },
   "stable": {
    "version": [
@@ -96703,11 +97147,11 @@
   "repo": "DamienCassou/ox-linuxmag-fr",
   "unstable": {
    "version": [
-    20240624,
-    1829
+    20250825,
+    2001
    ],
-   "commit": "3319c309f6fb0b0771363bec80557bc387243a82",
-   "sha256": "0iq63n4r78s4v75iadaqk06m37pg3allzrrdz2r1x3pm3br24nz0"
+   "commit": "1273146d58ca05f2e43278e9d15787f1b39c70a4",
+   "sha256": "1vfblkihy9ixiv1v76jijsn9n7iwhq1c283ihcnlwxqklbwni8c2"
   },
   "stable": {
    "version": [
@@ -96897,14 +97341,14 @@
   "repo": "masfj/ox-review",
   "unstable": {
    "version": [
-    20220619,
-    724
+    20250826,
+    1233
    ],
    "deps": [
     "org"
    ],
-   "commit": "f7dc418f9812088afc0ee0d08f778a5654686ef3",
-   "sha256": "0yplmrzb2j47plj99l06mznva93wynsqjcz5v4bkryswnwn10jab"
+   "commit": "516bce8fb298e84d813d3c65b9cba200fa72e3b0",
+   "sha256": "1b48b1inr3q1155449jdcsd8pwns5k2j5rjgx7hnjj7fyf59w901"
   },
   "stable": {
    "version": [
@@ -97000,14 +97444,26 @@
   "repo": "lorniu/ox-spectacle",
   "unstable": {
    "version": [
-    20250217,
-    832
+    20250218,
+    1032
    ],
    "deps": [
     "org"
    ],
-   "commit": "8774cf855c5585e70563a8edce80c763881f25b1",
-   "sha256": "0fkq0vg3fkqqqfmz3xvhw1bzcaqqg6myp02myycfl20j9yi4cadl"
+   "commit": "42bf787371560f89bdffafcec689f133a13b63ea",
+   "sha256": "0pq6ci6v36bmfahnclyfwdg1n81p90zq4pg80zx7qfjbqqgng777"
+  },
+  "stable": {
+   "version": [
+    2,
+    0,
+    1
+   ],
+   "deps": [
+    "org"
+   ],
+   "commit": "42bf787371560f89bdffafcec689f133a13b63ea",
+   "sha256": "0pq6ci6v36bmfahnclyfwdg1n81p90zq4pg80zx7qfjbqqgng777"
   }
  },
  {
@@ -97282,14 +97738,14 @@
   "repo": "zkry/p-search",
   "unstable": {
    "version": [
-    20250608,
-    617
+    20250802,
+    538
    ],
    "deps": [
     "compat"
    ],
-   "commit": "38a66610a094d4026aaf7733148582375387fd99",
-   "sha256": "1j7h5hag65ksvljj6p7qh857rdg1wdjw0a9vzl77aaz7xmc4w3bc"
+   "commit": "c382c80947a95825e258332d6f89bd6be496d914",
+   "sha256": "1fn5fjwpw9ghqfv4zbzvfyz54bik4vwb2wxyh1085jw6c907vfyd"
   },
   "stable": {
    "version": [
@@ -97475,14 +97931,14 @@
   "repo": "melpa/package-build",
   "unstable": {
    "version": [
-    20250708,
-    1908
+    20250807,
+    1034
    ],
    "deps": [
     "compat"
    ],
-   "commit": "79fbbb9df3a4dfa9fb7a3f547b6f1982fde508bb",
-   "sha256": "0m29ri2sk7n2wyn49pxnc3816i5n34hipmbznvkdhf5pjyvinfvh"
+   "commit": "546e7d7f119be9b0aff5c87064a8000f9a6dfc4a",
+   "sha256": "1fakckyidijal8ddc8fq6s37kb09224vr24m518fkx7agqms6rs0"
   },
   "stable": {
    "version": [
@@ -97517,14 +97973,14 @@
   "repo": "purcell/package-lint",
   "unstable": {
    "version": [
-    20250527,
-    1845
+    20250819,
+    1304
    ],
    "deps": [
     "let-alist"
    ],
-   "commit": "29ccfea319ee6bac4b80045aa473b3aa2b77d074",
-   "sha256": "02v53clzr8jaby5kjcqr9d5ry9v2v2dh3xagdw98j99wbicmi3yn"
+   "commit": "078f403d57e3056338ef45e37973e7a27297f545",
+   "sha256": "15hbh13prjmavy4563xwaaph9jnmxy3mabwjnj63wa1x5kf4lrzk"
   },
   "stable": {
    "version": [
@@ -98150,32 +98606,32 @@
  },
  {
   "ename": "paren-face",
-  "commit": "d398398d1d5838dc4985a06515ee668f0f566aab",
-  "sha256": "0dmzk66m3rd8x0rb925pyrfpc2qsvayks4kmhpb2ccdrx68pg8gf",
+  "commit": "890e94376ea0b6ada2c49a0a3e11b2a59aab7caa",
+  "sha256": "0sm536nm6k9w98cpvlvmg0pxm6mjx6yd9gpaszw3ibm8h7ygc8v3",
   "fetcher": "github",
   "repo": "tarsius/paren-face",
   "unstable": {
    "version": [
-    20250531,
-    2229
+    20250822,
+    1936
    ],
    "deps": [
     "compat"
    ],
-   "commit": "80b26f6409a615d13738c480d543b47be1af0c0a",
-   "sha256": "1dzxf1a0c8ri6pnidx50jlk7n2x03kpisyh4bipkdccixvdqj6m5"
+   "commit": "88cbcf779d3c382cf785a540a2134a663b753d7b",
+   "sha256": "0rxrcnpsar1550ihfr6a8qf0cx1p5va14cdx70ykqzfpvcbg5rdw"
   },
   "stable": {
    "version": [
     1,
-    1,
-    4
+    2,
+    0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "80b26f6409a615d13738c480d543b47be1af0c0a",
-   "sha256": "1dzxf1a0c8ri6pnidx50jlk7n2x03kpisyh4bipkdccixvdqj6m5"
+   "commit": "3804fde5c6da5bd92413e471a2a0c6df224d0946",
+   "sha256": "1fsrbkxanjjrlybxmwhzxn7a6jh73r4hpz5m5zva52p2fb09g387"
   }
  },
  {
@@ -98200,6 +98656,21 @@
    ],
    "commit": "9fe5363b2a190619641c79b3a40d874d8c8f9f40",
    "sha256": "1ki22rkbyglr3wppjph6gy23lcx2nwj9w0ff9h3ryd197j4yvvgi"
+  }
+ },
+ {
+  "ename": "parenthesis-face",
+  "commit": "890e94376ea0b6ada2c49a0a3e11b2a59aab7caa",
+  "sha256": "078c97yjxp6344i4d5v5k07yxpm9y0qbjcmgim89hmgmira8iqvx",
+  "fetcher": "github",
+  "repo": "tarsius/paren-face",
+  "unstable": {
+   "version": [
+    20250822,
+    1936
+   ],
+   "commit": "88cbcf779d3c382cf785a540a2134a663b753d7b",
+   "sha256": "0rxrcnpsar1550ihfr6a8qf0cx1p5va14cdx70ykqzfpvcbg5rdw"
   }
  },
  {
@@ -98433,16 +98904,16 @@
   "repo": "NicolasPetton/pass",
   "unstable": {
    "version": [
-    20250616,
-    1457
+    20250721,
+    1935
    ],
    "deps": [
     "f",
     "password-store",
     "password-store-otp"
    ],
-   "commit": "2391d6ee4e3b65d6c6ae522e362a0ec1f2d57866",
-   "sha256": "0rimfbysb0q5khkj4s65w5df743k04jhvjz5xijngckas3mmgjhj"
+   "commit": "7651389c52919f5e0e41d9217b29c7166e3a45c2",
+   "sha256": "1nzwa4z7nm1m0y6sjp1nhargp6ah4hp5z7vaxfffgsb4hxcsawcs"
   },
   "stable": {
    "version": [
@@ -98734,6 +99205,24 @@
    ],
    "commit": "4493be98b743b4d062cb4e00760125e394a55022",
    "sha256": "0bmm18d84lrkclg4md46k1ma03w7a97s10hrvjcm9yj8xbrjqqsc"
+  }
+ },
+ {
+  "ename": "pasvortilo",
+  "commit": "27bfef74233025ad33b325f3fd615d5d612812ab",
+  "sha256": "0cxpcdl2ig1l7q0cxblffw6is5lcfslz98dnq4igqn13whyd8xdv",
+  "fetcher": "codeberg",
+  "repo": "mester/pasvortilo",
+  "unstable": {
+   "version": [
+    20250803,
+    1944
+   ],
+   "deps": [
+    "transient"
+   ],
+   "commit": "04167f479ab38d6de61544abd84d409747b6f802",
+   "sha256": "1nxaxjr6p6i5l4cx2jhph2z10xzb862hpidjiskgj8x32iw345nb"
   }
  },
  {
@@ -99103,11 +99592,19 @@
   "repo": "lorniu/pdd.el",
   "unstable": {
    "version": [
-    20250708,
-    1559
+    20250809,
+    509
    ],
-   "commit": "2ac3e9a2954009e6ccfeda3d7cad6e4debd40299",
-   "sha256": "1ar5vjkrxiqgrpv5v2np3hkx17y0s1ij4pdzabxfc5xh8lxn1hrg"
+   "commit": "533e8fde36cb9fae1fae3bf44eb6dbf39ec10f53",
+   "sha256": "02sfc0qv1fr5l4lfvmbgi23knx0zpylsraa5v15y0m1lxfva69nm"
+  },
+  "stable": {
+   "version": [
+    0,
+    23
+   ],
+   "commit": "8f7516510459477c2ff368a7fde4cc68cead2402",
+   "sha256": "0xx35811kxlrnsa2ydkgli60xvqjd9i7cx7j5z8zidzgzkywdnj5"
   }
  },
  {
@@ -99463,11 +99960,11 @@
   "repo": "jamescherti/persist-text-scale.el",
   "unstable": {
    "version": [
-    20250429,
-    1936
+    20250822,
+    1937
    ],
-   "commit": "4a23ae098186d3f193eca86b172050ecdd6db017",
-   "sha256": "17w7ha59y5mhlimhxrvwqr52lap7kfpfx42iiyx75b9d4m7spbmj"
+   "commit": "d73c195cd2abd3941c50941552349951bcaa1f25",
+   "sha256": "05nv8f98ywnpm7rrkrcf8l68v2kzmcklsr65p3fh0ly0bmcbsc0l"
   },
   "stable": {
    "version": [
@@ -99526,15 +100023,15 @@
   "repo": "rolandwalker/persistent-soft",
   "unstable": {
    "version": [
-    20150223,
-    1853
+    20250805,
+    1017
    ],
    "deps": [
     "list-utils",
     "pcache"
    ],
-   "commit": "a1e0ddf2a12a6f18cab565dee250f070384cbe02",
-   "sha256": "14p20br8vzxs39d4hswzrrkgwql5nnmn5j17cpbabzjvck42rixc"
+   "commit": "24e41d1952bef5953ef0af2288de146265c7ee10",
+   "sha256": "0wp4hd4j7dbiqf08yywi3s0y9rmpk2hycmlzqk0c0iq0r3kwl83d"
   },
   "stable": {
    "version": [
@@ -99590,20 +100087,20 @@
   "repo": "Bad-ptr/persp-mode.el",
   "unstable": {
    "version": [
-    20240730,
-    1353
+    20250814,
+    1552
    ],
-   "commit": "40e9993a9711cba5fb56dfec81a507fabeba9668",
-   "sha256": "0fi07h5q0srjasjxn7rzzd8zahl15agspm6q9hs2rzd0m8x3zp52"
+   "commit": "82680795b3dbb9f9fb023b1754902f38519d9875",
+   "sha256": "1q43i9m4jqwmzj2k431c697am8kgwd8ydhpc7zl6jvf2hphxxv1d"
   },
   "stable": {
    "version": [
     3,
     0,
-    8
+    9
    ],
-   "commit": "345baaa520ab2d62205f85cc5f29d57d6063c141",
-   "sha256": "0y29vyvqdfxcpmzkyv2c6msbshx2f680izk2r0djrqj08ii8zmpr"
+   "commit": "40e9993a9711cba5fb56dfec81a507fabeba9668",
+   "sha256": "0fi07h5q0srjasjxn7rzzd8zahl15agspm6q9hs2rzd0m8x3zp52"
   }
  },
  {
@@ -99799,21 +100296,21 @@
   "repo": "wyuenho/emacs-pet",
   "unstable": {
    "version": [
-    20250519,
-    1203
+    20250803,
+    1832
    ],
    "deps": [
     "f",
     "map",
     "seq"
    ],
-   "commit": "6d48c24d8e136dac41d9d96e7b10f36d2ae8d131",
-   "sha256": "1h182iz8zargbqjzqr0hz7ja306cxf0rwvdpspilv3z5zbvknvl0"
+   "commit": "6b62cf5f7e968c8137d8818b58638b2f0e64d02b",
+   "sha256": "01rll2sg5sbhhg1csw0i91kj1hdym4kga198jh1f83q1myspzing"
   },
   "stable": {
    "version": [
-    3,
-    1,
+    4,
+    0,
     0
    ],
    "deps": [
@@ -99821,8 +100318,8 @@
     "map",
     "seq"
    ],
-   "commit": "2041ba1caee94242362c955e697a3c03bfbc0402",
-   "sha256": "18mz7nhsii9l1iqa9yk97xbf6dn4mladwrnl5w7ksa2zcpcpph61"
+   "commit": "6b62cf5f7e968c8137d8818b58638b2f0e64d02b",
+   "sha256": "01rll2sg5sbhhg1csw0i91kj1hdym4kga198jh1f83q1myspzing"
   }
  },
  {
@@ -99857,25 +100354,25 @@
   "repo": "emarsden/pg-el",
   "unstable": {
    "version": [
-    20250629,
-    1346
+    20250823,
+    2007
    ],
    "deps": [
     "peg"
    ],
-   "commit": "63690547ce37f627b163c3138bcf28c8f07ef3bc",
-   "sha256": "1frxa7v3s92y44mdhgw257zq1j4pia4a53s36nivg83lp629zigb"
+   "commit": "614617eb2c342feaa91a88caba87107bb5194040",
+   "sha256": "0lk2byk0dydxxaw0k7qfs734dyfi5ya0y9x364qhkkakv9l07j67"
   },
   "stable": {
    "version": [
     0,
-    55
+    58
    ],
    "deps": [
     "peg"
    ],
-   "commit": "63690547ce37f627b163c3138bcf28c8f07ef3bc",
-   "sha256": "1frxa7v3s92y44mdhgw257zq1j4pia4a53s36nivg83lp629zigb"
+   "commit": "991bd9429d30b05a351fe2d46e628569ce6b661c",
+   "sha256": "1vzd3wj9nwhnp2whxfy6z6zfig3hr1vm4d0zgzaz1zjwicqiznjn"
   }
  },
  {
@@ -100686,20 +101183,20 @@
   "repo": "EricCrosson/pine-script-mode",
   "unstable": {
    "version": [
-    20210629,
-    1257
+    20250826,
+    901
    ],
-   "commit": "c04309be9fb73012b4c5c839741b1abcfe0b8aa9",
-   "sha256": "1hahd9w5pww3nx1xvbci4pscpbzb0k5xv3yff896jg66di36fvwg"
+   "commit": "f8c8ae596ca6296b9d5f618ff5b82c223d007ed5",
+   "sha256": "0f87m18b7jap06p4ycdhrwbcz4cz4h324cx94d8rn0hyw8bahqd5"
   },
   "stable": {
    "version": [
-    1,
-    0,
-    0
+    3,
+    5,
+    4
    ],
-   "commit": "f7892d373e30df0b2e8d2191e4ddb2064a92dd3c",
-   "sha256": "1zxmc2l41h28rl058lrfr8c26hjzqmp37ii8r29mpsm03hsw30fh"
+   "commit": "203ba62b1c36620dc59a85c5f6084037db48b146",
+   "sha256": "0mfc7wfn7abfhfp8b6iggsasp6bqvbj20yjqrrf7plrnv70czzdc"
   }
  },
  {
@@ -101190,17 +101687,17 @@
  },
  {
   "ename": "plaster",
-  "commit": "7e363cffa021e649c052f38cedb7cc01dbe9e24a",
-  "sha256": "0vfixc0f5n4flsmdf1iqlbx03yv28w3nqm1ycz2fx6p5jvhkvfqk",
-  "fetcher": "github",
-  "repo": "Shirakumo/plaster",
+  "commit": "ecf9070b9008001f776a39c8a87fc7408d218fa1",
+  "sha256": "1bfsqfl7mz4d85vy2rfrgqc7vym01h9lk7d9mp6nd5wx1n013d3z",
+  "fetcher": "codeberg",
+  "repo": "shirakumo/plaster",
   "unstable": {
    "version": [
-    20180127,
-    2050
+    20250821,
+    1444
    ],
-   "commit": "11eb23920410818fe444887b97ad4c8722d66c85",
-   "sha256": "0lqz8m8a2ahvgm0i9cz0j4bisi34czc4s29z70p5p6rdg4g21fk1"
+   "commit": "9d77d89aef9ea438e4e0a144256f0ccbe3072a7c",
+   "sha256": "0kmmvw442859klhxx5wpy91fw7qas181bl76k42sgnblbf62d116"
   }
  },
  {
@@ -102278,6 +102775,25 @@
   }
  },
  {
+  "ename": "pomo-cat",
+  "commit": "b02441a9ca385a5a499a7ee1900637f02c53da41",
+  "sha256": "0f3akvsq021sxfzyil82l9f9hcqm7jji1yhvf687j1rlnnfiaqpb",
+  "fetcher": "github",
+  "repo": "kn66/pomo-cat.el",
+  "unstable": {
+   "version": [
+    20250819,
+    1022
+   ],
+   "deps": [
+    "popon",
+    "posframe"
+   ],
+   "commit": "a924765965ecc1a8da684f7691bce553ece6f336",
+   "sha256": "1nc2n62syzf7pwgrr939vbf5jr0j8ik1d8smn3vdvd5fy9fa022b"
+  }
+ },
+ {
   "ename": "pomodoro",
   "commit": "0b5c2c50eb87952d01c1b338b7d3e4b3a4546555",
   "sha256": "075sbypas8xlhsw8wg3mgi3fn5yf7xb3klyjgyy8wfkgdz0269f8",
@@ -102345,21 +102861,11 @@
   "repo": "ponylang/ponylang-mode",
   "unstable": {
    "version": [
-    20211015,
-    331
+    20250819,
+    1840
    ],
-   "deps": [
-    "company-ctags",
-    "dash",
-    "fill-column-indicator",
-    "hl-todo",
-    "hydra",
-    "rainbow-delimiters",
-    "yafolding",
-    "yasnippet"
-   ],
-   "commit": "1abf04bc8f4f09a6add4b587c7cf5ca23735e7c0",
-   "sha256": "1iv04dj2nc9cyyslhir7aj5sligwan1yyclsiarn86lik7b9lmwn"
+   "commit": "7e6425f2c12538bfeffce754b32ba75a14c72cbd",
+   "sha256": "1iz4sgfvvbwj9ls800ckj4j3m8wgnl291syg7hm9axkvybsy1nf1"
   },
   "stable": {
    "version": [
@@ -103106,20 +103612,20 @@
   "repo": "radian-software/prescient.el",
   "unstable": {
    "version": [
-    20250704,
-    505
+    20250816,
+    19
    ],
-   "commit": "85ab01b89f881a131a5b3ec5a617ca4c1d7854c2",
-   "sha256": "1abglp7436l7yrlc0963d849afbmifdk6s1rf5g7lfhzwig3d0cw"
+   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
+   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
   },
   "stable": {
    "version": [
     6,
     3,
-    1
+    2
    ],
-   "commit": "2b8a8b41228bddb2e11eb1c200e98a9edd04797c",
-   "sha256": "0qz3xv38vazxqsl7lan7fshj3gmb0qagkrvl5xzwqhdg0rir981j"
+   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
+   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
   }
  },
  {
@@ -103766,6 +104272,29 @@
    ],
    "commit": "7a20dd1e0672942ba971978baffa063b399151ef",
    "sha256": "1a4d0m6gri04njm70xyc64nk8ypcvbywdhxpvvwa13sbaqq8af3p"
+  }
+ },
+ {
+  "ename": "project-cmake",
+  "commit": "74f0e26c27d43134997266d5cc2b244824baf334",
+  "sha256": "0nam5sxqhml7mckwcfgwf8bn4l54fy38mnajirwx8498ggg1ka97",
+  "fetcher": "github",
+  "repo": "lucius-martius/project-cmake",
+  "unstable": {
+   "version": [
+    20250824,
+    2004
+   ],
+   "commit": "4a261cef5b7ca406577d3b0eaeabfae88419edeb",
+   "sha256": "1m4pachj26gdbmwbv15d7wshay7qnmaxy6x5nzi9hnvcfhg5v7xs"
+  },
+  "stable": {
+   "version": [
+    0,
+    1
+   ],
+   "commit": "4a261cef5b7ca406577d3b0eaeabfae88419edeb",
+   "sha256": "1m4pachj26gdbmwbv15d7wshay7qnmaxy6x5nzi9hnvcfhg5v7xs"
   }
  },
  {
@@ -104604,11 +105133,11 @@
   },
   "stable": {
    "version": [
-    31,
-    1
+    32,
+    0
    ],
-   "commit": "74211c0dfc2777318ab53c2cd2c317a2ef9012de",
-   "sha256": "1rdxm75bqwjj4qd3hz4vlydra6bw5dq391kwln2q0pjfx9gbrjhk"
+   "commit": "4fbd1111a292d04746c732573025e3251de0bb9c",
+   "sha256": "1hhlpkx16w513wi4l3pr6sy69h9j6bmrcqwkqrpjzljllqzk884j"
   }
  },
  {
@@ -105159,14 +105688,14 @@
   "repo": "voxpupuli/puppet-mode",
   "unstable": {
    "version": [
-    20210305,
-    645
+    20250716,
+    542
    ],
    "deps": [
     "pkg-info"
    ],
-   "commit": "ab25cf379236f4e1bd4bc9c1d77a93c95800e9bf",
-   "sha256": "0djrq3wl7crpjd2p1zzzz1spqfdrfzf7991g5fi8zwbf3pi79gpd"
+   "commit": "f02aa30f5c0ce7fd0e1ffb245e5c832538bf6a91",
+   "sha256": "00vkiq8irp01s147r1mbzg3g241z3d3j37i1b1la85ph05y5811m"
   },
   "stable": {
    "version": [
@@ -105579,11 +106108,11 @@
   "repo": "statmobile/pydoc",
   "unstable": {
    "version": [
-    20221222,
-    1426
+    20250816,
+    1529
    ],
-   "commit": "c9d8b5249c1b3814da062ed9976e4137d6e8d869",
-   "sha256": "1ifyhdcvj25rnrvq78qjma3dg826hpj3x5ic1sydrvj0yb13jhim"
+   "commit": "dbfbe0fc9ac1dfb12a202062b6639a1d335ddc49",
+   "sha256": "120ddz4714h4mv1lwlmqc7gfvzs89a6mxhaiw9kn4bjypp8csafq"
   },
   "stable": {
    "version": [
@@ -105847,11 +106376,26 @@
   "repo": "emacsorphanage/pyimpsort",
   "unstable": {
    "version": [
-    20250707,
-    1327
+    20250710,
+    1607
    ],
-   "commit": "e26c8932fc666c33a9dcbec6207c966c5b3b81ad",
-   "sha256": "0kpn8b4z42pmaklyc4612l2708z3x25hshvxwxqh02xdka0l4q04"
+   "deps": [
+    "python"
+   ],
+   "commit": "70d739c134d89ba2025322fee101a13420d0b032",
+   "sha256": "1wdlkwzimkmj50qhpcq20wxvvw3bqjpa9mag7kv27gnidggn1qd6"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    1
+   ],
+   "deps": [
+    "python"
+   ],
+   "commit": "70d739c134d89ba2025322fee101a13420d0b032",
+   "sha256": "1wdlkwzimkmj50qhpcq20wxvvw3bqjpa9mag7kv27gnidggn1qd6"
   }
  },
  {
@@ -106218,11 +106762,11 @@
   "repo": "python-mode-devs/python-mode",
   "unstable": {
    "version": [
-    20250624,
-    1530
+    20250821,
+    1140
    ],
-   "commit": "37a14e1c07fe2d99786c7faa12b928b9654e79ed",
-   "sha256": "1p77gjxnk1v7bgx51kr6yklg7f9d38jjb7zh5rc0vbl84s9mh9x8"
+   "commit": "fcff76c308b4409007c61492e4936e7c0b7d5aee",
+   "sha256": "12xhws04ljqdibfnyl5sn7nl05ndz5a3r2spk8aqvfcwd29zkn4d"
   },
   "stable": {
    "version": [
@@ -106242,16 +106786,16 @@
   "repo": "wbolster/emacs-python-pytest",
   "unstable": {
    "version": [
-    20250706,
-    2057
+    20250726,
+    1726
    ],
    "deps": [
     "dash",
     "s",
     "transient"
    ],
-   "commit": "02784b0701cf0698277e3252c2e394cf02fab055",
-   "sha256": "0sibih2nw1l7bpp9clr6bfd246vgdsig967qxqy6k9qpfzsk634l"
+   "commit": "ed2ecee09d1cccb4245842860d91940cb2fda769",
+   "sha256": "1787bks1zi47qglib42vnlqa7m4899n5vh1ics0013ldd89jqrr1"
   },
   "stable": {
    "version": [
@@ -106277,11 +106821,26 @@
   "repo": "vladimirlagunov/python-switch-quotes",
   "unstable": {
    "version": [
-    20161228,
-    809
+    20250804,
+    904
    ],
-   "commit": "93f1e9b40e061a6cea480139e8b1362b6404abd0",
-   "sha256": "1x04hnf3m8cgqp0i566q4n7kh59cayzfxka3g07kv0h543xbys4n"
+   "commit": "dc3bf1d7c206168605f4df7a605bc4615d296cd6",
+   "sha256": "1l9zif6bv7qp363nkpj7fhw6xfl2m8v8ggmsqpxvf1s82kdq1rwv"
+  }
+ },
+ {
+  "ename": "python-tdd-mode",
+  "commit": "41d97c8d9bf8e0b6e3d8a863173388f15c4e897c",
+  "sha256": "055a00lrbfvymyskliq9d48lnl38c2p0gjz58sdh4kr5vr6xw9f7",
+  "fetcher": "github",
+  "repo": "marcwebbie/python-tdd-mode",
+  "unstable": {
+   "version": [
+    20250719,
+    1438
+   ],
+   "commit": "e0c05730c76bfed1d819bc981c90ab16e681b55d",
+   "sha256": "1yv20qqndchfc6gbbivi7ll4g4zs011wbl6gz4xdf2gnc609z6qp"
   }
  },
  {
@@ -106446,11 +107005,11 @@
   "repo": "psaris/q-mode",
   "unstable": {
    "version": [
-    20250415,
-    154
+    20250823,
+    1746
    ],
-   "commit": "7f41e1c62640c1badcb67daaead24dc291cd16ab",
-   "sha256": "0y7qf3h16xca9dj36d95p0bl6q4nf4ycygzx97jbx98hnlzvdcy2"
+   "commit": "e6bf9fb684fd857d61757260e023c2fc4a33772b",
+   "sha256": "0d3z1ixfcvand7f799vj50lg97n1sbmlfcnvkdrc540jbjxy4532"
   }
  },
  {
@@ -106507,11 +107066,11 @@
   "repo": "K6SM/Emacs-QSO-Logger",
   "unstable": {
    "version": [
-    20250701,
-    1933
+    20250709,
+    1505
    ],
-   "commit": "09bfabd9d2f3336ee66371c102064e0d508035ec",
-   "sha256": "14g2m8jjhk7pzj5spszbjx8sbf0qj4ii1p2rpp2c81qcladsg37g"
+   "commit": "33d3211748aa7e94f1aa187570beca8b9b2093d8",
+   "sha256": "033l5pg7bfc598xqniavwwlhlq488fzl92d17603c45f51v5yvff"
   }
  },
  {
@@ -107016,14 +107575,14 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20250609,
-    1522
+    20250711,
+    1236
    ],
    "deps": [
     "compat"
    ],
-   "commit": "4395797ff130fcdcc9750fb2456d4f762d56852f",
-   "sha256": "0lfzl09d6rxi4qjrykd4xg78gaj3bbpd6s1g8n9l9fxwd31vgix9"
+   "commit": "8a80578405cb1dcce460fd34c23daed4c5f0546b",
+   "sha256": "1mkk7g43ifd0j12nfjhpclq89248ifwf66f5j233ih2rm5x21n69"
   }
  },
  {
@@ -107774,11 +108333,11 @@
   "repo": "xenodium/ready-player",
   "unstable": {
    "version": [
-    20250410,
-    816
+    20250826,
+    451
    ],
-   "commit": "ea0633f7b8cb4478073b3082e01c3a46b2e888b1",
-   "sha256": "1qhdmb1rlj7r3nzhv8ajl90yibgmfjb1x9rjyljgqyfmizrp87lv"
+   "commit": "c78300c0afaf9328bac66bab083a2f0b8e10fd25",
+   "sha256": "187mkiy8a9zb1zjq645xiidwv6spbbp5nssng745jlm0a5fbib4q"
   },
   "stable": {
    "version": [
@@ -108953,11 +109512,11 @@
   "repo": "Reagankm/renpy-mode",
   "unstable": {
    "version": [
-    20250707,
-    1816
+    20250712,
+    1708
    ],
-   "commit": "6755d59b5153b61829a2ccf266d89c5b69bc0c21",
-   "sha256": "135j4g1l5y06cny1mk92nq7sjxbkn466d1naajjsj622mlf87bdk"
+   "commit": "feba611ed07fe26774f4106fcdbf31c2de28856c",
+   "sha256": "1j5055lwkx87yi2ymb1khs9q2lrixfwh8m239xpwdwp6lk9gv2wi"
   }
  },
  {
@@ -108968,11 +109527,11 @@
   "repo": "ideasman42/emacs-repeat-fu",
   "unstable": {
    "version": [
-    20250613,
-    304
+    20250824,
+    918
    ],
-   "commit": "b91d55001cca71e5df7a9f665c7da73ab9f55efd",
-   "sha256": "04kpzwcl3lzqvaw16wy7qjw5kfnbhndby1adwkv8p3bbqjqj5g48"
+   "commit": "9cffa91052a0f5a1c7f1ff44c254f33b9350d6b8",
+   "sha256": "0h3xgijyfzpnqx3m7ivnq64znrhjnqnc7wph0653iy1mvig1pxzd"
   }
  },
  {
@@ -108988,6 +109547,26 @@
    ],
    "commit": "41dea6fba2edd6ac748d0ca7a6da4058290feede",
    "sha256": "1lnwb2z8y9cjah545n27j62a5pdksid0rah2bzws9xi8c7dgavkm"
+  }
+ },
+ {
+  "ename": "repeat-ring",
+  "commit": "79e2930c23ac4b35baf9caa5cf2c35c196c3fb76",
+  "sha256": "19js5mqc6dg0nkr75l4v0qrx8fiymnkh9y0p38pj8dwzbx6z1rfw",
+  "fetcher": "github",
+  "repo": "countvajhula/repeat-ring",
+  "unstable": {
+   "version": [
+    20250712,
+    625
+   ],
+   "deps": [
+    "mantra",
+    "pubsub",
+    "virtual-ring"
+   ],
+   "commit": "f2e67a961476a9a871f245f2d7c1df94e51ef721",
+   "sha256": "0wzxw7hxkijhm5mzhsrjdk3l31c3mv62jwx349w1j27hs3dx4pgp"
   }
  },
  {
@@ -109194,6 +109773,30 @@
    ],
    "commit": "1572f3ee82eaadc06e741f03e1889281308c79fa",
    "sha256": "0y8j3hf5r69fxj2vsbaxwr9qdchddn53w25xzmxv1kfh6hbagzv3"
+  }
+ },
+ {
+  "ename": "repo-grep",
+  "commit": "5ba375b5244ff9c523fe879d6184c631376e9d0c",
+  "sha256": "0k32vf8cwwsr95xfbp67bddqrjgn8g3km97ii7qlwq7wf1ygx8r6",
+  "fetcher": "github",
+  "repo": "BHFock/repo-grep",
+  "unstable": {
+   "version": [
+    20250826,
+    1109
+   ],
+   "commit": "98dd4b492d93b8d13f9bc7b80efe91577c13e779",
+   "sha256": "1fhj9hyxawn3pdy0jhnc4fw1dfrxzm13q36bkz51kcnw2lkl1njk"
+  },
+  "stable": {
+   "version": [
+    1,
+    5,
+    2
+   ],
+   "commit": "98dd4b492d93b8d13f9bc7b80efe91577c13e779",
+   "sha256": "1fhj9hyxawn3pdy0jhnc4fw1dfrxzm13q36bkz51kcnw2lkl1njk"
   }
  },
  {
@@ -109414,14 +110017,14 @@
   "repo": "emacsorphanage/restclient",
   "unstable": {
    "version": [
-    20250705,
-    2050
+    20250817,
+    0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "e7a54135233d66fc5bb0dbae315d673abdfb4146",
-   "sha256": "15hwxxrvla12i71039dz0a5p0fbdm7xx5a5yqn7mxkv0dr1vngxf"
+   "commit": "ad97f666b607b1947aae4bcfb5b91fb3b0d97b87",
+   "sha256": "0bamndc9g1l2hv9sm5cfjmhzwnvkg922fhkav7zkxhzmk9v1n0qa"
   }
  },
  {
@@ -109451,15 +110054,15 @@
   "repo": "emacsorphanage/restclient",
   "unstable": {
    "version": [
-    20250704,
-    2009
+    20250803,
+    2119
    ],
    "deps": [
     "jq-mode",
     "restclient"
    ],
-   "commit": "6ec11373492d1a489402161632a8ce59f079daf0",
-   "sha256": "14nkv63mzg1imdkwg5z2x6pvpw6jw88xr523rj3594hbwwl4in3i"
+   "commit": "6764278a3d63520eaf117344d8dc23654b640645",
+   "sha256": "16m3qv5g1kgx6x8df6i32dxmhg9na3k7mlzdcr9a5x53cfk98rpj"
   }
  },
  {
@@ -109843,11 +110446,11 @@
   "repo": "raegnald/rg-themes",
   "unstable": {
    "version": [
-    20250528,
-    1149
+    20250718,
+    1826
    ],
-   "commit": "4765a3884da3c8ccd85945319a7152143e11404c",
-   "sha256": "15dprnhmn43183wwva28kzr6wq650mhp842ifjabskknxdfnzrm0"
+   "commit": "5947efd002f262e685aae169e4ce68b088dacb7d",
+   "sha256": "1yffd994h45xsks19dn79mnxnansmcx6i590fc0njz9kdb7hwlxl"
   }
  },
  {
@@ -110729,11 +111332,11 @@
   "repo": "Andersbakken/rtags",
   "unstable": {
    "version": [
-    20250218,
-    2303
+    20250801,
+    1701
    ],
-   "commit": "94269d3558e5db8bab381379dc347bdc7f7ded68",
-   "sha256": "12iv0h14brybqlld5b7z8yicpm3y0wcmmswx9pv261izp7dr41xc"
+   "commit": "a09caa2d56aa9523222243764e99477458447913",
+   "sha256": "0l41pxshr3086jz8lsmf6wqzjz246ldkgcyyi1mf85g9gn5ncj0x"
   },
   "stable": {
    "version": [
@@ -110752,14 +111355,14 @@
   "repo": "Andersbakken/rtags",
   "unstable": {
    "version": [
-    20250218,
-    2303
+    20250801,
+    1701
    ],
    "deps": [
     "rtags"
    ],
-   "commit": "94269d3558e5db8bab381379dc347bdc7f7ded68",
-   "sha256": "12iv0h14brybqlld5b7z8yicpm3y0wcmmswx9pv261izp7dr41xc"
+   "commit": "62d881dab01ecb9ee6d54b705124ca8dadba726f",
+   "sha256": "1jfq3vfdjjhww34rc655jzm4cx5pw39y3w1j7a9s0ss1nb56f6dr"
   }
  },
  {
@@ -111770,15 +112373,11 @@
   "repo": "thapakrish/samskritam.el",
   "unstable": {
    "version": [
-    20240723,
-    1609
+    20250815,
+    440
    ],
-   "deps": [
-    "google-translate",
-    "popper"
-   ],
-   "commit": "c1ff0ff27d37312549c7345b58593ab0a6083e31",
-   "sha256": "0rr8snrmgr1vadr6ivczz3zk0h2zyxrqqq9fs3kps3hwidpi6gcf"
+   "commit": "07fd19057dc8122c6f7174bcd9b36ce711375385",
+   "sha256": "0j6ara5nsv0ykxihfy78w2ag6p5nammjbpd07iqq4xs4k34fjngi"
   }
  },
  {
@@ -111896,6 +112495,24 @@
    ],
    "commit": "8203a05a322324ec17b14437c8dfb38efdb53241",
    "sha256": "1zc7f5l7i60fpi8vw41xhpnhz5jpiqkk7fdkd2k6lnmv7jnnilfc"
+  }
+ },
+ {
+  "ename": "savefold",
+  "commit": "cde73b45f80c32cdc87ccb24a65bd72f2222c5be",
+  "sha256": "0b1kks066wdvk9whp303m4dx8h1hrgpk40zqc0yzxwdb3k7swm2f",
+  "fetcher": "github",
+  "repo": "jcfk/savefold.el",
+  "unstable": {
+   "version": [
+    20250817,
+    1933
+   ],
+   "deps": [
+    "compat"
+   ],
+   "commit": "68ec792ced589f64e747bee4fddaba89339f11ca",
+   "sha256": "1fq083k2783xv4zj7qhpdz147y31ck8c0khqh1n9z6zny5pg2b8x"
   }
  },
  {
@@ -112022,25 +112639,25 @@
   "repo": "openscad/emacs-scad-mode",
   "unstable": {
    "version": [
-    20250128,
-    2140
+    20250728,
+    238
    ],
    "deps": [
     "compat"
    ],
-   "commit": "1f5a2dd4d602aca0f4ceb3230f8d11107a9187fe",
-   "sha256": "12px37fyq7pzl9hbi7vpn6pvh2grzp2432g7yrhrrrc30j0imbsb"
+   "commit": "44b4ac086bd01791ff2ccb25234b4e5d701bc10a",
+   "sha256": "1h86z2qn9q7ww2m7p992fx8abzdffcd3bcp3bmck3c9q2aksjl5j"
   },
   "stable": {
    "version": [
-    96,
+    97,
     0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "36852e689c34936464b32d1558f6f9428dce63b8",
-   "sha256": "0vsidz3qws89z8blq5nng7mvzn3kj06lw9417aymhykyjgjn5f8m"
+   "commit": "44b4ac086bd01791ff2ccb25234b4e5d701bc10a",
+   "sha256": "1h86z2qn9q7ww2m7p992fx8abzdffcd3bcp3bmck3c9q2aksjl5j"
   }
  },
  {
@@ -112393,6 +113010,30 @@
   }
  },
  {
+  "ename": "scratch-plus",
+  "commit": "7c38f3c375e3097a56ffeb595d3e7dbc43277814",
+  "sha256": "0qr42mlqvhgln8x3n655zj1lc6daav5rwjqd0r2vrsfh2k8vgz6w",
+  "fetcher": "sourcehut",
+  "repo": "swflint/scratch-plus",
+  "unstable": {
+   "version": [
+    20250728,
+    109
+   ],
+   "commit": "b794901f968000f6e338808307385b683b79ec8b",
+   "sha256": "0afnxhlf72xw27s2i2r8hs50b5nlnz59x4pi7ahzng41wjrjb1p0"
+  },
+  "stable": {
+   "version": [
+    1,
+    2,
+    0
+   ],
+   "commit": "cfecace1a6f3389fcabbfdd009f2b14db6dcc637",
+   "sha256": "05f7brkgn8y8dn9xnrzg94nq2lz2imanb2wwd65h6wggdlaw62b8"
+  }
+ },
+ {
   "ename": "scratch-pop",
   "commit": "420fb3408b64f1a3e42316262016728c483bf0c1",
   "sha256": "0s7g1fbnc5hgz8gqmp1lynj5g7vvxisj7scxx5wil9qpn2zyggq1",
@@ -112464,11 +113105,11 @@
   "repo": "ideasman42/emacs-scroll-on-jump",
   "unstable": {
    "version": [
-    20250706,
-    1124
+    20250712,
+    1317
    ],
-   "commit": "00522ba63218b7f8ea3be7da97c7be05a108f3ce",
-   "sha256": "032chba2nqj64cshc8iwsfkfgwnn2zxbf55148wdhdy827mp8kjd"
+   "commit": "8b108786da855dffd0f1957a0906dd3921e25711",
+   "sha256": "0k5rbkj1z81i0g2wsa854sc5xfmbk2irqzm86jd1z548zf14wr5f"
   }
  },
  {
@@ -113010,28 +113651,28 @@
   "repo": "radian-software/prescient.el",
   "unstable": {
    "version": [
-    20240803,
-    2320
+    20250816,
+    19
    ],
    "deps": [
     "prescient",
     "selectrum"
    ],
-   "commit": "2b8a8b41228bddb2e11eb1c200e98a9edd04797c",
-   "sha256": "0qz3xv38vazxqsl7lan7fshj3gmb0qagkrvl5xzwqhdg0rir981j"
+   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
+   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
   },
   "stable": {
    "version": [
     6,
     3,
-    1
+    2
    ],
    "deps": [
     "prescient",
     "selectrum"
    ],
-   "commit": "2b8a8b41228bddb2e11eb1c200e98a9edd04797c",
-   "sha256": "0qz3xv38vazxqsl7lan7fshj3gmb0qagkrvl5xzwqhdg0rir981j"
+   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
+   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
   }
  },
  {
@@ -113886,20 +114527,20 @@
   "repo": "xenodium/shell-maker",
   "unstable": {
    "version": [
-    20250702,
-    1116
+    20250820,
+    939
    ],
-   "commit": "3a88d3b909b4fbe3baa37a71e1245327adb845f8",
-   "sha256": "1941jyyg8wv5ajpr83s8bwmpdmcqcz0vqqzsj6yf91xsf60v7gwb"
+   "commit": "b33eed1f939d107c01d4c1f7cfd50d76078f715e",
+   "sha256": "1hflmj6fnbbrnbbvrmjr7w9vbckx5hxsxx5h91yklmw8vy0xpn5l"
   },
   "stable": {
    "version": [
     0,
-    76,
-    2
+    80,
+    1
    ],
-   "commit": "72ce76bb3059e6c715b2471856851aac21198ac7",
-   "sha256": "0df0mxaz2g4fzdlhxygifmsjnxw7n8v1ghz1pnlhad0anpwdsdv9"
+   "commit": "d5748939c7209f927a4e563f03ad8a94cf5f802b",
+   "sha256": "1bcca4mg07rjb8x8875cggmhd1nxj0filb6qkfhq196rcsq7yckn"
   }
  },
  {
@@ -114148,14 +114789,14 @@
   "repo": "purcell/emacs-shfmt",
   "unstable": {
    "version": [
-    20250610,
-    1538
+    20250709,
+    1443
    ],
    "deps": [
     "reformatter"
    ],
-   "commit": "61b790405b0198f72db99df235c184eb86ffe405",
-   "sha256": "14zcj69gwvspnnzgcaddjm9njwrh426bzhmfy9sjmg7hq626a42j"
+   "commit": "c81cb23fed1a77732b972ea036d74cbeb7c13bb1",
+   "sha256": "0r1xw5xnzfyknk8p0w7w5xmrl5lnbzgnkwwlc518zxgwz18xnyh3"
   },
   "stable": {
    "version": [
@@ -114177,11 +114818,11 @@
   "repo": "ideasman42/emacs-shift-number",
   "unstable": {
    "version": [
-    20250610,
-    34
+    20250710,
+    340
    ],
-   "commit": "d0d852ea302db96942938960a1022f943d863130",
-   "sha256": "02pci1x1lq3xbdxhnf2gb5lqpxj67b83q51m1rv78rzbh6zwz7mi"
+   "commit": "cfe8e90591ec3271cb901cc34b68f2ca3d858c1f",
+   "sha256": "10ww6djgb5s2ghknvhx9yl210iawkhp1ll80ls5lvmk7vph6bnay"
   },
   "stable": {
    "version": [
@@ -114219,11 +114860,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20250702,
-    658
+    20250806,
+    224
    ],
-   "commit": "bf3315747a469ef2692ebf57fcd2c4f853392c24",
-   "sha256": "1fnwqfryz3nxrsh816c9a5j8lq3c7afx5cwqkqw4wfdipp0azk4y"
+   "commit": "7945f3bbd52288e671bfb4d0bee30d908ae0289b",
+   "sha256": "1mwjis4ds60c06lfjz8nfnz3nmdmhkr2yzrjph4v49cp98rwc6rx"
   }
  },
  {
@@ -114424,28 +115065,28 @@
   "repo": "chenyanming/shrface",
   "unstable": {
    "version": [
-    20250330,
-    1106
+    20250807,
+    649
    ],
    "deps": [
     "language-detection",
     "org"
    ],
-   "commit": "beabf1c7dfc4f1dc69f2cbcc438a74b5497a90ec",
-   "sha256": "1f1kd0hdhn4536vabvv4kplbwmy0mznhvhzn3pa581h580jzg9hf"
+   "commit": "5571cc62635628c8661f123b6d4a8335cb0ff8a1",
+   "sha256": "1skxyy87c6iwfqc0rwjls5vg2m43m3qfmzdyl1pgsjs9p1njp06b"
   },
   "stable": {
    "version": [
     2,
     6,
-    4
+    5
    ],
    "deps": [
     "language-detection",
     "org"
    ],
-   "commit": "41e7cfcb42f97d652835e0b702f29aae5955f1f4",
-   "sha256": "144w7fvfrk3659d5ig8rbl3qwmcb5ssgnqgs798vfwanni7r1ggg"
+   "commit": "0c98fa80bf8fc7f0864cd30063202235e12b8ad4",
+   "sha256": "1vvshfghkdq9f69vnpdjn8df8lkvypqqr06yqxpwg1vvhjxkzl4a"
   }
  },
  {
@@ -114862,8 +115503,8 @@
   "repo": "emacs-sideline/sideline-lsp",
   "unstable": {
    "version": [
-    20250101,
-    857
+    20250805,
+    922
    ],
    "deps": [
     "dash",
@@ -114872,8 +115513,8 @@
     "s",
     "sideline"
    ],
-   "commit": "29b95888a91f53e5161a3f2e2fc27a9cfc71ebe5",
-   "sha256": "0dzfff4wxwpas76cc6rhi152w875j89qiw7fvz8adqdkqbcji306"
+   "commit": "fed3ab896be6b508ce3e37994600dd56af993185",
+   "sha256": "0rp5wr8h1fsa3l6hambzakxqhd5vw4rpkg6rc32pcmnzxyx7c4sr"
   },
   "stable": {
    "version": [
@@ -115370,8 +116011,8 @@
   "repo": "magit/sisyphus",
   "unstable": {
    "version": [
-    20250601,
-    1100
+    20250801,
+    950
    ],
    "deps": [
     "compat",
@@ -115379,14 +116020,14 @@
     "llama",
     "magit"
    ],
-   "commit": "d8b2130cd3aaa4e6b604cdb6fc0262152e5aa55f",
-   "sha256": "0z885k44nyvr2p41652xbpb8awyxjsnp20nps8c2xllam2pa80rl"
+   "commit": "9c9fc0624308fba0fe0cc112d1e4de21db81803f",
+   "sha256": "06gsl5cr2x73njhxia2xlxdhkdddzv6w7q3asgj1f6xjx50vvc7b"
   },
   "stable": {
    "version": [
     0,
     2,
-    4
+    5
    ],
    "deps": [
     "compat",
@@ -115394,8 +116035,8 @@
     "llama",
     "magit"
    ],
-   "commit": "d8b2130cd3aaa4e6b604cdb6fc0262152e5aa55f",
-   "sha256": "0z885k44nyvr2p41652xbpb8awyxjsnp20nps8c2xllam2pa80rl"
+   "commit": "9c9fc0624308fba0fe0cc112d1e4de21db81803f",
+   "sha256": "06gsl5cr2x73njhxia2xlxdhkdddzv6w7q3asgj1f6xjx50vvc7b"
   }
  },
  {
@@ -115638,8 +116279,8 @@
   "repo": "emacs-slack/emacs-slack",
   "unstable": {
    "version": [
-    20250708,
-    2121
+    20250819,
+    1012
    ],
    "deps": [
     "alert",
@@ -115651,8 +116292,8 @@
     "ts",
     "websocket"
    ],
-   "commit": "761daa69cff3bf7bb44df19f38a61ca88663bbc1",
-   "sha256": "1jkpchh4ckiqxa6iakchx9r5krw1c03jarwpfa3gkfy9r1g05qll"
+   "commit": "b75ac2a6a65477c2ecc6b989d3f08cc833c8627a",
+   "sha256": "0m32252lv1pwd4i0z7f8ayhq2iwd84f4dmz1c6wb90xly5zc5l65"
   }
  },
  {
@@ -115710,14 +116351,14 @@
   "repo": "slime/slime",
   "unstable": {
    "version": [
-    20250706,
-    1422
+    20250817,
+    2347
    ],
    "deps": [
     "macrostep"
    ],
-   "commit": "5e234b45c6fcc3fc99ff75a62f489163e59f42bc",
-   "sha256": "1wb1axpvi5adfqq39dw3wqlnyjfmd5wjk7fg1af92isza2lcxxrr"
+   "commit": "fe2090079cf933c72c48861582477d1c0c896f6a",
+   "sha256": "19h92mbssx9442dpcy6h0v1x4ipvbq8zx3all6kf7b62vakyrdm4"
   },
   "stable": {
    "version": [
@@ -115739,15 +116380,15 @@
   "repo": "anwyn/slime-company",
   "unstable": {
    "version": [
-    20250301,
-    21
+    20250815,
+    757
    ],
    "deps": [
     "company",
     "slime"
    ],
-   "commit": "e4f012bf989d832275e7ba43b46134666a34cd90",
-   "sha256": "1lzl08fadjn58s9r8kcn1m2sj8qpkg230cjx382jkd5h7ahksx1n"
+   "commit": "38ab03e4015029de74cc23d499bf29de60da9bad",
+   "sha256": "13n18rpg242wbhbya6rj318ljp8fqsqrhvl737ycl1b819ck7a1x"
   },
   "stable": {
    "version": [
@@ -117019,16 +117660,16 @@
   "repo": "danielfm/smudge",
   "unstable": {
    "version": [
-    20250115,
-    52
+    20250806,
+    1826
    ],
    "deps": [
     "oauth2",
     "request",
     "simple-httpd"
    ],
-   "commit": "aa806e84506d332bdbf379c199f66813daf4c855",
-   "sha256": "1qc4zysyny84a3z755nlqsjhhn2igbn1i2284dxarcswl56i6a7d"
+   "commit": "422e2b78e7d56ab77815c38d01d2f22ea2472965",
+   "sha256": "16ihsjcbms3k0pdwc1f3gpx4d92l3na2g0d2j10slw8j8pd9435c"
   }
  },
  {
@@ -117388,11 +118029,11 @@
   "repo": "nlordell/sol-mode",
   "unstable": {
    "version": [
-    20250517,
-    1926
+    20250805,
+    2103
    ],
-   "commit": "93d96af2b7d19edd9caaf35478ec88e1530785aa",
-   "sha256": "12xjmda0hiydmknpnw973kz318z3d68bppc9v2ff72sycgbkpzwg"
+   "commit": "1379290f360fb3fea98ae397996b08d32372d77d",
+   "sha256": "1brq866b9wj7s6wrniqqapkf5cz820hfvjc9rc1yr5cmv3kv7ndc"
   },
   "stable": {
    "version": [
@@ -118311,14 +118952,14 @@
   "repo": "dakra/speed-type",
   "unstable": {
    "version": [
-    20250701,
-    2208
+    20250806,
+    2155
    ],
    "deps": [
     "compat"
    ],
-   "commit": "b4dbaac540d924a431969417b77ea09ea817cf4d",
-   "sha256": "18x5zpq3m8zr5d3bb4kaj9s7xik337z16hjhdqy0knzpdyqs8k3f"
+   "commit": "76f74d313420111cb0f8ce578d6c348b1a46817b",
+   "sha256": "089c1997i1y20dkj29h8zpk39kwyyiv5rx6bmna23jzjvcwh21b7"
   },
   "stable": {
    "version": [
@@ -118386,11 +119027,11 @@
   "repo": "ideasman42/emacs-spell-fu",
   "unstable": {
    "version": [
-    20241011,
-    206
+    20250712,
+    1319
    ],
-   "commit": "d465d70126d7ff8e37013ef942c292aaa1ca23f3",
-   "sha256": "0v9jr5z8v76d94hl2akf8db7y9gfs2hfamgb8b3dz3jhdrgs62x1"
+   "commit": "e2eda668f5af063ecc3d97321eda6a50951c87a1",
+   "sha256": "1pqzpwig4zs6rx4cnrizpicmj4dcx1czhw458zfirq4k0m622755"
   }
  },
  {
@@ -119002,11 +119643,11 @@
   "repo": "srcery-colors/srcery-emacs",
   "unstable": {
    "version": [
-    20250523,
-    1304
+    20250728,
+    1144
    ],
-   "commit": "55771c3190f2ed2fdcde3d6e6e94d4366830657c",
-   "sha256": "1pml61zxq0pzd60ppssxcr5mn44ckfg5c8x2wrf63fcbyfqy61xm"
+   "commit": "a0e3409c97dc24f3468a352a4fcf00ed9923cac7",
+   "sha256": "1lb24j9zgpgxmyynmibvn2mynggb0limd0cpja3jliw2zygw6j15"
   }
  },
  {
@@ -119040,11 +119681,11 @@
   "repo": "srfi-explorations/emacs-srfi",
   "unstable": {
    "version": [
-    20250609,
-    2346
+    20250726,
+    420
    ],
-   "commit": "0b0f58f1cdeaf631017bc7593b81c8343d459b58",
-   "sha256": "0vd9b0nkjql2ghgmrsxa1kbd12zcl8a6j9vx100lmpp7gx8n0afp"
+   "commit": "3a98b7dbf9618143026c437815f22cacbe81c4b6",
+   "sha256": "1ylqfynkjkdl1w2cwwj618jwwbnw19phgfkfqpi8zq9nfk32wf9z"
   },
   "stable": {
    "version": [
@@ -119490,20 +120131,20 @@
   "repo": "stacked-git/stgit",
   "unstable": {
    "version": [
-    20250701,
-    356
+    20250811,
+    357
    ],
-   "commit": "f88c7f0e375e069ea35f7db1294d1408d69e7a1d",
-   "sha256": "0lz88v4qny6l9fnxykaz7ys5cb7fds0y5b589gvqdqzjw3ijkd8j"
+   "commit": "d05f56db8124fc76c37a10c61e8db8a45e8cae15",
+   "sha256": "16r5vx6pnw6ricdv25vx8vqihlkhf092p3n4mrn0qly9m5a7dj2f"
   },
   "stable": {
    "version": [
     2,
     5,
-    3
+    4
    ],
-   "commit": "a9fd1cb3baf5ea3f7d0edb6c319a16507aa9a64c",
-   "sha256": "1876366a0vmn90sfwhzx1l7lwyhc2527yvz2lsbzj228wgi5zck2"
+   "commit": "d05f56db8124fc76c37a10c61e8db8a45e8cae15",
+   "sha256": "16r5vx6pnw6ricdv25vx8vqihlkhf092p3n4mrn0qly9m5a7dj2f"
   }
  },
  {
@@ -119772,11 +120413,11 @@
   "repo": "akicho8/string-inflection",
   "unstable": {
    "version": [
-    20250630,
-    555
+    20250823,
+    45
    ],
-   "commit": "02ab7b2ea8530c63c20556c1afb795924e08dfca",
-   "sha256": "1hzjmiz3ybqpd8wla92pf5sx32cpq5b04iiy3sg0zax4wvyr8v8g"
+   "commit": "e56f40737b6925de5c212aaa9485014f42cbdbcd",
+   "sha256": "0m205jdy76ml3dgn2fwrn5lzz3cr0dxcny1iqq74vhq7azn9hvlk"
   },
   "stable": {
    "version": [
@@ -119871,11 +120512,11 @@
   "repo": "jamescherti/stripspace.el",
   "unstable": {
    "version": [
-    20250513,
-    1731
+    20250822,
+    1937
    ],
-   "commit": "ad553e53dad42c89b8bf7225d1c60f94cba930d5",
-   "sha256": "0c59cyj2n40sbafn2qv1hfwj3y6hzdbs2whm888jrn692zbxxxvk"
+   "commit": "3935581cc5d84aa6134b430c63fff9185a99564c",
+   "sha256": "0777638j29wj9a7r4yc73gjh09ns8lm0ksh450ahldq5x18bwmdf"
   },
   "stable": {
    "version": [
@@ -120250,8 +120891,8 @@
   "repo": "kiyoka/Sumibi",
   "unstable": {
    "version": [
-    20250705,
-    2349
+    20250809,
+    1425
    ],
    "deps": [
     "deferred",
@@ -120259,13 +120900,13 @@
     "popup",
     "unicode-escape"
    ],
-   "commit": "af6c53ed79f6df61e77d40207f942190cf6459e6",
-   "sha256": "1xl961k1kq4cnd1vyhcx8ndxl54dyr07sx62zzq8vvbyg2v5vrch"
+   "commit": "11485c5b6008e7dbf405036e1f08d103531517e9",
+   "sha256": "1rpsv6b8wdafizdrc84fwa0xyhsb5v39p8zkwm4fzgd18h57j5jf"
   },
   "stable": {
    "version": [
     3,
-    2,
+    6,
     0
    ],
    "deps": [
@@ -120274,8 +120915,8 @@
     "popup",
     "unicode-escape"
    ],
-   "commit": "af6c53ed79f6df61e77d40207f942190cf6459e6",
-   "sha256": "1xl961k1kq4cnd1vyhcx8ndxl54dyr07sx62zzq8vvbyg2v5vrch"
+   "commit": "11485c5b6008e7dbf405036e1f08d103531517e9",
+   "sha256": "1rpsv6b8wdafizdrc84fwa0xyhsb5v39p8zkwm4fzgd18h57j5jf"
   }
  },
  {
@@ -120395,11 +121036,11 @@
   "repo": "mkleehammer/surround",
   "unstable": {
    "version": [
-    20250124,
-    1628
+    20250725,
+    511
    ],
-   "commit": "32a63da201064bb0787fd2e7a79e41878e0223a4",
-   "sha256": "12p5srddv2acmklsl9d8rkhk9i680i3c0ws2slhb8imja45k6w3z"
+   "commit": "6807bf69be1591a419a009adf8a5071b1cdcc76e",
+   "sha256": "0vi0hnyp6bwfqlj8gwj95hm8vjz3z6cy0yprw7xhm0197fawj4qi"
   }
  },
  {
@@ -121182,11 +121823,11 @@
   "repo": "liushihao456/symbols-outline.el",
   "unstable": {
    "version": [
-    20250226,
-    456
+    20250728,
+    1231
    ],
-   "commit": "01e4438981e4884cf44ecc44dbf2e6e4e89c0a1a",
-   "sha256": "07gs54hwhr019d9zxv6a3inhr5b2065y5ykrdp76j6cabzlpj5gp"
+   "commit": "ee595d395d6137ce7d31da6bb4d6391ad9f6883c",
+   "sha256": "1mp5saap2wq5ddyqlgx1gp7m1wyl4whpvccibid4311fy9xa2i1y"
   }
  },
  {
@@ -121213,49 +121854,6 @@
    ],
    "commit": "273dece5b04f7abc4c35048b2f64f04b33774b87",
    "sha256": "0gpm0zy1kwqxkakvfdgh1lylp99msyamwvi19c53g9jl01m9avyd"
-  }
- },
- {
-  "ename": "symex",
-  "commit": "8d14a6b06d97b36d5d76e418f800d6bc3156700f",
-  "sha256": "0y6nma82mxggp0724axy1fnvi3girnscjygdhl28dd3wx6kk268b",
-  "fetcher": "github",
-  "repo": "drym-org/symex.el",
-  "unstable": {
-   "version": [
-    20250102,
-    50
-   ],
-   "deps": [
-    "evil",
-    "evil-cleverparens",
-    "evil-surround",
-    "hydra",
-    "lispy",
-    "paredit",
-    "seq",
-    "tree-sitter",
-    "tsc"
-   ],
-   "commit": "94e5040f0c24f870b7217d8ddf6675c6b17eaff4",
-   "sha256": "11lj9vrfiiz2my519kc54lrg5dfhk66bp34c3rg1psjr99f118zv"
-  },
-  "stable": {
-   "version": [
-    1,
-    1
-   ],
-   "deps": [
-    "evil",
-    "evil-cleverparens",
-    "evil-surround",
-    "hydra",
-    "lispy",
-    "paredit",
-    "seq"
-   ],
-   "commit": "47b5296cf357eb0fc94b531e0126740aa168ed8d",
-   "sha256": "1ksmqj6kk0l3k57yswwqy49qrz2nggg487p10i2zbza7wk5hnra3"
   }
  },
  {
@@ -122068,11 +122666,11 @@
   "repo": "tmalsburg/tango-plus-theme",
   "unstable": {
    "version": [
-    20240703,
-    1443
+    20250813,
+    1242
    ],
-   "commit": "e042de79ba009a55aeebe30aafed01234c925be2",
-   "sha256": "109g4w47bx17rpl4n96bcx254xiai89gbi4j89yhzf5cbldmj764"
+   "commit": "6c57ae3745ab66c75d4ebb336d3403d90537206a",
+   "sha256": "1apvwc5v27dq4mjv0rk5yqs0pgxmd6ar3jgxdb2488lws2z08xdq"
   }
  },
  {
@@ -122122,11 +122720,11 @@
   "repo": "11111000000/tao-theme-emacs",
   "unstable": {
    "version": [
-    20240615,
-    517
+    20250717,
+    347
    ],
-   "commit": "cd8ac4aee9fff55bc092ce78d93bd40517fa2c2a",
-   "sha256": "1r27zvymbgq50akhj6l7s1aj0sz81a375lxdhl8cl9jg74w31i6i"
+   "commit": "33c0d44048afe444e7a8aee30fbc101a00453799",
+   "sha256": "18a3njjg9d5s97ymm67s995cgzx2fvc9x613vsn3rp659pkd2rcb"
   },
   "stable": {
    "version": [
@@ -122161,11 +122759,11 @@
   "repo": "saf-dmitry/taskpaper-mode",
   "unstable": {
    "version": [
-    20241231,
-    1206
+    20250823,
+    1538
    ],
-   "commit": "1558c12b647d289285b638075be016f7f0c3466e",
-   "sha256": "0ksa9ndypkvjm00zzhd1bj163jd7v5rim4ssvnqhhsps0mdrch6l"
+   "commit": "208e6832ca68b33263440c472386ca033ba2735c",
+   "sha256": "05banf0gsw8kab4d6vpibjw2vk4dkgwfsnd05qvqljawa3i0dc6a"
   },
   "stable": {
    "version": [
@@ -122491,14 +123089,14 @@
   "repo": "minad/tempel",
   "unstable": {
    "version": [
-    20250620,
-    1157
+    20250823,
+    2003
    ],
    "deps": [
     "compat"
    ],
-   "commit": "9fa2c59660fe9473429a51872d3c00e1b95cab86",
-   "sha256": "104wifdqglk6hxs6z3gr6rmxf3hdqsl3y9bvcp3wwm10yqkpnmkx"
+   "commit": "779d9577ac537534fad4221c96e6c565bb14908a",
+   "sha256": "0nf3jqibg9xnwsfznvsfkd5cjyj2amg705n2bcrbc92plsjfmxnd"
   },
   "stable": {
    "version": [
@@ -122972,11 +123570,19 @@
   "repo": "milanglacier/termint.el",
   "unstable": {
    "version": [
-    20250627,
-    25
+    20250824,
+    1809
    ],
-   "commit": "eb9e63e15f8b03a51ef114fb0ec73b6f3b9b4ace",
-   "sha256": "1qkdk9gacg6qknhcfj3fxrp6dh82mhk6ir09xc2mmx9p7hhyx37g"
+   "commit": "0e5ae2c685bf8b45f89fd91dc235ddaf5d4ffbd5",
+   "sha256": "0lp0rinxjlalb2d4lp2sxngwnr3sjdyr90djx97ylrrx7s1g6jax"
+  },
+  "stable": {
+   "version": [
+    0,
+    1
+   ],
+   "commit": "18f60f732dd91d274a8cbdfa2508aaa922c32708",
+   "sha256": "0mw8sk071ph3s0vcvbkkqd8bwp8n7y3ijnfrfpkklilg3zb0vrqq"
   }
  },
  {
@@ -123155,15 +123761,15 @@
   "stable": {
    "version": [
     1,
-    0,
-    1
+    1,
+    0
    ],
    "deps": [
     "dash",
     "hcl-mode"
    ],
-   "commit": "56f19abae95afb7e13e48ec3e6aeba3820d31307",
-   "sha256": "10wndnlsv7f2yn83n1wamnhiwyhxkdlmwld9yk0m2kkxx4pwfgfj"
+   "commit": "80383ff42bd0047cde6e3a1dfb87bdb9e0340da3",
+   "sha256": "15xgjyl864crx3vpalds68x0vn1qzibkqdcjlbp87xiq88dx2q1x"
   }
  },
  {
@@ -123736,21 +124342,21 @@
   "repo": "facebook/fbthrift",
   "unstable": {
    "version": [
-    20250707,
-    1302
+    20250824,
+    1632
    ],
-   "commit": "0f0cd92a6e051e7a5980182d60941e3da492f634",
-   "sha256": "0hl3cf7hvrn7kjn12a40abkslijp509qgqrcdcqpczjscm5m172v"
+   "commit": "879208449207e47a4b655e11848979f41a7e4b29",
+   "sha256": "0wabymrm7r1zjcz32sl28yrmgcn96axw8i3ab9aszvxx3alb77fg"
   },
   "stable": {
    "version": [
     2025,
-    7,
-    7,
+    8,
+    25,
     0
    ],
-   "commit": "0f0cd92a6e051e7a5980182d60941e3da492f634",
-   "sha256": "0hl3cf7hvrn7kjn12a40abkslijp509qgqrcdcqpczjscm5m172v"
+   "commit": "879208449207e47a4b655e11848979f41a7e4b29",
+   "sha256": "0wabymrm7r1zjcz32sl28yrmgcn96axw8i3ab9aszvxx3alb77fg"
   }
  },
  {
@@ -123800,26 +124406,26 @@
   "repo": "uzu/tidal",
   "unstable": {
    "version": [
-    20250628,
-    806
+    20250711,
+    1955
    ],
    "deps": [
     "haskell-mode"
    ],
-   "commit": "7b1624ac83177ecf4ceead7dc50448258988af8b",
-   "sha256": "0cl7mr58sm7x4rx3lb7ss6yk0rxbwxgk09zgmbzvpq7h3r0blbs5"
+   "commit": "660ac746ec5c89da7ead100c0c46bf67e4037f41",
+   "sha256": "05xf1ifd24afqmxfs9kkhkc1m9sc2cs9q9xkyym6r3bywgi5zs4j"
   },
   "stable": {
    "version": [
     1,
     10,
-    0
+    1
    ],
    "deps": [
     "haskell-mode"
    ],
-   "commit": "433ed7f8524f2ec00f626146830537bd897eb08f",
-   "sha256": "0sy9kc0rchj5ilkg3sz5f94p4bslymq7rq1a17fgn6zynl3b3f7g"
+   "commit": "660ac746ec5c89da7ead100c0c46bf67e4037f41",
+   "sha256": "05xf1ifd24afqmxfs9kkhkc1m9sc2cs9q9xkyym6r3bywgi5zs4j"
   }
  },
  {
@@ -124009,11 +124615,11 @@
   "repo": "karthink/timeout",
   "unstable": {
    "version": [
-    20240623,
-    2023
+    20250822,
+    1813
    ],
-   "commit": "d59ca149307182b20e9843db0dd1738e01504cf1",
-   "sha256": "1adbcam0cz7gkijjzgajybz9z2cfizxylfggamqp23w52c1nbrxm"
+   "commit": "0efdd2173cfd84a9f49b721ce7ef685048499905",
+   "sha256": "0j4adn4kir87kqc4j3fd8h3fkdi5c4dnqsy8q22s99p12i2c37v4"
   }
  },
  {
@@ -124681,11 +125287,11 @@
   "repo": "gongo/emacs-toml",
   "unstable": {
    "version": [
-    20250529,
-    1353
+    20250729,
+    635
    ],
-   "commit": "cf0e6c1675b67858588c43a68cc49fc45696771e",
-   "sha256": "1qay3y10bclfmqngq0if88kkkvp8p8khi7s9iy5s2ld3yq123r2f"
+   "commit": "8d8cefa2a0590ed4b68064a7a55a552c0a16a68a",
+   "sha256": "04kyzpb4gwvx7r1nkv8z63rl92nvc32kssv7ncpmb4la97lcq09k"
   },
   "stable": {
    "version": [
@@ -124762,11 +125368,11 @@
   "repo": "jamescherti/tomorrow-night-deepblue-theme.el",
   "unstable": {
    "version": [
-    20250628,
-    1608
+    20250805,
+    2016
    ],
-   "commit": "d15dc91f99aa30fbe570f29fe689d49727ee248d",
-   "sha256": "105zxj6w9ipjhfzv19br66iicp21fq62la4rf17qsqy75kfqrj9z"
+   "commit": "0265dc8b8f0da55dfbf83a7e814ebb0ac4fad97b",
+   "sha256": "04ab631fkhwzihlqlka27xfazpn006a1rdm1igij02ybxkvg30fh"
   },
   "stable": {
    "version": [
@@ -124876,15 +125482,15 @@
   "repo": "sarg/torrent-mode.el",
   "unstable": {
    "version": [
-    20240923,
-    503
+    20250813,
+    1529
    ],
    "deps": [
     "bencoding",
     "tablist"
    ],
-   "commit": "c7ef935dcf7b999981f441794ddbd98c3216bfee",
-   "sha256": "06mxlsg5yqhssyr612377l0pv67xjr4g06rmmim7jh7w0z379ibv"
+   "commit": "5dbb59c60c0c2db24d3d138eb003c66c3578b7b4",
+   "sha256": "0r6hi18mjlip002lqfbch7fnkkzn5g1h2p3y9c6qmw79kd32qlf8"
   }
  },
  {
@@ -125337,28 +125943,28 @@
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20250701,
-    1223
+    20250816,
+    1830
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "49bbb29fd34b807948d4f2b91f61587c12a595f0",
-   "sha256": "0iqxb0njhfi025w3mmzjh67wg35wk3cfgjd5f11hxxp81akqnxp2"
+   "commit": "07a104aa73b5d5e3168ba6e202ebfb60188af6ed",
+   "sha256": "1rka160jgk1i1bqlizyb46la3gck2i8gb1ywy0r51a3grl2x92rk"
   },
   "stable": {
    "version": [
     0,
     9,
-    3
+    4
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "49bbb29fd34b807948d4f2b91f61587c12a595f0",
-   "sha256": "0iqxb0njhfi025w3mmzjh67wg35wk3cfgjd5f11hxxp81akqnxp2"
+   "commit": "aa32e0d66cc389befed7a8e8df9439d92a729daa",
+   "sha256": "1bv4ziz44yn4jnzbi6px55hk5h9cxr8jv2v1cdafc2bs9i11qb3n"
   }
  },
  {
@@ -125731,16 +126337,16 @@
   "repo": "ShuguangSun/tree-sitter-ess-r",
   "unstable": {
    "version": [
-    20241120,
-    1547
+    20250729,
+    1500
    ],
    "deps": [
     "ess",
     "tree-sitter",
     "tree-sitter-langs"
    ],
-   "commit": "5e5dbd4d1cf6417530bae2f620405d304fac7772",
-   "sha256": "12lami5z8ji19y79zpwvk1p15zzhnjawj1bp2i5gnr38r8h9k2qy"
+   "commit": "205b105c72220ae0db5e1cbbb1c54756c7492761",
+   "sha256": "0mif9nm3xrarw8d3igdrr93anrw4y9w4298qp2glhcscxw6jizki"
   },
   "stable": {
    "version": [
@@ -125813,26 +126419,26 @@
   "repo": "emacs-tree-sitter/tree-sitter-langs",
   "unstable": {
    "version": [
-    20250706,
-    1346
+    20250824,
+    1812
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "b9339dcce36c58140fda64c71fe36886475d954c",
-   "sha256": "0n6wi5s3qny65yx366l5hnbvb1mzkbz7kgiyv016bhh7jw77lk7v"
+   "commit": "3d22dcde8574a7991bea412d45d7db71d50ce544",
+   "sha256": "032wljj3qf7lqk8dyzbr24zppyfjjdbljilhlyv5bnxszxgs8wap"
   },
   "stable": {
    "version": [
     0,
     12,
-    290
+    301
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "b9339dcce36c58140fda64c71fe36886475d954c",
-   "sha256": "0n6wi5s3qny65yx366l5hnbvb1mzkbz7kgiyv016bhh7jw77lk7v"
+   "commit": "3d22dcde8574a7991bea412d45d7db71d50ce544",
+   "sha256": "032wljj3qf7lqk8dyzbr24zppyfjjdbljilhlyv5bnxszxgs8wap"
   }
  },
  {
@@ -125909,8 +126515,8 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20250707,
-    2001
+    20250729,
+    1429
    ],
    "deps": [
     "ace-window",
@@ -125922,8 +126528,8 @@
     "pfuture",
     "s"
    ],
-   "commit": "246d9505edf86c25a08cfbd131c441c8d402f8c3",
-   "sha256": "0x9zp2dd9l79lp2pcj7a9x4a0h6kp6x5cyaiw4h8cw6ym3pym5lc"
+   "commit": "5fa84199501fd43e5573b1277a2b1699c7473cc1",
+   "sha256": "08wjq7czw9ix9aaz82f7n3x14byv2cc8whmirqjzsp19l29r2qq4"
   },
   "stable": {
    "version": [
@@ -126043,16 +126649,16 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20250320,
-    2145
+    20250726,
+    2233
    ],
    "deps": [
     "magit",
     "pfuture",
     "treemacs"
    ],
-   "commit": "55079b017fb821a34ace398cd3d8c5b556a22f6d",
-   "sha256": "0z8pc7y8p32vhlv5ibr11mrd8r8fk09dfgsj7a63d48r992p7gih"
+   "commit": "68e444e066a30d70a201fb162c8cf3d472226853",
+   "sha256": "1sx9pjkfdb7kbihvrc847x68bq6x7ai8p3234df2gf5czxsfk0r7"
   },
   "stable": {
    "version": [
@@ -126959,15 +127565,15 @@
   "repo": "tmalsburg/txl.el",
   "unstable": {
    "version": [
-    20250318,
-    726
+    20250709,
+    1113
    ],
    "deps": [
     "guess-language",
     "request"
    ],
-   "commit": "95064614df192c563b37e6135f5986c786a6826e",
-   "sha256": "0rxq13nviz7681ajmlklys87iwv6i940r5jk8z06dxxp8a7a65ri"
+   "commit": "ad0ff6b9b66465457709c9f79d881b7e0ddbd352",
+   "sha256": "13qsqhxvvbqv9mbb76y8j4vp6jb5hsj2i77v2sjs4dhi2s2hzgf6"
   }
  },
  {
@@ -127016,20 +127622,20 @@
   "repo": "KeyWeeUsr/typewriter-roll-mode",
   "unstable": {
    "version": [
-    20241127,
-    1742
+    20250718,
+    2028
    ],
-   "commit": "821a0c6e13e160e9a6f02c6232449c163043f75b",
-   "sha256": "0ijihkx1lnl8hkbl5m6hn9n9bf3a0w90b00hz3xlsw1i32wriik3"
+   "commit": "dd6738e86db6492c945e3a9238e0cfbe154ad98b",
+   "sha256": "06za43nbcz8s5iw2rh7qb42qaqmixwdg44djhybqd2i8ha8l2jfh"
   },
   "stable": {
    "version": [
     1,
     2,
-    1
+    2
    ],
-   "commit": "821a0c6e13e160e9a6f02c6232449c163043f75b",
-   "sha256": "0ijihkx1lnl8hkbl5m6hn9n9bf3a0w90b00hz3xlsw1i32wriik3"
+   "commit": "dd6738e86db6492c945e3a9238e0cfbe154ad98b",
+   "sha256": "06za43nbcz8s5iw2rh7qb42qaqmixwdg44djhybqd2i8ha8l2jfh"
   }
  },
  {
@@ -127081,17 +127687,17 @@
  },
  {
   "ename": "typo",
-  "commit": "11e080fa5a065ca4c2a3eff1203f80d7d1b1c597",
-  "sha256": "0aarir50ffgy2pk7jz6s8ivqhin9siy56x2hmhc9ky2va5qpnm8m",
-  "fetcher": "codeberg",
-  "repo": "pkal/typo.el",
+  "commit": "2f9993b1a95398e307a7864865be3c894ab7c602",
+  "sha256": "1p8is1n525lmzq588hj6vazmhl9wi6rairnfx1g1p6g6ijdycd4h",
+  "fetcher": "github",
+  "repo": "jorgenschaefer/typoel",
   "unstable": {
    "version": [
-    20230725,
-    2003
+    20200706,
+    1714
    ],
-   "commit": "f5920481422460837572646656f8ad2307e70c58",
-   "sha256": "0hc873mhwwmwgscrjsq00zs0r61ngvwcirpm6zm0na2c3q9qrvbn"
+   "commit": "173ebe4fc7ac38f344b16e6eaf41f79e38f20d57",
+   "sha256": "09835zlfzxby5lpz9njl705nqc2n2h2f7a4vpcyx89f5rb9qhy68"
   },
   "stable": {
    "version": [
@@ -127395,6 +128001,30 @@
    ],
    "commit": "7f52f030e5bf6e98ba9eee75631a6e2b95f90583",
    "sha256": "0iqkwrqmbcblnh00w0lsgnf79mcqdb52wrdx41mvq6hx31zgrcjp"
+  }
+ },
+ {
+  "ename": "ultra-scroll",
+  "commit": "21b5917792cf971a29e5902bd57e22590c62f9d8",
+  "sha256": "05n59nxdh50169zgi4sf2a96gry96r0p5kf6mp0kqfsh3iakk193",
+  "fetcher": "github",
+  "repo": "jdtsmith/ultra-scroll",
+  "unstable": {
+   "version": [
+    20250714,
+    2049
+   ],
+   "commit": "077d1e32a604fc4244edbf4ff6ec0f37c738b585",
+   "sha256": "0k1xqkxq89mz8dvzbfpks3jnrcmbd0hcz8a0hib1m3ka55hpczqz"
+  },
+  "stable": {
+   "version": [
+    0,
+    4,
+    2
+   ],
+   "commit": "077d1e32a604fc4244edbf4ff6ec0f37c738b585",
+   "sha256": "0k1xqkxq89mz8dvzbfpks3jnrcmbd0hcz8a0hib1m3ka55hpczqz"
   }
  },
  {
@@ -127953,14 +128583,14 @@
   "repo": "tbanel/uniline",
   "unstable": {
    "version": [
-    20250706,
-    1924
+    20250825,
+    917
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "475912a831ffb41b5b25d1eec79afb7a2279d9e3",
-   "sha256": "0xdij41clradmgjp1gzx163y8qdkdkjn3s5ivn3fjzq8307cxpna"
+   "commit": "193205f2c08cc905909398ef902ffb2cb49c86cd",
+   "sha256": "04pmkzq3f4sl3xm75dzz6ilsbz2x24cs4rf5rn7zjqlqwzwihgrm"
   }
  },
  {
@@ -128079,14 +128709,14 @@
   "repo": "swflint/emacs-universal-sidecar",
   "unstable": {
    "version": [
-    20250704,
-    342
+    20250731,
+    200
    ],
    "deps": [
     "magit-section"
    ],
-   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
-   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
+   "commit": "c7dcbfe357b7b32f15f3a34db29adb49044d4942",
+   "sha256": "102lmxqrz788s6izwlwyiw2z5v4mrk4vn5rpnnrn5kbhrnx8g3ag"
   },
   "stable": {
    "version": [
@@ -128669,11 +129299,11 @@
   "repo": "ideasman42/emacs-utimeclock",
   "unstable": {
    "version": [
-    20250421,
-    1055
+    20250716,
+    39
    ],
-   "commit": "179f50ea3c46ab99d7c8635ef1f8753e485ce689",
-   "sha256": "0alfr11mldchiwns7s471m7xcpabi5vq7n55pmcyg8r7i5d0qg1k"
+   "commit": "2b959be31103ca645c28e45b476e89fe17d23777",
+   "sha256": "133fj5r15sblvdk3vh33jqag32sm4lsic4wk4jd06kanhy9nwjkr"
   }
  },
  {
@@ -128684,26 +129314,26 @@
   "repo": "diml/utop",
   "unstable": {
    "version": [
-    20241125,
-    1512
+    20250722,
+    1319
    ],
    "deps": [
     "tuareg"
    ],
-   "commit": "3322adaa5267b1188d14b15e85c802c21fe061cb",
-   "sha256": "0g5inax35v3m8bxvbrdvjv0zg1b7q4jk8xp5jwhgjp5n3w3hryy1"
+   "commit": "bd6a1546e5c73c7a626e456fac5e81027106e4d6",
+   "sha256": "1d7zbqlz1jfy84gpqy1m53z7rhgfzzii11np0kikh0dd69cyz8kz"
   },
   "stable": {
    "version": [
     2,
-    15,
+    16,
     0
    ],
    "deps": [
     "tuareg"
    ],
-   "commit": "3322adaa5267b1188d14b15e85c802c21fe061cb",
-   "sha256": "0g5inax35v3m8bxvbrdvjv0zg1b7q4jk8xp5jwhgjp5n3w3hryy1"
+   "commit": "bd6a1546e5c73c7a626e456fac5e81027106e4d6",
+   "sha256": "1d7zbqlz1jfy84gpqy1m53z7rhgfzzii11np0kikh0dd69cyz8kz"
   }
  },
  {
@@ -129483,11 +130113,11 @@
   "repo": "federicotdn/verb",
   "unstable": {
    "version": [
-    20250318,
-    2150
+    20250731,
+    2205
    ],
-   "commit": "2e778afd08b8a9872b8273528052f52d53c2bd45",
-   "sha256": "12y2shqhbl21xj18hldg17n03pq3qcycwmswxdwr0pnac8613pq6"
+   "commit": "e818377f2ceddf5670dcd9a32d3de0e8bf82a8f1",
+   "sha256": "14pjrq87nzgh7vm34vdhadbxgblzwc5rb5gsbql7v2lqha898svs"
   },
   "stable": {
    "version": [
@@ -129544,8 +130174,8 @@
   "repo": "gmlarumbe/verilog-ext",
   "unstable": {
    "version": [
-    20250708,
-    1347
+    20250821,
+    1213
    ],
    "deps": [
     "ag",
@@ -129559,14 +130189,14 @@
     "verilog-ts-mode",
     "yasnippet"
    ],
-   "commit": "98f6ddc228449eb53cf425613887e44f46f3549f",
-   "sha256": "1mf04506zxl884w88cm3z0181nh92awn1r50f8dk5yzhfjwibqmm"
+   "commit": "740ce49e9d6f70486acd2aa0952b5f25d8a324fd",
+   "sha256": "19nm5vfmci96n3bc53575m0amrbsbwq345phwz31xh2haqgn1g3f"
   },
   "stable": {
    "version": [
     0,
-    6,
-    2
+    7,
+    0
    ],
    "deps": [
     "ag",
@@ -129575,14 +130205,13 @@
     "flycheck",
     "hydra",
     "lsp-mode",
-    "outshine",
     "ripgrep",
     "verilog-mode",
     "verilog-ts-mode",
     "yasnippet"
    ],
-   "commit": "f7e70560d817125721aa7e02a2f527fce15bcf30",
-   "sha256": "18vig4bkd74vzws9kgqlgalx0j1dcszg2i5gc3h00is7gimhhgj8"
+   "commit": "869ecc0a07ad018f16310055e34c630ece8f549c",
+   "sha256": "19rks3iwa7naqscx7scppk69g7avdwgc3vkgyaxf79dpxx85aa8v"
   }
  },
  {
@@ -129593,26 +130222,26 @@
   "repo": "gmlarumbe/verilog-ts-mode",
   "unstable": {
    "version": [
-    20250623,
-    1457
+    20250812,
+    1617
    ],
    "deps": [
     "verilog-mode"
    ],
-   "commit": "34f0dc244eb54d84346afa7e914e12d41b3c109a",
-   "sha256": "046d1lzwvnw78kaihh9f7k2s30a7gz58kamysq151mffjmk9sinv"
+   "commit": "c57897fbb529c6cd768b96d22c54b645cfc6194a",
+   "sha256": "1nnq2a1qjqfn0hkqj4n4r49llqks5krvh6chvi42wyhkpn62i1bg"
   },
   "stable": {
    "version": [
     0,
-    3,
+    4,
     0
    ],
    "deps": [
     "verilog-mode"
    ],
-   "commit": "85153dd3442b88213cb53b4c484b4173f9f040a3",
-   "sha256": "12da6drd429bdk8figvfnp7jwzd0vvcirdngl8v717agk9mbzh7n"
+   "commit": "efcd2207dfb7e5ae3e1fc6d6eeea9b8267ec9ef9",
+   "sha256": "1i6f9ya0zlxf9nv19w1a3akq4bm0lwswflcnl53nrh4qw0p4j0zh"
   }
  },
  {
@@ -129701,14 +130330,14 @@
   "repo": "minad/vertico",
   "unstable": {
    "version": [
-    20250702,
-    1403
+    20250824,
+    1017
    ],
    "deps": [
     "compat"
    ],
-   "commit": "d8dc49a3520ab908c2b0f62a4a8ae32ca23f2726",
-   "sha256": "1zrbhm5hm225xs5h54wyfniz8w4mp34ksmknmdsnpgqpfjqpq45p"
+   "commit": "5140630c2396623c3d7de85cebba72cfd11b9af5",
+   "sha256": "110m6nkaiakhrlz9bcf56waq4bwy7njdwkwcl7cdfydwysv0r48b"
   },
   "stable": {
    "version": [
@@ -129730,30 +130359,30 @@
   "repo": "radian-software/prescient.el",
   "unstable": {
    "version": [
-    20240803,
-    2320
+    20250816,
+    19
    ],
    "deps": [
     "compat",
     "prescient",
     "vertico"
    ],
-   "commit": "2b8a8b41228bddb2e11eb1c200e98a9edd04797c",
-   "sha256": "0qz3xv38vazxqsl7lan7fshj3gmb0qagkrvl5xzwqhdg0rir981j"
+   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
+   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
   },
   "stable": {
    "version": [
     6,
     3,
-    1
+    2
    ],
    "deps": [
     "compat",
     "prescient",
     "vertico"
    ],
-   "commit": "2b8a8b41228bddb2e11eb1c200e98a9edd04797c",
-   "sha256": "0qz3xv38vazxqsl7lan7fshj3gmb0qagkrvl5xzwqhdg0rir981j"
+   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
+   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
   }
  },
  {
@@ -129808,8 +130437,8 @@
   "repo": "gmlarumbe/vhdl-ext",
   "unstable": {
    "version": [
-    20250318,
-    1348
+    20250821,
+    1757
    ],
    "deps": [
     "ag",
@@ -129817,18 +130446,17 @@
     "flycheck",
     "hydra",
     "lsp-mode",
-    "outshine",
     "ripgrep",
     "vhdl-ts-mode"
    ],
-   "commit": "277cfaa9a1a4fa051ae94b331c59a02336adbafe",
-   "sha256": "13rj7ahh6pplpclgdjq1l59lf073s26wwwxp49fk9dwzphb9yq84"
+   "commit": "99a4a17940872e3e122375eff20caf1ee8ef8655",
+   "sha256": "1nl1z4mh7fn3di7gbqgkm33pgcq0axa75svrv6kln1wqymlb7vvn"
   },
   "stable": {
    "version": [
     0,
-    5,
-    4
+    6,
+    1
    ],
    "deps": [
     "ag",
@@ -129836,12 +130464,11 @@
     "flycheck",
     "hydra",
     "lsp-mode",
-    "outshine",
     "ripgrep",
     "vhdl-ts-mode"
    ],
-   "commit": "3f5f0778e87d9d4272903797a2366e603f9f1641",
-   "sha256": "0vgmhsgrh8x8br5grnh1jnf01r2q148xxyf028jgaq09wwjkdvkc"
+   "commit": "04c7e7738376af45c6397f08cfafb4f34222af17",
+   "sha256": "1nzh8vk3pp7chk5vnwa5d9ddqvgv95ar2djnjnnhmrk2z79klpg5"
   }
  },
  {
@@ -129852,20 +130479,20 @@
   "repo": "gmlarumbe/vhdl-ts-mode",
   "unstable": {
    "version": [
-    20250318,
-    1346
+    20250721,
+    1616
    ],
-   "commit": "3fb4af3653323979eb66b4c01f850fa03335046a",
-   "sha256": "19v3l37qzhkl22ignn5a8j0fw4az1gc185j4cs9rfh6byq8glpi3"
+   "commit": "3f9916cda24d014cf02af841fa0e9e0c411e1f56",
+   "sha256": "063d37jjc60kdkb7cx8hfbsrirwccw9jladwbpv86dimc0fqknp5"
   },
   "stable": {
    "version": [
     0,
-    2,
-    2
+    3,
+    1
    ],
-   "commit": "0f2e70eddab3bc000ad12625f31c62bea0c5994b",
-   "sha256": "0vqq1819czzliicanv00hhv13zy9apvj4326pnj9n3iqx45q6a96"
+   "commit": "3f9916cda24d014cf02af841fa0e9e0c411e1f56",
+   "sha256": "063d37jjc60kdkb7cx8hfbsrirwccw9jladwbpv86dimc0fqknp5"
   }
  },
  {
@@ -129966,11 +130593,11 @@
   "repo": "jamescherti/vim-tab-bar.el",
   "unstable": {
    "version": [
-    20250629,
-    344
+    20250820,
+    1631
    ],
-   "commit": "abf7fb4f83c0dd87fa247c776c5d91963fb785e0",
-   "sha256": "126p9363dqciar2gxj12ipr7gqjbr3l4j0mglaxyk5lbmg98xji6"
+   "commit": "6fdb71cbb74449d9cc5492159691ee3d2eb42eab",
+   "sha256": "1g718jpilwl831ypq2y8f654453fadn3jqfkg15bkdswgpav8kzg"
   },
   "stable": {
    "version": [
@@ -130285,11 +130912,11 @@
   "repo": "szermatt/visual-replace",
   "unstable": {
    "version": [
-    20250528,
-    1608
+    20250719,
+    2051
    ],
-   "commit": "687a59a1e3438d20e413f50d5c773c06bf705e1f",
-   "sha256": "17wr6zyv2n4xmd0p7mgvrh0ma6kdkfvzyxns44hjfdk8x8rm1nzr"
+   "commit": "d64e22028d32cebcc9a8b041a62b0f000c60659c",
+   "sha256": "0cd81f0p2x43fxbh0y71y5x88z5lwdr75cmcr41axzh5lyvq5ha3"
   },
   "stable": {
    "version": [
@@ -130391,19 +131018,19 @@
   "repo": "k-talo/volatile-highlights.el",
   "unstable": {
    "version": [
-    20250402,
-    1217
+    20250723,
+    2155
    ],
-   "commit": "ca4c7fed9d85d5f5119e9a0f895629804dcb2e99",
-   "sha256": "1bj0klr1zcbnfrmqld9dync5dh9v6yaaw72xpcyq6cm7sanhfcp3"
+   "commit": "3952439feb0173745ce36c1fc192c84494186b55",
+   "sha256": "0ykjry3adcc7k6bmhxixr1xykpp83n7m8nwd7kpqhq35f4w8pmfm"
   },
   "stable": {
    "version": [
     1,
-    16
+    18
    ],
-   "commit": "afccb5ce83848c3daa937098da83af45b50b71b4",
-   "sha256": "0rlqwj6whxbvzgkf78d8arjva49aphj4bd2wkpv8djykcmi8nf6m"
+   "commit": "11861d7ea1603fca305dd1d0488f7e697c8a7e1e",
+   "sha256": "10vaidj32wbhmjx4chr1zgfzikysns1fqx4gh2iya7cy75likw4m"
   }
  },
  {
@@ -130429,11 +131056,11 @@
   "repo": "emacs-vs/vs-dark-theme",
   "unstable": {
    "version": [
-    20250408,
-    452
+    20250725,
+    1905
    ],
-   "commit": "12ba997de72db95effae672d9615e7dcba56dd9f",
-   "sha256": "1rzdvj0br5rjqs1kmvhx6wrp7jpp6nxwh82r4jk3p2qjhqkxlhxs"
+   "commit": "c3a6d1545600ff4813d8ce2cf5a77beb9e3f8a1e",
+   "sha256": "0imikmw2dkh8ajyr47bcz49w00y96xszlj9fry8sjgfla2d8srad"
   },
   "stable": {
    "version": [
@@ -130452,11 +131079,11 @@
   "repo": "emacs-vs/vs-light-theme",
   "unstable": {
    "version": [
-    20250408,
-    453
+    20250725,
+    1905
    ],
-   "commit": "a561237f191048e505b72899b4a6c340a8e5e7f1",
-   "sha256": "0jqan8wg7fbch26ic1r328sjzd3l7w0lqcc9hf77m1qhqfpc64ja"
+   "commit": "a3edd50b794816e59ef5ab744dffe5dc3e192210",
+   "sha256": "10zfhran587zaxp0wdl0xbhq2qr0ciki1wmzb7ms85qfw1pgc2jz"
   },
   "stable": {
    "version": [
@@ -130529,11 +131156,11 @@
   "repo": "hardenedapple/vsh",
   "unstable": {
    "version": [
-    20241104,
-    1341
+    20250812,
+    757
    ],
-   "commit": "47b6190777be9e1c4c0efb94c166b29c83b10553",
-   "sha256": "1ywzd4mr3szcspv16k78cj4fn0m897sy6nx4cchy6bza92qw2k08"
+   "commit": "0746df2fb306e0c3d8dea26899f618c68b6b63e3",
+   "sha256": "0dpn0vy98b0fmyampxb5vc2sc25ybl18z1265j41jgd4pwl82zq1"
   }
  },
  {
@@ -130761,14 +131388,14 @@
   "repo": "embed-me/vunit-mode",
   "unstable": {
    "version": [
-    20250707,
-    1741
+    20250714,
+    523
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "e730a771355dd02c92dedfe3aaea1889d523c198",
-   "sha256": "1nrqiwyrngpr60c5i6438fghywgs7wf4yyb4h6a7zmih4q76z8rs"
+   "commit": "b26ecc46464a57eb00bf62b15c0d717774ec804e",
+   "sha256": "1b6qn824jywg57yy9has123zmrmsxhb3i0rdr7xnqbnhvq0zkp65"
   }
  },
  {
@@ -131215,20 +131842,20 @@
   "repo": "gmlarumbe/wavedrom-mode",
   "unstable": {
    "version": [
-    20250318,
-    1349
+    20250720,
+    1337
    ],
-   "commit": "249aec11fdab12ae6228c2bc2580b581d16e3443",
-   "sha256": "1anw072va8w3648zdb62437mjg76b098jq6jhy0bc3qpbxb74cai"
+   "commit": "159767bc9e1726035c9e21ac50f2d0f7fe315fa8",
+   "sha256": "06kiv7qsfj4xw55jzzbmf1l6n4an5rn13ms9z2516x26v3sjyix7"
   },
   "stable": {
    "version": [
     0,
     1,
-    0
+    1
    ],
-   "commit": "b360aa39c87e033b65676d3ac542bc26fd5abd34",
-   "sha256": "1fml8yv4l8f83vrqj725vx60ld81hcgjdhg2v7d0gip30w0b1v3h"
+   "commit": "159767bc9e1726035c9e21ac50f2d0f7fe315fa8",
+   "sha256": "06kiv7qsfj4xw55jzzbmf1l6n4an5rn13ms9z2516x26v3sjyix7"
   }
  },
  {
@@ -131339,14 +131966,14 @@
   "repo": "ruediger/weather-metno-el",
   "unstable": {
    "version": [
-    20230129,
-    1540
+    20250727,
+    1642
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "58b3aa479d85b4b38eb233ac2fbac40faf906f4c",
-   "sha256": "1r82arsrl7s4gvkfrkbjmwhg198f6r5gqbf7wq3z8m1wxapypsza"
+   "commit": "00eab9a9486e192917238145a4f2505d17fad77a",
+   "sha256": "18cwcg14c7sglg9v13mbp07v3g3ddcmg1n056qvcb3gnfdd45w8p"
   },
   "stable": {
    "version": [
@@ -131453,11 +132080,11 @@
   "repo": "fxbois/web-mode",
   "unstable": {
    "version": [
-    20250619,
-    1334
+    20250714,
+    657
    ],
-   "commit": "994cb350bceeebb031406112cf6da119e066ef8e",
-   "sha256": "08w8r1hs4kf733ghlipfmixgl5xccd0qmsrd6m65r2cw7mf0wv4r"
+   "commit": "f1f22bc9ce8cc80d7eb00e63d62b78140fae1e54",
+   "sha256": "0gih4vhbkmmyhmv2f8r6abc96cfrf0xgq4dy1sbcadl1plh6n4zs"
   },
   "stable": {
    "version": [
@@ -132413,15 +133040,15 @@
   "repo": "progfolio/wikinforg",
   "unstable": {
    "version": [
-    20240104,
-    603
+    20250809,
+    56
    ],
    "deps": [
     "org",
     "wikinfo"
    ],
-   "commit": "6c06f297a45c457e5bd1e2b55e870cd102e2a878",
-   "sha256": "0xpizw611w18bfjqdlwsbh2280h7sdmpfshwfmznfgk2jkix8maw"
+   "commit": "edf2fc770e32e82a9ffa226ce602dbb9636d9ac5",
+   "sha256": "0vb9br9n237m59dq76m6adad8p3vbs30y6lbs6i07369j2qaw7l7"
   }
  },
  {
@@ -132468,21 +133095,6 @@
    ],
    "commit": "ab0ed9cc5b4a285cddef52b193c26a979e1dcd08",
    "sha256": "152hilpbjmbf8yvyr9w4m4j2q0zczzsw4mc9vkwixk8m6a0x4i9q"
-  }
- },
- {
-  "ename": "wilson-ng-theme",
-  "commit": "dfc9db7856c7e25814846a8458bc6f4e7fcd736d",
-  "sha256": "1x2vw1i05cmycgypypn4w19g0g8m551lvzh3nz200v4cckcas2dl",
-  "fetcher": "github",
-  "repo": "levindue/emacs-wilson-theme",
-  "unstable": {
-   "version": [
-    20250621,
-    1426
-   ],
-   "commit": "81ddb3a2a8d3d69b03fe008fee96ffe99201c1f3",
-   "sha256": "0sc3ljbdkgf6nxhi3jxlfbj05iyxfr65i6qp84bysd3di4qd9i7k"
   }
  },
  {
@@ -132903,26 +133515,26 @@
   "repo": "magit/with-editor",
   "unstable": {
    "version": [
-    20250531,
-    2230
+    20250801,
+    1152
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f32cd7b09d518b629bfaa3eeb92b539891c6b9bc",
-   "sha256": "18nz4830pc15lrlyj61rh3df17mss7v12b54f5037cg1ym4jrqm7"
+   "commit": "0a2df46e2831c3b8ddc8f688069f2b4a49898731",
+   "sha256": "081h1l22py0hrix9wdhjm9gnjbw1ijqlahg67wiv41083wg8jmfv"
   },
   "stable": {
    "version": [
     3,
     4,
-    4
+    5
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f32cd7b09d518b629bfaa3eeb92b539891c6b9bc",
-   "sha256": "18nz4830pc15lrlyj61rh3df17mss7v12b54f5037cg1ym4jrqm7"
+   "commit": "0a2df46e2831c3b8ddc8f688069f2b4a49898731",
+   "sha256": "081h1l22py0hrix9wdhjm9gnjbw1ijqlahg67wiv41083wg8jmfv"
   }
  },
  {
@@ -133237,11 +133849,11 @@
   "repo": "progfolio/wordel",
   "unstable": {
    "version": [
-    20250104,
-    1247
+    20250803,
+    2033
    ],
-   "commit": "f6ca7c7068e2cca8260ae8b061b41cee60d5845c",
-   "sha256": "1zb6rf9f71kskzfrg5ynzy1mjp733yprkbnamnqk900cd9yzna5p"
+   "commit": "e1686812cc72467df2845407b1ffd6cf55e49743",
+   "sha256": "0x107h7yxc33p9s8xkpk7xq3n91b0xz26srp2ly0xi6jjawnqd2q"
   }
  },
  {
@@ -134644,26 +135256,26 @@
   "repo": "knu/yaml-imenu.el",
   "unstable": {
    "version": [
-    20220406,
-    1703
+    20250818,
+    1432
    ],
    "deps": [
     "yaml-mode"
    ],
-   "commit": "c1fbba8b03a7bef4fc2b87404914fa9c6eb67b55",
-   "sha256": "1p5zyjj9hvqjfhyp68c04w6cxj5qh4psd4y8kafyrz3n05wimzl5"
+   "commit": "c2f32557c11cbd402853104da8f644df4ee88434",
+   "sha256": "1qvz3kihprw8vw9pzhqkz94dl45vpwg6jfjmcvlybp5mg2xz7r84"
   },
   "stable": {
    "version": [
     1,
-    0,
-    3
+    1,
+    0
    ],
    "deps": [
     "yaml-mode"
    ],
-   "commit": "01741205fb33d2ed511502d1cd65a711e07a3117",
-   "sha256": "1z8yzi322y8wnvci77xp7fb7x5l3z8zy1ng4zaa1z856va8x2971"
+   "commit": "c2f32557c11cbd402853104da8f644df4ee88434",
+   "sha256": "1qvz3kihprw8vw9pzhqkz94dl45vpwg6jfjmcvlybp5mg2xz7r84"
   }
  },
  {
@@ -134698,26 +135310,26 @@
   "repo": "zkry/yaml-pro",
   "unstable": {
    "version": [
-    20250529,
-    914
+    20250817,
+    452
    ],
    "deps": [
     "yaml"
    ],
-   "commit": "8dce99ba3e5fcb5e2c3de360c4ee658055051f33",
-   "sha256": "0ylvyr5ymdkczcnmkbvs232008v7wh433qyjaq7hkn5h1xj8md7l"
+   "commit": "9b9509188e5b88bb933e98ab36ab992519b9554b",
+   "sha256": "1sipz42gb8pl8w9xci5m0kdz5dlinxj409hvyz173z3gzg7f4qr1"
   },
   "stable": {
    "version": [
     1,
     3,
-    2
+    3
    ],
    "deps": [
     "yaml"
    ],
-   "commit": "dd3e14adc0f1bc9483ac32fccedceeefeb3533d9",
-   "sha256": "0pj5rnj77ia3g9bx2yhhwg971ma880j30gakdg8fx21396wx2h4v"
+   "commit": "9b9509188e5b88bb933e98ab36ab992519b9554b",
+   "sha256": "1sipz42gb8pl8w9xci5m0kdz5dlinxj409hvyz173z3gzg7f4qr1"
   }
  },
  {
@@ -134965,14 +135577,14 @@
   "repo": "AndreaCrotti/yasnippet-snippets",
   "unstable": {
    "version": [
-    20250507,
-    2002
+    20250808,
+    819
    ],
    "deps": [
     "yasnippet"
    ],
-   "commit": "48e968d555afe8bf64829da364d5c8915980cc32",
-   "sha256": "04w2lk4y7x47b6rc4a2z3rypxy5n2sln6p8hr0wh4msfq11iy4wx"
+   "commit": "4f9f9e7b29822d66a34b7d5f1c19ed65cce1d8e1",
+   "sha256": "16br8pmhv3i4jcxwrk39f9ki5pixzwfz9x1bw5cvywdpqs0d4367"
   },
   "stable": {
    "version": [
@@ -135151,6 +135763,21 @@
   }
  },
  {
+  "ename": "year-1984-theme",
+  "commit": "77d2011f96edab0a176eb16acd994c8509d1e53a",
+  "sha256": "1amk9qrj8b523w4mhbj41bkyc2z0bb5p7l4ml41kyshydw6q2j1c",
+  "fetcher": "github",
+  "repo": "mastro35/year-1984-theme",
+  "unstable": {
+   "version": [
+    20250806,
+    655
+   ],
+   "commit": "7d8b5ec7eb9ee364a66cc7c83d6490915543ba1f",
+   "sha256": "10p9xgadmpim8g2i6knxy11imv4hm18zkxn9f04ysv27ipnjx36g"
+  }
+ },
+ {
   "ename": "yeetube",
   "commit": "258bbc1c9a9e9a2197573d5349457d7c84a4b863",
   "sha256": "1zva45wq1yy5r0nv5k85lxh776w400m32m389hy4289b2dk4vk9v",
@@ -135158,14 +135785,14 @@
   "url": "https://git.thanosapollo.org/yeetube",
   "unstable": {
    "version": [
-    20250612,
-    2131
+    20250815,
+    610
    ],
    "deps": [
     "compat"
    ],
-   "commit": "b46fff22e7381444b5362d8bc175acad3c5d61f8",
-   "sha256": "1zf0y2f0ygx6mrfcpgdyjcd2x6yaj7d9bsqpsb6f1y32rd4migl4"
+   "commit": "bc094600f5b39a7d1f6c6aeb125054fab276fb9a",
+   "sha256": "0b8h63sz4n4al38xdny87dklllm2m1pajppjg74j2sb91gy7fqdv"
   },
   "stable": {
    "version": [
@@ -135477,6 +136104,21 @@
    ],
    "commit": "0356cbe1e1e2b780ba0ddb4aaa055fa246a67931",
    "sha256": "0jlnxxzh9p7285m16w33l5529iglg5cihs6gqwnb6y34wpzwyar6"
+  }
+ },
+ {
+  "ename": "zathura",
+  "commit": "026478ca7866bc90af70070446df9e78d8ce9760",
+  "sha256": "1qwcyqhj883zc06rfrh59bg4msh84a77ip47h3fcvsbssikdmvzf",
+  "fetcher": "codeberg",
+  "repo": "treflip/zathura.el",
+  "unstable": {
+   "version": [
+    20250728,
+    1208
+   ],
+   "commit": "947b8332f25810105d35e350f604cdad4e32ee6f",
+   "sha256": "16hprzf15y7zwr28dimlmlylz5sxy54kfq2yniqwxsrm3r59j1bp"
   }
  },
  {
@@ -136040,18 +136682,17 @@
   "repo": "WillForan/zim-wiki-mode",
   "unstable": {
    "version": [
-    20250425,
-    2345
+    20250824,
+    157
    ],
    "deps": [
     "dokuwiki-mode",
-    "helm-ag",
     "helm-projectile",
     "link-hint",
     "pretty-hydra"
    ],
-   "commit": "a6ddbdfe41ddb1f445d3480801f1db0f000c31a2",
-   "sha256": "18z3h7vc1wzqlx3byp00jwhp03shs852zi8s0rp2kmrjs61svq3x"
+   "commit": "d376b456b275975946e03a393ce16b122962195d",
+   "sha256": "1yz03vg2dl4843zf3954siiq6rb383pb11wahncni9bg3808qgjm"
   }
  },
  {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- emacs-overlay commit: 3b3e842cce376e332b0a4606ca18a846fbc49430
- [hydra](https://hydra.nix-community.org/eval/569073?filter=x86_64-linux.unstable.packages.)
- new failed toplevel builds:
  - [X] [emacs-euslisp-mode-20170830.1929](https://hydra.nix-community.org/build/7060240): [upstream report](https://github.com/iory/euslisp-mode/issues/5)
  - [X] [emacs-iso-date-1.0.3](https://hydra.nix-community.org/build/7061539): [upstream report](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=79283)
  - [ ] [emacs-ninetyfive-20250819.2039](https://hydra.nix-community.org/build/7071648): [upstream report](https://github.com/ninetyfive-gg/ninetyfive.el/issues/19)
  - [X] [emacs-verilog-ext-20250812.1625](https://hydra.nix-community.org/build/7074363): [upstream report](https://github.com/gmlarumbe/verilog-ext/issues/32)
  - [X] [emacs-vhdl-ext-20250806.1615](https://hydra.nix-community.org/build/7074329): [upstream report](https://github.com/gmlarumbe/vhdl-ext/issues/15)
  - [X] [emacs-zim-wiki-mode-20250425.2345](https://hydra.nix-community.org/build/7074653): [upstream report](https://github.com/WillForan/zim-wiki-mode/issues/12)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
