### PR TITLE
font-{encodings,bh-{ttf,type1},mutt-misc}: refactor, move to pkgs/by-name & rename

### DIFF
--- a/pkgs/by-name/fo/font-bh-ttf/package.nix
+++ b/pkgs/by-name/fo/font-bh-ttf/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-bh-ttf";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-bh-ttf-${finalAttrs.version}.tar.xz";
+    hash = "sha256-haX5DQDEjCsG/RJeqK28i47pdCnjB1CByHEJJu/sOlY=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ mkfontscale ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Luxi TrueType fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/bh-ttf";
+    license = lib.licenses.unfreeRedistributable;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-bh-type1/package.nix
+++ b/pkgs/by-name/fo/font-bh-type1/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-bh-type1";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-bh-type1-${finalAttrs.version}.tar.xz";
+    hash = "sha256-Gd7D7Aar3mvt0QCUV56Si+Dw/DvbT76T9MaczkBtcqY=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ mkfontscale ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Luxi PostScript Type 1 fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/bh-type1";
+    license = lib.licenses.unfreeRedistributable;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-encodings/package.nix
+++ b/pkgs/by-name/fo/font-encodings/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-encodings";
+  version = "1.1.0";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/encodings-${finalAttrs.version}.tar.xz";
+    hash = "sha256-n/E8YhdWz6EulfMrpIpbI4Oej1d9AEi+2mbGfatN6XU=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ mkfontscale ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname encodings \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Font encoding tables for libfontenc";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/encodings";
+    license = lib.licenses.publicDomain;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-mutt-misc/package.nix
+++ b/pkgs/by-name/fo/font-mutt-misc/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-mutt-misc";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-mutt-misc-${finalAttrs.version}.tar.xz";
+    hash = "sha256-sSNZ9OEsI7z8tEi5GCl+l1+pG+9Sk9iNPCU0PMdouyQ=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [
+    bdftopcf
+    mkfontscale
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "ClearU pcf fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/mutt-misc";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -3,6 +3,7 @@
   lib,
   bdftopcf,
   font-alias,
+  font-encodings,
   font-util,
   gccmakedep,
   ico,
