### PR TITLE
oscar64: init at 1.32.263

### DIFF
--- a/pkgs/by-name/os/oscar64/package.nix
+++ b/pkgs/by-name/os/oscar64/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  nix-update-script,
+  fetchFromGitHub,
+  fetchpatch,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "oscar64";
+  version = "1.32.263";
+
+  src = fetchFromGitHub {
+    owner = "drmortalwombat";
+    repo = "oscar64";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-g8HUJcoI7fBmypPO79QYiOdhIYh1/sctSaEC8RLaM+s=";
+  };
+
+  # FIXME: can be removed whenever the version is bumped.
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/drmortalwombat/oscar64/commit/3b0f954144e36903fd396c099714722f9fa2430a.patch";
+      hash = "sha256-6S7Gx9pZSNBHxX9uyS0zApe263dUo5DGviEczpP1FpQ=";
+    })
+    (fetchpatch {
+      url = "https://github.com/drmortalwombat/oscar64/commit/744f496f0f71fae098063a1f3ed71722d31f7b1a.patch";
+      hash = "sha256-84UBgVuKN7HMdkQfWUXMCfQSNqAe2QQ2yiifEN1JuOU=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace ./oscar64.1 \
+      --replace-fail "/usr/local/bin/oscar64" "$out/bin/oscar64" \
+      --replace-fail "/usr/local/share/oscar64/" "$out/include/oscar64"
+  '';
+
+  enableParallelBuilding = true;
+
+  makeFlags = [
+    "-C ./make"
+    "prefix=$(out)"
+  ];
+
+  buildTarget = "compiler";
+
+  doCheck = true;
+  checkTarget = "check";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Optimizing small memory C compiler, assembler, and runtime for C64";
+    homepage = "https://github.com/drmortalwombat/oscar64";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.nekowinston ];
+    mainProgram = "oscar64";
+    platforms = lib.platforms.unix;
+    # FIXME: enable aarch64-linux for the next version.
+    broken = stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux;
+  };
+})


### PR DESCRIPTION
[oscar64](https://github.com/drmortalwombat/oscar64) is an optimizing small memory C compiler, assembler, and runtime, targeting the 6502 family of processors, mainly focusing on C64, PET or VIC20.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
