### PR TITLE
libx{composite,font_{1,2},damage,ft,i}: refactor, move to pkgs/by-name and rename from xorg namespace

### DIFF
--- a/pkgs/by-name/li/libxcomposite/package.nix
+++ b/pkgs/by-name/li/libxcomposite/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxfixes,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxcomposite";
+  version = "0.4.6";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libXcomposite-${finalAttrs.version}.tar.xz";
+    hash = "sha256-/kC88K4aCQcOuiQIil65gQ7+V0U3eeweIKVQgMbcLIc=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxfixes
+  ];
+
+  propagatedBuildInputs = [
+    xorgproto
+    # header file dependencies
+    libxfixes
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libXcomposite \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Client library for the Composite extension to the X11 protocol";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcomposite";
+    license = with lib.licenses; [
+      hpndSellVariant
+      mit
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [ "xcomposite" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxdamage/package.nix
+++ b/pkgs/by-name/li/libxdamage/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxfixes,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxdamage";
+  version = "1.1.6";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libXdamage-${finalAttrs.version}.tar.xz";
+    hash = "sha256-UnM8H1Ji/KNfZOfVBgxvzYGogLqOHmXJYhzwcnr7XRE=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxfixes
+  ];
+
+  propagatedBuildInputs = [ xorgproto ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libXdamage \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "X Damage Extension library";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxdamage";
+    license = lib.licenses.hpndSellVariant;
+    maintainers = [ ];
+    pkgConfigModules = [ "xdamage" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxfont_1/package.nix
+++ b/pkgs/by-name/li/libxfont_1/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libfontenc,
+  xorgproto,
+  freetype,
+  xtrans,
+  zlib,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxfont_1";
+  version = "1.5.4";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libXfont-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-Gn90kHdMh/IFLRRtHg5kUY0y5oSBhKGGVOjQu1eIMkI=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libfontenc
+    xorgproto
+    freetype
+    xtrans
+    zlib
+  ];
+
+  propagatedBuildInputs = [ xorgproto ];
+
+  # prevents "misaligned_stack_error_entering_dyld_stub_binder"
+  configureFlags = lib.optional stdenv.hostPlatform.isDarwin "CFLAGS=-O0";
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libXfont \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "X font handling library for server & utilities";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxfont";
+    license = with lib.licenses; [
+      mit
+      mitOpenGroup
+      hpnd
+      hpndSellVariant
+      # this was originally BSD-3-Clause-UC, however the University of California rescinded
+      # clause 3, the advertising clause, in 1999 effectively reverting it to a BSD-3-Clause
+      bsd3
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [ "xfont" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxfont_2/package.nix
+++ b/pkgs/by-name/li/libxfont_2/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libfontenc,
+  xorgproto,
+  freetype,
+  xtrans,
+  zlib,
+  writeScript,
+  testers,
+  # for inheriting the meta attributes
+  libxfont_1,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxfont_2";
+  version = "2.0.7";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libXfont2-${finalAttrs.version}.tar.xz";
+    hash = "sha256-i3uC/eukh2m2lDPo4/u5hKX2vzaLDV9Hq+7EnePljvs=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libfontenc
+    xorgproto
+    freetype
+    xtrans
+    zlib
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libXfont2 \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    inherit (libxfont_1.meta) description homepage license;
+    maintainers = [ ];
+    pkgConfigModules = [ "xfont2" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxft/package.nix
+++ b/pkgs/by-name/li/libxft/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  fontconfig,
+  freetype,
+  libx11,
+  libxrender,
+  xorgproto,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxft";
+  version = "2.3.9";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libXft-${finalAttrs.version}.tar.xz";
+    hash = "sha256-YKJbeJRe1pMmNbO7GJmlF9Md90VuaYZ/+6J/if85dvU=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    fontconfig
+    freetype
+    libx11
+    libxrender
+    xorgproto
+  ];
+
+  propagatedBuildInputs = [
+    xorgproto
+    # header file dependencies
+    freetype
+    fontconfig
+    libxrender
+  ];
+
+  configureFlags = lib.optional (
+    stdenv.hostPlatform != stdenv.buildPlatform
+  ) "--enable-malloc0returnsnull";
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libXft \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "X FreeType library";
+    longDescription = ''
+      libXft is the client side font rendering library, using libfreetype, libX11, and the
+      X Render extension to display anti-aliased text.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxft";
+    license = lib.licenses.hpndSellVariant;
+    maintainers = [ ];
+    pkgConfigModules = [ "xft" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxi/package.nix
+++ b/pkgs/by-name/li/libxi/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxext,
+  libxfixes,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxi";
+  version = "1.8.2";
+
+  outputs = [
+    "out"
+    "dev"
+    "man"
+    "doc"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libXi-${finalAttrs.version}.tar.xz";
+    hash = "sha256-0OBVXlPW4hFOq/pEImuhYtJwhQGiXhjZnPs1wJTGwQQ=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxext
+    libxfixes
+  ];
+
+  propagatedBuildInputs = [
+    xorgproto
+    # header file dependencies
+    libx11
+    libxext
+    libxfixes
+  ];
+
+  configureFlags =
+    lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "xorg_cv_malloc0_returns_null=no"
+    ++ lib.optional stdenv.hostPlatform.isStatic "--disable-shared";
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libXi \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "library for the X Input Extension";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxi";
+    license = with lib.licenses; [
+      mitOpenGroup
+      hpnd
+      mit
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [ "xi" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -36,6 +36,8 @@
   libxdmcp,
   libxext,
   libxfixes,
+  libxfont_1,
+  libxfont_2,
   libxmu,
   libxpm,
   libxrandr,
@@ -138,6 +140,8 @@ self: with self; {
   libXdmcp = libxdmcp;
   libXext = libxext;
   libXfixes = libxfixes;
+  libXfont2 = libxfont_2;
+  libXfont = libxfont_1;
   libXmu = libxmu;
   libXpm = libxpm;
   libXrandr = libxrandr;
@@ -1757,90 +1761,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xtrap" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXfont = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libfontenc,
-      xorgproto,
-      freetype,
-      xtrans,
-      zlib,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXfont";
-      version = "1.5.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXfont-1.5.4.tar.bz2";
-        sha256 = "0hiji1bvpl78aj3a3141hkk353aich71wv8l5l2z51scfy878zqs";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libfontenc
-        xorgproto
-        freetype
-        xtrans
-        zlib
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xfont" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXfont2 = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libfontenc,
-      xorgproto,
-      freetype,
-      xtrans,
-      zlib,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXfont2";
-      version = "2.0.7";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXfont2-2.0.7.tar.xz";
-        sha256 = "1ywfwpirvi7fmd3my3cb6szzd9c4p7xy7s1kjjv6k1x4xgyq4ywb";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libfontenc
-        xorgproto
-        freetype
-        xtrans
-        zlib
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xfont2" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -39,6 +39,7 @@
   libxfont_1,
   libxfont_2,
   libxft,
+  libxi,
   libxmu,
   libxpm,
   libxrandr,
@@ -144,6 +145,7 @@ self: with self; {
   libXfont2 = libxfont_2;
   libXfont = libxfont_1;
   libXft = libxft;
+  libXi = libxi;
   libXmu = libxmu;
   libXpm = libxpm;
   libXrandr = libxrandr;
@@ -1763,46 +1765,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xtrap" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXi = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libX11,
-      libXext,
-      libXfixes,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXi";
-      version = "1.8.2";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXi-1.8.2.tar.xz";
-        sha256 = "0161qsac0dgvkkcihpm2062p1lk2l5mj4i7smd713qnnadg5bq6h";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libX11
-        libXext
-        libXfixes
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xi" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -32,6 +32,7 @@
   libxcomposite,
   libxcursor,
   libxcvt,
+  libxdamage,
   libxdmcp,
   libxext,
   libxfixes,
@@ -133,6 +134,7 @@ self: with self; {
   libXaw = libxaw;
   libXcomposite = libxcomposite;
   libXcursor = libxcursor;
+  libXdamage = libxdamage;
   libXdmcp = libxdmcp;
   libXext = libxext;
   libXfixes = libxfixes;
@@ -1755,44 +1757,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xtrap" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXdamage = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libX11,
-      libXfixes,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXdamage";
-      version = "1.1.6";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXdamage-1.1.6.tar.xz";
-        sha256 = "04axzdx75w0wcb4na7lfpa0ai0fddw60dmg7cigs7z32a8gkqwsj";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libX11
-        libXfixes
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xdamage" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -29,8 +29,9 @@
   libxcb-render-util,
   libxcb-util,
   libxcb-wm,
-  libxcvt,
+  libxcomposite,
   libxcursor,
+  libxcvt,
   libxdmcp,
   libxext,
   libxfixes,
@@ -130,6 +131,7 @@ self: with self; {
   libX11 = libx11;
   libXau = libxau;
   libXaw = libxaw;
+  libXcomposite = libxcomposite;
   libXcursor = libxcursor;
   libXdmcp = libxdmcp;
   libXext = libxext;
@@ -1753,44 +1755,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xtrap" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXcomposite = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libX11,
-      libXfixes,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXcomposite";
-      version = "0.4.6";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXcomposite-0.4.6.tar.xz";
-        sha256 = "11rcvk380l5540gfqy9p8mbzw3l1p5g8l214p870f28smvqbqh7y";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libX11
-        libXfixes
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xcomposite" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -38,6 +38,7 @@
   libxfixes,
   libxfont_1,
   libxfont_2,
+  libxft,
   libxmu,
   libxpm,
   libxrandr,
@@ -142,6 +143,7 @@ self: with self; {
   libXfixes = libxfixes;
   libXfont2 = libxfont_2;
   libXfont = libxfont_1;
+  libXft = libxft;
   libXmu = libxmu;
   libXpm = libxpm;
   libXrandr = libxrandr;
@@ -1761,48 +1763,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xtrap" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXft = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontconfig,
-      freetype,
-      libX11,
-      xorgproto,
-      libXrender,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXft";
-      version = "2.3.9";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXft-2.3.9.tar.xz";
-        sha256 = "1xbn77zqjzx2zdzqcsbf8pvivlqplnciifxk6lk97mjyjiw5p8k0";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        fontconfig
-        freetype
-        libX11
-        xorgproto
-        libXrender
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xft" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -69,6 +69,7 @@ $pcMap{"xext"} = "libXext";
 $pcMap{"xfixes"} = "libXfixes";
 $pcMap{"xfont"} = "libXfont";
 $pcMap{"xfont2"} = "libXfont2";
+$pcMap{"xft"} = "libXft";
 $pcMap{"xmu"} = "libXmu";
 $pcMap{"xmuu"} = "libXmu";
 $pcMap{"xpm"} = "libXpm";
@@ -358,6 +359,7 @@ print OUT <<EOF;
   libxfixes,
   libxfont_1,
   libxfont_2,
+  libxft,
   libxmu,
   libxpm,
   libxrandr,
@@ -462,6 +464,7 @@ self: with self; {
   libXfixes = libxfixes;
   libXfont2 = libxfont_2;
   libXfont = libxfont_1;
+  libXft = libxft;
   libXmu = libxmu;
   libXpm = libxpm;
   libXrandr = libxrandr;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -67,6 +67,8 @@ $pcMap{"xdamage"} = "libXdamage";
 $pcMap{"xdmcp"} = "libXdmcp";
 $pcMap{"xext"} = "libXext";
 $pcMap{"xfixes"} = "libXfixes";
+$pcMap{"xfont"} = "libXfont";
+$pcMap{"xfont2"} = "libXfont2";
 $pcMap{"xmu"} = "libXmu";
 $pcMap{"xmuu"} = "libXmu";
 $pcMap{"xpm"} = "libXpm";
@@ -354,6 +356,8 @@ print OUT <<EOF;
   libxdmcp,
   libxext,
   libxfixes,
+  libxfont_1,
+  libxfont_2,
   libxmu,
   libxpm,
   libxrandr,
@@ -456,6 +460,8 @@ self: with self; {
   libXdmcp = libxdmcp;
   libXext = libxext;
   libXfixes = libxfixes;
+  libXfont2 = libxfont_2;
+  libXfont = libxfont_1;
   libXmu = libxmu;
   libXpm = libxpm;
   libXrandr = libxrandr;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -70,6 +70,7 @@ $pcMap{"xfixes"} = "libXfixes";
 $pcMap{"xfont"} = "libXfont";
 $pcMap{"xfont2"} = "libXfont2";
 $pcMap{"xft"} = "libXft";
+$pcMap{"xi"} = "libXi";
 $pcMap{"xmu"} = "libXmu";
 $pcMap{"xmuu"} = "libXmu";
 $pcMap{"xpm"} = "libXpm";
@@ -360,6 +361,7 @@ print OUT <<EOF;
   libxfont_1,
   libxfont_2,
   libxft,
+  libxi,
   libxmu,
   libxpm,
   libxrandr,
@@ -465,6 +467,7 @@ self: with self; {
   libXfont2 = libxfont_2;
   libXfont = libxfont_1;
   libXft = libxft;
+  libXi = libxi;
   libXmu = libxmu;
   libXpm = libxpm;
   libXrandr = libxrandr;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -61,6 +61,7 @@ $pcMap{"xcb-keysyms"} = "xcbutilkeysyms";
 $pcMap{"xcb-proto"} = "xcbproto";
 $pcMap{"xcb-renderutil"} = "xcbutilrenderutil";
 $pcMap{"xcb-util"} = "xcbutil";
+$pcMap{"xcomposite"} = "libXcomposite";
 $pcMap{"xcursor"} = "libXcursor";
 $pcMap{"xdmcp"} = "libXdmcp";
 $pcMap{"xext"} = "libXext";
@@ -345,8 +346,9 @@ print OUT <<EOF;
   libxcb-render-util,
   libxcb-util,
   libxcb-wm,
-  libxcvt,
+  libxcomposite,
   libxcursor,
+  libxcvt,
   libxdmcp,
   libxext,
   libxfixes,
@@ -446,6 +448,7 @@ self: with self; {
   libX11 = libx11;
   libXau = libxau;
   libXaw = libxaw;
+  libXcomposite = libxcomposite;
   libXcursor = libxcursor;
   libXdmcp = libxdmcp;
   libXext = libxext;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -63,6 +63,7 @@ $pcMap{"xcb-renderutil"} = "xcbutilrenderutil";
 $pcMap{"xcb-util"} = "xcbutil";
 $pcMap{"xcomposite"} = "libXcomposite";
 $pcMap{"xcursor"} = "libXcursor";
+$pcMap{"xdamage"} = "libXdamage";
 $pcMap{"xdmcp"} = "libXdmcp";
 $pcMap{"xext"} = "libXext";
 $pcMap{"xfixes"} = "libXfixes";
@@ -349,6 +350,7 @@ print OUT <<EOF;
   libxcomposite,
   libxcursor,
   libxcvt,
+  libxdamage,
   libxdmcp,
   libxext,
   libxfixes,
@@ -450,6 +452,7 @@ self: with self; {
   libXaw = libxaw;
   libXcomposite = libxcomposite;
   libXcursor = libxcursor;
+  libXdamage = libxdamage;
   libXdmcp = libxdmcp;
   libXext = libxext;
   libXfixes = libxfixes;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -204,14 +204,6 @@ self: super:
     };
   });
 
-  libXcomposite = super.libXcomposite.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-    ];
-    propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [ xorg.libXfixes ];
-  });
-
   libXdamage = super.libXdamage.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -194,24 +194,6 @@ self: super:
     };
   });
 
-  libXi = super.libXi.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-      "man"
-      "doc"
-    ];
-    propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [
-      xorg.libXfixes
-      xorg.libXext
-    ];
-    configureFlags =
-      lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-        "xorg_cv_malloc0_returns_null=no"
-      ]
-      ++ lib.optional stdenv.hostPlatform.isStatic "--disable-shared";
-  });
-
   libXinerama = super.libXinerama.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -194,27 +194,6 @@ self: super:
     };
   });
 
-  libXft = super.libXft.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-    ];
-    propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [
-      xorg.libXrender
-      freetype
-      fontconfig
-    ];
-    configureFlags = attrs.configureFlags or [ ] ++ malloc0ReturnsNullCrossFlag;
-
-    # the include files need ft2build.h, and Requires.private isn't enough for us
-    postInstall = ''
-      sed "/^Requires:/s/$/, freetype2/" -i "$dev/lib/pkgconfig/xft.pc"
-    '';
-    passthru = attrs.passthru // {
-      inherit freetype fontconfig;
-    };
-  });
-
   libXi = super.libXi.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -204,13 +204,6 @@ self: super:
     };
   });
 
