### PR TITLE
asterisk: enabling a postgresql override for pgsql support

### DIFF
--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -33,6 +33,8 @@
   withOpus ? true,
   ldapSupport ? false,
   openldap,
+  postgresqlSupport ? false,
+  postgresql,
 }:
 
 let
@@ -45,7 +47,8 @@ let
     }:
     stdenv.mkDerivation {
       inherit version;
-      pname = "asterisk" + lib.optionalString ldapSupport "-ldap";
+      pname =
+        "asterisk" + lib.optionalString ldapSupport "-ldap" + lib.optionalString postgresqlSupport "-psql";
 
       buildInputs = [
         jansson
@@ -70,13 +73,18 @@ let
         opusfile
         libogg
       ]
-      ++ lib.optionals ldapSupport [ openldap ];
+      ++ lib.optionals ldapSupport [ openldap ]
+      ++ lib.optionals postgresqlSupport [ postgresql ];
+
       nativeBuildInputs = [
         util-linux
         pkg-config
         autoconf
         libtool
         automake
+      ]
+      ++ lib.optionals postgresqlSupport [
+        postgresql.pg_config
       ];
 
       patches = [
@@ -130,6 +138,9 @@ let
         "--with-lua=${lua}/lib"
         "--with-pjproject-bundled"
         "--with-externals-cache=$(PWD)/externals_cache"
+      ]
+      ++ lib.optionals postgresqlSupport [
+        "--with-postgres"
       ];
 
       preBuild = ''


### PR DESCRIPTION
I wanted to use postgresql configuration for asterisk, so I have added a postgresql override, similar to the LDAP override to ensure that the needed modules get built:
```
❯ ls /nix/store/lsi1d2lkb4vvl18jz2g3v2p59s1jvi6q-asterisk-psql-22.5.1/lib/asterisk/modules/ | grep pgsql
cdr_pgsql.so
cel_pgsql.so
res_config_pgsql.so
```

This should allow me to store configuration in the postgresql database instead of flat-files. I haven't yet verified it all, because I'm still building the configuration, but the server builds the modules. I still have to tweak my configuration to figure out how to not use unixodbc and just use pgsql. First step was getting this module built, however.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
