### PR TITLE
qt6Packages.qodeassist-plugin: init at 0.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28565,6 +28565,14 @@
     githubId = 3449926;
     name = "David Costa";
   };
+  zatm8 = {
+    email = "maxis1191@gmail.com";
+    github = "mourogurt";
+    githubId = 4152680;
+    keys = [ { fingerprint = "51BB 531F 219E 43C6 66E6  DD65 C4AD 9641 7F72 5D42"; } ];
+    matrix = "@zatm8:zinzaguras.ru";
+    name = "ZatM8";
+  };
   zauberpony = {
     email = "elmar@athmer.org";
     github = "elmarx";

--- a/pkgs/development/libraries/qodeassist-plugin/default.nix
+++ b/pkgs/development/libraries/qodeassist-plugin/default.nix
@@ -1,0 +1,67 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  qttools,
+  ninja,
+  cups,
+  curl,
+  libGL,
+  qtbase,
+  qt5compat,
+  qtcreator,
+  vulkan-headers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qodeassist-plugin";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "Palm1r";
+    repo = "QodeAssist";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+Yc8Vm8uFlMOFIGwuAgmJl6NtCQ7ETbxabFdXJqoVXw=";
+  };
+
+  dontWrapQtApps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    ninja
+    (qttools.override { withClang = true; })
+  ];
+
+  buildInputs = [
+    cups
+    curl
+    libGL
+    qtbase
+    qt5compat
+    qtcreator
+    vulkan-headers
+  ];
+
+  outputs = [ "out" ];
+
+  cmakeFlags = [ ];
+
+  installPhase = "mkdir -p $out; cp -R lib $out/";
+
+  meta = {
+    description = "AI-powered coding assistant plugin for Qt Creator";
+    longDescription = ''
+      QodeAssist is an AI-powered coding assistant plugin for Qt Creator.
+      It provides intelligent code completion and suggestions for C++ and QML,
+      leveraging large language models through local providers like Ollama.
+      Enhance your coding productivity with context-aware AI assistance directly
+      in your Qt development environment.
+    '';
+    homepage = "https://github.com/Palm1r/QodeAssist";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.zatm8 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/development/tools/qtcreator/default.nix
+++ b/pkgs/development/tools/qtcreator/default.nix
@@ -29,12 +29,12 @@
   perf,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "qtcreator";
   version = "17.0.1";
 
   src = fetchurl {
-    url = "mirror://qt/official_releases/${pname}/${lib.versions.majorMinor version}/${version}/qt-creator-opensource-src-${version}.tar.xz";
+    url = "mirror://qt/official_releases/${finalAttrs.pname}/${lib.versions.majorMinor finalAttrs.version}/${finalAttrs.version}/qt-creator-opensource-src-${finalAttrs.version}.tar.xz";
     hash = "sha256-9WcYCEdnBzkami7bmWPqSmtrkMeMvnTs4aygxrQuUYQ=";
   };
 
@@ -69,25 +69,42 @@ stdenv.mkDerivation rec {
     elfutils
   ];
 
+  outputs = [
+    "out"
+    "dev"
+  ];
+
   cmakeFlags = [
     # workaround for missing CMAKE_INSTALL_DATAROOTDIR
     # in pkgs/development/tools/build-managers/cmake/setup-hook.sh
-    "-DCMAKE_INSTALL_DATAROOTDIR=${placeholder "out"}/share"
+    (lib.cmakeFeature "CMAKE_INSTALL_DATAROOTDIR" "${placeholder "out"}/share")
     # qtdeclarative in nixpkgs does not provide qmlsc
     # fix can't find Qt6QmlCompilerPlusPrivate
-    "-DQT_NO_FIND_QMLSC=TRUE"
-    "-DWITH_DOCS=ON"
-    "-DBUILD_DEVELOPER_DOCS=ON"
-    "-DBUILD_QBS=OFF"
-    "-DQTC_CLANG_BUILDMODE_MATCH=ON"
-    "-DCLANGTOOLING_LINK_CLANG_DYLIB=ON"
+    (lib.cmakeBool "QT_NO_FIND_QMLSC" true)
+    (lib.cmakeBool "WITH_DOCS" true)
+    (lib.cmakeBool "BUILD_DEVELOPER_DOCS" true)
+    (lib.cmakeBool "BUILD_QBS" false)
+    (lib.cmakeBool "QTC_CLANG_BUILDMODE_MATCH" true)
+    (lib.cmakeBool "CLANGTOOLING_LINK_CLANG_DYLIB" true)
   ];
 
   qtWrapperArgs = [
     "--set-default PERFPROFILER_PARSER_FILEPATH ${lib.getBin perf}/bin"
   ];
 
-  meta = with lib; {
+  postInstall = ''
+    # Small hack to set-up right prefix in cmake modules for header files
+    cmake . $cmakeFlags -DCMAKE_INSTALL_PREFIX="''${!outputDev}"
+
+    cmake --install . --prefix "''${!outputDev}" --component Devel
+  '';
+
+  # Remove prefix from the QtC config to make sane output path for 3rd-party plug-ins.
+  postFixup = ''
+    substituteInPlace ''${!outputDev}/lib/cmake/QtCreator/QtCreatorConfig.cmake --replace "$out/" ""
+  '';
+
+  meta = {
     description = "Cross-platform IDE tailored to the needs of Qt developers";
     longDescription = ''
       Qt Creator is a cross-platform IDE (integrated development environment)
@@ -95,8 +112,12 @@ stdenv.mkDerivation rec {
       advanced code editor, a visual debugger and a GUI designer.
     '';
     homepage = "https://wiki.qt.io/Qt_Creator";
-    license = licenses.gpl3Only; # annotated with The Qt Company GPL Exception 1.0
-    maintainers = [ maintainers.rewine ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Only; # annotated with The Qt Company GPL Exception 1.0
+    maintainers = with lib.maintainers; [
+      rewine
+      zatm8
+    ];
+    platforms = lib.platforms.linux;
+    mainProgram = "qtcreator";
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7123,8 +7123,8 @@ with pkgs;
 
   qtcreator = qt6Packages.callPackage ../development/tools/qtcreator {
     inherit (linuxPackages) perf;
-    llvmPackages = llvmPackages_18;
-    stdenv = llvmPackages_18.stdenv;
+    llvmPackages = llvmPackages_21;
+    stdenv = llvmPackages_21.stdenv;
   };
 
   qxmledit = libsForQt5.callPackage ../applications/editors/qxmledit { };

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -92,6 +92,8 @@ makeScopeWithSplicing' {
       qmlbox2d = callPackage ../development/libraries/qmlbox2d { };
       packagekit-qt = callPackage ../tools/package-management/packagekit/qt.nix { };
 
+      qodeassist-plugin = callPackage ../development/libraries/qodeassist-plugin { };
+
       qt6ct = callPackage ../tools/misc/qt6ct { };
 
       qt6gtk2 = callPackage ../tools/misc/qt6gtk2 { };


### PR DESCRIPTION
Added module for Qt Creator package to manage third-party plug-ins and added the QodeAssist plug-in: AI-powered coding assistant plugin for Qt Creator.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. Added dev output for Qt Creator package to be able to compile third-party plug-ins;
2. Added myself as an additional maintainer for Qt Creator (actively using it);
3. Bump LLVM version for Qt Creator;
4. Added QodeAssist plug-in;

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
