### PR TITLE
[release-25.05] ci,modules: Backport additions of #431450 meta-maintainers.nix

### DIFF
--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -30,6 +30,7 @@ let
           "doc"
           "lib"
           "maintainers"
+          "modules"
           "nixos"
           "pkgs"
           ".version"

--- a/modules/README.md
+++ b/modules/README.md
@@ -1,0 +1,9 @@
+# `<nixpkgs>/modules`
+
+This directory hosts subdirectories representing each module [class](https://nixos.org/manual/nixpkgs/stable/#module-system-lib-evalModules-param-class) for which the `nixpkgs` repository has user-importable modules.
+
+Exceptions:
+- `_class = "nixos";` modules go in the `<nixpkgs>/nixos/modules` tree
+- modules whose only purpose is to test code in this repository
+
+The emphasis is on _importable_ modules, i.e. ones that aren't inherent to and built into the Module System application.

--- a/modules/generic/meta-maintainers.nix
+++ b/modules/generic/meta-maintainers.nix
@@ -1,0 +1,63 @@
+# Test:
+#   ./meta-maintainers/test.nix
+{ lib, ... }:
+let
+  inherit (lib)
+    mkOption
+    mkOptionType
+    types
+    ;
+
+  maintainer = mkOptionType {
+    name = "maintainer";
+    check = email: lib.elem email (lib.attrValues lib.maintainers);
+    merge = loc: defs: {
+      # lib.last: Perhaps this could be merged instead, if "at most once per module"
+      # is a problem (see option description).
+      ${(lib.last defs).file} = (lib.last defs).value;
+    };
+  };
+
+  listOfMaintainers = types.listOf maintainer // {
+    merge =
+      loc: defs:
+      lib.zipAttrs (
+        lib.flatten (
+          lib.imap1 (
+            n: def:
+            lib.imap1 (
+              m: def':
+              maintainer.merge (loc ++ [ "[${toString n}-${toString m}]" ]) [
+                {
+                  inherit (def) file;
+                  value = def';
+                }
+              ]
+            ) def.value
+          ) defs
+        )
+      );
+  };
+in
+{
+  _class = null; # not specific to NixOS
+  options = {
+    meta = {
+      maintainers = mkOption {
+        type = listOfMaintainers;
+        default = [ ];
+        example = lib.literalExpression ''[ lib.maintainers.alice lib.maintainers.bob ]'';
+        description = ''
+          List of maintainers of each module.
+          This option should be defined at most once per module.
+
+          The option value is not a list of maintainers, but an attribute set that maps module file names to lists of maintainers.
+        '';
+      };
+    };
+  };
+  meta.maintainers = with lib.maintainers; [
+    pierron
+    roberth
+  ];
+}

--- a/modules/generic/meta-maintainers/test.nix
+++ b/modules/generic/meta-maintainers/test.nix
@@ -1,0 +1,34 @@
+# Run:
+#   $ nix-instantiate --eval 'modules/generic/meta-maintainers/test.nix'
+#
+# Expected output:
+#   { }
+#
+# Debugging:
+#   drop .test from the end of this file, then use nix repl on it
+rec {
+  lib = import ../../../lib;
+
+  example = lib.evalModules {
+    modules = [
+      ../meta-maintainers.nix
+      {
+        _file = "eelco.nix";
+        meta.maintainers = [ lib.maintainers.eelco ];
+      }
+    ];
+  };
+
+  test =
+    assert
+      example.config.meta.maintainers == {
+        ${toString ../meta-maintainers.nix} = [
+          lib.maintainers.pierron
+          lib.maintainers.roberth
+        ];
+        "eelco.nix" = [ lib.maintainers.eelco ];
+      };
+    { };
+
+}
+.test


### PR DESCRIPTION
Reason: keep ci directory in sync
- https://github.com/NixOS/nixpkgs/pull/431450#issuecomment-3209546418

This requires that we have a modules directory, in which case the easy and robust solution is to only port the addition parts of the refactor. It's about as easy as a .keep file, but more useful.

This means that some duplication is created, but we avoid backporting the changes to the documentation generation, which is a somewhat complex component I'd rather not touch until these changes have been proven out on unstable.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
