### PR TITLE
ci/nixpkgs-vet: use Nix 2.30+ inside sandbox

### DIFF
--- a/ci/default.nix
+++ b/ci/default.nix
@@ -134,7 +134,9 @@ rec {
   manual-nixos = (import ../nixos/release.nix { }).manual.${system} or null;
   manual-nixpkgs = (import ../doc { inherit pkgs; });
   manual-nixpkgs-tests = (import ../doc { inherit pkgs; }).tests;
-  nixpkgs-vet = pkgs.callPackage ./nixpkgs-vet.nix { };
+  nixpkgs-vet = pkgs.callPackage ./nixpkgs-vet.nix {
+    nix = pkgs.nixVersions.latest;
+  };
   parse = pkgs.lib.recurseIntoAttrs {
     latest = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.latest; };
     lix = pkgs.callPackage ./parse.nix { nix = pkgs.lix; };


### PR DESCRIPTION
This should fix the random symlink creation errors.

Latest one was here: https://github.com/NixOS/nixpkgs/pull/435496#issuecomment-3209303196 / https://github.com/NixOS/nixpkgs/actions/runs/17119620497/job/48557404478.

We are already running the daemon with Nix 2.30, but inside the sandbox we still have Nix 2.28 right now.

SIde effect: This also seems to make nixpkgs-vet faster, from ~58s down to 45s on my machine.

## Things done

- [x] Tested locally.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
