### PR TITLE
nixos/byedpi: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27618,6 +27618,12 @@
     githubId = 25372613;
     name = "Woze Parrot";
   };
+  wozrer = {
+    name = "wozrer";
+    email = "wozrer@proton.me";
+    github = "wrrrzr";
+    githubId = 161970349;
+  };
   wr0belj = {
     name = "Jakub Wróbel";
     email = "wrobel.jakub@protonmail.com";

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -18,6 +18,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- [byedpi](https://github.com/hufrea/byedpi), a DPI bypass service. Available as [services.byedpi](#opt-services.byedpi.enable).
+
 - [Overseerr](https://overseerr.dev), a request management and media discovery tool for the Plex ecosystem. Available as [services.overseerr](#opt-services.overseerr.enable).
 
 - [gtklock](https://github.com/jovanlanik/gtklock), a GTK-based lockscreen for Wayland. Available as [programs.gtklock](#opt-programs.gtklock.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1094,6 +1094,7 @@
   ./services/networking/bitlbee.nix
   ./services/networking/blockbook-frontend.nix
   ./services/networking/blocky.nix
+  ./services/networking/byedpi.nix
   ./services/networking/cato-client.nix
   ./services/networking/centrifugo.nix
   ./services/networking/cgit.nix

--- a/nixos/modules/services/networking/byedpi.nix
+++ b/nixos/modules/services/networking/byedpi.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.byedpi;
+in
+{
+  options.services.byedpi = {
+    enable = lib.mkEnableOption "the ByeDPI service";
+    package = lib.mkPackageOption pkgs "byedpi" { };
+    extraArgs = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [ ];
+      example = [
+        "--split"
+        "1"
+        "--disorder"
+        "3+s"
+        "--mod-http=h,d"
+        "--auto=torst"
+        "--tlsrec"
+        "1+s"
+      ];
+      description = "Extra command line arguments.";
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    systemd.services.byedpi = {
+      description = "ByeDPI";
+      wantedBy = [ "default.target" ];
+      wants = [ "network-online.target" ];
+      after = [
+        "network-online.target"
+        "nss-lookup.target"
+      ];
+      serviceConfig = {
+        ExecStart = lib.escapeShellArgs ([ (lib.getExe cfg.package) ] ++ cfg.extraArgs);
+        NoNewPrivileges = "yes";
+        StandardOutput = "null";
+        StandardError = "journal";
+        TimeoutStopSec = "5s";
+        PrivateTmp = "true";
+        ProtectSystem = "full";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ wozrer ];
+}


### PR DESCRIPTION
Create byedpi service

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
---

Add a :+1: [reaction] to [pull requests you find important].