### PR TITLE
[Backport to release-25.05] warp-terminal: 0.2025.07.09.08.11.stable_01 -> 0.2025.08.20.08.11.stable_03

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/package.nix
+++ b/pkgs/by-name/wa/warp-terminal/package.nix
@@ -112,7 +112,6 @@ let
     license = licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     maintainers = with maintainers; [
-      emilytrau
       imadnyc
       FlameFlag
       johnrtitor

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-nRI0xtLFyFqqNCZjIH07Dxut4OdZMO3KHHyPeNT3XKo=",
-    "version": "0.2025.07.09.08.11.stable_01"
+    "hash": "sha256-JAqWQ3dfk4B+CNV5knj4HCnpVu3Q5STnyriqaeLPQD0=",
+    "version": "0.2025.07.23.08.12.stable_02"
   },
   "linux_x86_64": {
-    "hash": "sha256-zk3yHo3aimdmgA9bxbQrrZXXWYzNjJRB619PB/MRIG4=",
-    "version": "0.2025.07.09.08.11.stable_01"
+    "hash": "sha256-C9p95LRS/ma5FEIq6ZQqda+dQhgbVT8dhDJIDpCilWI=",
+    "version": "0.2025.07.23.08.12.stable_02"
   },
   "linux_aarch64": {
-    "hash": "sha256-b208xahTJ0e0wABB2m2M7x6CAyHKr/7uHMF/cY4LVfM=",
-    "version": "0.2025.07.09.08.11.stable_01"
+    "hash": "sha256-KGmkuL/4I+oN99ubjtGMrEt6Ijlak9yv39LksPAo8/U=",
+    "version": "0.2025.07.23.08.12.stable_02"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-s4SHM2pU1CZPJZFiWE5VDeSEprLsSYChFazNGOpz+oo=",
-    "version": "0.2025.08.06.08.12.stable_01"
+    "hash": "sha256-wO3xE8cSSMaYVc6eoswDcR3acBzWwB/BHbins8ciM4Y=",
+    "version": "0.2025.08.06.08.12.stable_02"
   },
   "linux_x86_64": {
-    "hash": "sha256-u0TH9u1o+g3GngEMg6r78fSZH778kGcKe5tB/lpExZE=",
-    "version": "0.2025.08.06.08.12.stable_01"
+    "hash": "sha256-/Nhy0fyslK8h5zzhwlDJT+6nhNmdBowj/jGOTCunX4w=",
+    "version": "0.2025.08.06.08.12.stable_02"
   },
   "linux_aarch64": {
-    "hash": "sha256-smg2QiXRlADGBKxl9Wlq2yWsCCi3JwjxhwR13yG70mA=",
-    "version": "0.2025.08.06.08.12.stable_01"
+    "hash": "sha256-Jqm2aUg11nrIZUofcLDYZ7BQtaSPx7KrrM91i0bc+ig=",
+    "version": "0.2025.08.06.08.12.stable_02"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-3j6Kqlo/nsc+gjSrW5Afuamnh0qb9TnG+sFN4E5pnxc=",
-    "version": "0.2025.07.30.08.12.stable_02"
+    "hash": "sha256-s4SHM2pU1CZPJZFiWE5VDeSEprLsSYChFazNGOpz+oo=",
+    "version": "0.2025.08.06.08.12.stable_01"
   },
   "linux_x86_64": {
-    "hash": "sha256-GbkTghYchdUdYdvPNAqPv+PD7UJ2sgVc7+AAA+5bHGI=",
-    "version": "0.2025.07.30.08.12.stable_02"
+    "hash": "sha256-u0TH9u1o+g3GngEMg6r78fSZH778kGcKe5tB/lpExZE=",
+    "version": "0.2025.08.06.08.12.stable_01"
   },
   "linux_aarch64": {
-    "hash": "sha256-xIf12oEOHQE1+Sz3L/nrqli2tlP0+wWFA9dA+HHNrr0=",
-    "version": "0.2025.07.30.08.12.stable_02"
+    "hash": "sha256-smg2QiXRlADGBKxl9Wlq2yWsCCi3JwjxhwR13yG70mA=",
+    "version": "0.2025.08.06.08.12.stable_01"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-JAqWQ3dfk4B+CNV5knj4HCnpVu3Q5STnyriqaeLPQD0=",
-    "version": "0.2025.07.23.08.12.stable_02"
+    "hash": "sha256-3j6Kqlo/nsc+gjSrW5Afuamnh0qb9TnG+sFN4E5pnxc=",
+    "version": "0.2025.07.30.08.12.stable_02"
   },
   "linux_x86_64": {
-    "hash": "sha256-C9p95LRS/ma5FEIq6ZQqda+dQhgbVT8dhDJIDpCilWI=",
-    "version": "0.2025.07.23.08.12.stable_02"
+    "hash": "sha256-GbkTghYchdUdYdvPNAqPv+PD7UJ2sgVc7+AAA+5bHGI=",
+    "version": "0.2025.07.30.08.12.stable_02"
   },
   "linux_aarch64": {
-    "hash": "sha256-KGmkuL/4I+oN99ubjtGMrEt6Ijlak9yv39LksPAo8/U=",
-    "version": "0.2025.07.23.08.12.stable_02"
+    "hash": "sha256-xIf12oEOHQE1+Sz3L/nrqli2tlP0+wWFA9dA+HHNrr0=",
+    "version": "0.2025.07.30.08.12.stable_02"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-B9Qhh+1vvisdpE9XYQRbJ87Ilo4Qmy9Uvd7Zn4+TLxg=",
-    "version": "0.2025.08.13.08.12.stable_02"
+    "hash": "sha256-qfhEXZbsqLhS1yTWwjbcUwUW5/3mIe2sC+GT6NG9bmY=",
+    "version": "0.2025.08.20.08.11.stable_03"
   },
   "linux_x86_64": {
-    "hash": "sha256-x87HElhBSrh00LiCcKX9AnWiROVN4SEZTqu7D1R72LI=",
-    "version": "0.2025.08.13.08.12.stable_02"
+    "hash": "sha256-8aU5tFqqoD8yABQ2F5axqpD1ppL1FQyu5cY9MBEWgME=",
+    "version": "0.2025.08.20.08.11.stable_03"
   },
   "linux_aarch64": {
-    "hash": "sha256-+lv8dpx5fi12rhG258zSj0att/vTi7DidKCYlUCIbvo=",
-    "version": "0.2025.08.13.08.12.stable_02"
+    "hash": "sha256-xFAMoRQJ1Qpuun+VRmmj8DnJaIk+/48zwyIUO9xl6io=",
+    "version": "0.2025.08.20.08.11.stable_03"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-wO3xE8cSSMaYVc6eoswDcR3acBzWwB/BHbins8ciM4Y=",
-    "version": "0.2025.08.06.08.12.stable_02"
+    "hash": "sha256-B9Qhh+1vvisdpE9XYQRbJ87Ilo4Qmy9Uvd7Zn4+TLxg=",
+    "version": "0.2025.08.13.08.12.stable_02"
   },
   "linux_x86_64": {
-    "hash": "sha256-/Nhy0fyslK8h5zzhwlDJT+6nhNmdBowj/jGOTCunX4w=",
-    "version": "0.2025.08.06.08.12.stable_02"
+    "hash": "sha256-x87HElhBSrh00LiCcKX9AnWiROVN4SEZTqu7D1R72LI=",
+    "version": "0.2025.08.13.08.12.stable_02"
   },
   "linux_aarch64": {
-    "hash": "sha256-Jqm2aUg11nrIZUofcLDYZ7BQtaSPx7KrrM91i0bc+ig=",
-    "version": "0.2025.08.06.08.12.stable_02"
+    "hash": "sha256-+lv8dpx5fi12rhG258zSj0att/vTi7DidKCYlUCIbvo=",
+    "version": "0.2025.08.13.08.12.stable_02"
   }
 }


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
