### PR TITLE
python3Packages.xvfbwrapper: fix build and enable tests

### DIFF
--- a/pkgs/development/python-modules/xvfbwrapper/default.nix
+++ b/pkgs/development/python-modules/xvfbwrapper/default.nix
@@ -1,31 +1,37 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
+  setuptools,
   xorg,
-  mock,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "xvfbwrapper";
   version = "0.2.13";
-  format = "setuptools";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-ouR2yaTxlzf+Ky0LgB5m8P9wH9oz2YakvzTdxBR1QQI=";
+  src = fetchFromGitHub {
+    owner = "cgoldberg";
+    repo = "xvfbwrapper";
+    tag = version;
+    sha256 = "sha256-8JO5NMRawqFmGEmjeVed8dd9b2JD/n547rM9fp7A8L8=";
   };
-  propagatedBuildInputs = [ xorg.xvfb ];
 
-  # See: https://github.com/cgoldberg/xvfbwrapper/issues/30
-  doCheck = false;
+  build-system = [ setuptools ];
 
-  nativeCheckInputs = [ mock ];
+  dependencies = [ xorg.xvfb ];
 
-  meta = with lib; {
-    description = "Run headless display inside X virtual framebuffer (Xvfb)";
+  nativeCheckInputs = [
+    pytestCheckHook
+    xorg.xvfb
+  ];
+
+  meta = {
+    description = "Run headless displays inside X virtual framebuffers (Xvfb)";
     homepage = "https://github.com/cgoldberg/xvfbwrapper";
-    license = licenses.mit;
-    maintainers = with maintainers; [ ashgillman ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ashgillman ];
   };
 }


### PR DESCRIPTION
Fixes the build so that it works properly, and also modernizes the package code to align with modern Nix python packaging.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
