### PR TITLE
curl: enable HTTP/3 support by default 

### DIFF
--- a/nixos/tests/haproxy.nix
+++ b/nixos/tests/haproxy.nix
@@ -68,7 +68,7 @@
     client =
       { pkgs, ... }:
       {
-        environment.systemPackages = [ pkgs.curlHTTP3 ];
+        environment.systemPackages = [ pkgs.curl ];
       };
   };
   testScript = ''

--- a/nixos/tests/nginx-http3.nix
+++ b/nixos/tests/nginx-http3.nix
@@ -66,7 +66,7 @@ builtins.listToAttrs (
           client =
             { pkgs, ... }:
             {
-              environment.systemPackages = [ pkgs.curlHTTP3 ];
+              environment.systemPackages = [ pkgs.curl ];
               networking = {
                 interfaces.eth1 = {
                   ipv4.addresses = [

--- a/nixos/tests/rustls-libssl.nix
+++ b/nixos/tests/rustls-libssl.nix
@@ -64,7 +64,7 @@ in
     client =
       { pkgs, ... }:
       {
-        environment.systemPackages = [ pkgs.curlHTTP3 ];
+        environment.systemPackages = [ pkgs.curl ];
         networking = {
           interfaces.eth1 = {
             ipv4.addresses = [

--- a/nixos/tests/sing-box.nix
+++ b/nixos/tests/sing-box.nix
@@ -249,7 +249,7 @@ in
         ];
 
         environment.systemPackages = [
-          pkgs.curlHTTP3
+          pkgs.curl
           pkgs.iproute2
         ];
 
@@ -308,7 +308,7 @@ in
         ];
 
         environment.systemPackages = [
-          pkgs.curlHTTP3
+          pkgs.curl
           pkgs.iproute2
         ];
 
@@ -369,7 +369,7 @@ in
           (builtins.readFile ./common/acme/server/ca.cert.pem)
         ];
 
-        environment.systemPackages = [ pkgs.curlHTTP3 ];
+        environment.systemPackages = [ pkgs.curl ];
 
         systemd.services.sing-box.serviceConfig.ExecStartPost = [
           "+${tproxyPost}/bin/exe"

--- a/nixos/tests/web-servers/h2o/basic.nix
+++ b/nixos/tests/web-servers/h2o/basic.nix
@@ -44,7 +44,7 @@ in
       { pkgs, ... }:
       {
         environment.systemPackages = [
-          pkgs.curlHTTP3
+          pkgs.curl
         ];
 
         services.h2o = {

--- a/pkgs/by-name/cu/curlMinimal/package.nix
+++ b/pkgs/by-name/cu/curlMinimal/package.nix
@@ -34,7 +34,6 @@
   http3Support ? false,
   nghttp3,
   ngtcp2,
-  quictls,
   websocketSupport ? false,
   idnSupport ? false,
   libidn2,
@@ -85,10 +84,6 @@ assert
     ]) > 1
   );
 
-let
-  openssl' = if http3Support then quictls else openssl;
-in
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "curl";
   version = "8.14.1";
@@ -137,7 +132,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [
     # See https://github.com/curl/curl/pull/16928
-    openssl'
+    openssl
   ];
 
   # Zlib and OpenSSL must be propagated because `libcurl.la' contains
@@ -156,7 +151,7 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optional idnSupport libidn2
     ++ lib.optional ldapSupport openldap
-    ++ lib.optional opensslSupport openssl'
+    ++ lib.optional opensslSupport openssl
     ++ lib.optional pslSupport libpsl
     ++ lib.optional rtmpSupport rtmpdump
     ++ lib.optional scpSupport libssh2
@@ -190,7 +185,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.withFeatureAs brotliSupport "brotli" (lib.getDev brotli))
     (lib.withFeatureAs gnutlsSupport "gnutls" (lib.getDev gnutls))
     (lib.withFeatureAs idnSupport "libidn2" (lib.getDev libidn2))
-    (lib.withFeatureAs opensslSupport "openssl" (lib.getDev openssl'))
+    (lib.withFeatureAs opensslSupport "openssl" (lib.getDev openssl))
     (lib.withFeatureAs scpSupport "libssh2" (lib.getDev libssh2))
     (lib.withFeatureAs wolfsslSupport "wolfssl" (lib.getDev wolfssl))
   ]
@@ -255,8 +250,7 @@ stdenv.mkDerivation (finalAttrs: {
       useThisCurl = attr: attr.override { curl = finalAttrs.finalPackage; };
     in
     {
-      inherit opensslSupport;
-      openssl = openssl';
+      inherit opensslSupport openssl;
       tests = {
         withCheck = finalAttrs.finalPackage.overrideAttrs (_: {
           doCheck = true;

--- a/pkgs/by-name/ht/https-dns-proxy/package.nix
+++ b/pkgs/by-name/ht/https-dns-proxy/package.nix
@@ -5,13 +5,10 @@
   cmake,
   gtest,
   c-ares,
-  curlHTTP3,
+  curl,
   libev,
 }:
 
-let
-  curl' = curlHTTP3;
-in
 stdenv.mkDerivation rec {
   pname = "https-dns-proxy";
   # there are no stable releases (yet?)
@@ -38,7 +35,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     c-ares
-    curl'
+    curl
     libev
   ];
 

--- a/pkgs/by-name/ng/nghttp2/package.nix
+++ b/pkgs/by-name/ng/nghttp2/package.nix
@@ -18,7 +18,6 @@
   enableHttp3 ? false,
   ngtcp2,
   nghttp3,
-  quictls,
   enableJemalloc ? false,
   jemalloc,
   enablePython ? false,
@@ -68,15 +67,14 @@ stdenv.mkDerivation rec {
       c-aresMinimal
       libev
       zlib
+      openssl
     ]
-    ++ lib.optionals (enableApp && !enableHttp3) [ openssl ]
     ++ lib.optionals (enableGetAssets) [ libxml2 ]
     ++ lib.optionals (enableHpack) [ jansson ]
     ++ lib.optionals (enableJemalloc) [ jemalloc ]
     ++ lib.optionals (enableHttp3) [
       ngtcp2
       nghttp3
-      quictls
     ]
     ++ lib.optionals (enablePython) [ python3 ];
 

--- a/pkgs/by-name/ng/nghttp2/package.nix
+++ b/pkgs/by-name/ng/nghttp2/package.nix
@@ -46,11 +46,11 @@ assert enableJemalloc -> enableApp;
 
 stdenv.mkDerivation rec {
   pname = "nghttp2";
-  version = "1.66.0";
+  version = "1.67.1";
 
   src = fetchurl {
     url = "https://github.com/nghttp2/nghttp2/releases/download/v${version}/nghttp2-${version}.tar.bz2";
-    hash = "sha256-HUhK03NU35/KuXCBTpOl3KkaUyVug/T1jdcxGcYyEBc=";
+    hash = "sha256-37cg1CQ6eVBYn6JjI3i+te6a1ELpS3lLO44soowdfio=";
   };
 
   outputs = [

--- a/pkgs/by-name/ng/nghttp3/package.nix
+++ b/pkgs/by-name/ng/nghttp3/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
+  fetchurl,
   cmake,
   curlHTTP3,
 }:
@@ -10,12 +10,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "nghttp3";
   version = "1.11.0";
 
-  src = fetchFromGitHub {
-    owner = "ngtcp2";
-    repo = "nghttp3";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-8WQfXzzF3K0IJNectrE1amQ6Njq4pZslrcVun6Uhi6E=";
-    fetchSubmodules = true;
+  src = fetchurl {
+    url = "https://github.com/ngtcp2/nghttp3/releases/download/v${finalAttrs.version}/nghttp3-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-AAKlyoVtsFmqbcac9zL7sA2aHnPteISPXUjyYh8gyoo=";
   };
 
   outputs = [
@@ -38,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://github.com/ngtcp2/nghttp3";
-    changelog = "https://github.com/ngtcp2/nghttp3/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/ngtcp2/nghttp3/releases/tag/v${finalAttrs.version}";
     description = "Implementation of HTTP/3 mapping over QUIC and QPACK in C";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/ng/nghttp3/package.nix
+++ b/pkgs/by-name/ng/nghttp3/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   cmake,
-  curlHTTP3,
+  curl,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   passthru.tests = {
-    inherit curlHTTP3;
+    inherit curl;
   };
 
   meta = {

--- a/pkgs/development/libraries/ngtcp2/default.nix
+++ b/pkgs/development/libraries/ngtcp2/default.nix
@@ -9,7 +9,7 @@
   openssl,
   withJemalloc ? false,
   jemalloc,
-  curlHTTP3,
+  curl,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   passthru.tests = {
-    inherit curlHTTP3;
+    inherit curl;
   };
 
   meta = {

--- a/pkgs/development/libraries/ngtcp2/default.nix
+++ b/pkgs/development/libraries/ngtcp2/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
+  fetchurl,
   cmake,
   brotli,
   libev,
@@ -14,15 +14,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ngtcp2";
-  version = "1.14.0";
+  version = "1.15.1";
 
-  src = fetchFromGitHub {
-    owner = "ngtcp2";
-    repo = "ngtcp2";
-    # must match version usage in meta.changelog
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-5Pmk752i/lgO/os2SegevGN+MKaVuQii2HrVWaR15Gg=";
-    fetchSubmodules = true;
+  src = fetchurl {
+    url = "https://github.com/ngtcp2/ngtcp2/releases/download/v${finalAttrs.version}/ngtcp2-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-Bbf6cvldAd3fvDVuHL89VPx1h1wvY2CGW5gIsDNM75c=";
   };
 
   outputs = [

--- a/pkgs/development/libraries/ngtcp2/default.nix
+++ b/pkgs/development/libraries/ngtcp2/default.nix
@@ -6,7 +6,7 @@
   brotli,
   libev,
   nghttp3,
-  quictls,
+  openssl,
   withJemalloc ? false,
   jemalloc,
   curlHTTP3,
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     brotli
     libev
     nghttp3
-    quictls
+    openssl
   ]
   ++ lib.optional withJemalloc jemalloc;
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -694,6 +694,7 @@ mapAliases {
   cudaPackages_12_4 = throw "CUDA 12.4 has been removed from Nixpkgs, as it is unmaintained upstream and depends on unsupported compilers"; # Added 2025-08-08
   cudaPackages_12_5 = throw "CUDA 12.5 has been removed from Nixpkgs, as it is unmaintained upstream and depends on unsupported compilers"; # Added 2025-08-08
   cups-kyodialog3 = cups-kyodialog; # Added 2022-11-12
+  curlHTTP3 = lib.warnOnInstantiate "'curlHTTP3' has been removed, as 'curl' now has HTTP/3 support enabled by default" curl; # Added 2025-08-22
   cutemarked-ng = throw "'cutemarked-ng' has been removed due to lack of maintenance upstream. Consider using 'kdePackages.ghostwriter' instead"; # Added 2024-12-27
   cvs_fast_export = throw "'cvs_fast_export' has been renamed to/replaced by 'cvs-fast-export'"; # Converted to throw 2024-10-17
   cyber = throw "cyber has been removed, as it does not build with supported Zig versions"; # Added 2025-08-09

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2652,6 +2652,7 @@ with pkgs;
       idnSupport = true;
       pslSupport = true;
       zstdSupport = true;
+      http3Support = true;
     }
     // lib.optionalAttrs (!stdenv.hostPlatform.isStatic) {
       brotliSupport = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2643,10 +2643,6 @@ with pkgs;
     websocketSupport = true;
   };
 
-  curlHTTP3 = curl.override {
-    http3Support = true;
-  };
-
   curl = curlMinimal.override (
     {
       idnSupport = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
See https://curl.se/docs/http3.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
