### PR TITLE
lpac: 2.2.1 -> 2.3.0, cleanups, add docs, add qmi + mbim support

### DIFF
--- a/pkgs/by-name/lp/lpac/package.nix
+++ b/pkgs/by-name/lp/lpac/package.nix
@@ -30,9 +30,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [ ./lpac-version.patch ];
 
-  cmakeFlags =
-    optional withDrivers "-DLPAC_DYNAMIC_DRIVERS=on"
-    ++ optional withLibeuicc "-DLPAC_DYNAMIC_LIBEUICC=on";
+  cmakeFlags = [
+    (lib.cmakeBool "LPAC_DYNAMIC_DRIVERS" withDrivers)
+    (lib.cmakeBool "LPAC_DYNAMIC_LIBEUICC" withLibeuicc)
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/lp/lpac/package.nix
+++ b/pkgs/by-name/lp/lpac/package.nix
@@ -6,8 +6,12 @@
   pkg-config,
   pcsclite,
   curl,
+  libmbim,
+  libqmi,
   withDrivers ? true,
   withLibeuicc ? true,
+  withMbim ? true,
+  withQmi ? true,
   nix-update-script,
 }:
 
@@ -33,6 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "LPAC_DYNAMIC_DRIVERS" withDrivers)
     (lib.cmakeBool "LPAC_DYNAMIC_LIBEUICC" withLibeuicc)
+    (lib.cmakeBool "LPAC_WITH_APDU_MBIM" withMbim)
+    (lib.cmakeBool "LPAC_WITH_APDU_QMI" withQmi)
   ];
 
   nativeBuildInputs = [
@@ -43,7 +49,9 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     curl
     pcsclite
-  ];
+  ]
+  ++ optional withMbim libmbim
+  ++ optional withQmi libqmi;
 
   postInstall = ''
     mkdir -p $out/share/doc/lpac

--- a/pkgs/by-name/lp/lpac/package.nix
+++ b/pkgs/by-name/lp/lpac/package.nix
@@ -52,6 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "C-based eUICC LPA";
     homepage = "https://github.com/estkme-group/lpac";
     mainProgram = "lpac";
+    changelog = "https://github.com/estkme-group/lpac/releases/tag/v${finalAttrs.version}";
     license = [ lib.licenses.agpl3Plus ] ++ optional withLibeuicc lib.licenses.lgpl21Plus;
     maintainers = with lib.maintainers; [ sarcasticadmin ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/lp/lpac/package.nix
+++ b/pkgs/by-name/lp/lpac/package.nix
@@ -17,13 +17,13 @@ in
 stdenv.mkDerivation (finalAttrs: {
 
   pname = "lpac";
-  version = "2.2.1";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "estkme-group";
     repo = "lpac";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-dxoYuX3dNj4piXQBqU4w1ICeyOGid35c+6ZITQiN6wA=";
+    hash = "sha256-ALne5sHB6ff7cHAWe0rFwpP/Yz4EhZBiOrgdM2B8+OE=";
   };
 
   env.LPAC_VERSION = finalAttrs.version;

--- a/pkgs/by-name/lp/lpac/package.nix
+++ b/pkgs/by-name/lp/lpac/package.nix
@@ -45,6 +45,11 @@ stdenv.mkDerivation (finalAttrs: {
     pcsclite
   ];
 
+  postInstall = ''
+    mkdir -p $out/share/doc/lpac
+    cp -vr $src/docs/* $out/share/doc/lpac
+  '';
+
   passthru = {
     updateScript = nix-update-script { attrPath = finalAttrs.pname; };
   };


### PR DESCRIPTION
This switches the derivation to use cmakeBool in feature flags, adds a `meta.changelog` attribute, bumps to 2.3.0, installs docs and enables mbim and qmi backends.

With this, I can successfully talk to a 9esim card plugged into a Quectel EC25 LTE modem, setting `PAC_APDU_QMI_DEVICE=/dev/cdc-wdm0` and `LPAC_APDU=qmi`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
