### PR TITLE
peertube: 7.2.1 -> 7.2.3

### DIFF
--- a/pkgs/by-name/pe/peertube/package.nix
+++ b/pkgs/by-name/pe/peertube/package.nix
@@ -47,23 +47,23 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "peertube";
-  version = "7.2.1";
+  version = "7.2.3";
 
   src = fetchFromGitHub {
     owner = "Chocobozzz";
     repo = "PeerTube";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-I53LCCtB8iNGuABgvhRjUfxocasXCv4TV7jXtHVpMnU=";
+    hash = "sha256-vbjQoysm5ERY6kG3JhG6z/zKxVlmWmRXQyUnCrVgjFk=";
   };
 
   yarnOfflineCacheServer = fetchYarnDeps {
     yarnLock = "${finalAttrs.src}/yarn.lock";
-    hash = "sha256-PMU6ZMcT+9Z3Y6+085e3hRnvs4Xii5FIkkOPvsltfMY=";
+    hash = "sha256-baQgvzJ3W5lULrdukwM9niovtzAI0yvc2c7mqhtCDxk=";
   };
 
   yarnOfflineCacheClient = fetchYarnDeps {
     yarnLock = "${finalAttrs.src}/client/yarn.lock";
-    hash = "sha256-AWUnxC/cwtKCa70MKmHeOr6ussMYyQ5awQAnWYzCA1s=";
+    hash = "sha256-Y1boUDDegqCRt9fQaP+svIKYFz+gowGyV6sV7vq8vMA=";
   };
 
   yarnOfflineCacheAppsCli = fetchYarnDeps {


### PR DESCRIPTION
Contains some security fixes caused by some transitive deps.

Changes:
https://github.com/Chocobozzz/PeerTube/releases/tag/v7.2.3 https://github.com/Chocobozzz/PeerTube/releases/tag/v7.2.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
