### PR TITLE
nasin-nanpa-ucsur: init at 4.0.2

### DIFF
--- a/pkgs/by-name/na/nasin-nanpa-ucsur/package.nix
+++ b/pkgs/by-name/na/nasin-nanpa-ucsur/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "nasin-nanpa-ucsur";
+  version = "4.0.2";
+
+  src = fetchurl {
+    url = "https://github.com/ETBCOR/nasin-nanpa/releases/download/n${version}/nasin-nanpa-${version}-UCSUR.otf";
+    hash = "sha256-9DkY7wbB22IFsIAAgyg8gYALpkfROKzzc5AhpYKt6oI=";
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    cp $src $out/share/fonts/opentype/nasin-nanpa-ucsur.otf
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    homepage = "https://github.com/ETBCOR/nasin-nanpa";
+    description = ''UCSUR OpenType monospaced font for the Toki Pona writing system, Sitelen Pona ("UCSUR only" version; doesn't have latin ligatures)'';
+    longDescription = ''
+      ni li nasin pi sitelen pona.
+      sitelen ale pi nasin ni li sama mute weka.
+      sitelen pi nasin ni li lon nasin UCSUR kin.
+    '';
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ feathecutie ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Initializes the UCSUR variant of [`nasin-nanpa`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/na/nasin-nanpa/package.nix) at version 4.0.2: https://github.com/etbcor/nasin-nanpa/releases/tag/n4.0.2

See [this section of the README](https://github.com/etbcor/nasin-nanpa/tree/n4.0.2?tab=readme-ov-file#font-versions) for the differences between font versions.

This font version is a seperate package from the `nasin-nanpa` package because both the main font file (packaged in `nasin-nanpa`) and the UCSUR font file (packaged here) provide a font with the exact same name, and thus are most likely not desirable to have installed at the same time.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
