### PR TITLE
h3_4: 4.2.0 -> 4.3.0

### DIFF
--- a/pkgs/development/misc/h3/default.nix
+++ b/pkgs/development/misc/h3/default.nix
@@ -55,7 +55,7 @@ in
   };
 
   h3_4 = generic {
-    version = "4.2.0";
-    hash = "sha256-SzuxoYjsXCLhlAhQS7JoKvH8C3vquXttf58d4LnkeVM=";
+    version = "4.3.0";
+    hash = "sha256-DUILKZ1QvML6qg+WdOxir6zRsgTvk+En6yjeFf6MQBg=";
   };
 }


### PR DESCRIPTION
https://raw.githubusercontent.com/uber/h3/v4.3.0/CHANGELOG.md
https://github.com/uber/h3/compare/refs/tags/v4.2.1...refs/tags/v4.3.0

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `2170297e6288d299bbcc5050df7add17bff3be1f`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 16 packages built:</summary>
  <ul>
    <li>h3_4</li>
    <li>h3_4.dev</li>
    <li>postgresql13Packages.h3-pg</li>
    <li>postgresql14Packages.h3-pg</li>
    <li>postgresql15Packages.h3-pg</li>
    <li>postgresql16Packages.h3-pg</li>
    <li>postgresql17Packages.h3-pg</li>
    <li>postgresql18Packages.h3-pg</li>
    <li>python312Packages.h3</li>
    <li>python312Packages.h3.dist</li>
    <li>python312Packages.timezonefinder</li>
    <li>python312Packages.timezonefinder.dist</li>
    <li>python313Packages.h3</li>
    <li>python313Packages.h3.dist</li>
    <li>python313Packages.timezonefinder</li>
    <li>python313Packages.timezonefinder.dist</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc