### PR TITLE
xs{et,etroot,m,tdcmap}: refactor and move to pkgs/by-name from xorg namespace

### DIFF
--- a/pkgs/by-name/xs/xset/package.nix
+++ b/pkgs/by-name/xs/xset/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxext,
+  libxmu,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xset";
+  version = "1.2.5";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xset-${finalAttrs.version}.tar.xz";
+    hash = "sha256-n2ktVWNbOGLNY2M7EiKodoDsKDx6jo7W3WmKMUf3Xi8=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxext
+    libxmu
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "User preference utility for X servers";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xset";
+    license = lib.licenses.mitOpenGroup;
+    mainProgram = "xset";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xs/xsetroot/package.nix
+++ b/pkgs/by-name/xs/xsetroot/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  xbitmaps,
+  libx11,
+  libxcursor,
+  libxmu,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xsetroot";
+  version = "1.1.3";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xsetroot-${finalAttrs.version}.tar.xz";
+    hash = "sha256-YIG0Wp60Qm4EXSWdHhRLMkF/tjXluWqpBkc2WslmONE=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    xbitmaps
+    libx11
+    libxcursor
+    libxmu
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Root window parameter setting utility for X";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xsetroot";
+    license = lib.licenses.mitOpenGroup;
+    mainProgram = "xsetroot";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xs/xsm/package.nix
+++ b/pkgs/by-name/xs/xsm/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  wrapWithXFileSearchPathHook,
+  xorgproto,
+  libice,
+  libsm,
+  libx11,
+  libxaw,
+  libxt,
+  makeBinaryWrapper,
+  writeScript,
+  # run time dependencies
+  iceauth,
+  smproxy,
+  twm,
+  xterm,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xsm";
+  version = "1.0.6";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xsm-${finalAttrs.version}.tar.xz";
+    hash = "sha256-t0zHdMYGDDdZL2ipDb0xsPKmL7FOVidpQ095vihKY84=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapWithXFileSearchPathHook
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [
+    xorgproto
+    libice
+    libsm
+    libx11
+    libxaw
+    libxt
+  ];
+
+  installFlags = [ "appdefaultdir=$(out)/share/X11/app-defaults" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/xsm \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          iceauth
+          smproxy
+          twm
+          xterm
+        ]
+      }
+  '';
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "X Session Manager";
+    longDescription = ''
+      A session is a group of X applications, each of which has a particular state. xsm allows you
+      to create arbitrary sessions - for example, you might have a "light" session, a "development"
+      session, or an "xterminal" session. Each session can have its own set of applications. Within
+      a session, you can perform a "checkpoint" to save application state, or a "shutdown" to save
+      state and exit the session. When you log back in to the system, you can load a specific
+      session, and you can delete sessions you no longer want to keep.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xsm";
+    license = lib.licenses.mitOpenGroup;
+    mainProgram = "xsm";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xs/xstdcmap/package.nix
+++ b/pkgs/by-name/xs/xstdcmap/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxmu,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xstdcmap";
+  version = "1.0.5";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xstdcmap-${finalAttrs.version}.tar.xz";
+    hash = "sha256-NlhH43k5hJnsmtmimcxHoNbn/rqVRt/U5bQiIEtawYA=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxmu
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "X standard colormap utility";
+    longDescription = ''
+      The xstdcmap utility can be used to selectively define standard colormap properties.
+      It is intended to be run from a user's X startup script to create standard colormap
+      definitions in order to facilitate sharing of scarce colormap resources among clients using
+      PseudoColor visuals.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xstdcmap";
+    license = lib.licenses.mitOpenGroup;
+    mainProgram = "xstdcmap";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -83,6 +83,7 @@
   xrandr,
   xrefresh,
   xset,
+  xsetroot,
   xtrans,
   xvinfo,
   xwininfo,
