### PR TITLE
treewide: paperless-ngx fixes

### DIFF
--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -152,15 +152,6 @@ python.pkgs.buildPythonApplication rec {
 
   inherit version src;
 
-  # Manual partial backport of:
-  # - https://github.com/paperless-ngx/paperless-ngx/commit/9889c59d3daa8f4ac8ec2400c00ddc36a7ca63c9
-  # - https://github.com/paperless-ngx/paperless-ngx/pull/10538
-  # Fixes build with latest dependency versions.
-  # FIXME: remove in next update
-  patches = [
-    ./dep-updates.patch
-  ];
-
   postPatch = ''
     # pytest-xdist with to many threads makes the tests flaky
     if (( $NIX_BUILD_CORES > 3)); then

--- a/pkgs/development/python-modules/django-cachalot/default.nix
+++ b/pkgs/development/python-modules/django-cachalot/default.nix
@@ -56,19 +56,23 @@ buildPythonPackage rec {
   # redisTestHook does not work on darwin
   doCheck = !stdenv.hostPlatform.isDarwin;
 
-  # disable broken pinning test
   preCheck = ''
-    substituteInPlace cachalot/tests/read.py \
-      --replace-fail \
-        "def test_explain(" \
-        "def _test_explain("
+    export DJANGO_SETTINGS_MODULE=settings
   '';
 
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} runtests.py
-    runHook postCheck
-  '';
+  pytestFlags = [
+    "-o python_files=*.py"
+    "-o collect_imported_tests=false"
+    "cachalot/tests"
+    "cachalot/admin_tests"
+  ];
+
+  disabledTests = [
+    # relies on specific EXPLAIN output format from sqlite, which is not stable
+    "test_explain"
+    # broken on django-debug-toolbar 6.0
+    "test_rendering"
+  ];
 
   meta = with lib; {
     description = "No effort, no worry, maximum performance";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
