### PR TITLE
actions/checkout: use single tmpfs with subfolders

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -79,22 +79,20 @@ runs:
           // This would fail without --refetch, because the we had a partial clone before, but changed it above.
           await run('git', 'fetch', '--depth=1', '--refetch', 'origin', ...(commits.map(({ sha }) => sha)))
 
+          // Checking out onto tmpfs takes 1s and is faster by at least factor 10x.
+          await run('mkdir', 'nixpkgs')
+          switch (process.env.RUNNER_OS) {
+            case 'macOS':
+              await run('sudo', 'mount_tmpfs', 'nixpkgs')
+              break
+            case 'Linux':
+              await run('sudo', 'mount', '-t', 'tmpfs', 'tmpfs', 'nixpkgs')
+              break
+          }
+
           // Create all worktrees in parallel.
           await Promise.all(commits.map(async ({ sha, path }) => {
-            // Checking out onto tmpfs takes 1s and is faster by at least factor 10x.
-            await run('mkdir', path)
-            switch (process.env.RUNNER_OS) {
-              case 'macOS':
-                await run('sudo', 'mount_tmpfs', path)
-                // macOS creates this hidden folder to log file system activity.
-                // This trips up git when adding a worktree below, because the target folder is not empty.
-                await run('sudo', 'rm', '-rf', join(path, '.fseventsd'))
-                break
-              case 'Linux':
-                await run('sudo', 'mount', '-t', 'tmpfs', 'tmpfs', path)
-                break
-            }
-            await run('git', 'worktree', 'add', path, sha, '--no-checkout', '--force')
-            await run('git', '-C', path, 'sparse-checkout', 'disable')
-            await run('git', '-C', path, 'checkout', '--progress')
+            await run('git', 'worktree', 'add', join('nixpkgs', path), sha, '--no-checkout')
+            await run('git', '-C', join('nixpkgs', path), 'sparse-checkout', 'disable')
+            await run('git', '-C', join('nixpkgs', path), 'checkout', '--progress')
           }))

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,33 +66,33 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           pushFilter: '(-source$|-nixpkgs-tarball-)'
 
-      - run: nix-env --install -f pinned -A nix-build-uncached
+      - run: nix-env --install -f nixpkgs/pinned -A nix-build-uncached
 
       - name: Build shell
         if: contains(matrix.builds, 'shell')
-        run: echo "${{ matrix.systems }}" | xargs -n1 nix-build-uncached untrusted/ci --arg nixpkgs ./pinned -A shell --argstr system
+        run: echo "${{ matrix.systems }}" | xargs -n1 nix-build-uncached nixpkgs/untrusted/ci --arg nixpkgs ./nixpkgs/pinned -A shell --argstr system
 
       - name: Build NixOS manual
         if: |
           contains(matrix.builds, 'manual-nixos') && !cancelled() &&
           contains(fromJSON(inputs.baseBranch).type, 'primary')
-        run: nix-build-uncached untrusted/ci --arg nixpkgs ./pinned -A manual-nixos --out-link nixos-manual
+        run: nix-build-uncached nixpkgs/untrusted/ci --arg nixpkgs ./nixpkgs/pinned -A manual-nixos --out-link nixos-manual
 
       - name: Build Nixpkgs manual
         if: contains(matrix.builds, 'manual-nixpkgs') && !cancelled()
-        run: nix-build-uncached untrusted/ci --arg nixpkgs ./pinned -A manual-nixpkgs -A manual-nixpkgs-tests
+        run: nix-build-uncached nixpkgs/untrusted/ci --arg nixpkgs ./nixpkgs/pinned -A manual-nixpkgs -A manual-nixpkgs-tests
 
       - name: Build Nixpkgs manual tests
         if: contains(matrix.builds, 'manual-nixpkgs-tests') && !cancelled()
-        run: nix-build-uncached untrusted/ci --arg nixpkgs ./pinned -A manual-nixpkgs-tests
+        run: nix-build-uncached nixpkgs/untrusted/ci --arg nixpkgs ./nixpkgs/pinned -A manual-nixpkgs-tests
 
       - name: Build lib tests
         if: contains(matrix.builds, 'lib-tests') && !cancelled()
-        run: nix-build-uncached untrusted/ci --arg nixpkgs ./pinned -A lib-tests
+        run: nix-build-uncached nixpkgs/untrusted/ci --arg nixpkgs ./nixpkgs/pinned -A lib-tests
 
       - name: Build tarball
         if: contains(matrix.builds, 'tarball') && !cancelled()
-        run: nix-build-uncached untrusted/ci --arg nixpkgs ./pinned -A tarball
+        run: nix-build-uncached nixpkgs/untrusted/ci --arg nixpkgs ./nixpkgs/pinned -A tarball
 
       - name: Upload NixOS manual
         if: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -117,7 +117,7 @@ jobs:
           pushFilter: -source$
 
       - name: Build codeowners validator
-        run: nix-build trusted/ci --arg nixpkgs ./pinned -A codeownersValidator
+        run: nix-build nixpkgs/trusted/ci --arg nixpkgs ./nixpkgs/pinned -A codeownersValidator
 
       - uses: actions/create-github-app-token@0f859bf9e69e887678d5bbfbee594437cb440ffe # v2.1.0
         if: github.event_name == 'pull_request_target' && vars.OWNER_RO_APP_ID
@@ -137,9 +137,9 @@ jobs:
       - name: Validate codeowners
         if: steps.app-token.outputs.token
         env:
