### PR TITLE
workflows/eval.misc: run tasks in parallel

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -354,9 +354,10 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31
 
-      - name: Ensure flake outputs on all systems still evaluate
-        run: nix flake check --all-systems --no-build './nixpkgs/untrusted?shallow=1'
-
-      - name: Query nixpkgs with aliases enabled to check for basic syntax errors
+      - name: Run misc eval tasks in parallel
         run: |
-          time nix-env -I ./nixpkgs/untrusted -f ./nixpkgs/untrusted -qa '*' --option restrict-eval true --option allow-import-from-derivation false >/dev/null
+          # Ensure flake outputs on all systems still evaluate
+          nix flake check --all-systems --no-build './nixpkgs/untrusted?shallow=1' &
+          # Query nixpkgs with aliases enabled to check for basic syntax errors
+          nix-env -I ./nixpkgs/untrusted -f ./nixpkgs/untrusted -qa '*' --option restrict-eval true --option allow-import-from-derivation false >/dev/null &
+          wait


### PR DESCRIPTION
Both `nix flake check` and `nix-env` are single-threaded, so no reason to serialize their calls and waste time.

This brings down the runtime for this job from ~1:51 to ~1:27 in my tests.

## Things done

- [x] Tested in my fork.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
