### PR TITLE
lib.attrsets.genAttrs': init

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1221,6 +1221,10 @@ rec {
   /**
     Like `genAttrs`, but allows the name of each attribute to be specified in addition to the value.
     The applied function should return both the new name and value as a `nameValuePair`.
+    ::: {.warning}
+    In case of attribute name collision the first entry determines the value,
+    all subsequent conflicting entries for the same name are silently ignored.
+    :::
 
     # Inputs
 

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1230,7 +1230,7 @@ rec {
 
     `f`
 
-    : A function, given the a string s from the list xs, returns a new `nameValuePair`.
+    : A function, given a string `s` from the list `xs`, returns a new `nameValuePair`.
 
     # Type
 

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1226,7 +1226,7 @@ rec {
 
     `xs`
 
-    : A list of strings used as generator.
+    : A list of strings `s` used as generator.
 
     `f`
 

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1219,6 +1219,39 @@ rec {
   genAttrs = names: f: listToAttrs (map (n: nameValuePair n (f n)) names);
 
   /**
+    Like `genAttrs`, but allows the name of each attribute to be specified in addition to the value.
+    The applied function should return both the new name and value as a `nameValuePair`.
+
+    # Inputs
+
+    `xs`
+
+    : A list of strings used as generator.
+
+    `f`
+
+    : A function, given the a string s from the list xs, returns a new `nameValuePair`.
+
+    # Type
+
+    ```
+    genAttrs' :: [ Any ] -> (Any -> { name :: String; value :: Any; }) -> AttrSet
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.attrsets.genAttrs'` usage example
+
+    ```nix
+    genAttrs' [ "foo" "bar" ] (s: nameValuePair ("x_" + s) ("y_" + s))
+    => { x_foo = "y_foo"; x_bar = "y_bar"; }
+    ```
+
+    :::
+  */
+  genAttrs' = xs: f: listToAttrs (map f xs);
+
+  /**
     Check whether the argument is a derivation. Any set with
     `{ type = "derivation"; }` counts as a derivation.
 

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1216,7 +1216,7 @@ rec {
 
     :::
   */
-  genAttrs = names: f: listToAttrs (map (n: nameValuePair n (f n)) names);
+  genAttrs = names: f: genAttrs' names (n: nameValuePair n (f n));
 
   /**
     Like `genAttrs`, but allows the name of each attribute to be specified in addition to the value.

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -207,6 +207,7 @@ let
         mapAttrsRecursive
         mapAttrsRecursiveCond
         genAttrs
+        genAttrs'
         isDerivation
         toDerivation
         optionalAttrs

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -1961,6 +1961,13 @@ runTests {
       x_foo = "y_baz";
     };
   };
+  testGenAttrs'ConflictingName = {
+    # c.f. warning of genAttrs'
+    expr = attrsets.genAttrs' [ "foo" "bar" "baz" ] (s: nameValuePair "foo" s);
+    expected = {
+      foo = "foo";
+    };
+  };
 
   testConcatMapAttrs = {
     expr =

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -1936,6 +1936,32 @@ runTests {
 
   # ATTRSETS
 
+  testGenAttrs = {
+    expr = attrsets.genAttrs [ "foo" "bar" ] (name: "x_" + name);
+    expected = {
+      foo = "x_foo";
+      bar = "x_bar";
+    };
+  };
+  testGenAttrs' = {
+    expr = attrsets.genAttrs' [ "foo" "bar" ] (s: nameValuePair ("x_" + s) ("y_" + s));
+    expected = {
+      x_foo = "y_foo";
+      x_bar = "y_bar";
+    };
+  };
+  testGenAttrs'Example2 = {
+    expr = attrsets.genAttrs' [
+      {
+        x = "foo";
+        y = "baz";
+      }
+    ] (s: lib.nameValuePair ("x_" + s.x) ("y_" + s.y));
+    expected = {
+      x_foo = "y_baz";
+    };
+  };
+
   testConcatMapAttrs = {
     expr =
       concatMapAttrs


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds `genAttrs'`. It's like `genAttrs`, but allows the name of each attribute to be specified in addition to the value. The applied function should return both the new name and value as a `nameValuePair`.

I'm not aware if there are tests for library functions, do let me know and I'll add one if needed :)



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
