### PR TITLE
[Backport release-25.05] blocky: 0.25 -> 0.26.2

### DIFF
--- a/pkgs/by-name/bl/blocky/package.nix
+++ b/pkgs/by-name/bl/blocky/package.nix
@@ -7,20 +7,20 @@
 
 buildGoModule rec {
   pname = "blocky";
-  version = "0.25";
+  version = "0.26.2";
 
   src = fetchFromGitHub {
     owner = "0xERR0R";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-yd9qncTuzf7p1hIYHzzXyxAx1C1QiuQAIYSKcjCiF0E=";
+    hash = "sha256-yo21f12BLINXb8HWdR3ZweV5+cTZN07kxCxO1FMJq/4=";
   };
 
   # needs network connection and fails at
   # https://github.com/0xERR0R/blocky/blob/development/resolver/upstream_resolver_test.go
   doCheck = false;
 
-  vendorHash = "sha256-Ck80ym64RIubtMHKkXsbN1kFrB6F9G++0U98jPvyoHw=";
+  vendorHash = "sha256-cIDKUzOAs6XsyuUbnR2MRIeH3LI4QuohUZovh/DVJzA=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Manual backport of https://github.com/NixOS/nixpkgs/pull/409196 to release-25.05.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
-    Even as a non-committer, if you find that it is not acceptable, leave a comment.