### PR TITLE
python3Packages.compressed-tensors: 0.10.2 -> 0.11.0

### DIFF
--- a/pkgs/development/python-modules/compressed-tensors/default.nix
+++ b/pkgs/development/python-modules/compressed-tensors/default.nix
@@ -1,12 +1,19 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   setuptools,
+  setuptools-scm,
+
+  # dependencies
+  frozendict,
   pydantic,
   torch,
   transformers,
+
+  # tests
   nbconvert,
   nbformat,
   pytestCheckHook,
@@ -14,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "compressed-tensors";
-  version = "0.10.2";
+  version = "0.11.0";
   pyproject = true;
 
   # Release on PyPI is missing the `utils` directory, which `setup.py` wants to import
@@ -22,12 +29,21 @@ buildPythonPackage rec {
     owner = "neuralmagic";
     repo = "compressed-tensors";
     tag = version;
-    hash = "sha256-BJsMyCs+rupt5+i5JlO7oY08Udc8hI3ZnMiN+8ja0mc=";
+    hash = "sha256-sSXn4/N/Pn+wOCY1Z0ziqFxfMRvRA1c90jPOBe+SwZw=";
   };
 
-  build-system = [ setuptools ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools_scm==8.2.0" "setuptools_scm"
+  '';
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
 
   dependencies = [
+    frozendict
     pydantic
     torch
     transformers
@@ -45,12 +61,17 @@ buildPythonPackage rec {
 
   disabledTests = [
     # these try to download models from HF Hub
+    "test_apply_tinyllama_dynamic_activations"
+    "test_compress_model"
+    "test_compress_model_meta"
+    "test_compressed_linear_from_linear_usage"
+    "test_decompress_model"
     "test_get_observer_token_count"
     "test_kv_cache_quantization"
-    "test_target_prioritization"
     "test_load_compressed_sharded"
+    "test_model_forward_pass"
     "test_save_compressed_model"
-    "test_apply_tinyllama_dynamic_activations"
+    "test_target_prioritization"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
## Things done

Diff: https://github.com/neuralmagic/compressed-tensors/compare/0.10.2...0.11.0
Changelog: https://github.com/neuralmagic/compressed-tensors/releases/tag/0.11.0

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc