### PR TITLE
mediasynclite 0.4.2 -> cleanup

### DIFF
--- a/pkgs/by-name/me/mediasynclite/package.nix
+++ b/pkgs/by-name/me/mediasynclite/package.nix
@@ -5,6 +5,8 @@
   gtk3,
   glib,
   gsettings-desktop-schemas,
+  copyDesktopItems,
+  makeDesktopItem,
   pkg-config,
   curl,
   openssl,
@@ -25,10 +27,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     curl
-    glib
-    gtk3
     openssl
     jansson
+    gtk3
+    glib
   ];
 
   strictDeps = true;
@@ -37,13 +39,40 @@ stdenv.mkDerivation rec {
     gsettings-desktop-schemas
     pkg-config
     wrapGAppsHook3
+    copyDesktopItems
   ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  postPatch = ''
-    substitute ./src/ibmsl.c ./src/ibmsl.c --subst-var out
+  preInstall = ''
+    mkdir -p $out/share/icons
+    cp -rv share/* $out/share
+    cp -v share/ui/icon.png $out/share/icons
   '';
+
+  postPatch = ''
+    substituteInPlace src/ibmsl.c --replace-fail "share/ui" "$out/share/ui"
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = lib.toLower pname;
+      desktopName = "iBroadcast Mediasynclite";
+      comment = meta.description;
+      exec = "mediasynclite";
+      keywords = [
+        "iBroadcast"
+        "mediasynclite"
+      ];
+      categories = [
+        "GTK"
+        "Music"
+      ];
+      terminal = false;
+      type = "Application";
+      icon = "mediasynclite";
+    })
+  ];
 
   meta = with lib; {
     description = "Linux-native graphical uploader for iBroadcast";


### PR DESCRIPTION
## Things done

Ensured that mediasynclite opens correctly. This is done by substituting a line in the source code to point to `$out`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
