### PR TITLE
rimsort: fix desktop items, 1.0.30 -> 1.0.39, add auto update script

### DIFF
--- a/pkgs/by-name/ri/rimsort/package.nix
+++ b/pkgs/by-name/ri/rimsort/package.nix
@@ -16,13 +16,13 @@
 }:
 let
   pname = "rimsort";
-  version = "1.0.30";
+  version = "1.0.39";
 
   src = fetchFromGitHub {
     owner = "RimSort";
     repo = "RimSort";
     rev = "v${version}";
-    hash = "sha256-f1wYoBC0EbkvYNJHkVuoMukJZMY7eNjCIzJra7/hpLs=";
+    hash = "sha256-p9+8KlqADCq3WtFAvKpemhJCVnk3r4MRAQxjJEtI9bU=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/ri/rimsort/package.nix
+++ b/pkgs/by-name/ri/rimsort/package.nix
@@ -164,6 +164,8 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
     description = "Open source mod manager for the video game RimWorld";
     homepage = "https://github.com/RimSort/RimSort";

--- a/pkgs/by-name/ri/rimsort/package.nix
+++ b/pkgs/by-name/ri/rimsort/package.nix
@@ -7,6 +7,7 @@
   makeBinaryWrapper,
 
   makeDesktopItem,
+  copyDesktopItems,
   replaceVars,
 
   todds,
@@ -24,6 +25,7 @@ let
     hash = "sha256-f1wYoBC0EbkvYNJHkVuoMukJZMY7eNjCIzJra7/hpLs=";
     fetchSubmodules = true;
   };
+
   steamworksSrc = fetchzip {
     url = "https://web.archive.org/web/20250527013243/https://partner.steamgames.com/downloads/steamworks_sdk_162.zip"; # Steam sometimes requires auth to download.
     hash = "sha256-yDA92nGj3AKTNI4vnoLaa+7mDqupQv0E4YKRRUWqyZw=";
@@ -70,6 +72,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     makeBinaryWrapper
+    copyDesktopItems
   ];
 
   buildInputs =
@@ -134,7 +137,7 @@ stdenv.mkDerivation {
       name = "RimSort";
       desktopName = "RimSort";
       exec = "rimsort";
-      icon = "io.github.rimsort.rimsort";
+      icon = "rimsort.png";
       comment = "RimWorld Mod Manager";
       categories = [ "Game" ];
     })
@@ -156,7 +159,7 @@ stdenv.mkDerivation {
       --prefix PYTHONPATH : "$PYTHONPATH" \
       --set RIMSORT_DISABLE_UPDATER 1
 
-    install -D ./themes/default-icons/AppIcon_a.png $out/share/icons/hicolor/512x512/apps/io.github.rimsort.rimsort
+    install -D ./themes/default-icons/AppIcon_a.png $out/share/icons/hicolor/512x512/apps/rimsort.png
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ri/rimsort/update.sh
+++ b/pkgs/by-name/ri/rimsort/update.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix-prefetch-github gnused
+
+set -euo pipefail
+
+nix_file="$(dirname "${BASH_SOURCE[@]}")/package.nix"
+version=$(curl -s https://api.github.com/repos/RimSort/RimSort/releases/latest | jq -r '.tag_name | sub("^v"; "")')
+hash=$(nix-prefetch-github --fetch-submodules --rev v${version} RimSort RimSort | jq '.hash')
+
+sed -i "0,/version =.*/s||version = \"$version\";|" $nix_file
+sed -i "0,/hash =.*/s||hash = $hash;|" $nix_file


### PR DESCRIPTION
Fixes the major issues with the package. Notably downloading using Steam still does not work, since RimSort uses a fork of SteamworksPy. Users can use steamcmd to download instead for the time being.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
