### PR TITLE
fetchTraefikPlugin: init

### DIFF
--- a/pkgs/build-support/fetchtraefikplugin/default.nix
+++ b/pkgs/build-support/fetchtraefikplugin/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  fetchzip,
+  traefik,
+}:
+
+lib.extendMkDerivation {
+  constructDrv = fetchzip;
+  extendDrvArgs =
+    finalAttrs:
+    {
+      plugin,
+      owner,
+      provider ? "github.com", # Most Traefik plugins are developed in GitHub repositories.
+
+      version,
+      hash,
+
+      pname ? plugin,
+      name ? "${pname}-${version}",
+      meta ? { },
+    }:
+    let
+      moduleName = lib.concatStringsSep "/" [
+        provider
+        owner
+        plugin
+      ];
+    in
+    {
+      inherit
+        hash
+        name
+        ;
+
+      url = "https://plugins.traefik.io/public/download/${moduleName}/${version}";
+      postFetch = ''
+        export tmpdir=$(mktemp -d)
+        mv -R * .* $tmpdir
+        mkdir -p $out/src/${moduleName}
+        mv -R $tmpdir/* $tmpdir/.* $out/src/${moduleName}
+      '';
+
+      passthru = {
+        inherit
+          moduleName
+          plugin
+          provider
+          owner
+          ;
+      };
+
+      meta = {
+        homepage = "https://plugins.traefik.io/plugins";
+        inherit (traefik) platforms;
+      }
+      // meta;
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -707,6 +707,8 @@ with pkgs;
 
   fetchPypiLegacy = callPackage ../build-support/fetchpypilegacy { };
 
+  fetchTraefikPlugin = callPackage ../build-support/fetchtraefikplugin { };
+
   resolveMirrorURLs =
     { url }:
     fetchurl {


### PR DESCRIPTION
This function takes in the provider, owner and plugin name, and outputs a correctly-formatted derivation with the Traefik plugin, which can be `symlinkJoin`ed in the `/var/lib/traefik/plugins-local` folder.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
