### PR TITLE
python3Packages.btlewrap: init at 0.1.1

### DIFF
--- a/pkgs/development/python-modules/beewi-smartclim/default.nix
+++ b/pkgs/development/python-modules/beewi-smartclim/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  btlewrap,
+  bluepy,
+}:
+
+buildPythonPackage rec {
+  pname = "beewi-smartclim";
+  version = "0.0.10";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "alemuro";
+    repo = "beewi_smartclim";
+    tag = version;
+    hash = "sha256-xdr545Q4DFhup2BCMZZ1WYWgt97qT6oipIHWcsp90+A=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    btlewrap
+    bluepy
+  ];
+
+  # No tests available
+  doCheck = false;
+
+  pythonImportsCheck = [ "beewi_smartclim" ];
+
+  meta = {
+    description = "Library to read data from BeeWi SmartClim sensor using Bluetooth LE";
+    homepage = "https://github.com/alemuro/beewi_smartclim";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+}

--- a/pkgs/development/python-modules/btlewrap/default.nix
+++ b/pkgs/development/python-modules/btlewrap/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  bluepy,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "btlewrap";
+  version = "0.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ChristianKuehnel";
+    repo = "btlewrap";
+    tag = "v${version}";
+    hash = "sha256-cjPj+Uw/L9kq/BbxlnOCJtaBcnf9VOJKN2NJ3cmKe6U=";
+  };
+
+  build-system = [ setuptools ];
+
+  optional-dependencies = {
+    bluepy = [ bluepy ];
+  };
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTestPaths = [
+    # Require optional dependencies or hardware
+    "test/unit_tests/test_bluepy.py"
+    "test/unit_tests/test_pygatt.py"
+    "test/integration_tests/"
+    "test/unit_tests/test_available_backends.py"
+  ];
+
+  pythonImportsCheck = [ "btlewrap" ];
+
+  meta = {
+    description = "Wrapper around different bluetooth low energy backends";
+    homepage = "https://github.com/ChristianKuehnel/btlewrap";
+    changelog = "https://github.com/ChristianKuehnel/btlewrap/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -562,7 +562,8 @@
       ];
     "beewi_smartclim" =
       ps: with ps; [
-      ]; # missing inputs: beewi-smartclim
+        beewi-smartclim
+      ];
     "bge" =
       ps: with ps; [
       ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1803,6 +1803,8 @@ self: super: with self; {
 
   beetcamp = callPackage ../development/python-modules/beetcamp { };
 
+  beewi-smartclim = callPackage ../development/python-modules/beewi-smartclim { };
+
   before-after = callPackage ../development/python-modules/before-after { };
 
   behave = callPackage ../development/python-modules/behave { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2168,6 +2168,8 @@ self: super: with self; {
 
   bthomehub5-devicelist = callPackage ../development/python-modules/bthomehub5-devicelist { };
 
+  btlewrap = callPackage ../development/python-modules/btlewrap { };
+
   btrees = callPackage ../development/python-modules/btrees { };
 
   btrfs = callPackage ../development/python-modules/btrfs { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://pypi.org/project/beewi-smartclim/
- https://github.com/alemuro/beewi_smartclim
- https://www.home-assistant.io/integrations/beewi_smartclim/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
