### PR TITLE
apl2741-unicode: init at 0-unstable-2022-11-10

### DIFF
--- a/pkgs/by-name/ap/apl2741-unicode/package.nix
+++ b/pkgs/by-name/ap/apl2741-unicode/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "apl2741-unicode";
+  version = "0-unstable-2022-11-10";
+
+  src = fetchFromGitHub {
+    owner = "abrudz";
+    repo = "APL2741";
+    rev = "1e11efae38e5095bfe49a786b111d563e83dad03";
+    hash = "sha256-/sAO+HL3zGMJZ+5SFHnkHxxevG0nJ7wo1yLTlHqYPkQ=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 -t $out/share/fonts/truetype *.ttf
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "APL font based on Adrian Smith's IBM Selectric APL2741 golf-ball font";
+    license = lib.licenses.unlicense;
+    homepage = "https://abrudz.github.io/APL2741/";
+    maintainers = [ lib.maintainers.sternenseemann ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/b6/b612/package.nix
+++ b/pkgs/by-name/b6/b612/package.nix
@@ -46,6 +46,7 @@ stdenvNoCC.mkDerivation rec {
       epl10
       bsd3
     ];
+    maintainers = with lib.maintainers; [ sternenseemann ];
     platforms = lib.platforms.all;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
