### PR TITLE
cargo-tauri*: cleanup dependencies; cargo-tauri_1: 1.8.1 -> 1.6.6

### DIFF
--- a/pkgs/by-name/ca/cargo-tauri/package.nix
+++ b/pkgs/by-name/ca/cargo-tauri/package.nix
@@ -7,6 +7,7 @@
   fetchFromGitHub,
   nix-update-script,
   pkg-config,
+  testers,
   xz,
   zstd,
 }:
@@ -51,6 +52,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
     tests = {
       hook = callPackage ./test-app.nix { cargo-tauri = finalAttrs.finalPackage; };
+      version = testers.testVersion { package = finalAttrs.finalPackage; };
     };
 
     updateScript = nix-update-script {

--- a/pkgs/by-name/ca/cargo-tauri/package.nix
+++ b/pkgs/by-name/ca/cargo-tauri/package.nix
@@ -11,14 +11,14 @@
   zstd,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tauri";
   version = "2.7.1";
 
   src = fetchFromGitHub {
     owner = "tauri-apps";
     repo = "tauri";
-    tag = "tauri-cli-v${version}";
+    tag = "tauri-cli-v${finalAttrs.version}";
     hash = "sha256-0J55AvAvvqTVls4474GcgLPBtSC+rh8cXVKluMjAVBE=";
   };
 
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage rec {
     ];
 
   cargoBuildFlags = [ "--package tauri-cli" ];
-  cargoTestFlags = cargoBuildFlags;
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
 
   env = lib.optionalAttrs stdenv.hostPlatform.isLinux {
     ZSTD_SYS_USE_PKG_CONFIG = true;
@@ -47,10 +47,10 @@ rustPlatform.buildRustPackage rec {
 
   passthru = {
     # See ./doc/hooks/tauri.section.md
-    hook = callPackage ./hook.nix { };
+    hook = callPackage ./hook.nix { cargo-tauri = finalAttrs.finalPackage; };
 
     tests = {
-      hook = callPackage ./test-app.nix { };
+      hook = callPackage ./test-app.nix { cargo-tauri = finalAttrs.finalPackage; };
     };
 
     updateScript = nix-update-script {
@@ -64,7 +64,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Build smaller, faster, and more secure desktop applications with a web frontend";
     homepage = "https://tauri.app/";
-    changelog = "https://github.com/tauri-apps/tauri/releases/tag/${src.tag}";
+    changelog = "https://github.com/tauri-apps/tauri/releases/tag/tauri-cli-v${finalAttrs.version}";
     license = with lib.licenses; [
       asl20 # or
       mit
@@ -76,4 +76,4 @@ rustPlatform.buildRustPackage rec {
     ];
     mainProgram = "cargo-tauri";
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-tauri_1/package.nix
+++ b/pkgs/by-name/ca/cargo-tauri_1/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   bzip2,
-  fetchFromGitHub,
   pkg-config,
   rustPlatform,
   xz,
@@ -11,28 +10,25 @@
 }:
 
 cargo-tauri.overrideAttrs (
-  newAttrs: oldAttrs: {
-    version = "1.8.1";
+  finalAttrs: oldAttrs: {
+    version = "1.6.6";
 
-    src = fetchFromGitHub {
-      owner = "tauri-apps";
-      repo = "tauri";
-      rev = "tauri-v${newAttrs.version}";
-      hash = "sha256-z8dfiLghN6m95PLCMDgpBMNo+YEvvsGN9F101fAcVF4=";
+    src = oldAttrs.src.override {
+      hash = "sha256-UE/mJ0WdbVT4E1YuUCtu80UB+1WR+KRWs+4Emy3Nclc=";
     };
 
     # Manually specify the sourceRoot since this crate depends on other crates in the workspace. Relevant info at
     # https://discourse.nixos.org/t/difficulty-using-buildrustpackage-with-a-src-containing-multiple-cargo-workspaces/10202
-    sourceRoot = "${newAttrs.src.name}/tooling/cli";
+    sourceRoot = "${finalAttrs.src.name}/tooling/cli";
 
     cargoDeps = rustPlatform.fetchCargoVendor {
-      inherit (newAttrs)
+      inherit (finalAttrs)
         pname
         version
         src
         sourceRoot
         ;
-      hash = "sha256-t5sR02qC06H7A2vukwyZYKA2XMVUzJrgIOYuNSf42mE=";
+      hash = "sha256-kAaq6Kam3e5n8569Y4zdFEiClI8q97XFX1hBD7NkUqw=";
     };
 
     nativeBuildInputs = oldAttrs.nativeBuildInputs or [ ] ++ [ pkg-config ];

--- a/pkgs/by-name/ca/cargo-tauri_1/package.nix
+++ b/pkgs/by-name/ca/cargo-tauri_1/package.nix
@@ -1,14 +1,13 @@
 {
   lib,
   stdenv,
-  rustPlatform,
+  bzip2,
   fetchFromGitHub,
-  cargo-tauri,
-  gtk3,
-  libsoup_2_4,
-  openssl,
   pkg-config,
-  webkitgtk_4_0,
+  rustPlatform,
+  xz,
+  zstd,
+  cargo-tauri,
 }:
 
 cargo-tauri.overrideAttrs (
@@ -39,13 +38,16 @@ cargo-tauri.overrideAttrs (
     nativeBuildInputs = oldAttrs.nativeBuildInputs or [ ] ++ [ pkg-config ];
 
     buildInputs = [
-      openssl
+      # Required by `zip` in `tauri-bundler`
+      bzip2
+      zstd
     ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
-      gtk3
-      libsoup_2_4
-      webkitgtk_4_0
-    ];
+    # Required by `rpm` in `tauri-bundler`
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ xz ];
+
+    env = {
+      ZSTD_SYS_USE_PKG_CONFIG = true;
+    };
 
     passthru = {
       inherit (oldAttrs.passthru) hook;

--- a/pkgs/by-name/ca/cargo-tauri_1/package.nix
+++ b/pkgs/by-name/ca/cargo-tauri_1/package.nix
@@ -4,7 +4,6 @@
   rustPlatform,
   fetchFromGitHub,
   cargo-tauri,
-  cargo-tauri_1,
   gtk3,
   libsoup_2_4,
   openssl,
@@ -48,9 +47,7 @@ cargo-tauri.overrideAttrs (
       webkitgtk_4_0
     ];
 
-    passthru = {
-      hook = cargo-tauri.hook.override { cargo-tauri = cargo-tauri_1; };
-    };
+    passthru = { inherit (oldAttrs.passthru) hook; };
 
     meta = {
       inherit (oldAttrs.meta)

--- a/pkgs/by-name/ca/cargo-tauri_1/package.nix
+++ b/pkgs/by-name/ca/cargo-tauri_1/package.nix
@@ -8,6 +8,7 @@
   gtk3,
   libsoup_2_4,
   openssl,
+  pkg-config,
   webkitgtk_4_0,
 }:
 
@@ -35,6 +36,8 @@ cargo-tauri.overrideAttrs (
         ;
       hash = "sha256-t5sR02qC06H7A2vukwyZYKA2XMVUzJrgIOYuNSf42mE=";
     };
+
+    nativeBuildInputs = oldAttrs.nativeBuildInputs or [ ] ++ [ pkg-config ];
 
     buildInputs = [
       openssl

--- a/pkgs/by-name/ca/cargo-tauri_1/package.nix
+++ b/pkgs/by-name/ca/cargo-tauri_1/package.nix
@@ -47,7 +47,10 @@ cargo-tauri.overrideAttrs (
       webkitgtk_4_0
     ];
 
-    passthru = { inherit (oldAttrs.passthru) hook; };
+    passthru = {
+      inherit (oldAttrs.passthru) hook;
+      tests = { inherit (oldAttrs.passthru.tests) version; };
+    };
 
     meta = {
       inherit (oldAttrs.meta)


### PR DESCRIPTION
This fixes a few mistakes in the current Tauri packaging, mainly:

- Unused webkitgtk and gtk3/4 dependencies
  - This removes the insecure flag `cargo-tauri_1` had due to libsoup
- Undeclared dependencies on bzip2, xz, and zstd
- Following the wrong tag series for the v1 CLI

Thanks to @transcaffeine for making https://github.com/NixOS/nixpkgs/pull/435516 and helpine me come across these!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
