### PR TITLE
msgpack-tools: unbreak

### DIFF
--- a/pkgs/by-name/ms/msgpack-tools/package.nix
+++ b/pkgs/by-name/ms/msgpack-tools/package.nix
@@ -4,48 +4,60 @@
   fetchurl,
   fetchFromGitHub,
   cmake,
+  versionCheckHook,
 }:
 
-stdenv.mkDerivation rec {
+let
+  libb64 = fetchurl {
+    url = "mirror://sourceforge/libb64/libb64-1.2.1.zip";
+    hash = "sha256-IBBvC6lc/Zw1oTxxIGZD4/s+RlEt8+Lvsv2/hxFjFLI=";
+  };
+  rapidjson = fetchurl {
+    url = "https://github.com/miloyip/rapidjson/archive/9bd618f545ab647e2c3bcbf2f1d87423d6edf800.tar.gz";
+    hash = "sha256-O66yxOidLgLqk5+PAuP67H8eDxnVOK+3BQCQPjrPVxM=";
+  };
+  mpack = fetchurl {
+    url = "https://github.com/ludocode/mpack/archive/df17e83f0fa8571b9cd0d8ccf38144fa90e244d1.tar.gz";
+    hash = "sha256-hyiXygbAHnNgF4TIg+DemBvtdBnSgJ7fAhknVuL+T/c=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
   pname = "msgpack-tools";
   version = "0.6";
 
   src = fetchFromGitHub {
     owner = "ludocode";
     repo = "msgpack-tools";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "1ygjk25zlpqjckxgqmahnz999704zy2bd9id6hp5jych1szkjgs5";
   };
 
-  libb64 = fetchurl {
-    url = "mirror://sourceforge/libb64/libb64-1.2.1.zip";
-    sha256 = "1chlcc8qggzxnbpy5wrda533xyz38dk20w9wl4srrzawm45ny410";
-  };
-
-  rapidjson = fetchurl {
-    url = "https://github.com/miloyip/rapidjson/archive/99ba17bd66a85ec64a2f322b68c2b9c3b77a4391.tar.gz";
-    sha256 = "0jxgyy5n0lf9w36dycwwgz2wici4z9dnxlsn0z6m23zaa47g3wyw";
-  };
-
-  mpack = fetchurl {
-    url = "https://github.com/ludocode/mpack/archive/df17e83f0fa8571b9cd0d8ccf38144fa90e244d1.tar.gz";
-    sha256 = "1br8g3rf86h8z8wbqkd50aq40953862lgn0xk7cy68m07fhqc3pg";
-  };
+  # fix rapidjson dependency version
+  # https://github.com/ludocode/msgpack-tools/issues/18
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+       --replace-fail 'set(RAPIDJSON_COMMIT "99ba17bd66a85ec64a2f322b68c2b9c3b77a4391")' 'set(RAPIDJSON_COMMIT "9bd618f545ab647e2c3bcbf2f1d87423d6edf800")'
+  '';
 
   postUnpack = ''
     mkdir $sourceRoot/contrib
-    cp ${rapidjson} $sourceRoot/contrib/rapidjson-99ba17bd66a85ec64a2f322b68c2b9c3b77a4391.tar.gz
+    cp ${rapidjson} $sourceRoot/contrib/rapidjson-9bd618f545ab647e2c3bcbf2f1d87423d6edf800.tar.gz
     cp ${libb64} $sourceRoot/contrib/libb64-1.2.1.zip
     cp ${mpack} $sourceRoot/contrib/mpack-df17e83f0fa8571b9cd0d8ccf38144fa90e244d1.tar.gz
   '';
 
   nativeBuildInputs = [ cmake ];
 
-  meta = with lib; {
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/json2msgpack";
+  versionCheckProgramArg = "-v";
+  doInstallCheck = true;
+
+  meta = {
     description = "Command-line tools for converting between MessagePack and JSON";
     homepage = "https://github.com/ludocode/msgpack-tools";
-    license = licenses.mit;
-    platforms = platforms.linux ++ platforms.darwin;
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
Unbreak msgpack-tools by fixing dependency version as suggested in upstream [issue](https://github.com/ludocode/msgpack-tools/issues/18). Also, modernize a bit. Tested the binaries and they work correctly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
