### PR TITLE
workflows/test: init

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -18,8 +18,6 @@ on:
     secrets:
       CACHIX_AUTH_TOKEN:
         required: true
-      OWNER_APP_PRIVATE_KEY:
-        required: false
 
 permissions: {}
 

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -2,6 +2,17 @@ name: Merge Group
 
 on:
   merge_group:
+  workflow_call:
+    inputs:
+      mergedSha:
+        required: true
+        type: string
+      targetSha:
+        required: true
+        type: string
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: true
 
 permissions: {}
 
@@ -12,8 +23,8 @@ jobs:
     secrets:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
-      mergedSha: ${{ github.event.merge_group.head_sha }}
-      targetSha: ${{ github.event.merge_group.base_sha }}
+      mergedSha: ${{ inputs.mergedSha || github.event.merge_group.head_sha }}
+      targetSha: ${{ inputs.targetSha || github.event.merge_group.base_sha }}
 
   # This job's only purpose is to serve as a target for the "Required Status Checks" branch ruleset.
   # It "needs" all the jobs that should block the Merge Queue.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -80,7 +80,6 @@ jobs:
       statuses: write
     secrets:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      OWNER_APP_PRIVATE_KEY: ${{ secrets.OWNER_APP_PRIVATE_KEY }}
     with:
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
       targetSha: ${{ needs.prepare.outputs.targetSha }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,17 +1,18 @@
 name: PR
 
 on:
-  pull_request:
-    paths:
-      - .github/actions/checkout/action.yml
-      - .github/workflows/build.yml
-      - .github/workflows/check.yml
-      - .github/workflows/eval.yml
-      - .github/workflows/lint.yml
-      - .github/workflows/pr.yml
-      - .github/workflows/labels.yml
-      - .github/workflows/reviewers.yml # needs eval results from the same event type
   pull_request_target:
+  workflow_call:
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: true
+      NIXPKGS_CI_APP_PRIVATE_KEY:
+        required: true
+      OWNER_APP_PRIVATE_KEY:
+        # The Test workflow should not actually request reviews from owners.
+        required: false
+      OWNER_RO_APP_PRIVATE_KEY:
+        required: true
 
 concurrency:
   group: pr-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,6 +10,10 @@ on:
       - staging-*
       - haskell-updates
   workflow_call:
+    inputs:
+      mergedSha:
+        required: true
+        type: string
     secrets:
       CACHIX_AUTH_TOKEN:
         required: true
@@ -43,5 +47,5 @@ jobs:
     secrets:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
-      mergedSha: ${{ github.sha }}
+      mergedSha: ${{ inputs.mergedSha || github.sha }}
       systems: ${{ needs.prepare.outputs.systems }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,10 +1,6 @@
 name: Push
 
 on:
-  pull_request:
-    paths:
-      - .github/workflows/push.yml
-      # eval is tested via pr.yml
   push:
     # Keep this synced with ci/request-reviews/dev-branches.txt
     branches:
@@ -13,6 +9,10 @@ on:
       - release-*
       - staging-*
       - haskell-updates
+  workflow_call:
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: true
 
 permissions: {}
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -39,8 +39,6 @@ jobs:
     # Those are not actually used on push, but will throw an error if not set.
     permissions:
       # compare
-      issues: write
-      pull-requests: write
       statuses: write
     secrets:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/reviewers.yml
+++ b/.github/workflows/reviewers.yml
@@ -95,7 +95,7 @@ jobs:
             const run_id = (await github.rest.actions.listWorkflowRuns({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              workflow_id: 'pr.yml',
+              workflow_id: context.eventName === 'pull_request' ? 'test.yml' : 'pr.yml',
               event: context.eventName,
               head_sha: context.payload.pull_request.head.sha
             })).data.workflow_runs[0].id

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,11 @@ jobs:
   prepare:
     runs-on: ubuntu-24.04-arm
     outputs:
+      merge-group: ${{ steps.files.outputs.merge-group }}
       mergedSha: ${{ steps.prepare.outputs.mergedSha }}
       pr: ${{ steps.files.outputs.pr }}
       push: ${{ steps.files.outputs.push }}
+      targetSha: ${{ steps.prepare.outputs.targetSha }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -46,6 +48,12 @@ jobs:
             })).map(file => file.filename)
 
             if (files.some(file => [
+              '.github/workflows/lint.yml',
+              '.github/workflows/merge-group.yml',
+              '.github/workflows/test.yml',
+            ].includes(file))) core.setOutput('merge-group', true)
+
+            if (files.some(file => [
               '.github/actions/checkout/action.yml',
               '.github/workflows/build.yml',
               '.github/workflows/check.yml',
@@ -62,6 +70,17 @@ jobs:
               '.github/workflows/push.yml',
               '.github/workflows/test.yml',
             ].includes(file))) core.setOutput('push', true)
