### PR TITLE
ffmpeg_8{,-headless,-full}: init at 8.0

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -112,6 +112,8 @@
 
 - `lisp-modules` were brought in sync with the [June 2025 Quicklisp release](http://blog.quicklisp.org/2025/07/june-2025-quicklisp-dist-now-available.html).
 
+- `ffmpeg_8`, `ffmpeg_8-headless`, and `ffmpeg_8-full` have been added. The default version of FFmpeg remains ffmpeg_7 for now, though this may change before release.
+
 - `searx` was updated to use `envsubst` instead of `sed` for parsing secrets from environment variables.
   If your previous configuration included a secret reference like `server.secret_key = "@SEARX_SECRET_KEY@"`, you must migrate to the new envsubst syntax: `server.secret_key = "$SEARX_SECRET_KEY"`.
 

--- a/pkgs/by-name/op/openapv/package.nix
+++ b/pkgs/by-name/op/openapv/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  writeText,
+  fetchFromGitHub,
+  cmake,
+}:
+let
+  # Requires an /etc/os-release file, so we override it with this.
+  osRelease = writeText "os-release" ''ID=NixOS'';
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "openapv";
+  version = "0.2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "AcademySoftwareFoundation";
+    repo = "openapv";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Edj3xQ7AcHcdIbg4o2FidAGZ06fUBltW+1ojJPoIktA=";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "/etc/os-release" "${osRelease}"
+  '';
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    changelog = "https://github.com/AcademySoftwareFoundation/openapv/releases/tag/v${finalAttrs.version}";
+    description = "Reference implementation of the APV codec";
+    homepage = "https://github.com/AcademySoftwareFoundation/openapv";
+    license = [ lib.licenses.bsd3 ];
+    maintainers = with lib.maintainers; [ pyrox0 ];
+  };
+})

--- a/pkgs/development/libraries/ffmpeg/default.nix
+++ b/pkgs/development/libraries/ffmpeg/default.nix
@@ -29,6 +29,10 @@ let
     version = "7.1.1";
     hash = "sha256-GyS8imOqfOUPxXrzCiQtzCQIIH6bvWmQAB0fKUcRsW4=";
   };
