### PR TITLE
maintainers: remove shyim

### DIFF
--- a/nixos/tests/opensearch.nix
+++ b/nixos/tests/opensearch.nix
@@ -5,7 +5,7 @@ let
       { pkgs, lib, ... }:
       {
         name = "opensearch";
-        meta.maintainers = with pkgs.lib.maintainers; [ shyim ];
+        meta.maintainers = with pkgs.lib.maintainers; [ ];
 
         nodes.machine = lib.mkMerge [
           {

--- a/pkgs/by-name/ad/adminerevo/package.nix
+++ b/pkgs/by-name/ad/adminerevo/package.nix
@@ -69,9 +69,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       asl20
       gpl2Only
     ];
-    maintainers = with maintainers; [
-      shyim
-    ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
   };
 })

--- a/pkgs/by-name/an/anydesk/package.nix
+++ b/pkgs/by-name/an/anydesk/package.nix
@@ -143,8 +143,6 @@ stdenv.mkDerivation (finalAttrs: {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     platforms = [ "x86_64-linux" ];
-    maintainers = with lib.maintainers; [
-      shyim
-    ];
+    maintainers = with lib.maintainers; [ ];
   };
 })

--- a/pkgs/by-name/bl/blackfire/package.nix
+++ b/pkgs/by-name/bl/blackfire/package.nix
@@ -107,7 +107,7 @@ stdenv.mkDerivation rec {
     homepage = "https://blackfire.io/";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
-    maintainers = with maintainers; [ shyim ];
+    maintainers = with maintainers; [ ];
     platforms = [
       "x86_64-linux"
       "aarch64-linux"

--- a/pkgs/by-name/bl/blackfire/php-probe.nix
+++ b/pkgs/by-name/bl/blackfire/php-probe.nix
@@ -156,7 +156,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Blackfire Profiler PHP module";
     homepage = "https://blackfire.io/";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ shyim ];
+    maintainers = with lib.maintainers; [ ];
     platforms = [
       "x86_64-linux"
       "aarch64-linux"

--- a/pkgs/by-name/dy/dynamodb-local/package.nix
+++ b/pkgs/by-name/dy/dynamodb-local/package.nix
@@ -86,7 +86,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = licenses.unfree;
     mainProgram = "dynamodb-local";
     maintainers = with maintainers; [
-      shyim
       martinjlowm
     ];
     platforms = platforms.all;

--- a/pkgs/by-name/fa/fastly/package.nix
+++ b/pkgs/by-name/fa/fastly/package.nix
@@ -82,7 +82,6 @@ buildGoModule rec {
     license = licenses.asl20;
     maintainers = with maintainers; [
       ereslibre
-      shyim
     ];
     mainProgram = "fastly";
   };

--- a/pkgs/by-name/fr/frankenphp/package.nix
+++ b/pkgs/by-name/fr/frankenphp/package.nix
@@ -133,7 +133,6 @@ buildGoModule rec {
     mainProgram = "frankenphp";
     maintainers = with lib.maintainers; [
       gaelreyrol
-      shyim
     ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };

--- a/pkgs/by-name/fs/fsnotifier/package.nix
+++ b/pkgs/by-name/fs/fsnotifier/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     description = "IntelliJ Platform companion program for watching and reporting file and directory structure modification";
     license = lib.licenses.asl20;
     mainProgram = "fsnotifier";
-    maintainers = with lib.maintainers; [ shyim ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/gi/git-credential-oauth/package.nix
+++ b/pkgs/by-name/gi/git-credential-oauth/package.nix
@@ -35,7 +35,7 @@ buildGoModule rec {
     homepage = "https://github.com/hickford/git-credential-oauth";
     changelog = "https://github.com/hickford/git-credential-oauth/releases/tag/${src.rev}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ shyim ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "git-credential-oauth";
   };
 }

--- a/pkgs/by-name/lu/ludtwig/package.nix
+++ b/pkgs/by-name/lu/ludtwig/package.nix
@@ -24,7 +24,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/MalteJanz/ludtwig";
     license = licenses.mit;
     maintainers = with maintainers; [
-      shyim
       maltejanz
     ];
     mainProgram = "ludtwig";

--- a/pkgs/by-name/my/mysql84/package.nix
+++ b/pkgs/by-name/my/mysql84/package.nix
@@ -119,7 +119,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.gpl2;
     maintainers = with maintainers; [
       orivej
-      shyim
     ];
     platforms = platforms.unix;
   };

--- a/pkgs/by-name/op/opensearch-cli/package.nix
+++ b/pkgs/by-name/op/opensearch-cli/package.nix
@@ -32,7 +32,7 @@ buildGoModule rec {
     homepage = "https://github.com/opensearch-project/opensearch-cli";
     license = lib.licenses.asl20;
     mainProgram = "opensearch-cli";
-    maintainers = with lib.maintainers; [ shyim ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
   };

--- a/pkgs/by-name/op/opensearch/package.nix
+++ b/pkgs/by-name/op/opensearch/package.nix
@@ -61,7 +61,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Open Source, Distributed, RESTful Search Engine";
     homepage = "https://github.com/opensearch-project/OpenSearch";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ shyim ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
     sourceProvenance = with lib.sourceTypes; [
       binaryBytecode

--- a/pkgs/by-name/pl/platformsh/package.nix
+++ b/pkgs/by-name/pl/platformsh/package.nix
@@ -65,7 +65,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     mainProgram = "platform";
     maintainers = with lib.maintainers; [
-      shyim
       spk
     ];
     platforms = [

--- a/pkgs/by-name/ro/roadrunner/package.nix
+++ b/pkgs/by-name/ro/roadrunner/package.nix
@@ -56,6 +56,6 @@ buildGoModule rec {
     homepage = "https://roadrunner.dev";
     license = lib.licenses.mit;
     mainProgram = "rr";
-    maintainers = with lib.maintainers; [ shyim ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/vi/viceroy/package.nix
+++ b/pkgs/by-name/vi/viceroy/package.nix
@@ -28,7 +28,6 @@ rustPlatform.buildRustPackage rec {
     license = licenses.asl20;
     maintainers = with maintainers; [
       ereslibre
-      shyim
     ];
     platforms = platforms.unix;
   };

--- a/pkgs/development/php-packages/zstd/default.nix
+++ b/pkgs/development/php-packages/zstd/default.nix
@@ -30,6 +30,6 @@ buildPecl {
     description = "Zstd Extension for PHP";
     license = licenses.mit;
     homepage = "https://github.com/kjdev/php-ext-zstd";
-    maintainers = with lib.maintainers; [ shyim ];
+    maintainers = with lib.maintainers; [ ];
   };
 }


### PR DESCRIPTION
I removed myself from several packages as maintainer, which I don't use anymore

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
