### PR TITLE
python3Packages.reflex: 0.8.6 -> 0.8.7

### DIFF
--- a/pkgs/by-name/uv/uv-sort/package.nix
+++ b/pkgs/by-name/uv/uv-sort/package.nix
@@ -17,6 +17,11 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-umKMcQcQST0bBGf7ZXxNcWq/5/ht3jp+3JVjowBdeO0=";
   };
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"packaging~=24.1"' '"packaging"'
+  '';
+
   build-system = with python3Packages; [
     hatchling
     uv-dynamic-versioning

--- a/pkgs/development/python-modules/reflex-chakra/default.nix
+++ b/pkgs/development/python-modules/reflex-chakra/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   hatchling,
-  uv-dynamic-versioning,
   pythonOlder,
   reflex,
   pytestCheckHook,
@@ -11,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "reflex-chakra";
-  version = "0.8.2post1";
+  version = "0.8.2";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -20,18 +19,11 @@ buildPythonPackage rec {
     owner = "reflex-dev";
     repo = "reflex-chakra";
     tag = "v${version}";
-    hash = "sha256-DugZRZpGP90EFkBjpAS1XkjrNPG6WWwCQPUcEZJ0ff8=";
+    hash = "sha256-6KWIpTtr2tNBxXoj2hY0zuX0bpSUvsoA1Y7uwln3HDY=";
   };
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail ', "uv-dynamic-versioning"' "" \
-      --replace-fail 'source = "uv-dynamic-versioning"' 'source = "env"${"\n"}variable = "version"'
-  '';
 
   build-system = [
     hatchling
-    uv-dynamic-versioning
   ];
   dependencies = [ reflex ];
 

--- a/pkgs/development/python-modules/reflex-hosting-cli/default.nix
+++ b/pkgs/development/python-modules/reflex-hosting-cli/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "reflex-hosting-cli";
-  version = "0.1.54";
+  version = "0.1.55";
   pyproject = true;
 
   # source is not published https://github.com/reflex-dev/reflex/issues/3762
   src = fetchPypi {
     pname = "reflex_hosting_cli";
     inherit version;
-    hash = "sha256-agfG9nKCvKqWUOfXZ54S25jMYPSg9oVItcu0PTbIoB4=";
+    hash = "sha256-9dWwwmzv3HujNWlUt75r+o7FAmfBOiJH9s8YoUDpWRg=";
   };
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/reflex/default.nix
+++ b/pkgs/development/python-modules/reflex/default.nix
@@ -43,14 +43,14 @@
 
 buildPythonPackage rec {
   pname = "reflex";
-  version = "0.8.6";
+  version = "0.8.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "reflex-dev";
     repo = "reflex";
     tag = "v${version}";
-    hash = "sha256-Tas67x9UEFSR7yyENvixzCWbbKgP+OBMw6prnxWgCQo=";
+    hash = "sha256-ieR+Wxj1bJp3dQpw6j2Wki1nm4MWtVZ+UOtDl+6ip7M=";
   };
 
   # 'rich' is also somehow checked when building the wheel,

--- a/pkgs/development/python-modules/returns/default.nix
+++ b/pkgs/development/python-modules/returns/default.nix
@@ -2,7 +2,6 @@
   lib,
   anyio,
   buildPythonPackage,
-  curio,
   fetchFromGitHub,
   httpx,
   hypothesis,
@@ -42,7 +41,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     anyio
-    curio
     httpx
     hypothesis
     pytestCheckHook


### PR DESCRIPTION
- **python3Packages.reflex: 0.8.6 -> 0.8.7**
- **python3Packages.reflex-chakra: 0.8.2post1 -> 0.8.2**
- **python3Packages.reflex-hosting-cli: 0.1.54 -> 0.1.55**

closes https://github.com/NixOS/nixpkgs/pull/436660 and closes https://github.com/NixOS/nixpkgs/pull/436399


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
