### PR TITLE
roomarranger: 10.0.1 -> 10.2

### DIFF
--- a/pkgs/by-name/ro/roomarranger/package.nix
+++ b/pkgs/by-name/ro/roomarranger/package.nix
@@ -15,7 +15,7 @@ let
     exec = "roomarranger";
     name = "roomarranger";
     desktopName = "Room Arranger";
-    genericName = "Design your room, office, apartment, house.";
+    genericName = "Design your room, office, apartment or house, plan gardens and more...";
     icon = "roomarranger-icon";
     terminal = false;
     categories = [ "Graphics" ];
@@ -28,11 +28,11 @@ in
 
 stdenv.mkDerivation {
   pname = "roomarranger";
-  version = "10.0.1";
+  version = "10.2";
 
   src = fetchurl {
-    url = "https://f000.backblazeb2.com/file/rooarr/rooarr1001-linux64.tar.gz";
-    hash = "sha256-OwJSOfyTQinVKzrJftpFa5NN1kGweBezedpL2aE4LbE=";
+    url = "https://f000.backblazeb2.com/file/rooarr/rooarr1020-linux64.tar.gz";
+    hash = "sha256-24AGP2le5HfcVMlqDjiMRcRWKU/zjACV7KzJlVWMpkw=";
   };
 
   nativeBuildInputs = [
@@ -52,9 +52,6 @@ stdenv.mkDerivation {
 
     mkdir -p $out/lib $out/bin
     cp -r rooarr-bin/* $out/lib/
-
-    # Delete bundled dynamic libraries that reference major Qt version 6
-    rm -f $out/lib/*.6
 
     ln -s $out/lib/RoomArranger $out/bin/roomarranger
 

--- a/pkgs/by-name/ro/roomarranger/package.nix
+++ b/pkgs/by-name/ro/roomarranger/package.nix
@@ -77,6 +77,7 @@ stdenv.mkDerivation {
       Free for 30 days. Updates are free.
     '';
     homepage = "https://www.roomarranger.com/";
+    changelog = "https://www.roomarranger.com/whatsnew.txt";
     license = lib.licenses.unfree;
     platforms = [ "x86_64-linux" ];
     maintainers = with lib.maintainers; [ bellackn ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - `nixpkgs-review pr -p roomarranger 436800` has run successfully
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

Also:

- Added `changelog` meta attribute
- Changed Qt6 lib removal behaviour (the package builds and runs fine without this now)
- Updated `genericName` for desktop entry according to website

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
