### PR TITLE
h2o: 2.3.0-untagged-2025-08-14 → 2.3.0-rolling-2025-08-22

### DIFF
--- a/pkgs/by-name/h2/h2o/package.nix
+++ b/pkgs/by-name/h2/h2o/package.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "h2o";
-  version = "2.3.0-untagged-2025-08-14";
+  version = "2.3.0-rolling-2025-08-22";
 
   src = fetchFromGitHub {
     owner = "h2o";
     repo = "h2o";
-    rev = "ffab9c49c33b1f0e9aec9804028156aae9db8ef0";
-    hash = "sha256-kdU2p9oUhxGnw8JU9qGjV4mn2jMeSUL0rLgveMs6NiI=";
+    rev = "6476496bd544c3c7f601d7ab2b07e378e8310e11";
+    hash = "sha256-ZSBYg1HCuYifTyDmHyNIjEWab5N1TT+q/4m62mFFDJ0=";
   };
 
   outputs = [


### PR DESCRIPTION
<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Looks like a lot of documentation fixes + 1 pointer issue. This is a good time to move version from `-untagged-` to `-rolling-` as per the Discourse discussion.

```sh-session
$ uname -srvm
Linux 6.12.42 #1-NixOS SMP PREEMPT_DYNAMIC Fri Aug 15 10:14:14 UTC 2025 x86_64
$ git branch --show-current
h2o-c61611c
$ git rev-parse HEAD
8dbab6bd7c858bdfe2b2a96fdc76b1a3f91ff3ec
$ nix-build -A nixosTests.h2o
/nix/store/m21cjvg33514b7cm97b34wdlb4lfcaix-vm-test-run-h2o-basic
/nix/store/am1ahc3s1chp0wc0y5r9q77x2j6xzp1d-vm-test-run-h2o-mruby
/nix/store/8s19qyrby6m6chwsy9miw8rji51hm8zp-vm-test-run-h2o-tls-recommendations
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
