### PR TITLE
python3Packages.cupy: 13.5.1 -> 13.6.0

### DIFF
--- a/pkgs/development/python-modules/cupy/default.nix
+++ b/pkgs/development/python-modules/cupy/default.nix
@@ -3,16 +3,14 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  cython_0,
+  cython,
   fastrlock,
   numpy,
-  wheel,
   pytestCheckHook,
   mock,
   setuptools,
   cudaPackages,
   addDriverRunpath,
-  pythonOlder,
   symlinkJoin,
 }:
 
@@ -58,10 +56,8 @@ let
 in
 buildPythonPackage rec {
   pname = "cupy";
-  version = "13.5.1";
-  format = "setuptools";
-
-  disabled = pythonOlder "3.7";
+  version = "13.6.0";
+  pyproject = true;
 
   stdenv = cudaPackages.backendStdenv;
 
@@ -69,7 +65,7 @@ buildPythonPackage rec {
     owner = "cupy";
     repo = "cupy";
     tag = "v${version}";
-    hash = "sha256-8RgyvsU3lnt6nO0J1tiLBOdYsX0jJkjPH/SpKQz4o7s=";
+    hash = "sha256-nU3VL0MSCN+mI5m7C5sKAjBSL6ybM6YAk5lJiIDY0ck=";
     fetchSubmodules = true;
   };
 
@@ -83,11 +79,14 @@ buildPythonPackage rec {
     export CUPY_NUM_NVCC_THREADS="$NIX_BUILD_CORES"
   '';
 
-  nativeBuildInputs = [
+  build-system = [
+    cython
+    fastrlock
     setuptools
-    wheel
+  ];
+
+  nativeBuildInputs = [
     addDriverRunpath
-    cython_0
     cudaPackages.cuda_nvcc
   ];
 
@@ -101,7 +100,7 @@ buildPythonPackage rec {
   NVCC = "${lib.getExe cudaPackages.cuda_nvcc}"; # FIXME: splicing/buildPackages
   CUDA_PATH = "${cudatoolkit-joined}";
 
-  propagatedBuildInputs = [
+  dependencies = [
     fastrlock
     numpy
   ];


### PR DESCRIPTION
Diff: https://github.com/cupy/cupy/compare/v13.3.0...v13.6.0

Changelog: https://github.com/cupy/cupy/releases/tag/v13.6.0

fixes https://github.com/NixOS/nixpkgs/issues/428055
closes https://github.com/NixOS/nixpkgs/pull/428078
cc @pfmephisto
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
