### PR TITLE
ocamlPackages.multicore-magic-dscheck: init; ocamlPackages.saturn: 0.5.0 → 1.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/multicore-magic/dscheck.nix
+++ b/pkgs/development/ocaml-modules/multicore-magic/dscheck.nix
@@ -1,0 +1,20 @@
+{
+  lib,
+  buildDunePackage,
+  dscheck,
+  multicore-magic,
+}:
+
+buildDunePackage {
+  pname = "multicore-magic-dscheck";
+
+  inherit (multicore-magic) src version;
+
+  propagatedBuildInputs = [
+    dscheck
+  ];
+
+  meta = multicore-magic.meta // {
+    description = "Implementation of multicore-magic API using the atomic module of DScheck to make DScheck tests possible in libraries using multicore-magic";
+  };
+}

--- a/pkgs/development/ocaml-modules/saturn/default.nix
+++ b/pkgs/development/ocaml-modules/saturn/default.nix
@@ -1,35 +1,55 @@
 {
   lib,
-  buildDunePackage,
+  fetchurl,
   ocaml,
-  saturn_lockfree,
+  version ? "1.0.0",
+  buildDunePackage,
+  backoff,
   domain_shims,
   dscheck,
+  mdx,
   multicore-bench,
+  multicore-magic,
+  multicore-magic-dscheck,
   qcheck,
   qcheck-alcotest,
   qcheck-stm,
 }:
 
 buildDunePackage {
+  inherit version;
+
   pname = "saturn";
 
-  inherit (saturn_lockfree) src version;
+  minimalOCamlVersion = "4.14";
 
-  propagatedBuildInputs = [ saturn_lockfree ];
+  src = fetchurl {
+    url = "https://github.com/ocaml-multicore/saturn/releases/download/${version}/saturn-${version}.tbz";
+    sha512 = "925104a4293326d345701e80932ace2b5d2da02ca6406271d33cd54f9e9c6583f35b060bc42c640357c98669f5bc42e8447dbd21614ae02ce5b5efaa8f04a132";
+  };
 
-  doCheck = lib.versionAtLeast ocaml.version "5.0";
+  propagatedBuildInputs = [
+    backoff
+    multicore-magic
+  ];
+
+  doCheck = lib.versionAtLeast ocaml.version "5.2";
   checkInputs = [
     domain_shims
     dscheck
+    mdx
     multicore-bench
+    multicore-magic-dscheck
     qcheck
     qcheck-alcotest
     qcheck-stm
   ];
+  nativeCheckInputs = [ mdx.bin ];
 
-  meta = saturn_lockfree.meta // {
+  meta = {
     description = "Parallelism-safe data structures for multicore OCaml";
+    homepage = "https://github.com/ocaml-multicore/lockfree";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
   };
-
 }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1323,6 +1323,7 @@ let
         multicore-bench = callPackage ../development/ocaml-modules/multicore-bench { };
 
         multicore-magic = callPackage ../development/ocaml-modules/multicore-magic { };
+        multicore-magic-dscheck = callPackage ../development/ocaml-modules/multicore-magic/dscheck.nix { };
 
         multipart_form = callPackage ../development/ocaml-modules/multipart_form { };
 


### PR DESCRIPTION
Seems versions have diverged from saturn_lockfree…

@vbgl I think I need some help with what is going on with the failing tests & cache directories. …Tho there is a possibility #435862 could have a fix with a version bump??

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.