### PR TITLE
WIP: freebsd various

### DIFF
--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -2,10 +2,15 @@
   lib,
   stdenv,
   fetchurl,
-
-  # test suite depends on dejagnu which cannot be used during bootstrapping
-  # dejagnu also requires tcl which can't be built statically at the moment
-  doCheck ? !(stdenv.hostPlatform.isStatic),
+  doCheck ?
+    !(
+      # test suite depends on dejagnu which cannot be used during bootstrapping
+      # dejagnu also requires tcl which can't be built statically at the moment
+      stdenv.hostPlatform.isStatic
+      ||
+        # checks fail on freebsd since v3.5
+        stdenv.hostPlatform.isFreeBSD
+    ),
   dejagnu,
   nix-update-script,
   testers,

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8433,12 +8433,13 @@ with pkgs;
         "musl"
         "nblibc"
         "wasilibc"
-        "fblibc"
       ]
     then
       libcIconv pkgs.libc
     else if stdenv.hostPlatform.isDarwin then
       darwin.libiconv
+    else if stdenv.hostPlatform.isFreeBSD then
+      libcIconv (if stdenv.hostPlatform != stdenv.buildPlatform then libc else stdenv.cc.libc)
     else
       libiconvReal;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
