### PR TITLE
nginxMainline: 1.27.5 -> 1.29.1

### DIFF
--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -218,13 +218,6 @@ stdenv.mkDerivation {
         ./nix-etag-1.15.4.patch
         ./nix-skip-check-logs-path.patch
       ]
-      ++ lib.optionals (!lib.versionAtLeast version "1.29.1") [
-        (fetchpatch {
-          name = "CVE-2025-53859.patch";
-          url = "https://nginx.org/download/patch.2025.smtp.txt";
-          hash = "sha256-v49sLskFNMoKuG8HQISw8ST7ga6DS+ngJiL0D3sUyGk=";
-        })
-      ]
       ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
         (fetchpatch {
           url = "https://raw.githubusercontent.com/openwrt/packages/c057dfb09c7027287c7862afab965a4cd95293a3/net/nginx/patches/102-sizeof_test_fix.patch";

--- a/pkgs/servers/http/nginx/mainline.nix
+++ b/pkgs/servers/http/nginx/mainline.nix
@@ -1,6 +1,6 @@
 { callPackage, ... }@args:
 
 callPackage ./generic.nix args {
-  version = "1.27.5";
-  hash = "sha256-6WrOu5wqbbigAMPdGzLsuhuBDwzVhiMtTZIeN2Z03Q4=";
+  version = "1.29.1";
+  hash = "sha256-xYn35+2AHdvZBK+/PeJq4k6wzOJ8dxei6U33+xLWrSc=";
 }

--- a/pkgs/servers/http/nginx/stable.nix
+++ b/pkgs/servers/http/nginx/stable.nix
@@ -1,6 +1,13 @@
-{ callPackage, ... }@args:
+{ callPackage, fetchpatch, ... }@args:
 
 callPackage ./generic.nix args {
   version = "1.28.0";
   hash = "sha256-xrXGsIbA3508o/9eCEwdDvkJ5gOCecccHD6YX1dv92o=";
+  extraPatches = [
+    (fetchpatch {
+      name = "CVE-2025-53859.patch";
+      url = "https://nginx.org/download/patch.2025.smtp.txt";
+      hash = "sha256-v49sLskFNMoKuG8HQISw8ST7ga6DS+ngJiL0D3sUyGk=";
+    })
+  ];
 }


### PR DESCRIPTION
This change was already accepted in #433600 but reverted in 106b1418bc30cbae35addcb643a883e22de9573b.

Changes:
```
Changes with nginx 1.29.1                                        13 Aug 2025

    *) Security: processing of a specially crafted login/password when using
       the "none" authentication method in the ngx_mail_smtp_module might
       cause worker process memory disclosure to the authentication server
       (CVE-2025-53859).

    *) Change: now TLSv1.3 certificate compression is disabled by default.

    *) Feature: the "ssl_certificate_compression" directive.

    *) Feature: support for 0-RTT in QUIC when using OpenSSL 3.5.1 or newer.

    *) Bugfix: the 103 response might be buffered when using HTTP/2 and the
       "early_hints" directive.

    *) Bugfix: in handling "Host" and ":authority" header lines with equal
       values when using HTTP/2; the bug had appeared in 1.17.9.

    *) Bugfix: in handling "Host" header lines with a port when using
       HTTP/3.

    *) Bugfix: nginx could not be built on NetBSD 10.0.

    *) Bugfix: in the "none" parameter of the "smtp_auth" directive.

Changes with nginx 1.29.0                                        24 Jun 2025

    *) Feature: support for response code 103 from proxy and gRPC backends;
       the "early_hints" directive.

    *) Feature: loading of secret keys from hardware tokens with OpenSSL
       provider.

    *) Feature: support for the "so_keepalive" parameter of the "listen"
       directive on macOS.

    *) Change: the logging level of SSL errors in a QUIC handshake has been
       changed from "error" to "crit" for critical errors, and to "info" for
       the rest; the logging level of unsupported QUIC transport parameters
       has been lowered from "info" to "debug".

    *) Change: the native nginx/Windows binary release is now built using
       Windows SDK 10.

    *) Bugfix: nginx could not be built by gcc 15 if ngx_http_v2_module or
       ngx_http_v3_module modules were used.

    *) Bugfix: nginx might not be built by gcc 14 or newer with -O3 -flto
       optimization if ngx_http_v3_module was used.

    *) Bugfixes and improvements in HTTP/3.
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
