### PR TITLE
 keepercommander: init at 17.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23019,6 +23019,12 @@
     githubId = 11613056;
     name = "Scott Dier";
   };
+  sdubey-ks = {
+    email = "sdubey@keepersecurity.com";
+    github = "sdubey-ks";
+    githubId = 221318348;
+    name = "Sharad Dubey";
+  };
   seanrmurphy = {
     email = "sean@gopaddy.ch";
     github = "seanrmurphy";

--- a/pkgs/development/python-modules/aioice/default.nix
+++ b/pkgs/development/python-modules/aioice/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  attrs,
+  dnspython,
+  netifaces,
+  ifaddr,
+}:
+
+buildPythonPackage rec {
+  pname = "aioice";
+  version = "0.9.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-/CQBscS24ZNy6q6qKP0b2cv2sOQS5IYlKXxTtJXuvR4=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    attrs
+    dnspython
+    netifaces
+    ifaddr
+  ];
+
+  pythonImportsCheck = [ "aioice" ];
+
+  meta = {
+    description = "ICE (Interactive Connectivity Establishment) library for asyncio";
+    homepage = "https://github.com/aiortc/aioice";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ sdubey-ks ];
+  };
+}

--- a/pkgs/development/python-modules/aiortc/default.nix
+++ b/pkgs/development/python-modules/aiortc/default.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  pkg-config,
+  ffmpeg,
+  libvpx,
+  libopus,
+  srtp,
+  av,
+  cryptography,
+  numpy,
+  pyee,
+  dnspython,
+  netifaces,
+  google-crc32c,
+  pyopenssl,
+  aioice,
+  pylibsrtp,
+  audioop-lts,
+  pythonAtLeast,
+}:
+
+buildPythonPackage rec {
+  pname = "aiortc";
+  version = "1.5.0";
+
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-grQTHYT4YuJOHDVQtz94QSzJVUFAoldVd+s/BGdbutI=";
+  };
+
+  build-system = [
+    setuptools
+    pkg-config
+  ];
+  buildInputs = [
+    ffmpeg
+    libvpx
+    libopus
+    srtp
+  ];
+
+  dependencies = [
+    av
+    cryptography
+    numpy
+    pyee
+    dnspython
+    netifaces
+    google-crc32c
+    pyopenssl
+    aioice
+    pylibsrtp
+  ]
+  ++ lib.optionals (pythonAtLeast "3.13") [
+    audioop-lts
+  ];
+
+  pythonImportsCheck = [ "aiortc" ];
+
+  dontCheckRuntimeDeps = true; # Avoid runtime dependency checks that may fail due to missing ffmpeg or other media libraries.
+
+  meta = {
+    description = "WebRTC and ORTC implementation for Python using asyncio";
+    homepage = "https://github.com/aiortc/aiortc";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ sdubey-ks ];
+  };
+}

--- a/pkgs/development/python-modules/keeper-secrets-manager-core/default.nix
+++ b/pkgs/development/python-modules/keeper-secrets-manager-core/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  requests,
+  cryptography,
+  importlib-metadata,
+}:
+
+buildPythonPackage rec {
+  pname = "keeper-secrets-manager-core";
+  version = "16.6.4";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "keeper-secrets-manager-core";
+    inherit version;
+    hash = "sha256-msgx3wZmucvqYltfe7UfqWRFrEIFdQvEzSpeD8Lki+Y=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    requests
+    cryptography
+    importlib-metadata
+  ];
+
+  pythonImportsCheck = [ "keeper_secrets_manager_core" ];
+
+  meta = {
+    description = "Core library for Keeper Secrets Manager";
+    homepage = "https://github.com/Keeper-Security/secrets-manager";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sdubey-ks ];
+  };
+}

