### PR TITLE
pkgs/development/compilers/llvm: add replacement entrypoint using mak…

### DIFF
--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -62,6 +62,10 @@ stdenv.mkDerivation (finalAttrs: {
         + lib.optionalString (lib.versionAtLeast release_version "14") ''
           cp -r ${monorepoSrc}/cmake "$out"
         ''
+        # Needs "libcxx/utils/merge_archives.py"
+        + lib.optionalString (lib.versions.major release_version == "13") ''
+          cp -r ${monorepoSrc}/libcxx "$out"
+        ''
         + lib.optionalString (lib.versionAtLeast release_version "21") ''
           cp -r ${monorepoSrc}/third-party "$out"
         ''

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -6,23 +6,20 @@
   lib,
   stdenv,
   libxcrypt,
-  substitute,
-  replaceVars,
   fetchFromGitHub,
-  fetchpatch,
-  fetchpatch2,
   overrideCC,
   wrapCCWith,
   wrapBintoolsWith,
   buildPackages,
-  buildLlvmTools, # tools, but from the previous stage, for cross
-  targetLlvmLibraries, # libraries, but from the next stage, for cross
-  targetLlvm,
+  buildLlvmPackages,
+  targetLlvmPackages,
+  makeScopeWithSplicing',
+  otherSplices,
   # This is the default binutils, but with *this* version of LLD rather
   # than the default LLVM version's, if LLD is the choice. We use these for
   # the `useLLVM` bootstrapping below.
-  bootBintoolsNoLibc ? if stdenv.targetPlatform.linker == "lld" then null else pkgs.bintoolsNoLibc,
-  bootBintools ? if stdenv.targetPlatform.linker == "lld" then null else pkgs.bintools,
+  bootBintoolsNoLibc,
+  bootBintools,
   darwin,
   gitRelease ? null,
   officialRelease ? null,
@@ -110,16 +107,27 @@ let
           "${patchDir}/${p}";
       };
   };
-
-  tools = lib.makeExtensible (
-    tools:
+in
+makeScopeWithSplicing' {
+  inherit otherSplices;
+  f =
+    llvmPackages:
     let
-      callPackage = newScope (tools // args // metadata);
+      callPackage = llvmPackages.newScope (
+        args
+        // metadata
+        // {
+          buildLlvmTools = buildLlvmPackages;
+          targetLlvm = targetLlvmPackages.llvm;
+        }
+      );
+
       clangVersion =
         if (lib.versionOlder metadata.release_version "16") then
           metadata.release_version
         else
           lib.versions.major metadata.release_version;
+
       mkExtraBuildCommands0 =
         cc:
         ''
@@ -139,37 +147,41 @@ let
               ln -s "${lib.getLib cc}/lib/clang/${clangVersion}/include" "$rsrc"
             ''
         );
+
       mkExtraBuildCommandsBasicRt =
         cc:
         mkExtraBuildCommands0 cc
         + ''
-          ln -s "${targetLlvmLibraries.compiler-rt-no-libc.out}/lib" "$rsrc/lib"
+          ln -s "${targetLlvmPackages.compiler-rt-no-libc.out}/lib" "$rsrc/lib"
         '';
+
       mkExtraBuildCommands =
         cc:
         mkExtraBuildCommands0 cc
         + ''
-          ln -s "${targetLlvmLibraries.compiler-rt.out}/lib" "$rsrc/lib"
-          ln -s "${targetLlvmLibraries.compiler-rt.out}/share" "$rsrc/share"
+          ln -s "${targetLlvmPackages.compiler-rt.out}/lib" "$rsrc/lib"
+          ln -s "${targetLlvmPackages.compiler-rt.out}/share" "$rsrc/share"
         '';
 