@@ -128,6 +129,7 @@ self: with self; {
     xrandr
     xrefresh
     xset
+    xsetroot
     xtrans
     xvinfo
     xwininfo
@@ -5423,48 +5425,6 @@ self: with self; {
       nativeBuildInputs = [ pkg-config ];
       buildInputs = [
         libX11
-        libXmu
-        xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xsetroot = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      xbitmaps,
-      libXcursor,
-      libXmu,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xsetroot";
-      version = "1.1.3";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xsetroot-1.1.3.tar.xz";
-        sha256 = "1l9qcv4mldj70slnmfg56nv7yh9j9ca1x795bl26whmlkrdb90b0";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        xbitmaps
-        libXcursor
         libXmu
         xorgproto
       ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -82,6 +82,7 @@
   xprop,
   xrandr,
   xrefresh,
+  xset,
   xtrans,
   xvinfo,
   xwininfo,
@@ -126,6 +127,7 @@ self: with self; {
     xprop
     xrandr
     xrefresh
+    xset
     xtrans
     xvinfo
     xwininfo
@@ -5423,48 +5425,6 @@ self: with self; {
         libX11
         libXmu
         xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xset = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libXext,
-      libXmu,
-      xorgproto,
-      libXxf86misc,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xset";
-      version = "1.2.5";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xset-1.2.5.tar.xz";
-        sha256 = "0bsyyx3k32k9vpb8x3ks7hlfr03nm0i14fv3cg6n4f2vcdajsscz";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        libXext
-        libXmu
-        xorgproto
-        libXxf86misc
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -84,6 +84,7 @@
   xrefresh,
   xset,
   xsetroot,
+  xsm,
   xtrans,
   xvinfo,
   xwininfo,
@@ -130,6 +131,7 @@ self: with self; {
     xrefresh
     xset
     xsetroot
+    xsm
     xtrans
     xvinfo
     xwininfo
@@ -5427,54 +5429,6 @@ self: with self; {
         libX11
         libXmu
         xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xsm = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libICE,
-      libSM,
-      libX11,
-      libXaw,
-      xorgproto,
-      libXt,
-      wrapWithXFileSearchPathHook,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xsm";
-      version = "1.0.6";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xsm-1.0.6.tar.xz";
-        sha256 = "1kk398lbwyag8dljfmjfn4psdwmh66yhvab85xckf306qrscfk5p";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        wrapWithXFileSearchPathHook
-      ];
-      buildInputs = [
-        libICE
-        libSM
-        libX11
-        libXaw
-        xorgproto
-        libXt
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -85,6 +85,7 @@
   xset,
   xsetroot,
   xsm,
+  xstdcmap,
   xtrans,
   xvinfo,
   xwininfo,
@@ -132,6 +133,7 @@ self: with self; {
     xset
     xsetroot
     xsm
+    xstdcmap
     xtrans
     xvinfo
     xwininfo
@@ -5418,44 +5420,6 @@ self: with self; {
       src = fetchurl {
         url = "mirror://xorg/individual/app/xrdb-1.2.2.tar.xz";
         sha256 = "1x1ka0zbcw66a06jvsy92bvnsj9vxbvnq1hbn1az4f0v4fmzrx9i";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        libXmu
-        xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xstdcmap = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libXmu,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xstdcmap";
-      version = "1.0.5";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xstdcmap-1.0.5.tar.xz";
-        sha256 = "1061b95j08mlwpadyilmpbzfgmm08z69k8nrkbn9k11rg7ilfn1n";
       };
       hardeningDisable = [
         "bindnow"

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -398,6 +398,7 @@ print OUT <<EOF;
   xprop,
   xrandr,
   xrefresh,
+  xset,
   xtrans,
   xvinfo,
   xwininfo,
@@ -442,6 +443,7 @@ self: with self; {
     xprop
     xrandr
     xrefresh
+    xset
     xtrans
     xvinfo
     xwininfo

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -399,6 +399,7 @@ print OUT <<EOF;
   xrandr,
   xrefresh,
   xset,
+  xsetroot,
   xtrans,
   xvinfo,
   xwininfo,
@@ -444,6 +445,7 @@ self: with self; {
     xrandr
     xrefresh
     xset
+    xsetroot
     xtrans
     xvinfo
     xwininfo

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -400,6 +400,7 @@ print OUT <<EOF;
   xrefresh,
   xset,
   xsetroot,
+  xsm,
   xtrans,
   xvinfo,
   xwininfo,
@@ -446,6 +447,7 @@ self: with self; {
     xrefresh
     xset
     xsetroot
+    xsm
     xtrans
     xvinfo
     xwininfo

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -401,6 +401,7 @@ print OUT <<EOF;
   xset,
   xsetroot,
   xsm,
+  xstdcmap,
   xtrans,
   xvinfo,
   xwininfo,
@@ -448,6 +449,7 @@ self: with self; {
     xset
     xsetroot
     xsm
+    xstdcmap
     xtrans
     xvinfo
     xwininfo

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -982,7 +982,6 @@ self: super:
     };
   });
 
-  xset = addMainProgram super.xset { };
   xsetroot = addMainProgram super.xsetroot { };
   xsm = addMainProgram super.xsm { };
   xstdcmap = addMainProgram super.xstdcmap { };

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -982,7 +982,6 @@ self: super:
     };
   });
 
-  xsetroot = addMainProgram super.xsetroot { };
   xsm = addMainProgram super.xsm { };
   xstdcmap = addMainProgram super.xstdcmap { };
   xwd = addMainProgram super.xwd { };

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -982,7 +982,6 @@ self: super:
     };
   });
 
-  xsm = addMainProgram super.xsm { };
   xstdcmap = addMainProgram super.xstdcmap { };
   xwd = addMainProgram super.xwd { };
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -982,7 +982,6 @@ self: super:
     };
   });
 
-  xstdcmap = addMainProgram super.xstdcmap { };
   xwd = addMainProgram super.xwd { };
 
   # convert Type1 vector fonts to OpenType fonts

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -33,7 +33,6 @@ mirror://xorg/individual/app/xmessage-1.0.7.tar.xz
 mirror://xorg/individual/app/xmore-1.0.4.tar.xz
 mirror://xorg/individual/app/xpr-1.2.0.tar.xz
 mirror://xorg/individual/app/xrdb-1.2.2.tar.xz
-mirror://xorg/individual/app/xsetroot-1.1.3.tar.xz
 mirror://xorg/individual/app/xsm-1.0.6.tar.xz
 mirror://xorg/individual/app/xstdcmap-1.0.5.tar.xz
 mirror://xorg/individual/app/xtrap-1.0.3.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -33,7 +33,6 @@ mirror://xorg/individual/app/xmessage-1.0.7.tar.xz
 mirror://xorg/individual/app/xmore-1.0.4.tar.xz
 mirror://xorg/individual/app/xpr-1.2.0.tar.xz
 mirror://xorg/individual/app/xrdb-1.2.2.tar.xz
-mirror://xorg/individual/app/xsm-1.0.6.tar.xz
 mirror://xorg/individual/app/xstdcmap-1.0.5.tar.xz
 mirror://xorg/individual/app/xtrap-1.0.3.tar.bz2
 mirror://xorg/individual/app/xwd-1.0.9.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -33,7 +33,6 @@ mirror://xorg/individual/app/xmessage-1.0.7.tar.xz
 mirror://xorg/individual/app/xmore-1.0.4.tar.xz
 mirror://xorg/individual/app/xpr-1.2.0.tar.xz
 mirror://xorg/individual/app/xrdb-1.2.2.tar.xz
-mirror://xorg/individual/app/xstdcmap-1.0.5.tar.xz
 mirror://xorg/individual/app/xtrap-1.0.3.tar.bz2
 mirror://xorg/individual/app/xwd-1.0.9.tar.xz
 mirror://xorg/individual/driver/xf86-input-evdev-2.11.0.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -33,7 +33,6 @@ mirror://xorg/individual/app/xmessage-1.0.7.tar.xz
 mirror://xorg/individual/app/xmore-1.0.4.tar.xz
 mirror://xorg/individual/app/xpr-1.2.0.tar.xz
 mirror://xorg/individual/app/xrdb-1.2.2.tar.xz
-mirror://xorg/individual/app/xset-1.2.5.tar.xz
 mirror://xorg/individual/app/xsetroot-1.1.3.tar.xz
 mirror://xorg/individual/app/xsm-1.0.6.tar.xz
 mirror://xorg/individual/app/xstdcmap-1.0.5.tar.xz


### PR DESCRIPTION
<details>
<summary>this is the script i use to get the packages that don't depend on other xorg packages:</summary>

```nix
let
  inherit (import <nixpkgs> { }) lib;

  done = import ./pkgs/servers/x11/xorg/default.nix |> lib.functionArgs |> lib.attrNames;

  pkgs =
    (import ./default.nix { }).xorg
    |> lib.filterAttrs (
      n: v:
      lib.isAttrs v
      && v ? pname
      && !lib.elem n done
      && !lib.elem n (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem v.pname done
      && !lib.elem v.pname (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem (lib.toLower n) done
      && !lib.elem (lib.toLower n) (map (lib.replaceStrings [ "-" ] [ "" ]) done)
    );

  pnames = lib.mapAttrsToList (_: v: v.pname) pkgs;

  filteredPkgs =
    pkgs
    |> lib.filterAttrs (
      n: v:
      true
      # && !v.meta.unfree
      # && !v.meta.broken
      # && !v.meta.unsupported
      # && !lib.hasPrefix "font" n
      && !lib.hasPrefix "xf86" n
    );
in
filteredPkgs
# get deps
|> lib.mapAttrs (
  _: v:
  v.buildInputs ++ v.nativeBuildInputs ++ v.propagatedBuildInputs ++ v.propagatedNativeBuildInputs
)
# filter deps for xorg packages
|> lib.mapAttrs (_: v: lib.filter (x: x ? pname && lib.elem x.pname pnames) v)
# map deps to list and count
|> lib.mapAttrsToList (
  name: value: {
    inherit name;
    deps = map (x: x.pname or "error") value |> lib.unique;
    count = lib.length value;
  }
)
# sort
|> lib.sort (
  x: y: x.count < y.count || (x.count == y.count && (lib.toLower x.name) > (lib.toLower y.name))
)
|> lib.reverseList
# represent as string
|> map (x: "${toString x.count} - ${toString x.name}: ${lib.concatStringsSep " " x.deps}")
```

you can call it like this to get a nice output:

```sh
nix eval --json --file ./xorg-nodepends.nix | jq .[] --raw-output
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] x86_64-linux static 
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - as far as  they are testable inside a wayland compositor
  - mostly only the help output or something
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] ran passthru.updateScript
- [x] ran nixpkgs-hammer
- [x] ran nix-check-deps 
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc