### PR TITLE
asgiref: 3.8.1 -> 3.9.1

### DIFF
--- a/pkgs/development/python-modules/asgiref/default.nix
+++ b/pkgs/development/python-modules/asgiref/default.nix
@@ -10,17 +10,17 @@
 }:
 
 buildPythonPackage rec {
-  version = "3.8.1";
+  version = "3.9.1";
   pname = "asgiref";
   format = "setuptools";
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "django";
     repo = "asgiref";
     tag = version;
-    hash = "sha256-xepMbxglBpHL7mnJYlnvNUgixrFwf/Tc6b1zL4Wy+to=";
+    hash = "sha256-VD8OQP+Xq3JpUz3fZRl6g+SL7mGZjeHjOU9Cd+scYzc=";
   };
 
   propagatedBuildInputs = [ typing-extensions ];


### PR DESCRIPTION
https://github.com/django/asgiref/blob/fbe9506df140a437921a01ea824dbe51d8c38c24/CHANGELOG.txt#L1-L28

⚠️ THIS IS NOT A PLACE OF HONOR ⚠️

What lies below 3.9.1 is cursed.

This bump from asgiref 3.8.1 fixes deep, hard-to-reproduce deadlocks when sync meets async, particularly in WSGI/async apps (Django, Starlette, etc.) with compatibility code with another asynchronous engine, e.g. Tornado. (For example: Zulip's event server)

These are not simple bugs.
They are coroutine limbo. You will wait forever.

Here lies peace between sync and async, until the next time.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tested in production.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.