### PR TITLE
cargo_tauri_1: use libsoup_3, webkitgtk_4_1

### DIFF
--- a/pkgs/by-name/ca/cargo-tauri_1/package.nix
+++ b/pkgs/by-name/ca/cargo-tauri_1/package.nix
@@ -6,20 +6,20 @@
   cargo-tauri,
   cargo-tauri_1,
   gtk3,
-  libsoup_2_4,
+  libsoup_3,
   openssl,
-  webkitgtk_4_0,
+  webkitgtk_4_1,
 }:
 
 cargo-tauri.overrideAttrs (
   newAttrs: oldAttrs: {
-    version = "1.8.1";
+    version = "1.8.3";
 
     src = fetchFromGitHub {
       owner = "tauri-apps";
       repo = "tauri";
       rev = "tauri-v${newAttrs.version}";
-      hash = "sha256-z8dfiLghN6m95PLCMDgpBMNo+YEvvsGN9F101fAcVF4=";
+      hash = "sha256-2GRiMptdztii0+F566LTHFaIh4SuHdOcIFZbNI7WI8w=";
     };
 
     # Manually specify the sourceRoot since this crate depends on other crates in the workspace. Relevant info at
@@ -33,7 +33,7 @@ cargo-tauri.overrideAttrs (
         src
         sourceRoot
         ;
-      hash = "sha256-t5sR02qC06H7A2vukwyZYKA2XMVUzJrgIOYuNSf42mE=";
+      hash = "sha256-AIcfR4ROj0MXh5Yj6z+bvqou7aOnyNugUw3Pr1vuErQ=";
     };
 
     buildInputs = [
@@ -41,8 +41,8 @@ cargo-tauri.overrideAttrs (
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       gtk3
-      libsoup_2_4
-      webkitgtk_4_0
+      libsoup_3
+      webkitgtk_4_1
     ];
 
     passthru = {

--- a/pkgs/pkgs-lib/formats/hocon/src/src/main.rs
+++ b/pkgs/pkgs-lib/formats/hocon/src/src/main.rs
@@ -210,10 +210,16 @@ impl ToString for HOCONValue {
                 let content = (if includes.is_empty() {
                     items
                 } else {
-                    format!("{}{}", includes, items)
+                    format!("{}\n{}", includes, items)
                 })
                 .split('\n')
-                .map(|s| format!("  {}", s))
+                .map(|s| {
+                    if s.is_empty() {
+                        "".to_string()
+                    } else {
+                        format!("  {}", s)
+                    }
+                })
                 .collect::<Vec<String>>()
                 .join("\n");
 

--- a/pkgs/pkgs-lib/formats/hocon/test/comprehensive/expected.txt
+++ b/pkgs/pkgs-lib/formats/hocon/test/comprehensive/expected.txt
@@ -42,6 +42,7 @@
     include required(file("/nix/store/ccnzr53dpipdacxgci3ii3bqacvb5hxm-hocon-test-include.conf"))
     include "/nix/store/ccnzr53dpipdacxgci3ii3bqacvb5hxm-hocon-test-include.conf"
     include url("https://example.com")
+
   }
 }
 


### PR DESCRIPTION
Extremly optimistic bump of libsoup_2_4 -> libsoup_3 and webkitgtk_4_0 -> webkitgtk_4_1 for cargo_tauri_1

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
