### PR TITLE
nixos/profiles/bashless: init

### DIFF
--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -36,6 +36,24 @@ in
 
   options = {
 
+    environment.shell.enable = lib.mkEnableOption "" // {
+      default = true;
+      internal = true;
+      description = ''
+        Whether to enable the shell environment.
+
+        This does NOT necessarily disable all shells on your system. Instead it
+        just disables the shell environment that configures user shells (i.e.
+        those in `environment.shells`).
+
+        System services might still depend on and use shells even if this
+        option is set to false.
+
+        Only set this option if you're sure that you can recover from potential
+        issues.
+      '';
+    };
+
     environment.variables = lib.mkOption {
       default = { };
       example = {
@@ -175,10 +193,10 @@ in
     };
 
     environment.binsh = lib.mkOption {
-      default = "${config.system.build.binsh}/bin/sh";
-      defaultText = lib.literalExpression ''"''${config.system.build.binsh}/bin/sh"'';
+      default = null;
+      defaultText = lib.literalExpression ''"''${pkgs.bashInteractive}/bin/sh"'';
       example = lib.literalExpression ''"''${pkgs.dash}/bin/dash"'';
-      type = lib.types.path;
+      type = lib.types.nullOr lib.types.path;
       visible = false;
       description = ''
         The shell executable that is linked system-wide to
@@ -201,9 +219,10 @@ in
 
   };
 
-  config = {
+  config = lib.mkIf cfg.shell.enable {
 
-    system.build.binsh = pkgs.bashInteractive;
+    # Set this here so its enabled only when shell support is enabled
+    environment.binsh = lib.mkDefault "${pkgs.bashInteractive}/bin/sh";
 
     # Set session variables in the shell as well. This is usually
     # unnecessary, but it allows changes to session variables to take

--- a/nixos/modules/profiles/bashless.nix
+++ b/nixos/modules/profiles/bashless.nix
@@ -1,0 +1,46 @@
+{ lib, ... }:
+
+{
+
+  # Bashless builds on perlless
+  imports = [ ./perlless.nix ];
+
+  # Remove bash from activation
+  system.nixos-init.enable = lib.mkDefault true;
+  system.activatable = lib.mkDefault false;
+  environment.shell.enable = lib.mkDefault false;
+  programs.bash.enable = lib.mkDefault false;
+
+  # Random bash remnants
+  environment.corePackages = lib.mkForce [ ];
+  # Contains bash completions
+  nix.enable = lib.mkDefault false;
+  # The fuse{,3} package contains a runtime dependency on bash.
+  programs.fuse.enable = lib.mkDefault false;
+  documentation.man.man-db.enable = lib.mkDefault false;
+  # autovt depends on bash
+  console.enable = lib.mkDefault false;
+  # dhcpcd and openresolv depend on bash
+  networking.useNetworkd = lib.mkDefault true;
+  # bcache tools depend on bash.
+  boot.bcache.enable = lib.mkDefault false;
+  # iptables depends on bash and nixos-firewall-tool is a bash script
+  networking.firewall.enable = lib.mkDefault false;
+  # the wrapper script is in bash
+  security.enableWrappers = lib.mkDefault false;
+  # kexec script is written in bash
+  boot.kexec.enable = lib.mkDefault false;
+  # Relies on bash scripts
+  powerManagement.enable = lib.mkDefault false;
+  # Has some bash inside
+  systemd.shutdownRamfs.enable = lib.mkDefault false;
+  # Relies on the gzip command which depends on bash
+  services.logrotate.enable = lib.mkDefault false;
+  # Service relies on bash scripts
+  services.timesyncd.enable = lib.mkDefault false;
+
+  # Check that the system does not contain a Nix store path that contains the
+  # string "bash".
+  system.forbiddenDependenciesRegexes = [ "bash" ];
+
+}

--- a/nixos/modules/programs/shadow.nix
+++ b/nixos/modules/programs/shadow.nix
@@ -158,6 +158,8 @@ in
         This must not be a store path, since the path is
         used outside the store (in particular in /etc/passwd).
       '';
+      # /bin/sh is also the compiled in default of the shadow package.
+      default = "/bin/sh";
       example = lib.literalExpression "pkgs.zsh";
       type = lib.types.either lib.types.path lib.types.shellPackage;
     };

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -376,7 +376,9 @@ in
       );
       # End if legacy environment variables
 
-      preSwitchCheck = config.system.preSwitchChecksScript;
+      preSwitchCheck = lib.mkIf (
+        config.system.preSwitchChecks != { }
+      ) config.system.preSwitchChecksScript;
 
       # Not actually used in the builder. `passedChecks` is just here to create
       # the build dependencies. Checks are similar to build dependencies in the

--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -85,6 +85,9 @@ in
 {
 
   options.testing = {
+    backdoor = lib.mkEnableOption "backdoor service in stage 2" // {
+      default = true;
+    };
 
     initrdBackdoor = lib.mkEnableOption ''
       backdoor.service in initrd. Requires
@@ -107,12 +110,14 @@ in
       }
     ];
 
