### PR TITLE
linux/generic: Test that ikconfig == configfile

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -398,9 +398,20 @@ let
                       )
                     )).version
                     emptyFile;
+                ikconfigSameAsConfigfile =
+                  pkgsBuildBuild.runCommandNoCC "${finalAttrs.finalPackage.name}-ikconfig-same"
+                    {
+                      nativeBuildInputs = [ pkgsBuildBuild.linux-scripts ];
+                      kernel = "${finalAttrs.finalPackage}/${stdenv.hostPlatform.linux-kernel.target}";
+                    }
+                    ''
+                      extract-ikconfig "$kernel" > ikconfig
+                      diff -U0 "${configfile}" ikconfig
+                      touch "$out"
+                    '';
               in
               {
-                inherit versionDoesNotDependOnPatchesEtc;
+                inherit versionDoesNotDependOnPatchesEtc ikconfigSameAsConfigfile;
                 testsForKernel = nixosTests.kernel-generic.passthru.testsForKernel overridableKernel;
                 # Disabled by default, because the infinite recursion is hard to understand. The other test's error is better and produces a shorter trace.
                 # inherit versionDoesNotDependOnPatchesEtcNixOS;


### PR DESCRIPTION
For linuxManualConfig, we run make oldconfig. However, the generic kernels should not have their config change at this point. If it changed, there's something wrong.

In fact, make oldconfig avoid rewriting the config file if it does not change, so we can rely on it being an exact match.

Hopefully this means things like the build breaking Rust support (see #436245) does not happen again.

This depends on IKCONFIG=y, however it is already in our common config, and thus should only fail if someone uses the generic kernel, *and* overrides IKCONFIG=n, *and* tries to run this test.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
