### PR TITLE
tayga: fix cross

### DIFF
--- a/pkgs/by-name/ta/tayga/package.nix
+++ b/pkgs/by-name/ta/tayga/package.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-xOm4fetFq2UGuhOojrT8WOcX78c6MLTMVbDv+O62x2E=";
   };
 
+  makeFlags = [ "CC=${lib.getExe stdenv.cc}" ];
+
   preBuild = ''
     echo "#define TAYGA_VERSION \"${finalAttrs.version}\"" > version.h
   '';


### PR DESCRIPTION
Current builds fail like this:


```
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/rzfc959mxb7lvl03zfli3m9piz19rivw-source
       > source root is source
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > build flags: SHELL=/nix/store/4bacfs7zrg714ffffbjp57nsvcz6zfkq-bash-5.3p3/bin/bash
       > /nix/store/4bacfs7zrg714ffffbjp57nsvcz6zfkq-bash-5.3p3/bin/bash: line 1: git: command not found
       > /nix/store/4bacfs7zrg714ffffbjp57nsvcz6zfkq-bash-5.3p3/bin/bash: line 1: git: command not found
       > /nix/store/4bacfs7zrg714ffffbjp57nsvcz6zfkq-bash-5.3p3/bin/bash: line 1: git: command not found
       >
       > gcc -Wall -O2 -o tayga nat64.c addrmap.c dynamic.c tayga.c conffile.c -flto=auto
       > /nix/store/4bacfs7zrg714ffffbjp57nsvcz6zfkq-bash-5.3p3/bin/bash: line 1: gcc: command not found
       > make: *** [Makefile:15: all] Error 127
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
