### PR TITLE
arttime: init at 2.4.0

### DIFF
--- a/pkgs/by-name/ar/arttime/package.nix
+++ b/pkgs/by-name/ar/arttime/package.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  installShellFiles,
+  patchRcPathBash,
+  makeWrapper,
+  zsh,
+  coreutils,
+  gnused,
+  tzdata,
+  diffutils,
+  less,
+
+  # Optional dependencies
+  withLibnotify ? true,
+  withVorbistools ? true,
+  withFzf ? true,
+
+  libnotify,
+  vorbis-tools,
+  fzf,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "arttime";
+  version = "2.4.0";
+
+  src = fetchFromGitHub {
+    owner = "poetaman";
+    repo = "arttime";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-luz2tz8ammN4Xiw5q4vUVAAwIpbDNU/vO/ewTlvjRHA=";
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+    patchRcPathBash
+    makeWrapper
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share
+    cp -a bin $out
+    cp -a share/arttime $out/share
+
+    runHook postInstall
+  '';
+
+  postInstall =
+    let
+      runtimeDependencies = [
+        gnused
+        diffutils
+        less
+      ]
+      ++ lib.optionals withLibnotify [ libnotify ]
+      ++ lib.optionals withVorbistools [ vorbis-tools ]
+      ++ lib.optionals withFzf [ fzf ];
+    in
+    ''
+      installManPage share/man/man1/*
+
+      installShellCompletion --zsh --name _artprint share/zsh/functions/_artprint
+      installShellCompletion --zsh --name _arttime share/zsh/functions/_arttime
+
+      substituteInPlace $out/share/arttime/src/arttime.zsh \
+        --replace-warn "/bin/stty" "${lib.getExe' coreutils "stty"}" \
+        --replace-warn "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo" \
+        --replace-warn "W: make $etclocaltime" \
+          "W: set time.timeZone in your NixOS configuration or make $etclocaltime"
+
+      patchRcPathBash $out/share/arttime/src/arttime.zsh ${lib.makeBinPath runtimeDependencies}
+
+      wrapProgram $out/bin/arttime \
+        --set-default TZDIR ${tzdata}/share/zoneinfo \
+        --suffix PATH : ${lib.makeBinPath [ zsh ]}
+
+      wrapProgram $out/bin/artprint \
+        --suffix PATH : ${
+          lib.makeBinPath [
+            zsh
+            gnused
+          ]
+        }
+    '';
+
+  meta = {
+    description = "Clock, timer, time manager and ASCII text-art viewer for the terminal";
+    longDescription = ''
+      Beauty of text art meets the functionality of a feature-rich clock/timer/pattern-based
+      time manager. Arttime brings curated text art to otherwise artless terminal emulators
+      of starving developers and other users who can use the terminal. (Arttime CFLAv1 GPLv3)
+    '';
+    homepage = "https://github.com/poetaman/arttime";
+    license = with lib.licenses; [
+      gpl3Only
+      unfreeRedistributable
+    ];
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.mimvoid ];
+  };
+})


### PR DESCRIPTION
[Arttime](https://github.com/poetaman/arttime) is a feature-rich clock/timer/pattern-based time manager in the terminal with curated text-art.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
