### PR TITLE
dwarf-fortress-packages: DF 51.11 -> DF 52.04; DT 42.1.13 -> DT 42.1.18 

### DIFF
--- a/pkgs/games/dwarf-fortress/df.lock.json
+++ b/pkgs/games/dwarf-fortress/df.lock.json
@@ -1,28 +1,48 @@
 {
   "game": {
     "latest": {
-      "linux": "51.11",
+      "linux": "52.04",
       "darwin": "0.47.05"
     },
     "versions": {
-      "51.11": {
+      "52.04": {
         "df": {
-          "version": "51.11",
+          "version": "52.04",
           "urls": {
             "linux": {
-              "url": "https://www.bay12games.com/dwarves/df_51_11_linux.tar.bz2",
-              "outputHash": "sha256-51cwIFMm5cwSaXjjhpz4pS3D8B5/Mt5+k1ALu1F+JWc="
+              "url": "https://www.bay12games.com/dwarves/df_52_04_linux.tar.bz2",
+              "outputHash": "sha256-x/v4yWuojnbea0N7KUAINBdhPBjl0DoWy8Pi/eDCpec="
             }
           }
         },
         "hack": {
-          "version": "51.11-r1.2",
+          "version": "52.04-r1",
           "git": {
             "url": "https://github.com/DFHack/dfhack.git",
-            "revision": "51.11-r1.2",
-            "outputHash": "sha256-x8zY8IGDhnyoeNz24Mt00o+2XLzSHZG165MXQHXW+YA="
+            "revision": "52.04-r1",
+            "outputHash": "sha256-DPW+fvurUYnwfGrEqV3JEN1TfllOJPHqGIlNJ3Wha90="
           },
-          "xmlRev": "6502bdefd1796315365a7bb58e30e0ce34359bea"
+          "xmlRev": "7b691d256f9427036e7ff24fa795a0f9334739e7"
+        }
+      },
+      "51.13": {
+        "df": {
+          "version": "51.13",
+          "urls": {
+            "linux": {
+              "url": "https://www.bay12games.com/dwarves/df_51_13_linux.tar.bz2",
+              "outputHash": "sha256-Fdb3QS+P0xL4/U0z6nZyMh78KVHDiu9TI3fF6saAw3I="
+            }
+          }
+        },
+        "hack": {
+          "version": "51.13-r1",
+          "git": {
+            "url": "https://github.com/DFHack/dfhack.git",
+            "revision": "51.13-r1",
+            "outputHash": "sha256-Z6ZmXl4BmSg9jRwPpYKMIw3fW6DYxBJEv8oboh+PbZQ="
+          },
+          "xmlRev": "ae7424d3f40bf60b3906b5b9b472cb9a7209a3a8"
         }
       },
       "50.15": {
@@ -96,12 +116,12 @@
     }
   },
   "therapist": {
-    "version": "42.1.13",
-    "maxDfVersion": "51.11",
+    "version": "42.1.18",
+    "maxDfVersion": "52.03",
     "git": {
       "url": "https://github.com/Dwarf-Therapist/Dwarf-Therapist.git",
-      "revision": "v42.1.13",
-      "outputHash": "sha256-y/kUur/BTArznrEzw54FZBrxnD2KXHcwfrHE4WvoemA="
+      "revision": "v42.1.18",
+      "outputHash": "sha256-RdBUpVkjvsNjTowHpQ2FQUCtJiwfqls4dnoUIwKoXGg="
     }
   }
 }

--- a/pkgs/games/dwarf-fortress/dfhack/default.nix
+++ b/pkgs/games/dwarf-fortress/dfhack/default.nix
@@ -120,22 +120,15 @@ stdenv.mkDerivation {
       name = "rename-lerp.patch";
       url = "https://github.com/DFHack/dfhack/commit/389dcf5cfcdb8bfb8deeb05fa5756c9f4f5709d1.patch";
       hash = "sha256-QuDtGURhP+nM+x+8GIKO5LrMcmBkl9JSHHIeqzqGIPQ=";
-    });
+    })
+    # Newer versions use SDL_GetBasePath and SDL_GetPrefPath with a Windows-esque directory
+    # that mismatches where we have historically stored data in nixpkgs:
+    # https://github.com/libsdl-org/SDL/blob/release-2.24.x/src/filesystem/unix/SDL_sysfilesystem.c#L136
+    # Use SDL_GetPrefPath since this takes XDG_DATA_HOME into account (which is correct).
+    ++ optional (versionAtLeast version "52.02-r2") ./use-df-linux-dir.patch;
 
   # gcc 11 fix
   CXXFLAGS = optionalString (versionOlder version "0.47.05-r3") "-fpermissive";
