### PR TITLE
bcompare: 4.4.7.28397 -> 5.2.0.31950

### DIFF
--- a/pkgs/by-name/bc/bcompare/package.nix
+++ b/pkgs/by-name/bc/bcompare/package.nix
@@ -1,0 +1,119 @@
+{
+  lib,
+  autoPatchelfHook,
+  bzip2,
+  fetchurl,
+  glibc,
+  kdePackages,
+  stdenv,
+  runtimeShell,
+  unzip,
+}:
+
+let
+  pname = "bcompare";
+  version = "5.2.0.31950";
+
+  throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
+
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://www.scootersoftware.com/files/bcompare-${version}_amd64.deb";
+      sha256 = "sha256-CCSRNGWIYVKAoQVVJ8McDUtc45nK0S4CdamcT5uVlQM=";
+    };
+
+    x86_64-darwin = fetchurl {
+      url = "https://www.scootersoftware.com/files/BCompareOSX-${version}.zip";
+      sha256 = "sha256-R+G2Zlr074i2W4GaEDweK0c0q8tnzjs6M0N106WVAlg=";
+    };
+
+    aarch64-darwin = srcs.x86_64-darwin;
+  };
+
+  src = srcs.${stdenv.hostPlatform.system} or throwSystem;
+
+  linux = stdenv.mkDerivation {
+    inherit
+      pname
+      version
+      src
+      meta
+      ;
+    unpackPhase = ''
+      ar x $src
+      tar xfz data.tar.gz
+    '';
+
+    installPhase = ''
+      mkdir -p $out/{bin,lib,share}
+
+      cp -R usr/{bin,lib,share} $out/
+
+      # Remove library that refuses to be autoPatchelf'ed
+      #  - bcompare_ext_kde.amd64.so is linked with Qt4
+      #  - bcompare_ext_kde5.amd64.so is linked with Qt5
+      rm $out/lib/beyondcompare/ext/bcompare_ext_kde.amd64.so
+      rm $out/lib/beyondcompare/ext/bcompare_ext_kde5.amd64.so
+
+      substituteInPlace $out/bin/bcompare \
+        --replace "/usr/lib/beyondcompare" "$out/lib/beyondcompare" \
+        --replace "ldd" "${glibc.bin}/bin/ldd" \
+        --replace "/bin/bash" "${runtimeShell}"
+    '';
+
+    nativeBuildInputs = [ autoPatchelfHook ];
+
+    buildInputs = [
+      (lib.getLib stdenv.cc.cc)
+      kdePackages.kio
+      kdePackages.kservice
+      kdePackages.ki18n
+      kdePackages.kcoreaddons
+      bzip2
+    ];
+
+    dontBuild = true;
+    dontConfigure = true;
+    dontWrapQtApps = true;
+
+    __structuredAttrs = true;
+    strictDeps = true;
+  };
+
+  darwin = stdenv.mkDerivation {
+    inherit
+      pname
+      version
+      src
+      meta
+      ;
+    nativeBuildInputs = [ unzip ];
+
+    installPhase = ''
+      mkdir -p $out/Applications/BCompare.app
+      cp -R . $out/Applications/BCompare.app
+    '';
+
+    __structuredAttrs = true;
+    strictDeps = true;
+  };
+
+  meta = {
+    description = "GUI application that allows to quickly and easily compare files and folders";
+    longDescription = ''
+      Beyond Compare is focused. Beyond Compare allows you to quickly and easily compare your files and folders.
+      By using simple, powerful commands you can focus on the differences you're interested in and ignore those you're not.
+      You can then merge the changes, synchronize your files, and generate reports for your records.
+    '';
+    homepage = "https://www.scootersoftware.com";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [
+      ktor
+      arkivm
+    ];
+    platforms = builtins.attrNames srcs;
+    mainProgram = "bcompare";
+  };
+in
+if stdenv.hostPlatform.isDarwin then darwin else linux

--- a/pkgs/by-name/bc/bcompare4/package.nix
+++ b/pkgs/by-name/bc/bcompare4/package.nix
@@ -15,7 +15,7 @@
 }:
 
 let
-  pname = "bcompare";
+  pname = "bcompare4";
   version = "4.4.7.28397";
 
   throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
@@ -83,6 +83,9 @@ let
     dontBuild = true;
     dontConfigure = true;
     dontWrapQtApps = true;
+
+    __structuredAttrs = true;
+    strictDeps = true;
   };
 
   darwin = stdenv.mkDerivation {
@@ -98,6 +101,9 @@ let
       mkdir -p $out/Applications/BCompare.app
       cp -R . $out/Applications/BCompare.app
     '';
+
+    __structuredAttrs = true;
+    strictDeps = true;
   };
 
   meta = {


### PR DESCRIPTION
- Rename bcompare to bcompare4
  Some users only have license for v4 so it's important to keep this version
- Update bcompare from 4.4.7.28397 to 5.2.0.31950.

See #424769.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