+
+  merge-group:
+    if: needs.prepare.outputs.merge-group
+    name: Merge Group
+    needs: [prepare]
+    uses: ./.github/workflows/merge-group.yml
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+    with:
+      mergedSha: ${{ needs.prepare.outputs.mergedSha }}
+      targetSha: ${{ needs.prepare.outputs.targetSha }}
 
   pr:
     if: needs.prepare.outputs.pr

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,72 @@
+name: Test
+
+on:
+  pull_request:
+
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  prepare:
+    runs-on: ubuntu-24.04-arm
+    outputs:
+      pr: ${{ steps.files.outputs.pr }}
+      push: ${{ steps.files.outputs.push }}
+    steps:
+      - name: Determine changed files
+        id: files
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const files = (await github.paginate(github.rest.pulls.listFiles, {
+              ...context.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            })).map(file => file.filename)
+
+            if (files.some(file => [
+              '.github/actions/checkout/action.yml',
+              '.github/workflows/build.yml',
+              '.github/workflows/check.yml',
+              '.github/workflows/eval.yml',
+              '.github/workflows/labels.yml',
+              '.github/workflows/lint.yml',
+              '.github/workflows/pr.yml',
+              '.github/workflows/reviewers.yml',
+              '.github/workflows/test.yml',
+            ].includes(file))) core.setOutput('pr', true)
+
+            if (files.some(file => [
+              '.github/workflows/eval.yml',
+              '.github/workflows/push.yml',
+              '.github/workflows/test.yml',
+            ].includes(file))) core.setOutput('push', true)
+
+  pr:
+    if: needs.prepare.outputs.pr
+    name: PR
+    needs: [prepare]
+    uses: ./.github/workflows/pr.yml
+    # Those are not actually used on pull_request, but will throw an error if not set.
+    permissions:
+      issues: write
+      pull-requests: write
+      statuses: write
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      NIXPKGS_CI_APP_PRIVATE_KEY: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}
+      OWNER_RO_APP_PRIVATE_KEY: ${{ secrets.OWNER_RO_APP_PRIVATE_KEY }}
+
+  push:
+    if: needs.prepare.outputs.push
+    name: Push
+    needs: [prepare]
+    uses: ./.github/workflows/push.yml
+    # Those are not actually used on push, but will throw an error if not set.
+    permissions:
+      statuses: write
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,27 @@ jobs:
   prepare:
     runs-on: ubuntu-24.04-arm
     outputs:
+      mergedSha: ${{ steps.prepare.outputs.mergedSha }}
       pr: ${{ steps.files.outputs.pr }}
       push: ${{ steps.files.outputs.push }}
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          sparse-checkout-cone-mode: true # default, for clarity
+          sparse-checkout: |
+            ci/github-script
+      - id: prepare
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            require('./ci/github-script/prepare.js')({
+              github,
+              context,
+              core,
+              // Review comments will be posted by the main PR workflow on the pull_request_target event.
+              dry: false,
+            })
+
       - name: Determine changed files
         id: files
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -70,3 +88,5 @@ jobs:
       statuses: write
     secrets:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+    with:
+      mergedSha: ${{ needs.prepare.outputs.mergedSha }}

--- a/ci/github-script/commits.js
+++ b/ci/github-script/commits.js
@@ -16,7 +16,7 @@ module.exports = async ({ github, context, core, dry }) => {
           run_id: context.runId,
           per_page: 100,
         })
-      ).find(({ name }) => name === 'Check / cherry-pick').html_url +
+      ).find(({ name }) => name.endsWith('Check / cherry-pick')).html_url +
         '?pr=' +
         pull_number
 


### PR DESCRIPTION
(1st commit from #435526, 2nd and 3rd from #435535 - the latter is needed to avoid name conflicts of artifacts between the push and pr parts of this new workflow)

This workflow runs the PR and Push workflow files on a `pull_request` trigger. The intent is to test changes to the workflow files immediately. Previously, these were run directly from the respective workflow files.

The new approach allows us to move the logic to run this only when workflow files changed from the pull_request trigger into a job. This has the advantage that older jobs are cleaned up, when the PR changes from a state of "workflow files changed" to "no workflow files changed". This can happen when changing a PR's base from staging to master, in which case changes from master would temporarily appear in the PR as changes. When these include changes to workflow files, this would trigger the PR workflow via `pull_request`. Once the base is changed, the PR is closed and re-opened, so CI runs again - but since it's on the same commit and the new run doesn't trigger `pull_request`, the results of the previous run are still kept and displayed. These results may include cancelled or failed jobs, which are impossible to recover from without another force-push.

Checking this condition at run-time is only possible, because we move it into a separate workflow, turning the `pr.yml` workflow into a re-usable workflow. This will make sure to skip the whole workflow at once, when no change was detected, which will prevent the "no PR failures" job from appearing as skipped - which would imply "success" and make the PR mergeable immediately. Instead the "no PR failures" job is not shown at all for this trigger, which is generally what we want.

Do the same for `push.yml` for consistency. Also adds the `merge_group.yml` file to the test workflow to confirm we don't break that.

Note: This does not fully disable the "no PR failures" job for `pull_request` triggers, yet. It only affects the special case when switching branches in a PR. There will still be a second change required for the more general case, i.e. auto-merging a CI-related PR, which might trigger either of the two "no PR failures" jobs first and thus ignore the other.

## Things done

- [x] Tested in my fork.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
