### PR TITLE
mattermost: charset fixes

### DIFF
--- a/nixos/modules/services/web-apps/mattermost.nix
+++ b/nixos/modules/services/web-apps/mattermost.nix
@@ -668,7 +668,7 @@ in
               }
             else if cfg.database.driver == "mysql" then
               {
-                charset = "utf8mb4,utf8";
+                charset = "utf8mb4";
                 writeTimeout = "60s";
                 readTimeout = "60s";
               }
@@ -682,7 +682,7 @@ in
               }
             else if config.mattermost.database.driver == "mysql" then
               {
-                charset = "utf8mb4,utf8";
+                charset = "utf8mb4";
                 writeTimeout = "60s";
                 readTimeout = "60s";
               }

--- a/pkgs/by-name/ma/mattermost/tests.nix
+++ b/pkgs/by-name/ma/mattermost/tests.nix
@@ -337,7 +337,7 @@ mattermost.overrideAttrs (
 
       # Start Postgres.
       export PGDATA="$NIX_BUILD_TOP/.postgres"
-      initdb -U postgres
+      initdb -E UTF8 -U postgres
       mkdir -p "$PGDATA/run"
       cat <<EOF >> "$PGDATA/postgresql.conf"
       unix_socket_directories = '$PGDATA/run'


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This was causing issues on newer versions of MariaDB (breaking NixOS tests) like:

```
Error 1064 (42000): You have an error in your SQL syntax;
check the manual that corresponds to your MariaDB server version
for the right syntax to use near '%2Cutf8' at line 1
```

Since this is simply a fallback character set and all supported versions of MariaDB support utf8mb4, delete the fallback.

Also fix the tests, since they started checking for this, at least for Postgres.

This change should be fully compatible with existing deployments.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
