### PR TITLE
fetchNextcloudApp: add sha512

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -391,9 +391,10 @@ in
           inherit (pkgs.nextcloud31Packages.apps) mail calendar contacts;
           phonetrack = pkgs.fetchNextcloudApp {
             name = "phonetrack";
-            sha256 = "0qf366vbahyl27p9mshfma1as4nvql6w75zy2zk5xwwbp343vsbc";
-            url = "https://gitlab.com/eneiluj/phonetrack-oc/-/wikis/uploads/931aaaf8dca24bf31a7e169a83c17235/phonetrack-0.6.9.tar.gz";
-            version = "0.6.9";
+            license = "agpl3Plus";
+            sha512 = "f67902d1b48def9a244383a39d7bec95bb4215054963a9751f99dae9bd2f2740c02d2ef97b3b76d69a36fa95f8a9374dd049440b195f4dad2f0c4bca645de228";
+            url = "https://github.com/julien-nc/phonetrack/releases/download/v0.8.2/phonetrack-0.8.2.tar.gz";
+            version = "0.8.2";
           };
         }
       '';

--- a/pkgs/build-support/fetchnextcloudapp/default.nix
+++ b/pkgs/build-support/fetchnextcloudapp/default.nix
@@ -9,6 +9,7 @@
   url,
   hash ? "",
   sha256 ? "",
+  sha512 ? "",
   appName ? null,
   appVersion ? null,
   license,
@@ -23,7 +24,12 @@ applyPatches (
   {
     inherit patches;
     src = (if unpack then fetchzip else fetchurl) {
-      inherit url hash sha256;
+      inherit
+        url
+        hash
+        sha256
+        sha512
+        ;
       meta = {
         license = lib.licenses.${license};
         longDescription = description;
@@ -42,6 +48,7 @@ applyPatches (
         exit 1
       fi
     '';
+    # Optionally set name if appName and appVersion are provided
   }
   // lib.optionalAttrs (appName != null && appVersion != null) {
     name = "nextcloud-app-${appName}-${appVersion}";

--- a/pkgs/build-support/fetchnextcloudapp/default.nix
+++ b/pkgs/build-support/fetchnextcloudapp/default.nix
@@ -48,7 +48,6 @@ applyPatches (
         exit 1
       fi
     '';
-    # Optionally set name if appName and appVersion are provided
   }
   // lib.optionalAttrs (appName != null && appVersion != null) {
     name = "nextcloud-app-${appName}-${appVersion}";

--- a/pkgs/build-support/fetchnextcloudapp/default.nix
+++ b/pkgs/build-support/fetchnextcloudapp/default.nix
@@ -6,6 +6,8 @@
   ...
 }:
 {
+  name ?
+    if appName == null || appVersion == null then null else "nextcloud-app-${appName}-${appVersion}",
   url,
   hash ? "",
   sha256 ? "",
@@ -15,41 +17,34 @@
   license,
   patches ? [ ],
   description ? null,
+  longDescription ? description,
   homepage ? null,
   maintainers ? [ ],
   teams ? [ ],
   unpack ? false, # whether to use fetchzip rather than fetchurl
 }:
-applyPatches (
-  {
-    inherit patches;
-    src = (if unpack then fetchzip else fetchurl) {
-      inherit
-        url
-        hash
-        sha256
-        sha512
-        ;
-      meta = {
-        license = lib.licenses.${license};
-        longDescription = description;
-        inherit homepage maintainers teams;
-      }
-      // lib.optionalAttrs (description != null) {
-        longDescription = description;
-      }
-      // lib.optionalAttrs (homepage != null) {
-        inherit homepage;
-      };
+applyPatches {
+  ${if name == null then null else "name"} = name;
+  inherit patches;
+
+  src = (if unpack then fetchzip else fetchurl) {
+    inherit url;
+    ${if hash == "" then null else "hash"} = hash;
+    ${if sha256 == "" then null else "sha256"} = sha256;
+    ${if sha512 == "" then null else "sha512"} = sha512;
+
+    meta = {
+      license = lib.licenses.${license};
+      ${if description == null then null else "description"} = description;
+      ${if longDescription == null then null else "longDescription"} = longDescription;
+      ${if homepage == null then null else "homepage"} = homepage;
+      inherit maintainers teams;
     };
-    prePatch = ''
-      if [ ! -f ./appinfo/info.xml ]; then
-        echo "appinfo/info.xml doesn't exist in $out, aborting!"
-        exit 1
-      fi
-    '';
-  }
-  // lib.optionalAttrs (appName != null && appVersion != null) {
-    name = "nextcloud-app-${appName}-${appVersion}";
-  }
-)
+  };
+  prePatch = ''
+    if [ ! -f ./appinfo/info.xml ]; then
+      echo "appinfo/info.xml doesn't exist in $out, aborting!"
+      exit 1
+    fi
+  '';
+}

--- a/pkgs/build-support/fetchnextcloudapp/tests.nix
+++ b/pkgs/build-support/fetchnextcloudapp/tests.nix
@@ -1,0 +1,22 @@
+{
+  testers,
+  fetchNextcloudApp,
+  ...
+}:
+
+{
+  simple-sha512 = testers.invalidateFetcherByDrvHash (fetchNextcloudApp {
+    appName = "phonetrack";
+    appVersion = "0.8.2";
+    license = "agpl3Plus";
+    sha512 = "f67902d1b48def9a244383a39d7bec95bb4215054963a9751f99dae9bd2f2740c02d2ef97b3b76d69a36fa95f8a9374dd049440b195f4dad2f0c4bca645de228";
+    url = "https://github.com/julien-nc/phonetrack/releases/download/v0.8.2/phonetrack-0.8.2.tar.gz";
+  });
+  simple-sha256 = testers.invalidateFetcherByDrvHash (fetchNextcloudApp {
+    appName = "phonetrack";
+    appVersion = "0.8.2";
+    license = "agpl3Plus";
+    sha256 = "7c4252186e0ff8e0b97fc3d30131eeadd51bd2f9cc6aa321eb0c1c541f9572c0";
+    url = "https://github.com/julien-nc/phonetrack/releases/download/v0.8.2/phonetrack-0.8.2.tar.gz";
+  });
+}

--- a/pkgs/build-support/fetchnextcloudapp/tests.nix
+++ b/pkgs/build-support/fetchnextcloudapp/tests.nix
@@ -5,18 +5,18 @@
 }:
 
 {
-  simple-sha512 = testers.invalidateFetcherByDrvHash (fetchNextcloudApp {
+  simple-sha512 = testers.invalidateFetcherByDrvHash fetchNextcloudApp {
     appName = "phonetrack";
     appVersion = "0.8.2";
     license = "agpl3Plus";
     sha512 = "f67902d1b48def9a244383a39d7bec95bb4215054963a9751f99dae9bd2f2740c02d2ef97b3b76d69a36fa95f8a9374dd049440b195f4dad2f0c4bca645de228";
     url = "https://github.com/julien-nc/phonetrack/releases/download/v0.8.2/phonetrack-0.8.2.tar.gz";
-  });
-  simple-sha256 = testers.invalidateFetcherByDrvHash (fetchNextcloudApp {
+  };
+  simple-sha256 = testers.invalidateFetcherByDrvHash fetchNextcloudApp {
     appName = "phonetrack";
     appVersion = "0.8.2";
     license = "agpl3Plus";
     sha256 = "7c4252186e0ff8e0b97fc3d30131eeadd51bd2f9cc6aa321eb0c1c541f9572c0";
     url = "https://github.com/julien-nc/phonetrack/releases/download/v0.8.2/phonetrack-0.8.2.tar.gz";
-  });
+  };
 }

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -131,6 +131,9 @@ with pkgs;
   fetchDebianPatch = recurseIntoAttrs (callPackages ../build-support/fetchdebianpatch/tests.nix { });
   fetchzip = recurseIntoAttrs (callPackages ../build-support/fetchzip/tests.nix { });
   fetchgit = recurseIntoAttrs (callPackages ../build-support/fetchgit/tests.nix { });
+  fetchNextcloudApp = recurseIntoAttrs (
+    callPackages ../build-support/fetchnextcloudapp/tests.nix { }
+  );
   fetchFromBitbucket = recurseIntoAttrs (callPackages ../build-support/fetchbitbucket/tests.nix { });
   fetchFirefoxAddon = recurseIntoAttrs (
     callPackages ../build-support/fetchfirefoxaddon/tests.nix { }


### PR DESCRIPTION
Closes #435915

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
