### PR TITLE
[Backport release-25.05] mautrix-slack: 0.2.1 -> 0.2.3

### DIFF
--- a/pkgs/by-name/ma/mautrix-slack/package.nix
+++ b/pkgs/by-name/ma/mautrix-slack/package.nix
@@ -13,7 +13,7 @@
   withGoolm ? false,
 }:
 let
-  version = "0.2.1";
+  version = "0.2.2";
 in
 buildGoModule {
   pname = "mautrix-slack";
@@ -23,10 +23,10 @@ buildGoModule {
     owner = "mautrix";
     repo = "slack";
     tag = "v${version}";
-    hash = "sha256-1/OuwyQU68tsg9WOl0Eg4ZM28sD6JDMQN9i1LZLYOuE=";
+    hash = "sha256-Ha3Rwd9+2RFxOF+H5jG6wRlgqLfUbCcoZcaXehyr1m0=";
   };
 
-  vendorHash = "sha256-YjM2ZpXm3DGNRtCGvj7+0+bXAnb7HXYzQvxCSL4+hHo=";
+  vendorHash = "sha256-BjKEf4cG9kPcwuUefosBFzyCUpYhK7fm+w/GtG+oicg=";
 
   buildInputs = lib.optional (!withGoolm) olm;
   tags = lib.optional withGoolm "goolm";

--- a/pkgs/by-name/ma/mautrix-slack/package.nix
+++ b/pkgs/by-name/ma/mautrix-slack/package.nix
@@ -13,7 +13,7 @@
   withGoolm ? false,
 }:
 let
-  version = "0.2.2";
+  version = "0.2.3";
 in
 buildGoModule {
   pname = "mautrix-slack";
@@ -23,10 +23,10 @@ buildGoModule {
     owner = "mautrix";
     repo = "slack";
     tag = "v${version}";
-    hash = "sha256-Ha3Rwd9+2RFxOF+H5jG6wRlgqLfUbCcoZcaXehyr1m0=";
+    hash = "sha256-gR5D2uCNS+LiP0KXup/iIiOThWohzeBe4CD/oWak1BM=";
   };
 
-  vendorHash = "sha256-BjKEf4cG9kPcwuUefosBFzyCUpYhK7fm+w/GtG+oicg=";
+  vendorHash = "sha256-aukL6RThtWcznz/x25btTTvloYkRZ/vhAQj1hOdI1U4=";
 
   buildInputs = lib.optional (!withGoolm) olm;
   tags = lib.optional withGoolm "goolm";


### PR DESCRIPTION
Manual backport of #425762 #434569 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
