### PR TITLE
ci,workflows: deal with ghost reviews

### DIFF
--- a/.github/workflows/dismissed-review.yml
+++ b/.github/workflows/dismissed-review.yml
@@ -49,7 +49,7 @@ jobs:
                     repo: context.repo.repo,
                     pull_number: pull_request.number
                   })).filter(review =>
-                    review.user.login == 'github-actions[bot]' &&
+                    review.user?.login == 'github-actions[bot]' &&
                     review.state == 'DISMISSED'
                   ).map(review => github.graphql(`
                     mutation($node_id:ID!) {

--- a/ci/github-script/reviews.js
+++ b/ci/github-script/reviews.js
@@ -12,7 +12,7 @@ async function dismissReviews({ github, context, dry }) {
         pull_number,
       })
     )
-      .filter((review) => review.user.login === 'github-actions[bot]')
+      .filter((review) => review.user?.login === 'github-actions[bot]')
       .map(async (review) => {
         if (review.state === 'CHANGES_REQUESTED') {
           await github.rest.pulls.dismissReview({
@@ -46,7 +46,7 @@ async function postReview({ github, context, core, dry, body }) {
     })
   ).find(
     (review) =>
-      review.user.login === 'github-actions[bot]' &&
+      review.user?.login === 'github-actions[bot]' &&
       // If a review is still pending, we can just update this instead
       // of posting a new one.
       (review.state === 'CHANGES_REQUESTED' ||


### PR DESCRIPTION
When a user deletes their account, they appear as a "ghost user". This user is represented as `null` on API requests. If such a user had posted a review before, this breaks a few places, which assume to be able to access `user.login`.

Example in #413992, https://github.com/NixOS/nixpkgs/actions/runs/17208956375/job/48815819939?pr=413992.

## Things done

- [x] Tested locally.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
