### PR TITLE
pshash: 0.1.15.0 -> 0.1.15.1

### DIFF
--- a/pkgs/by-name/ps/pshash/package.nix
+++ b/pkgs/by-name/ps/pshash/package.nix
@@ -10,7 +10,7 @@ haskellPackages.mkDerivation rec {
     owner = "thornoar";
     repo = "pshash";
     tag = "v${version}";
-    hash = "sha256-Fqf5qg8TbtVxamXHzDMWJs52dRLhT09eakK71opDR/4=";
+    hash = "sha256-TnMXT0sgUkHCbZ2YgDmSgOg8A2DKk/LyKK2XXwabrYc=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/ps/pshash/package.nix
+++ b/pkgs/by-name/ps/pshash/package.nix
@@ -5,12 +5,12 @@
 }:
 haskellPackages.mkDerivation rec {
   pname = "pshash";
-  version = "0.1.15.0";
+  version = "0.1.15.1";
   src = fetchFromGitHub {
     owner = "thornoar";
     repo = "pshash";
     tag = "v${version}";
-    hash = "sha256-i3jDt9ghA21OkkKjBk5a7Xok+ESskMPNA8WP+MUZxVk=";
+    hash = "sha256-Fqf5qg8TbtVxamXHzDMWJs52dRLhT09eakK71opDR/4=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/pull/436322, where the pull request was premature.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
