### PR TITLE
npingler: init at unstable-2025-08-21

### DIFF
--- a/pkgs/by-name/np/npingler/package.nix
+++ b/pkgs/by-name/np/npingler/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "npingler";
+  version = "unstable-2025-08-21";
+
+  src = fetchFromGitHub {
+    owner = "9999years";
+    repo = "npingler";
+    rev = "de47bb5c5c188ba3b36958c2284dbc6d24f2687f";
+    hash = "sha256-4Q8oG2iem9dgsTTEFfhyw2rPAxtXdGx+Uhb/9uAdUy4=";
+  };
+
+  cargoHash = "sha256-wTW0cwi6C2WRlH2ifPMTdLAEZg4VbE5Jr5Mh+e+SjaM=";
+
+  meta = {
+    description = "Nix profile manager for use with npins";
+    homepage = "https://github.com/9999years/npingler";
+    license = lib.licenses.mit;
+    maintainers = [
+      lib.maintainers._9999years
+    ];
+    mainProgram = "npingler";
+  };
+
+  passthru.updateScript = nix-update-script { };
+}


### PR DESCRIPTION
`npingler` is an [`npins`](https://github.com/andir/npins)-based Nix profile manager.

See: https://github.com/9999years/npingler

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
