### PR TITLE
Revert "linuxManualConfig: reinstate Rust"

### DIFF
--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -245,13 +245,11 @@ lib.makeOverridable (
           rust-bindgen-unwrapped
         ];
 
-        env = {
-          RUST_LIB_SRC = lib.optionalString withRust rustPlatform.rustLibSrc;
+        RUST_LIB_SRC = lib.optionalString withRust rustPlatform.rustLibSrc;
 
-          # avoid leaking Rust source file names into the final binary, which adds
-          # a false dependency on rust-lib-src on targets with uncompressed kernels
-          KRUSTFLAGS = lib.optionalString withRust "--remap-path-prefix ${rustPlatform.rustLibSrc}=/";
-        };
+        # avoid leaking Rust source file names into the final binary, which adds
+        # a false dependency on rust-lib-src on targets with uncompressed kernels
+        KRUSTFLAGS = lib.optionalString withRust "--remap-path-prefix ${rustPlatform.rustLibSrc}=/";
 
         patches =
           # kernelPatches can contain config changes and no actual patch


### PR DESCRIPTION
Reverts NixOS/nixpkgs#436245

Reason for revert: be able to build nixos-unstable with less rebuilds __now__ and re-apply the same after that (e.g. after another kernel bump).