### PR TITLE
python3Packages.pizzapi: init at 0.0.6

### DIFF
--- a/pkgs/development/python-modules/pizzapi/default.nix
+++ b/pkgs/development/python-modules/pizzapi/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  requests,
+  xmltodict,
+  pyhamcrest,
+  mock,
+  pytestCheckHook,
+}:
+
+buildPythonPackage {
+  pname = "pizzapi";
+  version = "0.0.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ggrammar";
+    repo = "pizzapi";
+    rev = "2a67ceb0f6df285988f1a2d7b678bbd2526c26a4";
+    hash = "sha256-oBwNNsnRhm/kv8DxNrAKkeGv2RZA+RMdYRgByy3qmsU=";
+  };
+
+  postPatch = ''
+    # Remove pytest-runner from setup_requires
+    substituteInPlace setup.py \
+      --replace-fail 'setup_requires=["pytest-runner"],' 'setup_requires=[],'
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    requests
+    xmltodict
+    pyhamcrest
+  ];
+
+  nativeCheckInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pizzapi" ];
+
+  meta = {
+    description = "Python wrapper for the Dominos Pizza API";
+    homepage = "https://github.com/ggrammar/pizzapi";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -1253,7 +1253,8 @@
       ];
     "dominos" =
       ps: with ps; [
-      ]; # missing inputs: pizzapi
+        pizzapi
+      ];
     "doods" =
       ps: with ps; [
         pillow

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11733,6 +11733,8 @@ self: super: with self; {
 
   pixel-ring = callPackage ../development/python-modules/pixel-ring { };
 
+  pizzapi = callPackage ../development/python-modules/pizzapi { };
+
   pjsua2 =
     (toPythonModule (
       pkgs.pjsip.override {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://pypi.org/project/pizzapi/
- https://github.com/ggrammar/pizzapi
- https://www.home-assistant.io/integrations/dominos/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
