### PR TITLE
python3Packages.pymc: fix

### DIFF
--- a/pkgs/development/python-modules/pymc/default.nix
+++ b/pkgs/development/python-modules/pymc/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
 
   # build-system
   setuptools,
@@ -32,13 +33,19 @@ buildPythonPackage rec {
     hash = "sha256-zh6FsCEviuyqapguTrUDsWKq70ef0IKRhnn2dkgQ/KA=";
   };
 
+  patches = [
+    # TODO: remove at next release
+    # https://github.com/pymc-devs/pytensor/pull/1471
+    (fetchpatch2 {
+      name = "pytensor-2-32-compat";
+      url = "https://github.com/pymc-devs/pymc/commit/59176b6adda88971e546a0cf93ca04424af5197f.patch";
+      hash = "sha256-jkDwlKwxbn9DwpkxEbSXk/kbGjT/Xu8bsZHFBWYpMgA=";
+    })
+  ];
+
   build-system = [
     setuptools
     versioneer
-  ];
-
-  pythonRelaxDeps = [
-    "pytensor"
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/pytensor/default.nix
+++ b/pkgs/development/python-modules/pytensor/default.nix
@@ -83,6 +83,11 @@ buildPythonPackage rec {
   '';
 
   disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # Numerical assertion error
+    # tests.unittest_tools.WrongValue: WrongValue
+    "test_op_sd"
+    "test_op_ss"
+
     # pytensor.link.c.exceptions.CompileError: Compilation failed (return status=1)
     "OpFromGraph"
     "add"
@@ -123,6 +128,7 @@ buildPythonPackage rec {
     "test_modes"
     "test_mul_s_v_grad"
     "test_multiple_outputs"
+    "test_nnet"
     "test_not_inplace"
     "test_numba_Cholesky_grad"
     "test_numba_pad"


### PR DESCRIPTION
## Things done

https://github.com/pymc-devs/pytensor/pull/1471/files

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<string>", line 1, in <lambda>
  File "/nix/store/18l19gnl8dq75v6knghbcgkrikmpc0yv-python3-3.12.11/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/nix/store/6jvbllywnyfis494k5s18s652ph1833v-python3.12-pymc-5.25.1/lib/python3.12/site-packages/pymc/__init__.py", line 50, in <module>
    from pymc import _version, gp, ode, sampling
  File "/nix/store/6jvbllywnyfis494k5s18s652ph1833v-python3.12-pymc-5.25.1/lib/python3.12/site-packages/pymc/gp/__init__.py", line 17, in <module>
    from pymc.gp import cov, mean, util
  File "/nix/store/6jvbllywnyfis494k5s18s652ph1833v-python3.12-pymc-5.25.1/lib/python3.12/site-packages/pymc/gp/util.py", line 25, in <module>
    from pymc.model.core import modelcontext
  File "/nix/store/6jvbllywnyfis494k5s18s652ph1833v-python3.12-pymc-5.25.1/lib/python3.12/site-packages/pymc/model/__init__.py", line 17, in <module>
    from pymc.model.core import *
  File "/nix/store/6jvbllywnyfis494k5s18s652ph1833v-python3.12-pymc-5.25.1/lib/python3.12/site-packages/pymc/model/core.py", line 53, in <module>
    from pymc.initial_point import PointType, make_initial_point_fn
  File "/nix/store/6jvbllywnyfis494k5s18s652ph1833v-python3.12-pymc-5.25.1/lib/python3.12/site-packages/pymc/initial_point.py", line 30, in <module>
    from pymc.logprob.transforms import Transform
  File "/nix/store/6jvbllywnyfis494k5s18s652ph1833v-python3.12-pymc-5.25.1/lib/python3.12/site-packages/pymc/logprob/__init__.py", line 52, in <module>
    import pymc.logprob.linalg
  File "/nix/store/6jvbllywnyfis494k5s18s652ph1833v-python3.12-pymc-5.25.1/lib/python3.12/site-packages/pymc/logprob/linalg.py", line 17, in <module>
    from pytensor.tensor.math import _matrix_matrix_matmul
ImportError: cannot import name '_matrix_matrix_matmul' from 'pytensor.tensor.math' (/nix/store/47l64i4gy5iab0g65akaf2rjjbk0zm8b-python3.12-pytensor-2.32.0/lib/python3.12/site-packages/pytensor/tensor/math.py)
```

cc @nidabdella @ferrine

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
