### PR TITLE
python3Packages.fill-voids: init at v2.1.0

### DIFF
--- a/pkgs/development/python-modules/fill-voids/default.nix
+++ b/pkgs/development/python-modules/fill-voids/default.nix
@@ -14,7 +14,7 @@ let
 in
 buildPythonPackage {
   name = "fill-voids";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchPypi {
     inherit version;

--- a/pkgs/development/python-modules/fill-voids/default.nix
+++ b/pkgs/development/python-modules/fill-voids/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  cython,
+  numpy,
+  pbr,
+  setuptools,
+  fastremap,
+}:
+
+let
+  version = "2.1.0";
+in
+buildPythonPackage {
+  name = "fill-voids";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "fill_voids";
+    hash = "sha256-Y/dvfb3Yy18w6ihBoxYk66RhLZEhHW/3TSMX9E1EmGA=";
+  };
+
+  build-system = [
+    cython
+    numpy
+    pbr
+    setuptools
+  ];
+
+  dependencies = [
+    numpy
+    fastremap
+  ];
+
+  pythonImportsCheck = [
+    "fill_voids"
+  ];
+
+  meta = {
+    description = "Remap, mask, renumber, unique, and in-place transposition of 3D labeled images and point clouds";
+    homepage = "https://github.com/seung-lab/fill_voids";
+    license = with lib.licenses; [
+      gpl3
+      lgpl3
+    ];
+    maintainers = with lib.maintainers; [ afermg ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/fill-voids/default.nix
+++ b/pkgs/development/python-modules/fill-voids/default.nix
@@ -42,8 +42,8 @@ buildPythonPackage {
     description = "Remap, mask, renumber, unique, and in-place transposition of 3D labeled images and point clouds";
     homepage = "https://github.com/seung-lab/fill_voids";
     license = with lib.licenses; [
-      gpl3
-      lgpl3
+      gpl3Only
+      lgpl3Plus
     ];
     maintainers = with lib.maintainers; [ afermg ];
     platforms = lib.platforms.all;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5133,6 +5133,8 @@ self: super: with self; {
 
   filetype = callPackage ../development/python-modules/filetype { };
 
+  fill-voids = callPackage ../development/python-modules/fill-voids { };
+
   filterpy = callPackage ../development/python-modules/filterpy { };
 
   finalfusion = callPackage ../development/python-modules/finalfusion { };


### PR DESCRIPTION
I added the Python Package [fill-voids](https://github.com/seung-lab/fill_voids), which fills holes in binary 2D & 3D images fast. I tested that it build in linux x86_64, and tested its functionality in Linux and MacOS computers. One of the tests fails due to the test itself being wrong, but the package runs fine and works, LMK if I should somehow prevent that bugged test from running.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
