### PR TITLE
update-python-libraries: support GitHub repositories with tag releases only

### DIFF
--- a/pkgs/by-name/up/update-python-libraries/update-python-libraries.py
+++ b/pkgs/by-name/up/update-python-libraries/update-python-libraries.py
@@ -283,7 +283,14 @@ def _get_latest_version_github(attr_path, package, extension, current_version, t
     releases = list(filter(lambda x: not x["prerelease"], all_releases))
 
     if len(releases) == 0:
-        raise ValueError(f"{homepage} does not contain any stable releases")
+        logging.warning(f"{homepage} does not contain any stable releases, looking for tags instead...")
+        url = f"https://api.github.com/repos/{owner}/{repo}/tags"
+        all_tags = _fetch_github(url)
+        # Releases are used with a couple of fields that tags possess as well. We will fake these releases.
+        releases = [{'tag_name': tag['name'], 'tarball_url': tag['tarball_url']} for tag in all_tags]
+
+    if len(releases) == 0:
+        raise ValueError(f"{homepage} does not contain any stable releases neither tags, stopping now.")
 
     versions = map(lambda x: strip_prefix(x["tag_name"]), releases)
     version = _determine_latest_version(current_version, target, versions)
@@ -457,6 +464,7 @@ def _update_package(path, target):
             successful_fetch = True
             break
         except ValueError:
+            logging.exception(f"Failed to fetch releases for {pname}")
             continue
 
     if not successful_fetch:


### PR DESCRIPTION
Certain repositories such as https://github.com/django/asgiref do not contain any stable releases in the GitHub parlance but tags.

Those tags are still releases.

These repositories are important.

Let's expand the capabilities of update-python-libraries to make the life of the hero making Python packages up-to-date.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Tested, as applicable:
  - [x] Tested on asgiref.