### PR TITLE
python3Packages.pygls: 1.3.1 -> 2.0.0a6

### DIFF
--- a/pkgs/development/python-modules/pygls/default.nix
+++ b/pkgs/development/python-modules/pygls/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "pygls";
-  version = "1.3.1";
+  version = "2.0.0a6";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -23,19 +23,18 @@ buildPythonPackage rec {
     owner = "openlawlibrary";
     repo = "pygls";
     tag = "v${version}";
-    hash = "sha256-AvrGoQ0Be1xKZhFn9XXYJpt5w+ITbDbj6NFZpaDPKao=";
+    hash = "sha256-S3MKg9zkjf6SXhLzUBgy3HvPkLQPgA57Ne9fqW3GHYo=";
   };
 
   pythonRelaxDeps = [
-    # https://github.com/openlawlibrary/pygls/pull/432
     "lsprotocol"
   ];
 
-  nativeBuildInputs = [
+  build-system = [
     poetry-core
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     lsprotocol
     typeguard
   ];


### PR DESCRIPTION
Not released yet
https://github.com/openlawlibrary/pygls/tree/v2.0.0a6
Current pygls fails to build probably due to recently updated lsprotocol in [afec46afffb5a8b12ddc451e951d2a69d24a8d3f](https://github.com/NixOS/nixpkgs/commit/afec46afffb5a8b12ddc451e951d2a69d24a8d3f).
<details><summary>pygls build log</summary>

    ImportError while loading conftest '/build/source/tests/conftest.py'.
    tests/conftest.py:27: in <module>
        from pygls.workspace import Workspace
    pygls/workspace/__init__.py:6: in <module>
        from .workspace import Workspace
    pygls/workspace/workspace.py:32: in <module>
        from pygls.workspace.text_document import TextDocument
    pygls/workspace/text_document.py:37: in <module>
        class TextDocument(object):
    pygls/workspace/text_document.py:76: in TextDocument
        self, change: types.TextDocumentContentChangeEvent_Type1
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    E   AttributeError: module 'lsprotocol.types' has no attribute 'TextDocumentContentChangeEvent_Type1'

</details>
Hydra job is scheduled thus not failed yet.

Also swapped `nativeBuildInputs` → `build-system` and `propagatedBuildInputs` → `dependencies`, removed comment about relaxed lsprotocol as the PR mentioned already merged (left relaxation itself as the dependency is strict).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