-          OWNERS_FILE: untrusted/ci/OWNERS
+          OWNERS_FILE: nixpkgs/untrusted/ci/OWNERS
           GITHUB_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPOSITORY_PATH: untrusted
+          REPOSITORY_PATH: nixpkgs/untrusted
           OWNER_CHECKER_REPOSITORY: ${{ github.repository }}
           # Set this to "notowned,avoid-shadowing" to check that all files are owned by somebody
           EXPERIMENTAL_CHECKS: "avoid-shadowing"

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -111,7 +111,7 @@ jobs:
           MATRIX_SYSTEM: ${{ matrix.system }}
           MATRIX_VERSION: ${{ matrix.version || 'nixVersions.latest' }}
         run: |
-          nix-build untrusted/ci --arg nixpkgs ./pinned  -A eval.singleSystem \
+          nix-build nixpkgs/untrusted/ci --arg nixpkgs ./nixpkgs/pinned  -A eval.singleSystem \
             --argstr evalSystem "$MATRIX_SYSTEM" \
             --arg chunkSize 8000 \
             --argstr nixPath "$MATRIX_VERSION" \
@@ -190,7 +190,7 @@ jobs:
         env:
           MATRIX_SYSTEM: ${{ matrix.system }}
         run: |
-          nix-build untrusted/ci --arg nixpkgs ./pinned -A eval.diff \
+          nix-build nixpkgs/untrusted/ci --arg nixpkgs ./nixpkgs/pinned -A eval.diff \
             --arg beforeDir ./target \
             --arg afterDir "$(readlink ./merged)" \
             --argstr evalSystem "$MATRIX_SYSTEM" \
@@ -233,7 +233,7 @@ jobs:
 
       - name: Combine all output paths and eval stats
         run: |
-          nix-build trusted/ci --arg nixpkgs ./pinned -A eval.combine \
+          nix-build nixpkgs/trusted/ci --arg nixpkgs ./nixpkgs/pinned -A eval.combine \
             --arg diffDir ./diff \
             --out-link combined
 
@@ -241,11 +241,11 @@ jobs:
         env:
           AUTHOR_ID: ${{ github.event.pull_request.user.id }}
         run: |
-          git -C trusted diff --name-only ${{ inputs.mergedSha }} \
+          git -C nixpkgs/trusted diff --name-only ${{ inputs.mergedSha }} \
             | jq --raw-input --slurp 'split("\n")[:-1]' > touched-files.json
 
           # Use the target branch to get accurate maintainer info
-          nix-build trusted/ci --arg nixpkgs ./pinned -A eval.compare \
+          nix-build nixpkgs/trusted/ci --arg nixpkgs ./nixpkgs/pinned -A eval.compare \
             --arg combinedDir "$(realpath ./combined)" \
             --arg touchedFilesJson ./touched-files.json \
             --argstr githubAuthorId "$AUTHOR_ID" \
@@ -392,8 +392,8 @@ jobs:
         uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31
 
       - name: Ensure flake outputs on all systems still evaluate
-        run: nix flake check --all-systems --no-build './untrusted?shallow=1'
+        run: nix flake check --all-systems --no-build './nixpkgs/untrusted?shallow=1'
 
       - name: Query nixpkgs with aliases enabled to check for basic syntax errors
         run: |
-          time nix-env -I ./untrusted -f ./untrusted -qa '*' --option restrict-eval true --option allow-import-from-derivation false >/dev/null
+          time nix-env -I ./nixpkgs/untrusted -f ./nixpkgs/untrusted -qa '*' --option restrict-eval true --option allow-import-from-derivation false >/dev/null

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,7 @@ jobs:
           # Note that it's fine to run this on untrusted code because:
           # - There's no secrets accessible here
           # - The build is sandboxed
-          if ! nix-build untrusted/ci --arg nixpkgs ./pinned -A fmt.check; then
+          if ! nix-build nixpkgs/untrusted/ci --arg nixpkgs ./nixpkgs/pinned -A fmt.check; then
             echo "Some files are not properly formatted"
             echo "Please format them by going to the Nixpkgs root directory and running one of:"
             echo "  nix-shell --run treefmt"
@@ -81,7 +81,7 @@ jobs:
       - name: Parse all nix files
         run: |
           # Tests multiple versions at once, let's make sure all of them run, so keep-going.
-          nix-build untrusted/ci --arg nixpkgs ./pinned -A parse --keep-going
+          nix-build nixpkgs/untrusted/ci --arg nixpkgs ./nixpkgs/pinned -A parse --keep-going
 
   nixpkgs-vet:
     runs-on: ubuntu-24.04-arm
@@ -112,7 +112,7 @@ jobs:
           # Force terminal colors to be enabled. The library that `nixpkgs-vet` uses respects https://bixense.com/clicolors/
           CLICOLOR_FORCE: 1
         run: |
-          if nix-build untrusted/ci --arg nixpkgs ./pinned -A nixpkgs-vet --arg base "./trusted" --arg head "./untrusted"; then
+          if nix-build nixpkgs/untrusted/ci --arg nixpkgs ./nixpkgs/pinned -A nixpkgs-vet --arg base "./nixpkgs/trusted" --arg head "./nixpkgs/untrusted"; then
             exit 0
           else
             exitCode=$?


### PR DESCRIPTION
This fixes problems on darwin, where the new tmpfs folder would not be fully empty, but git only creates worktrees on fully empty directories.

Fixes https://github.com/NixOS/nixpkgs/pull/435526/files#r2292959252

## Things done

Still needs testing.

- [x] Tested via `pull_request` trigger.
- [x] Tested in my fork.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
