### PR TITLE
pantheon.elementary-terminal: 7.1.0 -> 7.1.1

### DIFF
--- a/pkgs/desktops/pantheon/apps/elementary-terminal/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-terminal/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   nix-update-script,
   pkg-config,
   meson,
@@ -22,23 +21,14 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-terminal";
-  version = "7.1.0";
+  version = "7.1.1";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = "terminal";
     rev = version;
-    sha256 = "sha256-IbN01o3rojlwp4rBt8NlIPthxIPMOm/bD1rzD5Taibw=";
+    sha256 = "sha256-B/VEVS1dJQGJ8+gqgJ/mb3+r29ZPtCSSlur/CAr6BJg=";
   };
-
-  patches = [
-    # Fix incorrect line breaks when pasting/dropping into foreground processes
-    # https://github.com/elementary/terminal/pull/862
-    (fetchpatch {
-      url = "https://github.com/elementary/terminal/commit/8f93bc77437e45090e59266c7813436a0903d27b.patch";
-      hash = "sha256-4xUFnFVUV4EIDZFprEbL+S49j5Maof5/egHPVaJAVg4=";
-    })
-  ];
 
   nativeBuildInputs = [
     desktop-file-utils


### PR DESCRIPTION
https://github.com/elementary/terminal/compare/7.1.0...7.1.1



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

