### PR TITLE
nixos/tests: fix tests that use SDDM

### DIFF
--- a/nixos/tests/lxqt.nix
+++ b/nixos/tests/lxqt.nix
@@ -37,6 +37,7 @@
       with subtest("Wait for login"):
           machine.wait_for_x()
           machine.wait_for_file("/tmp/xauth_*")
+          machine.sleep(1)
           machine.succeed("xauth merge /tmp/xauth_*")
           machine.succeed("su - ${user.name} -c 'xauth merge /tmp/xauth_*'")
 

--- a/nixos/tests/maestral.nix
+++ b/nixos/tests/maestral.nix
@@ -70,8 +70,9 @@
 
       with subtest("GUI"):
         gui.wait_for_x()
-        gui.wait_for_file("/tmp/xauth_*")
-        gui.succeed("xauth merge /tmp/xauth_*")
+        gui.wait_for_file("/run/user/1000/xauth_*")
+        gui.sleep(1)
+        gui.succeed("xauth merge /run/user/1000/xauth_*")
         gui.wait_for_window("^Desktop ")
         gui.wait_for_unit("maestral.service", "${user.name}")
     '';

--- a/nixos/tests/plasma6.nix
+++ b/nixos/tests/plasma6.nix
@@ -32,8 +32,10 @@
     ''
       with subtest("Wait for login"):
           start_all()
-          machine.wait_for_file("/tmp/xauth_*")
-          machine.succeed("xauth merge /tmp/xauth_*")
+          machine.wait_for_file("/run/user/1000/xauth_*")
+          machine.sleep(1)
+          machine.succeed("xauth merge /run/user/1000/xauth_*")
+          machine.succeed("su - ${user.name} -c 'xauth merge /run/user/1000/xauth_*'")
 
       with subtest("Check plasmashell started"):
           machine.wait_until_succeeds("pgrep plasmashell")
@@ -44,8 +46,6 @@
 
       with subtest("Ensure Elisa is not installed"):
           machine.fail("which elisa")
-
-      machine.succeed("su - ${user.name} -c 'xauth merge /tmp/xauth_*'")
 
       with subtest("Run Dolphin"):
           machine.execute("su - ${user.name} -c 'DISPLAY=:0.0 dolphin >&2 &'")

--- a/nixos/tests/retroarch.nix
+++ b/nixos/tests/retroarch.nix
@@ -16,7 +16,7 @@
         enable = true;
         package = pkgs.retroarch-bare;
       };
-      services.xserver.displayManager = {
+      services.displayManager = {
         sddm.enable = true;
         defaultSession = "RetroArch";
         autoLogin = {
@@ -29,7 +29,7 @@
   testScript =
     { nodes, ... }:
     let
-      user = nodes.machine.config.users.users.alice;
+      user = nodes.machine.users.users.alice;
       xdo = "${pkgs.xdotool}/bin/xdotool";
     in
     ''

--- a/nixos/tests/retroarch.nix
+++ b/nixos/tests/retroarch.nix
@@ -35,8 +35,9 @@
     ''
       with subtest("Wait for login"):
           start_all()
-          machine.wait_for_file("/tmp/xauth_*")
-          machine.succeed("xauth merge /tmp/xauth_*")
+          machine.wait_for_file("/run/sddm/xauth_*")
+          machine.sleep(1)
+          machine.succeed("xauth merge /run/sddm/xauth_*")
 
       with subtest("Check RetroArch started"):
           machine.wait_until_succeeds("pgrep retroarch")

--- a/nixos/tests/sddm.nix
+++ b/nixos/tests/sddm.nix
@@ -24,6 +24,7 @@
         machine.screenshot("sddm")
         machine.send_chars("${user.password}\n")
         machine.wait_for_file("/tmp/xauth_*")
+        machine.sleep(1)
         machine.succeed("xauth merge /tmp/xauth_*")
         machine.wait_for_window("^IceWM ")
       '';
@@ -54,6 +55,7 @@
       testScript = ''
         start_all()
         machine.wait_for_file("/tmp/xauth_*")
+        machine.sleep(1)
         machine.succeed("xauth merge /tmp/xauth_*")
         machine.wait_for_window("^IceWM ")
       '';


### PR DESCRIPTION
Newer versions of SDDM moved the Xauth cookie from /tmp to $XDG_RUNTIME_DIR, so update tests accordingly.

Also, add a delay before reading the cookie, as SDDM does not create the file atomically, so it's possible we try to read it before the cookie is actually written.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
