### PR TITLE
zulu21: 21.0.4 -> 21.0.8

### DIFF
--- a/pkgs/development/compilers/zulu/21.nix
+++ b/pkgs/development/compilers/zulu/21.nix
@@ -4,49 +4,50 @@
   ...
 }@args:
 
+let
+  # JDK FX can potentially be different version than regular JDK
+  zuluVersion = if enableJavaFX then "21.44.17" else "21.44.17";
+  jdkVersion = "21.0.8";
+in
 callPackage ./common.nix (
   {
     # Details from https://www.azul.com/downloads/?version=java-21-lts&package=jdk
     # Note that the latest build may differ by platform
     dists = {
       x86_64-linux = {
-        zuluVersion = "21.36.17";
-        jdkVersion = "21.0.4";
+        inherit zuluVersion jdkVersion;
         hash =
           if enableJavaFX then
-            "sha256-Q2bdM0/a2t5aBRCIzXBlhXamf8N7wdSUsK5VhaU9DcY="
+            "sha256-T+bGfe0IoYwX1Odh66CdRL1fzbvA63NqM9e2hLCbx2Y="
           else
-            "sha256-MY0MLtPIdvt+oslSlFzc997PtSZMpRrs4VnmNaxT1UQ=";
+            "sha256-Y/Vru0aVjPVzUvugjydV4JU3mRleVUWswMipKSC+/x4=";
       };
 
       aarch64-linux = {
-        zuluVersion = "21.36.17";
-        jdkVersion = "21.0.4";
+        inherit zuluVersion jdkVersion;
         hash =
           if enableJavaFX then
-            "sha256-BzNEcDrQo5yOWnEsJxw9JfXYdZGN6/wxnTDB0qC1i/0="
+            "sha256-6qFwo2rBV+mbEFDZNoqEs3z+2saj31fsOHG9jToST2Q="
           else
-            "sha256-2jwtfbM2cLz2ZTJEGut/M9zw0ifI2v5841zuZ/aCnEw=";
+            "sha256-/38u3R1cFTy2y0k6OqNSNFPimgXsUTslwkqhR37AxyI=";
       };
 
       x86_64-darwin = {
-        zuluVersion = "21.36.17";
-        jdkVersion = "21.0.4";
+        inherit zuluVersion jdkVersion;
         hash =
           if enableJavaFX then
-            "sha256-H3gM2XCCcuUxlAEzX6IO7Cp6NtH85PYHlH54k5XvNAc="
+            "sha256-PGnYq+9MskgczsEjx4aH5yDYjZLw8Tk8IZSMOXw03aw="
           else
-            "sha256-XOdaaiR8cCm3TEynz29g/SstaM4eiVb7RI0phDFrX+o=";
+            "sha256-KvCAUAtcwoamNTGHx8WbWq/LPtwpwch9H9cbotalI/E=";
       };
 
       aarch64-darwin = {
-        zuluVersion = "21.36.17";
-        jdkVersion = "21.0.4";
+        inherit zuluVersion jdkVersion;
         hash =
           if enableJavaFX then
-            "sha256-lLAb8MABo95A5WcayBLNvsBSdVFptnO4EmhX2gjo6r8="
+            "sha256-Bj1cYFfm3dq+HB9tdnFwT7onVQ9Slf0zRFBK4z9LUoY="
           else
-            "sha256-vCdQ+BoWbMbpwwroqrpU8lOoyOydjPwEpVX+IHEse/8=";
+            "sha256-0izgX+o+PyjIxZ8sNIvHjulnvxKJpPsoeWzAF3/2yNs=";
       };
     };
   }


### PR DESCRIPTION
Update to the latest binary release of Zulu JDK 21

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR -- `aarch64-linux` only.
- [x] Tested basic functionality of some binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
