### PR TITLE
klee: 3.1 -> 3.1-unstable-2025-07-11, bump to LLVM 18

### DIFF
--- a/pkgs/applications/science/logic/klee/default.nix
+++ b/pkgs/applications/science/logic/klee/default.nix
@@ -37,13 +37,6 @@
   extraKleeuClibcConfig ? { },
 }:
 
-# Klee supports these LLVM versions.
-let
-  llvmVersion = llvmPackages.llvm.version;
-  inherit (lib.strings) versionAtLeast versionOlder;
-in
-assert versionAtLeast llvmVersion "11" && versionOlder llvmVersion "17";
-
 let
   # The chosen version of klee-uclibc.
   chosenKleeuClibc =
@@ -122,6 +115,105 @@ llvmPackages.stdenv.mkDerivation rec {
 
   env.FILECHECK_OPTS = "--dump-input-filter=all";
 
+  env.LIT_XFAIL = lib.concatStringsSep ";" [
+    "KLEE :: ArrayOpt/test_expr_arbitrary.c"
+    "KLEE :: CXX/SimpleVirtual.cpp"
+    "KLEE :: CXX/StaticConstructor.cpp"
+    "KLEE :: CXX/StaticDestructor.cpp"
+    "KLEE :: Concrete/ConstantExpr.ll"
+    "KLEE :: Concrete/OverlappingPhiNodes.ll"
+    "KLEE :: Concrete/UnorderedPhiNodes.ll"
+    "KLEE :: DeterministicAllocation/nullpage-read.c"
+    "KLEE :: DeterministicAllocation/nullpage-write.c"
+    "KLEE :: DeterministicAllocation/use-after-free-loh.c"
+    "KLEE :: DeterministicAllocation/use-after-free.c"
+    "KLEE :: Dogfood/ImmutableSet.cpp"
+    "KLEE :: Feature/Atomic.c"
+    "KLEE :: Feature/DivCheck.c"
+    "KLEE :: Feature/ExtCall.c"
+    "KLEE :: Feature/ExtCallWarnings.c"
+    "KLEE :: Feature/FunctionAlias.c"
+    "KLEE :: Feature/FunctionAliasExit.c"
+    "KLEE :: Feature/LargeArrayBecomesSym.c"
+    "KLEE :: Feature/LowerSwitch.c"
+    "KLEE :: Feature/MakeSymbolicName.c"
+    "KLEE :: Feature/NoExternalCallsAllowed.c"
+    "KLEE :: Feature/Optimize.c"
+    "KLEE :: Feature/OvershiftCheck.c"
+    "KLEE :: Feature/ReadStringAtAddress.c"
+    "KLEE :: Feature/SeedConcretizeExternalCall.c"
+    "KLEE :: Feature/ShiftCheck.c"
+    "KLEE :: Feature/consecutive_divide_by_zero.c"
+    "KLEE :: Feature/srem.c"
+    "KLEE :: InlineAsm/RaiseAsm.c"
+    "KLEE :: InlineAsm/asm_lifting.ll"
+    "KLEE :: Intrinsics/IntrinsicTrap.ll"
+    "KLEE :: Intrinsics/IsConstant.ll"
+    "KLEE :: Intrinsics/Missing.ll"
+    "KLEE :: Intrinsics/Overflow.ll"
+    "KLEE :: Intrinsics/OverflowMul.ll"
+    "KLEE :: Intrinsics/Saturating.ll"
+    "KLEE :: Intrinsics/noalias-scope-decl.ll"
+    "KLEE :: Intrinsics/objectsize.ll"
+    "KLEE :: Replay/klee-replay/KleeZesti.c"
+    "KLEE :: Replay/libkleeruntest/replay_posix_runtime.c"
+    "KLEE :: Runtime/FreeStanding/memcpy_chk_err.c"
+    "KLEE :: Runtime/POSIX/CanonicalizeFileName.c"
+    "KLEE :: Runtime/POSIX/DirConsistency.c"
+    "KLEE :: Runtime/POSIX/DirSeek.c"
+    "KLEE :: Runtime/POSIX/Envp.c"
+    "KLEE :: Runtime/POSIX/FDNumbers.c"
+    "KLEE :: Runtime/POSIX/FD_Fail.c"
+    "KLEE :: Runtime/POSIX/FD_Fail2.c"
+    "KLEE :: Runtime/POSIX/Fcntl.c"
+    "KLEE :: Runtime/POSIX/FilePerm.c"
+    "KLEE :: Runtime/POSIX/FreeArgv.c"
+    "KLEE :: Runtime/POSIX/Futimesat.c"
+    "KLEE :: Runtime/POSIX/Getenv.c"
+    "KLEE :: Runtime/POSIX/Ioctl.c"
+    "KLEE :: Runtime/POSIX/Isatty.c"
+    "KLEE :: Runtime/POSIX/MixedConcreteSymbolic.c"
+    "KLEE :: Runtime/POSIX/Openat.c"
+    "KLEE :: Runtime/POSIX/PrgName.c"
+    "KLEE :: Runtime/POSIX/Read1.c"
+    "KLEE :: Runtime/POSIX/Replay.c"
+    "KLEE :: Runtime/POSIX/SeedAndFail.c"
+    "KLEE :: Runtime/POSIX/Stdin.c"
+    "KLEE :: Runtime/POSIX/SymFileConsistency.c"
+    "KLEE :: Runtime/POSIX/TestMain.c"
+    "KLEE :: Runtime/POSIX/Usage.c"
+    "KLEE :: Runtime/POSIX/Write1.c"
+    "KLEE :: Runtime/POSIX/Write2.c"
+    "KLEE :: Runtime/POSIX/_exit.c"
+    "KLEE :: Runtime/Uclibc/2007-10-08-optimization-calls-wrong-libc-functions.c"
+    "KLEE :: Runtime/klee-libc/mempcpy.c"
+    "KLEE :: Solver/Z3ConstantArray.c"
+    "KLEE :: UBSan/ubsan_alignment-type-mismatch.c"
+    "KLEE :: UBSan/ubsan_array_bounds.c"
+    "KLEE :: UBSan/ubsan_pointer_overflow-pointer_arithmetic.c"
+    "KLEE :: UBSan/ubsan_signed_integer_overflow.c"
+    "KLEE :: UBSan/ubsan_unsigned_integer_overflow.c"
+    "KLEE :: UBSan/ubsan_unsigned_shift_base.c"
+    "KLEE :: UBSan/ubsan_vla_bound.c"
+    "KLEE :: VarArgs/FunctionAliasVarArg.c"
+    "KLEE :: VarArgs/VarArg.c"
+    "KLEE :: VarArgs/VarArgAlignment.c"
+    "KLEE :: VarArgs/VarArgByVal.c"
+    "KLEE :: VarArgs/VarArgByValReported.c"
+    "KLEE :: VarArgs/VarArgLongDouble.c"
+    "KLEE :: VectorInstructions/floating_point_ops_constant.c"
+    "KLEE :: VectorInstructions/integer_ops_constant.c"
+    "KLEE :: VectorInstructions/integer_ops_signed_symbolic.c"
+    "KLEE :: VectorInstructions/integer_ops_unsigned_symbolic.c"
+    "KLEE :: VectorInstructions/memset.c"
+    "KLEE :: VectorInstructions/oob-write.c"
+    "KLEE :: VectorInstructions/shuffle_element.c"
+    "KLEE :: klee-stats/KleeStatsTermClasses.c"
+    "KLEE :: regression/2008-03-11-free-of-malloc-zero.c"
+    "KLEE :: regression/2014-07-04-unflushed-error-report.c"
+    "KLEE :: regression/2016-11-24-bitcast-weak-alias.c"
+  ];
+
   prePatch = ''
     patchShebangs --build .
   '';
@@ -142,6 +234,8 @@ llvmPackages.stdenv.mkDerivation rec {
     # Let the user access the chosen uClibc outside the derivation.
     uclibc = chosenKleeuClibc;
   };
+
+  __structuredAttrs = true;
 
   meta = with lib; {
     mainProgram = "klee";
@@ -169,5 +263,19 @@ llvmPackages.stdenv.mkDerivation rec {
     license = licenses.ncsa;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ numinit ];
+    # Upstream is still working on support for LLVM ≥ 16; see:
+    #
+    # * <https://github.com/klee/klee/pull/1664>
+    # * <https://github.com/klee/klee/pull/1745>
+    # * <https://github.com/klee/klee/pull/1751>
+    # * <https://github.com/klee/klee/issues/1754>
+    #
+    # The package builds with LLVM 18 but 23% of the tests unexpectedly
+    # fail due to missing functionality for newer LLVM versions. We
+    # mark them as expected failures above to allow the package to
+    # build for those who want to experiment with KLEE, but mark it
+    # broken to avoid giving the impression that this is the expected
+    # user experience and level of support.
+    broken = true;
   };
 }

