### PR TITLE
ci: disable `allowAliases` in the pinned pkgs instance

### DIFF
--- a/ci/default.nix
+++ b/ci/default.nix
@@ -60,8 +60,7 @@ let
 
         programs.keep-sorted.enable = true;
 
-        # This uses nixfmt underneath,
-        # the default formatter for Nix code.
+        # This uses nixfmt underneath, the default formatter for Nix code.
         # See https://github.com/NixOS/nixfmt
         programs.nixfmt.enable = true;
 

--- a/ci/default.nix
+++ b/ci/default.nix
@@ -62,7 +62,10 @@ let
 
         # This uses nixfmt underneath, the default formatter for Nix code.
         # See https://github.com/NixOS/nixfmt
-        programs.nixfmt.enable = true;
+        programs.nixfmt = {
+          enable = true;
+          package = pkgs.nixfmt;
+        };
 
         programs.yamlfmt = {
           enable = true;

--- a/ci/default.nix
+++ b/ci/default.nix
@@ -17,7 +17,12 @@ let
     else
       nixpkgs;
 
-  pkgs = import nixpkgs' { inherit system; };
+  pkgs = import nixpkgs' {
+    inherit system;
+    # Nixpkgs generally — and CI specifically — do not use aliases,
+    # because we want to ensure they are not load-bearing.
+    allowAliases = false;
+  };
 
   fmt =
     let


### PR DESCRIPTION
It was [requested in the Nix Formatting matrix room](https://matrix.to/#/!JHmxsrPoybcbBVDSjm:numtide.com/$rG3Mnrwbsupoo7V2i8yFi8HAGUErhjzjhe2uYnLHu4A?via=nixos.org&via=matrix.org&via=nixos.dev) to switch from the `nixfmt-rfc-style` alias in the nixpkgs shell, because @SuperSandro2000 configures `allowAliases = false` globally in their `config.nix`.

We don't explicitly use that alias anywhere, however it is the default value of treefmt-nix's ``programs.nixfmt.package`` option. As outlined in the commit message, that is a sane default when the nixpkgs revision is not strictly known. However, in our case we _do_ know the nixpkgs revision, so we can safely switch to the new attrname if we want to.

Along with switching to the new attrname, I've also disabled `allowAliases` in the CI pkgs instance. While I'm skeptical disabling `allowAliases` is a good idea (generally, outside of nixpkgs internals), it _should_ be fine to disable aliases on an instances of nixpkgs that has a known/pinned source revision.

---

Trace reported by @SuperSandro2000:

```
 ➜ nix-shell
unpacking 'https://github.com/NixOS/nixpkgs/archive/641d909c4a7538f1539da9240dedb1755c907e40.tar.gz' into the Git cache...
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'nix-shell'
         whose name attribute is located at /nix/store/qdpngwc9f0rr4ph265nwwz4hmfq8xjz9-source/pkgs/stdenv/generic/make-derivation.nix:480:13

       … while evaluating attribute 'nativeBuildInputs' of derivation 'nix-shell'
         at /nix/store/qdpngwc9f0rr4ph265nwwz4hmfq8xjz9-source/pkgs/stdenv/generic/make-derivation.nix:531:13:
          530|             depsBuildBuild = elemAt (elemAt dependencies 0) 0;
          531|             nativeBuildInputs = elemAt (elemAt dependencies 0) 1;
             |             ^
          532|             depsBuildTarget = elemAt (elemAt dependencies 0) 2;

       … while evaluating the option `build.programs':

       … while evaluating definitions from `/nix/store/rqlw2af3kd5f64m6ljw1zn32ln2w4yi5-source/module-options.nix':

       … while evaluating the option `programs.nixfmt.package':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: nixfmt-rfc-style cannot be found in pkgs
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built `nix-shell` on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] ?
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
