### PR TITLE
{tango-idl, tango-cpp, tango-database, jive}: init

### DIFF
--- a/pkgs/by-name/ji/jive/package.nix
+++ b/pkgs/by-name/ji/jive/package.nix
@@ -1,0 +1,40 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  makeWrapper,
+  jre,
+}:
+stdenv.mkDerivation rec {
+  pname = "jive";
+  version = "7.45";
+
+  src = fetchurl {
+    url = "https://repo.maven.apache.org/maven2/org/tango-controls/Jive/${version}/Jive-${version}-jar-with-dependencies.jar";
+    hash = "sha256-a/I4jMlTVYWN9zNBQnWbvT2MBHItexnwPly1XyOeR8U=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/java
+    cp $src $out/share/java/jive.jar
+    makeWrapper ${jre}/bin/java $out/bin/jive \
+      --add-flags "-classpath $out/share/java/jive.jar jive3.MainPanel"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Standalone JAVA application designed to browse and edit the static TANGO database";
+    homepage = "https://gitlab.com/tango-controls/jive";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.gilice ];
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+  };
+}

--- a/pkgs/by-name/ta/tango-cpp/package.nix
+++ b/pkgs/by-name/ta/tango-cpp/package.nix
@@ -1,0 +1,63 @@
+{
+  stdenv,
+  lib,
+  cmake,
+  cppzmq,
+  curl,
+  fetchFromGitLab,
+  fetchpatch,
+  libjpeg,
+  omniorb,
+  openssl,
+  opentelemetry-cpp,
+  protobuf,
+  tango-idl,
+  zeromq,
+}:
+stdenv.mkDerivation rec {
+  pname = "tango-cpp";
+  version = "10.1.1";
+
+  src = fetchFromGitLab {
+    owner = "tango-controls";
+    repo = "cppTango";
+    tag = version;
+    fetchSubmodules = true;
+    hash = "sha256-Edv7ZGnESjpuwt0Hentl0qgV2PfBgXWED7v9pUvTW0o=";
+  };
+
+  patches = [
+    # corresponds to PR https://gitlab.com/tango-controls/cppTango/-/merge_requests/1525
+    (fetchpatch {
+      url = "https://gitlab.com/tango-controls/cppTango/-/commit/66bd2d9deb79fb557eb2314376f9559e7476d3a1.patch";
+      hash = "sha256-ZUcBS4apVfXmXKnpGOQJ9DF8t79qJ2yqKXwaseiOC6U=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    cppzmq
+    tango-idl
+  ];
+
+  buildInputs = [
+    curl
+    libjpeg
+    omniorb
+    openssl
+    (opentelemetry-cpp.override {
+      enableGrpc = true;
+      enableHttp = true;
+    })
+    protobuf
+    zeromq
+  ];
+
+  meta = {
+    description = "Tango Distributed Control System - C++ library";
+    homepage = "https://gitlab.com/tango-controls/cppTango";
+    license = lib.licenses.lgpl3;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.gilice ];
+  };
+}

--- a/pkgs/by-name/ta/tango-database/package.nix
+++ b/pkgs/by-name/ta/tango-database/package.nix
@@ -1,0 +1,67 @@
+{
+  stdenv,
+  lib,
+  cmake,
+  cppzmq,
+  fetchFromGitLab,
+  libjpeg,
+  mariadb,
+  mariadb-connector-c,
+  omniorb,
+  opentelemetry-cpp,
+  protobuf,
+  tango-cpp,
+}:
+
+# NOTE: You need to manually set up the database structure to run Tango successfully.
+# See $out/share/tango/db/create_db.sh
+stdenv.mkDerivation rec {
+  pname = "tango-database";
+  version = "5.25";
+
+  src = fetchFromGitLab {
+    owner = "tango-controls";
+    repo = "TangoDatabase";
+    tag = "Database-Release-${version}";
+    fetchSubmodules = true;
+    hash = "sha256-hu2TIPxXyUtLK3bHFHuBYho23TGLkmsHfxEabsjsvmE=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    cppzmq
+    libjpeg
+    mariadb.client
+    mariadb-connector-c.dev
+    omniorb
+    (opentelemetry-cpp.override {
+      enableGrpc = true;
+      enableHttp = true;
+    })
+    protobuf
+    tango-cpp
+  ];
+
+  # their FindMySQL.cmake fails to find these libraries,
+  # maybe because mariadb-connector-c puts its libraries into $out/lib/mariadb, not $out/lib?
+  cmakeFlags = [
+    "-DMySQL_INCLUDE_DIR=${mariadb-connector-c.dev}/include/mysql"
+    "-DMySQL_LIBRARY_DEBUG=${mariadb-connector-c}/lib/mariadb/libmariadb.so"
+    "-DMySQL_LIBRARY_RELEASE=${mariadb-connector-c}/lib/mariadb/libmariadb.so"
+  ];
+
+  postFixup = ''
+    patchelf --add-rpath ${mariadb-connector-c}/lib/mariadb $out/bin/Databaseds
+  '';
+
+  meta = {
+    description = "Tango distributed control system - database server";
+    homepage = "https://gitlab.com/tango-controls/TangoDatabase";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.gilice ];
+  };
+}

--- a/pkgs/by-name/ta/tango-idl/package.nix
+++ b/pkgs/by-name/ta/tango-idl/package.nix
@@ -1,0 +1,36 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  fetchpatch,
+  cmake,
+}:
+stdenv.mkDerivation rec {
+  pname = "tango-idl";
+  version = "6.0.4";
+
+  src = fetchFromGitLab {
+    owner = "tango-controls";
+    repo = "tango-idl";
+    tag = version;
+    hash = "sha256-etXjey4X5mNCHLtu3TyQv0S9uP4BSfZVNN8YDc/fp68=";
+  };
+
+  patches = [
+    # corresponds to PR https://gitlab.com/tango-controls/tango-idl/-/merge_requests/31/
+    (fetchpatch {
+      url = "https://gitlab.com/tango-controls/tango-idl/-/commit/8fd75a4079bf96544697f7783c2de0027d030b8e.patch";
+      hash = "sha256-2NMfHakoHzxnYqxVDvH2LnEtLe8S8K88prT9AAs95MA=";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Tango CORBA IDL file";
+    homepage = "https://gitlab.com/tango-controls/tango-idl";
+    license = lib.licenses.lgpl3;
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.gilice ];
+  };
+}


### PR DESCRIPTION
- Tango is an open source distributed [SCADA](https://en.wikipedia.org/wiki/SCADA) control system.
Homepage: https://www.tango-controls.org/

- Jive is a GUI browser for a running Tango server.
I've tried to package it from source, but ran into issues with Maven dependency resolution such as
https://gitlab.com/tango-controls/jive/-/issues/79 and https://gitlab.com/tango-controls/jive/-/issues/75.
I am not sure if it is possible to compile from source right now *at all*, with the conflicting dependencies.

Supersedes #183077 and #247936 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