--- a/pkgs/development/python-modules/keepercommander/default.nix
+++ b/pkgs/development/python-modules/keepercommander/default.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  requests,
+  pycryptodomex,
+  colorama,
+  prompt-toolkit,
+  keyring,
+  pykeepass,
+  asciitree,
+  bcrypt,
+  fido2,
+  flask,
+  flask-limiter,
+  protobuf,
+  psutil,
+  pyngrok,
+  pyperclip,
+  pysocks,
+  python-dotenv,
+  tabulate,
+  websockets,
+  pydantic,
+  fpdf2,
+  keeper-secrets-manager-core,
+  aiortc,
+}:
+
+buildPythonPackage rec {
+  pname = "keepercommander";
+  version = "17.1.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Keeper-Security";
+    repo = "Commander";
+    rev = "21c5eabf05ca8031da97d3ab9b8bcdc8039c558c";
+    hash = "sha256-LxVv3n8RsxDM8a4EogN70zxphgVgiAb+xgx4ZZmveIw=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    requests
+    pycryptodomex
+    colorama
+    prompt-toolkit
+    keyring
+    pykeepass
+    asciitree
+    bcrypt
+    fido2
+    flask
+    flask-limiter
+    protobuf
+    psutil
+    pyngrok
+    pyperclip
+    pysocks
+    python-dotenv
+    tabulate
+    websockets
+    pydantic
+    fpdf2
+    keeper-secrets-manager-core
+    aiortc
+  ];
+
+  pythonImportsCheck = [ "keepercommander" ];
+
+  meta = {
+    description = "Command-line interface and SDK for Keeper Password Manager";
+    homepage = "https://github.com/Keeper-Security/Commander";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sdubey-ks ];
+  };
+}

--- a/pkgs/development/python-modules/pylibsrtp/default.nix
+++ b/pkgs/development/python-modules/pylibsrtp/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  cffi,
+  srtp,
+}:
+
+buildPythonPackage rec {
+  pname = "pylibsrtp";
+  version = "0.7.0";
+
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-4a5BXvH5Z7oICpVRvpoHJs4F2PTNksEJXauA7WkuxXc=";
+  };
+
+  build-system = [
+    setuptools
+    cffi
+  ];
+  buildInputs = [ srtp ];
+
+  dependencies = [ cffi ];
+
+  pythonImportsCheck = [ "pylibsrtp" ];
+
+  meta = {
+    description = "Python bindings for libsrtp";
+    homepage = "https://github.com/aiortc/pylibsrtp";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ sdubey-ks ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -450,6 +450,8 @@ self: super: with self; {
 
   aiorpcx = callPackage ../development/python-modules/aiorpcx { };
 
+  aiortc = callPackage ../development/python-modules/aiortc { };
+
   aiortm = callPackage ../development/python-modules/aiortm { };
 
   aiortsp = callPackage ../development/python-modules/aiortsp { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7729,6 +7729,8 @@ self: super: with self; {
     callPackage ../development/python-modules/keeper-secrets-manager-core
       { };
 
+  keepercommander = callPackage ../development/python-modules/keepercommander { };
+
   keepkey = callPackage ../development/python-modules/keepkey { };
 
   keepkey-agent = callPackage ../development/python-modules/keepkey-agent { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7725,6 +7725,10 @@ self: super: with self; {
 
   keepalive = callPackage ../development/python-modules/keepalive { };
 
+  keeper-secrets-manager-core =
+    callPackage ../development/python-modules/keeper-secrets-manager-core
+      { };
+
   keepkey = callPackage ../development/python-modules/keepkey { };
 
   keepkey-agent = callPackage ../development/python-modules/keepkey-agent { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -338,6 +338,8 @@ self: super: with self; {
 
   aiohwenergy = callPackage ../development/python-modules/aiohwenergy { };
 
+  aioice = callPackage ../development/python-modules/aioice { };
+
   aioimaplib = callPackage ../development/python-modules/aioimaplib { };
 
   aioimmich = callPackage ../development/python-modules/aioimmich { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13258,6 +13258,8 @@ self: super: with self; {
 
   pylibrespot-java = callPackage ../development/python-modules/pylibrespot-java { };
 
+  pylibsrtp = callPackage ../development/python-modules/pylibsrtp { };
+
   pylink-square = callPackage ../development/python-modules/pylink-square { };
 
   pylint = callPackage ../development/python-modules/pylint { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
Updated fpdf2 from version 2.8.2 to 2.8.3 to meet the version requirement of keepercommander.
Added aiortc: A required dependency for keepercommander, used for WebRTC and real-time communication features.
Added aioice: Required by aiortc to support ICE (Interactive Connectivity Establishment) in peer-to-peer connections.
Added pylibsrtp: A dependency of aiortc providing SRTP (Secure Real-time Transport Protocol) support for encrypted media streams.
Added keeper-secrets-manager-core: This is a core dependency of keepercommander and is required for secrets management functionality.
These changes ensure all required dependencies are available to successfully build and run keepercommander within the Nixpkgs environment.
 
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Keeper Commander](https://www.keepersecurity.com/commander.html) is a command-line and SDK interface to Keeper® Password Manager. Commander can be used to access and control your Keeper vault, perform administrative functions (such as end-user onboarding and data import/export), launch remote sessions, rotate passwords, eliminate hardcoded passwords and more.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
