### PR TITLE
kdbg: 3.1.0 -> 3.2.0

### DIFF
--- a/pkgs/development/tools/misc/kdbg/default.nix
+++ b/pkgs/development/tools/misc/kdbg/default.nix
@@ -3,41 +3,39 @@
   stdenv,
   fetchurl,
   cmake,
-  extra-cmake-modules,
-  qt5,
-  ki18n,
-  kconfig,
-  kiconthemes,
-  kxmlgui,
-  kwindowsystem,
-  qtbase,
-  makeWrapper,
+  qt6,
+  kdePackages,
 }:
 
 stdenv.mkDerivation rec {
   pname = "kdbg";
-  version = "3.1.0";
+  version = "3.2.0";
   src = fetchurl {
-    url = "mirror://sourceforge/kdbg/${version}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-aLX/0GXof77NqQj7I7FUCZjyDtF1P8MJ4/NHJNm4Yr0=";
+    url = "mirror://sourceforge/kdbg/${version}/kdbg-${version}.tar.gz";
+    hash = "sha256-GoWLKWD/nWXBTiTbDLxeNArDMyPI/gSzADqyOgxrNHE=";
   };
 
   nativeBuildInputs = [
     cmake
-    extra-cmake-modules
-    makeWrapper
+    kdePackages.extra-cmake-modules
+    qt6.wrapQtAppsHook
   ];
   buildInputs = [
-    qt5.qtbase
-    ki18n
-    kconfig
-    kiconthemes
-    kxmlgui
-    kwindowsystem
+    qt6.qt5compat
+    qt6.qtbase
+    kdePackages.ki18n
+    kdePackages.kconfig
+    kdePackages.kiconthemes
+    kdePackages.kxmlgui
+    kdePackages.kwindowsystem
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "BUILD_FOR_KDE_VERSION" "6")
   ];
 
   postInstall = ''
-    wrapProgram $out/bin/kdbg --prefix QT_PLUGIN_PATH : ${qtbase}/${qtbase.qtPluginPrefix}
+    wrapProgram $out/bin/kdbg --prefix QT_PLUGIN_PATH : ${qt6.qtbase}/${qt6.qtbase.qtPluginPrefix}
   '';
 
   dontWrapQtApps = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3413,7 +3413,7 @@ with pkgs;
     lua = lua5_2_compat;
   };
 
-  kdbg = libsForQt5.callPackage ../development/tools/misc/kdbg { };
+  kdbg = callPackage ../development/tools/misc/kdbg { };
 
   kristall = libsForQt5.callPackage ../applications/networking/browsers/kristall { };
 


### PR DESCRIPTION
https://github.com/j6t/kdbg/blob/master/ReleaseNotes-3.2.0.md

https://github.com/NixOS/nixpkgs/pull/429372#issuecomment-3133579259

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
