### PR TITLE
emacsPackages.holo-layer: 0-unstable-2025-06-13 -> 0-unstable-2025-08-13

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/holo-layer/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/holo-layer/package.nix
@@ -31,13 +31,13 @@ in
 melpaBuild {
 
   pname = "holo-layer";
-  version = "0-unstable-2025-06-13";
+  version = "0-unstable-2025-08-13";
 
   src = fetchFromGitHub {
     owner = "manateelazycat";
     repo = "holo-layer";
-    rev = "464b6996268a81fa3b524ced02a60fcc266f8965";
-    hash = "sha256-uTxfnhtDybWx+Na4fj5TJuZh+tKoNuSZ03IR9ErvI7s=";
+    rev = "6584d8057a264f199e0cf6e90095fa63d36e6049";
+    hash = "sha256-80uGyQltHBtrEtG/hkhHP5qbBfShw5BDyfR3GUHlhJk=";
   };
 
   packageRequires = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
