### PR TITLE
yap: 6.3.3 -> 7.6.0-unstable-2025-05-23

### DIFF
--- a/pkgs/by-name/ya/yap/package.nix
+++ b/pkgs/by-name/ya/yap/package.nix
@@ -1,28 +1,47 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  R,
   readline,
   gmp,
   zlib,
+  librdf_raptor2,
 }:
 
-stdenv.mkDerivation rec {
-  version = "6.3.3";
+stdenv.mkDerivation {
   pname = "yap";
+  version = "7.6.0-unstable-2025-05-23";
 
-  src = fetchurl {
-    url = "https://www.dcc.fc.up.pt/~vsc/Yap/${pname}-${version}.tar.gz";
-    sha256 = "0y7sjwimadqsvgx9daz28c9mxcx9n1znxklih9xg16k6n54v9qxf";
+  src = fetchFromGitHub {
+    owner = "vscosta";
+    repo = "yap";
+    rev = "010bb5e48d2f4fbdc0c47ae9faa830a179b3c31b";
+    hash = "sha256-ojhporq7vCEtdwCIRHwzjpc6dbFFXAgF+p6M7eL3JIE=";
   };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    R
+  ];
 
   buildInputs = [
     readline
     gmp
     zlib
+    librdf_raptor2
   ];
 
-  configureFlags = [ "--enable-tabling=yes" ];
+  cmakeFlags = [
+    (lib.cmakeBool "WITH_READLINE" true)
+    (lib.cmakeBool "WITH_R" true)
+    (lib.cmakeBool "WITH_Raptor2" true)
+    (lib.cmakeBool "WITH_CUDD" false)
+    (lib.cmakeBool "WITH_Gecode" false)
+  ];
 
   # -fcommon: workaround build failure on -fno-common toolchains like upstream
   # gcc-10. Otherwise build fails as:
@@ -31,13 +50,12 @@ stdenv.mkDerivation rec {
   env.NIX_CFLAGS_COMPILE = "-fpermissive -fcommon";
 
   meta = {
-    # the linux 32 bit build fails.
+    # linux 32 bit build fails.
     broken =
       (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) || !stdenv.hostPlatform.is64bit;
-    homepage = "http://www.dcc.fc.up.pt/~vsc/Yap/";
+    homepage = "https://github.com/vscosta/yap";
     description = "ISO-compatible high-performance Prolog compiler";
     license = lib.licenses.artistic2;
-
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/vscosta/yap/commit/010bb5e48d2f4fbdc0c47ae9faa830a179b3c31b

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
