### PR TITLE
[25.05] flightgear: use forked openscenegraph

### DIFF
--- a/pkgs/games/flightgear/default.nix
+++ b/pkgs/games/flightgear/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitLab,
   wrapQtAppsHook,
+  callPackage,
   libglut,
   freealut,
   libGLU,
@@ -10,7 +11,6 @@
   libICE,
   libjpeg,
   openal,
-  openscenegraph,
   plib,
   libSM,
   libunwind,
@@ -55,6 +55,7 @@ let
       cp ${src}/* -a "$out/share/FlightGear/"
     '';
   };
+  openscenegraph = callPackage ./openscenegraph-flightgear.nix { };
 in
 stdenv.mkDerivation rec {
   pname = "flightgear";
@@ -90,7 +91,7 @@ stdenv.mkDerivation rec {
     libXi
     libXmu
     libXt
-    simgear
+    (simgear.override { openscenegraph = openscenegraph; })
     zlib
     boost
     libpng
@@ -104,9 +105,7 @@ stdenv.mkDerivation rec {
     curl
   ];
 
-  qtWrapperArgs = [
-    "--set FG_ROOT ${data}/share/FlightGear"
-  ];
+  qtWrapperArgs = [ "--set FG_ROOT ${data}/share/FlightGear" ];
 
   meta = with lib; {
     description = "Flight simulator";

--- a/pkgs/games/flightgear/openscenegraph-flightgear.nix
+++ b/pkgs/games/flightgear/openscenegraph-flightgear.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  pkg-config,
+  cmake,
+  doxygen,
+  fetchpatch,
+  fetchurl,
+  glib,
+  libxml2,
+  pcre,
+  zlib,
+  libjpeg,
+  giflib,
+  libtiff,
+  libpng,
+  curl,
+  freetype,
+  boost,
+  libGLU,
+  libGL,
+  libX11,
+  libXinerama,
+  libXrandr,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "openscenegraph";
+  version = "2024-build";
+
+  src = fetchFromGitLab {
+    owner = "flightgear";
+    repo = "openscenegraph";
+    # release/2024-build as of 2025-08-08
+    rev = "a4ea8ec535cc969e31e2026b13be147dcb978689";
+    sha256 = "sha256-wnxm4G40j2e6Paqx0vfAR4s4L7esfCHcgxUJWNxk1SM=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    doxygen
+  ];
+
+  buildInputs =
+    lib.optionals (!stdenv.hostPlatform.isDarwin) [
+      libX11
+      libXinerama
+      libXrandr
+      libGLU
+      libGL
+    ]
+    ++ [
+      glib
+      libxml2
+      pcre
+      zlib
+      libjpeg
+      giflib
+      libtiff
+      libpng
+      curl
+      freetype
+      boost
+    ];
+
+  patches = [
+    (fetchpatch {
+      name = "opencascade-api-patch";
+      url = "https://github.com/openscenegraph/OpenSceneGraph/commit/bc2daf9b3239c42d7e51ecd7947d31a92a7dc82b.patch";
+      hash = "sha256-VR8YKOV/YihB5eEGZOGaIfJNrig1EPS/PJmpKsK284c=";
+    })
+    # Fix compiling with libtiff when libtiff is compiled using CMake
+    (fetchurl {
+      url = "https://github.com/openscenegraph/OpenSceneGraph/commit/9da8d428f6666427c167b951b03edd21708e1f43.patch";
+      hash = "sha256-YGG/DIHU1f6StbeerZoZrNDm348wYB3ydmVIIGTM7fU=";
+    })
+  ];
+
+  cmakeFlags = [ "-DBUILD_OSG_APPLICATIONS=OFF" ];
+
+  meta = with lib; {
+    description = "3D graphics toolkit";
+    homepage = "http://www.openscenegraph.org/";
+    maintainers = with maintainers; [
+      aanderse
+      raskin
+    ];
+    platforms = with platforms; linux ++ darwin;
+    license = "OpenSceneGraph Public License - free LGPL-based license";
+  };
+}


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/432102 since this fixed a major bug in flightgear.

As discussed on https://gitlab.com/flightgear/flightgear/-/issues/3106 , version 2024.1.1 of flightgear should be compiled against a version of openscenegraph that was forked from the main project.

This fork includes several fixes such as
https://gitlab.com/flightgear/openscenegraph/-/commit/724ff2ef687d84b266402724239f61a392d36f4c .

(cherry picked from commit d03caf08fd5d86dac822c3916777a018cb1e65a1)