### PR TITLE
jellyfin_exporter: init at 1.3.8

### DIFF
--- a/pkgs/by-name/je/jellyfin_exporter/package.nix
+++ b/pkgs/by-name/je/jellyfin_exporter/package.nix
@@ -1,0 +1,30 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+}:
+buildGoModule (finalAttrs: {
+  pname = "jellyfin_exporter";
+  version = "1.3.8";
+
+  src = fetchFromGitHub {
+    owner = "rebelcore";
+    repo = "jellyfin_exporter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7fIrjcy6y/Ayj43WeuPNCx3uVJyl5Wf6bWs5ta2PpWc=";
+  };
+
+  vendorHash = "sha256-JSOKDbefQyDLNy2y1oW7HUplQw8uhhOGZ+ueWyUYYQ0=";
+
+  preCheck = ''
+    GOPATH=$out
+  '';
+
+  meta = {
+    description = "Jellyfin Media System metrics exporter for prometheus";
+    homepage = "https://github.com/rebelcore/jellyfin_exporter";
+    license = lib.licenses.asl20;
+    mainProgram = "jellyfin_exporter";
+    maintainers = with lib.maintainers; [ pizzapim ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Packaging `jellyfin_exporter`, a Prometheus exporter for Jellyfin metrics.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
