### PR TITLE
autotrash: refactor

### DIFF
--- a/pkgs/by-name/au/autotrash/package.nix
+++ b/pkgs/by-name/au/autotrash/package.nix
@@ -27,12 +27,12 @@ python3Packages.buildPythonPackage rec {
   postInstall = "installManPage doc/autotrash.1";
 
   pythonImportsCheck = [ "autotrash" ];
-  nativeCheckInputs = [ python3Packages.pytestCheckHook ];
 
   meta = {
     description = "Tool to automatically purge old trashed files";
     license = lib.licenses.gpl3Plus;
     homepage = "https://bneijt.nl/pr/autotrash";
+    changelog = "https://github.com/bneijt/autotrash/releases/tag/${src.tag}";
     maintainers = with lib.maintainers; [
       sigmanificient
       mithicspirit

--- a/pkgs/by-name/au/autotrash/package.nix
+++ b/pkgs/by-name/au/autotrash/package.nix
@@ -5,6 +5,7 @@
   pandoc,
   installShellFiles,
 }:
+
 python3Packages.buildPythonPackage rec {
   pname = "autotrash";
   version = "0.4.7";
@@ -28,7 +29,9 @@ python3Packages.buildPythonPackage rec {
     installShellFiles
     pandoc
   ];
+
   postBuild = "make -C doc autotrash.1";
+
   postInstall = "installManPage doc/autotrash.1";
 
   pythonImportsCheck = [ "autotrash" ];

--- a/pkgs/by-name/au/autotrash/package.nix
+++ b/pkgs/by-name/au/autotrash/package.nix
@@ -17,6 +17,11 @@ python3Packages.buildPythonPackage rec {
     hash = "sha256-qMU3jjBL5+fd9vKX5BIqES5AM8D/54aBOmdHFiBtfEo=";
   };
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'version = "0.0.0"' 'version = "${version}"'
+  '';
+
   build-system = [ python3Packages.poetry-core ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
