### PR TITLE
python312Packages.nipype: fix dependencies, minor refactor

### DIFF
--- a/pkgs/development/python-modules/nipype/default.nix
+++ b/pkgs/development/python-modules/nipype/default.nix
@@ -9,8 +9,6 @@
   python-dateutil,
   etelemetry,
   filelock,
-  funcsigs,
-  future,
   looseversion,
   mock,
   networkx,
@@ -19,6 +17,7 @@
   packaging,
   prov,
   psutil,
+  puremagic,
   pybids,
   pydot,
   pytest,
@@ -42,7 +41,6 @@
 buildPythonPackage rec {
   pname = "nipype";
   version = "1.10.0";
-  disabled = pythonOlder "3.7";
   format = "setuptools";
 
   src = fetchPypi {
@@ -52,18 +50,16 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace nipype/interfaces/base/tests/test_core.py \
-      --replace "/usr/bin/env bash" "${bash}/bin/bash"
+      --replace-fail "/usr/bin/env bash" "${bash}/bin/bash"
   '';
 
   pythonRelaxDeps = [ "traits" ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     click
     python-dateutil
     etelemetry
     filelock
-    funcsigs
-    future
     looseversion
     networkx
     nibabel
@@ -71,6 +67,7 @@ buildPythonPackage rec {
     packaging
     prov
     psutil
+    puremagic
     pydot
     rdflib
     scipy
@@ -97,11 +94,12 @@ buildPythonPackage rec {
   '';
   pythonImportsCheck = [ "nipype" ];
 
-  meta = with lib; {
-    homepage = "https://nipy.org/nipype/";
+  meta = {
+    homepage = "https://nipy.org/nipype";
     description = "Neuroimaging in Python: Pipelines and Interfaces";
+    changelog = "https://github.com/nipy/nipype/releases/tag/${version}";
     mainProgram = "nipypecli";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ ashgillman ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ashgillman ];
   };
 }


### PR DESCRIPTION
Removing `future` allows building with Python 3.13.

Also minor refactor of `meta`. Package could also use some build and test refactor but didn't get to that here.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
