### PR TITLE
nixos/mihomo: add an option for processes info

### DIFF
--- a/nixos/modules/services/networking/mihomo.nix
+++ b/nixos/modules/services/networking/mihomo.nix
@@ -10,6 +10,14 @@
 }:
 let
   cfg = config.services.mihomo;
+
+  AmbientCapabilities =
+    lib.optional cfg.tunMode "CAP_NET_ADMIN"
+    ++ lib.optionals cfg.processesInfo [
+      "CAP_DAC_READ_SEARCH"
+      "CAP_SYS_PTRACE"
+    ];
+  CapabilityBoundingSet = AmbientCapabilities;
 in
 {
   options.services.mihomo = {
@@ -48,9 +56,13 @@ in
     };
 
     tunMode = lib.mkEnableOption ''
-      necessary permission for Mihomo's systemd service for TUN mode to function properly.
+      necessary capabilities for Mihomo's systemd service for TUN mode to function properly.
 
       Keep in mind, that you still need to enable TUN mode manually in Mihomo's configuration
+    '';
+
+    processesInfo = lib.mkEnableOption ''
+      necessary capabilities for rules about process information such as `process-name`
     '';
   };
 
@@ -76,8 +88,7 @@ in
         LoadCredential = "config.yaml:${cfg.configFile}";
 
         ### Hardening
-        AmbientCapabilities = "";
-        CapabilityBoundingSet = "";
+        inherit AmbientCapabilities CapabilityBoundingSet;
         DeviceAllow = "";
         LockPersonality = true;
         MemoryDenyWriteExecute = true;
@@ -105,8 +116,6 @@ in
         UMask = "0077";
       }
       // lib.optionalAttrs cfg.tunMode {
-        AmbientCapabilities = "CAP_NET_ADMIN";
-        CapabilityBoundingSet = "CAP_NET_ADMIN";
         PrivateDevices = false;
         PrivateUsers = false;
         RestrictAddressFamilies = "AF_INET AF_INET6 AF_NETLINK";


### PR DESCRIPTION
Add an option for processes info to let rules with process-name and etc to work.

**Test method**
1. add `- PROCESS-NAME:curl:DIRECT` into rules.
2. run `curl` with any address and check whether mihomo filter it.

Without these permissions, mihomo will log `find process error ...` in debug.

**nixos tests**
Test with `nix build '.#nixosTests.mihomo'` is passed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