-  libXdamage = super.libXdamage.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-    ];
-  });
-
   libXft = super.libXft.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -156,16 +156,6 @@ self: super:
     };
   });
 
-  libXfont = super.libXfont.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-    ];
-    propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [ freetype ]; # propagate link reqs. like bzip2
-    # prevents "misaligned_stack_error_entering_dyld_stub_binder"
-    configureFlags = lib.optional isDarwin "CFLAGS=-O0";
-  });
-
   libWindowsWM = super.libWindowsWM.overrideAttrs (attrs: {
     configureFlags = attrs.configureFlags or [ ] ++ malloc0ReturnsNullCrossFlag;
   });

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -126,7 +126,6 @@ mirror://xorg/individual/font/font-sun-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-winitzki-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-xfree86-type1-1.0.5.tar.xz
 mirror://xorg/individual/lib/libWindowsWM-1.0.1.tar.bz2
-mirror://xorg/individual/lib/libXcomposite-0.4.6.tar.xz
 mirror://xorg/individual/lib/libXdamage-1.1.6.tar.xz
 mirror://xorg/individual/lib/libXfont-1.5.4.tar.bz2
 mirror://xorg/individual/lib/libXfont2-2.0.7.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -126,8 +126,6 @@ mirror://xorg/individual/font/font-sun-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-winitzki-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-xfree86-type1-1.0.5.tar.xz
 mirror://xorg/individual/lib/libWindowsWM-1.0.1.tar.bz2
