### PR TITLE
lxqt-wayland-session: add passthru.providedSessions

### DIFF
--- a/pkgs/desktops/lxqt/lxqt-wayland-session/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-wayland-session/default.nix
@@ -60,6 +60,8 @@ stdenv.mkDerivation rec {
 
   passthru.updateScript = gitUpdater { };
 
+  passthru.providedSessions = [ "lxqt-wayland" ];
+
   meta = {
     homepage = "https://github.com/lxqt/lxqt-wayland-session";
     description = "Files needed for the LXQt Wayland Session";


### PR DESCRIPTION
It's required in order to add it to `services.displayManager.sessionPackages`, so it shows up as a session in display managers, like this:

```nix
{
  services.displayManager.sessionPackages = [ pkgs.lxqt.lxqt-wayland-session ];
}
```

<img width="968" height="338" alt="SDDM picker showing LXQt (Wayland) as an option" src="https://github.com/user-attachments/assets/33130810-c169-4b8e-8a59-0668669aa12e" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
