### PR TITLE
ci: remove python-updates from development branches

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,6 @@ on:
       - release-*
       - staging-*
       - haskell-updates
-      - python-updates
 
 permissions: {}
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -36,7 +36,7 @@ For the purposes of CI, branches in the NixOS/nixpkgs repository are classified 
   - Pull Requests required.
   - Long-lived, no deletion, no force push.
 - **Secondary development** branches
-  - `staging-` prefix, `haskell-updates` and `python-updates`
+  - `staging-` prefix and `haskell-updates`
   - Pull Requests normally required, except when merging development branches into each other.
   - Long-lived, no deletion, no force push.
 - **Work-In-Progress** branches

--- a/ci/request-reviews/dev-branches.txt
+++ b/ci/request-reviews/dev-branches.txt
@@ -6,4 +6,3 @@ staging
 release-*
 staging-*
 haskell-updates
-python-updates

--- a/ci/supportedBranches.js
+++ b/ci/supportedBranches.js
@@ -9,7 +9,6 @@ const typeConfig = {
   staging: ['development', 'secondary'],
   'staging-next': ['development', 'secondary'],
   'haskell-updates': ['development', 'secondary'],
-  'python-updates': ['development', 'secondary'],
   nixos: ['channel'],
   nixpkgs: ['channel'],
 }


### PR DESCRIPTION
The python-updates branch is not a "development" branch in the sense of ci/README.md's classification. That's because it allows force pushes. When rewrites are possible, cherry-picking from this branch should not be allowed, because the commit references will potentially end up out of sync.

These kind of branches are now termed "Work-in-Progress" branches. Up until recently these branches didn't work well for Pull Requests targeting them, because Eval wouldn't run on them with a push event and thus, Eval in the PR couldn't succeed either. That's now [fixed](https://github.com/NixOS/nixpkgs/pull/435535), PRs towards *any* WIP branch should work correctly.

Related discussion in https://github.com/NixOS/org/issues/118.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
