### PR TITLE
xm{ag,ore,essage}: refactor and move to pkgs/by-name from xorg namespace

### DIFF
--- a/pkgs/by-name/xm/xmag/package.nix
+++ b/pkgs/by-name/xm/xmag/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  wrapWithXFileSearchPathHook,
+  xorgproto,
+  libx11,
+  libxaw,
+  libxmu,
+  libxt,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xmag";
+  version = "1.0.8";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xmag-${finalAttrs.version}.tar.xz";
+    hash = "sha256-Mm08WD15W7U6xgnRROf3+xSZurp+rsFLjmzSMuoGlTI=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapWithXFileSearchPathHook
+  ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxaw
+    libxmu
+    libxt
+  ];
+
+  installFlags = [ "appdefaultdir=$(out)/share/X11/app-defaults" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Utility to display a magnified snapshot of a portion of an X11 screen.";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xmag";
+    license = with lib.licenses; [
+      mitOpenGroup
+      x11
+    ];
+    mainProgram = "xmag";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xm/xmessage/package.nix
+++ b/pkgs/by-name/xm/xmessage/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libxaw,
+  libxt,
+  wrapWithXFileSearchPathHook,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xmessage";
+  version = "1.0.7";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xmessage-${finalAttrs.version}.tar.xz";
+    hash = "sha256-cD/Mt6C3ctYdfmA8GJuXOYZqqXuphccnJ1Qg+CmjA1Y=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapWithXFileSearchPathHook
+  ];
+
+  buildInputs = [
+    libxaw
+    libxt
+  ];
+
+  installFlags = [ "appdefaultdir=$(out)/share/X11/app-defaults" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Display a message or query in a window";
+    longDescription = ''
+      xmessage displays a message or query in a window. The user can click on an "okay" button to
+      dismiss it or can select one of several buttons to answer a question. xmessage can also exit
+      after a specified time.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xmessage";
+    license = lib.licenses.x11;
+    mainProgram = "xmessage";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xm/xmore/package.nix
+++ b/pkgs/by-name/xm/xmore/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  wrapWithXFileSearchPathHook,
+  xorgproto,
+  libxaw,
+  libxt,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xmore";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xmore-${finalAttrs.version}.tar.xz";
+    hash = "sha256-frVg28HeTkPGT+SRrXOQeinXNMyoKprYLH0/65zbCpo=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapWithXFileSearchPathHook
+  ];
+
+  buildInputs = [
+    xorgproto
+    libxaw
+    libxt
+  ];
+
+  installFlags = [ "appdefaultdir=$(out)/share/X11/app-defaults" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Plain text display program for the X Window System";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xmore";
+    license = with lib.licenses; [
+      hpndSellVariant
+      mitOpenGroup
+    ];
+    mainProgram = "xmore";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -65,6 +65,7 @@
   xlsclients,
   xlsfonts,
   xmag,
+  xmessage,
   xmodmap,
   xorg-cf-files,
   xorg-docs,
@@ -108,6 +109,7 @@ self: with self; {
     xlsclients
     xlsfonts
     xmag
+    xmessage
     xmodmap
     xorgproto
     xprop
@@ -5544,46 +5546,6 @@ self: with self; {
         libXaw
         libXmu
         xorgproto
-        libXt
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xmessage = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libXaw,
-      libXt,
-      wrapWithXFileSearchPathHook,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xmessage";
-      version = "1.0.7";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xmessage-1.0.7.tar.xz";
-        sha256 = "0mh3lclzh82l4wkwg1d9gflnm1irjydihg30gqfxcwmpl2vwqgvh";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        wrapWithXFileSearchPathHook
-      ];
-      buildInputs = [
-        libXaw
         libXt
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -67,6 +67,7 @@
   xmag,
   xmessage,
   xmodmap,
+  xmore,
   xorg-cf-files,
   xorg-docs,
   xorgproto,
@@ -111,6 +112,7 @@ self: with self; {
     xmag
     xmessage
     xmodmap
+    xmore
     xorgproto
     xprop
     xrandr
@@ -5545,48 +5547,6 @@ self: with self; {
         libX11
         libXaw
         libXmu
-        xorgproto
-        libXt
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xmore = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libXaw,
-      xorgproto,
-      libXt,
-      wrapWithXFileSearchPathHook,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xmore";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xmore-1.0.4.tar.xz";
-        sha256 = "16havfffngvx5kc9lam8rhsdfabsj1rsv4g49z346knyq7dn1dby";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        wrapWithXFileSearchPathHook
-      ];
-      buildInputs = [
-        libXaw
         xorgproto
         libXt
       ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -64,6 +64,7 @@
   xlsatoms,
   xlsclients,
   xlsfonts,
+  xmag,
   xmodmap,
   xorg-cf-files,
   xorg-docs,
@@ -106,6 +107,7 @@ self: with self; {
     xlsatoms
     xlsclients
     xlsfonts
+    xmag
     xmodmap
     xorgproto
     xprop
@@ -5535,52 +5537,6 @@ self: with self; {
       nativeBuildInputs = [
         pkg-config
         gettext
-        wrapWithXFileSearchPathHook
-      ];
-      buildInputs = [
-        libX11
-        libXaw
-        libXmu
-        xorgproto
-        libXt
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xmag = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libXaw,
-      libXmu,
-      xorgproto,
-      libXt,
-      wrapWithXFileSearchPathHook,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xmag";
-      version = "1.0.8";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xmag-1.0.8.tar.xz";
-        sha256 = "0clm0vm35lkcir5w3bkypax9j57vyzkl9l89qqxbanvr7mc3qv9j";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
         wrapWithXFileSearchPathHook
       ];
       buildInputs = [

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -381,6 +381,7 @@ print OUT <<EOF;
   xlsclients,
   xlsfonts,
   xmag,
+  xmessage,
   xmodmap,
   xorg-cf-files,
   xorg-docs,
@@ -424,6 +425,7 @@ self: with self; {
     xlsclients
     xlsfonts
     xmag
+    xmessage
     xmodmap
     xorgproto
     xprop

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -383,6 +383,7 @@ print OUT <<EOF;
   xmag,
   xmessage,
   xmodmap,
+  xmore,
   xorg-cf-files,
   xorg-docs,
   xorgproto,
@@ -427,6 +428,7 @@ self: with self; {
     xmag
     xmessage
     xmodmap
+    xmore
     xorgproto
     xprop
     xrandr

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -380,6 +380,7 @@ print OUT <<EOF;
   xlsatoms,
   xlsclients,
   xlsfonts,
+  xmag,
   xmodmap,
   xorg-cf-files,
   xorg-docs,
@@ -422,6 +423,7 @@ self: with self; {
     xlsatoms
     xlsclients
     xlsfonts
+    xmag
     xmodmap
     xorgproto
     xprop

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -973,7 +973,6 @@ self: super:
   xkbprint = addMainProgram super.xkbprint { };
   xkill = addMainProgram super.xkill { };
   xload = addMainProgram super.xload { };
-  xmessage = addMainProgram super.xmessage { };
   xmore = addMainProgram super.xmore { };
 
   xpr = addMainProgram super.xpr { };

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -973,7 +973,6 @@ self: super:
   xkbprint = addMainProgram super.xkbprint { };
   xkill = addMainProgram super.xkill { };
   xload = addMainProgram super.xload { };
-  xmag = addMainProgram super.xmag { };
   xmessage = addMainProgram super.xmessage { };
   xmore = addMainProgram super.xmore { };
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -973,7 +973,6 @@ self: super:
   xkbprint = addMainProgram super.xkbprint { };
   xkill = addMainProgram super.xkill { };
   xload = addMainProgram super.xload { };
-  xmore = addMainProgram super.xmore { };
 
   xpr = addMainProgram super.xpr { };
 

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -33,7 +33,6 @@ mirror://xorg/individual/app/xkbprint-1.0.7.tar.xz
 mirror://xorg/individual/app/xkbutils-1.0.6.tar.xz
 mirror://xorg/individual/app/xkill-1.0.6.tar.xz
 mirror://xorg/individual/app/xload-1.2.0.tar.xz
-mirror://xorg/individual/app/xmessage-1.0.7.tar.xz
 mirror://xorg/individual/app/xmore-1.0.4.tar.xz
 mirror://xorg/individual/app/xpr-1.2.0.tar.xz
 mirror://xorg/individual/app/xrdb-1.2.2.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -33,7 +33,6 @@ mirror://xorg/individual/app/xkbprint-1.0.7.tar.xz
 mirror://xorg/individual/app/xkbutils-1.0.6.tar.xz
 mirror://xorg/individual/app/xkill-1.0.6.tar.xz
 mirror://xorg/individual/app/xload-1.2.0.tar.xz
-mirror://xorg/individual/app/xmag-1.0.8.tar.xz
 mirror://xorg/individual/app/xmessage-1.0.7.tar.xz
 mirror://xorg/individual/app/xmore-1.0.4.tar.xz
 mirror://xorg/individual/app/xpr-1.2.0.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -33,7 +33,6 @@ mirror://xorg/individual/app/xkbprint-1.0.7.tar.xz
 mirror://xorg/individual/app/xkbutils-1.0.6.tar.xz
 mirror://xorg/individual/app/xkill-1.0.6.tar.xz
 mirror://xorg/individual/app/xload-1.2.0.tar.xz
-mirror://xorg/individual/app/xmore-1.0.4.tar.xz
 mirror://xorg/individual/app/xpr-1.2.0.tar.xz
 mirror://xorg/individual/app/xrdb-1.2.2.tar.xz
 mirror://xorg/individual/app/xset-1.2.5.tar.xz


### PR DESCRIPTION
<details>
<summary>this is the script i use to get the packages that don't depend on other xorg packages:</summary>

```nix
let
  inherit (import <nixpkgs> { }) lib;

  done = import ./pkgs/servers/x11/xorg/default.nix |> lib.functionArgs |> lib.attrNames;

  pkgs =
    (import ./default.nix { }).xorg
    |> lib.filterAttrs (
      n: v:
      lib.isAttrs v
      && v ? pname
      && !lib.elem n done
      && !lib.elem n (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem v.pname done
      && !lib.elem v.pname (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem (lib.toLower n) done
      && !lib.elem (lib.toLower n) (map (lib.replaceStrings [ "-" ] [ "" ]) done)
    );

  pnames = lib.mapAttrsToList (_: v: v.pname) pkgs;

  filteredPkgs =
    pkgs
    |> lib.filterAttrs (
      n: v:
      true
      # && !v.meta.unfree
      # && !v.meta.broken
      # && !v.meta.unsupported
      # && !lib.hasPrefix "font" n
      && !lib.hasPrefix "xf86" n
    );
in
filteredPkgs
# get deps
|> lib.mapAttrs (
  _: v:
  v.buildInputs ++ v.nativeBuildInputs ++ v.propagatedBuildInputs ++ v.propagatedNativeBuildInputs
)
# filter deps for xorg packages
|> lib.mapAttrs (_: v: lib.filter (x: x ? pname && lib.elem x.pname pnames) v)
# map deps to list and count
|> lib.mapAttrsToList (
  name: value: {
    inherit name;
    deps = map (x: x.pname or "error") value |> lib.unique;
    count = lib.length value;
  }
)
# sort
|> lib.sort (
  x: y: x.count < y.count || (x.count == y.count && (lib.toLower x.name) > (lib.toLower y.name))
)
|> lib.reverseList
# represent as string
|> map (x: "${toString x.count} - ${toString x.name}: ${lib.concatStringsSep " " x.deps}")
```

you can call it like this to get a nice output:

```sh
nix eval --json --file ./xorg-nodepends.nix | jq .[] --raw-output
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] x86_64-linux static 
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - as far as  they are testable inside a wayland compositor (pretty good for xmore, xmessage)
  - xmag didn't work, but `nixpkgs#xorg.xmag` didn't either
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] ran passthru.updateScript
- [x] ran nixpkgs-hammer
- [x] ran nix-check-deps 
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc