### PR TITLE
x{cursor{gen,-themes},ev,fsinfo,randr,vinfo}: refactor and move to pkgs/by-name from xorg namespace

### DIFF
--- a/pkgs/by-name/xc/xcursor-themes/package.nix
+++ b/pkgs/by-name/xc/xcursor-themes/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xcursorgen,
+  xorgproto,
+  libxcursor,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xcursor-themes";
+  version = "1.0.7";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/data/xcursor-themes-${finalAttrs.version}.tar.xz";
+    hash = "sha256-lbro9Igj2JSgW/Qt+/RTZ0q3296xHivAeehSWtRzeMg=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [
+    pkg-config
+    xcursorgen
+  ];
+  buildInputs = [
+    xorgproto
+    libxcursor
+  ];
+
+  configureFlags = [ "--with-cursordir=$(out)/share/icons" ];
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/data/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Default set of cursor themes for use with libXcursor.";
+    homepage = "https://gitlab.freedesktop.org/xorg/data/cursors";
+    license = lib.licenses.x11;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xc/xcursorgen/package.nix
+++ b/pkgs/by-name/xc/xcursorgen/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libpng,
+  libx11,
+  libxcursor,
+  xorgproto,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xcursorgen";
+  version = "1.0.9";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xcursorgen-${finalAttrs.version}.tar.xz";
+    hash = "sha256-DMnhVqyEyhbqkCcQrzXg+v+lHRN5cHHjtLbMfL1JO7w=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libpng
+    libx11
+    libxcursor
+    xorgproto
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "prepares X11 cursor sets for use with libXcursor";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xcursorgen";
+    license = lib.licenses.hpndSellVariant;
+    mainProgram = "xcursorgen";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xe/xev/package.nix
+++ b/pkgs/by-name/xe/xev/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxrandr,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xev";
+  version = "1.2.6";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xev-${finalAttrs.version}.tar.xz";
+    hash = "sha256-YeHF4AismXOsp83d826d90EOdwg7Aw6wT03HN8UYB9c=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    xorgproto
+    libx11
+    libxrandr
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "X event monitor";
+    longDescription = ''
+      xev creates a window and then asks the X server to send it X11 events whenever anything
+      happens to the window (such as it being moved, resized, typed in, clicked in, etc.).
+      You can also attach it to an existing window. It is useful for seeing what causes events to
+      occur and to display the information that they contain; it is essentially a debugging and
+      development tool, and should not be needed in normal usage.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xev";
+    license = lib.licenses.x11;
+    mainProgram = "xev";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xf/xfsinfo/package.nix
+++ b/pkgs/by-name/xf/xfsinfo/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libfs,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xfsinfo";
+  version = "1.0.8";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xfsinfo-${finalAttrs.version}.tar.xz";
+    hash = "sha256-roBZK2Bj2pKOPQyBAjcJsvopoE/NpJ9sNjrFedl/I6I=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libfs
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "X font server information utility";
+    longDescription = ''
+      xfsinfo is a utility for displaying information about an X font server.
+      It is used to examine the capabilities of a server, the predefined values for various
+      parameters used in communicating between clients and the server, and the font catalogues and
+      alternate servers that are available.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xfsinfo";
+    license = with lib.licenses; [
+      mitOpenGroup
+      hpndSellVariant
+    ];
+    mainProgram = "xfsinfo";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xr/xrandr/package.nix
+++ b/pkgs/by-name/xr/xrandr/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxrandr,
+  libxrender,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xrandr";
+  version = "1.5.3";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xrandr-${finalAttrs.version}.tar.xz";
+    hash = "sha256-+N11Zq23QUf6uZZGgLa7re6Hz0Bqf8/1Fxil5pSbhBw=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxrandr
+    libxrender
+  ];
+
+  postInstall = ''
+    # remove useless xkeystone script
+    # it is written in a language not packaged in nixpkgs
+    rm $out/bin/xkeystone
+  '';
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Command line interface to X11 Resize, Rotate, and Reflect (RandR) extension";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xrandr";
+    license = lib.licenses.hpndSellVariant;
+    mainProgram = "xrandr";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xv/xvinfo/package.nix
+++ b/pkgs/by-name/xv/xvinfo/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxv,
+  libxext,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xvinfo";
+  version = "1.1.5";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xvinfo-${finalAttrs.version}.tar.xz";
+    hash = "sha256-Pt5x7LJtlhTMvGkWcgKF6VosfgxeGbhXDqr3KtfFxAQ=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxv
+    libxext
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Utility to print out X-Video extension adaptor information";
+    longDescription = ''
+      xvinfo prints out the capabilities of any video adaptors associated with the display that are
+      accessible through the X-Video extension.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xvinfo";
+    license = lib.licenses.x11;
+    mainProgram = "xvinfo";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -38,6 +38,7 @@
   xcursorgen,
   xcursor-themes,
   xdriinfo,
