### PR TITLE
[staging-next] postgresqlPackages.pgvecto-rs: fix build with rust 1.89

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pgvecto-rs/0002-allow-dangerous-implicit-autorefs.diff
+++ b/pkgs/servers/sql/postgresql/ext/pgvecto-rs/0002-allow-dangerous-implicit-autorefs.diff
@@ -1,0 +1,21 @@
+diff --git a/crates/common/src/lib.rs b/crates/common/src/lib.rs
+index 18172b9..6fc7e82 100644
+--- a/crates/common/src/lib.rs
++++ b/crates/common/src/lib.rs
+@@ -1,3 +1,4 @@
++#![warn(dangerous_implicit_autorefs)]
+ pub mod clean;
+ pub mod dir_ops;
+ pub mod file_atomic;
+diff --git a/src/lib.rs b/src/lib.rs
+index 068c65d..82609e9 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -6,6 +6,7 @@
+ #![allow(clippy::needless_range_loop)]
+ #![allow(clippy::single_match)]
+ #![allow(clippy::too_many_arguments)]
++#![warn(dangerous_implicit_autorefs)]
+ 
+ mod bgworker;
+ mod datatype;

--- a/pkgs/servers/sql/postgresql/ext/pgvecto-rs/package.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgvecto-rs/package.nix
@@ -27,6 +27,9 @@ buildPgrxExtension (finalAttrs: {
     (replaceVars ./0001-read-clang-flags-from-environment.diff {
       clang = lib.getExe clang;
     })
+    # Rust 1.89 denies implicit autorefs by default, making the compilation fail.
+    # This restores the behaviour of previous rust versions by making the lint throw a warning instead.
+    ./0002-allow-dangerous-implicit-autorefs.diff
   ];
 
   src = fetchFromGitHub {


### PR DESCRIPTION
The `dangerous_implicit_autorefs` lint now causes a compile error [1], which breaks pgvecto-rs.
This commit forces the lint to only throw a warning.

[1]: https://github.com/rust-lang/rust/pull/141661

Hydra failure: https://hydra.nixos.org/build/305231743

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
