### PR TITLE
lixPackageSets.{lix_2_93,git}.perl-bindings: init

### DIFF
--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -74,6 +74,7 @@ assert lib.assertMsg (
     version = "${version}${suffix}";
     cargoDeps = docCargoDeps;
   },
+  perl-bindings,
 
   enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
   enableStatic ? stdenv.hostPlatform.isStatic,
@@ -371,7 +372,7 @@ stdenv.mkDerivation (finalAttrs: {
   __darwinAllowLocalNetworking = true;
 
   passthru = {
-    inherit aws-sdk-cpp boehmgc;
+    inherit aws-sdk-cpp boehmgc perl-bindings;
     tests = {
       misc = nixosTests.nix-misc.default.passthru.override { nixPackage = finalAttrs.finalPackage; };
       installer = nixosTests.installer.simple.override { selectNixPackage = _: finalAttrs.finalPackage; };

--- a/pkgs/tools/package-management/lix/common-perl-bindings.nix
+++ b/pkgs/tools/package-management/lix/common-perl-bindings.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  suffix ? "",
+  version,
+  src,
+  patches ? [ ],
+  ...
+}@args:
+
+{
+  stdenv,
+  lib,
+  lix,
+  boost,
+  capnproto,
+  perl,
+  libsodium,
+  meson,
+  pkg-config,
+  ninja,
+}:
+
+perl.pkgs.toPerlModule (
+  stdenv.mkDerivation {
+    pname = "lix-perl";
+    version = "${version}${suffix}";
+    inherit src patches;
+
+    # sourceRoot doesn't work due to us wanting to apply patches at the root
+    preConfigure = "cd perl";
+
+    nativeBuildInputs = [
+      pkg-config
+      meson
+      ninja
+    ];
+
+    buildInputs = [
+      lix
+      perl
+      boost
+      libsodium
+      perl.pkgs.DBI
+      perl.pkgs.DBDSQLite
+      # for kj-async
+      capnproto
+    ];
+
+    # point 'nix edit' and ofborg at the file that defines the attribute,
+    # not this common file.
+    pos = builtins.unsafeGetAttrPos "version" args;
+
+    enableParallelBuilding = true;
+
+    passthru = { inherit perl; };
+
+    meta = {
+      description = "Perl bindings for Lix";
+      homepage = "https://git.lix.systems/lix-project/lix/src/branch/main/perl";
+      license = lib.licenses.lgpl21Plus;
+      teams = [ lib.teams.lix ];
+      platforms = lib.platforms.unix;
+      # perl version checking is grumpy and we could patch it but we want to kill <2.93 anyway
+      broken = lib.versionOlder version "2.93";
+    };
+  }
+)

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -94,6 +94,10 @@ let
             stdenv = lixStdenv;
           };
 
+          perl-bindings = self.callPackage (callPackage ./common-perl-bindings.nix lix-args) {
+            stdenv = lixStdenv;
+          };
+
           nixpkgs-review = nixpkgs-review.override {
             nix = self.lix;
           };


### PR DESCRIPTION
Used by Lix Hydra (and pretty much just Lix Hydra). Sorta useful to getting rid of Lix's in-tree packaging of perl bindings.

Fixes: https://git.lix.systems/lix-project/lix/issues/976


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
