### PR TITLE
envoy: switch default WASM runtime to wasmtime

### DIFF
--- a/pkgs/by-name/en/envoy/bazel_nix.BUILD.bazel
+++ b/pkgs/by-name/en/envoy/bazel_nix.BUILD.bazel
@@ -1,12 +1,26 @@
 load("@bazel_tools//tools/sh:sh_toolchain.bzl", "sh_toolchain")
 load("@rules_rust//rust:toolchain.bzl", "rust_toolchain")
+load("@rules_rust//rust:defs.bzl", "rust_stdlib_filegroup")
 
 toolchains = {
     "x86_64": "x86_64-unknown-linux-gnu",
     "aarch64": "aarch64-unknown-linux-gnu",
 }
 
-exports_files(["cargo", "rustdoc", "ruststd", "rustc"])
+exports_files(["cargo", "rustdoc", "rustc"])
+
+[
+    rust_stdlib_filegroup(
+        name = "rust_nix_" + k + "_stdlib",
+        srcs = glob(
+            [
+                "rustcroot/lib/rustlib/" + v + "/lib/**",
+            ],
+            allow_empty=True,
+        ),
+    )
+    for k, v in toolchains.items()
+]
 
 [
     rust_toolchain(
@@ -16,7 +30,7 @@ exports_files(["cargo", "rustdoc", "ruststd", "rustc"])
         exec_triple = v,
         cargo = ":cargo",
         rust_doc = ":rustdoc",
-        rust_std = ":ruststd",
+        rust_std = ":rust_nix_" + k + "_stdlib",
         rustc = ":rustc",
         stdlib_linkflags = ["-ldl", "-lpthread"],
         staticlib_ext = ".a",

--- a/pkgs/by-name/en/envoy/package.nix
+++ b/pkgs/by-name/en/envoy/package.nix
@@ -94,7 +94,7 @@ buildBazelPackage rec {
     ln -sf "${cargo}/bin/cargo" bazel/nix/cargo
     ln -sf "${rustc}/bin/rustc" bazel/nix/rustc
     ln -sf "${rustc}/bin/rustdoc" bazel/nix/rustdoc
-    ln -sf "${rustPlatform.rustLibSrc}" bazel/nix/ruststd
+    ln -sf "${rustc.unwrapped}" bazel/nix/rustcroot
     substituteInPlace bazel/dependency_imports.bzl \
       --replace-fail 'crate_universe_dependencies()' 'crate_universe_dependencies(rust_toolchain_cargo_template="@@//bazel/nix:cargo", rust_toolchain_rustc_template="@@//bazel/nix:rustc")' \
       --replace-fail 'crates_repository(' 'crates_repository(rust_toolchain_cargo_template="@@//bazel/nix:cargo", rust_toolchain_rustc_template="@@//bazel/nix:rustc",'
@@ -239,6 +239,7 @@ buildBazelPackage rec {
     "--linkopt=-Wl,-z,noexecstack"
     "--config=gcc"
     "--verbose_failures"
+    "--incompatible_enable_cc_toolchain_resolution=true"
 
     # Force use of system Java.
     "--extra_toolchains=@local_jdk//:all"

--- a/pkgs/by-name/en/envoy/package.nix
+++ b/pkgs/by-name/en/envoy/package.nix
@@ -26,7 +26,7 @@
   git,
 
   # v8 (upstream default), wavm, wamr, wasmtime, disabled
-  wasmRuntime ? "wamr",
+  wasmRuntime ? "wasmtime",
 
   # Allows overriding the deps hash used for building - you will likely need to
   # set this if you have changed the 'wasmRuntime' setting.
@@ -50,8 +50,8 @@ let
       depsHash
     else
       {
-        x86_64-linux = "sha256-E6yUSd00ngmjaMds+9UVZLtcYhzeS8F9eSIkC1mZSps=";
-        aarch64-linux = "sha256-ivboOrV/uORKVHRL3685aopcElGvzsxgVcUmYsBwzXY=";
+        x86_64-linux = "sha256-t4Xv4UGYW5YU0kmv+1rdf2JvM1BYQyNWdtpz6Cdmxm4=";
+        aarch64-linux = "sha256-aIBnNGzc0hTdlTgRyJ7eLnWvHqZ5ywhqOM+mHfH3/18=";
       }
       .${stdenv.system} or (throw "unsupported system ${stdenv.system}");
 

--- a/pkgs/by-name/en/envoy/package.nix
+++ b/pkgs/by-name/en/envoy/package.nix
@@ -27,6 +27,10 @@
 
   # v8 (upstream default), wavm, wamr, wasmtime, disabled
   wasmRuntime ? "wamr",
+
+  # Allows overriding the deps hash used for building - you will likely need to
+  # set this if you have changed the 'wasmRuntime' setting.
+  depsHash ? null,
 }:
 
 let
@@ -41,12 +45,15 @@ let
   };
 
   # these need to be updated for any changes to fetchAttrs
-  depsHash =
-    {
-      x86_64-linux = "sha256-E6yUSd00ngmjaMds+9UVZLtcYhzeS8F9eSIkC1mZSps=";
-      aarch64-linux = "sha256-ivboOrV/uORKVHRL3685aopcElGvzsxgVcUmYsBwzXY=";
-    }
-    .${stdenv.system} or (throw "unsupported system ${stdenv.system}");
+  depsHash' =
+    if depsHash != null then
+      depsHash
+    else
+      {
+        x86_64-linux = "sha256-E6yUSd00ngmjaMds+9UVZLtcYhzeS8F9eSIkC1mZSps=";
+        aarch64-linux = "sha256-ivboOrV/uORKVHRL3685aopcElGvzsxgVcUmYsBwzXY=";
+      }
+      .${stdenv.system} or (throw "unsupported system ${stdenv.system}");
 
   python3 = python312;
 
@@ -127,7 +134,7 @@ buildBazelPackage rec {
   buildInputs = [ linuxHeaders ];
 
   fetchAttrs = {
-    sha256 = depsHash;
+    sha256 = depsHash';
     env.CARGO_BAZEL_REPIN = true;
     dontUseCmakeConfigure = true;
     dontUseGnConfigure = true;

--- a/pkgs/by-name/en/envoy/package.nix
+++ b/pkgs/by-name/en/envoy/package.nix
@@ -23,6 +23,7 @@
   gnutar,
   gnugrep,
   envoy,
+  git,
 
   # v8 (upstream default), wavm, wamr, wasmtime, disabled
   wasmRuntime ? "wamr",
@@ -120,6 +121,7 @@ buildBazelPackage rec {
     ninja
     patchelf
     cacert
+    git
   ];
 
   buildInputs = [ linuxHeaders ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Switches the default WASM runtime from WAMR to wasmtime, which is better maintained (although both under the Bytecode Alliance umbrella).

@mccurdyc 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
