### PR TITLE
 appres: refactor and move to pkgs/by-name from xorg namespace 

### DIFF
--- a/pkgs/by-name/ap/appres/package.nix
+++ b/pkgs/by-name/ap/appres/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  meson,
+  ninja,
+  xorgproto,
+  libx11,
+  libxt,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "appres";
+  version = "1.0.7";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/appres-${finalAttrs.version}.tar.xz";
+    hash = "sha256-ERSxiSOf2HqNHbQz7ctEhjRtKZEhMrkeru5WZ/E7gZ8=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+  ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxt
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Utility to list X application resource database";
+    longDescription = ''
+      The appres program prints the resources seen by an application (or subhierarchy of an
+      application) with the specified class and instance names.
+      It can be used to determine which resources a particular program will load.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/appres";
+    license = lib.licenses.mitOpenGroup;
+    mainProgram = "appres";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1,6 +1,7 @@
 # THIS IS A GENERATED FILE.  DO NOT EDIT!
 {
   lib,
+  appres,
   bdftopcf,
   font-alias,
   font-bh-ttf,
@@ -81,6 +82,7 @@
 self: with self; {
 
   inherit
+    appres
     bdftopcf
     gccmakedep
     ico
@@ -157,44 +159,6 @@ self: with self; {
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
   xorgsgmldoctools = xorg-sgml-doctools;
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  appres = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      xorgproto,
-      libXt,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "appres";
-      version = "1.0.7";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/appres-1.0.7.tar.xz";
-        sha256 = "17w17gqnfmpfmqgbjci1j4lnsd468k5yscxl3n6pmn4z4f4v250i";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        xorgproto
-        libXt
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   bitmap = callPackage (

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -317,6 +317,7 @@ print OUT <<EOF;
 # THIS IS A GENERATED FILE.  DO NOT EDIT!
 {
   lib,
+  appres,
   bdftopcf,
   font-alias,
   font-bh-ttf,
@@ -397,6 +398,7 @@ print OUT <<EOF;
 self: with self; {
 
   inherit
+    appres
     bdftopcf
     gccmakedep
     ico

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -112,16 +112,6 @@ self: super:
       )
   ) { };
 
-  appres = super.appres.overrideAttrs (attrs: {
-    nativeBuildInputs = attrs.nativeBuildInputs ++ [
-      meson
-      ninja
-    ];
-    meta = attrs.meta // {
-      mainProgram = "appres";
-    };
-  });
-
   bitmap = addMainProgram super.bitmap { };
 
   editres = super.editres.overrideAttrs (attrs: {

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/app/appres-1.0.7.tar.xz
 mirror://xorg/individual/app/bitmap-1.1.1.tar.xz
 mirror://xorg/individual/app/editres-1.0.9.tar.xz
 mirror://xorg/individual/app/fonttosfnt-1.2.4.tar.xz


### PR DESCRIPTION
<details>
<summary>this is the script i use to get the packages that don't depend on other xorg packages:</summary>

```nix
let
  inherit (import <nixpkgs> { }) lib;

  done = import ./pkgs/servers/x11/xorg/default.nix |> lib.functionArgs |> lib.attrNames;

  pkgs =
    (import ./default.nix { }).xorg
    |> lib.filterAttrs (
      n: v:
      lib.isAttrs v
      && v ? pname
      && !lib.elem n done
      && !lib.elem n (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem v.pname done
      && !lib.elem v.pname (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem (lib.toLower n) done
      && !lib.elem (lib.toLower n) (map (lib.replaceStrings [ "-" ] [ "" ]) done)
    );

  pnames = lib.mapAttrsToList (_: v: v.pname) pkgs;

  filteredPkgs =
    pkgs
    |> lib.filterAttrs (
      n: v:
      true
      # && !v.meta.unfree
      # && !v.meta.broken
      # && !v.meta.unsupported
      # && !lib.hasPrefix "font" n
      && !lib.hasPrefix "xf86" n
    );
in
filteredPkgs
# get deps
|> lib.mapAttrs (
  _: v:
  v.buildInputs ++ v.nativeBuildInputs ++ v.propagatedBuildInputs ++ v.propagatedNativeBuildInputs
)
# filter deps for xorg packages
|> lib.mapAttrs (_: v: lib.filter (x: x ? pname && lib.elem x.pname pnames) v)
# map deps to list and count
|> lib.mapAttrsToList (
  name: value: {
    inherit name;
    deps = map (x: x.pname or "error") value |> lib.unique;
    count = lib.length value;
  }
)
# sort
|> lib.sort (
  x: y: x.count < y.count || (x.count == y.count && (lib.toLower x.name) > (lib.toLower y.name))
)
|> lib.reverseList
# represent as string
|> map (x: "${toString x.count} - ${toString x.name}: ${lib.concatStringsSep " " x.deps}")
```

you can call it like this to get a nice output:

```sh
nix eval --json --file ./xorg-nodepends.nix | jq .[] --raw-output
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] x86_64-linux static 
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - as far as  appres is testable inside a wayland compositor, so only the help output
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] ran passthru.updateScript
- [x] ran nixpkgs-hammer
- [x] ran nix-check-deps 
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc