### PR TITLE
python3Packages.python-sat: 0.1.8.dev17 -> 0.1.8.dev20

### DIFF
--- a/pkgs/development/python-modules/python-sat/default.nix
+++ b/pkgs/development/python-modules/python-sat/default.nix
@@ -18,10 +18,13 @@ buildPythonPackage rec {
     hash = "sha256-fKZcdEVuqpv8jWnK8Cr1UJ7szJqXivK6x3YPYHH5ccI=";
   };
 
-  # Build SAT solver backends in parallel
+  # Build SAT solver backends in parallel and fix hard-coded g++ reference for
+  # darwin, where stdenv uses clang
   postPatch = ''
     substituteInPlace solvers/prepare.py \
       --replace-fail "&& make &&" "&& make -j$NIX_BUILD_CORES &&"
+    substituteInPlace solvers/patches/glucose421.patch \
+      --replace-fail "+CXX      := g++" "+CXX      := c++"
   '';
 
   propagatedBuildInputs = [
@@ -43,6 +46,5 @@ buildPythonPackage rec {
       maintainers.chrjabs
     ];
     platforms = lib.platforms.all;
-    badPlatforms = lib.platforms.darwin ++ [ "i686-linux" ];
   };
 }

--- a/pkgs/development/python-modules/python-sat/default.nix
+++ b/pkgs/development/python-modules/python-sat/default.nix
@@ -8,15 +8,21 @@
 }:
 buildPythonPackage rec {
   pname = "python-sat";
-  version = "0.1.8.dev17";
+  version = "0.1.8.dev20";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "pysathq";
     repo = "pysat";
-    rev = "a04763de6dafb8d3a0d7f1b231fc0d30be1de4c0"; # upstream does not tag releases
-    hash = "sha256-FG6oAAI8XKXumj6Ys2QjjYcRp1TpwkUZzyfpkdq5V6E=";
+    rev = "d94f51e5eff2feef35abbc25480659eafa615cc0"; # upstream does not tag releases
+    hash = "sha256-fKZcdEVuqpv8jWnK8Cr1UJ7szJqXivK6x3YPYHH5ccI=";
   };
+
+  # Build SAT solver backends in parallel
+  postPatch = ''
+    substituteInPlace solvers/prepare.py \
+      --replace-fail "&& make &&" "&& make -j$NIX_BUILD_CORES &&"
+  '';
 
   propagatedBuildInputs = [
     six


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Update `python-sat` to `0.1.8.dev20`
Changelog: https://pysathq.github.io/updates/

Also now build SAT solver backends with `NIX_BUILD_CORES` in parallel.

Lastly, unbreak build on darwin by replacing hard-coded reference to `g++` with `c++`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
