### PR TITLE
maintainers: drop ertes

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7790,12 +7790,6 @@
     githubId = 5427394;
     name = "Ersin Akinci";
   };
-  ertes = {
-    email = "esz@posteo.de";
-    github = "ertes";
-    githubId = 1855930;
-    name = "Ertugrul Söylemez";
-  };
   esau79p = {
     github = "EsAu79p";
     githubId = 21313906;

--- a/pkgs/by-name/do/doom-bcc/package.nix
+++ b/pkgs/by-name/do/doom-bcc/package.nix
@@ -32,6 +32,5 @@ stdenv.mkDerivation {
     mainProgram = "bcc";
     homepage = "https://github.com/wormt/bcc";
     license = licenses.mit;
-    maintainers = with maintainers; [ ertes ];
   };
 }

--- a/pkgs/by-name/pa/pari/package.nix
+++ b/pkgs/by-name/pa/pari/package.nix
@@ -78,7 +78,6 @@ stdenv.mkDerivation rec {
     '';
     downloadPage = "http://pari.math.u-bordeaux.fr/download.html";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ ertes ];
     teams = [ teams.sage ];
     platforms = platforms.linux ++ platforms.darwin;
     mainProgram = "gp";

--- a/pkgs/by-name/pi/picom/package.nix
+++ b/pkgs/by-name/pi/picom/package.nix
@@ -131,7 +131,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/yshui/picom";
     mainProgram = "picom";
     maintainers = with lib.maintainers; [
-      ertes
       gepbird
       thiagokokada
       twey

--- a/pkgs/games/doom-ports/slade/git.nix
+++ b/pkgs/games/doom-ports/slade/git.nix
@@ -74,6 +74,5 @@ stdenv.mkDerivation {
     homepage = "http://slade.mancubus.net/";
     license = lib.licenses.gpl2Only; # https://github.com/sirjuddington/SLADE/issues/1754
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ ertes ];
   };
 }


### PR DESCRIPTION
Last activity in 2014. Dropping according to maintainer guidelines: https://github.com/NixOS/nixpkgs/tree/master/maintainers#how-to-lose-maintainer-status

@ertes if you'd like to stay involved, please respond within a week.