### PR TITLE
nasin-nanpa: 3.1.0 -> 4.0.2

### DIFF
--- a/pkgs/by-name/na/nasin-nanpa/package.nix
+++ b/pkgs/by-name/na/nasin-nanpa/package.nix
@@ -2,15 +2,16 @@
   lib,
   stdenvNoCC,
   fetchurl,
+  nix-update-script,
 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "nasin-nanpa";
-  version = "3.1.0";
+  version = "4.0.2";
 
   src = fetchurl {
     url = "https://github.com/ETBCOR/nasin-nanpa/releases/download/n${version}/nasin-nanpa-${version}.otf";
-    hash = "sha256-remTvvOt7kpvTdq9H8tFI2yU+BtqePXlDDLQv/jtETU=";
+    hash = "sha256-eWPcFUo0yE2r4cL3kyFBcdHp0RBKUF3kgYqV5B55w0M=";
   };
 
   dontUnpack = true;
@@ -20,9 +21,11 @@ stdenvNoCC.mkDerivation rec {
     cp $src $out/share/fonts/opentype/nasin-nanpa.otf
   '';
 
+  passthru.updateScript = nix-update-script { };
+
   meta = with lib; {
     homepage = "https://github.com/ETBCOR/nasin-nanpa";
-    description = "UCSUR OpenType monospaced font for the Toki Pona writing system, Sitelen Pona";
+    description = ''UCSUR OpenType monospaced font for the Toki Pona writing system, Sitelen Pona ("main" version; uses UCSUR and ligatures from latin characters)'';
     longDescription = ''
       ni li nasin pi sitelen pona.
       sitelen ale pi nasin ni li sama mute weka.
@@ -30,6 +33,9 @@ stdenvNoCC.mkDerivation rec {
     '';
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = with maintainers; [ somasis ];
+    maintainers = with maintainers; [
+      somasis
+      feathecutie
+    ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates [`nasin-nanpa`](https://github.com/etbcor/nasin-nanpa) to latest stable version: https://github.com/etbcor/nasin-nanpa/releases/tag/n4.0.2

### Help wanted:

Original text:

> Since the last packaged version, `nasin-nanpa` has started shipping two additional font files:
> - [`nasin-nanpa-${version}-Helvetica.otf`](https://github.com/etbcor/nasin-nanpa/releases/download/n4.0.2/nasin-nanpa-4.0.2-Helvetica.otf)
> - [`nasin-nanpa-${version}-UCSUR.otf`](https://github.com/etbcor/nasin-nanpa/releases/download/n4.0.2/nasin-nanpa-4.0.2-UCSUR.otf)
> 
> These files should be packaged as well, but I'm not sure whether these should be separate derivations or be bundled into this derivation, and would appreciate some thoughts on this. ~~I assume it's the latter, but in this case I'm not sure how to "idiomatically" fetch multiple files in the derivation. This can be done in a separate PR.~~
> 
> EDIT: Since both the base font and the `UCSUR` version provide a font with the exact same name (`nasin-nanpa`) (and thus conflict), and the `Helvetica` version provides a font intended to shadow another font (`Helvetica`), these files should almost certainly not be packaged into the same derivation. I'll open separate PRs for them.

I have now created PRs for the respective font variants:
- https://github.com/NixOS/nixpkgs/pull/436816
- https://github.com/NixOS/nixpkgs/pull/436817

I also added myself as a maintainer of this package in order to match with the packages created in the PRs above.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
