### PR TITLE
prowlarr: 1.37.0.5076 -> 2.0.5.5160

### DIFF
--- a/pkgs/by-name/pr/prowlarr/deps.json
+++ b/pkgs/by-name/pr/prowlarr/deps.json
@@ -609,8 +609,8 @@
   },
   {
     "pname": "Polly",
-    "version": "8.5.2",
-    "hash": "sha256-IrN06ddOIJ0VYuVefe3LvfW0kX20ATRQkEBg9CBomRA="
+    "version": "8.6.0",
+    "hash": "sha256-wlvYcfcOExa3LopwRFO4axW682jkUZvioHe+kznspHk="
   },
   {
     "pname": "Polly.Contrib.WaitAndRetry",
@@ -619,8 +619,8 @@
   },
   {
     "pname": "Polly.Core",
-    "version": "8.5.2",
-    "hash": "sha256-PAwsWqrCieCf/7Y87fV7XMKoaY2abCQNtI+4oyyMifk="
+    "version": "8.6.0",
+    "hash": "sha256-NEGMMQ+3+i4ytsGekKfP1trUe0mRZP7MV0eBiSFXHW8="
   },
   {
     "pname": "RestSharp",

--- a/pkgs/by-name/pr/prowlarr/package.nix
+++ b/pkgs/by-name/pr/prowlarr/package.nix
@@ -19,7 +19,7 @@
   applyPatches,
 }:
 let
-  version = "1.37.0.5076";
+  version = "2.0.5.5160";
   # The dotnet8 compatibility patches also change `yarn.lock`, so we must pass
   # the already patched lockfile to `fetchYarnDeps`.
   src = applyPatches {
@@ -27,32 +27,11 @@ let
       owner = "Prowlarr";
       repo = "Prowlarr";
       tag = "v${version}";
-      hash = "sha256-uSdZaPq/aXehmRKMobwYNs5iYGPv5R76Ix9lCEVdLzM=";
+      hash = "sha256-xSAEDcBaItA+retaSKtEI6wlwj5Knfi4RwUN6GGYms0=";
     };
     postPatch = ''
       mv src/NuGet.config NuGet.Config
     '';
-    patches = lib.optionals (lib.versionOlder version "2.0") [
-      # See https://github.com/Prowlarr/Prowlarr/pull/2399
-      # Unfortunately, the .NET 8 upgrade will be merged into the v2 branch,
-      # and it may take some time for that to become stable.
-      # However, the patches cleanly apply to v1 as well.
-      (fetchpatch {
-        name = "dotnet8-compatibility";
-        url = "https://github.com/Prowlarr/Prowlarr/commit/21c408a7dac8abaac91c05958f18a556220b2304.patch";
-        hash = "sha256-Es7JEXycOJPMXN+Kgv4wRnJA+l6zltUdP2i/wVodTBs=";
-      })
-      (fetchpatch {
-        name = "dotnet8-darwin-compatibility";
-        url = "https://github.com/Prowlarr/Prowlarr/commit/7a1fca5e23a3e75a9a2b2e1073a33eaa2ce865fe.patch";
-        hash = "sha256-bReCHXC3RHgm1MYmE2kGqStt4fuBHowcupLIXT3fEes=";
-      })
-      (fetchpatch {
-        name = "bump-swashbuckle-version";
-        url = "https://github.com/Prowlarr/Prowlarr/commit/8eec321a0eaa396e2f964576e5883890c719b202.patch";
-        hash = "sha256-SOdzGvq8FFYa451zTOw8yD1CDvM++AiFYFHhFW5Soco=";
-      })
-    ];
   };
   rid = dotnetCorePackages.systemToDotnetRid stdenvNoCC.hostPlatform.system;
 in


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
