### PR TITLE
[Backport release-25.05] garnet: 1.0.80 -> 1.0.82

### DIFF
--- a/pkgs/by-name/ga/garnet/package.nix
+++ b/pkgs/by-name/ga/garnet/package.nix
@@ -8,13 +8,13 @@
 
 buildDotnetModule rec {
   pname = "garnet";
-  version = "1.0.80";
+  version = "1.0.81";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "garnet";
     tag = "v${version}";
-    hash = "sha256-9B2Ai+W6+rZ8xLrrO7d8jd6LYWaMGIq3a+lz8rY32uA=";
+    hash = "sha256-CEpxV6BoTfkC3Lka1Xuci3uyUYoWxoyYKTQTco5NVY4=";
   };
 
   projectFile = "main/GarnetServer/GarnetServer.csproj";

--- a/pkgs/by-name/ga/garnet/package.nix
+++ b/pkgs/by-name/ga/garnet/package.nix
@@ -8,13 +8,13 @@
 
 buildDotnetModule rec {
   pname = "garnet";
-  version = "1.0.81";
+  version = "1.0.82";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "garnet";
     tag = "v${version}";
-    hash = "sha256-CEpxV6BoTfkC3Lka1Xuci3uyUYoWxoyYKTQTco5NVY4=";
+    hash = "sha256-ju39u5GvlxKxTn47MAicNFM9Delk6n/ht74p2XxmM44=";
   };
 
   projectFile = "main/GarnetServer/GarnetServer.csproj";


### PR DESCRIPTION
Manual backport of #432947 #435177 to `release-25.05`.

- [x] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.