### PR TITLE
libtatsu: init at 1.0.5; idevicerestore: 1.0.0+date=2023-05-23 -> 1.0.0-unstable-2025-08-21

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18995,6 +18995,12 @@
     githubId = 1348;
     name = "Nate Smith";
   };
+  nxm = {
+    email = "szturomski@jakub.app";
+    name = "Jakub Szturomski";
+    github = "nxm";
+    githubId = 22380073;
+  };
   nyabinary = {
     name = "Niko Cantero";
     email = "nyanbinary@keemail.me";

--- a/pkgs/by-name/id/idevicerestore/package.nix
+++ b/pkgs/by-name/id/idevicerestore/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "idevicerestore";
-  version = "1.0.0+date=2023-05-23";
+  version = "1.0.0-unstable-2025-10-02";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = "idevicerestore";
-    rev = "609f7f058487596597e8e742088119fdd46729df";
-    hash = "sha256-VXtXAitPC1+pxZlkGBg+u6yYhyM/jVpSgDO/6dXh5V4=";
+    rev = "f4d0f7e83105cc362527566315abee07b0840848";
+    hash = "sha256-fqTVAHTxamk2lIllr7ZNHOJ1YTJHM4JpVQylMV33CJI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libimobiledevice/package.nix
+++ b/pkgs/by-name/li/libimobiledevice/package.nix
@@ -9,6 +9,7 @@
   libgcrypt,
   libplist,
   libtasn1,
+  libtatsu,
   libusbmuxd,
   libimobiledevice-glue,
   unstableGitUpdater,
@@ -16,24 +17,14 @@
 
 stdenv.mkDerivation rec {
   pname = "libimobiledevice";
-  version = "1.3.0-unstable-2024-05-20";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = "libimobiledevice";
-    rev = "9ccc52222c287b35e41625cc282fb882544676c6";
-    hash = "sha256-pNvtDGUlifp10V59Kah4q87TvLrcptrCJURHo+Y+hs4=";
+    tag = version;
+    hash = "sha256-SWWsa7asCXpcz80VNhxoePWr74QY8SP0byGSCp+nGG0=";
   };
-
-  patches = [
-    # Fix gcc-14 and clang-16 build:
-    #   https://github.com/libimobiledevice/libimobiledevice/pull/1569
-    (fetchpatch {
-      name = "fime.h.patch";
-      url = "https://github.com/libimobiledevice/libimobiledevice/commit/92256c2ae2422dac45d8648a63517598bdd89883.patch";
-      hash = "sha256-sB+wEFuXFoQnuf7ntWfvYuCgWfYbmlPL7EjW0L0F74o=";
-    })
-  ];
 
   preAutoreconf = ''
     export RELEASE_VERSION=${version}
@@ -51,6 +42,7 @@ stdenv.mkDerivation rec {
     libgcrypt
     libplist
     libtasn1
+    libtatsu
     libusbmuxd
     libimobiledevice-glue
   ];

--- a/pkgs/by-name/li/libirecovery/package.nix
+++ b/pkgs/by-name/li/libirecovery/package.nix
@@ -11,7 +11,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libirecovery";
-  version = "1.2.1";
+  version = "1.3.1";
 
   outputs = [
     "out"
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     owner = "libimobiledevice";
     repo = "libirecovery";
     rev = version;
-    hash = "sha256-R+oBC7F4op0qoIk3d/WqS4MwzZY3WMAMIqlJfJb188Q=";
+    hash = "sha256-CSDG8mOLvKAIpxmZnNLMKY1HvQIqk66/rkjmzq7F8vY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libtatsu/package.nix
+++ b/pkgs/by-name/li/libtatsu/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  libplist,
+  libimobiledevice-glue,
+  curl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libtatsu";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "libimobiledevice";
+    repo = "libtatsu";
+    tag = finalAttrs.version;
+    hash = "sha256-vf4xBTTGDJCTj4TMLOhojjAfzSbkx+ogGBnf+UeumG0=";
+  };
+
+  preAutoreconf = ''
+    echo ${finalAttrs.version} > .tarball-version
+    export PACKAGE_VERSION=${finalAttrs.version}
+  '';
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    libplist
+    libimobiledevice-glue
+    curl
+  ];
+
+  meta = {
+    description = "Library handling the communication with Apple's Tatsu Signing Server (TSS)";
+    homepage = "https://github.com/libimobiledevice/libtatsu";
+    license = lib.licenses.lgpl21Plus;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ nxm ];
+  };
+})


### PR DESCRIPTION
Add `libtatsu` package and update `idevicerestore` to support latest iOS devices.

`libtatsu` is a new required dependency for `idevicerestore` that handles communication with Apple's Tatsu Signing Server (TSS). This library was previously part of idevicerestore but has been split into its own project. Without this package, idevicerestore fails to build with recent versions due to the missing `libtatsu-1.0 >= 1.0.4` dependency.

This PR:
- Adds `libtatsu` 1.0.5 as a new package
- Updates `idevicerestore` to the latest commit (2914bf66) from 2025-08-21
- Adds `libtatsu` as a dependency to `idevicerestore`

These changes are necessary to maintain iOS device restore functionality with current firmware versions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
