### PR TITLE
nixos/iwd: fix DriverQuirks.DefaultInterface config option

### DIFF
--- a/nixos/modules/services/networking/iwd.nix
+++ b/nixos/modules/services/networking/iwd.nix
@@ -13,17 +13,18 @@ let
     mkOption
     types
     recursiveUpdate
+    optionalAttrs
     ;
 
   cfg = config.networking.wireless.iwd;
   ini = pkgs.formats.ini { };
-  defaults = {
-    # without UseDefaultInterface, sometimes wlan0 simply goes AWOL with NetworkManager
-    # https://iwd.wiki.kernel.org/interface_lifecycle#interface_management_in_iwd
-    DriverQuirks.UseDefaultInterface =
-      with config.networking.networkmanager;
-      (enable && (wifi.backend == "iwd"));
-  };
+  defaults =
+    with config.networking.networkmanager;
+    optionalAttrs (enable && (wifi.backend == "iwd")) {
+      # without DefaultInterface, sometimes wlan0 simply goes AWOL with NetworkManager
+      # https://iwd.wiki.kernel.org/interface_lifecycle#interface_management_in_iwd
+      DriverQuirks.DefaultInterface = "?*";
+    };
   configFile = ini.generate "main.conf" (recursiveUpdate defaults cfg.settings);
 
 in
@@ -64,7 +65,7 @@ in
       {
         assertion = !(cfg.settings ? General && cfg.settings.General ? UseDefaultInterface);
         message = ''
-          `networking.wireless.iwd.settings.General.UseDefaultInterface` has been deprecated. Use `networking.wireless.iwd.settings.DriverQuirks.UseDefaultInterface` instead.
+          `networking.wireless.iwd.settings.General.UseDefaultInterface` has been deprecated. Use `networking.wireless.iwd.settings.DriverQuirks.DefaultInterface` instead.
         '';
       }
     ];


### PR DESCRIPTION
`[DriverQuirks].DefaultInterface` option accepts a comma-separated list of drivers or glob matches as its value. The previous commit in this file incorrectly introduced `DriverQuirks.UseDefaultInterface`, which doesn't exist.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
