### PR TITLE
python3Packages.raspyrfm-client: init at 1.2.8

### DIFF
--- a/pkgs/development/python-modules/raspyrfm-client/default.nix
+++ b/pkgs/development/python-modules/raspyrfm-client/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "raspyrfm-client";
+  version = "1.2.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "markusressel";
+    repo = "raspyrfm-client";
+    tag = "v${version}";
+    hash = "sha256-WiL69bb4h8xVdMYxAVU0NHEfTWyW2NVR86zigsr5dmk=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail 'subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])' "'master'" \
+      --replace-fail 'GIT_BRANCH = GIT_BRANCH.decode()' ""
+  '';
+
+  build-system = [ setuptools ];
+
+  # Tests require hardware
+  doCheck = false;
+
+  pythonImportsCheck = [ "raspyrfm_client" ];
+
+  meta = {
+    description = "Library to send rc signals with the RaspyRFM module";
+    homepage = "https://github.com/markusressel/raspyrfm-client";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -4860,7 +4860,8 @@
       ];
     "raspyrfm" =
       ps: with ps; [
-      ]; # missing inputs: raspyrfm-client
+        raspyrfm-client
+      ];
     "raven_rock_mfg" =
       ps: with ps; [
       ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15499,6 +15499,8 @@ self: super: with self; {
 
   rarfile = callPackage ../development/python-modules/rarfile { inherit (pkgs) libarchive; };
 
+  raspyrfm-client = callPackage ../development/python-modules/raspyrfm-client { };
+
   rasterio = callPackage ../development/python-modules/rasterio { };
 
   ratarmount = callPackage ../development/python-modules/ratarmount { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://pypi.org/project/raspyrfm-client/
- https://github.com/markusressel/raspyrfm-client
- https://www.home-assistant.io/integrations/raspyrfm/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
