### PR TITLE
liferea: 1.16-RC2 -> 1.16.1

### DIFF
--- a/pkgs/by-name/li/liferea/package.nix
+++ b/pkgs/by-name/li/liferea/package.nix
@@ -17,7 +17,7 @@
   libnotify,
   gtk3,
   gsettings-desktop-schemas,
-  libpeas,
+  libpeas2,
   libsecret,
   gobject-introspection,
   glib-networking,
@@ -26,11 +26,11 @@
 
 stdenv.mkDerivation rec {
   pname = "liferea";
-  version = "1.16-RC2";
+  version = "1.16.1";
 
   src = fetchurl {
     url = "https://github.com/lwindolf/${pname}/releases/download/v${version}/${pname}-${version}.tar.bz2";
-    hash = "sha256-yOfePUcr6NauNQjkWnSxPD5tJSqx5OSTFGUxOz3hDhg=";
+    hash = "sha256-4KmqxG8D0vwrMlBo5qGBIUdKpB8wCGAhYyqSyvn2muw=";
   };
 
   nativeBuildInputs = [
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     libxslt
     sqlite
     libsoup_3
-    libpeas
+    libpeas2
     gsettings-desktop-schemas
     json-glib
     libsecret
@@ -68,6 +68,9 @@ stdenv.mkDerivation rec {
   postFixup = ''
     buildPythonPath ${python3Packages.pycairo}
     patchPythonScript $out/lib/liferea/plugins/trayicon.py
+
+    buildPythonPath ${python3Packages.requests}
+    patchPythonScript $out/lib/liferea/plugins/download-manager.py
   '';
 
   passthru.updateScript = gitUpdater {


### PR DESCRIPTION
Diff: https://github.com/lwindolf/liferea/compare/v1.16-RC2...v1.16.1

This PR cannot be backported due to a switch from `libpeas` to `libpeas2` which might break compatibility of 3rd party plugins.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
