### PR TITLE
postgresqlPackages.documentdb{,_distributed}: init at 0.108-0-unstable-2025-08-27

### DIFF
--- a/pkgs/by-name/in/intelrdfpmath/package.nix
+++ b/pkgs/by-name/in/intelrdfpmath/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "intelrdfpmath";
+  version = "2.0U3";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchurl {
+    url = "http://www.netlib.org/misc/intel/IntelRDFPMathLib${
+      builtins.replaceStrings [ "." ] [ "" ] finalAttrs.version
+    }.tar.gz";
+    hash = "sha256-E/aSSy7XHfmxN6ffmHBqDcw7Q8KDoOMvi26tykMFE2o=";
+  };
+
+  # unpacks to multiple dirs
+  sourceRoot = "LIBRARY";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 -t "$out/lib" *.a
+    install -Dm444 -t "$dev/include" src/bid_{conf,functions}.h
+    mkdir -p "$out/lib/pkgconfig"
+    cat > "$out/lib/pkgconfig/intelmathlib.pc" << EOF
+    Name: intelmathlib
+    Version: ${builtins.replaceStrings [ "U" ] [ " Update " ] finalAttrs.version}
+    Description: Intel Decimal Floating point math library
+    Requires:
+    Libs: -L$out/lib -lbid
+    Cflags: -I$dev/include/
+    EOF
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Software implementation of the IEEE 754-2008 Decimal Floating-Point Arithmetic specification";
+    longDescription = ''
+      Software implementation of the IEEE 754-2008 Decimal Floating-Point
+      Arithmetic specification, aimed at financial applications, especially in
+      cases where legal requirements make it necessary to use decimal, and not
+      binary floating-point arithmetic (as computation performed with binary
+      floating-point operations may introduce small, but unacceptable errors).
+    '';
+    homepage = "https://www.intel.com/content/www/us/en/developer/articles/tool/intel-decimal-floating-point-math-library.html";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      jk
+    ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/servers/sql/postgresql/ext/documentdb.nix
+++ b/pkgs/servers/sql/postgresql/ext/documentdb.nix
@@ -1,0 +1,174 @@
+{
+  lib,
+  postgresqlBuildExtension,
+  fetchFromGitHub,
+
+  pkg-config,
+
+  intelrdfpmath,
+  libkrb5,
+  mongoc,
+  openssl,
+  pcre2,
+
+  rum,
+
+  postgresqlTestExtension,
+  postgresql,
+  stdenv,
+}:
+
+postgresqlBuildExtension (finalAttrs: {
+  pname = "documentdb";
+  # require https://github.com/microsoft/documentdb/pull/241 to build with current mongoc
+  # also note some tags in CHANGELOG.md are marked (Unreleased)
+  # see version in pg_documentdb/documentdb.control
+  version = "0.108-0-unstable-2025-08-27";
+
+  src = fetchFromGitHub {
+    owner = "documentdb";
+    repo = "documentdb";
+    # update postPatch when moving to release tags
+    rev = "4b0faabbe305ca7a369234ef07aa283c2b5b40db";
+    hash = "sha256-tQ+f8iuZbTBarxbh0pS5x4MpR/BshQWesQsOvqvooL8=";
+  };
+
+  postPatch = ''
+    patchShebangs scripts/generate_extension_version.sh
+    substituteInPlace scripts/generate_extension_version.sh \
+      --replace-fail 'GIT_VERSION="unknown"'        'GIT_VERSION="${finalAttrs.src.rev}"' \
+      --replace-fail 'BUILD_VER=" buildId:unknown"' 'BUILD_VER=" buildId:nixpkgs"' \
+      --replace-fail 'GIT_SHA=" sha:unknown"'       'GIT_SHA=" sha:${
+        builtins.substring 0 7 finalAttrs.src.rev
+      }"'
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    intelrdfpmath
+    libkrb5
+    mongoc
+    openssl
+    pcre2
+  ];
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang (
+    lib.concatStringsSep " " [
+      # src/types/pcre_regex.c:46:3: error: redefinition of typedef 'PcreData' is a C11 feature
+      "-Wno-typedef-redefinition"
+      # src/api_hooks.c:284:60: error: passing arguments to a function without a prototype is deprecated in all versions of C and is not supported in C23
+      "-Wno-deprecated-non-prototype"
+      # src/aggregation/bson_aggregation_pipeline.c:918:1: error: unused function 'CreateChangeStreamContinuationtVar'
+      "-Wno-unused-function"
+      # src/roaring_bitmaps/roaring.h:1107:5: error: static function 'printf' is used in an inline function with external linkage
+      "-Wno-static-in-inline"
+    ]
+  );
+
+  postInstall =
+    let
+      libName = "rum${stdenv.hostPlatform.extensions.library}";
+    in
+    ''
+      ln -s ${lib.getLib rum}/lib/${libName} $out/lib/${libName}
+    '';
+
+  enableUpdateScript = false;
+  # to be replaced with proper dependency declaration in the future
+  # see discussion in https://github.com/NixOS/nixpkgs/pull/436566
+  passthru.withPackages = [
+    "rum"
+    "pg_cron"
+    "pgvector"
+    "postgis"
+  ];
+  passthru.tests.extension = postgresqlTestExtension {
+    inherit (finalAttrs) finalPackage;
+
+    inherit (finalAttrs.passthru) withPackages;
+
+    postgresqlExtraSettings = ''
+      shared_preload_libraries='pg_cron, pg_documentdb_core, pg_documentdb'
+      cron.database_name = 'test_db'
+    '';
+
+    sql = ''
+      -- not using CASCADE to stay aware of dependencies
+      -- can cascade in NixOS VM test
+      CREATE EXTENSION rum;
+      CREATE EXTENSION pg_cron;
+      CREATE EXTENSION tsm_system_rows;
+      CREATE EXTENSION vector;
+      CREATE EXTENSION postgis;
+      CREATE EXTENSION documentdb_core;
+      CREATE EXTENSION documentdb;
+
+      SELECT documentdb_api.create_collection('documentdb','fruit');
+
+      SELECT documentdb_api.insert_one('documentdb','fruit', '{ "fruit_id": "F001", "name": "Apple", "tags": ["Crunchy", "Sweet"] }');
+      SELECT documentdb_api.insert_one('documentdb','fruit', '{ "fruit_id": "F002", "name": "Orange", "tags": ["Peel", "Sweet"] }');
+      SELECT documentdb_api.insert_one('documentdb','fruit', '{ "fruit_id": "F003", "name": "Peach", "tags": ["Fluffy", "Sweet"] }');
+      SELECT documentdb_api.insert_one('documentdb','fruit', '{ "fruit_id": "F004", "name": "Kiwi", "tags": ["Hairy", "Sour"] }');
+      SELECT documentdb_api.insert_one('documentdb','fruit', '{ "fruit_id": "F005", "name": "Blueberry", "tags": ["Small", "Sour", "Sweet"] }');
+
+      SELECT collection FROM documentdb_api.collection('documentdb','fruit');
+    '';
+    asserts = [
+      # ERROR:  Collection function should have been simplified during planning. Collection function should be only used in a FROM clause
+      # {
+      #   query = "SELECT count(collection) FROM documentdb_api.collection('documentdb','fruit')";
+      #   expected = "5";
+      #   description = "documentdb can be queried successfully.";
+      # }
+      {
+        query = "select documentdb_api.binary_version()";
+        # replace ending - with .
+        # for now trim `-unstable` onwards
+        expected = "'${
+          lib.replaceStrings [ "-" ] [ "." ] (
+            builtins.elemAt (lib.splitString "-unstable" finalAttrs.version) 0
+          )
+        }'";
+        description = "version reported matches.";
+      }
+      {
+        # take any version, any gitref other than unknown, a short commit sha, and force buildId to nixpkgs
+        query = ''
+          SELECT
+            array_length(REGEXP_MATCHES(
+              binary_extended_version,
+              '\d+\.\d+\.\d+(-\w+)* gitref: ((?!unknown)\w)* sha:[a-z0-9]{7} buildId:nixpkgs'
+            ), 1)::BOOLEAN AS matches_regex
+          FROM documentdb_api.binary_extended_version()
+        '';
+        expected = "true";
+        description = "extended version output matches regex.";
+      }
+    ];
+  };
+
+  meta = {
+    description = "Graph database extension for PostgreSQL";
+    longDescription = ''
+      DocumentDB is a MongoDB compatible open source document database built on
+      PostgreSQL. It offers a native implementation of a document-oriented NoSQL
+      database, enabling seamless CRUD (Create, Read, Update, Delete) operations
+      on BSON(Binary JSON) data types within a PostgreSQL framework. Beyond
+      basic operations, DocumentDB empowers users to execute complex workloads,
+      including full-text searches, geospatial queries, and vector search,
+      delivering robust functionality and flexibility for diverse data
+      management needs.
+    '';
+    homepage = "https://documentdb.io/";
+    downloadPage = "https://github.com/documentdb/documentdb/";
+    changelog = "https://github.com/documentdb/documentdb/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    maintainers = with lib.maintainers; [
+      jk
+    ];
+    platforms = postgresql.meta.platforms;
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/servers/sql/postgresql/ext/documentdb_distributed.nix
+++ b/pkgs/servers/sql/postgresql/ext/documentdb_distributed.nix
@@ -1,0 +1,146 @@
+{
+  lib,
+  runCommand,
+  stdenv,
+  stdenvNoCC,
+
+  documentdb,
+  postgresqlTestExtension,
+}:
+
+let
+  runCommandWithExtensible =
+    let
+      # prevent infinite recursion for the default stdenv value
+      defaultStdenv = stdenv;
+    in
+    {
+      # which stdenv to use, defaults to a stdenv with a C compiler, pkgs.stdenv
+      stdenv ? defaultStdenv,
+      # whether to build this derivation locally instead of substituting
+      runLocal ? false,
+      # name of the resulting derivation
+      name,
+    }:
+    lib.extendMkDerivation {
+      constructDrv = stdenv.mkDerivation;
+
+      excludeDrvArgNames = [
+        "buildCommand"
+        # "requiredExtensions"
+      ];
+
+      extendDrvArgs =
+        finalAttrs:
+        {
+          buildCommand,
+          ...
+        }@prevAttrs:
+        (
+          {
+            enableParallelBuilding = true;
+            inherit buildCommand name;
+            passAsFile = [ "buildCommand" ] ++ (prevAttrs.passAsFile or [ ]);
+          }
+          // lib.optionalAttrs (!prevAttrs ? meta) {
+            pos =
+              let
+                args = builtins.attrNames prevAttrs;
+              in
+              if builtins.length args > 0 then builtins.unsafeGetAttrPos (builtins.head args) prevAttrs else null;
+          }
+          // (lib.optionalAttrs runLocal {
+            preferLocalBuild = true;
+            allowSubstitutes = false;
+          })
+          // builtins.removeAttrs prevAttrs [ "passAsFile" ]
+        );
+    };
+  runCommandExtensible =
+    name:
+    runCommandWithExtensible {
+      stdenv = stdenvNoCC;
+      runLocal = false;
+      inherit name;
+    };
+in
+# wrap existing documentdb to avoid rebuilding
+runCommandExtensible "documentdb_distributed" (finalAttrs: {
+  pname = "documentdb_distributed";
+  inherit (documentdb) version meta;
+
+  buildCommand = ''
+    ln -s ${documentdb} $out
+  '';
+
+  passthru.tests.extension = postgresqlTestExtension {
+    inherit (finalAttrs) finalPackage;
+
+    # technically "works" without but will result in warnings
+    #  WARNING:  transaction recovery cannot connect to localhost:5432
+    env.postgresqlEnableTCP = 1;
+
+    withPackages = documentdb.withPackages ++ [
+      "citus"
+    ];
+
+    # pg_documentdb_distributed lib depends on SkipDocumentDBLoad symbol from pg_documentdb
+    # also
+    # "Note that pg_documentdb_distributed should be placed right after citus and pg_documentdb."
+    # https://github.com/documentdb/documentdb/blob/4b0faabbe305ca7a369234ef07aa283c2b5b40db/internal/pg_documentdb_distributed/src/documentdb_distributed.c#L44C9-L44C98
+    postgresqlExtraSettings = ''
+      shared_preload_libraries='pg_cron, citus, pg_documentdb_core, pg_documentdb, pg_documentdb_distributed'
+      cron.database_name = 'test_db'
+    '';
+
+    sql = ''
+      -- not using CASCADE to stay aware of dependencies
+      -- can cascade in NixOS VM test
+      CREATE EXTENSION rum;
+      CREATE EXTENSION pg_cron;
+      CREATE EXTENSION tsm_system_rows;
+      CREATE EXTENSION vector;
+      CREATE EXTENSION postgis;
+      CREATE EXTENSION citus;
+      CREATE EXTENSION documentdb_core;
+      CREATE EXTENSION documentdb;
+      CREATE EXTENSION documentdb_distributed;
+
+      SELECT citus_set_coordinator_host('localhost', 5432);
+      SELECT citus_add_node('localhost', 5432);
+      SELECT citus_set_node_property('localhost', 5432, 'shouldhaveshards', true);
+
+      -- take snapshot of citus_tables before queries
+      CREATE TABLE citus_tables_before AS SELECT * FROM citus_tables;
+
+      SELECT documentdb_api.create_collection('documentdb','fruit');
+
+      SELECT documentdb_api.insert_one('documentdb','fruit', '{ "fruit_id": "F001", "name": "Apple", "tags": ["Crunchy", "Sweet"] }');
+      SELECT documentdb_api.insert_one('documentdb','fruit', '{ "fruit_id": "F002", "name": "Orange", "tags": ["Peel", "Sweet"] }');
+      SELECT documentdb_api.insert_one('documentdb','fruit', '{ "fruit_id": "F003", "name": "Peach", "tags": ["Fluffy", "Sweet"] }');
+      SELECT documentdb_api.insert_one('documentdb','fruit', '{ "fruit_id": "F004", "name": "Kiwi", "tags": ["Hairy", "Sour"] }');
+      SELECT documentdb_api.insert_one('documentdb','fruit', '{ "fruit_id": "F005", "name": "Blueberry", "tags": ["Small", "Sour", "Sweet"] }');
+
+      SELECT collection FROM documentdb_api.collection('documentdb','fruit');
+    '';
+    asserts = [
+      {
+        query = "SELECT citus_is_coordinator()";
+        expected = "true";
+        description = "Citus was up";
+      }
+      {
+        query = "SELECT count(*) FROM citus_tables_before";
+        expected = "0";
+        description = "Citus tables are readable and started empty";
+      }
+    ]
+    ++ lib.optionals (finalAttrs.passthru.tests.extension.postgresqlEnableTCP == 1) [
+      {
+        query = "SELECT count(*) FROM citus_tables";
+        expected = "4";
+        description = "Citus tables were populated";
+      }
+    ];
+  };
+})

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -665,8 +665,8 @@ let
             ''
               wrapProgram "$out/bin/postgres" ${lib.concatStringsSep " " args}
 
-              mkdir -p "$dev/nix-support"
-              substitute "${lib.getDev postgresql}/nix-support/pg_config.env" "$dev/nix-support/pg_config.env" \
+              mkdir -p "$out/nix-support"
+              substitute "${lib.getDev postgresql}/nix-support/pg_config.env" "$out/nix-support/pg_config.env" \
                 --replace-fail "${postgresql}" "$out" \
                 --replace-fail "${postgresql.man}" "$out"
             '';
@@ -714,7 +714,6 @@ let
             # buildEnv doesn't support passing `outputs`, so going via overrideAttrs.
             outputs = [
               "out"
-              "dev"
             ];
           };
     in


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- `intelrdfpmath`: init at 2.0U3
- `postgresqlPackages.documentdb`: init at 0.106-0-unstable-2025-08-24
- `postgres`: fix `postgresqlWithPackages` loading in `postgresqlTestExtension`

related to #436486 

Draft because:

* `intelrdfpmath`
  * Want input on:
    * Package name
    * Package version
    * Other patches to potentially adopt same as [debian](https://sources.debian.org/src/intelrdfpmath/2.0u3-1/debian/patches)
  * Doesn't run the checks in the `TESTS` dir, any suggestions for a good way to point to another `makefile`. Is it as simple as `preCheck` `cd ../TESTS`?
* `postgresqlPackages.documentdb`
  * Some help getting the final assert in the test to work would be ideal, if not just the raw `sql` should be enough
  * Anything needed to define "required other extensions"?
  * Thoughts on using latest commit. Could maybe try and cherry pick commits we need off tag...
  * Need to ask upstream which versions of postgresql they support
* `postgresqlWithPackages` tweak
  * I just made the change so the tests would work. On current master all tests using `postgresqlTestExtension` seem to be broken.
    * cc: @NixOS/postgres 
  * I'm open to any other method which mean `initdb` etc show up in the `PATH`
    * (error below)

```
/nix/store/1shr16l4v98qqiv196r9i9pjwzrsnhd0-postgresql-test-hook/nix-support/setup-hook: line 52: type: initdb: not found
initdb not found. Did you add postgresql to the nativeCheckInputs?
```

---


- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
