### PR TITLE
nixos/lomiri: Exclude Morph Browser by default

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -125,7 +125,10 @@ in
             lomiri-thumbnailer
             lomiri-url-dispatcher
             mediascanner2 # TODO possibly needs to be kicked off by graphical-session.target
-            morph-browser
+            # Qt5 qtwebengine is not secure: https://github.com/NixOS/nixpkgs/pull/435067
+            # morph-browser
+            # Adding another browser that is known-working until Morph Browser can migrate to Qt6
+            pkgs.epiphany
             qtmir # not having its desktop file for Xwayland available causes any X11 application to crash the session
             teleports
           ]);

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -431,15 +431,16 @@ in
               machine.send_key("alt-f4")
 
           # Morph is how we go online
-          with subtest("morph browser works"):
-              open_starter()
-              machine.send_chars("Morph\n")
-              wait_for_text(r"(Bookmarks|address|site|visited any)")
-              machine.screenshot("morph_open")
-
-              # morph-browser has a separate VM test to test its basic functionalities
-
-              machine.send_key("alt-f4")
+          # Qt5 qtwebengine is not secure: https://github.com/NixOS/nixpkgs/pull/435067
+          # with subtest("morph browser works"):
+          #     open_starter()
+          #     machine.send_chars("Morph\n")
+          #     wait_for_text(r"(Bookmarks|address|site|visited any)")
+          #     machine.screenshot("morph_open")
+          #
+          #     # morph-browser has a separate VM test to test its basic functionalities
+          #
+          #     machine.send_key("alt-f4")
 
           # LSS provides DE settings
           with subtest("system settings open"):

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -614,14 +614,14 @@ in
               machine.send_key("ret")
 
               # Peers should be loaded
-              wait_for_text("Morph") # or Gallery, but Morph is already packaged
+              wait_for_text("Gallery")
               machine.screenshot("settings_lomiri-content-hub_peers")
 
-              # Select Morph as content source
-              mouse_click(340, 80)
+              # Select Gallery as content source
+              mouse_click(460, 80)
 
-              # Expect Morph to be brought into the foreground, with its Downloads page open
-              wait_for_text("No downloads")
+              # Expect Gallery to be brought into the foreground, with its sharing page open
+              wait_for_text("Photos")
 
               # If lomiri-content-hub encounters a problem, it may have crashed the original application issuing the request.
               # Check that it's still alive
@@ -630,9 +630,10 @@ in
               machine.screenshot("lomiri-content-hub_exchange")
 
               # Testing any more would require more applications & setup, the fact that it's already being attempted is a good sign
-              machine.send_key("esc")
+              machine.send_key("tab")
+              machine.send_key("ret")
 
-              machine.sleep(2) # sleep a tiny bit so morph can close & the focus can return to LSS
+              machine.sleep(2) # sleep a tiny bit so gallery can close & the focus can return to LSS
               machine.send_key("alt-f4")
         '';
     }

--- a/pkgs/by-name/ay/ayatana-indicator-sound/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-sound/package.nix
@@ -48,6 +48,17 @@ stdenv.mkDerivation (finalAttrs: {
     # Build-time Vala codegen
     substituteInPlace src/CMakeLists.txt \
       --replace-fail '/usr/share/gir-1.0/AccountsService-1.0.gir' '${lib.getDev accountsservice}/share/gir-1.0/AccountsService-1.0.gir'
+
+    # timeouts are too short for aarch64 OfBorg builder under loads, which leads to spurious test failures
+    substituteInPlace \
+      tests/accounts-service-user.cc \
+      tests/media-player-user.cc \
+      tests/name-watch-test.cc \
+      tests/notifications-test.cc \
+      tests/volume-control-test.cc \
+      --replace-quiet 'loop(50)' 'loop(500)' \
+      --replace-quiet 'loop(100)' 'loop(1000)' \
+      --replace-quiet 'loop(500)' 'loop(5000)' \
   '';
 
   strictDeps = true;


### PR DESCRIPTION
[Qt5 `qtwebengine` has been marked insecure](https://github.com/NixOS/nixpkgs/pull/435067), so this blocks the entire DE from being usable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
