### PR TITLE
python3Packages.lsp-tree-sitter: 0.0.17 -> 0.0.18, unbreak

### DIFF
--- a/pkgs/development/python-modules/lsp-tree-sitter/default.nix
+++ b/pkgs/development/python-modules/lsp-tree-sitter/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "lsp-tree-sitter";
-  version = "0.0.17";
+  version = "0.0.18";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "neomutt";
     repo = "lsp-tree-sitter";
     tag = version;
-    hash = "sha256-4DQzHdii2YS/Xg6AdT/kXC/8B88ZQaLgUf2oWoOthV8=";
+    hash = "sha256-Hjl3EASaOWmLZpBxmyelSUTy7jJEIEo77IIQh5DHIbg=";
   };
 
   build-system = [
@@ -40,12 +40,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "lsp_tree_sitter" ];
 
-  meta = with lib; {
+  meta = {
     description = "Library to create language servers";
     homepage = "https://github.com/neomutt/lsp-tree-sitter";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ doronbehar ];
-    # https://github.com/neomutt/lsp-tree-sitter/issues/4
-    broken = true;
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ doronbehar ];
   };
 }


### PR DESCRIPTION
Release notes: https://github.com/neomutt/lsp-tree-sitter/releases/tag/0.0.18

Closes https://github.com/NixOS/nixpkgs/issues/425798
~~Depends on https://github.com/NixOS/nixpkgs/pull/431280~~
~~Depends on https://github.com/NixOS/nixpkgs/pull/437306~~

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
