### PR TITLE
python313Packages.edlib: 1.3.9 -> 1.3.9post1

### DIFF
--- a/pkgs/by-name/ed/edlib/package.nix
+++ b/pkgs/by-name/ed/edlib/package.nix
@@ -5,15 +5,15 @@
   cmake,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "edlib";
-  version = "unstable-2021-08-20";
+  version = "1.3.9.post1";
 
   src = fetchFromGitHub {
     owner = "Martinsos";
     repo = "edlib";
-    rev = "f8afceb49ab0095c852e0b8b488ae2c88e566afd";
-    hash = "sha256-P/tFbvPBtA0MYCNDabW+Ypo3ltwP4S+6lRDxwAZ1JFo=";
+    tag = finalAttrs.version;
+    hash = "sha256-XejxohLVdBBzpYZ//OpqC1ActmCaZ8tunJyhOYtZmKQ=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -25,11 +25,11 @@ stdenv.mkDerivation {
     runHook postCheck
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://martinsos.github.io/edlib";
     description = "Lightweight, fast C/C++ library for sequence alignment using edit distance";
-    maintainers = with maintainers; [ bcdarwin ];
-    license = licenses.mit;
-    platforms = platforms.unix;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/development/python-modules/edlib/default.nix
+++ b/pkgs/development/python-modules/edlib/default.nix
@@ -4,14 +4,17 @@
   edlib,
   cython,
   python,
+  setuptools,
 }:
 
 buildPythonPackage {
-  inherit (edlib) pname src meta;
-  version = "1.3.9";
-  format = "setuptools";
-
-  disabled = pythonOlder "3.6";
+  inherit (edlib)
+    pname
+    src
+    version
+    meta
+    ;
+  pyproject = true;
 
   sourceRoot = "${edlib.src.name}/bindings/python";
 
@@ -19,10 +22,14 @@ buildPythonPackage {
     ln -s ${edlib.src}/edlib .
   '';
 
-  EDLIB_OMIT_README_RST = 1;
-  EDLIB_USE_CYTHON = 1;
+  env.EDLIB_OMIT_README_RST = 1;
+  env.EDLIB_USE_CYTHON = 1;
 
-  nativeBuildInputs = [ cython ];
+  build-system = [
+    setuptools
+    cython
+  ];
+
   buildInputs = [ edlib ];
 
   checkPhase = ''


### PR DESCRIPTION
edlib: unstable-2021-08-20 -> 1.3.9post1

Routine update and minor cleanup. ([changelog](https://github.com/Martinsos/edlib/compare/f8afceb49ab0095c852e0b8b488ae2c88e566afd...1.3.9.post1))

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
