### PR TITLE
topiary: 0.6.0 -> 0.6.1

### DIFF
--- a/pkgs/by-name/to/topiary/package.nix
+++ b/pkgs/by-name/to/topiary/package.nix
@@ -8,22 +8,21 @@
   versionCheckHook,
   nix-update-script,
 }:
-
 rustPlatform.buildRustPackage rec {
   pname = "topiary";
-  version = "0.6.0";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "tweag";
     repo = "topiary";
     tag = "v${version}";
-    hash = "sha256-nRVxjdEtYvgF8Vpw0w64hUd1scZh7f+NjFtbTg8L5Qc=";
+    hash = "sha256-CyqZhkzAOqC3xWhwUzCpkDO0UFsO0S4/3sV7zIILiVg=";
   };
 
   nativeBuildInputs = [ installShellFiles ];
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  cargoHash = "sha256-EqalIF1wx3F/5CiD21IaYsPdks6Mv1VfwL8OTRWsWaU=";
+  cargoHash = "sha256-akAjn9a7dMwjPSNveDY2KJ62evjHCAWpRR3A7Ghkb5A=";
 
   # https://github.com/NixOS/nixpkgs/pull/359145#issuecomment-2542418786
   depsExtraArgs.postBuild = ''
@@ -42,6 +41,31 @@ rustPlatform.buildRustPackage rec {
 
   # Skip tests that cannot be executed in sandbox (operation not permitted)
   checkFlags = [
+    "--skip=formatted_query_tester"
+    "--skip=test_coverage::coverage_input_bash"
+    "--skip=test_coverage::coverage_input_css"
+    "--skip=test_coverage::coverage_input_json"
+    "--skip=test_coverage::coverage_input_nickel"
+    "--skip=test_coverage::coverage_input_ocaml"
+    "--skip=test_coverage::coverage_input_ocamllex"
+    "--skip=test_coverage::coverage_input_openscad"
+    "--skip=test_coverage::coverage_input_sdml"
+    "--skip=test_coverage::coverage_input_toml"
+    "--skip=test_coverage::coverage_input_tree_sitter_query"
+    "--skip=test_coverage::coverage_input_wit"
+    "--skip=test_fmt::fmt_input_bash"
+    "--skip=test_fmt::fmt_input_css"
+    "--skip=test_fmt::fmt_input_json"
+    "--skip=test_fmt::fmt_input_nickel"
+    "--skip=test_fmt::fmt_input_ocaml"
+    "--skip=test_fmt::fmt_input_ocaml_interface"
+    "--skip=test_fmt::fmt_input_ocamllex"
+    "--skip=test_fmt::fmt_input_openscad"
+    "--skip=test_fmt::fmt_input_sdml"
+    "--skip=test_fmt::fmt_input_toml"
+    "--skip=test_fmt::fmt_input_tree_sitter_query"
+    "--skip=test_fmt::fmt_input_wit"
+    "--skip=test_fmt::fmt_queries"
     "--skip=test_fmt_dir"
     "--skip=test_fmt_files"
     "--skip=test_fmt_files_query_fallback"
@@ -50,9 +74,7 @@ rustPlatform.buildRustPackage rec {
     "--skip=test_fmt_stdin_query"
     "--skip=test_fmt_stdin_query_fallback"
     "--skip=test_vis"
-    "--skip=formatted_query_tester"
-    "--skip=input_output_tester"
-    "--skip=coverage_tester"
+    "--skip=test_vis_invalid"
   ];
 
   env.TOPIARY_LANGUAGE_DIR = "${placeholder "out"}/share/queries";


### PR DESCRIPTION
updates topiary version 0.6.0 -> 0.6.1.

This package does have an updateScript, however it has been failing due to more impure tests being added to the upstream testing suite. These have been added to the skipped tests.

Resolves #435610

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
