### PR TITLE
joplin-desktop: 3.3.13 -> 3.4.6

### DIFF
--- a/pkgs/by-name/jo/joplin-desktop/release-data.json
+++ b/pkgs/by-name/jo/joplin-desktop/release-data.json
@@ -1,15 +1,15 @@
 {
-  "version": "3.3.13",
+  "version": "3.4.6",
   "x86_64-linux": {
-    "url": "https://github.com/laurent22/joplin/releases/download/v3.3.13/Joplin-3.3.13.AppImage",
-    "sha256": "1gd5qlkjwrx8kxx5d97r58v5wxw4zbzjblr24ydjqbbfhjrr1zr2"
+    "url": "https://github.com/laurent22/joplin/releases/download/v3.4.6/Joplin-3.4.6.AppImage",
+    "sha256": "0xf5lmjv49rq5bnczpydflzzhha8rzcn3iy7zpi5wqzmzsp0jg2p"
   },
   "x86_64-darwin": {
-    "url": "https://github.com/laurent22/joplin/releases/download/v3.3.13/Joplin-3.3.13.dmg",
-    "sha256": "05v5idqnajlya83ax252xs6d1nc0p6679aihij35b885nqiql6f5"
+    "url": "https://github.com/laurent22/joplin/releases/download/v3.4.6/Joplin-3.4.6.dmg",
+    "sha256": "1yahng1rciyrviykksqhk2wfkmrff77frsb7fkaxbhll1p8p74hm"
   },
   "aarch64-darwin": {
-    "url": "https://github.com/laurent22/joplin/releases/download/v3.3.13/Joplin-3.3.13-arm64.dmg",
-    "sha256": "1bafq33n0qdw4hxbq3mp2499zpzz0kc4gqh9cdp650994kmq8207"
+    "url": "https://github.com/laurent22/joplin/releases/download/v3.4.6/Joplin-3.4.6-arm64.dmg",
+    "sha256": "1k5ipsbss3qkyi5b3bw9agk4jmbsakvskrff71v8hg5wk6vi3m7c"
   }
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- changelog: https://github.com/laurent22/joplin/releases
- diff: https://github.com/laurent22/joplin/compare/v3.3.13...v3.4.6
- motivation: one of the dependencies updated, and now the Joplin desktop application works with synchronization targets requiring post-quantum key exchange algorithms.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
