### PR TITLE
metadata:  0.1.9 -> 0.1.10

### DIFF
--- a/pkgs/by-name/me/metadata/package.nix
+++ b/pkgs/by-name/me/metadata/package.nix
@@ -1,40 +1,32 @@
 {
   lib,
   fetchFromGitHub,
-  fetchpatch,
   pkg-config,
   ffmpeg,
   rustPlatform,
   glib,
   installShellFiles,
   asciidoc,
+  versionCheckHook,
 }:
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "metadata";
-  version = "0.1.9";
+  version = "0.1.10";
 
   src = fetchFromGitHub {
     owner = "zmwangx";
     repo = "metadata";
-    rev = "ec9614cfa64ffc95d74e4b19496ebd9b026e692b";
-    hash = "sha256-ugirYg3l+zIfKAqp2smLgG99mX9tsy9rmGe6lFAwx5o=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-wZ1wLygPFBFZsSYJGxNzYV+mXtbN68GY3nMYDFHPZHo=";
   };
 
-  cargoHash = "sha256-CqPRhfhTAEXTXRAJ9T5gQZx5jAQmJXYPbfQmyXkO6Sk=";
+  cargoHash = "sha256-pWekXsjAhK4wyjf95nZO+Wj9PcH87D8vYsRFAE/w/sw=";
 
   nativeBuildInputs = [
     pkg-config
     asciidoc
     installShellFiles
     rustPlatform.bindgenHook
-  ];
-
-  cargoPatches = [
-    (fetchpatch {
-      name = "update-crate-ffmpeg-next-version.patch";
-      url = "https://github.com/myclevorname/metadata/commit/a1bc9f53d9aa0aeb17cbb530a1da1de4fdf85328.diff";
-      hash = "sha256-LEwOK1UFUwLZhqLnoUor5CSOwz4DDjNFMnMOGq1S1Sc=";
-    })
   ];
 
   postBuild = ''
@@ -51,6 +43,15 @@ rustPlatform.buildRustPackage {
 
   env.FFMPEG_DIR = ffmpeg.dev;
 
+  checkFlags = [
+    # "AAC (HE-AAC v2)" is reported as "AAC (LC)" in newer ffmpeg
+    # https://github.com/zmwangx/metadata/issues/13
+    "--skip=aac_he_aac"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   meta = {
     description = "Media metadata parser and formatter designed for human consumption, powered by FFmpeg";
     maintainers = with lib.maintainers; [ ];
@@ -58,4 +59,4 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/zmwangx/metadata";
     mainProgram = "metadata";
   };
-}
+})


### PR DESCRIPTION
Update to [0.1.10](https://github.com/zmwangx/metadata/releases/tag/v0.1.10) which includes the commit previously pulled as a patch.

Due to update to newer ffmpeg, one of the tests is broken. Reported upstream, ignoring for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
