### PR TITLE
makeModulesClosure: Add allowEmpty to harden against modules vanishing

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -59,6 +59,8 @@
 
 - `linux` and all other Linux kernel packages have moved all in-tree kernel modules into a new `modules` output.
 
+- `makeModulesClosure` now fails by default if the resulting output is empty, preventing accidental mishaps when `allowMissing` is used. A new `allowEmpty` argument can be used if this is the desired outcome.
+
 - `webfontkitgenerator` has been renamed to `webfont-bundler`, following the rename of the upstream project.
   The binary name remains `webfontkitgenerator`.
   The `webfontkitgenerator` package is an alias to `webfont-bundler`.

--- a/pkgs/build-support/kernel/modules-closure.nix
+++ b/pkgs/build-support/kernel/modules-closure.nix
@@ -5,12 +5,23 @@
 
 {
   stdenvNoCC,
-  kernel,
-  firmware,
-  nukeReferences,
-  rootModules,
   kmod,
+  nukeReferences,
+
+  # Public API arguments
+
+  # A build output with `lib/modules` from which `rootModules` will be picked.
+  # NOTE: Do not use a NixOS kernel package!
+  # The NixOS kernel packages expose their modules in a split output (`modules`).
+  kernel,
+  # A build output with `lib/firmware/` from which `extraFirmwarePaths` will be picked.
+  firmware,
+  # Modules that are required (unless allowMissing is used) to be added in the closure.
+  # Their dependencies will also be added.
+  rootModules,
+  # When `true`, missing modules won't fail the build.
   allowMissing ? false,
+  # A list of firmware paths to be included in the closure.
   extraFirmwarePaths ? [ ],
 }:
 

--- a/pkgs/build-support/kernel/modules-closure.nix
+++ b/pkgs/build-support/kernel/modules-closure.nix
@@ -21,6 +21,8 @@
   rootModules,
   # When `true`, missing modules won't fail the build.
   allowMissing ? false,
+  # When `true`, an empty output won't fail the build.
+  allowEmpty ? false,
   # A list of firmware paths to be included in the closure.
   extraFirmwarePaths ? [ ],
 }:
@@ -37,6 +39,7 @@ stdenvNoCC.mkDerivation {
     firmware
     rootModules
     allowMissing
+    allowEmpty
     extraFirmwarePaths
     ;
   allowedReferences = [ "out" ];

--- a/pkgs/build-support/kernel/modules-closure.sh
+++ b/pkgs/build-support/kernel/modules-closure.sh
@@ -2,7 +2,7 @@
 # exist. Because the rest of the script assumes it does exist, we
 # handle this special case first.
 if ! test -d "$kernel/lib/modules"; then
-    if test -z "$rootModules" || test -n "$allowMissing"; then
+    if (test -z "$rootModules" || test -n "$allowMissing") && test -n "$allowEmpty"; then
         mkdir -p "$out"
         exit 0
     else

--- a/pkgs/build-support/kernel/modules-closure.sh
+++ b/pkgs/build-support/kernel/modules-closure.sh
@@ -6,8 +6,16 @@ if ! test -d "$kernel/lib/modules"; then
         mkdir -p "$out"
         exit 0
     else
-        echo "Required modules: $rootModules"
-        echo "Can not derive a closure of kernel modules because no modules were provided."
+        (
+        echo "Required modules:"
+        # Make list easier to grasp by limiting lines to 10 modules.
+        printf "    %s %s %s %s %s %s %s\n" $rootModules
+        echo
+        echo 'ERROR: The `kernel` argument to `makeModulesClosure` is missing the `/lib/modules` folder.'
+        echo '       Aborting since this would produce an empty output.'
+        echo '       If this is desired, pass `allowEmpty = true;` to `makeModulesClosure`.'
+        # Subshell used to lazily prefix all lines.
+        ) | sed -e 's/^/[makeModulesClosure] /'
         exit 1
     fi
 fi

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -766,6 +766,7 @@ with pkgs;
       firmware,
       rootModules,
       allowMissing ? false,
+      allowEmpty ? false,
       extraFirmwarePaths ? [ ],
     }:
     callPackage ../build-support/kernel/modules-closure.nix {
@@ -774,6 +775,7 @@ with pkgs;
         firmware
         rootModules
         allowMissing
+        allowEmpty
         extraFirmwarePaths
         ;
     };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -760,6 +760,7 @@ with pkgs;
   compressFirmwareZstd = callPackage ../build-support/kernel/compress-firmware.nix { type = "zstd"; };
 
   makeModulesClosure =
+    # Arguments documentation in `../build-support/kernel/modules-closure.nix`.
     {
       kernel,
       firmware,


### PR DESCRIPTION
The changes in https://github.com/NixOS/nixpkgs/pull/423933 caused previously working calls to `pkgs.makeModulesClosure` to produce empty outputs, when paired with `allowMissing = true;`.

In turn, this broke boot in those systems, as instead of having kernel modules (as one would expect), instead there was nothing to load.

This is not only a weird edge case, as due to how the options compose in the NixOS modules system, `allowMissing` ~~is~~ was de-facto required in some use-cases. (See e.g. https://github.com/NixOS/nixpkgs/issues/154163#issuecomment-1008362877 )

The choice of `allowEmpty` being set to `false` by default matches the default assumptions from `allowMissing`: something should be produced.

This *may* break some builds, but it will break them at build time, rather than breaking boot. In this situation setting `allowEmpty` will be the solution to fix this issue.

This is a tradeoff: break the usage of `makeModulesClosure` at build time for those that wanted an empty output, or break the usage of `makeModulesClosure` at boot for the others.

The latter is much much much preferrable, since it prevents problematic situations where a remote system is stuck not booting, without remote hands. The former situation will only be groan-inducing.

This change was tested with Mobile NixOS. Between https://github.com/NixOS/nixpkgs/pull/423933 and this change, it *will* produce broken stage-1 systems for modular kernels. With this change, it breaks the builds. ***This is as expected.***

* * *

(Previous section is the main commit's message, reproduced verbatim.)

I have also updated the `makeModulesClosure` to slightly document what the arguments mean, and also updated the related error message so it is obvious what is happening, and what can be done.

* * *

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
