### PR TITLE
{{view,list}res,smproxy,tab-window-manager,xauth,xbacklight}: refactor and move to pkgs/by-name from xorg namespace

### DIFF
--- a/pkgs/by-name/li/listres/package.nix
+++ b/pkgs/by-name/li/listres/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libxaw,
+  libxmu,
+  xorgproto,
+  libxt,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "listres";
+  version = "1.0.6";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/listres-${finalAttrs.version}.tar.xz";
+    hash = "sha256-TRxT79abplTyh34Vd+mUx4h0sFEvobBmbP/PRSruQ8o=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libxaw
+    libxmu
+    xorgproto
+    libxt
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Utility to list X resources for a widget written using a toolkit based on libXt";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/listres";
+    license = lib.licenses.x11;
+    mainProgram = "listres";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/sm/smproxy/package.nix
+++ b/pkgs/by-name/sm/smproxy/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libice,
+  libsm,
+  libxmu,
+  libxt,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "smproxy";
+  version = "1.0.8";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/smproxy-${finalAttrs.version}.tar.xz";
+    hash = "sha256-/uWE6uLsHOLReNctO0hJICcbpoonk1dpzvuvvDov9sg=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libice
+    libsm
+    libxmu
+    libxt
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "allows X applications that do not support X11R6 session management to participate in an X11R6 session";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/smproxy";
+    license = lib.licenses.mitOpenGroup;
+    mainProgram = "smproxy";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/ta/tab-window-manager/package.nix
+++ b/pkgs/by-name/ta/tab-window-manager/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  bison,
+  flex,
+  libice,
+  libsm,
+  libx11,
+  libxext,
+  libxmu,
+  xorgproto,
+  libxrandr,
+  libxt,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tab-window-manager";
+  version = "1.0.13.1";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/twm-${finalAttrs.version}.tar.xz";
+    hash = "sha256-pSU0dVqotJLIhOUvqYi6yEq01UZBlUZ5uarwjjI98sU=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    bison
+    flex
+  ];
+
+  buildInputs = [
+    xorgproto
+    libice
+    libsm
+    libx11
+    libxext
+    libxmu
+    libxrandr
+    libxt
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname twm \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Default Window Manager for the X Window System";
+    longDescription = ''
+      The Tab Window Manager (twm) is a window manager for the X Window System.
+      It provides titlebars, shaped windows, several forms of icon management, user-defined macro
+      functions, click-to-type and pointer-driven keyboard focus, and user-specified key and pointer
+      button bindings.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/twm";
+    license = with lib.licenses; [
+      mitOpenGroup
+      hpnd
+      x11
+    ];
+    mainProgram = "twm";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/vi/viewres/package.nix
+++ b/pkgs/by-name/vi/viewres/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libxaw,
+  libxmu,
+  libxt,
+  wrapWithXFileSearchPathHook,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "viewres";
+  version = "1.0.8";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/viewres-${finalAttrs.version}.tar.xz";
+    hash = "sha256-SyIcKxAzkLFmYzYSuav4A2y76QYF29ijfPKjd/orbNI=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapWithXFileSearchPathHook
+  ];
+
+  buildInputs = [
+    xorgproto
+    libxaw
+    libxmu
+    libxt
+  ];
+
+  installFlags = [ "appdefaultdir=$(out)/share/X11/app-defaults" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Displays a tree showing the widget class hierarchy of the Athena Widget Set (libxaw)";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/viewres";
+    license = lib.licenses.x11;
+    mainProgram = "viewres";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xa/xauth/package.nix
+++ b/pkgs/by-name/xa/xauth/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libx11,
+  libxau,
+  libxext,
+  libxmu,
+  xorgproto,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xauth";
+  version = "1.1.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xauth-${finalAttrs.version}.tar.xz";
+    hash = "sha256-6TGBQUZK17TcD4VkpYDw0g+XfIWjiMxA1admIGFRxpA=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libx11
+    libxau
+    libxext
+    libxmu
+    xorgproto
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "X authority file utility";
+    longDescription = ''
+      The xauth program is used to edit and display the authorization information used in connecting
+      to the X server.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xauth";
+    license = lib.licenses.mitOpenGroup;
+    mainProgram = "xauth";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xb/xbacklight/package.nix
+++ b/pkgs/by-name/xb/xbacklight/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libxcb,
+  libxcb-util,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xbacklight";
+  version = "1.2.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xbacklight-${finalAttrs.version}.tar.xz";
+    hash = "sha256-1MMLDm8YyC84dYWnN+47ctRoySeJKwiomMQbwSJI6O4=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libxcb
+    libxcb-util
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Utility to adjust X backlight brightness using RandR extension";
+    longDescription = ''
+      Xbacklight is used to adjust the backlight brightness where supported.
+      It uses the RandR extension to find all outputs on the X server supporting backlight
+      brightness control and changes them all in the same way.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xbacklight";
+    license = lib.licenses.hpndSellVariant;
+    mainProgram = "xbacklight";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -52,6 +52,7 @@
   pixman,
   sessreg,
   smproxy,
+  tab-window-manager,
   transset,
   util-macros,
   viewres,
@@ -150,6 +151,7 @@ self: with self; {
   libXxf86dga = libxxf86dga;
   libXxf86misc = libxxf86misc;
   libXxf86vm = libxxf86vm;
+  twm = tab-window-manager;
   utilmacros = util-macros;
   xcbproto = xcb-proto;
   xcbutilerrors = libxcb-errors;
@@ -2347,54 +2349,6 @@ self: with self; {
         libX11
         libxkbfile
         libXrandr
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  twm = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libICE,
-      libSM,
-      libX11,
-      libXext,
-      libXmu,
-      xorgproto,
-      libXrandr,
-      libXt,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "twm";
-      version = "1.0.13.1";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/twm-1.0.13.1.tar.xz";
-        sha256 = "1igj7lr8xw5ap5wld5a18vav8jn8pa4ajbz5hk495d58b9sk89d5";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libICE
-        libSM
-        libX11
-        libXext
-        libXmu
-        xorgproto
-        libXrandr
-        libXt
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -56,6 +56,7 @@
   transset,
   util-macros,
   viewres,
+  xauth,
   xbitmaps,
   xcb-proto,
   xcmsdb,
@@ -104,6 +105,7 @@ self: with self; {
     smproxy
     transset
     viewres
+    xauth
     xbitmaps
     xcmsdb
     xcursorgen
@@ -2393,48 +2395,6 @@ self: with self; {
         libXmu
         xorgproto
         libXrender
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xauth = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libXau,
-      libXext,
-      libXmu,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xauth";
-      version = "1.1.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xauth-1.1.4.tar.xz";
-        sha256 = "1466a5hj0rm7sm0cr253hmy9f3yjy20aar451zfb9msa8r0q2cg9";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        libXau
-        libXext
-        libXmu
-        xorgproto
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -57,6 +57,7 @@
   util-macros,
   viewres,
   xauth,
+  xbacklight,
   xbitmaps,
   xcb-proto,
   xcmsdb,
@@ -106,6 +107,7 @@ self: with self; {
     transset
     viewres
     xauth
+    xbacklight
     xbitmaps
     xcmsdb
     xcursorgen
@@ -2395,42 +2397,6 @@ self: with self; {
         libXmu
         xorgproto
         libXrender
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xbacklight = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libxcb,
-      xcbutil,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xbacklight";
-      version = "1.2.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xbacklight-1.2.4.tar.xz";
-        sha256 = "1vp890ic26y4k2l0haw94z4nim3j7gp3g9w5flw2zj0qdw70phyl";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libxcb
-        xcbutil
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -44,6 +44,7 @@
   libxxf86dga,
   libxxf86misc,
   libxxf86vm,
+  listres,
   lndir,
   luit,
   makedepend,
@@ -91,6 +92,7 @@ self: with self; {
     libpciaccess
     libxcb
     libxcvt
+    listres
     lndir
     luit
     makedepend
@@ -2263,46 +2265,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xshmfence" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  listres = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libXaw,
-      libXmu,
-      xorgproto,
-      libXt,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "listres";
-      version = "1.0.6";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/listres-1.0.6.tar.xz";
-        sha256 = "1jj3xqm4bkzzdikb189ga6q79267jklpf5byhzr599lvsvpm672d";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libXaw
-        libXmu
-        xorgproto
-        libXt
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -51,6 +51,7 @@
   mkfontscale,
   pixman,
   sessreg,
+  smproxy,
   transset,
   util-macros,
   viewres,
@@ -99,6 +100,7 @@ self: with self; {
     mkfontscale
     pixman
     sessreg
+    smproxy
     transset
     viewres
     xbitmaps
@@ -2345,46 +2347,6 @@ self: with self; {
         libX11
         libxkbfile
         libXrandr
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  smproxy = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libICE,
-      libSM,
-      libXmu,
-      libXt,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "smproxy";
-      version = "1.0.8";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/smproxy-1.0.8.tar.xz";
-        sha256 = "1j7n5wxbrbzvrrlmg4r7iak1n9r09543nbfpg38y477cwbm89rgy";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libICE
-        libSM
-        libXmu
-        libXt
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -52,6 +52,7 @@
   sessreg,
   transset,
   util-macros,
+  viewres,
   xbitmaps,
   xcb-proto,
   xcmsdb,
@@ -97,6 +98,7 @@ self: with self; {
     pixman
     sessreg
     transset
+    viewres
     xbitmaps
     xcmsdb
     xcursorgen
@@ -2468,50 +2470,6 @@ self: with self; {
         libXmu
         xorgproto
         libXrandr
-        libXt
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  viewres = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libXaw,
-      libXmu,
-      xorgproto,
-      libXt,
-      wrapWithXFileSearchPathHook,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "viewres";
-      version = "1.0.8";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/viewres-1.0.8.tar.xz";
-        sha256 = "1lkc5gx7g8zjgjixinq50vlvnv03z2mvj4incdkb341k20miq8jb";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        wrapWithXFileSearchPathHook
-      ];
-      buildInputs = [
-        libXaw
-        libXmu
-        xorgproto
         libXt
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -373,6 +373,7 @@ print OUT <<EOF;
   util-macros,
   viewres,
   xauth,
+  xbacklight,
   xbitmaps,
   xcb-proto,
   xcmsdb,
@@ -422,6 +423,7 @@ self: with self; {
     transset
     viewres
     xauth
+    xbacklight
     xbitmaps
     xcmsdb
     xcursorgen

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -372,6 +372,7 @@ print OUT <<EOF;
   transset,
   util-macros,
   viewres,
+  xauth,
   xbitmaps,
   xcb-proto,
   xcmsdb,
@@ -420,6 +421,7 @@ self: with self; {
     smproxy
     transset
     viewres
+    xauth
     xbitmaps
     xcmsdb
     xcursorgen

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -368,6 +368,7 @@ print OUT <<EOF;
   pixman,
   sessreg,
   smproxy,
+  tab-window-manager,
   transset,
   util-macros,
   viewres,
@@ -466,6 +467,7 @@ self: with self; {
   libXxf86dga = libxxf86dga;
   libXxf86misc = libxxf86misc;
   libXxf86vm = libxxf86vm;
+  twm = tab-window-manager;
   utilmacros = util-macros;
   xcbproto = xcb-proto;
   xcbutilerrors = libxcb-errors;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -360,6 +360,7 @@ print OUT <<EOF;
   libxxf86dga,
   libxxf86misc,
   libxxf86vm,
+  listres,
   lndir,
   luit,
   makedepend,
@@ -407,6 +408,7 @@ self: with self; {
     libpciaccess
     libxcb
     libxcvt
+    listres
     lndir
     luit
     makedepend

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -367,6 +367,7 @@ print OUT <<EOF;
   mkfontscale,
   pixman,
   sessreg,
+  smproxy,
   transset,
   util-macros,
   viewres,
@@ -415,6 +416,7 @@ self: with self; {
     mkfontscale
     pixman
     sessreg
+    smproxy
     transset
     viewres
     xbitmaps

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -368,6 +368,7 @@ print OUT <<EOF;
   sessreg,
   transset,
   util-macros,
+  viewres,
   xbitmaps,
   xcb-proto,
   xcmsdb,
@@ -413,6 +414,7 @@ self: with self; {
     pixman
     sessreg
     transset
+    viewres
     xbitmaps
     xcmsdb
     xcursorgen

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -170,8 +170,6 @@ self: super:
     configureFlags = attrs.configureFlags or [ ] ++ malloc0ReturnsNullCrossFlag;
   });
 
-  listres = addMainProgram super.listres { };
-
   xdpyinfo = super.xdpyinfo.overrideAttrs (attrs: {
     configureFlags = attrs.configureFlags or [ ] ++ malloc0ReturnsNullCrossFlag;
     preConfigure =

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -321,7 +321,6 @@ self: super:
   });
 
   oclock = addMainProgram super.oclock { };
-  smproxy = addMainProgram super.smproxy { };
 
   x11perf = super.x11perf.overrideAttrs (attrs: {
     buildInputs = attrs.buildInputs ++ [

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -325,8 +325,6 @@ self: super:
   oclock = addMainProgram super.oclock { };
   smproxy = addMainProgram super.smproxy { };
 
-  viewres = addMainProgram super.viewres { };
-
   x11perf = super.x11perf.overrideAttrs (attrs: {
     buildInputs = attrs.buildInputs ++ [
       freetype

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -846,19 +846,6 @@ self: super:
     ];
   });
 
-  xauth = super.xauth.overrideAttrs (attrs: {
-    doCheck = false; # fails
-    preConfigure =
-      attrs.preConfigure or ""
-      # missing transitive dependencies
-      + lib.optionalString stdenv.hostPlatform.isStatic ''
-        export NIX_CFLAGS_LINK="$NIX_CFLAGS_LINK -lxcb -lXau -lXdmcp"
-      '';
-    meta = attrs.meta // {
-      mainProgram = "xauth";
-    };
-  });
-
   xbacklight = addMainProgram super.xbacklight { };
   xclock = addMainProgram super.xclock { };
   xcompmgr = addMainProgram super.xcompmgr { };

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -846,7 +846,6 @@ self: super:
     ];
   });
 
-  xbacklight = addMainProgram super.xbacklight { };
   xclock = addMainProgram super.xclock { };
   xcompmgr = addMainProgram super.xcompmgr { };
   xconsole = addMainProgram super.xconsole { };

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -846,16 +846,6 @@ self: super:
     ];
   });
 
-  twm = super.twm.overrideAttrs (attrs: {
-    nativeBuildInputs = attrs.nativeBuildInputs ++ [
-      bison
-      flex
-    ];
-    meta = attrs.meta // {
-      mainProgram = "twm";
-    };
-  });
-
   xauth = super.xauth.overrideAttrs (attrs: {
     doCheck = false; # fails
     preConfigure =

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -5,7 +5,6 @@ mirror://xorg/individual/app/fonttosfnt-1.2.4.tar.xz
 mirror://xorg/individual/app/iceauth-1.0.10.tar.xz
 mirror://xorg/individual/app/oclock-1.0.6.tar.xz
 mirror://xorg/individual/app/setxkbmap-1.3.4.tar.xz
-mirror://xorg/individual/app/twm-1.0.13.1.tar.xz
 mirror://xorg/individual/app/x11perf-1.6.1.tar.bz2
 mirror://xorg/individual/app/xauth-1.1.4.tar.xz
 mirror://xorg/individual/app/xbacklight-1.2.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -6,7 +6,6 @@ mirror://xorg/individual/app/iceauth-1.0.10.tar.xz
 mirror://xorg/individual/app/oclock-1.0.6.tar.xz
 mirror://xorg/individual/app/setxkbmap-1.3.4.tar.xz
 mirror://xorg/individual/app/x11perf-1.6.1.tar.bz2
-mirror://xorg/individual/app/xauth-1.1.4.tar.xz
 mirror://xorg/individual/app/xbacklight-1.2.4.tar.xz
 mirror://xorg/individual/app/xcalc-1.1.2.tar.xz
 mirror://xorg/individual/app/xclock-1.1.1.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -8,7 +8,6 @@ mirror://xorg/individual/app/oclock-1.0.6.tar.xz
 mirror://xorg/individual/app/setxkbmap-1.3.4.tar.xz
 mirror://xorg/individual/app/smproxy-1.0.8.tar.xz
 mirror://xorg/individual/app/twm-1.0.13.1.tar.xz
-mirror://xorg/individual/app/viewres-1.0.8.tar.xz
 mirror://xorg/individual/app/x11perf-1.6.1.tar.bz2
 mirror://xorg/individual/app/xauth-1.1.4.tar.xz
 mirror://xorg/individual/app/xbacklight-1.2.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -5,7 +5,6 @@ mirror://xorg/individual/app/fonttosfnt-1.2.4.tar.xz
 mirror://xorg/individual/app/iceauth-1.0.10.tar.xz
 mirror://xorg/individual/app/oclock-1.0.6.tar.xz
 mirror://xorg/individual/app/setxkbmap-1.3.4.tar.xz
-mirror://xorg/individual/app/smproxy-1.0.8.tar.xz
 mirror://xorg/individual/app/twm-1.0.13.1.tar.xz
 mirror://xorg/individual/app/x11perf-1.6.1.tar.bz2
 mirror://xorg/individual/app/xauth-1.1.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -3,7 +3,6 @@ mirror://xorg/individual/app/bitmap-1.1.1.tar.xz
 mirror://xorg/individual/app/editres-1.0.9.tar.xz
 mirror://xorg/individual/app/fonttosfnt-1.2.4.tar.xz
 mirror://xorg/individual/app/iceauth-1.0.10.tar.xz
-mirror://xorg/individual/app/listres-1.0.6.tar.xz
 mirror://xorg/individual/app/oclock-1.0.6.tar.xz
 mirror://xorg/individual/app/setxkbmap-1.3.4.tar.xz
 mirror://xorg/individual/app/smproxy-1.0.8.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -6,7 +6,6 @@ mirror://xorg/individual/app/iceauth-1.0.10.tar.xz
 mirror://xorg/individual/app/oclock-1.0.6.tar.xz
 mirror://xorg/individual/app/setxkbmap-1.3.4.tar.xz
 mirror://xorg/individual/app/x11perf-1.6.1.tar.bz2
-mirror://xorg/individual/app/xbacklight-1.2.4.tar.xz
 mirror://xorg/individual/app/xcalc-1.1.2.tar.xz
 mirror://xorg/individual/app/xclock-1.1.1.tar.xz
 mirror://xorg/individual/app/xcompmgr-1.1.10.tar.xz


### PR DESCRIPTION
twm is unfortunately already used for a tmux workspace manager so i had to rename it
some repos call it xorg-twm on repology so that is what i chose initially
other ideas: x11-twm, twm-xorg, twm-x11, tab-window-manager, toms-window-manager (this hasn't been the name since 1989 but it seems to have stuck around since this is the name i knew it as lol)

<details>
<summary>this is the script i use to get the packages that don't depend on other xorg packages:</summary>

```nix
let
  inherit (import <nixpkgs> { }) lib;

  done = import ./pkgs/servers/x11/xorg/default.nix |> lib.functionArgs |> lib.attrNames;

  pkgs =
    (import ./default.nix { }).xorg
    |> lib.filterAttrs (
      n: v:
      lib.isAttrs v
      && v ? pname
      && !lib.elem n done
      && !lib.elem n (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem v.pname done
      && !lib.elem v.pname (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem (lib.toLower n) done
      && !lib.elem (lib.toLower n) (map (lib.replaceStrings [ "-" ] [ "" ]) done)
    );

  pnames = lib.mapAttrsToList (_: v: v.pname) pkgs;

  filteredPkgs =
    pkgs
    |> lib.filterAttrs (
      n: v:
      true
      # && !v.meta.unfree
      # && !v.meta.broken
      # && !v.meta.unsupported
      # && !lib.hasPrefix "font" n
      && !lib.hasPrefix "xf86" n
    );
in
filteredPkgs
# get deps
|> lib.mapAttrs (
  _: v:
  v.buildInputs ++ v.nativeBuildInputs ++ v.propagatedBuildInputs ++ v.propagatedNativeBuildInputs
)
# filter deps for xorg packages
|> lib.mapAttrs (_: v: lib.filter (x: x ? pname && lib.elem x.pname pnames) v)
# map deps to list and count
|> lib.mapAttrsToList (
  name: value: {
    inherit name;
    deps = map (x: x.pname or "error") value |> lib.unique;
    count = lib.length value;
  }
)
# sort
|> lib.sort (
  x: y: x.count < y.count || (x.count == y.count && (lib.toLower x.name) > (lib.toLower y.name))
)
|> lib.reverseList
# represent as string
|> map (x: "${toString x.count} - ${toString x.name}: ${lib.concatStringsSep " " x.deps}")
```

you can call it like this to get a nice output:

```sh
nix eval --json --file ./xorg-nodepends.nix | jq .[] --raw-output
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] x86_64-linux static 
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - as far as  they are testable inside a wayland compositor
  - mostly only the help output or something
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] ran passthru.updateScript
- [x] ran nixpkgs-hammer
- [x] ran nix-check-deps 
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc