### PR TITLE
codex: 0.22.0 -> 0.23.0

### DIFF
--- a/pkgs/by-name/co/codex/package.nix
+++ b/pkgs/by-name/co/codex/package.nix
@@ -7,70 +7,71 @@
   installShellFiles,
   nix-update-script,
   pkg-config,
-  python3,
   openssl,
   versionCheckHook,
   installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "codex";
-  version = "0.22.0";
+  version = "0.23.0";
 
   src = fetchFromGitHub {
     owner = "openai";
     repo = "codex";
     tag = "rust-v${finalAttrs.version}";
-    hash = "sha256-JTwtydW8LLBH/55+8a/BbqlZtkXsFKbT8dGoDEAjk1c=";
+    hash = "sha256-JS2nRh3/MNQ0mfdr2/Q10sAB38yWBLpw2zFf0dJORuM=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/codex-rs";
 
-  cargoHash = "sha256-3PljlyPfDsnjGmR/0iM7Fu1TnyDj31pKVcOU/izsL30=";
+  cargoHash = "sha256-HbhOiTO7qFp64v+Bb62V1LxPH7qeTnWwkJKPEN4Vx6c=";
 
   nativeBuildInputs = [
     installShellFiles
     pkg-config
   ];
 
-  buildInputs = [
-    openssl
-    # Required because of codex-rs/login/src/login_with_chatgpt.py
-    python3
-  ];
+  buildInputs = [ openssl ];
 
   nativeCheckInputs = [ gitMinimal ];
 
   __darwinAllowLocalNetworking = true;
-  env = {
+  preCheck = ''
     # Disables sandbox tests which want to access /usr/bin/touch
-    CODEX_SANDBOX = "seatbelt";
+    export CODEX_SANDBOX=seatbelt
     # Skips tests that require networking
-    CODEX_SANDBOX_NETWORK_DISABLED = 1;
-  };
+    export CODEX_SANDBOX_NETWORK_DISABLED=1
+    # Required by ui_snapshot_add_details and ui_snapshot_update_details_with_rename
+    export TERM=dumb
+    # Required by azure_overrides_assign_properties_used_for_responses_url and env_var_overrides_loaded_auth
+    export USER=test
+  '';
   checkFlags = [
-    # Wants to access /bin/zsh
-    "--skip=shell::tests::test_run_with_profile_escaping_and_execution"
     # Wants to access unix sockets
     "--skip=allow_unix_socketpair_recvfrom"
-    # Fails with 'stream ended unexpectedly: InternalAgentDied'
-    "--skip=includes_base_instructions_override_in_request"
-    "--skip=includes_user_instructions_message_in_request"
-    "--skip=originator_config_override_is_used"
-    "--skip=prefixes_context_and_instructions_once_and_consistently_across_requests"
-    # Fails with 'called `Result::unwrap()` on an `Err` value: NotPresent'
-    "--skip=azure_overrides_assign_properties_used_for_responses_url"
-    "--skip=env_var_overrides_loaded_auth"
+    # Needs access to python3. However, adding python3 to nativeCheckInputs doesn't resolve the issue
+    "--skip=python_multiprocessing_lock_works_under_sandbox"
     # Version 0.0.0 hardcoded
     "--skip=test_conversation_create_and_send_message_ok"
     "--skip=test_send_message_session_not_found"
     "--skip=test_send_message_success"
-    # Assertion fails
+    # Tests fail
     "--skip=diff_render::tests::ui_snapshot_add_details"
     "--skip=diff_render::tests::ui_snapshot_update_details_with_rename"
-    # Attempted to creat a NULL object
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Wants to access /bin/zsh
+    "--skip=shell::tests::test_run_with_profile_escaping_and_execution"
+    # Requires access to the Apple system configuration
+    "--skip=azure_overrides_assign_properties_used_for_responses_url"
+    "--skip=env_var_overrides_loaded_auth"
+    "--skip=includes_base_instructions_override_in_request"
+    "--skip=includes_user_instructions_message_in_request"
+    "--skip=originator_config_override_is_used"
+    "--skip=per_turn_overrides_keep_cached_prefix_and_key_constant"
+    "--skip=overrides_turn_context_but_keeps_cached_prefix_and_key_constant"
+    "--skip=prefixes_context_and_instructions_once_and_consistently_across_requests"
     "--skip=test_apply_patch_tool"
-    # Needs access to python3. However, adding python3 to nativeCHeckInputs doesn't resolve the issue
-    "--skip=python_multiprocessing_lock_works_under_sandbox"
   ];
 
   postInstall = lib.optionalString installShellCompletions ''


### PR DESCRIPTION
Waiting on rustc 1.89.0 due to build failures.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
