### PR TITLE
claude-monitor: init at 3.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9068,6 +9068,12 @@
     githubId = 65962770;
     name = "Gaurav Ghodinde";
   };
+  gauthsvenkat = {
+    email = "gauthsvenkat+nixpkgs@gmail.com";
+    github = "gauthsvenkat";
+    githubId = 26820345;
+    name = "Gautham Venkataraman";
+  };
   gavin = {
     email = "gavin.rogers@holo.host";
     github = "gavinrogers";

--- a/pkgs/by-name/cl/claude-monitor/package.nix
+++ b/pkgs/by-name/cl/claude-monitor/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "claude-monitor";
+  version = "3.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Maciek-roboblog";
+    repo = "Claude-Code-Usage-Monitor";
+    tag = "v${version}";
+    hash = "sha256-v5ooniaN1iVerBW77/00SpghIVE1j8cl2WENcPnS66M=";
+  };
+
+  build-system = with python3.pkgs; [ setuptools ];
+
+  dependencies = with python3.pkgs; [
+    numpy
+    pydantic
+    pydantic-settings
+    pytz
+    pyyaml
+    rich
+    tomli
+    tzdata
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytest-asyncio
+    pytest-benchmark
+    pytest-cov
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  # Some tests need writable home directory
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  # Disable coverage requirement for nixpkgs build
+  pytestFlags = [ "--no-cov" ];
+
+  # Platform-specific tests that fail in nix build environment
+  disabledTests = [
+    "test_get_timezone_windows"
+    "test_successful_main_execution"
+  ];
+
+  pythonImportsCheck = [ "claude_monitor" ];
+
+  meta = {
+    description = "Real-time terminal monitoring tool for Claude AI token usage";
+    longDescription = ''
+      A beautiful real-time terminal monitoring tool for Claude AI token usage with advanced analytics,
+      machine learning-based predictions, and Rich UI. Track your token consumption, burn rate, cost
+      analysis, and get intelligent predictions about session limits.
+    '';
+    mainProgram = "claude-monitor";
+    homepage = "https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor";
+    changelog = "https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.gauthsvenkat ];
+  };
+}


### PR DESCRIPTION
This PR adds myself to the maintainers list and packages [Claude-Code-Usage-Monitor
](https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
