### PR TITLE
doxx: init at unstable-2025-08-19

### DIFF
--- a/pkgs/tools/text/doxx/default.nix
+++ b/pkgs/tools/text/doxx/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, xorg
+, wayland
+, libxkbcommon
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "doxx";
+  # Pin to a known-good commit until upstream publishes releases.
+  # (Aug 19, 2025: fix multilevel lists and numbered headings; see upstream changelog)
+  # https://github.com/bgreenwell/doxx/commit/ccb407983be5f7da44f8576955e3c115a6da0c9b
+  version = "unstable-2025-08-19";
+
+  src = fetchFromGitHub {
+    owner = "bgreenwell";
+    repo = "doxx";
+    rev = "ccb407983be5f7da44f8576955e3c115a6da0c9b";
+    sha256 = "sha256-RtB+CD7nd2AwMhZZAv7RWw0xOnJG1Twjm7HYM0cHQso=";
+  };
+
+  cargoLock = {
+    lockFile = "${src}/Cargo.lock";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Terminal-native .docx viewer with TUI, search, table rendering, and export";
+    homepage = "https://github.com/bgreenwell/doxx";
+    license = licenses.mit;
+    mainProgram = "doxx";
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ jonochang ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2732,6 +2732,8 @@ with pkgs;
 
   dotnetfx40 = callPackage ../development/libraries/dotnetfx40 { };
 
+  doxx = callPackage ../tools/text/doxx { };
+
   drone = callPackage ../development/tools/continuous-integration/drone { };
   drone-oss = callPackage ../development/tools/continuous-integration/drone {
     enableUnfree = false;


### PR DESCRIPTION
Upstream: bgreenwell/doxx@ccb40798
- Rust/TUI .docx viewer with search and export
- Enable checks; vendor Cargo deps

Tested:
- aarch64-darwin: builds, runs --help and export to markdown

## Things done
- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