-      bintoolsNoLibc' = if bootBintoolsNoLibc == null then tools.bintoolsNoLibc else bootBintoolsNoLibc;
-      bintools' = if bootBintools == null then tools.bintools else bootBintools;
+      bintoolsNoLibc' =
+        if bootBintoolsNoLibc == null then llvmPackages.bintoolsNoLibc else bootBintoolsNoLibc;
+      bintools' = if bootBintools == null then llvmPackages.bintools else bootBintools;
     in
     {
-      libllvm = callPackage ./llvm {
-      };
+      inherit (metadata) release_version;
+
+      libllvm = callPackage ./llvm { };
 
       # `llvm` historically had the binaries.  When choosing an output explicitly,
       # we need to reintroduce `outputSpecified` to get the expected behavior e.g. of lib.get*
-      llvm = tools.libllvm;
+      llvm = llvmPackages.libllvm;
 
       tblgen = callPackage ./tblgen.nix {
         patches =
           builtins.filter
             # Crude method to drop polly patches if present, they're not needed for tblgen.
             (p: (!lib.hasInfix "-polly" p))
-            tools.libllvm.patches;
+            llvmPackages.libllvm.patches;
         clangPatches = [
           # Would take tools.libclang.patches, but this introduces a cycle due
           # to replacements depending on the llvm outpath (e.g. the LLVMgold patch).
@@ -183,20 +195,19 @@ let
             (metadata.getVersionFile "clang/aarch64-tblgen.patch");
       };
 
-      libclang = callPackage ./clang {
-      };
+      libclang = callPackage ./clang { };
 
-      clang-unwrapped = tools.libclang;
+      clang-unwrapped = llvmPackages.libclang;
 
       llvm-manpages = lowPrio (
-        tools.libllvm.override {
+        llvmPackages.libllvm.override {
           enableManpages = true;
           python3 = pkgs.python3; # don't use python-boot
         }
       );
 
       clang-manpages = lowPrio (
-        tools.libclang.override {
+        llvmPackages.libclang.override {
           enableManpages = true;
           python3 = pkgs.python3; # don't use python-boot
         }
@@ -208,44 +219,41 @@ let
       # pick clang appropriate for package set we are targeting
       clang =
         if stdenv.targetPlatform.libc == null then
-          tools.clangNoLibc
+          llvmPackages.clangNoLibc
         else if stdenv.targetPlatform.useLLVM or false then
-          tools.clangUseLLVM
+          llvmPackages.clangUseLLVM
         else if (pkgs.targetPackages.stdenv or args.stdenv).cc.isGNU then
-          tools.libstdcxxClang
+          llvmPackages.libstdcxxClang
         else
-          tools.libcxxClang;
+          llvmPackages.libcxxClang;
 
       libstdcxxClang = wrapCCWith rec {
-        cc = tools.clang-unwrapped;
+        cc = llvmPackages.clang-unwrapped;
         # libstdcxx is taken from gcc in an ad-hoc way in cc-wrapper.
         libcxx = null;
-        extraPackages = [ targetLlvmLibraries.compiler-rt ];
+        extraPackages = [ targetLlvmPackages.compiler-rt ];
         extraBuildCommands = mkExtraBuildCommands cc;
       };
 
       libcxxClang = wrapCCWith rec {
-        cc = tools.clang-unwrapped;
-        libcxx = targetLlvmLibraries.libcxx;
-        extraPackages = [ targetLlvmLibraries.compiler-rt ];
+        cc = llvmPackages.clang-unwrapped;
+        libcxx = targetLlvmPackages.libcxx;
+        extraPackages = [ targetLlvmPackages.compiler-rt ];
         extraBuildCommands = mkExtraBuildCommands cc;
       };
 
-      lld = callPackage ./lld {
-      };
+      lld = callPackage ./lld { };
 
       lldbPlugins = lib.makeExtensible (
         lldbPlugins:
         let
-          callPackage = newScope (lldbPlugins // tools // args // metadata);
+          callPackage = newScope (lldbPlugins // llvmPackages // args // metadata);
         in
         lib.recurseIntoAttrs { llef = callPackage ./lldb-plugins/llef.nix { }; }
       );
 
       lldb = callPackage ./lldb (
-        {
-        }
-        // lib.optionalAttrs (lib.versions.major metadata.release_version == "16") {
+        lib.optionalAttrs (lib.versions.major metadata.release_version == "16") {
           src = callPackage (
             { runCommand }:
             runCommand "lldb-src-${metadata.version}" { } ''
@@ -267,209 +275,214 @@ let
       bintools-unwrapped = callPackage ./bintools.nix { };
 
       bintoolsNoLibc = wrapBintoolsWith {
-        bintools = tools.bintools-unwrapped;
+        bintools = llvmPackages.bintools-unwrapped;
         libc = targetPackages.preLibcHeaders;
       };
 
-      bintools = wrapBintoolsWith { bintools = tools.bintools-unwrapped; };
+      bintools = wrapBintoolsWith {
+        bintools = llvmPackages.bintools-unwrapped;
+      };
 
-      clangUseLLVM = wrapCCWith (
-        rec {
-          cc = tools.clang-unwrapped;
-          libcxx = targetLlvmLibraries.libcxx;
-          bintools = bintools';
-          extraPackages = [
-            targetLlvmLibraries.compiler-rt
-          ]
-          ++ lib.optionals (!stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD) [
-            targetLlvmLibraries.libunwind
-          ];
-          extraBuildCommands =
-            lib.optionalString (lib.versions.major metadata.release_version == "13") (
-              ''
-                echo "-rtlib=compiler-rt -Wno-unused-command-line-argument" >> $out/nix-support/cc-cflags
-                echo "-B${targetLlvmLibraries.compiler-rt}/lib" >> $out/nix-support/cc-cflags
-              ''
-              + lib.optionalString (!stdenv.targetPlatform.isWasm) ''
-                echo "--unwindlib=libunwind" >> $out/nix-support/cc-cflags
-                echo "-L${targetLlvmLibraries.libunwind}/lib" >> $out/nix-support/cc-ldflags
-              ''
-              + lib.optionalString (!stdenv.targetPlatform.isWasm && stdenv.targetPlatform.useLLVM or false) ''
-                echo "-lunwind" >> $out/nix-support/cc-ldflags
-              ''
-              + lib.optionalString stdenv.targetPlatform.isWasm ''
-                echo "-fno-exceptions" >> $out/nix-support/cc-cflags
-              ''
+      clangUseLLVM = wrapCCWith (rec {
+        cc = llvmPackages.clang-unwrapped;
+        libcxx = targetLlvmPackages.libcxx;
+        bintools = bintools';
+        extraPackages = [
+          targetLlvmPackages.compiler-rt
+        ]
+        ++ lib.optionals (!stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD) [
+          targetLlvmPackages.libunwind
+        ];
+        extraBuildCommands = mkExtraBuildCommands cc;
+        nixSupport.cc-cflags = [
+          "-rtlib=compiler-rt"
+          "-Wno-unused-command-line-argument"
+          "-B${targetLlvmPackages.compiler-rt}/lib"
+        ]
+        ++ lib.optional (
+          !stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD
+        ) "--unwindlib=libunwind"
+        ++ lib.optional (
+          !stdenv.targetPlatform.isWasm
+          && !stdenv.targetPlatform.isFreeBSD
+          && stdenv.targetPlatform.useLLVM or false
+        ) "-lunwind"
+        ++ lib.optional stdenv.targetPlatform.isWasm "-fno-exceptions";
+        nixSupport.cc-ldflags = lib.optionals (
+          !stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD
+        ) [ "-L${targetLlvmPackages.libunwind}/lib" ];
+      });
+
+      clangWithLibcAndBasicRtAndLibcxx = wrapCCWith (rec {
+        cc = llvmPackages.clang-unwrapped;
+        libcxx = targetLlvmPackages.libcxx;
+        bintools = bintools';
+        extraPackages = [
+          targetLlvmPackages.compiler-rt-no-libc
+        ]
+        ++
+          lib.optionals
+            (
+              !stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD && !stdenv.targetPlatform.isDarwin
             )
-            + mkExtraBuildCommands cc;
-        }
-        // lib.optionalAttrs (lib.versionAtLeast metadata.release_version "14") {
-          nixSupport.cc-cflags = [
-            "-rtlib=compiler-rt"
-            "-Wno-unused-command-line-argument"
-            "-B${targetLlvmLibraries.compiler-rt}/lib"
-          ]
-          ++ lib.optional (
-            !stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD
-          ) "--unwindlib=libunwind"
-          ++ lib.optional (
-            !stdenv.targetPlatform.isWasm
-            && !stdenv.targetPlatform.isFreeBSD
-            && stdenv.targetPlatform.useLLVM or false
-          ) "-lunwind"
-          ++ lib.optional stdenv.targetPlatform.isWasm "-fno-exceptions";
-          nixSupport.cc-ldflags = lib.optionals (
-            !stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD
-          ) [ "-L${targetLlvmLibraries.libunwind}/lib" ];
-        }
-      );
+            [
+              targetLlvmPackages.libunwind
+            ];
+        extraBuildCommands = mkExtraBuildCommandsBasicRt cc;
+        nixSupport.cc-cflags = [
+          "-rtlib=compiler-rt"
+          "-Wno-unused-command-line-argument"
+          "-B${targetLlvmPackages.compiler-rt-no-libc}/lib"
+        ]
+        ++ lib.optional (
+          !stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD && !stdenv.targetPlatform.isDarwin
+        ) "--unwindlib=libunwind"
+        ++ lib.optional (
+          !stdenv.targetPlatform.isWasm
+          && !stdenv.targetPlatform.isFreeBSD
+          && stdenv.targetPlatform.useLLVM or false
+        ) "-lunwind"
+        ++ lib.optional stdenv.targetPlatform.isWasm "-fno-exceptions";
+        nixSupport.cc-ldflags = lib.optionals (
+          !stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD && !stdenv.targetPlatform.isDarwin
+        ) [ "-L${targetLlvmPackages.libunwind}/lib" ];
+      });
 
-      clangWithLibcAndBasicRtAndLibcxx = wrapCCWith (
-        rec {
-          cc = tools.clang-unwrapped;
-          libcxx = targetLlvmLibraries.libcxx;
-          bintools = bintools';
-          extraPackages = [
-            targetLlvmLibraries.compiler-rt-no-libc
-          ]
-          ++
-            lib.optionals
-              (
-                !stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD && !stdenv.targetPlatform.isDarwin
-              )
-              [
-                targetLlvmLibraries.libunwind
-              ];
-          extraBuildCommands =
-            lib.optionalString (lib.versions.major metadata.release_version == "13") (
-              ''
-                echo "-rtlib=compiler-rt -Wno-unused-command-line-argument" >> $out/nix-support/cc-cflags
-                echo "-B${targetLlvmLibraries.compiler-rt-no-libc}/lib" >> $out/nix-support/cc-cflags
-              ''
-              + lib.optionalString (!stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isDarwin) ''
-                echo "--unwindlib=libunwind" >> $out/nix-support/cc-cflags
-                echo "-L${targetLlvmLibraries.libunwind}/lib" >> $out/nix-support/cc-ldflags
-              ''
-              + lib.optionalString (!stdenv.targetPlatform.isWasm && stdenv.targetPlatform.useLLVM or false) ''
-                echo "-lunwind" >> $out/nix-support/cc-ldflags
-              ''
-              + lib.optionalString stdenv.targetPlatform.isWasm ''
-                echo "-fno-exceptions" >> $out/nix-support/cc-cflags
-              ''
-            )
-            + mkExtraBuildCommandsBasicRt cc;
-        }
-        // lib.optionalAttrs (lib.versionAtLeast metadata.release_version "14") {
-          nixSupport.cc-cflags = [
-            "-rtlib=compiler-rt"
-            "-Wno-unused-command-line-argument"
-            "-B${targetLlvmLibraries.compiler-rt-no-libc}/lib"
-          ]
-          ++ lib.optional (
-            !stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD && !stdenv.targetPlatform.isDarwin
-          ) "--unwindlib=libunwind"
-          ++ lib.optional (
-            !stdenv.targetPlatform.isWasm
-            && !stdenv.targetPlatform.isFreeBSD
-            && stdenv.targetPlatform.useLLVM or false
-          ) "-lunwind"
-          ++ lib.optional stdenv.targetPlatform.isWasm "-fno-exceptions";
-          nixSupport.cc-ldflags = lib.optionals (
-            !stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD && !stdenv.targetPlatform.isDarwin
-          ) [ "-L${targetLlvmLibraries.libunwind}/lib" ];
-        }
-      );
+      clangWithLibcAndBasicRt = wrapCCWith (rec {
+        cc = llvmPackages.clang-unwrapped;
+        libcxx = null;
+        bintools = bintools';
+        extraPackages = [ targetLlvmPackages.compiler-rt-no-libc ];
+        extraBuildCommands = mkExtraBuildCommandsBasicRt cc;
+        nixSupport.cc-cflags = [
+          "-rtlib=compiler-rt"
+          "-B${targetLlvmPackages.compiler-rt-no-libc}/lib"
+          "-nostdlib++"
+        ]
+        ++ lib.optional (
+          lib.versionAtLeast metadata.release_version "15" && stdenv.targetPlatform.isWasm
+        ) "-fno-exceptions";
+      });
 
-      clangWithLibcAndBasicRt = wrapCCWith (
-        rec {
-          cc = tools.clang-unwrapped;
-          libcxx = null;
-          bintools = bintools';
-          extraPackages = [ targetLlvmLibraries.compiler-rt-no-libc ];
-          extraBuildCommands =
-            lib.optionalString (lib.versions.major metadata.release_version == "13") ''
-              echo "-rtlib=compiler-rt" >> $out/nix-support/cc-cflags
-              echo "-B${targetLlvmLibraries.compiler-rt-no-libc}/lib" >> $out/nix-support/cc-cflags
-              echo "-nostdlib++" >> $out/nix-support/cc-cflags
-            ''
-            + mkExtraBuildCommandsBasicRt cc;
-        }
-        // lib.optionalAttrs (lib.versionAtLeast metadata.release_version "14") {
-          nixSupport.cc-cflags = [
-            "-rtlib=compiler-rt"
-            "-B${targetLlvmLibraries.compiler-rt-no-libc}/lib"
-            "-nostdlib++"
-          ]
-          ++ lib.optional (
-            lib.versionAtLeast metadata.release_version "15" && stdenv.targetPlatform.isWasm
-          ) "-fno-exceptions";
-        }
-      );
+      clangNoLibcWithBasicRt = wrapCCWith (rec {
+        cc = llvmPackages.clang-unwrapped;
+        libcxx = null;
+        bintools = bintoolsNoLibc';
+        extraPackages = [ targetLlvmPackages.compiler-rt-no-libc ];
+        extraBuildCommands = mkExtraBuildCommandsBasicRt cc;
+        nixSupport.cc-cflags = [
+          "-rtlib=compiler-rt"
+          "-B${targetLlvmPackages.compiler-rt-no-libc}/lib"
+        ]
+        ++ lib.optional (
+          lib.versionAtLeast metadata.release_version "15" && stdenv.targetPlatform.isWasm
+        ) "-fno-exceptions";
+      });
 
-      clangNoLibcWithBasicRt = wrapCCWith (
-        rec {
-          cc = tools.clang-unwrapped;
-          libcxx = null;
-          bintools = bintoolsNoLibc';
-          extraPackages = [ targetLlvmLibraries.compiler-rt-no-libc ];
-          extraBuildCommands =
-            lib.optionalString (lib.versions.major metadata.release_version == "13") ''
-              echo "-rtlib=compiler-rt" >> $out/nix-support/cc-cflags
-              echo "-B${targetLlvmLibraries.compiler-rt-no-libc}/lib" >> $out/nix-support/cc-cflags
-            ''
-            + mkExtraBuildCommandsBasicRt cc;
-        }
-        // lib.optionalAttrs (lib.versionAtLeast metadata.release_version "14") {
-          nixSupport.cc-cflags = [
-            "-rtlib=compiler-rt"
-            "-B${targetLlvmLibraries.compiler-rt-no-libc}/lib"
-          ]
-          ++ lib.optional (
-            lib.versionAtLeast metadata.release_version "15" && stdenv.targetPlatform.isWasm
-          ) "-fno-exceptions";
-        }
-      );
-
-      clangNoLibcNoRt = wrapCCWith (
-        rec {
-          cc = tools.clang-unwrapped;
-          libcxx = null;
-          bintools = bintoolsNoLibc';
-          extraPackages = [ ];
-          # "-nostartfiles" used to be needed for pkgsLLVM, causes problems so don't include it.
-          extraBuildCommands = mkExtraBuildCommands0 cc;
-        }
-        // lib.optionalAttrs (lib.versionAtLeast metadata.release_version "14") {
-          # "-nostartfiles" used to be needed for pkgsLLVM, causes problems so don't include it.
-          nixSupport.cc-cflags = lib.optional (
-            lib.versionAtLeast metadata.release_version "15" && stdenv.targetPlatform.isWasm
-          ) "-fno-exceptions";
-        }
-      );
+      clangNoLibcNoRt = wrapCCWith (rec {
+        cc = llvmPackages.clang-unwrapped;
+        libcxx = null;
+        bintools = bintoolsNoLibc';
+        extraPackages = [ ];
+        extraBuildCommands = mkExtraBuildCommands0 cc;
+        # "-nostartfiles" used to be needed for pkgsLLVM, causes problems so don't include it.
+        nixSupport.cc-cflags = lib.optional (
+          lib.versionAtLeast metadata.release_version "15" && stdenv.targetPlatform.isWasm
+        ) "-fno-exceptions";
+      });
 
       # This is an "oddly ordered" bootstrap just for Darwin. Probably
       # don't want it otherwise.
-      clangNoCompilerRtWithLibc =
-        wrapCCWith rec {
-          cc = tools.clang-unwrapped;
-          libcxx = null;
-          bintools = bintools';
-          extraPackages = [ ];
-          extraBuildCommands = mkExtraBuildCommands0 cc;
-        }
-        // lib.optionalAttrs (
-          lib.versionAtLeast metadata.release_version "15" && stdenv.targetPlatform.isWasm
-        ) { nixSupport.cc-cflags = [ "-fno-exceptions" ]; };
+      clangNoCompilerRtWithLibc = wrapCCWith rec {
+        cc = llvmPackages.clang-unwrapped;
+        libcxx = null;
+        bintools = bintools';
+        extraPackages = [ ];
+        extraBuildCommands = mkExtraBuildCommands0 cc;
+        nixSupport.cc-cflags = [ "-fno-exceptions" ];
+      };
 
       # Aliases
-      clangNoCompilerRt = tools.clangNoLibcNoRt;
-      clangNoLibc = tools.clangNoLibcWithBasicRt;
-      clangNoLibcxx = tools.clangWithLibcAndBasicRt;
+      clangNoCompilerRt = llvmPackages.clangNoLibcNoRt;
+      clangNoLibc = llvmPackages.clangNoLibcWithBasicRt;
+      clangNoLibcxx = llvmPackages.clangWithLibcAndBasicRt;
+
+      compiler-rt-libc = callPackage ./compiler-rt (
+        let
+          # temp rename to avoid infinite recursion
+          stdenv =
+            # Darwin needs to use a bootstrap stdenv to avoid an infinite recursion when cross-compiling.
+            if args.stdenv.hostPlatform.isDarwin then
+              overrideCC darwin.bootstrapStdenv buildLlvmPackages.clangWithLibcAndBasicRtAndLibcxx
+            else if args.stdenv.hostPlatform.useLLVM or false then
+              overrideCC args.stdenv buildLlvmPackages.clangWithLibcAndBasicRtAndLibcxx
+            else
+              args.stdenv;
+        in
+        {
+          inherit stdenv;
+        }
+        // lib.optionalAttrs (stdenv.hostPlatform.useLLVM or false) {
+          libxcrypt = (libxcrypt.override { inherit stdenv; }).overrideAttrs (old: {
+            configureFlags = old.configureFlags ++ [ "--disable-symvers" ];
+          });
+        }
+      );
+
+      compiler-rt-no-libc = callPackage ./compiler-rt {
+        doFakeLibgcc = stdenv.hostPlatform.useLLVM or false;
+        stdenv =
+          # Darwin needs to use a bootstrap stdenv to avoid an infinite recursion when cross-compiling.
+          if stdenv.hostPlatform.isDarwin then
+            overrideCC darwin.bootstrapStdenv buildLlvmPackages.clangNoLibcNoRt
+          else
+            overrideCC stdenv buildLlvmPackages.clangNoLibcNoRt;
+      };
+
+      compiler-rt =
+        if
+          stdenv.hostPlatform.libc == null
+          # Building the with-libc compiler-rt and WASM doesn't yet work,
+          # because wasilibc doesn't provide some expected things. See
+          # compiler-rt's file for further details.
+          || stdenv.hostPlatform.isWasm
+          # Failing `#include <term.h>` in
+          # `lib/sanitizer_common/sanitizer_platform_limits_freebsd.cpp`
+          # sanitizers, not sure where to get it.
+          || stdenv.hostPlatform.isFreeBSD
+        then
+          llvmPackages.compiler-rt-no-libc
+        else
+          llvmPackages.compiler-rt-libc;
+
+      stdenv = overrideCC stdenv buildLlvmPackages.clang;
+
+      libcxxStdenv = overrideCC stdenv buildLlvmPackages.libcxxClang;
+
+      libcxx = callPackage ./libcxx (
+        {
+          stdenv =
+            if stdenv.hostPlatform.isDarwin then
+              overrideCC darwin.bootstrapStdenv buildLlvmPackages.clangWithLibcAndBasicRt
+            else
+              overrideCC stdenv buildLlvmPackages.clangWithLibcAndBasicRt;
+        }
+        // lib.optionalAttrs (lib.versionOlder metadata.release_version "14") {
+          # TODO: remove this, causes LLVM 13 packages rebuild.
+          inherit (metadata) monorepoSrc; # Preserve bug during #307211 refactor.
+        }
+      );
+
+      libunwind = callPackage ./libunwind {
+        stdenv = overrideCC stdenv buildLlvmPackages.clangWithLibcAndBasicRt;
+      };
+
+      openmp = callPackage ./openmp { };
     }
     // lib.optionalAttrs (lib.versionAtLeast metadata.release_version "15") {
       # TODO: pre-15: lldb/docs/index.rst:155:toctree contains reference to nonexisting document 'design/structureddataplugins'
       lldb-manpages = lowPrio (
-        tools.lldb.override {
+        llvmPackages.lldb.override {
           enableManpages = true;
           python3 = pkgs.python3; # don't use python-boot
         }
@@ -479,8 +492,7 @@ let
       mlir = callPackage ./mlir { };
     }
     // lib.optionalAttrs (lib.versionAtLeast metadata.release_version "19") {
-      bolt = callPackage ./bolt {
-      };
+      bolt = callPackage ./bolt { };
     }
     //
       lib.optionalAttrs
@@ -490,130 +502,31 @@ let
         }
     // lib.optionalAttrs (lib.versionAtLeast metadata.release_version "20") {
       flang = callPackage ./flang {
-        mlir = tools.mlir;
+        inherit (targetLlvmPackages) mlir;
       };
-    }
-  );
 
