### PR TITLE
ci: add myself as a reviewer on anything in maintainers that's otherwise not maintained

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -19,6 +19,7 @@
 /.github/workflows                      @NixOS/nixpkgs-ci
 /ci                                     @NixOS/nixpkgs-ci
 /ci/OWNERS                              @infinisil @philiptaron
+/maintainers                            @philiptaron
 
 # Development support
 /.editorconfig @Mic92 @zowoq


### PR DESCRIPTION
> Anyway, I keep picturing all these little kids playing some game in this big field of rye and all. Thousands of little kids, and nobody’s around―nobody big, I mean―except me. And I’m standing on the edge of some crazy cliff. What I have to do, I have to catch everybody if they start to go over the cliff―I mean if they’re running and they don’t look where they’re going I have to come out from somewhere and catch them. That’s all I’d do all day. I’d just be the catcher in the rye and all. I know it’s crazy, but that’s the only thing I’d really like to be. I know it’s crazy.

-- Holden Caulfield, Catcher in the Rye, chapter 22.

I'm no Holden Caulfield, but I'd like to help people adding themselves as maintainers for the first time. This seems the most effective way to do so.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md