-
-  # As of
-  # https://github.com/DFHack/dfhack/commit/56e43a0dde023c5a4595a22b29d800153b31e3c4,
-  # dfhack gets its goodies from the directory above the Dwarf_Fortress
-  # executable, which leads to stock Dwarf Fortress and not the built
-  # environment where all the dfhack resources are symlinked to (typically
-  # ~/.local/share/df_linux). This causes errors like `tweak is not a
-  # recognized command` to be reported and dfhack to lose some of its
-  # functionality.
-  postPatch = ''
-    sed -i 's@cached_path = path_string.*@cached_path = getenv("DF_DIR");@' library/Process-linux.cpp
-  '';
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/games/dwarf-fortress/dfhack/use-df-linux-dir.patch
+++ b/pkgs/games/dwarf-fortress/dfhack/use-df-linux-dir.patch
@@ -1,0 +1,25 @@
+diff --git a/library/modules/Filesystem.cpp b/library/modules/Filesystem.cpp
+index 7a6b09a50..d5827f016 100644
+--- a/library/modules/Filesystem.cpp
++++ b/library/modules/Filesystem.cpp
+@@ -232,17 +232,10 @@ std::filesystem::path Filesystem::canonicalize(std::filesystem::path p) noexcept
+ 
+ std::filesystem::path Filesystem::getInstallDir() noexcept
+ {
+-    return std::filesystem::path{ DFSDL::DFSDL_GetBasePath() };
++    return std::filesystem::path{ DFSDL::DFSDL_GetPrefPath("", "df_linux") };
+ }
+ 
+ std::filesystem::path Filesystem::getBaseDir() noexcept
+ {
+-    auto getsavebase = []() {
+-        // assume portable mode is _on_ if init is missing
+-        if (!df::global::init || df::global::init->media.flag.is_set(df::enums::init_media_flags::PORTABLE_MODE))
+-            return DFSDL::DFSDL_GetBasePath();
+-        else
+-            return DFSDL::DFSDL_GetPrefPath("Bay 12 Games", "Dwarf Fortress");
+-        };
+-    return std::filesystem::path{ getsavebase() };
++    return std::filesystem::path{ DFSDL::DFSDL_GetPrefPath("", "df_linux") };
+ }
+

--- a/pkgs/games/dwarf-fortress/dwarf-therapist/wrapper.nix
+++ b/pkgs/games/dwarf-fortress/dwarf-therapist/wrapper.nix
@@ -74,9 +74,10 @@ stdenv.mkDerivation {
         local orig_md5="$2"
         local patched_md5="$3"
         echo "It doesn't support DF $dfVersion out of the box, so we're doing it the hard way."
-        export NIXPKGS_DF_HOME="$(mktemp -dt dfhack.XXXXXX)"
+        export HOME="$(mktemp -dt dfhack.XXXXXX)"
+        export XDG_DATA_HOME="$HOME/.local/share"
         expect ${dfHackExpectScript}
-        local ini="$NIXPKGS_DF_HOME/therapist.ini"
+        local ini="$XDG_DATA_HOME/df_linux/therapist.ini"
         if [ -f "$ini" ]; then
           if grep -q "$patched_md5" "$ini"; then
             cp -v "$ini" "$output"

--- a/pkgs/games/dwarf-fortress/update.rb
+++ b/pkgs/games/dwarf-fortress/update.rb
@@ -571,7 +571,7 @@ class DFLock < Struct.new(:game, :therapist, keyword_init: true)
 
   # Returns an array containing all versions.
   def all_versions
-    self.game.versions.keys.map {"DF #{_1}"}.to_a + ["DT #{self.therapist.version}"]
+    [self.game.versions.keys.lazy.map {"DF #{_1}"}.first] + ["DT #{self.therapist.version}"]
   end
 
   # Loads this DFLock.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added DF 52 and updated Dwarf Therapist. New patch for dfhack needed for DF 52.

Testing:

- `NIXPKGS_ALLOW_UNFREE=1 nix-build -A dwarf-fortress-full`
- `./result/bin/dfhack`
- `./result/bin/dwarf-therapist` and connect to a fortress
  - Note that running as root or with capsh may be needed if [ptrace_scope=1](https://www.kernel.org/doc/Documentation/security/Yama.txt): `process_vm_readv(176591, [{iov_base=0x7ffdcc701f00, iov_len=8}], 1, [{iov_base=0x2ed5568, iov_len=8}], 1, 0) = -1 EPERM (Operation not permitted)`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