-mirror://xorg/individual/lib/libXfont-1.5.4.tar.bz2
-mirror://xorg/individual/lib/libXfont2-2.0.7.tar.xz
 mirror://xorg/individual/lib/libXft-2.3.9.tar.xz
 mirror://xorg/individual/lib/libXi-1.8.2.tar.xz
 mirror://xorg/individual/lib/libXinerama-1.1.5.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -126,7 +126,6 @@ mirror://xorg/individual/font/font-sun-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-winitzki-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-xfree86-type1-1.0.5.tar.xz
 mirror://xorg/individual/lib/libWindowsWM-1.0.1.tar.bz2
-mirror://xorg/individual/lib/libXi-1.8.2.tar.xz
 mirror://xorg/individual/lib/libXinerama-1.1.5.tar.xz
 mirror://xorg/individual/lib/libxkbfile-1.1.3.tar.xz
 mirror://xorg/individual/lib/libXp-1.0.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -126,7 +126,6 @@ mirror://xorg/individual/font/font-sun-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-winitzki-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-xfree86-type1-1.0.5.tar.xz
 mirror://xorg/individual/lib/libWindowsWM-1.0.1.tar.bz2
-mirror://xorg/individual/lib/libXft-2.3.9.tar.xz
 mirror://xorg/individual/lib/libXi-1.8.2.tar.xz
 mirror://xorg/individual/lib/libXinerama-1.1.5.tar.xz
 mirror://xorg/individual/lib/libxkbfile-1.1.3.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -126,7 +126,6 @@ mirror://xorg/individual/font/font-sun-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-winitzki-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-xfree86-type1-1.0.5.tar.xz
 mirror://xorg/individual/lib/libWindowsWM-1.0.1.tar.bz2
