### PR TITLE
linux_6_15: remove

### DIFF
--- a/nixos/doc/manual/configuration/linux-kernel.chapter.md
+++ b/nixos/doc/manual/configuration/linux-kernel.chapter.md
@@ -24,6 +24,12 @@ abandoned by the kernel developers, even on stable NixOS versions. If you
 pin your kernel onto a non-longterm version, expect your evaluation to fail as
 soon as the version is out of maintenance.
 
+A kernel will be removed from nixpkgs when the first batch of stable kernels
+_after_ the final release is published. E.g. when 6.15.11 is the final release
+of the 6.15 series and is released together with 6.16.3 and 6.12.43, it will be
+removed on the release of 6.16.4 and 6.12.44. Custom kernel variants such
+as linux-hardened are also affected by this.
+
 Longterm versions of kernels will be removed before the next stable NixOS that will
 exceed the maintenance period of the kernel version.
 

--- a/nixos/tests/kernel-generic.nix
+++ b/nixos/tests/kernel-generic.nix
@@ -36,7 +36,6 @@ let
   kernels = pkgs.linuxKernel.vanillaPackages // {
     inherit (pkgs.linuxKernel.packages)
       linux_6_12_hardened
-      linux_6_15_hardened
       linux_rt_5_4
       linux_rt_5_10
       linux_rt_5_15

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -8,15 +8,5 @@
         },
         "sha256": "09qfpxyxi3z8cd64r2r5mxvh54a5sx8p5mk4d50y4ga2k6pa66bb",
         "version": "6.12.41"
-    },
-    "6.15": {
-        "patch": {
-            "extra": "-hardened1",
-            "name": "linux-hardened-v6.15.9-hardened1.patch",
-            "sha256": "132h0cgv8kzrlz7jprqvwcnragc2v793a759bhg0q6w3ninmncjc",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.15.9-hardened1/linux-hardened-v6.15.9-hardened1.patch"
-        },
-        "sha256": "0zcma8ycdwwzd4yci9752acsv85wh27lahclh5x2yc4jakw3lkz9",
-        "version": "6.15.9"
     }
 }

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -33,11 +33,6 @@
         "hash": "sha256:1vmxywg11z946i806sg7rk7jr9px87spmwwbzjxpps2nsjybpjqg",
         "lts": true
     },
-    "6.15": {
-        "version": "6.15.11",
-        "hash": "sha256:14sxwrvw9p4ybizb8ky1rgahc62q0aw5qkmzqp3cpnavqfgldaw9",
-        "lts": false
-    },
     "6.16": {
         "version": "6.16.3",
         "hash": "sha256:118bg72mdrf75r36gki5zi18ynl2kcygrf24pwd58by1anh9nhw0",

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -210,14 +210,6 @@ in
           ];
         };
 
-        linux_6_15 = callPackage ../os-specific/linux/kernel/mainline.nix {
-          branch = "6.15";
-          kernelPatches = [
-            kernelPatches.bridge_stp_helper
-            kernelPatches.request_key_helper
-          ];
-        };
-
         linux_6_16 = callPackage ../os-specific/linux/kernel/mainline.nix {
           branch = "6.16";
           kernelPatches = [
@@ -295,7 +287,6 @@ in
         linux_latest_libre = deblobKernel packageAliases.linux_latest.kernel;
 
         linux_6_12_hardened = hardenedKernelFor kernels.linux_6_12 { };
-        linux_6_15_hardened = hardenedKernelFor kernels.linux_6_15 { };
 
         linux_hardened = hardenedKernelFor packageAliases.linux_default.kernel { };
       }
@@ -306,6 +297,7 @@ in
         linux_6_11 = throw "linux 6.11 was removed because it has reached its end of life upstream";
         linux_6_13 = throw "linux 6.13 was removed because it has reached its end of life upstream";
         linux_6_14 = throw "linux 6.14 was removed because it has reached its end of life upstream";
+        linux_6_15 = throw "linux 6.15 was removed because it has reached its end of life upstream";
 
         linux_5_10_hardened = throw "linux_hardened on nixpkgs only contains latest stable and latest LTS";
         linux_5_15_hardened = throw "linux_hardened on nixpkgs only contains latest stable and latest LTS";
@@ -319,6 +311,7 @@ in
         linux_6_11_hardened = throw "linux 6.11 was removed because it has reached its end of life upstream";
         linux_6_13_hardened = throw "linux 6.13 was removed because it has reached its end of life upstream";
         linux_6_14_hardened = throw "linux 6.14 was removed because it has reached its end of life upstream";
+        linux_6_15_hardened = throw "linux 6.15 was removed because it has reached its end of life upstream";
 
         linux_ham = throw "linux_ham has been removed in favour of the standard kernel packages";
       }
@@ -738,7 +731,6 @@ in
     linux_6_1 = recurseIntoAttrs (packagesFor kernels.linux_6_1);
     linux_6_6 = recurseIntoAttrs (packagesFor kernels.linux_6_6);
     linux_6_12 = recurseIntoAttrs (packagesFor kernels.linux_6_12);
-    linux_6_15 = recurseIntoAttrs (packagesFor kernels.linux_6_15);
     linux_6_16 = recurseIntoAttrs (packagesFor kernels.linux_6_16);
   }
   // lib.optionalAttrs config.allowAliases {
@@ -748,6 +740,7 @@ in
     linux_6_11 = throw "linux 6.11 was removed because it reached its end of life upstream"; # Added 2025-03-23
     linux_6_13 = throw "linux 6.13 was removed because it reached its end of life upstream"; # Added 2025-06-22
     linux_6_14 = throw "linux 6.14 was removed because it reached its end of life upstream"; # Added 2025-06-22
+    linux_6_15 = throw "linux 6.15 was removed because it reached its end of life upstream"; # Added 2025-08-23
   };
 
   rtPackages = {
@@ -778,7 +771,6 @@ in
       linux_hardened = recurseIntoAttrs (packagesFor kernels.linux_hardened);
 
       linux_6_12_hardened = recurseIntoAttrs (packagesFor kernels.linux_6_12_hardened);
-      linux_6_15_hardened = recurseIntoAttrs (packagesFor kernels.linux_6_15_hardened);
 
       linux_zen = recurseIntoAttrs (packagesFor kernels.linux_zen);
       linux_lqx = recurseIntoAttrs (packagesFor kernels.linux_lqx);
@@ -805,6 +797,7 @@ in
       linux_6_11_hardened = throw "linux 6.11 was removed because it has reached its end of life upstream";
       linux_6_13_hardened = throw "linux 6.13 was removed because it has reached its end of life upstream";
       linux_6_14_hardened = throw "linux 6.14 was removed because it has reached its end of life upstream";
+      linux_6_15_hardened = throw "linux 6.15 was removed because it has reached its end of life upstream";
       linux_ham = throw "linux_ham has been removed in favour of the standard kernel packages";
     }
   );


### PR DESCRIPTION
EOL upstream.

We only have one hardened kernel at the moment now because LTS == latest available. This situation would've also happened before the cleanup since 6.13/6.14 were removed in June already[1].

[1] 23b573705de96bf400a30d22bc195acb0763ac12


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
