### PR TITLE
nixos/nginx: add sslEcdhCurve option

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -207,11 +207,11 @@ let
                 if cfg.sslDhparam == true then config.security.dhparams.params.nginx.path else cfg.sslDhparam
               };"
             }
+            ${optionalString (cfg.sslEcdhCurve != null) "ssl_conf_command Groups \"${cfg.sslEcdhCurve}\";"}
 
             ${optionalString cfg.recommendedTlsSettings ''
               # Consider https://ssl-config.mozilla.org/#server=nginx&config=intermediate as the lower bound
 
-              ssl_conf_command Groups "X25519MLKEM768:X25519:P-256:P-384";
               ssl_session_timeout 1d;
               ssl_session_cache shared:SSL:10m;
               # Breaks forward secrecy: https://github.com/mozilla/server-side-tls/issues/135
@@ -986,6 +986,13 @@ in
         default = false;
         example = "/path/to/dhparams.pem";
         description = "Path to DH parameters file, or `true` to generate with `security.dhparms.params.nginx`.";
+      };
+
+      sslEcdhCurve = mkOption {
+        type = types.nullOr types.str;
+        default = "X25519MLKEM768:X25519:P-256:P-384";
+        example = "X25519MLKEM768";
+        description = "Supported groups for TLS key exchange.";
       };
 
       proxyResolveWhileRunning = mkOption {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The [`ssl_ecdh_curve` setting](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ecdh_curve) was added to `recommendedTlsSettings` a month ago in #428594.

I had this option set in `appendHttpConfig`, and had `recommendedTlsSettings` enabled, which resulted in an error `nginx: [emerg] "ssl_ecdh_curve" directive is duplicate`.

Overriding this setting is desirable because the default provided by `recommendedTlsSettings` does not include any post-quantum hybrid groups, such as `X25519MLKEM768`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
