### PR TITLE
netbsd.compat: Fix cross-compilation from darwin

### DIFF
--- a/pkgs/os-specific/bsd/netbsd/pkgs/compat/package.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/compat/package.nix
@@ -32,6 +32,10 @@ mkDerivation (
 
     preConfigure = ''
       make include/.stamp configure nbtool_config.h.in defs.mk.in
+    ''
+    + lib.optionalString stdenv.buildPlatform.isDarwin ''
+      # Fix cross-compilation from darwin, remove after update to netbsd 10.0
+      substituteInPlace Makefile --replace-warn "-no-cpp-precomp" ""
     '';
 
     configurePlatforms = [


### PR DESCRIPTION
```sh
nix build -L .#pkgsCross.armv7l-hf-multiplatform.netbsd.compat
...
compat-netbsd-armv7l-unknown-linux-gnueabihf> --- basename.o ---
compat-netbsd-armv7l-unknown-linux-gnueabihf> armv7l-unknown-linux-gnueabihf-gcc: error: unrecognized command-line option '-no-cpp-precomp'
compat-netbsd-armv7l-unknown-linux-gnueabihf> --- dirname.o ---
compat-netbsd-armv7l-unknown-linux-gnueabihf> armv7l-unknown-linux-gnueabihf-gcc: error: unrecognized command-line option '-no-cpp-precomp'
compat-netbsd-armv7l-unknown-linux-gnueabihf> --- cdbr.o ---
compat-netbsd-armv7l-unknown-linux-gnueabihf> armv7l-unknown-linux-gnueabihf-gcc: error: unrecognized command-line option '-no-cpp-precomp'
compat-netbsd-armv7l-unknown-linux-gnueabihf> --- dirname.o ---
compat-netbsd-armv7l-unknown-linux-gnueabihf> *** [dirname.o] Error code 1
```

See https://cvsweb.netbsd.org/bsdweb.cgi/src/tools/compat/Makefile?rev=1.87;content-type=text%2Fplain;only_with_tag=netbsd-9-2-RELEASE:
```makefile
# Disable use of pre-compiled headers on Darwin.
.if ${BUILD_OSTYPE} == "Darwin"
CPPFLAGS+=	-no-cpp-precomp
.endif
```

## Things done
- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux (cross from darwin)
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
