### PR TITLE
luaPackages.lux-lua make compatible with `lua.withPackages`

### DIFF
--- a/pkgs/development/lua-modules/lux-lua.nix
+++ b/pkgs/development/lua-modules/lux-lua.nix
@@ -67,6 +67,8 @@ rustPlatform.buildRustPackage rec {
     runHook preInstall
     cp -r target/dist/share $out
     cp -r target/dist/lib $out
+    mkdir -p $out/lib/lua
+    ln -s $out/share/lux-lua/${luaVersionDir} $out/lib/lua/${luaVersionDir}
     runHook postInstall
   '';
 

--- a/pkgs/development/lua-modules/lux-lua.nix
+++ b/pkgs/development/lua-modules/lux-lua.nix
@@ -39,8 +39,11 @@ rustPlatform.buildRustPackage rec {
     gpgme
     libgit2
     libgpg-error
-    lua
     openssl
+  ];
+
+  propagatedBuildInputs = [
+    lua
   ];
 
   doCheck = false; # lux-lua tests are broken in nixpkgs


### PR DESCRIPTION
The `luaPackages.lux-lua` package has been designed to be usable with `lux-cli`, which can find it using `pkg-config`.
This PR makes it usable as a regular Lua library, so that if you run

```
nix-shell -p "lua.withPackages(ps: with ps; [lux-lua])"
lua
> require('lux')
```

Lua can find the `lux` module.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
