### PR TITLE
filen-desktop: add darwin support

### DIFF
--- a/pkgs/by-name/fi/filen-desktop/package.nix
+++ b/pkgs/by-name/fi/filen-desktop/package.nix
@@ -4,17 +4,13 @@
   fetchurl,
   appimageTools,
   makeDesktopItem,
+  _7zz,
+  makeWrapper,
 }:
+
 let
   pname = "filen-desktop";
   version = "3.0.47";
-
-  arch = builtins.head (builtins.split "-" stdenv.hostPlatform.system);
-
-  src = fetchurl {
-    url = "https://github.com/FilenCloudDienste/filen-desktop/releases/download/v${version}/Filen_linux_${arch}.AppImage";
-    hash = "sha256-keaD5PUjkoFrFTCuap4DvmYq5X3Tjnq+njtiLgAZ9W8=";
-  };
 
   desktopItem = makeDesktopItem {
     name = "filen-desktop";
@@ -25,17 +21,21 @@ let
     categories = [ "Office" ];
   };
 
-  appimageContents = appimageTools.extract { inherit pname version src; };
-in
-appimageTools.wrapType2 {
-  inherit pname version src;
+  sources = {
+    x86_64-linux = fetchurl {
+      url = "https://github.com/FilenCloudDienste/filen-desktop/releases/download/v${version}/Filen_linux_x86_64.AppImage";
+      hash = "sha256-keaD5PUjkoFrFTCuap4DvmYq5X3Tjnq+njtiLgAZ9W8=";
+    };
+    aarch64-darwin = fetchurl {
+      url = "https://github.com/FilenCloudDienste/filen-desktop/releases/download/v${version}/Filen_mac_arm64.dmg";
+      hash = "sha256-BB8ws2H7Wwf5A504DPnz5WsRgEkaHr9xHMXS2B1fdBs=";
+    };
+  };
 
-  extraInstallCommands = ''
-    mkdir -p $out/share
-    cp -rt $out/share ${desktopItem}/share/applications ${appimageContents}/usr/share/icons
-    chmod -R +w $out/share
-    find $out/share/icons -type f -iname "*.png" -execdir mv {} "$pname.png" \;
-  '';
+  appimageContents = appimageTools.extract {
+    inherit pname version;
+    src = sources.x86_64-linux;
+  };
 
   meta = {
     homepage = "https://filen.io/products/desktop";
@@ -46,9 +46,59 @@ appimageTools.wrapType2 {
       Sync your data, mount network drives, collaborate with others and access files natively — powered by robust encryption and seamless integration.
     '';
     mainProgram = "filen-desktop";
-    platforms = [ "x86_64-linux" ];
     license = lib.licenses.agpl3Only;
-    maintainers = with lib.maintainers; [ smissingham ];
+    maintainers = with lib.maintainers; [
+      smissingham
+      kashw2
+    ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
-}
+
+  linux = appimageTools.wrapType2 {
+    inherit pname version;
+
+    src = sources.x86_64-linux;
+
+    extraInstallCommands = ''
+      mkdir -p $out/share
+      cp -rt $out/share ${desktopItem}/share/applications ${appimageContents}/usr/share/icons
+      chmod -R +w $out/share
+      find $out/share/icons -type f -iname "*.png" -execdir mv {} "$pname.png" \;
+    '';
+
+    meta = meta // {
+      platforms = lib.platforms.linux;
+    };
+
+  };
+
+  darwin = stdenv.mkDerivation (finalAttrs: {
+    inherit pname version;
+
+    src = sources.aarch64-darwin;
+
+    nativeBuildInputs = [
+      _7zz
+      makeWrapper
+    ];
+
+    unpackPhase = ''
+      runHook preUnpack
+      7zz x $src -x!Filen/Applications
+      runHook postUnpack
+    '';
+
+    installPhase = ''
+      runHook preInstallPhase
+      mkdir -p $out/{Applications,bin}
+      mv Filen.app $out/Applications
+      makeWrapper $out/Applications/Filen.app/Contents/MacOS/Filen $out/bin/${pname}
+      runHook postInstallPhase
+    '';
+
+    meta = meta // {
+      platforms = lib.platforms.darwin;
+    };
+  });
+in
+if stdenv.isDarwin then darwin else linux


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Built against aarch64-darwin and x86_64-linux and ran as expected on x86_64-linux. I've also run this on my M1 Mac Mini (has rosetta installed) and the application ran as expected.

At the moment sources only contains two different architectures / platforms. With x86_64 darwin being deprecated sometime in the future I'm going to eventually also add support for aarch64-linux when I get the chance so I thought it was more fitting to have it's own attr set instead of just inlining them in the src for each platform.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
