### PR TITLE
kakaotalk: init at 25.7.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -369,6 +369,12 @@
     githubId = 7755101;
     name = "Aaron Andersen";
   };
+  aanhlongg = {
+    email = "nguyen.vietlong@protonmail.com";
+    github = "aanhlongg";
+    githubId = 169835631;
+    name = "Vietlong Nguyen";
+  };
   aaqaishtyaq = {
     email = "aaqaishtyaq@gmail.com";
     github = "aaqaishtyaq";

--- a/pkgs/by-name/ka/kakaotalk/package.nix
+++ b/pkgs/by-name/ka/kakaotalk/package.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  copyDesktopItems,
+  makeDesktopItem,
+  runtimeShell,
+  wine,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kakaotalk";
+  version = "25.7.3";
+
+  src = fetchurl {
+    url = "https://app-pc.kakaocdn.net/talk/win32/KakaoTalk_Setup.exe";
+    hash = "sha256-c4ufYpQgc3MCmE9Olbkta0YxE+fvN8RYeUvT0B72VMU=";
+  };
+
+  icon = fetchurl {
+    name = "kakaotalk.png";
+    url = "https://t1.kakaocdn.net/kakaocorp/kakaocorp/admin/service/453a624d017900001.png";
+    hash = "sha256-1RTNnl3GN84RhvWLjud5RNdHUu88CwsSyfNrko8IqCs=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    wine
+  ];
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cat <<'EOF' > $out/bin/kakaotalk
+    #!${runtimeShell}
+    export PATH=${wine}/bin:$PATH
+    export WINEARCH=win32
+    export WINEPREFIX="''${KAKAOTALK_HOME:-"''${XDG_DATA_HOME:-"''${HOME}/.local/share"}/kakaotalk"}/wine"
+    export WINEDLLOVERRIDES="mscoree=;winemenubuilder.exe="
+    if [ ! -d "$WINEPREFIX" ] ; then
+      mkdir -p "$WINEPREFIX"
+      wine ${finalAttrs.src} /S
+    fi
+    wine "$WINEPREFIX/drive_c/Program Files/Kakao/KakaoTalk/KakaoTalk.exe" &
+    KAKAO_PID=$!
+    CONFIG_FILE="$WINEPREFIX/drive_c/users/$(whoami)/AppData/Local/Kakao/KakaoTalk/pref.ini"
+    for i in {1..30}; do
+      if [ -f "$CONFIG_FILE" ]; then
+        sed -i 's/use_new_loco = .*/use_new_loco = no/' "$CONFIG_FILE"
+        if ! grep -q "use_new_loco" "$CONFIG_FILE"; then
+          echo "use_new_loco = no" >> "$CONFIG_FILE"
+        fi
+        break
+      fi
+      sleep 1
+    done
+    wait $KAKAO_PID
+    EOF
+    chmod +x $out/bin/kakaotalk
+    install -Dm644 ${finalAttrs.icon} $out/share/icons/hicolor/256x256/apps/kakaotalk.png
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "KakaoTalk";
+      exec = "kakaotalk";
+      icon = "kakaotalk";
+      desktopName = "KakaoTalk";
+      comment = finalAttrs.meta.description;
+      categories = [
+        "Network"
+        "InstantMessaging"
+      ];
+      terminal = false;
+    })
+  ];
+
+  meta = {
+    description = "Instant Messaging App operated by Kakao Corporation in South Korea";
+    homepage = "https://www.kakaocorp.com/page/service/service/KakaoTalk";
+    maintainers = with lib.maintainers; [ aanhlongg ];
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.linux;
+    mainProgram = "kakaotalk";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Init for  [KakaoTalk](https://www.kakaocorp.com/page/service/service/KakaoTalk), popular instant messaging app by Kakao Corporation in South Korea.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
