### PR TITLE
Hurl 6.1.1 -> 7.0.0

### DIFF
--- a/pkgs/by-name/hu/hurl/package.nix
+++ b/pkgs/by-name/hu/hurl/package.nix
@@ -13,26 +13,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "hurl";
-  version = "6.1.1";
+  version = "7.0.0";
 
   src = fetchFromGitHub {
     owner = "Orange-OpenSource";
     repo = "hurl";
     tag = version;
-    hash = "sha256-NtvBw8Nb2eZN0rjVL/LPyIdY5hBJGnz/cDun6VvwYZE=";
+    hash = "sha256-dmPXI2RHEi/wcdVVwBRtBgNXyBXFnm44236pqYjxgBs=";
   };
 
-  cargoHash = "sha256-WyNActmsHpr5fgN1a3X9ApEACWFVJMVoi4fBvKhGgZ0=";
-
-  patches = [
-    # Fix build with libxml-2.14, remove after next hurl release
-    # https://github.com/Orange-OpenSource/hurl/pull/3977
-    (fetchpatch2 {
-      name = "fix-libxml_2_14";
-      url = "https://github.com/Orange-OpenSource/hurl/commit/7c7b410c3017aeab0dfc74a6144e4cb8e186a10a.patch?full_index=1";
-      hash = "sha256-XjnCRIMwzfgUMIhm6pQ90pzA+c2U0EuhyvLUZDsI2GI=";
-    })
-  ];
+  cargoHash = "sha256-1bZaSdMJe39cDEOoqW82zS5NvOlZDGe1ia56BjXddyc=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/hu/hurl/package.nix
+++ b/pkgs/by-name/hu/hurl/package.nix
@@ -2,7 +2,6 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  fetchpatch2,
   pkg-config,
   installShellFiles,
   libxml2,
@@ -27,6 +26,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     pkg-config
     installShellFiles
+    rustPlatform.bindgenHook
   ];
 
   buildInputs = [


### PR DESCRIPTION
## Things done

updated version from 6.1.1 => 7.0.0
updated hash and cargo-hash
removed 6.1.1 version specific patch
added necessary libraries for hurl 7.0.0 to build ( rustPlatform.bindgenHook, clang, llvmPackages.libclang

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
