### PR TITLE
_1password-gui{,-beta}: 8.11.4 -> 8.11.6 || 8.11.4-21.BETA -> 8.11.8-32.BETA

### DIFF
--- a/pkgs/by-name/_1/_1password-gui/sources.json
+++ b/pkgs/by-name/_1/_1password-gui/sources.json
@@ -1,28 +1,28 @@
 {
   "stable": {
     "linux": {
-      "version": "8.11.4",
+      "version": "8.11.6",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.11.4.x64.tar.gz",
-          "hash": "sha256-s/CV1hA8j3ivWEmKfwMd6Hh74BY86C0MZLDwjm6ROd4="
+          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.11.6.x64.tar.gz",
+          "hash": "sha256-OjyJDesweUhLHuBeLCEvNOloDZO8/D6Z1FquLyapQ4Q="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.11.4.arm64.tar.gz",
-          "hash": "sha256-qljiVRVO0HlteI5oRQPLb6+JL282CwcbRydANUmNcRM="
+          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.11.6.arm64.tar.gz",
+          "hash": "sha256-sspmxX6xeVHvEww4D41PZTM2YftbILx06aMuDbAay74="
         }
       }
     },
     "darwin": {
-      "version": "8.11.4",
+      "version": "8.11.6",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.11.4-x86_64.zip",
-          "hash": "sha256-kv+TSoZcoCkL1Gr0dwgqtYK532wEnergVAwCMCv44/A="
+          "url": "https://downloads.1password.com/mac/1Password-8.11.6-x86_64.zip",
+          "hash": "sha256-HMwb22/4Dw3M3B1nrdURSQzMGAZxsVG6t8E+MUmRmjg="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.11.4-aarch64.zip",
-          "hash": "sha256-AhWPz/cwhBwSozZx6WrDPvCj73OIvBxXlsimM+FDFlA="
+          "url": "https://downloads.1password.com/mac/1Password-8.11.6-aarch64.zip",
+          "hash": "sha256-SrB4tUk2GroUOptdQlJsC9tFssYXduyLR1TqH7aU2N4="
         }
       }
     }

--- a/pkgs/by-name/_1/_1password-gui/sources.json
+++ b/pkgs/by-name/_1/_1password-gui/sources.json
@@ -29,28 +29,28 @@
   },
   "beta": {
     "linux": {
-      "version": "8.11.4-21.BETA",
+      "version": "8.11.8-32.BETA",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/linux/tar/beta/x86_64/1password-8.11.4-21.BETA.x64.tar.gz",
-          "hash": "sha256-HWPeTCtjHH8vngDX0+tGbiDMj1FoW8a4RCu34RqJXmI="
+          "url": "https://downloads.1password.com/linux/tar/beta/x86_64/1password-8.11.8-32.BETA.x64.tar.gz",
+          "hash": "sha256-FlJ7uXtqavcOUs/DRGCMR0ImX9mlQBYGxFzM45DByBg="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/linux/tar/beta/aarch64/1password-8.11.4-21.BETA.arm64.tar.gz",
-          "hash": "sha256-yPjzweuJPvvOkJcIElaAogzBpWPvYch6DQarRoaZojc="
+          "url": "https://downloads.1password.com/linux/tar/beta/aarch64/1password-8.11.8-32.BETA.arm64.tar.gz",
+          "hash": "sha256-Dqy9keq6aRrFp2zKGOpV9kmI4CZQFZpf8ey9n9OKy8A="
         }
       }
     },
     "darwin": {
-      "version": "8.11.4-21.BETA",
+      "version": "8.11.8-32.BETA",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.11.4-21.BETA-x86_64.zip",
-          "hash": "sha256-FozwWYQCrqWbfw9qaPRLbaUVWa5hTwG3NHjtZc4smdk="
+          "url": "https://downloads.1password.com/mac/1Password-8.11.8-32.BETA-x86_64.zip",
+          "hash": "sha256-OEl6maJ5bDW9ySLYXWnHUNYY48dtrjxZppRMCUzHrq8="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.11.4-21.BETA-aarch64.zip",
-          "hash": "sha256-0eXtLqknEPG+G+mxa7QYWkUVPu13/KAdkOb9fklZIqg="
+          "url": "https://downloads.1password.com/mac/1Password-8.11.8-32.BETA-aarch64.zip",
+          "hash": "sha256-cNKC+JIsPHMk9h5pBcuh6huLWd7aqt7AdB4ixQ99oeE="
         }
       }
     }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
