### PR TITLE
nixos/treewide: clean up some more references to deleted qt5 things

### DIFF
--- a/nixos/modules/config/qt.nix
+++ b/nixos/modules/config/qt.nix
@@ -17,11 +17,6 @@ let
       qt6Packages.qt6gtk2
     ];
     kde = [
-      libsForQt5.kio
-      libsForQt5.plasma-integration
-      libsForQt5.systemsettings
-    ];
-    kde6 = [
       kdePackages.kio
       kdePackages.plasma-integration
       kdePackages.systemsettings
@@ -34,11 +29,6 @@ let
       libsForQt5.qt5ct
       qt6Packages.qt6ct
     ];
-  };
-
-  # Maps style names to their QT_QPA_PLATFORMTHEME, if necessary.
-  styleNames = {
-    kde6 = "kde";
   };
 
   stylePackages = with pkgs; {
@@ -71,8 +61,8 @@ let
     ];
 
     breeze = [
-      libsForQt5.breeze-qt5
       kdePackages.breeze
+      kdePackages.breeze.qt5
     ];
 
     kvantum = [
@@ -113,19 +103,11 @@ in
           "qgnomeplatform-qt6"
           [
             "libsForQt5"
-            "plasma-integration"
-          ]
-          [
-            "libsForQt5"
             "qt5ct"
           ]
           [
             "libsForQt5"
             "qtstyleplugins"
-          ]
-          [
-            "libsForQt5"
-            "systemsettings"
           ]
           [
             "kdePackages"
@@ -158,8 +140,7 @@ in
           The options are
           - `gnome`: Use GNOME theme with [qgnomeplatform](https://github.com/FedoraQt/QGnomePlatform)
           - `gtk2`: Use GTK theme with [qtstyleplugins](https://github.com/qt/qtstyleplugins)
-          - `kde`: Use Qt settings from Plasma 5.
-          - `kde6`: Use Qt settings from Plasma 6.
+          - `kde`: Use Qt settings from Plasma.
           - `lxqt`: Use LXQt style set using the [lxqt-config-appearance](https://github.com/lxqt/lxqt-config)
              application.
           - `qt5ct`: Use Qt style set using the [qt5ct](https://sourceforge.net/projects/qt5ct/)
@@ -174,10 +155,6 @@ in
         relatedPackages = [
           "adwaita-qt"
           "adwaita-qt6"
-          [
-            "libsForQt5"
-            "breeze-qt5"
-          ]
           [
             "libsForQt5"
             "qtstyleplugin-kvantum"
@@ -236,9 +213,7 @@ in
       ];
 
     environment.variables = {
-      QT_QPA_PLATFORMTHEME =
-        lib.mkIf (cfg.platformTheme != null)
-          styleNames.${cfg.platformTheme} or cfg.platformTheme;
+      QT_QPA_PLATFORMTHEME = lib.mkIf (cfg.platformTheme != null) cfg.platformTheme;
       QT_STYLE_OVERRIDE = lib.mkIf (cfg.style != null) cfg.style;
     };
 

--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -558,7 +558,7 @@ in
 
       theme = mkOption {
         type = types.nullOr types.path;
-        example = literalExpression ''"''${pkgs.libsForQt5.breeze-grub}/grub/themes/breeze"'';
+        example = literalExpression ''"''${pkgs.kdePackages.breeze-grub}/grub/themes/breeze"'';
         default = null;
         description = ''
           Path to the grub theme to be used.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
