### PR TITLE
glitchtip: fix dependencies

### DIFF
--- a/pkgs/development/python-modules/django-modeltranslation/default.nix
+++ b/pkgs/development/python-modules/django-modeltranslation/default.nix
@@ -9,7 +9,8 @@
   pytest-django,
   pytestCheckHook,
   pythonOlder,
-  setuptools,
+  hatchling,
+  hatch-vcs,
 }:
 
 buildPythonPackage rec {
@@ -26,7 +27,10 @@ buildPythonPackage rec {
     hash = "sha256-8A5fIZuUMlXe8bHQR0Ha5HoT9VIQsgqpJVMONB5KqCI=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
 
   dependencies = [ django ];
 
@@ -40,11 +44,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "modeltranslation" ];
 
-  meta = with lib; {
+  meta = {
     description = "Translates Django models using a registration approach";
     homepage = "https://github.com/deschler/django-modeltranslation";
     changelog = "https://github.com/deschler/django-modeltranslation/blob/v${src.tag}/CHANGELOG.md";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ augustebaum ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ augustebaum ];
   };
 }

--- a/pkgs/development/python-modules/oracledb/default.nix
+++ b/pkgs/development/python-modules/oracledb/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   cryptography,
   cython,
-  fetchPypi,
+  fetchFromGitHub,
   pythonOlder,
   setuptools,
   wheel,
@@ -14,12 +14,20 @@ buildPythonPackage rec {
   version = "3.3.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.9";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-6DDTVEoVeClryqVMboyK4QpYx9tGfFKMSyetv5yLTLA=";
+  src = fetchFromGitHub {
+    owner = "oracle";
+    repo = "python-oracledb";
+    tag = "v${version}";
+    fetchSubmodules = true;
+    hash = "sha256-SHIEl4pzuQBJ02KRPmOydFtmVD9qF3LGk9WPiDSpVzQ=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "cython == 3.1" "cython"
+  '';
 
   build-system = [
     cython
@@ -34,14 +42,14 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "oracledb" ];
 
-  meta = with lib; {
+  meta = {
     description = "Python driver for Oracle Database";
     homepage = "https://oracle.github.io/python-oracledb";
     changelog = "https://github.com/oracle/python-oracledb/blob/v${version}/doc/src/release_notes.rst";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20 # and or
       upl
     ];
-    maintainers = with maintainers; [ harvidsen ];
+    maintainers = with lib.maintainers; [ harvidsen ];
   };
 }


### PR DESCRIPTION
These two packages were broken, causing `glitchtip` to not build properly. Now the package does build and run properly.

Also, the `oracledb` source was switched to git fetching, for better reliability. `pythonRelaxDeps` did not work to fix the cython dependency, so I used the `postPatch` hook instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
