### PR TITLE
grpc-health-probe: init at 0.4.40

### DIFF
--- a/pkgs/by-name/gr/grpc-health-probe/package.nix
+++ b/pkgs/by-name/gr/grpc-health-probe/package.nix
@@ -1,0 +1,27 @@
+{
+  buildGoModule,
+  lib,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "grpc-health-probe";
+  version = "0.4.40";
+
+  src = fetchFromGitHub {
+    owner = "grpc-ecosystem";
+    repo = "grpc-health-probe";
+    rev = "v${version}";
+    hash = "sha256-Na0y8fL109flHGJOniEpLgs60xf1V0YlSBrX9iHtymM=";
+  };
+
+  vendorHash = "sha256-eIjDs14PEzoVaRYoxN03pDfYzg4VF1tgskLY9oIkMLE=";
+
+  meta = with lib; {
+    description = "command-line tool to perform health-checks for gRPC applications";
+    homepage = "https://github.com/grpc-ecosystem/grpc-health-probe";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jpds ];
+    mainProgram = "grpc-health-probe";
+  };
+}


### PR DESCRIPTION
Init https://github.com/grpc-ecosystem/grpc-health-probe at 0.4.40

After realizing that I was going to add this to a bunch of tests - added a helper function to `test-driver`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
