### PR TITLE
linuxHeaders: patch for sysinfo redefinition under musl

### DIFF
--- a/pkgs/os-specific/linux/kernel-headers/1-4-glibc-specific-inclusion-of-sysinfo.h-in-kernel.h.patch
+++ b/pkgs/os-specific/linux/kernel-headers/1-4-glibc-specific-inclusion-of-sysinfo.h-in-kernel.h.patch
@@ -1,0 +1,12 @@
+--- a/include/uapi/linux/kernel.h
++++ b/include/uapi/linux/kernel.h
+@@ -1,7 +1,9 @@
+ #ifndef _UAPI_LINUX_KERNEL_H
+ #define _UAPI_LINUX_KERNEL_H
+ 
++#ifdef __GLIBC__
+ #include <linux/sysinfo.h>
++#endif
+ #include <linux/const.h>
+ 
+ #endif /* _UAPI_LINUX_KERNEL_H */

--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -162,6 +162,9 @@ in
       };
       patches = [
         ./no-relocs.patch # for building x86 kernel headers on non-ELF platforms
+
+        # As used by Void, Alpine to fix musl "struct sysinfo" redefinition issues
+        ./1-4-glibc-specific-inclusion-of-sysinfo.h-in-kernel.h.patch
       ];
     };
 }


### PR DESCRIPTION
## Things done

Ran into this while building xdp-tools (from #436206 checkout).
It seems to be a common issue with the musl headers, I'm not sure I understand it well enough to engage with upstream (Linux?). The musl people seem to agree that this include does not belong here, but removing it breaks glibc, so they add this condition.

So, I'm proposing to do what everyone else does for now.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