@@ -85,6 +86,7 @@ self: with self; {
     xwininfo
     xwud
     ;
+  encodings = font-encodings;
   fontalias = font-alias;
   fontutil = font-util;
   libAppleWM = libapplewm;
@@ -232,41 +234,6 @@ self: with self; {
         xorgproto
         libXt
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  encodings = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "encodings";
-      version = "1.1.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/encodings-1.1.0.tar.xz";
-        sha256 = "0xg99nmpvik6vaz4h03xay7rx0r3bf5a8azkjlpa3ksn2xi3rwcz";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        mkfontscale
-      ];
-      buildInputs = [ ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -3,6 +3,7 @@
   lib,
   bdftopcf,
   font-alias,
+  font-bh-ttf,
   font-encodings,
   font-util,
   gccmakedep,
@@ -88,6 +89,7 @@ self: with self; {
     ;
   encodings = font-encodings;
   fontalias = font-alias;
+  fontbhttf = font-bh-ttf;
   fontutil = font-util;
   libAppleWM = libapplewm;
   libFS = libfs;
@@ -635,44 +637,6 @@ self: with self; {
         pkg-config
         bdftopcf
         fontutil
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontbhttf = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-bh-ttf";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-bh-ttf-1.0.4.tar.xz";
-        sha256 = "0misxkpjc2bir20m01z355sfk3lbpjnshphjzl32p364006zk9c5";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
         mkfontscale
       ];
       buildInputs = [ fontutil ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -4,6 +4,7 @@
   bdftopcf,
   font-alias,
   font-bh-ttf,
+  font-bh-type1,
   font-encodings,
   font-util,
   gccmakedep,
@@ -90,6 +91,7 @@ self: with self; {
   encodings = font-encodings;
   fontalias = font-alias;
   fontbhttf = font-bh-ttf;
+  fontbhtype1 = font-bh-type1;
   fontutil = font-util;
   libAppleWM = libapplewm;
   libFS = libfs;
@@ -637,44 +639,6 @@ self: with self; {
         pkg-config
         bdftopcf
         fontutil
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontbhtype1 = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-bh-type1";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-bh-type1-1.0.4.tar.xz";
-        sha256 = "19kjdm0cx766yj9vwkyv7gyg1q4bjag5g500s7nnppmb0vnc7phr";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
         mkfontscale
       ];
       buildInputs = [ fontutil ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -6,6 +6,7 @@
   font-bh-ttf,
   font-bh-type1,
   font-encodings,
+  font-mutt-misc,
   font-util,
   gccmakedep,
   ico,
@@ -92,6 +93,7 @@ self: with self; {
   fontalias = font-alias;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
+  fontmuttmisc = font-mutt-misc;
   fontutil = font-util;
   libAppleWM = libapplewm;
   libFS = libfs;
@@ -1270,46 +1272,6 @@ self: with self; {
         pkg-config
         bdftopcf
         fontutil
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontmuttmisc = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-mutt-misc";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-mutt-misc-1.0.4.tar.xz";
-        sha256 = "095vd33kqd157j6xi4sjxwdsjpwpgqliifa8nkybq8rcw7s5j8xi";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
         mkfontscale
       ];
       buildInputs = [ fontutil ];

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -296,6 +296,7 @@ print OUT <<EOF;
   lib,
   bdftopcf,
   font-alias,
+  font-encodings,
   font-util,
   gccmakedep,
   ico,
@@ -378,6 +379,7 @@ self: with self; {
     xwininfo
     xwud
     ;
+  encodings = font-encodings;
   fontalias = font-alias;
   fontutil = font-util;
   libAppleWM = libapplewm;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -299,6 +299,7 @@ print OUT <<EOF;
   font-bh-ttf,
   font-bh-type1,
   font-encodings,
+  font-mutt-misc,
   font-util,
   gccmakedep,
   ico,
@@ -385,6 +386,7 @@ self: with self; {
   fontalias = font-alias;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
+  fontmuttmisc = font-mutt-misc;
   fontutil = font-util;
   libAppleWM = libapplewm;
   libFS = libfs;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -297,6 +297,7 @@ print OUT <<EOF;
   bdftopcf,
   font-alias,
   font-bh-ttf,
+  font-bh-type1,
   font-encodings,
   font-util,
   gccmakedep,
@@ -383,6 +384,7 @@ self: with self; {
   encodings = font-encodings;
   fontalias = font-alias;
   fontbhttf = font-bh-ttf;
+  fontbhtype1 = font-bh-type1;
   fontutil = font-util;
   libAppleWM = libapplewm;
   libFS = libfs;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -296,6 +296,7 @@ print OUT <<EOF;
   lib,
   bdftopcf,
   font-alias,
+  font-bh-ttf,
   font-encodings,
   font-util,
   gccmakedep,
@@ -381,6 +382,7 @@ self: with self; {
     ;
   encodings = font-encodings;
   fontalias = font-alias;
+  fontbhttf = font-bh-ttf;
   fontutil = font-util;
   libAppleWM = libapplewm;
   libFS = libfs;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1187,7 +1187,6 @@ self: super:
       "fontadobeutopiatype1"
       "fontadobeutopia100dpi"
       "fontadobeutopia75dpi"
-      "fontbhtype1"
       "fontibmtype1"
       "fontbh100dpi"
       "fontbh75dpi"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1189,7 +1189,6 @@ self: super:
       "fontadobeutopia75dpi"
       "fontbhtype1"
       "fontibmtype1"
-      "fontbhttf"
       "fontbh100dpi"
       "fontbh75dpi"
 

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -105,7 +105,6 @@ mirror://xorg/individual/driver/xf86-video-vesa-2.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-vmware-13.4.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-wsfb-0.4.0.tar.bz2
-mirror://xorg/individual/font/encodings-1.1.0.tar.xz
 mirror://xorg/individual/font/font-adobe-75dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-adobe-100dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-adobe-utopia-75dpi-1.0.5.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -115,7 +115,6 @@ mirror://xorg/individual/font/font-bh-75dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bh-100dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bh-lucidatypewriter-75dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bh-lucidatypewriter-100dpi-1.0.4.tar.xz
-mirror://xorg/individual/font/font-bh-ttf-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bh-type1-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bitstream-75dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bitstream-100dpi-1.0.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -115,7 +115,6 @@ mirror://xorg/individual/font/font-bh-75dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bh-100dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bh-lucidatypewriter-75dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bh-lucidatypewriter-100dpi-1.0.4.tar.xz
-mirror://xorg/individual/font/font-bh-type1-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bitstream-75dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bitstream-100dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bitstream-speedo-1.0.2.tar.gz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -131,7 +131,6 @@ mirror://xorg/individual/font/font-misc-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-ethiopic-1.0.5.tar.xz
 mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz
-mirror://xorg/individual/font/font-mutt-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-schumacher-misc-1.1.3.tar.xz
 mirror://xorg/individual/font/font-screen-cyrillic-1.0.5.tar.xz
 mirror://xorg/individual/font/font-sony-misc-1.0.4.tar.xz


### PR DESCRIPTION
I removed the `configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];` that made the fonts be installed in `$out/lib/X11/fonts` instead of `$out/share/fonts` where the default makefile would install them. Other fonts are also in `$out/share/fonts` so it made no sense to me why fonts from the xorg package set would be the exception. Let's see if something breaks. I highly doubt it though because nothing depends on these fonts.

this moves some xorg font packages from the middle of the list in order to be able to make more prs in the next iteration

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
