### PR TITLE
jitwatch: init at 1.5.0

### DIFF
--- a/pkgs/by-name/ji/jitwatch/package.nix
+++ b/pkgs/by-name/ji/jitwatch/package.nix
@@ -1,0 +1,82 @@
+{
+  maven,
+  lib,
+  fetchFromGitHub,
+  openjdk,
+  makeWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
+  nix-update-script,
+}:
+let
+  jdk = openjdk.override {
+    enableJavaFX = true;
+  };
+in
+maven.buildMavenPackage rec {
+  pname = "jitwatch";
+  version = "1.5.0";
+
+  src = fetchFromGitHub {
+    owner = "AdoptOpenJDK";
+    repo = "jitwatch";
+    tag = version;
+    hash = "sha256-ytLjIxfFqy56FsfZUMI7kuOCFr8xKUl8cGpQFM99+0E=";
+  };
+
+  mvnHash = "sha256-J25Ff0xbyKzKPA5MRj4+S43sLKwaSC8SvectmxRoiVI=";
+
+  nativeBuildInputs = [
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "jitwatch";
+      exec = "jitwatch";
+      terminal = false;
+      desktopName = "JITWatch";
+      genericName = "Log analyser and visualiser for the HotSpot JIT compiler";
+      comment = "Inspect inlining decisions, hot methods, bytecode, and assembly. View results in the JavaFX user interface.";
+      categories = [
+        "Development"
+        "Debugger"
+        "Profiling"
+        "Java"
+      ];
+      startupWMClass = "org.adoptopenjdk.jitwatch.ui.main.JITWatchUI";
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 ui/target/jitwatch-ui-shaded.jar $out/share/jitwatch/jitwatch.jar
+    makeWrapper ${lib.getExe' jdk "java"} $out/bin/jitwatch \
+      --add-flags "-jar $out/share/jitwatch/jitwatch.jar"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Log analyser and visualiser for the HotSpot JIT compiler";
+    longDescription = ''
+      Log analyser / visualiser for Java HotSpot JIT compiler.
+      Inspect inlining decisions, hot methods, bytecode, and assembly.
+      View results in the JavaFX user interface.
+    '';
+    homepage = "https://github.com/AdoptOpenJDK/jitwatch/wiki";
+    changelog = "https://github.com/AdoptOpenJDK/jitwatch/releases/tag/${version}";
+    license = lib.licenses.bsd2;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode
+    ];
+    mainProgram = "jitwatch";
+    maintainers = [ lib.maintainers.progrm_jarvis ];
+    inherit (jdk.meta) platforms;
+  };
+}


### PR DESCRIPTION
Init `jitwatch` at `1.5.0`.

This currently does *not* bundle hsdis because norally it would require adding it as an option to JDK, but it does not seem to be a problem since it is able to download the relevant binary itself (with no need for patching).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
