### PR TITLE
or-tools: enable SCIP support

### DIFF
--- a/pkgs/by-name/or/or-tools/package.nix
+++ b/pkgs/by-name/or/or-tools/package.nix
@@ -20,6 +20,9 @@
   swig,
   unzip,
   zlib,
+
+  scipopt-scip,
+  withScip ? true,
 }:
 
 let
@@ -87,8 +90,12 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
     (lib.cmakeBool "FETCH_PYTHON_DEPS" false)
     (lib.cmakeBool "USE_GLPK" true)
-    (lib.cmakeBool "USE_SCIP" false)
+    (lib.cmakeBool "USE_SCIP" withScip)
     (lib.cmakeFeature "Python3_EXECUTABLE" "${python3.pythonOnBuildForHost.interpreter}")
+  ]
+  ++ lib.optionals withScip [
+    # scip code parts require setting this unfortunately…
+    (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-Wno-error=format-security")
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     (lib.cmakeBool "CMAKE_MACOSX_RPATH" false)
@@ -137,7 +144,12 @@ stdenv.mkDerivation (finalAttrs: {
     python3.pkgs.immutabledict
     python3.pkgs.numpy
     python3.pkgs.pandas
+  ]
+  ++ lib.optionals withScip [
+    # Needed for downstream cmake consumers to not need to set SCIP_ROOT explicitly
+    scipopt-scip
   ];
+
   nativeCheckInputs = [
     python3.pkgs.matplotlib
     python3.pkgs.pandas

--- a/pkgs/by-name/sc/scipopt-scip/0001-check-fix-invalid-ctest-invocation.patch
+++ b/pkgs/by-name/sc/scipopt-scip/0001-check-fix-invalid-ctest-invocation.patch
@@ -1,0 +1,40 @@
+From 7772c64ee2face1c1099c23ecbfd20ff663cffc3 Mon Sep 17 00:00:00 2001
+From: Florian Klink <flokli@flokli.de>
+Date: Tue, 7 Oct 2025 16:19:31 +0300
+Subject: [PATCH] check: fix invalid ctest invocation
+
+ctest doesn't like `-R "-default"`. CMake 4.0 fails with the following
+error message:
+
+> CMake Error: Invalid value used with -R
+
+`-R` normally specifies the regex that needs to match. If none is
+specified, all are selected:
+
+https://cmake.org/cmake/help/latest/manual/ctest.1.html#cmdoption-ctest-R
+
+This maybe never worked, but got silently ignored until
+https://cmake.org/cmake/help/latest/policy/CMP0175.html
+
+Removing that regex should only cause *more* tests to get selected, not
+less - and the build now succeeds with it.
+---
+ check/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/check/CMakeLists.txt b/check/CMakeLists.txt
+index 0d667d5..c26b978 100644
+--- a/check/CMakeLists.txt
++++ b/check/CMakeLists.txt
+@@ -4,7 +4,7 @@ include(CTest)
+ # add a custom SCIP check target 'scip_check'
+ #
+ add_custom_target(scip_check
+-                COMMAND ${CMAKE_CTEST_COMMAND} -R "-default" -E "applications" --output-on-failure
++                COMMAND ${CMAKE_CTEST_COMMAND} -E "applications" --output-on-failure
+                 DEPENDS scip
+                 )
+ 
+-- 
+2.51.0
+

--- a/pkgs/by-name/sc/scipopt-scip/package.nix
+++ b/pkgs/by-name/sc/scipopt-scip/package.nix
@@ -51,8 +51,6 @@ stdenv.mkDerivation rec {
     mpfr # if not included, throws fatal error: mpfr.h not found
   ];
 
-  cmakeFlags = [ ];
-
   doCheck = true;
 
   meta = {

--- a/pkgs/by-name/sc/scipopt-scip/package.nix
+++ b/pkgs/by-name/sc/scipopt-scip/package.nix
@@ -29,6 +29,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-Zc1AXNpHQXXFO8jkMaJj6xYkmkQxAM8G+SiPiH9xCAw=";
   };
 
+  patches = [
+    # https://github.com/scipopt/scip/pull/169
+    ./0001-check-fix-invalid-ctest-invocation.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [

--- a/pkgs/by-name/sc/scipopt-scip/package.nix
+++ b/pkgs/by-name/sc/scipopt-scip/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  fetchzip,
   fetchFromGitHub,
   cmake,
   zlib,


### PR DESCRIPTION
This adds a new argument, withScip, defaulting to true, which will
configure or-tools with SCIP support.
    
or-tools usually is built with SCIP support, and only tested like this,
considering https://github.com/google/or-tools/pull/4745.
    
However, SCIP only was introduced to nixpkgs [March 2025](https://github.com/NixOS/nixpkgs/pull/374527), that's probably why or-tools in nixpkgs came without it so far.

I successfully built both variants on aarch64-linux and x86_64-linux.

cc @FettGoenner 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
