### PR TITLE
[Backport release 25.05]: gradia: 1.6.1 -> 1.9.0, add passthru.updateScript, 1.9.0 -> 1.11.1

### DIFF
--- a/pkgs/by-name/gr/gradia/package.nix
+++ b/pkgs/by-name/gr/gradia/package.nix
@@ -22,14 +22,14 @@
 }:
 python3Packages.buildPythonApplication rec {
   pname = "gradia";
-  version = "1.9.0";
+  version = "1.11.1";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "AlexanderVanhee";
     repo = "Gradia";
     tag = "v${version}";
-    hash = "sha256-iDldzS7LLJ/+CfKBpD50LW/YrZ2xb8aqZI9Bs1AOcCM=";
+    hash = "sha256-2PSpFmojAIyDNx5yYrLE3CjO/q5iBArmIRikxCGW1HM=";
   };
 
   nativeBuildInputs = [
@@ -54,6 +54,7 @@ python3Packages.buildPythonApplication rec {
   dependencies = with python3Packages; [
     pygobject3
     pillow
+    pytesseract
   ];
 
   postInstall = ''

--- a/pkgs/by-name/gr/gradia/package.nix
+++ b/pkgs/by-name/gr/gradia/package.nix
@@ -5,6 +5,7 @@
   meson,
   ninja,
   appstream,
+  gtksourceview5,
   desktop-file-utils,
   gobject-introspection,
   wrapGAppsHook4,
@@ -21,14 +22,14 @@
 }:
 python3Packages.buildPythonApplication rec {
   pname = "gradia";
-  version = "1.6.1";
+  version = "1.9.0";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "AlexanderVanhee";
     repo = "Gradia";
     tag = "v${version}";
-    hash = "sha256-OfSqjxNfIk3dQZp4T6W1aL24FGEQKlFLGT+mV1+GR5o=";
+    hash = "sha256-iDldzS7LLJ/+CfKBpD50LW/YrZ2xb8aqZI9Bs1AOcCM=";
   };
 
   nativeBuildInputs = [
@@ -43,6 +44,7 @@ python3Packages.buildPythonApplication rec {
   ];
 
   buildInputs = [
+    gtksourceview5
     libadwaita
     libportal-gtk4
     libsoup_3
@@ -55,7 +57,6 @@ python3Packages.buildPythonApplication rec {
   ];
 
   postInstall = ''
-    substituteInPlace $out/share/gradia/gradia/ui/image_exporters.py --replace-fail "/bin/bash" "${lib.getExe bash}"
     export GDK_PIXBUF_MODULE_FILE="${
       gnome._gdkPixbufCacheBuilder_DO_NOT_USE {
         extraLoaders = [

--- a/pkgs/by-name/gr/gradia/package.nix
+++ b/pkgs/by-name/gr/gradia/package.nix
@@ -17,6 +17,7 @@
   webp-pixbuf-loader,
   libsoup_3,
   bash,
+  nix-update-script,
 }:
 python3Packages.buildPythonApplication rec {
   pname = "gradia";
@@ -68,6 +69,8 @@ python3Packages.buildPythonApplication rec {
   dontWrapGApps = true;
 
   makeWrapperArgs = [ "\${gappsWrapperArgs[@]}" ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Make your screenshots ready for the world";


### PR DESCRIPTION
Backports #426869, #428160 (a fix for a problem introduced by #428160) and finally #430765

Essentially it updates `gradia` from v1.6.1 to v1.9.0 and [adds passthru.updateScript](https://github.com/NixOS/nixpkgs/pull/430765/commits/2e90eacdc5ce4ca3a3fa43201ee24f0602919176)

Changelog: https://github.com/AlexanderVanhee/Gradia/releases/tag/v1.9.0
Diff: https://github.com/AlexanderVanhee/Gradia/compare/v1.6.1...v1.9.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
