### PR TITLE
haskellPackages.{smtlib-backends-tests, liquidhaskell-boot, liquidhaskell, rest-rewrite}: no jailbreak needed anymore

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -3232,23 +3232,10 @@ with haskellLib;
       + "/libssh2";
   } super.libssh2;
 
-  # 2025-8-13: Too strict bound on tasty <1.15; relaxed on Hackage as of today
-  smtlib-backends-tests = doJailbreak super.smtlib-backends-tests;
-
   # 2025-8-19: dontCheck because of: https://github.com/ucsd-progsys/liquid-fixpoint/issues/760
   # i.e. tests assume existence of .git and also fail for some versions of CVC5,
   # including the current one in nixpkgs.
   liquid-fixpoint = dontCheck super.liquid-fixpoint;
-
-  # 2025-8-18: Too strict bound on Diff <0.6; relaxed on Hackage as of today
-  liquidhaskell-boot = doJailbreak super.liquidhaskell-boot;
-
-  # 2025-8-19: jailbreak because of the restrictive bytestring ==0.12.1.0,
-  # but we have 0.12.2.0. This was relaxed on Hackage to allow 0.12.2.0 on 2025-08-17.
-  liquidhaskell = doJailbreak super.liquidhaskell;
-
-  # 2025-8-13: Too strict bound on QuickCheck <2.15; relaxed on Hackage as of today
-  rest-rewrite = doJailbreak super.rest-rewrite;
 }
 // import ./configuration-tensorflow.nix { inherit pkgs haskellLib; } self super
 


### PR DESCRIPTION



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
