### PR TITLE
objection: init at 1.12.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19554,6 +19554,12 @@
     github = "nullishamy";
     githubId = 99221043;
   };
+  nullstring1 = {
+    email = "nullstring1+nixpkgs@nullstring.one";
+    name = "nullstring1";
+    github = "nullstring1";
+    githubId = 53035336;
+  };
   numbleroot = {
     email = "hello@lennartoldenburg.de";
     name = "Lennart Oldenburg";

--- a/pkgs/by-name/ob/objection/package.nix
+++ b/pkgs/by-name/ob/objection/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  frida-tools,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "objection";
+  version = "1.12.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "sensepost";
+    repo = "objection";
+    tag = version;
+    hash = "sha256-xOqBYwpq46czRZggTNmNcqGqTA8omTLiOeZaF7zSvxo=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  buildInputs = [
+    frida-tools
+  ];
+
+  dependencies = with python3Packages; [
+    frida-python
+    prompt-toolkit
+    click
+    tabulate
+    semver
+    delegator-py
+    requests
+    flask
+    pygments
+    setuptools
+    packaging
+    litecli
+  ];
+
+  pythonImportsCheck = [
+    "objection"
+  ];
+
+  doCheck = true;
+
+  pythonRuntimeDepsCheck = true;
+
+  meta = {
+    description = "Runtime mobile exploration toolkit, powered by Frida";
+    longDescription = ''
+      objection is a runtime mobile exploration toolkit, powered by Frida,
+      built to help you assess the security posture of your mobile applications,
+      without needing a jailbreak.
+    '';
+    homepage = "https://github.com/sensepost/objection";
+    changelog = "https://github.com/sensepost/objection/releases/tag/${version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ nullstring1 ];
+    mainProgram = "objection";
+  };
+}

--- a/pkgs/development/python-modules/litecli/default.nix
+++ b/pkgs/development/python-modules/litecli/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  click,
+  pygments,
+  prompt-toolkit,
+  sqlparse,
+  configobj,
+  cli-helpers,
+}:
+
+buildPythonPackage rec {
+  pname = "litecli";
+  version = "1.17.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "dbcli";
+    repo = "litecli";
+    tag = "v${version}";
+    hash = "sha256-YSPNtDL5rNgRh5lJBKfL1jjWemlmf3eesBMSLyJVRLY=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    click
+    pygments
+    prompt-toolkit
+    sqlparse
+    configobj
+    cli-helpers
+  ];
+
+  doCheck = true;
+
+  pythonImportsCheck = [
+    "litecli"
+  ];
+
+  meta = {
+    description = "CLI for SQLite Databases with auto-completion and syntax highlighting";
+    homepage = "https://github.com/dbcli/litecli";
+    changelog = "https://github.com/dbcli/litecli/releases/tag/v${version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ nullstring1 ];
+    mainProgram = "litecli";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8870,6 +8870,8 @@ self: super: with self; {
 
   lit = callPackage ../development/python-modules/lit { };
 
+  litecli = callPackage ../development/python-modules/litecli { };
+
   litellm = callPackage ../development/python-modules/litellm { };
 
   litemapy = callPackage ../development/python-modules/litemapy { };


### PR DESCRIPTION
Added [objection](https://github.com/sensepost/objection), and litecli as a python module

## Things done

- Built on platform:
  - [-] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [-] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [-] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [-] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
