### PR TITLE
maintainers: qwqawawow -> eihqnh; treewide: rename qwqawawow to eihqnh

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7274,6 +7274,12 @@
     github = "eigengrau";
     githubId = 4939947;
   };
+  eihqnh = {
+    email = "eihqnh@outlook.com";
+    github = "eihqnh";
+    githubId = 40905037;
+    name = "eihqnh";
+  };
   eikek = {
     email = "eike.kettner@posteo.de";
     github = "eikek";
@@ -20956,12 +20962,6 @@
     github = "Qusic";
     githubId = 2141853;
     name = "Bang Lee";
-  };
-  qwqawawow = {
-    email = "eihqnh@outlook.com";
-    github = "qwqawawow";
-    githubId = 40905037;
-    name = "qwqawawow";
   };
   qxrein = {
     email = "mnv07@proton.me";

--- a/pkgs/by-name/ca/cabinpkg/package.nix
+++ b/pkgs/by-name/ca/cabinpkg/package.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
     homepage = "https://cabinpkg.com";
     description = "Package manager and build system for C++";
     license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.qwqawawow ];
+    maintainers = [ lib.maintainers.eihqnh ];
     platforms = lib.platforms.unix;
     mainProgram = "cabin";
   };

--- a/pkgs/by-name/ca/cargo-seek/package.nix
+++ b/pkgs/by-name/ca/cargo-seek/package.nix
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/tareqimbasher/cargo-seek";
     changelog = "https://github.com/tareqimbasher/cargo-seek/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ qwqawawow ];
+    maintainers = with lib.maintainers; [ eihqnh ];
     mainProgram = "cargo-seek";
   };
 })

--- a/pkgs/by-name/po/podlet/package.nix
+++ b/pkgs/by-name/po/podlet/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/containers/podlet";
     changelog = "https://github.com/containers/podlet/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mpl20;
-    maintainers = with lib.maintainers; [ qwqawawow ];
+    maintainers = with lib.maintainers; [ eihqnh ];
     mainProgram = "podlet";
   };
 }

--- a/pkgs/development/python-modules/terminaltexteffects/default.nix
+++ b/pkgs/development/python-modules/terminaltexteffects/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     changelog = "https://chrisbuilds.github.io/terminaltexteffects/changeblog/";
     license = licenses.mit;
     platforms = with platforms; unix;
-    maintainers = with maintainers; [ qwqawawow ];
+    maintainers = with maintainers; [ eihqnh ];
     mainProgram = "tte";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