-    systemd.services.backdoor = lib.mkMerge [
-      backdoorService
-      {
-        wantedBy = [ "multi-user.target" ];
-      }
-    ];
+    systemd.services.backdoor = lib.mkIf cfg.backdoor (
+      lib.mkMerge [
+        backdoorService
+        {
+          wantedBy = [ "multi-user.target" ];
+        }
+      ]
+    );
 
     boot.initrd.systemd = lib.mkMerge [
       {

--- a/nixos/tests/activation/bashless-closure.nix
+++ b/nixos/tests/activation/bashless-closure.nix
@@ -1,0 +1,78 @@
+{
+  nixos,
+  stdenvNoCC,
+  jq,
+  zstd,
+  cpio,
+}:
+
+let
+  machine = nixos (
+    { lib, modulesPath, ... }:
+    {
+      imports = [ "${modulesPath}/profiles/bashless.nix" ];
+
+      fileSystems."/" = {
+        device = "/dev/disk/by-partlabel/root";
+        fsType = "ext4";
+      };
+
+      system.stateVersion = lib.trivial.release;
+    }
+  );
+in
+{
+  # Keep this around for easier debugging, e.g. with nix why-depends.
+  inherit (machine) toplevel;
+
+  machine = stdenvNoCC.mkDerivation {
+    name = "bashless-closure-machine";
+
+    __structuredAttrs = true;
+
+    exportReferencesGraph.closure = [ machine.toplevel ];
+
+    preferLocalBuild = true;
+
+    nativeBuildInputs = [
+      jq
+    ];
+
+    buildCommand = ''
+      set +e
+      jq -r '.closure[].path' < "$NIX_ATTRS_JSON_FILE" | grep bash
+
+      exit_code=$?
+      if [ $exit_code -eq 0 ]; then
+          echo "Error: toplevel contains bash"
+          exit 1
+      fi
+
+      touch $out
+    '';
+  };
+
+  initrd = stdenvNoCC.mkDerivation {
+    name = "bashless-closure-initrd";
+
+    preferLocalBuild = true;
+
+    nativeBuildInputs = [
+      zstd
+      cpio
+    ];
+
+    buildCommand = ''
+      set +e
+      zstd -dfc ${machine.toplevel}/initrd | cpio --quiet -t | grep bash
+
+      exit_code=$?
+      if [ $exit_code -eq 0 ]; then
+          echo "Error: initrd contains bash"
+          exit 1
+      fi
+
+      touch $out
+    '';
+  };
+}

--- a/nixos/tests/activation/bashless-image.nix
+++ b/nixos/tests/activation/bashless-image.nix
@@ -1,0 +1,109 @@
+# Tests a bashless image. The forbiddenDependenciesRegexes from the bashless
+# profile ensures that the closure doesn't contain any bash.
+
+{ lib, ... }:
+
+let
+  storePartitionLabel = "root";
+in
+{
+
+  name = "activation-bashless-image";
+
+  meta.maintainers = with lib.maintainers; [ nikstur ];
+
+  nodes.machine =
+    {
+      config,
+      pkgs,
+      modulesPath,
+      ...
+    }:
+    {
+      imports = [
+        "${modulesPath}/image/repart.nix"
+        "${modulesPath}/profiles/bashless.nix"
+      ];
+
+      # Backdoor uses bash
+      testing.backdoor = false;
+
+      virtualisation = {
+        directBoot.enable = false;
+        mountHostNixStore = false;
+        useEFIBoot = true;
+      };
+
+      boot.loader.grub.enable = false;
+
+      virtualisation.fileSystems = lib.mkForce {
+        "/" = {
+          fsType = "tmpfs";
+          options = [ "mode=0755" ];
+        };
+
+        "/nix/store" = {
+          device = "/dev/disk/by-partlabel/${storePartitionLabel}";
+          fsType = "erofs"; # Saves ~250MiB over ext4
+        };
+      };
+
+      image.repart = {
+        name = "bashless-image";
+        mkfsOptions = {
+          erofs = [ "-z lz4" ]; # Saves ~150MiB over no compression
+        };
+        partitions = {
+          "esp" = {
+            contents = {
+              "/EFI/BOOT/BOOT${lib.toUpper config.nixpkgs.hostPlatform.efiArch}.EFI".source =
+                "${config.system.build.uki}/${config.system.boot.loader.ukiFile}";
+            };
+            repartConfig = {
+              Type = "esp";
+              Format = "vfat";
+              SizeMinBytes = if config.nixpkgs.hostPlatform.isx86_64 then "64M" else "96M";
+            };
+          };
+          "root" = {
+            storePaths = [ config.system.build.toplevel ];
+            nixStorePrefix = "/";
+            repartConfig = {
+              Type = "linux-generic";
+              Format = config.fileSystems."/nix/store".fsType;
+              Label = storePartitionLabel;
+              Minimize = "best";
+            };
+          };
+        };
+      };
+    };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      import os
+      import subprocess
+      import tempfile
+
+      tmp_disk_image = tempfile.NamedTemporaryFile()
+
+      subprocess.run([
+        "${nodes.machine.virtualisation.qemu.package}/bin/qemu-img",
+        "create",
+        "-f",
+        "qcow2",
+        "-b",
+        "${nodes.machine.system.build.image}/${nodes.machine.image.fileName}",
+        "-F",
+        "raw",
+        tmp_disk_image.name,
+      ])
+
+      # Set NIX_DISK_IMAGE so that the qemu script finds the right disk image.
+      os.environ['NIX_DISK_IMAGE'] = tmp_disk_image.name
+
+      machine.start()
+      machine.wait_for_console_text("Startup finished.")
+    '';
+}

--- a/nixos/tests/activation/bashless.nix
+++ b/nixos/tests/activation/bashless.nix
@@ -1,0 +1,50 @@
+# This is a smoke test that tests that basic functionality is still available
+# with the bashless profile. For this, however, we have to re-enable bash.
+
+{ lib, ... }:
+
+{
+
+  name = "activation-bashless";
+
+  meta.maintainers = with lib.maintainers; [ nikstur ];
+
+  nodes.machine =
+    { pkgs, modulesPath, ... }:
+    {
+      imports = [ "${modulesPath}/profiles/bashless.nix" ];
+
+      # Forcibly re-set options that would normally be set by the bashless
+      # profile but that we have to re-enable to make the test instrumentation
+      # work.
+      environment.binsh = lib.mkForce null;
+      boot.initrd.systemd.shell.enable = false;
+
+      # This ensures that we only have the store paths of our closure in the
+      # in the guest. This is necessary so we can grep in the store.
+      virtualisation.mountHostNixStore = false;
+      virtualisation.useNixStoreImage = true;
+
+      # Re-enable just enough of a normal NixOS system to be able to run tests
+      programs.bash.enable = true;
+      environment.shell.enable = true;
+      environment.systemPackages = [
+        pkgs.coreutils
+        pkgs.gnugrep
+      ];
+
+      # Unset the regex because the tests instrumentation needs bash.
+      system.forbiddenDependenciesRegexes = lib.mkForce [ ];
+    };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("/bin/sh doesn't exist"):
+      machine.fail("stat /bin/sh")
+
+    bash_store_paths = machine.succeed("ls /nix/store | grep bash || true")
+    print(bash_store_paths)
+  '';
+
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -186,6 +186,9 @@ in
   acme = import ./acme/default.nix { inherit runTest; };
   acme-dns = runTest ./acme-dns.nix;
   activation = pkgs.callPackage ../modules/system/activation/test.nix { };
+  activation-bashless = runTest ./activation/bashless.nix;
+  activation-bashless-closure = pkgs.callPackage ./activation/bashless-closure.nix { };
+  activation-bashless-image = runTest ./activation/bashless-image.nix;
   activation-etc-overlay-immutable = runTest ./activation/etc-overlay-immutable.nix;
   activation-etc-overlay-mutable = runTest ./activation/etc-overlay-mutable.nix;
   activation-lib = pkgs.callPackage ../modules/system/activation/lib/test.nix { };


### PR DESCRIPTION
Concludes https://github.com/NixOS/nixpkgs/issues/428908

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
