### PR TITLE
img4lib: init at 0-unstable-2021-11-28

### DIFF
--- a/pkgs/by-name/im/img4lib/package.nix
+++ b/pkgs/by-name/im/img4lib/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  lzfse,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "img4lib";
+  version = "0-unstable-2021-11-28";
+
+  src = fetchFromGitHub {
+    owner = "xerub";
+    repo = "img4lib";
+    rev = "69772c72f3c08f021ec9fa4c386f2b3df60a38b7";
+    hash = "sha256-xCWovBJ9cxT17u1uo+aUQnxDoYFQXYy9Qer0mD45aOU=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    lzfse
+    openssl
+  ];
+
+  installPhase = "
+    runHook preInstall
+
+    install -Dm755 img4 $out/bin/img4
+
+    runHook postInstall
+  ";
+
+  strictDeps = true;
+
+  meta = {
+    description = "Library and tool for parsing, manipulating, and patching Apple .img4 container files";
+    homepage = "https://github.com/xerub/img4lib";
+    # No licensing information available
+    # https://github.com/xerub/img4lib/issues/14
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ onny ];
+    mainProgram = "img4";
+  };
+})


### PR DESCRIPTION
Library and tool for parsing, manipulating, and patching Apple .img4 container files https://github.com/xerub/img4lib

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
