### PR TITLE
ziptools: init at 0.1.0

### DIFF
--- a/pkgs/by-name/zi/ziptools/package.nix
+++ b/pkgs/by-name/zi/ziptools/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenvNoCC,
+  zig_0_15,
+  fetchFromGitHub,
+  installSymlinks ? true,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "ziptools";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "RossComputerGuy";
+    repo = "ziptools";
+    tag = finalAttrs.version;
+    hash = "sha256-oxlqNYaHLylzSdmejzzfs8Csiza5CR27iFO0PCFEGZE=";
+  };
+
+  nativeBuildInputs = [
+    zig_0_15
+    zig_0_15.hook
+  ];
+
+  postInstall = lib.optionalString installSymlinks ''
+    ln -s $out/bin/ziptools $out/bin/zip
+    ln -s $out/bin/ziptools $out/bin/unzip
+  '';
+
+  meta = {
+    description = "Modern zip & unzip replacements";
+    license = lib.licenses.lgpl21Only;
+    maintainers = with lib.maintainers; [ RossComputerGuy ];
+    homepage = "https://github.com/RossComputerGuy/ziptools";
+    changelog = "https://github.com/RossComputerGuy/ziptools/commits/${finalAttrs.version}";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Adds ziptools, modern zip & unzip replacements, which aims to replace Info-Zip's unzip & zip.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
