### PR TITLE
ivpn{,-service,-ui}: 3.14.29 -> 3.14.34

### DIFF
--- a/pkgs/by-name/iv/ivpn-ui/package.nix
+++ b/pkgs/by-name/iv/ivpn-ui/package.nix
@@ -10,7 +10,7 @@
   ivpn-service,
 }:
 let
-  version = "3.14.29";
+  version = "3.14.34";
 in
 buildNpmPackage {
   pname = "ivpn-ui";
@@ -20,12 +20,12 @@ buildNpmPackage {
     owner = "ivpn";
     repo = "desktop-app";
     tag = "v${version}";
-    hash = "sha256-8JScty/sGyxzC2ojRpatHpCqEXZw9ksMortIhZnukoU=";
+    hash = "sha256-Q96G5mJahJnXxpqJ8IF0oFie7l0Nd1p8drHH9NSpwEw=";
   };
 
   sourceRoot = "source/ui";
 
-  npmDepsHash = "sha256-2EsXYNo+rj2v+YkZT6ciEcDAirnEZ5MezFlf9zsb/os=";
+  npmDepsHash = "sha256-y/VxvSZUvcIuckJF87639i5pcVJLg8SDAbWmg5bO3/s=";
 
   nativeBuildInputs = [
     copyDesktopItems

--- a/pkgs/tools/networking/ivpn/default.nix
+++ b/pkgs/tools/networking/ivpn/default.nix
@@ -12,6 +12,7 @@
   iptables,
   gawk,
   util-linux,
+  nix-update-script,
 }:
 
 builtins.mapAttrs
@@ -46,6 +47,8 @@ builtins.mapAttrs
         postInstall = ''
           mv $out/bin/{${attrs.modRoot},${pname}}
         '';
+
+        passthru.updateScript = nix-update-script { };
 
         meta = {
           description = "Official IVPN Desktop app";

--- a/pkgs/tools/networking/ivpn/default.nix
+++ b/pkgs/tools/networking/ivpn/default.nix
@@ -55,7 +55,10 @@ builtins.mapAttrs
           homepage = "https://www.ivpn.net/apps";
           changelog = "https://github.com/ivpn/desktop-app/releases/tag/v${version}";
           license = lib.licenses.gpl3Only;
-          maintainers = with lib.maintainers; [ urandom ];
+          maintainers = with lib.maintainers; [
+            urandom
+            blenderfreaky
+          ];
           mainProgram = "ivpn";
         };
       }

--- a/pkgs/tools/networking/ivpn/default.nix
+++ b/pkgs/tools/networking/ivpn/default.nix
@@ -22,7 +22,7 @@ builtins.mapAttrs
       attrs
       // rec {
         inherit pname;
-        version = "3.14.29";
+        version = "3.14.34";
 
         buildInputs = [
           wirelesstools
@@ -32,7 +32,7 @@ builtins.mapAttrs
           owner = "ivpn";
           repo = "desktop-app";
           tag = "v${version}";
-          hash = "sha256-8JScty/sGyxzC2ojRpatHpCqEXZw9ksMortIhZnukoU=";
+          hash = "sha256-Q96G5mJahJnXxpqJ8IF0oFie7l0Nd1p8drHH9NSpwEw=";
         };
 
         proxyVendor = true; # .c file
@@ -64,11 +64,11 @@ builtins.mapAttrs
   {
     ivpn = {
       modRoot = "cli";
-      vendorHash = "sha256-STbkFchrmxwWnSgEJ7RGKN3jGaCC0npL80YjlwUcs1g=";
+      vendorHash = "sha256-xZ1tMiv06fE2wtpDagKjHiVTPYWpj32hM6n/v9ZcgrE=";
     };
     ivpn-service = {
       modRoot = "daemon";
-      vendorHash = "sha256-REIY3XPyMA2Loxo1mKzJMJwZrf9dQMOtnQOUEgN5LP8=";
+      vendorHash = "sha256-DVKSCcEeE7vI8aOYuEwk22n0wtF7MMDOyAgYoXYadwI=";
       nativeBuildInputs = [ makeWrapper ];
 
       patches = [ ./permissions.patch ];


### PR DESCRIPTION
Updates all the ivpn packages.

I've not seen anything from the maintainers in a while, so I added myself to the maintainers

- Closes #427152
- Closes #427151

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
