### PR TITLE
radicle-native-ci: init at 0.11.1

### DIFF
--- a/pkgs/by-name/ra/radicle-native-ci/package.nix
+++ b/pkgs/by-name/ra/radicle-native-ci/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromRadicle,
+  radicle-node,
+  gitMinimal,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "radicle-native-ci";
+  version = "0.11.1";
+
+  src = fetchFromRadicle {
+    seed = "seed.radicle.xyz";
+    repo = "z3qg5TKmN83afz2fj9z3fQjU8vaYE";
+    node = "z6MkgEMYod7Hxfy9qCvDv5hYHkZ4ciWmLFgfvm3Wn1b2w2FV";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OjQBq4QopT4dr1/z73fqlGLjQIjUY51/II9m2qQMW1w=";
+  };
+
+  cargoHash = "sha256-zyEdlAXaooEkxD4aZ1poIUX3OwXtP4nFAyOWJDdw1p8=";
+
+  preCheck = ''
+    git config --global user.name nixbld
+    git config --global user.email nixbld@example.com
+  '';
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    radicle-node
+    gitMinimal
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Radicle CI adapter for native CI";
+    homepage = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z3qg5TKmN83afz2fj9z3fQjU8vaYE";
+    changelog = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z3qg5TKmN83afz2fj9z3fQjU8vaYE/tree/NEWS.md";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ defelo ];
+    mainProgram = "radicle-native-ci";
+  };
+})

--- a/pkgs/by-name/ra/radicle-native-ci/update.sh
+++ b/pkgs/by-name/ra/radicle-native-ci/update.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p coreutils gnused gitMinimal nix-update
+
+set -euo pipefail
+
+dirname="$(dirname "${BASH_SOURCE[0]}")"
+
+url=$(nix-instantiate --eval --raw -A radicle-native-ci.src.url)
+old_node=$(nix-instantiate --eval --raw -A radicle-native-ci.src.node)
+
+ref=$(git ls-remote "$url" 'refs/namespaces/*/refs/tags/v*' \
+  | cut -f2 | grep -Ev '\^\{\}$' | sort -t/ -k6rV | head -1)
+[[ "$ref" =~ ^refs/namespaces/([^/]+)/refs/tags/v([^/]+)$ ]]
+new_node="${BASH_REMATCH[1]}"
+version="${BASH_REMATCH[2]}"
+
+sed -i "s/${old_node}/${new_node}/g" "${dirname}/package.nix"
+nix-update --version="$version" radicle-native-ci


### PR DESCRIPTION
> This is an adapter for the [Radicle CI broker](https://app.radicle.xyz/nodes/radicle.liw.fi/rad%3AzwTxygwuz5LDGBq255RA2CbNGrz8), for performing CI runs locally.

https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z3qg5TKmN83afz2fj9z3fQjU8vaYE

Related: #436583

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