--- a/pkgs/applications/science/logic/klee/default.nix
+++ b/pkgs/applications/science/logic/klee/default.nix
@@ -111,6 +111,7 @@ llvmPackages.stdenv.mkDerivation rec {
       "-DENABLE_POSIX_RUNTIME=${onOff true}"
       "-DENABLE_UNIT_TESTS=${onOff true}"
       "-DENABLE_SYSTEM_TESTS=${onOff true}"
+      "-DLIT_ARGS=--verbose"
       "-DGTEST_SRC_DIR=${gtest.src}"
       "-DGTEST_INCLUDE_DIR=${gtest.src}/googletest/include"
       "-Wno-dev"
@@ -118,6 +119,8 @@ llvmPackages.stdenv.mkDerivation rec {
 
   # Silence various warnings during the compilation of fortified bitcode.
   env.NIX_CFLAGS_COMPILE = toString [ "-Wno-macro-redefined" ];
+
+  env.FILECHECK_OPTS = "--dump-input-filter=all";
 
   prePatch = ''
     patchShebangs --build .

--- a/pkgs/applications/science/logic/klee/default.nix
+++ b/pkgs/applications/science/logic/klee/default.nix
@@ -21,7 +21,7 @@
   includeDebugInfo ? true,
 
   # Enable KLEE asserts. Defaults to true, since LLVM is built with them.
-  asserts ? true,
+  asserts ? false,
 
   # Build the KLEE runtime in debug mode. Defaults to true, as this improves
   # stack traces of the software under test.

--- a/pkgs/applications/science/logic/klee/default.nix
+++ b/pkgs/applications/science/logic/klee/default.nix
@@ -60,13 +60,13 @@ let
 in
 llvmPackages.stdenv.mkDerivation rec {
   pname = "klee";
-  version = "3.1";
+  version = "3.1-unstable-2025-07-11";
 
   src = fetchFromGitHub {
     owner = "klee";
     repo = "klee";
-    rev = "v${version}";
-    hash = "sha256-5js1N8qVF0lCkahSU3ojT7+p/a9IaUpPWhIyFHEzqto=";
+    rev = "1c9fbc1013a6000b39615cc9a5aba83e43a4bf75";
+    hash = "sha256-D93T0mBBrIhQTS42ScUHPrMoqCI55Y6Yp7snLmlriQM=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12212,7 +12212,7 @@ with pkgs;
   klayout = libsForQt5.callPackage ../applications/misc/klayout { };
 
   klee = callPackage ../applications/science/logic/klee {
-    llvmPackages = llvmPackages_13;
+    llvmPackages = llvmPackages_18;
   };
 
   kmplayer = libsForQt5.callPackage ../applications/video/kmplayer { };


### PR DESCRIPTION
@numinit KLEE officially supports up to LLVM 16, but all versions below 18 are planned to be removed for 25.11. How would you like to handle this one – bumping past the supported version, marking it broken for now in the hopes that there’ll be upstream progress on supporting newer versions, or dropping?

This PR implements the first option. There has been upstream work for supporting newer versions of LLVM (https://github.com/klee/klee/pull/1664, https://github.com/klee/klee/pull/1745, https://github.com/klee/klee/pull/1751), and it does build with LLVM 18 and 19, but it’s clearly a work‐in‐progress (https://github.com/klee/klee/issues/1754) and they don’t have CI for it. With LLVM 18, 330 (77%) of the tests have the expected result, but 96 (23%) have unexpected failures and we need to disable them to make the build go through. (A few more of them fail with LLVM 19, so it could be worse!)

The failures mostly relate to unimplemented intrinsics; I tested KLEE on an extremely basic program and it seemed to worked fine, but I imagine more complicated tests will run into issues. I don’t have enough KLEE experience to judge whether it’s still useful in this state, or whether it’d be more honest just to mark it `broken`. Hopefully you’re in a better position to figure that out than I am.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
