### PR TITLE
python3Packages.xgrammar: 0.1.22 -> 0.1.23

### DIFF
--- a/pkgs/development/python-modules/xgrammar/default.nix
+++ b/pkgs/development/python-modules/xgrammar/default.nix
@@ -96,6 +96,9 @@ buildPythonPackage rec {
     changelog = "https://github.com/mlc-ai/xgrammar/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     badPlatforms = [
+      # error: ‘operator delete’ called on unallocated object ‘result’ [-Werror=free-nonheap-object]
+      "aarch64-linux"
+
       # clang++: error: unsupported option '-ffat-lto-objects' for target 'arm64-apple-darwin'
       # idem for 'x86_64-apple-darwin'
       lib.systems.inspect.patterns.isDarwin

--- a/pkgs/development/python-modules/xgrammar/default.nix
+++ b/pkgs/development/python-modules/xgrammar/default.nix
@@ -95,5 +95,10 @@ buildPythonPackage rec {
     homepage = "https://xgrammar.mlc.ai";
     changelog = "https://github.com/mlc-ai/xgrammar/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
+    badPlatforms = [
+      # clang++: error: unsupported option '-ffat-lto-objects' for target 'arm64-apple-darwin'
+      # idem for 'x86_64-apple-darwin'
+      lib.systems.inspect.patterns.isDarwin
+    ];
   };
 }

--- a/pkgs/development/python-modules/xgrammar/default.nix
+++ b/pkgs/development/python-modules/xgrammar/default.nix
@@ -25,7 +25,7 @@
 
 buildPythonPackage rec {
   pname = "xgrammar";
-  version = "0.1.22";
+  version = "0.1.23";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     repo = "xgrammar";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-mz6eabETkAzDoPjXE5VJvgrR1vnXXmx3JO4xZRH4TRQ=";
+    hash = "sha256-asyxJsrsbfFNh1pLBDzM4kdmunQp7/mTDw3L8KuZf4g=";
   };
 
   patches = [
@@ -78,6 +78,7 @@ buildPythonPackage rec {
     "test_grammar_matcher_json_schema"
     "test_grammar_matcher_tag_dispatch"
     "test_regex_converter"
+    "test_serialize_compiled_grammar_with_hf_tokenizer"
     "test_tokenizer_info"
 
     # Torch not compiled with CUDA enabled


### PR DESCRIPTION
## Things done

- **python3Packages.xgrammar: 0.1.22 -> 0.1.23**
  - Diff: https://github.com/mlc-ai/xgrammar/compare/v0.1.22...v0.1.23
  - Changelog: https://github.com/mlc-ai/xgrammar/releases/tag/v0.1.23
- **python3Packages.xgrammar: mark as broken on darwin**
- **python3Packages.xgrammar: mark as broken on aarch64-linux**

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
