### PR TITLE
actions/checkout: update input descriptions

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -4,9 +4,9 @@ description: 'Checkout into trusted / untrusted / pinned folders consistently.'
 
 inputs:
   merged-as-untrusted-at:
-    description: "Whether and which SHA to checkout for the merge commit in the ./untrusted folder."
+    description: "Whether and which SHA to checkout for the merge commit in the ./nixpkgs/untrusted folder."
   target-as-trusted-at:
-    description: "Whether and which SHA to checkout for the target commit in the ./trusted folder."
+    description: "Whether and which SHA to checkout for the target commit in the ./nixpkgs/trusted folder."
 
 runs:
   using: composite


### PR DESCRIPTION
In https://github.com/NixOS/nixpkgs/pull/435806 the checked-out worktrees moved into a `nixpkgs` directory. Update the input descriptions to reflect this.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