+  xev,
   xkeyboard-config,
   xlsatoms,
   xlsclients,
@@ -77,6 +78,7 @@ self: with self; {
     xcmsdb
     xcursorgen
     xdriinfo
+    xev
     xlsatoms
     xlsclients
     xlsfonts
@@ -3759,44 +3761,6 @@ self: with self; {
         libXxf86dga
         libXxf86misc
         libXxf86vm
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xev = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      xorgproto,
-      libXrandr,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xev";
-      version = "1.2.6";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xev-1.2.6.tar.xz";
-        sha256 = "1mq7332kgisd9yq0w0rv11vhwhgpkmpg7pfdlyn776dc13hcbqb1";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        xorgproto
-        libXrandr
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -35,6 +35,7 @@
   xbitmaps,
   xcb-proto,
   xcmsdb,
+  xcursorgen,
   xdriinfo,
   xkeyboard-config,
   xlsatoms,
@@ -73,6 +74,7 @@ self: with self; {
     transset
     xbitmaps
     xcmsdb
+    xcursorgen
     xdriinfo
     xlsatoms
     xlsclients
@@ -3637,46 +3639,6 @@ self: with self; {
         libXmu
         xorgproto
         libXt
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xcursorgen = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libpng,
-      libX11,
-      libXcursor,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xcursorgen";
-      version = "1.0.9";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xcursorgen-1.0.9.tar.xz";
-        sha256 = "1g1v96yprk5nnkip2w3r2cfsbzzsw0ssy417j3m1djl4mibf3j8c";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libpng
-        libX11
-        libXcursor
-        xorgproto
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -39,6 +39,7 @@
   xcursor-themes,
   xdriinfo,
   xev,
+  xfsinfo,
   xkeyboard-config,
   xlsatoms,
   xlsclients,
@@ -79,6 +80,7 @@ self: with self; {
     xcursorgen
     xdriinfo
     xev
+    xfsinfo
     xlsatoms
     xlsclients
     xlsfonts
@@ -5879,42 +5881,6 @@ self: with self; {
         libXfont2
         xorgproto
         xtrans
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xfsinfo = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libFS,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xfsinfo";
-      version = "1.0.7";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xfsinfo-1.0.7.tar.xz";
-        sha256 = "0x48p4hk0lds2s8nwzgfl616r99s28ydx02zs7p1fxxs3i2wmwwj";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libFS
-        xorgproto
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -50,6 +50,7 @@
   xorgproto,
   xorg-sgml-doctools,
   xprop,
+  xrandr,
   xrefresh,
   xtrans,
   xwininfo,
@@ -87,6 +88,7 @@ self: with self; {
     xmodmap
     xorgproto
     xprop
+    xrandr
     xrefresh
     xtrans
     xwininfo
@@ -6545,46 +6547,6 @@ self: with self; {
         libX11
         libXmu
         xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xrandr = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      xorgproto,
-      libXrandr,
-      libXrender,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xrandr";
-      version = "1.5.3";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xrandr-1.5.3.tar.xz";
-        sha256 = "0744kfafd98q2zswyzva837qgvmdpfv80ilnp7x4fhdpmmk7bpgq";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        xorgproto
-        libXrandr
-        libXrender
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -53,6 +53,7 @@
   xrandr,
   xrefresh,
   xtrans,
+  xvinfo,
   xwininfo,
   xwud,
 }:
@@ -91,6 +92,7 @@ self: with self; {
     xrandr
     xrefresh
     xtrans
+    xvinfo
     xwininfo
     xwud
     ;
@@ -6793,44 +6795,6 @@ self: with self; {
         libX11
         libXt
         libXTrap
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xvinfo = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      xorgproto,
-      libXv,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xvinfo";
-      version = "1.1.5";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xvinfo-1.1.5.tar.xz";
-        sha256 = "0164qpbjmxxa1rbvh6ay1iz2qnp9hl1745k9pk6195kdnbn73piy";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        xorgproto
-        libXv
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -36,6 +36,7 @@
   xcb-proto,
   xcmsdb,
   xcursorgen,
+  xcursor-themes,
   xdriinfo,
   xkeyboard-config,
   xlsatoms,
@@ -104,6 +105,7 @@ self: with self; {
   utilmacros = util-macros;
   xcbproto = xcb-proto;
   xkeyboardconfig = xkeyboard-config;
+  xcursorthemes = xcursor-themes;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
   xorgsgmldoctools = xorg-sgml-doctools;
@@ -3640,38 +3642,6 @@ self: with self; {
         xorgproto
         libXt
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xcursorthemes = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libXcursor,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xcursor-themes";
-      version = "1.0.7";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/data/xcursor-themes-1.0.7.tar.xz";
-        sha256 = "1j3qfga5llp8g702n7mivvdvfjk7agsgnbglbfh99n13i3sfiflm";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [ libXcursor ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -343,6 +343,7 @@ print OUT <<EOF;
   xorgproto,
   xorg-sgml-doctools,
   xprop,
+  xrandr,
   xrefresh,
   xtrans,
   xwininfo,
@@ -380,6 +381,7 @@ self: with self; {
     xmodmap
     xorgproto
     xprop
+    xrandr
     xrefresh
     xtrans
     xwininfo

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -328,6 +328,7 @@ print OUT <<EOF;
   xbitmaps,
   xcb-proto,
   xcmsdb,
+  xcursorgen,
   xdriinfo,
   xkeyboard-config,
   xlsatoms,
@@ -366,6 +367,7 @@ self: with self; {
     transset
     xbitmaps
     xcmsdb
+    xcursorgen
     xdriinfo
     xlsatoms
     xlsclients

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -332,6 +332,7 @@ print OUT <<EOF;
   xcursor-themes,
   xdriinfo,
   xev,
+  xfsinfo,
   xkeyboard-config,
   xlsatoms,
   xlsclients,
@@ -372,6 +373,7 @@ self: with self; {
     xcursorgen
     xdriinfo
     xev
+    xfsinfo
     xlsatoms
     xlsclients
     xlsfonts

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -346,6 +346,7 @@ print OUT <<EOF;
   xrandr,
   xrefresh,
   xtrans,
+  xvinfo,
   xwininfo,
   xwud,
 }:
@@ -384,6 +385,7 @@ self: with self; {
     xrandr
     xrefresh
     xtrans
+    xvinfo
     xwininfo
     xwud
     ;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -329,6 +329,7 @@ print OUT <<EOF;
   xcb-proto,
   xcmsdb,
   xcursorgen,
+  xcursor-themes,
   xdriinfo,
   xkeyboard-config,
   xlsatoms,
@@ -397,6 +398,7 @@ self: with self; {
   utilmacros = util-macros;
   xcbproto = xcb-proto;
   xkeyboardconfig = xkeyboard-config;
+  xcursorthemes = xcursor-themes;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
   xorgsgmldoctools = xorg-sgml-doctools;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -331,6 +331,7 @@ print OUT <<EOF;
   xcursorgen,
   xcursor-themes,
   xdriinfo,
+  xev,
   xkeyboard-config,
   xlsatoms,
   xlsclients,
@@ -370,6 +371,7 @@ self: with self; {
     xcmsdb
     xcursorgen
     xdriinfo
+    xev
     xlsatoms
     xlsclients
     xlsfonts

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1026,7 +1026,6 @@ self: super:
   xclock = addMainProgram super.xclock { };
   xcompmgr = addMainProgram super.xcompmgr { };
   xconsole = addMainProgram super.xconsole { };
-  xcursorgen = addMainProgram super.xcursorgen { };
 
   xcursorthemes = super.xcursorthemes.overrideAttrs (attrs: {
     nativeBuildInputs = attrs.nativeBuildInputs ++ [ xorg.xcursorgen ];

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -685,13 +685,6 @@ self: super:
 
   xeyes = addMainProgram super.xeyes { };
 
-  xvinfo = super.xvinfo.overrideAttrs (attrs: {
-    buildInputs = attrs.buildInputs ++ [ xorg.libXext ];
-    meta = attrs.meta // {
-      mainProgram = "xvinfo";
-    };
-  });
-
   xkbcomp = super.xkbcomp.overrideAttrs (attrs: {
     configureFlags = [ "--with-xkb-config-root=${xorg.xkeyboardconfig}/share/X11/xkb" ];
     meta = attrs.meta // {

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1112,7 +1112,6 @@ self: super:
   xfd = addMainProgram super.xfd { };
   xfontsel = addMainProgram super.xfontsel { };
   xfs = addMainProgram super.xfs { };
-  xfsinfo = addMainProgram super.xfsinfo { };
   xgamma = addMainProgram super.xgamma { };
   xgc = addMainProgram super.xgc { };
   xhost = addMainProgram super.xhost { };

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1027,12 +1027,6 @@ self: super:
   xcompmgr = addMainProgram super.xcompmgr { };
   xconsole = addMainProgram super.xconsole { };
 
-  xcursorthemes = super.xcursorthemes.overrideAttrs (attrs: {
-    nativeBuildInputs = attrs.nativeBuildInputs ++ [ xorg.xcursorgen ];
-    buildInputs = attrs.buildInputs ++ [ xorg.xorgproto ];
-    configureFlags = [ "--with-cursordir=$(out)/share/icons" ];
-  });
-
   xinit =
     (super.xinit.override {
       stdenv = if isDarwin then clangStdenv else stdenv;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1133,15 +1133,6 @@ self: super:
     };
   });
 
-  xrandr = super.xrandr.overrideAttrs (attrs: {
-    postInstall = ''
-      rm $out/bin/xkeystone
-    '';
-    meta = attrs.meta // {
-      mainProgram = "xrandr";
-    };
-  });
-
   xset = addMainProgram super.xset { };
   xsetroot = addMainProgram super.xsetroot { };
   xsm = addMainProgram super.xsm { };

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -683,7 +683,6 @@ self: super:
     };
   });
 
-  xev = addMainProgram super.xev { };
   xeyes = addMainProgram super.xeyes { };
 
   xvinfo = super.xvinfo.overrideAttrs (attrs: {

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -54,7 +54,6 @@ mirror://xorg/individual/app/xstdcmap-1.0.5.tar.xz
 mirror://xorg/individual/app/xtrap-1.0.3.tar.bz2
 mirror://xorg/individual/app/xvinfo-1.1.5.tar.xz
 mirror://xorg/individual/app/xwd-1.0.9.tar.xz
-mirror://xorg/individual/data/xcursor-themes-1.0.7.tar.xz
 mirror://xorg/individual/driver/xf86-input-evdev-2.11.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-joystick-1.6.4.tar.xz
 mirror://xorg/individual/driver/xf86-input-keyboard-2.1.0.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -28,7 +28,6 @@ mirror://xorg/individual/app/xeyes-1.3.0.tar.xz
 mirror://xorg/individual/app/xfd-1.1.4.tar.xz
 mirror://xorg/individual/app/xfontsel-1.1.1.tar.xz
 mirror://xorg/individual/app/xfs-1.2.2.tar.xz
-mirror://xorg/individual/app/xfsinfo-1.0.7.tar.xz
 mirror://xorg/individual/app/xgamma-1.0.7.tar.xz
 mirror://xorg/individual/app/xgc-1.0.6.tar.xz
 mirror://xorg/individual/app/xhost-1.0.10.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -49,7 +49,6 @@ mirror://xorg/individual/app/xsetroot-1.1.3.tar.xz
 mirror://xorg/individual/app/xsm-1.0.6.tar.xz
 mirror://xorg/individual/app/xstdcmap-1.0.5.tar.xz
 mirror://xorg/individual/app/xtrap-1.0.3.tar.bz2
-mirror://xorg/individual/app/xvinfo-1.1.5.tar.xz
 mirror://xorg/individual/app/xwd-1.0.9.tar.xz
 mirror://xorg/individual/driver/xf86-input-evdev-2.11.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-joystick-1.6.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -22,7 +22,6 @@ mirror://xorg/individual/app/xcalc-1.1.2.tar.xz
 mirror://xorg/individual/app/xclock-1.1.1.tar.xz
 mirror://xorg/individual/app/xcompmgr-1.1.10.tar.xz
 mirror://xorg/individual/app/xconsole-1.1.0.tar.xz
-mirror://xorg/individual/app/xcursorgen-1.0.9.tar.xz
 mirror://xorg/individual/app/xdm-1.1.17.tar.xz
 mirror://xorg/individual/app/xdpyinfo-1.3.4.tar.xz
 mirror://xorg/individual/app/xev-1.2.6.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -24,7 +24,6 @@ mirror://xorg/individual/app/xcompmgr-1.1.10.tar.xz
 mirror://xorg/individual/app/xconsole-1.1.0.tar.xz
 mirror://xorg/individual/app/xdm-1.1.17.tar.xz
 mirror://xorg/individual/app/xdpyinfo-1.3.4.tar.xz
-mirror://xorg/individual/app/xev-1.2.6.tar.xz
 mirror://xorg/individual/app/xeyes-1.3.0.tar.xz
 mirror://xorg/individual/app/xfd-1.1.4.tar.xz
 mirror://xorg/individual/app/xfontsel-1.1.1.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -43,7 +43,6 @@ mirror://xorg/individual/app/xmag-1.0.8.tar.xz
 mirror://xorg/individual/app/xmessage-1.0.7.tar.xz
 mirror://xorg/individual/app/xmore-1.0.4.tar.xz
 mirror://xorg/individual/app/xpr-1.2.0.tar.xz
-mirror://xorg/individual/app/xrandr-1.5.3.tar.xz
 mirror://xorg/individual/app/xrdb-1.2.2.tar.xz
 mirror://xorg/individual/app/xset-1.2.5.tar.xz
 mirror://xorg/individual/app/xsetroot-1.1.3.tar.xz


### PR DESCRIPTION
it shouldn't conflict with any of my other open xorg migration prs
(although i cheated a bit for xcursor-themes by not keeping everything perfectly in order)

<details>
<summary>this is the script i use to get the packages that don't depend on other xorg packages:</summary>

```nix
let
  inherit (import <nixpkgs> { }) lib;

  done = import ./pkgs/servers/x11/xorg/default.nix |> lib.functionArgs |> lib.attrNames;

  pkgs =
    (import ./default.nix { }).xorg
    |> lib.filterAttrs (
      n: v:
      lib.isAttrs v
      && v ? pname
      && !lib.elem n done
      && !lib.elem n (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem v.pname done
      && !lib.elem v.pname (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem (lib.toLower n) done
      && !lib.elem (lib.toLower n) (map (lib.replaceStrings [ "-" ] [ "" ]) done)
    );

  pnames = lib.mapAttrsToList (_: v: v.pname) pkgs;

  filteredPkgs =
    pkgs
    |> lib.filterAttrs (
      n: v:
      true
      && !v.meta.unfree
      && !v.meta.broken
      && !v.meta.unsupported
      && !lib.hasPrefix "font" n
      && !lib.hasPrefix "xf86" n
    );
in
filteredPkgs
# get deps
|> lib.mapAttrs (
  _: v:
  v.buildInputs ++ v.nativeBuildInputs ++ v.propagatedBuildInputs ++ v.propagatedNativeBuildInputs
)
# filter deps for xorg packages
|> lib.mapAttrs (_: v: lib.filter (x: x ? pname && lib.elem x.pname pnames) v)
# map deps to list and count
|> lib.mapAttrsToList (
  name: value: {
    inherit name;
    deps = map (x: x.pname or "error") value |> lib.unique;
    count = lib.length value;
  }
)
# sort
|> lib.sort (
  x: y: x.count < y.count || (x.count == y.count && (lib.toLower x.name) > (lib.toLower y.name))
)
|> lib.reverseList
# represent as string
|> map (x: "${toString x.count} - ${toString x.name}: ${lib.concatStringsSep " " x.deps}")
```

you can call it like this to get a nice output:

```sh
nix eval --json --file ./xorg-nodepends.nix | jq .[] --raw-output
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] x86_64-linux static 
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - only help and version output
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
  - [x] ran passthru.updateScript
  - [x] ran nixpkgs-hammer
  - [x] ran nix-check-deps 
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
