### PR TITLE
qpdf: disable timestamp test for now

### DIFF
--- a/pkgs/by-name/qp/qpdf/disable-timestamp-test.patch
+++ b/pkgs/by-name/qp/qpdf/disable-timestamp-test.patch
@@ -1,0 +1,31 @@
+diff --git a/libtests/qtest/qutil/qutil.out b/libtests/qtest/qutil/qutil.out
+index a5f7b108c7..08c6c2eccc 100644
+--- a/libtests/qtest/qutil/qutil.out
++++ b/libtests/qtest/qutil/qutil.out
+@@ -126,13 +126,6 @@
+ create file
+ rename over existing
+ delete file
+----- timestamp
+-D:20210209144925-05'00'
+-2021-02-09T14:49:25-05:00
+-D:20210210011925+05'30'
+-2021-02-10T01:19:25+05:30
+-D:20210209191925Z
+-2021-02-09T19:19:25Z
+ ---- is_long_long
+ done
+ ---- memory usage
+diff --git a/libtests/qutil.cc b/libtests/qutil.cc
+index 78ae82c8e3..daa9281a19 100644
+--- a/libtests/qutil.cc
++++ b/libtests/qutil.cc
+@@ -766,8 +766,6 @@
+         hex_encode_decode_test();
+         std::cout << "---- rename/delete" << std::endl;
+         rename_delete_test();
+-        std::cout << "---- timestamp" << std::endl;
+-        timestamp_test();
+         std::cout << "---- is_long_long" << std::endl;
+         is_long_long_test();
+         std::cout << "---- memory usage" << std::endl;

--- a/pkgs/by-name/qp/qpdf/package.nix
+++ b/pkgs/by-name/qp/qpdf/package.nix
@@ -64,6 +64,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
+  # Cursed system‐dependent(?!) failure with libc++ because another
+  # test in the same process sets the global locale; skip for now.
+  #
+  # See:
+  # * <https://github.com/llvm/llvm-project/issues/39399>
+  # * <https://github.com/llvm/llvm-project/issues/123309>
+  ${if stdenv.cc.libcxx != null then "patches" else null} = [
+    ./disable-timestamp-test.patch
+  ];
+
   passthru.tests = {
     pkg-config = testers.hasPkgConfigModules { package = finalAttrs.finalPackage; };
     inherit (python3.pkgs) pikepdf;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