-mirror://xorg/individual/lib/libXdamage-1.1.6.tar.xz
 mirror://xorg/individual/lib/libXfont-1.5.4.tar.bz2
 mirror://xorg/individual/lib/libXfont2-2.0.7.tar.xz
 mirror://xorg/individual/lib/libXft-2.3.9.tar.xz


### PR DESCRIPTION
<details>
<summary>this is the script i use to get the packages that don't depend on other xorg packages:</summary>

```nix
let
  inherit (import <nixpkgs> { }) lib;

  done = import ./pkgs/servers/x11/xorg/default.nix |> lib.functionArgs |> lib.attrNames;

  pkgs =
    (import ./default.nix { }).xorg
    |> lib.filterAttrs (
      n: v:
      lib.isAttrs v
      && v ? pname
      && !lib.elem n done
      && !lib.elem n (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem v.pname done
      && !lib.elem v.pname (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem (lib.toLower n) done
      && !lib.elem (lib.toLower n) (map (lib.replaceStrings [ "-" ] [ "" ]) done)
    );

  pnames = lib.mapAttrsToList (_: v: v.pname) pkgs;

  filteredPkgs =
    pkgs
    |> lib.filterAttrs (
      n: v:
      true
      # && !v.meta.unfree
      # && !v.meta.broken
      # && !v.meta.unsupported
      # && !lib.hasPrefix "font" n
      && !lib.hasPrefix "xf86" n
    );
in
filteredPkgs
# get deps
|> lib.mapAttrs (
  _: v:
  v.buildInputs ++ v.nativeBuildInputs ++ v.propagatedBuildInputs ++ v.propagatedNativeBuildInputs
)
# filter deps for xorg packages
|> lib.mapAttrs (_: v: lib.filter (x: x ? pname && lib.elem x.pname pnames) v)
# map deps to list and count
|> lib.mapAttrsToList (
  name: value: {
    inherit name;
    deps = map (x: x.pname or "error") value |> lib.unique;
    count = lib.length value;
  }
)
# sort
|> lib.sort (
  x: y: x.count < y.count || (x.count == y.count && (lib.toLower x.name) > (lib.toLower y.name))
)
|> lib.reverseList
# represent as string
|> map (x: "${toString x.count} - ${toString x.name}: ${lib.concatStringsSep " " x.deps}")
```

you can call it like this to get a nice output:

```sh
nix eval --json --file ./xorg-nodepends.nix | jq .[] --raw-output
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] x86_64-linux static 
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] ran passthru.updateScript
- [x] ran nixpkgs-hammer
- [x] ran nix-check-deps 
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc