### PR TITLE
prek: init at 0.1.6

### DIFF
--- a/pkgs/by-name/pr/prek/package.nix
+++ b/pkgs/by-name/pr/prek/package.nix
@@ -1,0 +1,109 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  git,
+  uv,
+  python312,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "prek";
+  version = "0.1.6";
+
+  src = fetchFromGitHub {
+    owner = "j178";
+    repo = "prek";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MVdd67ssP64aEV6rjNA3fxypqKn0lJe/UN2waCEkLJM=";
+  };
+
+  cargoHash = "sha256-XW8na9kXgn7gKaN7OYlEGTv8cgtzKXggj1uXlvQh4N4=";
+
+  preBuild = ''
+    version312_str=$(${python312}/bin/python -c 'import sys; print(sys.version_info[:3])')
+
+    substituteInPlace ./tests/languages/python.rs \
+      --replace '(3, 12, 11)' "$version312_str"
+  '';
+
+  nativeCheckInputs = [
+    git
+    python312
+    uv
+  ];
+
+  preCheck = ''
+    export TEMP="$(mktemp -d)"
+    export TMP=$TEMP
+    export TMPDIR=$TEMP
+    export PREK_INTERNAL__TEST_DIR=$TEMP
+  '';
+
+  __darwinAllowLocalNetworking = true;
+  useNextest = true;
+
+  # some python tests use uv, which in turn needs python
+  UV_PYTHON = "${python312}/bin/python";
+
+  checkFlags = builtins.map (t: "--skip ${t}") [
+    # these tests require internet access
+    "check_added_large_files_hook"
+    "check_json_hook"
+    "end_of_file_fixer_hook"
+    "mixed_line_ending_hook"
+    "install_hooks_only"
+    "install_with_hooks"
+    "golang"
+    "node"
+    "script"
+    "check_useless_excludes_remote"
+    # "meta_hooks"
+    "reuse_env"
+    "docker::docker"
+    "docker_image::docker_image"
+    "pygrep::basic_case_sensitive"
+    "pygrep::case_insensitive"
+    "pygrep::case_insensitive_multiline"
+    "pygrep::complex_regex_patterns"
+    "pygrep::invalid_args"
+    "pygrep::invalid_regex"
+    "pygrep::multiline_mode"
+    "pygrep::negate_mode"
+    "pygrep::negate_multiline_mode"
+    "pygrep::pattern_not_found"
+    "pygrep::python_regex_quirks"
+    "python::additional_dependencies"
+    "python::can_not_download"
+    "python::hook_stderr"
+    "python::language_version"
+    # can't checkout pre-commit-hooks
+    "cjk_hook_name"
+    "fail_fast"
+    "file_types"
+    "files_and_exclude"
+    "git_commit_a"
+    "log_file"
+    "merge_conflicts"
+    "pass_env_vars"
+    "restore_on_interrupt"
+    "run_basic"
+    "run_last_commit"
+    "same_repo"
+    "skips"
+    "staged_files_only"
+    "subdirectory"
+    "check_yaml_hook"
+    "check_yaml_multiple_document"
+    # does not properly use TMP
+    "hook_impl"
+  ];
+
+  meta = {
+    homepage = "https://github.com/j178/prek";
+    description = "Better `pre-commit`, re-engineered in Rust ";
+    changelog = "https://github.com/j178/prek/releases/tag/${finalAttrs.src.tag}";
+    license = [ lib.licenses.mit ];
+    maintainers = [ lib.maintainers.knl ];
+  };
+})


### PR DESCRIPTION
This change adds prek, a pre-commit drop-in replacement implemented in Rust.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
