### PR TITLE
libwebp: set meta.pkgConfigModules

### DIFF
--- a/pkgs/by-name/li/libwebp/package.nix
+++ b/pkgs/by-name/li/libwebp/package.nix
@@ -29,6 +29,8 @@
   opencv,
   python3,
   vips,
+  testers,
+  libwebp,
 }:
 
 stdenv.mkDerivation rec {
@@ -79,6 +81,7 @@ stdenv.mkDerivation rec {
       ;
     inherit (python3.pkgs) pillow imread;
     haskell-webp = haskellPackages.webp;
+    pkg-config = testers.hasPkgConfigModules { package = libwebp; };
   };
 
   meta = with lib; {
@@ -87,5 +90,15 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     platforms = platforms.all;
     maintainers = with maintainers; [ ajs124 ];
+    pkgConfigModules = [
+      # configure_pkg_config() calls for these are unconditional
+      "libwebp"
+      "libwebpdecoder"
+      "libwebpdemux"
+      "libsharpyuv"
+    ]
+    ++ lib.optionals libwebpmuxSupport [
+      "libwebpmux"
+    ];
   };
 }


### PR DESCRIPTION
Using the package from the pkgs fixpoint instead of finalAttrs.finalPackage to mirror the other tests which also (indirectly) use pkgs.libwebp. Slight disadvantage of this is that it's not possible to test overridden variants of libwebp this way.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
