### PR TITLE
shader-slang: 2025.12.1 -> 2025.14.3

### DIFF
--- a/pkgs/by-name/sh/shader-slang/package.nix
+++ b/pkgs/by-name/sh/shader-slang/package.nix
@@ -27,13 +27,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "shader-slang";
-  version = "2025.12.1";
+  version = "2025.14.3";
 
   src = fetchFromGitHub {
     owner = "shader-slang";
     repo = "slang";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-5M/sKoCFVGW4VcOPzL8dVhTuo+esjINPXw76fnO7OEw=";
+    hash = "sha256-tHLm0XmS5vV+o3VmFHWG8wZnrb0p63Nz1zVyvc/e5+s=";
     fetchSubmodules = true;
   };
 
@@ -114,13 +114,14 @@ stdenv.mkDerivation (finalAttrs: {
     # Handled by separateDebugInfo so we don't need special installation handling
     "-DSLANG_ENABLE_SPLIT_DEBUG_INFO=OFF"
     "-DSLANG_VERSION_FULL=v${finalAttrs.version}-nixpkgs"
-    # slang-rhi tries to download WebGPU dawn binaries, and as stated on
-    # https://github.com/shader-slang/slang-rhi is "under active refactoring
-    # and development, and is not yet ready for general use."
-    "-DSLANG_ENABLE_SLANG_RHI=OFF"
     "-DSLANG_USE_SYSTEM_MINIZ=ON"
     "-DSLANG_USE_SYSTEM_LZ4=ON"
     "-DSLANG_SLANG_LLVM_FLAVOR=${if withLLVM then "USE_SYSTEM_LLVM" else "DISABLE"}"
+    # slang-rhi tries to download headers and precompiled binaries for these backends
+    "-DSLANG_RHI_ENABLE_OPTIX=OFF"
+    "-DSLANG_RHI_ENABLE_VULKAN=OFF"
+    "-DSLANG_RHI_ENABLE_METAL=OFF"
+    "-DSLANG_RHI_ENABLE_WGPU=OFF"
   ]
   ++ lib.optionals withGlslang [
     "-DSLANG_USE_SYSTEM_SPIRV_TOOLS=ON"


### PR DESCRIPTION
Changelogs:

- https://github.com/shader-slang/slang/releases/tag/v2025.13
- https://github.com/shader-slang/slang/releases/tag/v2025.13.1
- https://github.com/shader-slang/slang/releases/tag/v2025.13.2
- https://github.com/shader-slang/slang/releases/tag/v2025.14
- https://github.com/shader-slang/slang/releases/tag/v2025.14.1
- https://github.com/shader-slang/slang/releases/tag/v2025.14.2
- https://github.com/shader-slang/slang/releases/tag/v2025.14.3

I was originally waiting for https://github.com/shader-slang/slang/pull/8237 to land but eventually figured out that we can enable slang-rhi (which is now required for building the tests) by disabling all backends that require fetching external headers or binaries. Ideally we figure out how to pass them directly to slang-rhi instead of disabling these backends, but for now this at least gets us slang-rhi with the CPU backend.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
