### PR TITLE
kdePackages.kwayland-integration: fix build, use in Plasma 6

### DIFF
--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -183,7 +183,7 @@ in
       ++ lib.optionals config.services.desktopManager.plasma6.enableQt5Integration [
         breeze.qt5
         plasma-integration.qt5
-        pkgs.plasma5Packages.kwayland-integration
+        kwayland-integration
         (
           # Only symlink the KIO plugins, so we don't accidentally pull any services
           # like KCMs or kcookiejar

--- a/pkgs/kde/plasma/kwayland-integration/default.nix
+++ b/pkgs/kde/plasma/kwayland-integration/default.nix
@@ -1,6 +1,41 @@
-{ mkKdeDerivation }:
-mkKdeDerivation {
+{
+  stdenv,
+  sources,
+
+  cmake,
+  pkg-config,
+  libsForQt5,
+  wayland-scanner,
+
+  plasma-wayland-protocols,
+  wayland,
+  wayland-protocols,
+}:
+# not mkKdeDerivation because this is Qt5 land
+stdenv.mkDerivation rec {
   pname = "kwayland-integration";
-  # FIXME(qt5)
-  meta.broken = true;
+  inherit (sources.${pname}) version;
+
+  src = sources.${pname};
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    libsForQt5.extra-cmake-modules
+  ];
+
+  buildInputs = [
+    libsForQt5.qtbase
+    libsForQt5.qtwayland
+
+    libsForQt5.kwayland
+    libsForQt5.kwindowsystem
+
+    plasma-wayland-protocols
+    wayland
+    wayland-protocols
+    wayland-scanner
+  ];
+
+  dontWrapQtApps = true;
 }


### PR DESCRIPTION
This is still the Qt5 version, but we deleted the old Qt5 version along with the rest of Plasma 5 so we need this now.

Fixes #430298.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
