### PR TITLE
ci/github-script/commits: fix not-cherry-picked-because regex

### DIFF
--- a/ci/github-script/commits.js
+++ b/ci/github-script/commits.js
@@ -169,7 +169,16 @@ module.exports = async ({ github, context, core, dry }) => {
       core.startGroup(`Commit ${sha}`)
       core.info(`Author: ${commit.author.name} ${commit.author.email}`)
       core.info(`Date: ${new Date(commit.author.date)}`)
-      core[severity](message)
+      switch (severity) {
+        case 'error':
+          core.error(message)
+          break
+        case 'warning':
+          core.warning(message)
+          break
+        default:
+          core.info(message)
+      }
       core.endGroup()
       if (colored_diff) core.info(colored_diff)
     })

--- a/ci/github-script/commits.js
+++ b/ci/github-script/commits.js
@@ -22,7 +22,7 @@ module.exports = async ({ github, context, core, dry }) => {
 
     async function extract({ sha, commit }) {
       const noCherryPick = Array.from(
-        commit.message.matchAll(/^Not-cherry-picked-because: (.*)$/g),
+        commit.message.matchAll(/^Not-cherry-picked-because: (.*)$/gm),
       ).at(0)
 
       if (noCherryPick)


### PR DESCRIPTION
This needs the multiline flags, which enables `^` and `$` to match line start and line end, not start and end of the whole string.

Not sure how this got past testing when initially merged.

Fixes https://github.com/NixOS/nixpkgs/pull/435682#issuecomment-3212355320

## Things done

- [x] Tested locally with `./run commits NixOS nixpkgs 435682` in `ci/github-script`'s nix-shell.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
