### PR TITLE
x{gamma,gc,host,kbutils,kill}: update (some), refactor & move to pkgs/by-name from xorg namespace

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -713,6 +713,11 @@ lib.mapAttrs mkLicense (
       spdxId = "HPND-sell-variant";
     };
 
+    hpndDec = {
+      fullName = "Historical Permission Notice and Disclaimer - DEC variant";
+      spdxId = "HPND-DEC";
+    };
+
     hpndDoc = {
       fullName = "Historical Permission Notice and Disclaimer - documentation variant";
       spdxId = "HPND-doc";

--- a/pkgs/by-name/xg/xgamma/package.nix
+++ b/pkgs/by-name/xg/xgamma/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxxf86vm,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xgamma";
+  version = "1.0.8";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xgamma-${finalAttrs.version}.tar.xz";
+    hash = "sha256-mPn2nlOhHDVKZjfqXD12mc61xbH4rW8KFNmTHloQ0Hk=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxxf86vm
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Utility to query and alter the gamma correction of a X monitor";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xgamma";
+    license = with lib.licenses; [
+      x11
+      hpndSellVariant
+    ];
+    mainProgram = "xgamma";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xg/xgc/package.nix
+++ b/pkgs/by-name/xg/xgc/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libxaw,
+  libxt,
+  wrapWithXFileSearchPathHook,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xgc";
+  version = "1.0.7";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xgc-${finalAttrs.version}.tar.xz";
+    hash = "sha256-2FgljAXqrC0fSLtEgg3C3OCmhgGhT/+XhTxytI0bfQg=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapWithXFileSearchPathHook
+  ];
+
+  buildInputs = [
+    libxaw
+    libxt
+  ];
+
+  installFlags = [ "appdefaultdir=$(out)/share/X11/app-defaults" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Demo to show various features of the X11 core protocol graphics primitives";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xgc";
+    license = with lib.licenses; [
+      x11
+      mit
+    ];
+    mainProgram = "xgc";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xh/xhost/package.nix
+++ b/pkgs/by-name/xh/xhost/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  gettext,
+  xorgproto,
+  libx11,
+  libxau,
+  libxmu,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xhost";
+  version = "1.0.10";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xhost-${finalAttrs.version}.tar.xz";
+    hash = "sha256-qK/XAFlHnHEpSLiV5Bw1pKi/zt47otWkuFXIi7tyW+E=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    gettext
+  ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxau
+    libxmu
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "X server access control program";
+    longDescription = ''
+      xhost is used to manage the list of host names or user names allowed to make connections to
+      the X server.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xhost";
+    license = with lib.licenses; [
+      mit
+      icu
+    ];
+    mainProgram = "xhost";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xk/xkbutils/package.nix
+++ b/pkgs/by-name/xk/xkbutils/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxaw,
+  libxt,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xkbutils";
+  version = "1.0.6";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xkbutils-${finalAttrs.version}.tar.xz";
+    hash = "sha256-MaK77h4JzLoB3pKJe49UC1Rd6BLzGNMd4HvTpade4l4=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxaw
+    libxt
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Collection of small XKB utilities";
+    longDescription = ''
+      xkbutils is a collection of small utilities using the X Keyboard extenison:
+      - xkbbell: generate X Keyboard Extension bell events
+      - xkbvleds: display X Keyboard Extension LED state in a window
+      - xkbwatch: report state changes using the X Keyboard Extension
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xkbutils";
+    license = with lib.licenses; [
+      hpnd
+      hpndDec
+      mit
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xk/xkill/package.nix
+++ b/pkgs/by-name/xk/xkill/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxmu,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xkill";
+  version = "1.0.6";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xkill-${finalAttrs.version}.tar.xz";
+    hash = "sha256-5aiqeMR1Z3sRUEZG2o2T2swwdEJYB2ospBiiRDiuuQc=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxmu
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Utility to forcibly terminate X11 clients";
+    longDescription = ''
+      xkill is a utility for forcing the X server to close connections to clients.
+      This program is very dangerous, but is useful for aborting programs that have displayed
+      undesired windows on a user's screen.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xkill";
+    license = lib.licenses.mitOpenGroup;
+    mainProgram = "xkill";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -62,6 +62,7 @@
   xfsinfo,
   xgamma,
   xgc,
+  xhost,
   xkeyboard-config,
   xlsatoms,
   xlsclients,
@@ -107,6 +108,7 @@ self: with self; {
     xfsinfo
     xgamma
     xgc
+    xhost
     xlsatoms
     xlsclients
     xlsfonts
@@ -5107,50 +5109,6 @@ self: with self; {
         libXfont2
         xorgproto
         xtrans
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xhost = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libXau,
-      libXmu,
-      xorgproto,
-      gettext,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xhost";
-      version = "1.0.10";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xhost-1.0.10.tar.xz";
-        sha256 = "1qavfaxqpj2mp2jdb8ivvv7bza546lff95dq90lp3727b40dgbx8";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        gettext
-      ];
-      buildInputs = [
-        libX11
-        libXau
-        libXmu
-        xorgproto
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -60,6 +60,7 @@
   xdriinfo,
   xev,
   xfsinfo,
+  xgamma,
   xkeyboard-config,
   xlsatoms,
   xlsclients,
@@ -103,6 +104,7 @@ self: with self; {
     xdriinfo
     xev
     xfsinfo
+    xgamma
     xlsatoms
     xlsclients
     xlsfonts
@@ -5103,44 +5105,6 @@ self: with self; {
         libXfont2
         xorgproto
         xtrans
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xgamma = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      xorgproto,
-      libXxf86vm,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xgamma";
-      version = "1.0.7";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xgamma-1.0.7.tar.xz";
-        sha256 = "13xw2fqp9cs7xj3nqi8khqxv81rk0dd8khp59xgs2lw9bbldly8w";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        xorgproto
-        libXxf86vm
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -63,6 +63,7 @@
   xgamma,
   xgc,
   xhost,
+  xkbutils,
   xkeyboard-config,
   xlsatoms,
   xlsclients,
@@ -109,6 +110,7 @@ self: with self; {
     xgamma
     xgc
     xhost
+    xkbutils
     xlsatoms
     xlsclients
     xlsfonts
@@ -5301,46 +5303,6 @@ self: with self; {
         libX11
         libxkbfile
         xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xkbutils = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libX11,
-      libXaw,
-      libXt,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xkbutils";
-      version = "1.0.6";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xkbutils-1.0.6.tar.xz";
-        sha256 = "0pp2bsksblvvw0fx667k2bl5sm0baj7pp2cjvq0vmk093vpbp8ii";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libX11
-        libXaw
-        libXt
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -61,6 +61,7 @@
   xev,
   xfsinfo,
   xgamma,
+  xgc,
   xkeyboard-config,
   xlsatoms,
   xlsclients,
@@ -105,6 +106,7 @@ self: with self; {
     xev
     xfsinfo
     xgamma
+    xgc
     xlsatoms
     xlsclients
     xlsfonts
@@ -5105,46 +5107,6 @@ self: with self; {
         libXfont2
         xorgproto
         xtrans
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xgc = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libXaw,
-      libXt,
-      wrapWithXFileSearchPathHook,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xgc";
-      version = "1.0.6";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xgc-1.0.6.tar.xz";
-        sha256 = "0h5jm2946f5m1g8a3qh1c01h3zrsjjivi09vi9rmij2frvdvp1vv";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        wrapWithXFileSearchPathHook
-      ];
-      buildInputs = [
-        libXaw
-        libXt
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -65,6 +65,7 @@
   xhost,
   xkbutils,
   xkeyboard-config,
+  xkill,
   xlsatoms,
   xlsclients,
   xlsfonts,
@@ -111,6 +112,7 @@ self: with self; {
     xgc
     xhost
     xkbutils
+    xkill
     xlsatoms
     xlsclients
     xlsfonts
@@ -5302,44 +5304,6 @@ self: with self; {
       buildInputs = [
         libX11
         libxkbfile
-        xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xkill = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libXmu,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xkill";
-      version = "1.0.6";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xkill-1.0.6.tar.xz";
-        sha256 = "01xrmqw498hqlhn6l1sq89s31k6sjf6xlij6a08pnrvmqiwama75";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        libXmu
         xorgproto
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -377,6 +377,7 @@ print OUT <<EOF;
   xev,
   xfsinfo,
   xgamma,
+  xgc,
   xkeyboard-config,
   xlsatoms,
   xlsclients,
@@ -421,6 +422,7 @@ self: with self; {
     xev
     xfsinfo
     xgamma
+    xgc
     xlsatoms
     xlsclients
     xlsfonts

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -378,6 +378,7 @@ print OUT <<EOF;
   xfsinfo,
   xgamma,
   xgc,
+  xhost,
   xkeyboard-config,
   xlsatoms,
   xlsclients,
@@ -423,6 +424,7 @@ self: with self; {
     xfsinfo
     xgamma
     xgc
+    xhost
     xlsatoms
     xlsclients
     xlsfonts

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -379,6 +379,7 @@ print OUT <<EOF;
   xgamma,
   xgc,
   xhost,
+  xkbutils,
   xkeyboard-config,
   xlsatoms,
   xlsclients,
@@ -425,6 +426,7 @@ self: with self; {
     xgamma
     xgc
     xhost
+    xkbutils
     xlsatoms
     xlsclients
     xlsfonts

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -376,6 +376,7 @@ print OUT <<EOF;
   xdriinfo,
   xev,
   xfsinfo,
+  xgamma,
   xkeyboard-config,
   xlsatoms,
   xlsclients,
@@ -419,6 +420,7 @@ self: with self; {
     xdriinfo
     xev
     xfsinfo
+    xgamma
     xlsatoms
     xlsclients
     xlsfonts

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -381,6 +381,7 @@ print OUT <<EOF;
   xhost,
   xkbutils,
   xkeyboard-config,
+  xkill,
   xlsatoms,
   xlsclients,
   xlsfonts,
@@ -427,6 +428,7 @@ self: with self; {
     xgc
     xhost
     xkbutils
+    xkill
     xlsatoms
     xlsclients
     xlsfonts

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -965,7 +965,6 @@ self: super:
   xfd = addMainProgram super.xfd { };
   xfontsel = addMainProgram super.xfontsel { };
   xfs = addMainProgram super.xfs { };
-  xgc = addMainProgram super.xgc { };
   xhost = addMainProgram super.xhost { };
   xinput = addMainProgram super.xinput { };
   xkbevd = addMainProgram super.xkbevd { };

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -968,7 +968,6 @@ self: super:
   xinput = addMainProgram super.xinput { };
   xkbevd = addMainProgram super.xkbevd { };
   xkbprint = addMainProgram super.xkbprint { };
-  xkill = addMainProgram super.xkill { };
   xload = addMainProgram super.xload { };
   xmag = addMainProgram super.xmag { };
   xmessage = addMainProgram super.xmessage { };

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -965,7 +965,6 @@ self: super:
   xfd = addMainProgram super.xfd { };
   xfontsel = addMainProgram super.xfontsel { };
   xfs = addMainProgram super.xfs { };
-  xgamma = addMainProgram super.xgamma { };
   xgc = addMainProgram super.xgc { };
   xhost = addMainProgram super.xhost { };
   xinput = addMainProgram super.xinput { };

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -965,7 +965,6 @@ self: super:
   xfd = addMainProgram super.xfd { };
   xfontsel = addMainProgram super.xfontsel { };
   xfs = addMainProgram super.xfs { };
-  xhost = addMainProgram super.xhost { };
   xinput = addMainProgram super.xinput { };
   xkbevd = addMainProgram super.xkbevd { };
   xkbprint = addMainProgram super.xkbprint { };

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -27,7 +27,6 @@ mirror://xorg/individual/app/xinput-1.6.4.tar.xz
 mirror://xorg/individual/app/xkbcomp-1.4.7.tar.xz
 mirror://xorg/individual/app/xkbevd-1.1.6.tar.xz
 mirror://xorg/individual/app/xkbprint-1.0.7.tar.xz
-mirror://xorg/individual/app/xkbutils-1.0.6.tar.xz
 mirror://xorg/individual/app/xkill-1.0.6.tar.xz
 mirror://xorg/individual/app/xload-1.2.0.tar.xz
 mirror://xorg/individual/app/xmag-1.0.8.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -22,7 +22,6 @@ mirror://xorg/individual/app/xeyes-1.3.0.tar.xz
 mirror://xorg/individual/app/xfd-1.1.4.tar.xz
 mirror://xorg/individual/app/xfontsel-1.1.1.tar.xz
 mirror://xorg/individual/app/xfs-1.2.2.tar.xz
-mirror://xorg/individual/app/xhost-1.0.10.tar.xz
 mirror://xorg/individual/app/xinit-1.4.4.tar.xz
 mirror://xorg/individual/app/xinput-1.6.4.tar.xz
 mirror://xorg/individual/app/xkbcomp-1.4.7.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -22,7 +22,6 @@ mirror://xorg/individual/app/xeyes-1.3.0.tar.xz
 mirror://xorg/individual/app/xfd-1.1.4.tar.xz
 mirror://xorg/individual/app/xfontsel-1.1.1.tar.xz
 mirror://xorg/individual/app/xfs-1.2.2.tar.xz
-mirror://xorg/individual/app/xgamma-1.0.7.tar.xz
 mirror://xorg/individual/app/xgc-1.0.6.tar.xz
 mirror://xorg/individual/app/xhost-1.0.10.tar.xz
 mirror://xorg/individual/app/xinit-1.4.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -27,7 +27,6 @@ mirror://xorg/individual/app/xinput-1.6.4.tar.xz
 mirror://xorg/individual/app/xkbcomp-1.4.7.tar.xz
 mirror://xorg/individual/app/xkbevd-1.1.6.tar.xz
 mirror://xorg/individual/app/xkbprint-1.0.7.tar.xz
-mirror://xorg/individual/app/xkill-1.0.6.tar.xz
 mirror://xorg/individual/app/xload-1.2.0.tar.xz
 mirror://xorg/individual/app/xmag-1.0.8.tar.xz
 mirror://xorg/individual/app/xmessage-1.0.7.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -22,7 +22,6 @@ mirror://xorg/individual/app/xeyes-1.3.0.tar.xz
 mirror://xorg/individual/app/xfd-1.1.4.tar.xz
 mirror://xorg/individual/app/xfontsel-1.1.1.tar.xz
 mirror://xorg/individual/app/xfs-1.2.2.tar.xz
-mirror://xorg/individual/app/xgc-1.0.6.tar.xz
 mirror://xorg/individual/app/xhost-1.0.10.tar.xz
 mirror://xorg/individual/app/xinit-1.4.4.tar.xz
 mirror://xorg/individual/app/xinput-1.6.4.tar.xz


### PR DESCRIPTION
<details>
<summary>this is the script i use to get the packages that don't depend on other xorg packages:</summary>

```nix
let
  inherit (import <nixpkgs> { }) lib;

  done = import ./pkgs/servers/x11/xorg/default.nix |> lib.functionArgs |> lib.attrNames;

  pkgs =
    (import ./default.nix { }).xorg
    |> lib.filterAttrs (
      n: v:
      lib.isAttrs v
      && v ? pname
      && !lib.elem n done
      && !lib.elem n (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem v.pname done
      && !lib.elem v.pname (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem (lib.toLower n) done
      && !lib.elem (lib.toLower n) (map (lib.replaceStrings [ "-" ] [ "" ]) done)
    );

  pnames = lib.mapAttrsToList (_: v: v.pname) pkgs;

  filteredPkgs =
    pkgs
    |> lib.filterAttrs (
      n: v:
      true
      # && !v.meta.unfree
      # && !v.meta.broken
      # && !v.meta.unsupported
      # && !lib.hasPrefix "font" n
      && !lib.hasPrefix "xf86" n
    );
in
filteredPkgs
# get deps
|> lib.mapAttrs (
  _: v:
  v.buildInputs ++ v.nativeBuildInputs ++ v.propagatedBuildInputs ++ v.propagatedNativeBuildInputs
)
# filter deps for xorg packages
|> lib.mapAttrs (_: v: lib.filter (x: x ? pname && lib.elem x.pname pnames) v)
# map deps to list and count
|> lib.mapAttrsToList (
  name: value: {
    inherit name;
    deps = map (x: x.pname or "error") value |> lib.unique;
    count = lib.length value;
  }
)
# sort
|> lib.sort (
  x: y: x.count < y.count || (x.count == y.count && (lib.toLower x.name) > (lib.toLower y.name))
)
|> lib.reverseList
# represent as string
|> map (x: "${toString x.count} - ${toString x.name}: ${lib.concatStringsSep " " x.deps}")
```

you can call it like this to get a nice output:

```sh
nix eval --json --file ./xorg-nodepends.nix | jq .[] --raw-output
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] x86_64-linux static 
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - as far as  they are testable inside a wayland compositor
  - mostly only the help output or something
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] ran passthru.updateScript
- [x] ran nixpkgs-hammer
- [x] ran nix-check-deps 
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc