### PR TITLE
treewide: migrate usages of `nix hash` to `nix-hash`

### DIFF
--- a/pkgs/by-name/ci/cider-2/updater.sh
+++ b/pkgs/by-name/ci/cider-2/updater.sh
@@ -30,6 +30,6 @@ cd ../../../..
 
 if [[ "${1-default}" != "--deps-only" ]]; then
     SHA="$(nix-prefetch-url --quiet --unpack --type sha256 $DEB_URL)"
-    SRI=$(nix --experimental-features nix-command hash to-sri "sha256:$SHA")
+    SRI=$(nix-hash --to-sri "sha256:$SHA")
     update-source-version cider-2 "$NEW_VERSION" "$SRI"
 fi

--- a/pkgs/by-name/er/erlang-language-platform/update.sh
+++ b/pkgs/by-name/er/erlang-language-platform/update.sh
@@ -18,7 +18,7 @@ for release in $releases; do
   IFS=: read -r name url <<< "$release"
   hash_name=$(echo "$name" | sed 's/.tar.gz$//')
   hash_prefetched=$(nix-prefetch-url --type sha256 "$url")
-  hash_sri=$(nix hash to-sri --type sha256 "$hash_prefetched")
+  hash_sri=$(nix-hash --to-sri --type sha256 "$hash_prefetched")
   echo "$hash_name" "$hash_sri"
 done |
   jq -sR 'rtrimstr("\n") | split("\n") | map(split(" ") | {(.[0]): .[1]}) | add' > hashes.json

--- a/pkgs/by-name/et/etcd_3_6/update.sh
+++ b/pkgs/by-name/et/etcd_3_6/update.sh
@@ -27,7 +27,7 @@ OLD_VERSION="$(nix-instantiate --eval -E "with import $NIXPKGS_PATH {}; \
 if [ ! "$OLD_VERSION" = "$LATEST_VERSION" ]; then
     echo "Attempting to update etcd from $OLD_VERSION to $LATEST_VERSION"
     ETCD_SRC_HASH=$(nix-prefetch-url --quiet --unpack https://github.com/etcd-io/etcd/archive/refs/tags/${LATEST_TAG}.tar.gz)
-    ETCD_SRC_HASH=$(nix hash to-sri --type sha256 $ETCD_SRC_HASH)
+    ETCD_SRC_HASH=$(nix-hash --to-sri --type sha256 $ETCD_SRC_HASH)
 
     setKV () {
         sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" "$ETCD_PATH/default.nix"

--- a/pkgs/by-name/ki/kiro/update.sh
+++ b/pkgs/by-name/ki/kiro/update.sh
@@ -86,7 +86,7 @@ echo "Updating to version: $max_version"
 echo "Calculating hashes..."
 for platform in "${!platform_urls[@]}"; do
     echo "  Calculating hash for $platform..."
-    platform_hashes["$platform"]=$(nix hash convert --hash-algo sha256 "$(nix-prefetch-url "${platform_urls[$platform]}")")
+    platform_hashes["$platform"]=$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url "${platform_urls[$platform]}")")
 done
 
 # Update package.nix and generate sources.json

--- a/pkgs/by-name/li/libhsts/update.sh
+++ b/pkgs/by-name/li/libhsts/update.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")"
 
 chromium_version=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/chromium/chromium/tags" | jq -r 'map(select(.prerelease | not)) | .[1].name')
 sha256=$(nix-prefetch-url "https://raw.github.com/chromium/chromium/$chromium_version/net/http/transport_security_state_static.json")
-hash=$(nix hash convert --to sri "$sha256")
+hash=$(nix-hash --to-sri --type sha256 "$sha256")
 
 sed -e "0,/chromium_version/s/chromium_version = \".*\"/chromium_version = \"$chromium_version\"/" \
     -e "0,/hash/s/hash = \".*\"/sha256 = \"$hash\"/" \

--- a/pkgs/by-name/ry/ryubing/updater.sh
+++ b/pkgs/by-name/ry/ryubing/updater.sh
@@ -28,7 +28,7 @@ cd ../../../..
 
 if [[ "${1-default}" != "--deps-only" ]]; then
     SHA="$(nix-prefetch-git https://git.ryujinx.app/ryubing/ryujinx --rev "$NEW_VERSION" --quiet | jq -r '.sha256')"
-    SRI=$(nix --experimental-features nix-command hash to-sri "sha256:$SHA")
+    SRI=$(nix-hash --to-sri "sha256:$SHA")
     update-source-version ryubing "$NEW_VERSION" "$SRI"
 fi
 

--- a/pkgs/by-name/ta/tabnine/update.sh
+++ b/pkgs/by-name/ta/tabnine/update.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
 function prefetch-sri() {
     nix-prefetch-url "$1" 2>/dev/null |
-        xargs nix --experimental-features nix-command hash to-sri --type sha256
+        xargs nix-hash --to-sri --type sha256
 }
 
 declare -A platforms=(

--- a/pkgs/development/compilers/dart/update.sh
+++ b/pkgs/development/compilers/dart/update.sh
@@ -16,6 +16,6 @@ update-source-version dart $latestVersion --file=$MY_PATH/sources.nix
 
 systems=$(nix eval --json -f . dart.meta.platforms | jq --raw-output '.[]')
 for system in $systems; do
-  hash=$(nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url $(nix eval --raw -f . dart.src.url --system "$system")))
+  hash=$(nix-hash --to-sri --type sha256 $(nix-prefetch-url $(nix eval --raw -f . dart.src.url --system "$system")))
   update-source-version dart $latestVersion $hash --file=$MY_PATH/sources.nix --system=$system --ignore-same-version --ignore-same-hash
 done

--- a/pkgs/os-specific/windows/mingw-w64/update.nu
+++ b/pkgs/os-specific/windows/mingw-w64/update.nu
@@ -70,7 +70,7 @@ def main [] {
 
   # Prefetch to get the new hash
   let new_hash = nix-prefetch-url --type sha256 $new_url
-  | nix hash to-sri --type sha256 $in
+  | nix-hash --to-sri --type sha256 $in
 
   # Set the hash
   replace ./pkgs/os-specific/windows/mingw-w64/headers.nix $current_hash $new_hash

--- a/pkgs/os-specific/windows/msvcSdk/update.nu
+++ b/pkgs/os-specific/windows/msvcSdk/update.nu
@@ -38,7 +38,7 @@ def main [] {
 
     xwin --accept-license --cache-dir $dir --manifest $"($PATH | path join manifest.json)" --arch $arch splat --preserve-ms-arch-notation
 
-    let hash = nix hash path ($dir | path join splat)
+    let hash = nix-hash --sri --type sha256 ($dir | path join splat)
 
     {arch: $arch, hash: $hash}
   } | transpose -r -d


### PR DESCRIPTION
**NOTE: This PR is incomplete, pending discussion of the changes. Once a consensus is reached I will add in the rest of the changes.**

This PR is inspired by the discussion at https://github.com/NixOS/nixpkgs/pull/436230, and seeks to resolve the issues mentioned in https://github.com/NixOS/nixpkgs/pull/421823, but from a different direction.

The `nix hash` subcommand requires `experimental-features = nix-command ...` in `/etc/nix/nix.conf` (or passed via CLI args) in order to be used, otherwise it will fail with an error. Furthermore, other distributions of Nix (namely Lix) seem to lack the `nix hash convert` subcommand that the official Nix has, despite it having been added 2 years ago in Nix 2.20 (https://github.com/NixOS/nix/pull/9452). This means Lix users have to use `nix hash to-(base16|base32|base64|sri) ...`, which is considered deprecated by Nix (but still supported as of 2.28.4, though could be removed anytime).

Both of these issues will cause problems for other users looking to execute any code that uses them in Nixpkgs. One obvious solution is to tack on `--extra-experimental-features 'nix-command'` to the Nix command, but this flag is really long and easy to forget by most users (a few scripts were missed or added after https://github.com/NixOS/nixpkgs/pull/421823 that have been fixed here), and the issue of `nix hash convert` being non-existent on Lix is an issue that can cause a lot of confusion (as per https://github.com/NixOS/nixpkgs/pull/436230).

My solution involves transforming _all_ calls to `nix hash` (and variations with `--(extra-)?experimental-features`) into the equivalent `nix-hash` invocations. This will avoid the issues of forgetting the `nix-command` experimental-feature and be stable across all other Nix implementations since this is part of the legacy CLI interface.

cc @philiptaron @lonerOrz as relevant parties to this discussion.

#### Problems

The most obvious one to me is that `nix-hash` by default uses `md5` as the hashing algorithm (`nix hash` uses sha256), and uses base16 representation (`nix hash` uses sri). These _can_ be fixed by adding `--sri --type sha256` to the CLI arguments, but this creates an issue for forward compatibility with `nix hash`, and once again brings the same issue of "forgetting to add flags".

#### Alternative

We can instead choose to not concern ourselves with Lix being incompatible with upstream Nix (this isn't the only one, the experimental feature `pipe-operator` vs `pipe-operators` is another). This does mean that any contributors who use Lix will have to resolve their issues as they are encountered.

In this situation, the only thing this PR would seek to do would be to add the missing `--extra-experimental-features` to all `nix hash` calls that have it missing and remove all of the `nix hash` -> `nix-hash` changes.

#### Sidenote

I originally considered PRing to replace _all_ of the new nix3 subcommands with their nix-legacy equivalents, but I didn't do so because I figured that warranted a larger discussion. One benefit of doing so would be faster evaluation times (going from `nix eval` to `nix-instantiate` had pretty significant improvements due to not needing to copy the flake directory so much), but similar issues about forward compatibility arise, hence the need for a discussion.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
