### PR TITLE
qemu: Fix Python deps, the third time

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -169,8 +169,12 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     perl
 
-    # Don't change this to python3 and python3.pkgs.*, breaks cross-compilation
-    (python3Packages.python.withPackages (ps: with ps; [ distlib ]))
+    # For python changes other than simple package additions, ping @dramforever for review.
+    # Don't change `python3Packages` to `python3.pkgs.*`, breaks cross-compilation.
+    python3Packages.distlib
+    # Hooks from the python package are needed to add `$pythonPath` so
+    # `python/scripts/mkvenv.py` can detect `meson` otherwise the vendored meson without patches will be used.
+    python3Packages.python
   ]
   ++ lib.optionals gtkSupport [ wrapGAppsHook3 ]
   ++ lib.optionals enableDocs [


### PR DESCRIPTION
Hooks from `python` (specifically the one that adds `pythonPath`) are needed by `python/scripts/mkvenv.py` to find meson
With `python.withPackages`
```
python determined to be '/nix/store/r98crvxg8pmrvx9vzymhlwbbvffnzjhl-python3-3.13.6-env/bin/python3'
python version: Python 3.13.6
mkvenv: Creating non-isolated virtual environment (with packages from '/nix/store/r98crvxg8pmrvx9vzymhlwbbvffnzjhl-python3-3.13.6-env/lib/python3.13/site-packages') at 'pyvenv'
mkvenv: checking for meson>=1.5.0
mkvenv: checking for pycotap>=1.1.0
mkvenv: installing meson==1.5.0, pycotap==1.3.1
```
With `pythonPackages.python`
```
python version: Python 3.13.6
mkvenv: Creating non-isolated virtual environment at 'pyvenv'
mkvenv: checking for meson>=1.5.0
mkvenv: checking for pycotap>=1.1.0
mkvenv: installing pycotap==1.3.1
```

Here's a diff of the env-vars https://gist.github.com/Artturin/e79f1fcf125ebb138c0012008e719533

the `withPackages` without `pythonOnBuildForHost` was wrong too but
changing it didn't fix the issue
Fixes this error in qemu-user / qemu minimal
```
$ ./result/bin/qemu-aarch64
./result/bin/qemu-aarch64: error while loading shared libraries: libz.so.1: cannot open shared object file: No such file or directory
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
