### PR TITLE
spidermonkey_140: init at 140.2.0

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/140.nix
+++ b/pkgs/development/interpreters/spidermonkey/140.nix
@@ -1,0 +1,4 @@
+import ./common.nix {
+  version = "140.2.0";
+  hash = "sha512-5Fl8TYOuGoT86SSP5splKvbDYVYH/IlzvZF7/b0qu87Kk3/kxinAzcifoKXIRrXi2KS0Tav3/rIB3rOC3gzMWw==";
+}

--- a/pkgs/development/interpreters/spidermonkey/common.nix
+++ b/pkgs/development/interpreters/spidermonkey/common.nix
@@ -24,6 +24,7 @@
 
   # runtime
   icu75,
+  icu77,
   nspr,
   readline,
   zlib,
@@ -65,6 +66,14 @@ stdenv.mkDerivation (finalAttrs: {
         url = "https://src.fedoraproject.org/rpms/mozjs91/raw/e3729167646775e60a3d8c602c0412e04f206baf/f/0001-Python-Build-Use-r-instead-of-rU-file-read-modes.patch";
         hash = "sha256-WgDIBidB9XNQ/+HacK7jxWnjOF8PEUt5eB0+Aubtl48=";
       })
+    ]
+    ++ lib.optionals (lib.versionAtLeast version "140") [
+      # mozjs-140.pc does not contain -DXP_UNIX on Linux
+      # https://bugzilla.mozilla.org/show_bug.cgi?id=1973994
+      (fetchpatch {
+        url = "https://src.fedoraproject.org/rpms/mozjs140/raw/49492baa47bc1d7b7d5bc738c4c81b4661302f27/f/9aa8b4b051dd539e0fbd5e08040870b3c712a846.patch";
+        hash = "sha256-SsyO5g7wlrxE7y2+VTHfmUDamofeZVqge8fv2y0ZhuU=";
+      })
     ];
 
   nativeBuildInputs = [
@@ -89,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    icu75
+    (if (lib.versionAtLeast version "140") then icu77 else icu75)
     nspr
     readline
     zlib
@@ -119,6 +128,12 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals (lib.versionAtLeast version "91") [
     "--disable-debug"
+  ]
+  ++ lib.optionals (lib.versionAtLeast version "140") [
+    # For pkgconfig file.
+    # https://bugzilla.mozilla.org/show_bug.cgi?id=1907030
+    # https://bugzilla.mozilla.org/show_bug.cgi?id=1957023
+    "--includedir=${placeholder "dev"}/include"
   ]
   ++ [
     "--disable-jemalloc"
@@ -177,6 +192,11 @@ stdenv.mkDerivation (finalAttrs: {
       configureScript=../js/src/configure
     '';
 
+  env = lib.optionalAttrs (lib.versionAtLeast version "140") {
+    # '-Wformat-security' ignored without '-Wformat'
+    NIX_CFLAGS_COMPILE = "-Wformat";
+  };
+
   # Remove unnecessary static lib
   preFixup = ''
     moveToOutput bin/js${lib.versions.major version}-config "$dev"
@@ -196,6 +216,7 @@ stdenv.mkDerivation (finalAttrs: {
       abbradar
       lostnet
       catap
+      bobby285271
     ];
     broken = stdenv.hostPlatform.isDarwin; # 91 is broken, >=115 requires SDK 13.3 (see #242666).
     platforms = platforms.unix;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6545,10 +6545,12 @@ with pkgs;
       spidermonkey_91 = callPackage ../development/interpreters/spidermonkey/91.nix { };
       spidermonkey_115 = callPackage ../development/interpreters/spidermonkey/115.nix { };
       spidermonkey_128 = callPackage ../development/interpreters/spidermonkey/128.nix { };
+      spidermonkey_140 = callPackage ../development/interpreters/spidermonkey/140.nix { };
     })
     spidermonkey_91
     spidermonkey_115
     spidermonkey_128
+    spidermonkey_140
     ;
 
   supercollider = libsForQt5.callPackage ../development/interpreters/supercollider {


### PR DESCRIPTION
This should not trigger mass rebuilds.

With 6067f89d09cd25856dea868d53f55fd2ce4838fc and 65255c5db59501bddc1f5f3187726208f382c2ba (both changes unreviewed), gjs 1.85.2 builds and passes the tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

