### PR TITLE
mcp-language-server: use tag instead of rev

### DIFF
--- a/pkgs/by-name/mc/mcp-language-server/package.nix
+++ b/pkgs/by-name/mc/mcp-language-server/package.nix
@@ -10,7 +10,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "isaacphi";
     repo = "mcp-language-server";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-T0wuPSShJqVW+CcQHQuZnh3JOwqUxAKv1OCHwZMr7KM=";
   };
 


### PR DESCRIPTION
## Description

Add mcp-language-server, a language server that runs and exposes a language server to LLMs.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [ ] For non-Linux: Is sandboxing enabled in `nix.conf`?
- [ ] Tested, as applicable:
  - [ ] NixOS test(s)
  - [ ] nixpkgs-review
  - [ ] Tested compilation of all packages that depend on this change using `nix-build -A package-name`
  - [ ] Tested basic functionality of the binary
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc