### PR TITLE
gradle{,_7,_8,_9}{,-unwrapped}: remove callPackage from all-packages.nix

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -1,12 +1,107 @@
 {
+  callPackage,
   jdk17,
   jdk21,
   jdk23,
 }:
 
-rec {
-  gen =
+let
+  wrapGradle =
+    {
+      lib,
+      callPackage,
+      mitm-cache,
+      replaceVars,
+      symlinkJoin,
+      concatTextFile,
+      makeSetupHook,
+      nix-update-script,
+      runCommand,
+    }:
+    gradle-unwrapped: updateAttrPath:
+    lib.makeOverridable (
+      args:
+      let
+        gradle = gradle-unwrapped.override args;
+      in
+      symlinkJoin {
+        pname = "gradle";
+        inherit (gradle) version;
 
+        paths = [
+          (makeSetupHook { name = "gradle-setup-hook"; } (concatTextFile {
+            name = "setup-hook.sh";
+            files = [
+              (mitm-cache.setupHook)
+              (replaceVars ./setup-hook.sh {
+                # jdk used for keytool
+                inherit (gradle) jdk;
+                init_script = "${./init-build.gradle}";
+              })
+            ];
+          }))
+          gradle
+          mitm-cache
+        ];
+
+        passthru = {
+          fetchDeps = callPackage ./fetch-deps.nix { inherit mitm-cache; };
+          inherit (gradle) jdk;
+          unwrapped = gradle;
+          tests = {
+            toolchains =
+              let
+                javaVersion = lib.getVersion jdk23;
+                javaMajorVersion = lib.versions.major javaVersion;
+              in
+              runCommand "detects-toolchains-from-nix-env"
+                {
+                  # Use JDKs that are not the default for any of the gradle versions
+                  nativeBuildInputs = [
+                    (gradle.override {
+                      javaToolchains = [
+                        jdk23
+                      ];
+                    })
+                  ];
+                  src = ./tests/toolchains;
+                }
+                ''
+                  cp -a $src/* .
+                  substituteInPlace ./build.gradle --replace-fail '@JAVA_VERSION@' '${javaMajorVersion}'
+                  env GRADLE_USER_HOME=$TMPDIR/gradle org.gradle.native.dir=$TMPDIR/native \
+                  gradle run --no-daemon --quiet --console plain > $out
+                  actual="$(<$out)"
+                  if [[ "${javaVersion}" != "$actual"* ]]; then
+                    echo "Error: Expected '${javaVersion}', to start with '$actual'" >&2
+                    exit 1
+                  fi
+                '';
+          }
+          // gradle.tests;
+        }
+        // lib.optionalAttrs (updateAttrPath != null) {
+          updateScript = nix-update-script {
+            attrPath = updateAttrPath;
+            extraArgs = [
+              "--url=https://github.com/gradle/gradle"
+              # Gradle’s .0 releases are tagged as `vX.Y.0`, but the actual
+              # release version omits the `.0`, so we’ll wanto to only capture
+              # the version up but not including the the trailing `.0`.
+              "--version-regex=^v(\\d+\\.\\d+(?:\\.[1-9]\\d?)?)(\\.0)?$"
+            ];
+          };
+        };
+
+        meta = gradle.meta // {
+          # prefer normal gradle/mitm-cache over this wrapper, this wrapper only provides the setup hook
+          # and passthru
+          priority = (gradle.meta.priority or lib.meta.defaultPriority) + 1;
+        };
+      }
+    ) { };
+
+  gen =
     {
       version,
       hash,
@@ -34,12 +129,13 @@ rec {
       # Extra attributes to be merged into the resulting derivation's
       # meta attribute.
       meta ? { },
-    }:
+    }@genArgs:
 
     {
       lib,
       stdenv,
       fetchurl,
+      callPackage,
       makeWrapper,
       unzip,
       ncurses5,
@@ -186,6 +282,8 @@ rec {
         };
       };
       passthru.jdk = defaultJava;
+      passthru.unwrapped = gen' genArgs;
+      passthru.wrap = callPackage wrapGradle { } finalAttrs.finalPackage.unwrapped;
 
       meta =
         with lib;
@@ -219,119 +317,28 @@ rec {
         // meta;
     });
 
+  # Calls the generated Gradle package with default arguments.
+  gen' = args: callPackage (gen args) { };
+in
+{
   # NOTE: Default JDKs that are hardcoded below must be LTS versions
   # and respect the compatibility matrix at
   # https://docs.gradle.org/current/userguide/compatibility.html
 
-  gradle_9 = gen {
+  gradle_9 = gen' {
     version = "9.0.0";
     hash = "sha256-j609eClspRgRPz0pAWYXx/k2fcAF+TK9nZO/RbpGBys=";
     defaultJava = jdk21;
   };
-  gradle_8 = gen {
+  gradle_8 = gen' {
     version = "8.14.3";
     hash = "sha256-vXEQIhNJMGCVbsIp2Ua+7lcVjb2J0OYrkbyg+ixfNTE=";
     defaultJava = jdk21;
   };
 
-  gradle_7 = gen {
+  gradle_7 = gen' {
     version = "7.6.6";
     hash = "sha256-Zz2XdvMDvHBI/DMp0jLW6/EFGweJO9nRFhb62ahnO+A=";
     defaultJava = jdk17;
   };
-
-  wrapGradle =
-    {
-      lib,
-      callPackage,
-      mitm-cache,
-      replaceVars,
-      symlinkJoin,
-      concatTextFile,
-      makeSetupHook,
-      nix-update-script,
-      runCommand,
-    }:
-    gradle-unwrapped: updateAttrPath:
-    lib.makeOverridable (
-      args:
-      let
-        gradle = gradle-unwrapped.override args;
-      in
-      symlinkJoin {
-        pname = "gradle";
-        inherit (gradle) version;
-
-        paths = [
-          (makeSetupHook { name = "gradle-setup-hook"; } (concatTextFile {
-            name = "setup-hook.sh";
-            files = [
-              (mitm-cache.setupHook)
-              (replaceVars ./setup-hook.sh {
-                # jdk used for keytool
-                inherit (gradle) jdk;
-                init_script = "${./init-build.gradle}";
-              })
-            ];
-          }))
-          gradle
-          mitm-cache
-        ];
-
-        passthru = {
-          fetchDeps = callPackage ./fetch-deps.nix { inherit mitm-cache; };
-          inherit (gradle) jdk;
-          unwrapped = gradle;
-          tests = {
-            toolchains =
-              let
-                javaVersion = lib.getVersion jdk23;
-                javaMajorVersion = lib.versions.major javaVersion;
-              in
-              runCommand "detects-toolchains-from-nix-env"
-                {
-                  # Use JDKs that are not the default for any of the gradle versions
-                  nativeBuildInputs = [
-                    (gradle.override {
-                      javaToolchains = [
-                        jdk23
-                      ];
-                    })
-                  ];
-                  src = ./tests/toolchains;
-                }
-                ''
-                  cp -a $src/* .
-                  substituteInPlace ./build.gradle --replace-fail '@JAVA_VERSION@' '${javaMajorVersion}'
-                  env GRADLE_USER_HOME=$TMPDIR/gradle org.gradle.native.dir=$TMPDIR/native \
-                  gradle run --no-daemon --quiet --console plain > $out
-                  actual="$(<$out)"
-                  if [[ "${javaVersion}" != "$actual"* ]]; then
-                    echo "Error: Expected '${javaVersion}', to start with '$actual'" >&2
-                    exit 1
-                  fi
-                '';
-          }
-          // gradle.tests;
-        }
-        // lib.optionalAttrs (updateAttrPath != null) {
-          updateScript = nix-update-script {
-            attrPath = updateAttrPath;
-            extraArgs = [
-              "--url=https://github.com/gradle/gradle"
-              # Gradle’s .0 releases are tagged as `vX.Y.0`, but the actual
-              # release version omits the `.0`, so we’ll wanto to only capture
-              # the version up but not including the the trailing `.0`.
-              "--version-regex=^v(\\d+\\.\\d+(?:\\.[1-9]\\d?)?)(\\.0)?$"
-            ];
-          };
-        };
-
-        meta = gradle.meta // {
-          # prefer normal gradle/mitm-cache over this wrapper, this wrapper only provides the setup hook
-          # and passthru
-          priority = (gradle.meta.priority or lib.meta.defaultPriority) + 1;
-        };
-      }
-    ) { };
 }

--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -286,8 +286,7 @@ let
         };
       };
       passthru.jdk = defaultJava;
-      passthru.unwrapped = gen' genArgs;
-      passthru.wrapped = callPackage wrapGradle { } finalAttrs.finalPackage.unwrapped;
+      passthru.wrapped = callPackage wrapGradle { } (gen' genArgs);
 
       meta =
         with lib;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6915,25 +6915,18 @@ with pkgs;
   m4 = gnum4;
 
   gnumake = callPackage ../development/tools/build-managers/gnumake { };
-  gradle-packages = import ../development/tools/build-managers/gradle {
-    inherit
-      jdk17
-      jdk21
-      jdk23
-      ;
-  };
-  gradleGen = gradle-packages.gen;
-  wrapGradle = callPackage gradle-packages.wrapGradle { };
 
-  gradle_7-unwrapped = callPackage gradle-packages.gradle_7 { };
-  gradle_8-unwrapped = callPackage gradle-packages.gradle_8 { };
-  gradle_9-unwrapped = callPackage gradle-packages.gradle_9 { };
+  gradle-packages = callPackage ../development/tools/build-managers/gradle { };
+
+  gradle_7-unwrapped = gradle-packages.gradle_7.unwrapped;
+  gradle_8-unwrapped = gradle-packages.gradle_8.unwrapped;
+  gradle_9-unwrapped = gradle-packages.gradle_9.unwrapped;
   gradle-unwrapped = gradle_8-unwrapped;
 
-  gradle_7 = wrapGradle gradle_7-unwrapped null;
-  gradle_8 = wrapGradle gradle_8-unwrapped null;
-  gradle_9 = wrapGradle gradle_9-unwrapped null;
-  gradle = wrapGradle gradle-unwrapped "gradle-unwrapped";
+  gradle_7 = gradle_7-unwrapped.wrap null;
+  gradle_8 = gradle_8-unwrapped.wrap null;
+  gradle_9 = gradle_9-unwrapped.wrap null;
+  gradle = gradle-unwrapped.wrap "gradle-unwrapped";
 
   griffe = with python3Packages; toPythonApplication griffe;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6918,15 +6918,15 @@ with pkgs;
 
   gradle-packages = callPackage ../development/tools/build-managers/gradle { };
 
-  gradle_7-unwrapped = gradle-packages.gradle_7.unwrapped;
-  gradle_8-unwrapped = gradle-packages.gradle_8.unwrapped;
-  gradle_9-unwrapped = gradle-packages.gradle_9.unwrapped;
-  gradle-unwrapped = gradle_8-unwrapped;
+  gradle_7-unwrapped = gradle-packages.gradle_7;
+  gradle_8-unwrapped = gradle-packages.gradle_8;
+  gradle_9-unwrapped = gradle-packages.gradle_9;
+  gradle-unwrapped = gradle-packages.gradle;
 
-  gradle_7 = gradle_7-unwrapped.wrap null;
-  gradle_8 = gradle_8-unwrapped.wrap null;
-  gradle_9 = gradle_9-unwrapped.wrap null;
-  gradle = gradle-unwrapped.wrap "gradle-unwrapped";
+  gradle_7 = gradle-packages.gradle_7.wrapped;
+  gradle_8 = gradle-packages.gradle_8.wrapped;
+  gradle_9 = gradle-packages.gradle_9.wrapped;
+  gradle = gradle-packages.gradle.wrapped;
 
   griffe = with python3Packages; toPythonApplication griffe;
 


### PR DESCRIPTION
Since we now have a more strict nixpkgs-vet, deal with all the Gradle callPackage (including for unwrapped versions) in the package set, instead of continuing to fight against CI. See #421047 for context.
    
Should retain complete compatibility with previous nixpkgs versions, particularly check that there were no messups in the review.

(Related note: did gradleGen and wrapGradle need to be exposed? I've moved them to a let block, that is the only possible incompatibility but nothing was referencing them.)

Testing:

```
nom-build -A gradle_7 -A gradle_7-unwrapped -A gradle_8 -A gradle_8-unwrapped -A gradle_9 -A gradle_9-unwrapped \
    -A gradle -A gradle-unwrapped \
    -A gradle-packages
/nix/store/pfgchfmna0cfrqlxhxb3bmi4k01q6vxb-gradle-7.6.6
/nix/store/7ypr35w5g1c4bp55gn8r1dc5dpyr6x4s-gradle-7.6.6
/nix/store/klws7nsbs5bvxxi79j0m2xbiiw4fxdai-gradle-8.14.3
/nix/store/wzwhbsz5f98pychmffzpflkqp33qls9z-gradle-8.14.3
/nix/store/dj9pn0gxk5wpkcvwslrlxihmq9qz5sxx-gradle-9.0.0
/nix/store/vhjrb76n297mfv4an92yihl4g9kf24dz-gradle-9.0.0
/nix/store/klws7nsbs5bvxxi79j0m2xbiiw4fxdai-gradle-8.14.3
/nix/store/wzwhbsz5f98pychmffzpflkqp33qls9z-gradle-8.14.3
```

Rebuild count should be 0.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
