### PR TITLE
[25.05] linux: fix backwards-compat of structuredExtraConfig vs extraStructuredConfig

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -137,10 +137,23 @@ let
       structuredConfigFromPatches = map (
         {
           structuredExtraConfig ? { },
+          extraStructuredConfig ? { },
           ...
         }:
         {
-          settings = structuredExtraConfig;
+          settings =
+            if extraStructuredConfig != { } then
+              assert lib.assertMsg (structuredExtraConfig == { }) ''
+                Using both `extraStructuredConfig` & `structuredExtraConfig` for a single kernel
+                patch is not supported!
+              '';
+              lib.warn ''
+                Passing `extraStructuredConfig` to the Linux kernel build
+                (e.g. via `boot.kernelPatches` in NixOS) is deprecated and will fail at
+                evaluation in 25.11. Use `structuredExtraConfig` instead.
+              '' extraStructuredConfig
+            else
+              structuredExtraConfig;
         }
       ) kernelPatches;
 


### PR DESCRIPTION
Follow-up on #431115: the change from extraStructuredConfig to structuredExtraConfig is breaking. This patch accepts both variants (but not at the same time) and gives an eval-time warning about the hard-rename in unstable/25.11.

cc @EBADBEEF @viluon @dnr   

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
