### PR TITLE
audacious: darwin support

### DIFF
--- a/pkgs/by-name/au/audacious-bare/package.nix
+++ b/pkgs/by-name/au/audacious-bare/package.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation rec {
   buildInputs = [
     qt6.qtbase
     qt6.qtsvg
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     qt6.qtwayland
   ];
 
@@ -44,6 +46,8 @@ stdenv.mkDerivation rec {
     ln -s ${audacious-plugins}/share/audacious/Skins $out/share/audacious/
   '';
 
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-F${qt6.qtbase}/lib -iframework ${qt6.qtbase}/lib";
+
   meta = {
     description = "Lightweight and versatile audio player";
     homepage = "https://audacious-media-player.org";
@@ -54,7 +58,7 @@ stdenv.mkDerivation rec {
       ttuegel
       thiagokokada
     ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     license = with lib.licenses; [
       bsd2
       bsd3 # https://github.com/audacious-media-player/audacious/blob/master/COPYING

--- a/pkgs/by-name/au/audacious-plugins/package.nix
+++ b/pkgs/by-name/au/audacious-plugins/package.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   stdenv,
   fetchFromGitHub,
   alsa-lib,
@@ -64,7 +65,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     audacious-bare
-    alsa-lib
     curl
     faad2
     ffmpeg
@@ -90,17 +90,20 @@ stdenv.mkDerivation rec {
     libsndfile
     libvorbis
     libxml2
-    lirc
     mpg123
     neon
     opusfile
-    pipewire
     qt6.qtbase
     qt6.qtmultimedia
-    qt6.qtwayland
     soxr
     wavpack
     libopenmpt
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
+    lirc
+    pipewire
+    qt6.qtwayland
   ];
 
   mesonFlags = [
@@ -112,6 +115,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     ln -s ${vgmstream.audacious}/lib/audacious/Input/* $out/lib/audacious/Input
   '';
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-F${qt6.qtbase}/lib -iframework ${qt6.qtbase}/lib -F${qt6.qtmultimedia}/lib -iframework ${qt6.qtmultimedia}/lib";
 
   meta = audacious-bare.meta // {
     description = "Plugins for Audacious music player";


### PR DESCRIPTION
add darwin build support to audacious


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
