### PR TITLE
go-foks: init at 0.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18059,6 +18059,12 @@
     githubId = 265800;
     name = "Niklaus Giger";
   };
+  ngp = {
+    email = "noah@packetlost.dev";
+    github = "chiefnoah";
+    githubId = 3588683;
+    name = "Noah Pederson";
+  };
   nh2 = {
     email = "mail@nh2.me";
     matrix = "@nh2:matrix.org";

--- a/pkgs/by-name/go/go-foks/frontend.nix
+++ b/pkgs/by-name/go/go-foks/frontend.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  src,
+  buildNpmPackage,
+  version,
+}:
+buildNpmPackage (finalAttrs: {
+  inherit version src;
+  pname = "go-foks-frontend";
+  npmDepsHash = "sha256-mASu3taprCYP+muRh4b+qUTce7YTdISf/QnmSvUy6Mo=";
+  npmPackFlags = [ "--ignore-scripts" ];
+  # We only need to fetch the deps to be copied into the foks-server binary
+  dontNpmBuild = true;
+  NODE_OPTIONS = "--openssl-legacy-provider";
+  meta = {
+    description = "Web frontend to the Go FOKS implementation.";
+    homepage = "https://github.com/foks-proj/go-foks";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ngp ];
+  };
+  sourceRoot = finalAttrs.src.name + "/server/web/frontend";
+})

--- a/pkgs/by-name/go/go-foks/package.nix
+++ b/pkgs/by-name/go/go-foks/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  pkg-config,
+  templ,
+  tailwindcss_4,
+  uglify-js,
+  pcsclite,
+  buildGoModule,
+  fetchFromGitHub,
+  callPackage,
+}:
+let
+  version = "0.1.1";
+  src = fetchFromGitHub {
+    owner = "foks-proj";
+    repo = "go-foks";
+    tag = "v${version}";
+    hash = "sha256-N4sWxYnHeqvG/qcqoqakUbxjtoh8CNPegYPYdrgP+z4=";
+  };
+  go-foks-frontend = callPackage ./frontend.nix { inherit version src; };
+in
+buildGoModule {
+  pname = "go-foks";
+  inherit version src;
+  preBuild = ''
+    # Generate the .go files from .templ files
+    go tool templ generate -path server/web/templates
+    # Copy out the static web assets from the frontend dependencies, they are embedded
+    # using //go:embed directives in the server/web/static/js module
+    cp ${go-foks-frontend}/lib/node_modules/go-foks-frontend/node_modules/htmx.org/dist/htmx.js \
+       server/web/static/js/htmx.js
+    cp ${go-foks-frontend}/lib/node_modules/go-foks-frontend/node_modules/htmx.org/dist/htmx.min.js \
+       ./server/web/static/js/htmx.min.js
+    # Compile CSS and place in module to be embedded
+    tailwindcss -i server/web/frontend/css/input.css -o server/web/static/css/style.css
+    tailwindcss -i server/web/frontend/css/input.css -o server/web/static/css/style.min.css --minify
+    # Generate a minified version of foks.js to be embedded in the go module
+    uglifyjs -c < server/web/static/js/foks.js > server/web/static/js/foks.min.js
+  '';
+  subPackages = [
+    "client/foks"
+    "server/foks-tool"
+    "server/foks-server"
+  ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ pcsclite ];
+  nativeBuildInputs = [
+    templ
+    tailwindcss_4
+    uglify-js
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ pkg-config ];
+  vendorHash = "sha256-8/SVOWMoCfeiuH2As2cC/HLRs1WQIQ4/Ko1olXDq6bo=";
+  meta = {
+    homepage = "https://github.com/foks-proj/go-foks";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ngp ];
+    description = "Go implementation of FOKS server and client";
+    changelog = "https://github.com/foks-proj/go-foks/releases/tag/v${version}";
+    platforms = lib.platforms.all;
+    mainProgram = "foks";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
