### PR TITLE
python3Packages.cypari: build gmp and pari separately

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1093,6 +1093,13 @@
     githubId = 1078000;
     name = "Alejandro Sánchez Medina";
   };
+  alejo7797 = {
+    email = "alex@epelde.net";
+    matrix = "@alex:epelde.net";
+    github = "alejo7797";
+    githubId = 17302493;
+    name = "Alex Epelde";
+  };
   aleksana = {
     email = "me@aleksana.moe";
     github = "Aleksanaa";

--- a/pkgs/development/python-modules/cypari/default.nix
+++ b/pkgs/development/python-modules/cypari/default.nix
@@ -47,8 +47,7 @@ buildPythonPackage rec {
 
   checkPhase = ''
     runHook preCheck
-    rm -r cypari
-    ${python.interpreter} -m cypari.test
+    ${python.interpreter} -P -m cypari.test
     runHook postCheck
   '';
 

--- a/pkgs/development/python-modules/cypari/default.nix
+++ b/pkgs/development/python-modules/cypari/default.nix
@@ -3,29 +3,13 @@
   python,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchurl,
   setuptools,
   cython,
-  bash,
+  gmp,
+  pari,
   perl,
-  gnum4,
-  texliveBasic,
 }:
 
-let
-  pariVersion = "2.15.4";
-  gmpVersion = "6.3.0";
-
-  pariSrc = fetchurl {
-    url = "https://pari.math.u-bordeaux.fr/pub/pari/OLD/${lib.versions.majorMinor pariVersion}/pari-${pariVersion}.tar.gz";
-    hash = "sha256-w1Rb/uDG37QLd/tLurr5mdguYAabn20ovLbPAEyMXA8=";
-  };
-
-  gmpSrc = fetchurl {
-    url = "https://ftp.gnu.org/gnu/gmp/gmp-${gmpVersion}.tar.bz2";
-    hash = "sha256-rCghGnz7YJuuLiyNYFjWbI/pZDT3QM9v4uR7AA0cIMs=";
-  };
-in
 buildPythonPackage rec {
   pname = "cypari";
   version = "2.5.5";
@@ -39,13 +23,15 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace ./setup.py \
-      --replace-fail "/bin/bash" "${lib.getExe bash}"
     # final character is stripped from PARI error messages for some reason
     substituteInPlace ./cypari/handle_error.pyx \
       --replace-fail "not a function in function call" "not a function in function cal"
-    ln -s ${pariSrc} ${pariSrc.name}
-    ln -s ${gmpSrc} ${gmpSrc.name}
+  '';
+
+  preBuild = ''
+    mkdir libcache
+    ln -s ${gmp} libcache/gmp
+    ln -s ${pari} libcache/pari
   '';
 
   build-system = [
@@ -53,12 +39,8 @@ buildPythonPackage rec {
     cython
   ];
 
-  NIX_LDFLAGS = "-lc";
-
   nativeBuildInputs = [
-    gnum4
     perl
-    texliveBasic
   ];
 
   pythonImportsCheck = [ "cypari" ];

--- a/pkgs/development/python-modules/cypari/default.nix
+++ b/pkgs/development/python-modules/cypari/default.nix
@@ -23,16 +23,16 @@ buildPythonPackage rec {
     hash = "sha256-RJ9O1KsDHmMkTCIFUrcSUkA5ijTsxmoI939QCsCib0Y=";
   };
 
-  postPatch = ''
-    # final character is stripped from PARI error messages for some reason
-    substituteInPlace ./cypari/handle_error.pyx \
-      --replace-fail "not a function in function call" "not a function in function cal"
-  '';
   patches = [
     (fetchpatch {
       name = "support-aarch64-linux.patch";
       url = "https://github.com/3-manifolds/CyPari/commit/6197171b52ee4f44a4954ddd0e2e36769b189dee.patch";
       hash = "sha256-j2P7DEGD2B8q9Hh4G2mQng76fQdUpeAdFYoTD7Ui/Dk=";
+    })
+    (fetchpatch {
+      name = "fix-build-with-cython-3_1.patch";
+      url = "https://github.com/3-manifolds/CyPari/compare/622e112ffcf0383e2110954ff3ac3c42c006ebe1...50bcbd2b39177f5e4c5a3551a8a14f75ab05a5d6.patch";
+      hash = "sha256-6ayvtHMS3YtzzklHaaLzl9d4zHJhm0lVZQZFS9ykFY4=";
     })
   ];
 

--- a/pkgs/development/python-modules/cypari/default.nix
+++ b/pkgs/development/python-modules/cypari/default.nix
@@ -3,6 +3,7 @@
   python,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   setuptools,
   cython,
   gmp,
@@ -27,6 +28,13 @@ buildPythonPackage rec {
     substituteInPlace ./cypari/handle_error.pyx \
       --replace-fail "not a function in function call" "not a function in function cal"
   '';
+  patches = [
+    (fetchpatch {
+      name = "support-aarch64-linux.patch";
+      url = "https://github.com/3-manifolds/CyPari/commit/6197171b52ee4f44a4954ddd0e2e36769b189dee.patch";
+      hash = "sha256-j2P7DEGD2B8q9Hh4G2mQng76fQdUpeAdFYoTD7Ui/Dk=";
+    })
+  ];
 
   preBuild = ''
     mkdir libcache

--- a/pkgs/development/python-modules/cypari/default.nix
+++ b/pkgs/development/python-modules/cypari/default.nix
@@ -74,7 +74,10 @@ buildPythonPackage rec {
     description = "Sage's PARI extension, modified to stand alone";
     homepage = "https://github.com/3-manifolds/CyPari";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ noiioiu ];
+    maintainers = with lib.maintainers; [
+      noiioiu
+      alejo7797
+    ];
     changelog = "https://github.com/3-manifolds/CyPari/releases/tag/${src.tag}";
   };
 }

--- a/pkgs/development/python-modules/fxrays/default.nix
+++ b/pkgs/development/python-modules/fxrays/default.nix
@@ -37,6 +37,9 @@ buildPythonPackage rec {
     changelog = "https://github.com/3-manifolds/FXrays/releases/tag/${src.tag}";
     homepage = "https://github.com/3-manifolds/FXrays";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ noiioiu ];
+    maintainers = with lib.maintainers; [
+      noiioiu
+      alejo7797
+    ];
   };
 }

--- a/pkgs/development/python-modules/knot-floer-homology/default.nix
+++ b/pkgs/development/python-modules/knot-floer-homology/default.nix
@@ -37,6 +37,9 @@ buildPythonPackage rec {
     changelog = "https://github.com/3-manifolds/knot_floer_homology/releases/tag/${src.tag}";
     homepage = "https://github.com/3-manifolds/knot_floer_homology";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ noiioiu ];
+    maintainers = with lib.maintainers; [
+      noiioiu
+      alejo7797
+    ];
   };
 }

--- a/pkgs/development/python-modules/low-index/default.nix
+++ b/pkgs/development/python-modules/low-index/default.nix
@@ -33,6 +33,9 @@ buildPythonPackage rec {
     changelog = "https://github.com/3-manifolds/low_index/releases/tag/${src.tag}";
     homepage = "https://github.com/3-manifolds/low_index";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ noiioiu ];
+    maintainers = with lib.maintainers; [
+      noiioiu
+      alejo7797
+    ];
   };
 }

--- a/pkgs/development/python-modules/plink/default.nix
+++ b/pkgs/development/python-modules/plink/default.nix
@@ -34,6 +34,9 @@ buildPythonPackage rec {
     homepage = "https://3-manifolds.github.io/PLink";
     changelog = "https://github.com/3-manifolds/PLink/releases/tag/${src.tag}";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ noiioiu ];
+    maintainers = with lib.maintainers; [
+      noiioiu
+      alejo7797
+    ];
   };
 }

--- a/pkgs/development/python-modules/snappy-15-knots/default.nix
+++ b/pkgs/development/python-modules/snappy-15-knots/default.nix
@@ -29,6 +29,9 @@ buildPythonPackage rec {
     homepage = "https://snappy.computop.org";
     changelog = "https://github.com/3-manifolds/snappy_15_knots/releases/tag/${src.tag}";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ noiioiu ];
+    maintainers = with maintainers; [
+      noiioiu
+      alejo7797
+    ];
   };
 }

--- a/pkgs/development/python-modules/snappy-manifolds/default.nix
+++ b/pkgs/development/python-modules/snappy-manifolds/default.nix
@@ -26,6 +26,9 @@ buildPythonPackage rec {
     changelog = "https://github.com/3-manifolds/snappy_manifolds/releases/tag/${src.tag}";
     homepage = "https://snappy.computop.org";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ noiioiu ];
+    maintainers = with lib.maintainers; [
+      noiioiu
+      alejo7797
+    ];
   };
 }

--- a/pkgs/development/python-modules/spherogram/default.nix
+++ b/pkgs/development/python-modules/spherogram/default.nix
@@ -44,6 +44,9 @@ buildPythonPackage rec {
     homepage = "https://snappy.computop.org/spherogram.html";
     changelog = "https://github.com/3-manifolds/Spherogram/releases/tag/${src.tag}";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ noiioiu ];
+    maintainers = with lib.maintainers; [
+      noiioiu
+      alejo7797
+    ];
   };
 }

--- a/pkgs/development/python-modules/tkinter-gl/default.nix
+++ b/pkgs/development/python-modules/tkinter-gl/default.nix
@@ -29,6 +29,9 @@ buildPythonPackage rec {
     changelog = "https://github.com/3-manifolds/tkinter_gl/releases/tag/${src.tag}";
     homepage = "https://github.com/3-manifolds/tkinter_gl";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ noiioiu ];
+    maintainers = with lib.maintainers; [
+      noiioiu
+      alejo7797
+    ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3278,7 +3278,23 @@ self: super: with self; {
 
   cynthion = callPackage ../development/python-modules/cynthion { };
 
-  cypari = callPackage ../development/python-modules/cypari { };
+  cypari = callPackage ../development/python-modules/cypari {
+
+    inherit (pkgs.pkgsStatic) gmp;
+
+    pari = pkgs.pari.overrideAttrs rec {
+      version = "2.15.4";
+      src = pkgs.fetchurl {
+        url = "https://pari.math.u-bordeaux.fr/pub/pari/OLD/${lib.versions.majorMinor version}/pari-${version}.tar.gz";
+        hash = "sha256-w1Rb/uDG37QLd/tLurr5mdguYAabn20ovLbPAEyMXA8=";
+      };
+      installTargets = [
+        "install"
+        "install-lib-sta"
+      ];
+    };
+
+  };
 
   cypari2 = callPackage ../development/python-modules/cypari2 { };
 


### PR DESCRIPTION
We can get the needed static libraries `libpari.a` and `libgmp.a` from existing derivations.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