+  v8 = {
+    version = "8.0";
+    hash = "sha256-okNZ1/m/thFAY3jK/GSV0+WZFnjrMr8uBPsOdH6Wq9E=";
+  };
 in
 
 rec {
@@ -46,6 +50,10 @@ rec {
   ffmpeg_7 = mkFFmpeg v7 "small";
   ffmpeg_7-headless = mkFFmpeg v7 "headless";
   ffmpeg_7-full = mkFFmpeg v7 "full";
+
+  ffmpeg_8 = mkFFmpeg v8 "small";
+  ffmpeg_8-headless = mkFFmpeg v8 "headless";
+  ffmpeg_8-full = mkFFmpeg v8 "full";
 
   # Please make sure this is updated to new major versions once they
   # build and work on all the major platforms. If absolutely necessary

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -575,12 +575,14 @@ stdenv.mkDerivation (
       # Ffmpeg > 4 doesn't know about the flag anymore
       (enableFeature buildAvresample "avresample")
     ]
+    ++ [
+      (enableFeature buildAvutil "avutil")
+    ]
     ++ optionals (lib.versionOlder version "8.0") [
       # FFMpeg >= 8 doesn't know about the flag anymore
       (enableFeature (buildPostproc && withGPL) "postproc")
     ]
     ++ [
-      (enableFeature buildAvutil "avutil")
       (enableFeature buildSwresample "swresample")
       (enableFeature buildSwscale "swscale")
     ]
@@ -824,10 +826,10 @@ stdenv.mkDerivation (
       perl
       pkg-config
     ]
-    # Texinfo version 7.1 introduced breaking changes, which older versions of ffmpeg do not handle.
-    ++ (if versionOlder version "5" then [ texinfo6 ] else [ texinfo ])
     # 8.0 is only compatible with nasm, and we don't want to rebuild all older ffmpeg builds at this moment.
     ++ (if versionOlder version "8.0" then [ yasm ] else [ nasm ])
+    # Texinfo version 7.1 introduced breaking changes, which older versions of ffmpeg do not handle.
+    ++ (if versionOlder version "5" then [ texinfo6 ] else [ texinfo ])
     ++ optionals withCudaLLVM [ clang ]
     ++ optionals withCudaNVCC [ cuda_nvcc ];
 

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -10,6 +10,7 @@
   texinfo,
   texinfo6,
   yasm,
+  nasm,
 
   # You can fetch any upstream version using this derivation by specifying version and hash
   # NOTICE: Always use this argument to override the version. Do not use overrideAttrs.
@@ -108,6 +109,7 @@
   withNvdec ? withHeadlessDeps && withNvcodec,
   withNvenc ? withHeadlessDeps && withNvcodec,
   withOpenal ? withFullDeps, # OpenAL 1.1 capture support
+  withOpenapv ? withHeadlessDeps && lib.versionAtLeast version "8.0", # APV encoding support
   withOpencl ? withHeadlessDeps,
   withOpencoreAmrnb ? withFullDeps && withVersion3, # AMR-NB de/encoder
   withOpencoreAmrwb ? withFullDeps && withVersion3, # AMR-WB decoder
@@ -152,6 +154,7 @@
   withVulkan ? withHeadlessDeps && !stdenv.hostPlatform.isDarwin,
   withVvenc ? withFullDeps && lib.versionAtLeast version "7.1", # H.266/VVC encoding
   withWebp ? withHeadlessDeps, # WebP encoder
+  withWhisper ? withFullDeps && lib.versionAtLeast version "8.0", # Whisper speech recognition
   withX264 ? withHeadlessDeps && withGPL, # H.264/AVC encoder
   withX265 ? withHeadlessDeps && withGPL, # H.265/HEVC encoder
   withXavs ? withFullDeps && withGPL, # AVS encoder
@@ -206,7 +209,9 @@
   # https://github.com/NixOS/nixpkgs/pull/211834#issuecomment-1417435991)
   buildAvresample ? withHeadlessDeps && lib.versionOlder version "5", # Build avresample library
   buildAvutil ? withHeadlessDeps, # Build avutil library
-  buildPostproc ? withHeadlessDeps, # Build postproc library
+  # Libpostproc is only available on versions lower than 8.0
+  # https://code.ffmpeg.org/FFmpeg/FFmpeg/commit/8c920c4c396163e3b9a0b428dd550d3c986236aa
+  buildPostproc ? withHeadlessDeps && lib.versionOlder version "8.0", # Build postproc library
   buildSwresample ? withHeadlessDeps, # Build swresample library
   buildSwscale ? withHeadlessDeps, # Build swscale library
   withLib ?
@@ -313,6 +318,7 @@
   nv-codec-headers-12,
   ocl-icd, # OpenCL ICD
   openal,
+  openapv,
   opencl-headers, # OpenCL headers
   opencore-amr,
   openh264,
@@ -338,6 +344,7 @@
   vulkan-headers,
   vulkan-loader,
   vvenc,
+  whisper-cpp,
   x264,
   x265,
   xavs,
@@ -568,9 +575,12 @@ stdenv.mkDerivation (
       # Ffmpeg > 4 doesn't know about the flag anymore
       (enableFeature buildAvresample "avresample")
     ]
+    ++ optionals (lib.versionOlder version "8.0") [
+      # FFMpeg >= 8 doesn't know about the flag anymore
+      (enableFeature (buildPostproc && withGPL) "postproc")
+    ]
     ++ [
       (enableFeature buildAvutil "avutil")
-      (enableFeature (buildPostproc && withGPL) "postproc")
       (enableFeature buildSwresample "swresample")
       (enableFeature buildSwscale "swscale")
     ]
@@ -678,6 +688,11 @@ stdenv.mkDerivation (
       (enableFeature withNvdec "nvdec")
       (enableFeature withNvenc "nvenc")
       (enableFeature withOpenal "openal")
+    ]
+    ++ optionals (versionAtLeast version "8.0") [
+      (enableFeature withOpenapv "liboapv")
+    ]
+    ++ [
       (enableFeature withOpencl "opencl")
       (enableFeature withOpencoreAmrnb "libopencore-amrnb")
       (enableFeature withOpencoreAmrwb "libopencore-amrwb")
@@ -742,6 +757,11 @@ stdenv.mkDerivation (
     ]
     ++ [
       (enableFeature withWebp "libwebp")
+    ]
+    ++ optionals (versionAtLeast version "8.0") [
+      (enableFeature withWhisper "whisper")
+    ]
+    ++ [
       (enableFeature withX264 "libx264")
       (enableFeature withX265 "libx265")
       (enableFeature withXavs "libxavs")
@@ -803,10 +823,11 @@ stdenv.mkDerivation (
       addDriverRunpath
       perl
       pkg-config
-      yasm
     ]
     # Texinfo version 7.1 introduced breaking changes, which older versions of ffmpeg do not handle.
     ++ (if versionOlder version "5" then [ texinfo6 ] else [ texinfo ])
+    # 8.0 is only compatible with nasm, and we don't want to rebuild all older ffmpeg builds at this moment.
+    ++ (if versionOlder version "8.0" then [ yasm ] else [ nasm ])
     ++ optionals withCudaLLVM [ clang ]
     ++ optionals withCudaNVCC [ cuda_nvcc ];
 
@@ -874,6 +895,7 @@ stdenv.mkDerivation (
         cuda_nvcc
       ]
       ++ optionals withOpenal [ openal ]
+      ++ optionals withOpenapv [ openapv ]
       ++ optionals withOpencl [
         ocl-icd
         opencl-headers
@@ -928,6 +950,7 @@ stdenv.mkDerivation (
       ]
       ++ optionals withVvenc [ vvenc ]
       ++ optionals withWebp [ libwebp ]
+      ++ optionals withWhisper [ whisper-cpp ]
       ++ optionals withX264 [ x264 ]
       ++ optionals withX265 [ x265 ]
       ++ optionals withXavs [ xavs ]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7596,6 +7596,9 @@ with pkgs;
     ffmpeg_7
     ffmpeg_7-headless
     ffmpeg_7-full
+    ffmpeg_8
+    ffmpeg_8-headless
+    ffmpeg_8-full
     ffmpeg
     ffmpeg-headless
     ffmpeg-full


### PR DESCRIPTION
This is the latest major version of ffmpeg, codenamed "Huffman".

The feature flags added are one for Whisper filter support via
whisper-cpp, and APV encoding support via OpenAPV(which needed to be
packaged)


Further, the withPostproc feature flag is restricted to before version
8.0, as it was removed.

Currently, nasm is the only supported assembler on 8.0+, so we use that.
in order to not cause a mass rebuild, we don't change the assembler for
older builds, even though nasm has been supported since 3.4.

Also note that currently, this does not change the default version of ffmpeg, as that is much better targeted to staging.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
