### PR TITLE
kdePackages.sierra-breeze-enhanced: migrate to by-name, switch to unstable qt6

### DIFF
--- a/pkgs/by-name/si/sierra-breeze-enhanced/package.nix
+++ b/pkgs/by-name/si/sierra-breeze-enhanced/package.nix
@@ -9,13 +9,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "sierra-breeze-enhanced";
-  version = "2.1.1";
+  version = "2.1.1-unstable-2025-10-14";
 
   src = fetchFromGitHub {
     owner = "kupiqu";
     repo = "SierraBreezeEnhanced";
-    rev = if version == "2.1.1" then "V.2.1.1" else "V${version}";
-    hash = "sha256-7mQnJCQr/zm9zEdg2JPr7jQn8uajyCXvyYRQZWxG+Q8=";
+    rev = "4a4f085aa5c48ad11071dee4e92289c2cc4a36cd";
+    hash = "sha256-dOIC2EQqninEIktVK6dLctzN/IiQIRvp1Qmcop9h7Dw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/si/sierra-breeze-enhanced/package.nix
+++ b/pkgs/by-name/si/sierra-breeze-enhanced/package.nix
@@ -2,12 +2,11 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  extra-cmake-modules,
-  wrapQtAppsHook,
-  kwin,
+  kdePackages,
   lib,
+  unstableGitUpdater,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sierra-breeze-enhanced";
   version = "2.1.1-unstable-2025-10-14";
 
@@ -20,10 +19,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    extra-cmake-modules
-    wrapQtAppsHook
+    kdePackages.extra-cmake-modules
+    kdePackages.wrapQtAppsHook
   ];
-  buildInputs = [ kwin ];
+  buildInputs = [
+    kdePackages.kwin
+  ];
 
   cmakeFlags = [
     "-DCMAKE_INSTALL_PREFIX=$out"
@@ -31,11 +32,15 @@ stdenv.mkDerivation rec {
     "-DKDE_INSTALL_USE_QT_SYS_PATHS=ON"
   ];
 
+  passthru.updateScript = unstableGitUpdater {
+    branch = "master";
+  };
+
   meta = {
     description = "OSX-like window decoration for KDE Plasma written in C++";
     homepage = "https://github.com/kupiqu/SierraBreezeEnhanced";
-    changelog = "https://github.com/kupiqu/SierraBreezeEnhanced/releases/tag/V${version}";
+    changelog = "https://github.com/kupiqu/SierraBreezeEnhanced/compare/V.2.1.1...${finalAttrs.src.rev}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ A1ca7raz ];
   };
-}
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -181,7 +181,6 @@ let
       qmlkonsole
       rocs
       shelf
-      sierra-breeze-enhanced
       soundkonverter
       station
       telly-skout
@@ -1714,7 +1713,6 @@ mapAliases {
   shared_desktop_ontologies = throw "'shared_desktop_ontologies' has been removed as it had been abandoned upstream"; # Added 2025-11-09
   shipyard = throw "'shipyard' has been renamed to/replaced by 'jumppad'"; # Converted to throw 2025-10-27
   siduck76-st = throw "'siduck76-st' has been renamed to/replaced by 'st-snazzy'"; # Converted to throw 2025-10-27
-  sierra-breeze-enhanced = throw "'sierra-breeze-enhanced' has been removed, as it is only compatible with Plasma 5, which is EOL"; # Added 2025-08-20
   signal-desktop-source = throw "'signal-desktop-source' has been renamed to/replaced by 'signal-desktop'"; # Converted to throw 2025-10-27
   simplesamlphp = throw "'simplesamlphp' was removed because it was unmaintained in nixpkgs"; # Added 2025-10-17
   sioclient = throw "'sioclient' has been removed as it is no longer used by freedv, and doesn't build with newer asio"; # Added 2025-12-03

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -142,7 +142,7 @@ makeScopeWithSplicing' {
       sddm = kdePackages.callPackage ../applications/display-managers/sddm { };
 
       sierra-breeze-enhanced =
-        kdePackages.callPackage ../data/themes/kwin-decorations/sierra-breeze-enhanced
+        kdePackages.callPackage ../by-name/si/sierra-breeze-enhanced/package.nix
           { };
 
       signond = callPackage ../development/libraries/signond { };


### PR DESCRIPTION
This pull request updates the Sierra Breeze Enhanced KDE window decoration package in Nixpkgs. It migrates the package to the by-name directory, updates it to a newer git revision, and adds support for automated updates. The most significant changes are outlined below.

**Migration and Update of Sierra Breeze Enhanced:**

* Moved the package definition from `pkgs/data/themes/kwin-decorations/sierra-breeze-enhanced/default.nix` to `pkgs/by-name/si/sierra-breeze-enhanced/package.nix` and updated references in `pkgs/top-level/qt6-packages.nix` to point to the new location.

* Updated the package to a newer, unstable git revision (`4a4f085...`) with a new version string (`2.1.1-unstable-2025-10-14`).
* Changed the `changelog` URL to compare the previous release with the current git revision for more accurate change tracking.

**Automation Improvements:**

* Added a `passthru.updateScript` using `unstableGitUpdater` to enable automated updates from the `master` branch.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
