### PR TITLE
flameshot: 13.0.1 -> 13.1.0

### DIFF
--- a/pkgs/by-name/fl/flameshot/load-missing-deps.patch
+++ b/pkgs/by-name/fl/flameshot/load-missing-deps.patch
@@ -1,9 +1,15 @@
---- a/CMakeLists.txt	2025-08-15 11:37:20
-+++ b/CMakeLists.txt	2025-08-15 11:40:06
-@@ -29,21 +29,7 @@
- if(EXISTS "${CMAKE_SOURCE_DIR}/external/Qt-Color-Widgets/CMakeLists.txt")
-     add_subdirectory("${CMAKE_SOURCE_DIR}/external/Qt-Color-Widgets" EXCLUDE_FROM_ALL)
- else()
+--- a/CMakeLists.txt	2025-08-21 13:12:55
++++ b/CMakeLists.txt	2025-08-21 13:16:26
+@@ -24,28 +24,8 @@
+ #Needed due to linker error with QtColorWidget
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
++find_package(QtColorWidgets REQUIRED)
+ 
+-# Dependency can be fetched via flatpak builder
+-if(EXISTS "${CMAKE_SOURCE_DIR}/external/Qt-Color-Widgets/CMakeLists.txt")
+-    add_subdirectory("${CMAKE_SOURCE_DIR}/external/Qt-Color-Widgets" EXCLUDE_FROM_ALL)
+-else()
 -    FetchContent_Declare(
 -        qtColorWidgets
 -        GIT_REPOSITORY https://gitlab.com/mattbas/Qt-Color-Widgets.git
@@ -19,25 +25,12 @@
 -  else()
 -      FetchContent_MakeAvailable(qtColorWidgets)
 -  endif()
-+    find_package(QtColorWidgets REQUIRED)
- endif()
- 
+-endif()
+-
  # This can be read from ${PROJECT_NAME} after project() is called
-@@ -115,12 +101,7 @@
-   if(EXISTS "${CMAKE_SOURCE_DIR}/external/KDSingleApplication/CMakeLists.txt")
-     add_subdirectory("${CMAKE_SOURCE_DIR}/external/KDSingleApplication")
-   else()
--    FetchContent_Declare(
--        kdsingleApplication
--        GIT_REPOSITORY https://github.com/KDAB/KDSingleApplication.git
--        GIT_TAG v1.2.0
--    )
--    FetchContent_MakeAvailable(KDSingleApplication)
-+    find_package(KDSingleApplication-qt6 REQUIRED)
-   endif()
- endif()
- 
-@@ -128,12 +109,7 @@
+ if (APPLE)
+   set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
+@@ -133,12 +113,7 @@
  option(BUILD_STATIC_LIBS ON)
  
  if (APPLE)

--- a/pkgs/by-name/fl/flameshot/macos-build.patch
+++ b/pkgs/by-name/fl/flameshot/macos-build.patch
@@ -1,18 +1,11 @@
---- a/src/CMakeLists.txt	2025-08-12 16:34:27
-+++ b/src/CMakeLists.txt	2025-08-15 11:45:56
-@@ -220,7 +220,7 @@
- 
-   target_link_libraries(
-           flameshot
--          kdsingleapplication
-+          kdsingleapplication-qt6
-   )
- endif()
- 
-@@ -447,64 +447,3 @@
+--- a/src/CMakeLists.txt	2025-08-21 13:12:55
++++ b/src/CMakeLists.txt	2025-08-21 13:18:55
+@@ -449,66 +449,4 @@
+     else ()
+         message(WARNING "Unable to find executable windeployqt.")
      endif ()
- endif ()
- 
+-endif ()
+-
 -# macdeployqt
 -if (APPLE)
 -# Code signing settings - optional, set to empty string to skip signing
@@ -73,4 +66,4 @@
 -   endif()
 -
 -
--endif ()
+ endif ()

--- a/pkgs/by-name/fl/flameshot/package.nix
+++ b/pkgs/by-name/fl/flameshot/package.nix
@@ -10,7 +10,7 @@
   makeBinaryWrapper,
   kdsingleapplication,
   nix-update-script,
-  enableWlrSupport ? false,
+  enableWlrSupport ? !stdenv.hostPlatform.isDarwin,
   enableMonochromeIcon ? false,
 }:
 

--- a/pkgs/by-name/fl/flameshot/package.nix
+++ b/pkgs/by-name/fl/flameshot/package.nix
@@ -18,17 +18,18 @@ assert stdenv.hostPlatform.isDarwin -> (!enableWlrSupport);
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "flameshot";
-  version = "13.0.1";
+  version = "13.1.0";
 
   src = fetchFromGitHub {
     owner = "flameshot-org";
     repo = "flameshot";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Zo+rhvpwhcYqgn8PZ0b48sCb/YWqGSormFnY6pbY8Qc=";
+    hash = "sha256-Wg0jc1AqgetaESmTyhzAHx3zal/5DMDum7fzhClqeck=";
   };
 
   cmakeFlags = [
     "-DCMAKE_CXX_FLAGS=-I${kdsingleapplication}/include/kdsingleapplication-qt6"
+    (lib.cmakeBool "USE_BUNDLED_KDSINGLEAPPLICATION" false)
     (lib.cmakeBool "DISABLE_UPDATE_CHECKER" true)
     (lib.cmakeBool "USE_MONOCHROME_ICON" enableMonochromeIcon)
   ]


### PR DESCRIPTION
## Description of changes
Bumps the package's version to the latest release, 13.1.0.
Changelog: https://github.com/flameshot-org/flameshot/compare/v13.0.1...v13.1.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
