### PR TITLE
nixos/homebox: update module

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -182,7 +182,7 @@
 
 - The systemd initrd will now respect `x-systemd.wants` and `x-systemd.requires` for reliably unlocking multi-disk bcachefs volumes.
 
-- [`homebox` 0.20.0](https://github.com/sysadminsmedia/homebox/releases/tag/v0.20.0) changed how assets are stored and hashed. It is recommended to back up your database before this update.
+- [`homebox` 0.20.0](https://github.com/sysadminsmedia/homebox/releases/tag/v0.20.0) changed how assets are stored and hashed. It is recommended to back up your database before this update. In particular, `--storage-data` was replaced with `--storage-conn-string` and `--storage-prefix-path`. If your configuration set `HBOX_STORAGE_DATA` manually, you must migrate it to `HBOX_STORAGE_CONN_STRING` and `HBOX_STORAGE_PREFIX_PATH`.
 
 - `installShellCompletion`: now supports Nushell completion files
 

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24907,6 +24907,17 @@
     githubId = 4572854;
     name = "Shawn Warren";
   };
+  swarsel = {
+    name = "Leon Schwarzäugl";
+    email = "leon@swarsel.win";
+    github = "Swarsel";
+    githubId = 32304731;
+    keys = [
+      {
+        fingerprint = "4BE7 9252 6228 9B47 6DBB  C17B 76FD 3810 215A E097";
+      }
+    ];
+  };
   swdunlop = {
     email = "swdunlop@gmail.com";
     github = "swdunlop";

--- a/nixos/modules/services/web-apps/homebox.nix
+++ b/nixos/modules/services/web-apps/homebox.nix
@@ -131,5 +131,8 @@ in
       wantedBy = [ "multi-user.target" ];
     };
   };
-  meta.maintainers = with lib.maintainers; [ patrickdag ];
+  meta.maintainers = with lib.maintainers; [
+    patrickdag
+    swarsel
+  ];
 }

--- a/nixos/modules/services/web-apps/homebox.nix
+++ b/nixos/modules/services/web-apps/homebox.nix
@@ -10,19 +10,34 @@ let
     mkEnableOption
     mkPackageOption
     mkDefault
+    mkOption
     types
     mkIf
     ;
+
+  defaultUser = "homebox";
+  defaultGroup = "homebox";
 in
 {
   options.services.homebox = {
     enable = mkEnableOption "homebox";
     package = mkPackageOption pkgs "homebox" { };
-    settings = lib.mkOption {
-      type = types.attrsOf types.str;
+    user = mkOption {
+      type = types.str;
+      default = defaultUser;
+      description = "User account under which Homebox runs.";
+    };
+    group = mkOption {
+      type = types.str;
+      default = defaultGroup;
+      description = "Group under which Homebox runs.";
+    };
+    settings = mkOption {
+      type = types.submodule { freeformType = types.attrsOf (types.nullOr types.str); };
       defaultText = lib.literalExpression ''
         {
-          HBOX_STORAGE_DATA = "/var/lib/homebox/data";
+          HBOX_STORAGE_CONN_STRING = "file:///var/lib/homebox";
+          HBOX_STORAGE_PREFIX_PATH = "data";
           HBOX_DATABASE_DRIVER = "sqlite3";
           HBOX_DATABASE_SQLITE_PATH = "/var/lib/homebox/data/homebox.db?_pragma=busy_timeout=999&_pragma=journal_mode=WAL&_fk=1";
           HBOX_OPTIONS_ALLOW_REGISTRATION = "false";
@@ -31,12 +46,12 @@ in
         }
       '';
       description = ''
-        The homebox configuration as Environment variables. For definitions and available options see the upstream
+        The homebox configuration as environment variables. For definitions and available options see the upstream
         [documentation](https://homebox.software/en/configure/#configure-homebox).
       '';
     };
     database = {
-      createLocally = lib.mkOption {
+      createLocally = mkOption {
         type = lib.types.bool;
         default = false;
         description = ''
@@ -47,14 +62,31 @@ in
   };
 
   config = mkIf cfg.enable {
-    users.users.homebox = {
-      isSystemUser = true;
-      group = "homebox";
+    assertions = [
+      {
+        assertion = !(cfg.settings ? HBOX_STORAGE_DATA);
+        message = ''
+          `services.homebox.settings.HBOX_STORAGE_DATA` has been deprecated.
+          Please use `services.homebox.settings.HBOX_STORAGE_CONN_STRING` and `services.homebox.settings.HBOX_STORAGE_PREFIX_PATH` instead.
+        '';
+      }
+    ];
+
+    users = {
+      users = mkIf (cfg.user == defaultUser) {
+        ${defaultUser} = {
+          description = "homebox service user";
+          inherit (cfg) group;
+          isSystemUser = true;
+        };
+      };
+      groups = mkIf (cfg.group == defaultGroup) { ${defaultGroup} = { }; };
     };
-    users.groups.homebox = { };
+
     services.homebox.settings = lib.mkMerge [
       (lib.mapAttrs (_: mkDefault) {
-        HBOX_STORAGE_DATA = "/var/lib/homebox/data";
+        HBOX_STORAGE_CONN_STRING = "file:///var/lib/homebox";
+        HBOX_STORAGE_PREFIX_PATH = "data";
         HBOX_DATABASE_DRIVER = "sqlite3";
         HBOX_DATABASE_SQLITE_PATH = "/var/lib/homebox/data/homebox.db?_pragma=busy_timeout=999&_pragma=journal_mode=WAL&_fk=1";
         HBOX_OPTIONS_ALLOW_REGISTRATION = "false";
@@ -62,7 +94,7 @@ in
         HBOX_MODE = "production";
       })
 
-      (lib.mkIf cfg.database.createLocally {
+      (mkIf cfg.database.createLocally {
         HBOX_DATABASE_DRIVER = "postgres";
         HBOX_DATABASE_HOST = "/run/postgresql";
         HBOX_DATABASE_USERNAME = "homebox";
@@ -70,7 +102,8 @@ in
         HBOX_DATABASE_PORT = toString config.services.postgresql.settings.port;
       })
     ];
-    services.postgresql = lib.mkIf cfg.database.createLocally {
+
+    services.postgresql = mkIf cfg.database.createLocally {
       enable = true;
       ensureDatabases = [ "homebox" ];
       ensureUsers = [
@@ -83,18 +116,16 @@ in
     systemd.services.homebox = {
       requires = lib.optional cfg.database.createLocally "postgresql.target";
       after = lib.optional cfg.database.createLocally "postgresql.target";
-      environment = cfg.settings;
+      environment = lib.filterAttrs (_: v: v != null) cfg.settings;
       serviceConfig = {
-        User = "homebox";
-        Group = "homebox";
+        User = cfg.user;
+        Group = cfg.group;
         ExecStart = lib.getExe cfg.package;
-        StateDirectory = "homebox";
-        WorkingDirectory = "/var/lib/homebox";
         LimitNOFILE = "1048576";
         PrivateTmp = true;
         PrivateDevices = true;
-        StateDirectoryMode = "0700";
         Restart = "always";
+        StateDirectory = "homebox";
 
         # Hardening
         CapabilityBoundingSet = "";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
changelog: https://github.com/sysadminsmedia/homebox/releases

diff: https://github.com/sysadminsmedia/homebox/compare/v0.20.2...v0.21.0

[v0.20.0](https://github.com/sysadminsmedia/homebox/releases/tag/v0.20.0) replaced `--storage-data` with `--storage-conn-string` and `--storage-prefix-path` which is now reflected in the module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
