### PR TITLE
ferret: init at 0.18.1

### DIFF
--- a/pkgs/by-name/fe/ferret/package.nix
+++ b/pkgs/by-name/fe/ferret/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "ferret";
+  version = "0.18.1";
+
+  vendorHash = "sha256-F8NpMcIQUOlhjGB/Fc7mVW9HNn5O0AC26Onu9pGixz4=";
+
+  src = fetchFromGitHub {
+    owner = "MontFerret";
+    repo = "ferret";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-LqXP4h9V4rPgzPt6UQ3XZ0/RFFuGvSdTu3UIDeXKcT4=";
+  };
+
+  checkFlags = [
+    # Uses an HTTP request to validate that a URL returns a response.
+    # No networking in build sandbox.
+    # https://github.com/MontFerret/ferret/blob/v0.18.1/pkg/stdlib/html/document_exists.go#L17-L74
+    "-skip=TestDocumentExists"
+  ];
+
+  env.CGO_ENABLED = 0;
+
+  postInstall = ''
+    mv $out/bin/e2e $out/bin/ferret
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Declarative web scraping system aiming to simplify data extraction from the web";
+    homepage = "https://www.montferret.dev/";
+    downloadPage = "https://github.com/MontFerret/ferret/releases/v${finalAttrs.version}";
+    changelog = "https://github.com/MontFerret/ferret/blob/v${finalAttrs.version}/CHANGELOG.md";
+    maintainers = with lib.maintainers; [ kpbaks ];
+    license = lib.licenses.asl20;
+    mainProgram = "ferret";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add package for [ferret](https://www.montferret.dev/). A declarative web scraping system aiming to simplify data extraction from the web. Written in Go.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
