### PR TITLE
nmgui: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13854,6 +13854,12 @@
     github = "KSJ2000";
     githubId = 184105270;
   };
+  ktechmidas = {
+    email = "daniel@ktechmidas.net";
+    github = "ktechmidas";
+    githubId = 9920871;
+    name = "Monotoko";
+  };
   ktf = {
     email = "giulio.eulisse@cern.ch";
     github = "ktf";

--- a/pkgs/by-name/nm/nmgui/package.nix
+++ b/pkgs/by-name/nm/nmgui/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  wrapGAppsHook4,
+  gobject-introspection,
+  gtk4,
+  glib,
+  makeDesktopItem,
+  copyDesktopItems,
+  networkmanager,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "nmgui";
+  version = "1.0.0";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "s-adi-dev";
+    repo = "nmgui";
+    tag = "v${version}";
+    hash = "sha256-HS/n40Ng8S5N14DtEH/upwlxdzwCoOEJA40EMdCcLw4=io";
+  };
+
+  nativeBuildInputs = [
+    wrapGAppsHook4
+    gobject-introspection
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    gtk4
+    glib
+  ];
+
+  dependencies = with python3Packages; [
+    pygobject3
+    nmcli
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "nmgui";
+      exec = "nmgui";
+      icon = "network-wireless-symbolic";
+      comment = "GTK4-based Network Manager GUI using nmcli";
+      desktopName = "NM GUI";
+      categories = [
+        "Network"
+        "GTK"
+      ];
+      startupNotify = true;
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,share/applications,opt/nmgui}
+    # Copy the app files
+    cp -r app $out/opt/nmgui/
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/nmgui \
+      --add-flags "$out/opt/nmgui/app/main.py" \
+      --prefix PYTHONPATH : "$PYTHONPATH" \
+      "''${gappsWrapperArgs[@]}"
+  '';
+
+  meta = {
+    description = "Python library for interacting with NetworkManager CLI";
+    homepage = "https://github.com/s-adi-dev/nmgui";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ ktechmidas ];
+    mainProgram = "nmgui";
+    inherit (networkmanager.meta) platforms;
+    changelog = "https://github.com/s-adi-dev/nmgui/releases/tag/v${version}";
+  };
+}

--- a/pkgs/development/python-modules/nmcli/default.nix
+++ b/pkgs/development/python-modules/nmcli/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  replaceVars,
+  setuptools,
+  wheel,
+  networkmanager,
+}:
+
+buildPythonPackage rec {
+  pname = "nmcli";
+  version = "1.5.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ushiboy";
+    repo = "nmcli";
+    tag = "v${version}";
+    hash = "sha256-1gVj4WfTx1NcoyWA9OK5EyGze9hmrXV0Mq50C1S3bfM=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  patches = [
+    (replaceVars ./nmcli-path.patch {
+      nmcli = lib.getExe' networkmanager "nmcli";
+    })
+  ];
+
+  meta = {
+    description = "Python library for interacting with NetworkManager CLI";
+    homepage = "https://github.com/ushiboy/nmcli";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ktechmidas ];
+    inherit (networkmanager.meta) platforms;
+    changelog = "https://github.com/ushiboy/nmcli/releases/tag/v${version}";
+  };
+}

--- a/pkgs/development/python-modules/nmcli/nmcli-path.patch
+++ b/pkgs/development/python-modules/nmcli/nmcli-path.patch
@@ -1,0 +1,11 @@
+--- a/nmcli/_system.py
++++ b/nmcli/_system.py
+@@ -43,7 +43,7 @@ class System:
+     def nmcli(self, parameters: CommandParameter) -> str:
+         if isinstance(parameters, str):
+             parameters = [parameters]
+-        c = ['sudo', 'nmcli'] if self._use_sudo else ['nmcli']
++        c = ['sudo', '@nmcli@'] if self._use_sudo else ['@nmcli@']
+         commands = c + parameters
+         try:
+             env = dict(os.environ, **{'LANG': self._lang})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10461,6 +10461,8 @@ self: super: with self; {
 
   nmapthon2 = callPackage ../development/python-modules/nmapthon2 { };
 
+  nmcli = callPackage ../development/python-modules/nmcli { };
+
   nnpdf = toPythonModule (pkgs.nnpdf.override { python3 = python; });
 
   noaa-coops = callPackage ../development/python-modules/noaa-coops { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Built nmgui using Python 3.11 (and .12/13). This was requested https://github.com/s-adi-dev/nmgui/issues/3 - this application is mostly to be used with Hyprland, but is a standard GTK4 application and can be used anywhere.

~Note that it uses a cherry-picked commit from nmcli to function, if nmcli 1.5.1 is ever released we will use that instead of fetching from the forked nmcli~

Has been built with nix-build several times on an x86_64 system

Note: I have also cherrypicked my maintainers commit and added it here in case this package is accepted before my first one.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