-  libraries = lib.makeExtensible (
-    libraries:
-    let
-      callPackage = newScope (
-        libraries
-        // buildLlvmTools
-        // args
-        // metadata
-        # Previously monorepoSrc was erroneously not being passed through.
-        // lib.optionalAttrs (lib.versionOlder metadata.release_version "14") { monorepoSrc = null; } # Preserve a bug during #307211, TODO: remove; causes llvm 13 rebuild.
-      );
-    in
-    (
-      {
-        compiler-rt-libc = callPackage ./compiler-rt (
-          let
-            # temp rename to avoid infinite recursion
-            stdenv =
-              # Darwin needs to use a bootstrap stdenv to avoid an infinite recursion when cross-compiling.
-              if args.stdenv.hostPlatform.isDarwin then
-                overrideCC darwin.bootstrapStdenv buildLlvmTools.clangWithLibcAndBasicRtAndLibcxx
-              else if args.stdenv.hostPlatform.useLLVM or false then
-                overrideCC args.stdenv buildLlvmTools.clangWithLibcAndBasicRtAndLibcxx
-              else
-                args.stdenv;
-          in
-          {
-            inherit stdenv;
-          }
-          // lib.optionalAttrs (stdenv.hostPlatform.useLLVM or false) {
-            libxcrypt = (libxcrypt.override { inherit stdenv; }).overrideAttrs (old: {
-              configureFlags = old.configureFlags ++ [ "--disable-symvers" ];
-            });
-          }
-        );
+      libc-overlay = callPackage ./libc {
+        isFullBuild = false;
+        # Use clang due to "gnu::naked" not working on aarch64.
+        # Issue: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77882
+        stdenv = overrideCC stdenv buildLlvmPackages.clang;
+      };
 
-        compiler-rt-no-libc = callPackage ./compiler-rt {
-          doFakeLibgcc = stdenv.hostPlatform.useLLVM or false;
-          stdenv =
-            # Darwin needs to use a bootstrap stdenv to avoid an infinite recursion when cross-compiling.
-            if stdenv.hostPlatform.isDarwin then
-              overrideCC darwin.bootstrapStdenv buildLlvmTools.clangNoLibcNoRt
-            else
-              overrideCC stdenv buildLlvmTools.clangNoLibcNoRt;
-        };
-
-        compiler-rt =
-          if
-            stdenv.hostPlatform.libc == null
-            # Building the with-libc compiler-rt and WASM doesn't yet work,
-            # because wasilibc doesn't provide some expected things. See
-            # compiler-rt's file for further details.
-            || stdenv.hostPlatform.isWasm
-            # Failing `#include <term.h>` in
-            # `lib/sanitizer_common/sanitizer_platform_limits_freebsd.cpp`
-            # sanitizers, not sure where to get it.
-            || stdenv.hostPlatform.isFreeBSD
-          then
-            libraries.compiler-rt-no-libc
+      libc-full = callPackage ./libc {
+        isFullBuild = true;
+        # Use clang due to "gnu::naked" not working on aarch64.
+        # Issue: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77882
+        stdenv = overrideCC stdenv buildLlvmPackages.clangNoLibcNoRt;
+        cmake =
+          if stdenv.targetPlatform.libc == "llvm" then buildPackages.cmakeMinimal else buildPackages.cmake;
+        python3 =
+          if stdenv.targetPlatform.libc == "llvm" then
+            buildPackages.python3Minimal
           else
-            libraries.compiler-rt-libc;
+            buildPackages.python3;
+      };
 
-        stdenv = overrideCC stdenv buildLlvmTools.clang;
-
-        libcxxStdenv = overrideCC stdenv buildLlvmTools.libcxxClang;
-
-        libcxx = callPackage ./libcxx (
-          {
-            stdenv =
-              if stdenv.hostPlatform.isDarwin then
-                overrideCC darwin.bootstrapStdenv buildLlvmTools.clangWithLibcAndBasicRt
-              else
-                overrideCC stdenv buildLlvmTools.clangWithLibcAndBasicRt;
-          }
-          // lib.optionalAttrs (lib.versionOlder metadata.release_version "14") {
-            # TODO: remove this, causes LLVM 13 packages rebuild.
-            inherit (metadata) monorepoSrc; # Preserve bug during #307211 refactor.
-          }
-        );
-
-        libunwind = callPackage ./libunwind {
-          stdenv = overrideCC stdenv buildLlvmTools.clangWithLibcAndBasicRt;
-        };
-
-        openmp = callPackage ./openmp {
-        };
-      }
-      // lib.optionalAttrs (lib.versionAtLeast metadata.release_version "20") {
-        libc-overlay = callPackage ./libc {
-          isFullBuild = false;
-          # Use clang due to "gnu::naked" not working on aarch64.
-          # Issue: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77882
-          stdenv = overrideCC stdenv buildLlvmTools.clang;
-        };
-
-        libc-full = callPackage ./libc {
-          isFullBuild = true;
-          # Use clang due to "gnu::naked" not working on aarch64.
-          # Issue: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77882
-          stdenv = overrideCC stdenv buildLlvmTools.clangNoLibcNoRt;
-          cmake =
-            if stdenv.targetPlatform.libc == "llvm" then buildPackages.cmakeMinimal else buildPackages.cmake;
-          python3 =
-            if stdenv.targetPlatform.libc == "llvm" then
-              buildPackages.python3Minimal
-            else
-              buildPackages.python3;
-        };
-
-        libc = if stdenv.targetPlatform.libc == "llvm" then libraries.libc-full else libraries.libc-overlay;
-      }
-    )
-  );
-
-  noExtend = extensible: lib.attrsets.removeAttrs extensible [ "extend" ];
-in
-{
-  inherit tools libraries;
-  inherit (metadata) release_version;
+      libc =
+        if stdenv.targetPlatform.libc == "llvm" then llvmPackages.libc-full else llvmPackages.libc-overlay;
+    };
 }
-// (noExtend libraries)
-// (noExtend tools)


### PR DESCRIPTION
…eScopeWithSplicing'


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

To test:

Edit `pkgs/top-level/all-packages.nix`, find the `callPackage` for `pkgs/development/compilers/llvm`. Add in `useNG = true` and test eval on `llvmPackages_*`.

Plan:
1. Merge this
2. Wait for staging
3. Swap out `default-ng.nix` into `default.nix`
4. Create a PR to staging if evals explode

I believe it's likely this could cause a world rebuild since I did remove a bunch of `extraBuildCommands` stuff to make it easier to maintain.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
