### PR TITLE
pkgs/gnunet-messenger-gtk: init

### DIFF
--- a/pkgs/by-name/gn/gnunet-messenger-gtk/package.nix
+++ b/pkgs/by-name/gn/gnunet-messenger-gtk/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+
+  meson,
+  pkg-config,
+  ninja,
+
+  gnunet,
+  libgnunetchat,
+  libhandy,
+  libnotify,
+  qrencode,
+  gst_all_1,
+  pipewire,
+  libportal-gtk3,
+  gtk3,
+  gtk4,
+  desktop-file-utils,
+  libsodium,
+  libgcrypt,
+  libunistring,
+
+  gnome-characters,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gnunet-messenger-gtk";
+  version = "0.10.2";
+
+  src = fetchgit {
+    url = "https://git.gnunet.org/messenger-gtk.git";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-EhmWamlFfyMepp9W+6nvzrxkRHF9BObSomkwS/Qf5Ro=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    ninja
+
+    gtk3
+    gtk4
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    gnunet
+    libgnunetchat
+    libhandy
+    libnotify
+    qrencode
+    pipewire
+    libportal-gtk3
+    gtk3
+    gtk4
+    libsodium
+    libgcrypt
+    libunistring.dev
+
+    gnome-characters
+  ] ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base.dev
+  ]);
+
+  meta = {
+    description = "A GTK based GUI for the Messenger service of GNUnet";
+    homepage = "https://git.gnunet.org/messenger-gtk.git/about/";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.all;
+    teams = with lib.teams; [ ngi ];
+    maintainers = [ lib.maintainers.hustlerone ];
+    mainProgram = "messenger-gtk";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This is the gnunet gtk messaging app. It compiles and executes but for now the program freezes when you confirm account creation.

<img width="655" height="415" alt="image" src="https://github.com/user-attachments/assets/f12ad250-34ac-4218-a75e-e9f34b58b5d1" />

I am unsure as to if you require the gnunet service or not, but the module is broken currently.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
