### PR TITLE
treewide: Fix links in module documentation

### DIFF
--- a/nixos/lib/systemd-types.nix
+++ b/nixos/lib/systemd-types.nix
@@ -95,7 +95,7 @@ let
               minimal, "recommended" includes "required", and
               "suggested" includes "recommended".
 
-              See: https://systemd.io/ELF_DLOPEN_METADATA/
+              See: <https://systemd.io/ELF_DLOPEN_METADATA/>
             '';
           };
 

--- a/nixos/modules/hardware/fw-fanctrl.nix
+++ b/nixos/modules/hardware/fw-fanctrl.nix
@@ -27,7 +27,7 @@ in
     config = lib.mkOption {
       default = { };
       description = ''
-        Additional config entries for the fw-fanctrl service (documentation: https://github.com/TamtamHero/fw-fanctrl/blob/main/doc/configuration.md)
+        Additional config entries for the fw-fanctrl service (documentation: <https://github.com/TamtamHero/fw-fanctrl/blob/main/doc/configuration.md>)
       '';
       type = lib.types.submodule {
         freeformType = configFormat.type;

--- a/nixos/modules/hardware/nfc-nci.nix
+++ b/nixos/modules/hardware/nfc-nci.nix
@@ -139,7 +139,7 @@ in
       default = defaultSettings;
       description = ''
         Configuration to be written to the libncf-nci configuration files.
-        To understand the configuration format, refer to https://github.com/NXPNFCLinux/linux_libnfc-nci/tree/master/conf.
+        To understand the configuration format, refer to <https://github.com/NXPNFCLinux/linux_libnfc-nci/tree/master/conf>.
       '';
       type = lib.types.attrs;
     };

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -229,7 +229,7 @@ in
 
         Warning: This feature is relatively new, depending on your system this might
         work poorly. AMD support, especially so.
-        See: https://forums.developer.nvidia.com/t/the-all-new-outputsink-feature-aka-reverse-prime/129828
+        See: <https://forums.developer.nvidia.com/t/the-all-new-outputsink-feature-aka-reverse-prime/129828>
 
         Note that this option only has any effect if the "nvidia" driver is specified
         in {option}`services.xserver.videoDrivers`, and it should preferably

--- a/nixos/modules/programs/firefox.nix
+++ b/nixos/modules/programs/firefox.nix
@@ -268,7 +268,7 @@ in
         AutoConfig files can be used to set and lock preferences that are not covered
         by the policies.json for Mac and Linux. This method can be used to automatically
         change user preferences or prevent the end user from modifiying specific
-        preferences by locking them. More info can be found in https://support.mozilla.org/en-US/kb/customizing-firefox-using-autoconfig.
+        preferences by locking them. More info can be found in <https://support.mozilla.org/en-US/kb/customizing-firefox-using-autoconfig>.
       '';
     };
 
@@ -279,7 +279,7 @@ in
         AutoConfig files can be used to set and lock preferences that are not covered
         by the policies.json for Mac and Linux. This method can be used to automatically
         change user preferences or prevent the end user from modifiying specific
-        preferences by locking them. More info can be found in https://support.mozilla.org/en-US/kb/customizing-firefox-using-autoconfig.
+        preferences by locking them. More info can be found in <https://support.mozilla.org/en-US/kb/customizing-firefox-using-autoconfig>.
 
         Files are concated and autoConfig is appended.
       '';

--- a/nixos/modules/programs/lazygit.nix
+++ b/nixos/modules/programs/lazygit.nix
@@ -22,7 +22,7 @@ in
       description = ''
         Lazygit configuration.
 
-        See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md for documentation.
+        See <https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md> for documentation.
       '';
     };
   };

--- a/nixos/modules/programs/nautilus-open-any-terminal.nix
+++ b/nixos/modules/programs/nautilus-open-any-terminal.nix
@@ -17,7 +17,7 @@ in
       default = null;
       description = ''
         The terminal emulator to add to context-entry of nautilus. Supported terminal
-        emulators are listed in https://github.com/Stunkymonkey/nautilus-open-any-terminal#supported-terminal-emulators.
+        emulators are listed in <https://github.com/Stunkymonkey/nautilus-open-any-terminal#supported-terminal-emulators>.
       '';
     };
   };

--- a/nixos/modules/programs/ryzen-monitor-ng.nix
+++ b/nixos/modules/programs/ryzen-monitor-ng.nix
@@ -18,7 +18,7 @@ in
 
         SMU Set and Get for many parameters and CO counts.
 
-        https://github.com/mann1x/ryzen_monitor_ng
+        <https://github.com/mann1x/ryzen_monitor_ng>
 
         WARNING: Damage cause by use of your AMD processor outside of official AMD specifications or outside of factory settings are not covered under any AMD product warranty and may not be covered by your board or system manufacturer's warranty
       '';

--- a/nixos/modules/programs/starship.nix
+++ b/nixos/modules/programs/starship.nix
@@ -62,7 +62,7 @@ in
       description = ''
         Configuration included in `starship.toml`.
 
-        See https://starship.rs/config/#prompt for documentation.
+        See <https://starship.rs/config/#prompt> for documentation.
       '';
     };
 

--- a/nixos/modules/programs/yazi.nix
+++ b/nixos/modules/programs/yazi.nix
@@ -37,7 +37,7 @@ in
                     description = ''
                       Configuration included in `${name}.toml`.
 
-                      See https://yazi-rs.github.io/docs/configuration/${name}/ for documentation.
+                      See <https://yazi-rs.github.io/docs/configuration/${name}/> for documentation.
                     '';
                   }
                 )
@@ -71,7 +71,7 @@ in
       description = ''
         Lua plugins.
 
-        See https://yazi-rs.github.io/docs/plugins/overview/ for documentation.
+        See <https://yazi-rs.github.io/docs/plugins/overview/> for documentation.
       '';
       example = lib.literalExpression ''
         {
@@ -92,7 +92,7 @@ in
       description = ''
         Pre-made themes.
 
-        See https://yazi-rs.github.io/docs/flavors/overview/ for documentation.
+        See <https://yazi-rs.github.io/docs/flavors/overview/> for documentation.
       '';
       example = lib.literalExpression ''
         {

--- a/nixos/modules/programs/zsh/oh-my-zsh.nix
+++ b/nixos/modules/programs/zsh/oh-my-zsh.nix
@@ -117,7 +117,7 @@ in
         default = "";
         description = ''
           Shell commands executed before the `oh-my-zsh` is loaded.
-          For example, to disable async git prompt write `zstyle ':omz:alpha:lib:git' async-prompt no` (more information https://github.com/ohmyzsh/ohmyzsh?tab=readme-ov-file#async-git-prompt)
+          For example, to disable async git prompt write `zstyle ':omz:alpha:lib:git' async-prompt no` (more information <https://github.com/ohmyzsh/ohmyzsh?tab=readme-ov-file#async-git-prompt>)
         '';
       };
     };

--- a/nixos/modules/services/amqp/rabbitmq.nix
+++ b/nixos/modules/services/amqp/rabbitmq.nix
@@ -109,8 +109,8 @@ in
           will be merged into these options by RabbitMQ at runtime to
           form the final configuration.
 
-          See https://www.rabbitmq.com/configure.html#config-items
-          For the distinct formats, see https://www.rabbitmq.com/configure.html#config-file-formats
+          See <https://www.rabbitmq.com/configure.html#config-items>
+          For the distinct formats, see <https://www.rabbitmq.com/configure.html#config-file-formats>
         '';
       };
 
@@ -127,8 +127,8 @@ in
           The contents of this option will be merged into the `configItems`
           by RabbitMQ at runtime to form the final configuration.
 
-          See the second table on https://www.rabbitmq.com/configure.html#config-items
-          For the distinct formats, see https://www.rabbitmq.com/configure.html#config-file-formats
+          See the second table on <https://www.rabbitmq.com/configure.html#config-items>
+          For the distinct formats, see <https://www.rabbitmq.com/configure.html#config-file-formats>
         '';
       };
 

--- a/nixos/modules/services/audio/alsa.nix
+++ b/nixos/modules/services/audio/alsa.nix
@@ -278,7 +278,7 @@ in
         The content of the system-wide ALSA configuration (/etc/asound.conf).
 
         Documentation of the configuration language and examples can be found
-        in the unofficial ALSA wiki: https://alsa.opensrc.org/Asoundrc
+        in the unofficial ALSA wiki: <https://alsa.opensrc.org/Asoundrc>
       '';
     };
 

--- a/nixos/modules/services/backup/borgmatic.nix
+++ b/nixos/modules/services/backup/borgmatic.nix
@@ -131,7 +131,7 @@ in
 
     settings = lib.mkOption {
       description = ''
-        See https://torsion.org/borgmatic/docs/reference/configuration/
+        See <https://torsion.org/borgmatic/docs/reference/configuration/>
       '';
       default = null;
       type = lib.types.nullOr cfgType;
@@ -139,7 +139,7 @@ in
 
     configurations = lib.mkOption {
       description = ''
-        Set of borgmatic configurations, see https://torsion.org/borgmatic/docs/reference/configuration/
+        Set of borgmatic configurations, see <https://torsion.org/borgmatic/docs/reference/configuration/>
       '';
       default = { };
       type = lib.types.attrsOf cfgType;

--- a/nixos/modules/services/cluster/k3s/default.nix
+++ b/nixos/modules/services/cluster/k3s/default.nix
@@ -293,7 +293,7 @@ let
           description = ''
             Extra HelmChart field definitions that are merged with the rest of the HelmChart
             custom resource. This can be used to set advanced fields or to overwrite
-            generated fields. See https://docs.k3s.io/helm#helmchart-field-definitions
+            generated fields. See <https://docs.k3s.io/helm#helmchart-field-definitions>
             for possible fields.
           '';
         };

--- a/nixos/modules/services/continuous-integration/buildbot/master.nix
+++ b/nixos/modules/services/continuous-integration/buildbot/master.nix
@@ -86,7 +86,7 @@ in
 
       configurators = lib.mkOption {
         type = lib.types.listOf lib.types.str;
-        description = "Configurator Steps, see https://docs.buildbot.net/latest/manual/configuration/configurators.html";
+        description = "Configurator Steps, see <https://docs.buildbot.net/latest/manual/configuration/configurators.html>";
         default = [ ];
         example = [
           "util.JanitorConfigurator(logHorizon=timedelta(weeks=4), hour=12, dayOfWeek=6)"

--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -126,7 +126,7 @@ in
           settings = mkOption {
             description = ''
               Configuration for `act_runner daemon`.
-              See https://gitea.com/gitea/act_runner/src/branch/main/internal/pkg/config/config.example.yaml for an example configuration
+              See <https://gitea.com/gitea/act_runner/src/branch/main/internal/pkg/config/config.example.yaml> for an example configuration
             '';
 
             type = types.submodule {

--- a/nixos/modules/services/databases/dgraph.nix
+++ b/nixos/modules/services/databases/dgraph.nix
@@ -75,7 +75,7 @@ in
         type = settingsFormat.type;
         default = { };
         description = ''
-          Contents of the dgraph config. For more details see https://dgraph.io/docs/deploy/config
+          Contents of the dgraph config. For more details see <https://dgraph.io/docs/deploy/config>
         '';
       };
 

--- a/nixos/modules/services/databases/postgresql.md
+++ b/nixos/modules/services/databases/postgresql.md
@@ -56,8 +56,8 @@ invalidated most of its previous use cases:
 - psql >= 15 instead gives only the database owner create permissions
 - Even on psql < 15 (or databases migrated to >= 15), it is
   recommended to manually assign permissions along these lines
-  - https://www.postgresql.org/docs/release/15.0/
-  - https://www.postgresql.org/docs/15/ddl-schemas.html#DDL-SCHEMAS-PRIV
+  - <https://www.postgresql.org/docs/release/15.0/>
+  - <https://www.postgresql.org/docs/15/ddl-schemas.html#DDL-SCHEMAS-PRIV>
 
 ### Assigning ownership {#module-services-postgres-initializing-ownership}
 

--- a/nixos/modules/services/development/blackfire.nix
+++ b/nixos/modules/services/development/blackfire.nix
@@ -25,7 +25,7 @@ in
       enable = lib.mkEnableOption "Blackfire profiler agent";
       settings = lib.mkOption {
         description = ''
-          See https://blackfire.io/docs/up-and-running/configuration/agent
+          See <https://blackfire.io/docs/up-and-running/configuration/agent>
         '';
         type = lib.types.submodule {
           freeformType = with lib.types; attrsOf str;
@@ -36,7 +36,7 @@ in
               description = ''
                 Sets the server id used to authenticate with Blackfire
 
-                You can find your personal server-id at https://blackfire.io/my/settings/credentials
+                You can find your personal server-id at <https://blackfire.io/my/settings/credentials>
               '';
             };
 
@@ -45,7 +45,7 @@ in
               description = ''
                 Sets the server token used to authenticate with Blackfire
 
-                You can find your personal server-token at https://blackfire.io/my/settings/credentials
+                You can find your personal server-token at <https://blackfire.io/my/settings/credentials>
               '';
             };
           };

--- a/nixos/modules/services/development/jupyter/default.nix
+++ b/nixos/modules/services/development/jupyter/default.nix
@@ -126,7 +126,7 @@ in
       type = lib.types.str;
       description = ''
         Password to use with notebook.
-        Can be generated following: https://jupyter-server.readthedocs.io/en/stable/operators/public-server.html#preparing-a-hashed-password
+        Can be generated following: <https://jupyter-server.readthedocs.io/en/stable/operators/public-server.html#preparing-a-hashed-password>
       '';
       example = "argon2:$argon2id$v=19$m=10240,t=10,p=8$48hF+vTUuy1LB83/GzNhUg$J1nx4jPWD7PwOJHs5OtDW8pjYK2s0c1R3rYGbSIKB54";
     };

--- a/nixos/modules/services/development/jupyterhub/default.nix
+++ b/nixos/modules/services/development/jupyterhub/default.nix
@@ -64,7 +64,7 @@ in
         Extra contents appended to the jupyterhub configuration
 
         Jupyterhub configuration is a normal python file using
-        Traitlets. https://jupyterhub.readthedocs.io/en/stable/getting-started/config-basics.html. The
+        Traitlets. <https://jupyterhub.readthedocs.io/en/stable/getting-started/config-basics.html>. The
         base configuration of this module was designed to have sane
         defaults for configuration but you can override anything since
         this is a python file.

--- a/nixos/modules/services/games/mchprs.nix
+++ b/nixos/modules/services/games/mchprs.nix
@@ -201,7 +201,7 @@ in
 
         description = ''
           Configuration for MCHPRS via `Config.toml`.
-          See https://github.com/MCHPR/MCHPRS/blob/master/README.md for documentation.
+          See <https://github.com/MCHPR/MCHPRS/blob/master/README.md> for documentation.
         '';
       };
 

--- a/nixos/modules/services/hardware/display.md
+++ b/nixos/modules/services/hardware/display.md
@@ -74,7 +74,7 @@ Under the hood it adds `drm.edid_firmware` entry to `boot.kernelParams` NixOS op
 ## Pulling files from linuxhw/EDID database {#module-hardware-display-edid-linuxhw}
 
 `hardware.display.edid.linuxhw` utilizes `pkgs.linuxhw-edid-fetcher` to extract EDID files
-from https://github.com/linuxhw/EDID based on simple string/regexp search identifying exact entries:
+from <https://github.com/linuxhw/EDID> based on simple string/regexp search identifying exact entries:
 
 ```nix
 {

--- a/nixos/modules/services/hardware/display.nix
+++ b/nixos/modules/services/hardware/display.nix
@@ -141,7 +141,7 @@ in
                 An EDID filename to be used for configured display, as in `edid/<filename>`.
                 See for more information:
                 - `hardware.display.edid.packages`
-                - https://wiki.archlinux.org/title/Kernel_mode_setting#Forcing_modes_and_EDID
+                - <https://wiki.archlinux.org/title/Kernel_mode_setting#Forcing_modes_and_EDID>
               '';
             };
             mode = lib.mkOption {
@@ -153,8 +153,8 @@ in
                     <xres>x<yres>[M][R][-<bpp>][@<refresh>][i][m][eDd]
 
                 See for more information:
-                - https://docs.kernel.org/fb/modedb.html
-                - https://wiki.archlinux.org/title/Kernel_mode_setting#Forcing_modes
+                - <https://docs.kernel.org/fb/modedb.html>
+                - <https://wiki.archlinux.org/title/Kernel_mode_setting#Forcing_modes>
               '';
               example = lib.literalExpression ''
                 "e"

--- a/nixos/modules/services/hardware/tlp.nix
+++ b/nixos/modules/services/hardware/tlp.nix
@@ -42,7 +42,7 @@ in
           USB_BLACKLIST_PHONE = 1;
         };
         description = ''
-          Options passed to TLP. See https://linrunner.de/tlp for all supported options..
+          Options passed to TLP. See <https://linrunner.de/tlp> for all supported options..
         '';
       };
 

--- a/nixos/modules/services/home-automation/matter-server.nix
+++ b/nixos/modules/services/home-automation/matter-server.nix
@@ -42,7 +42,7 @@ in
       default = [ ];
       description = ''
         Extra arguments to pass to the matter-server executable.
-        See https://github.com/home-assistant-libs/python-matter-server?tab=readme-ov-file#running-the-development-server for options.
+        See <https://github.com/home-assistant-libs/python-matter-server?tab=readme-ov-file#running-the-development-server> for options.
       '';
     };
   };

--- a/nixos/modules/services/mail/mailman.md
+++ b/nixos/modules/services/mail/mailman.md
@@ -48,7 +48,7 @@ DNS records will also be required:
 After this has been done and appropriate DNS records have been
 set up, the Postorius mailing list manager and the Hyperkitty
 archive browser will be available at
-https://lists.example.org/. Note that this setup is not
+`https://lists.example.org/`. Note that this setup is not
 sufficient to deliver emails to most email providers nor to
 avoid spam -- a number of additional measures for authenticating
 incoming and outgoing mails, such as SPF, DMARC and DKIM are

--- a/nixos/modules/services/mail/roundcube.nix
+++ b/nixos/modules/services/mail/roundcube.nix
@@ -68,7 +68,7 @@ in
         '';
         description = ''
           Password file for the postgresql connection.
-          Must be formatted according to PostgreSQL .pgpass standard (see https://www.postgresql.org/docs/current/libpq-pgpass.html)
+          Must be formatted according to PostgreSQL .pgpass standard (see <https://www.postgresql.org/docs/current/libpq-pgpass.html>)
           but only one line, no comments and readable by user `nginx`.
           Ignored if `database.host` is set to `localhost`, as peer authentication will be used.
         '';

--- a/nixos/modules/services/matrix/dendrite.nix
+++ b/nixos/modules/services/matrix/dendrite.nix
@@ -225,7 +225,7 @@ in
             description = ''
               The language most likely to be used on the server - used when indexing, to
               ensure the returned results match expectations. A full list of possible languages
-              can be found at https://github.com/blevesearch/bleve/tree/master/analysis/lang
+              can be found at <https://github.com/blevesearch/bleve/tree/master/analysis/lang>
             '';
           };
         };

--- a/nixos/modules/services/matrix/maubot.md
+++ b/nixos/modules/services/matrix/maubot.md
@@ -33,7 +33,7 @@ framework for Matrix.
 4. Optionally, set `services.maubot.pythonPackages` to a list of python3
    packages to make available for Maubot plugins.
 5. Optionally, set `services.maubot.plugins` to a list of Maubot
-   plugins (full list available at https://plugins.maubot.xyz/):
+   plugins (full list available at <https://plugins.maubot.xyz/>):
    ```nix
    {
      services.maubot.plugins = with config.services.maubot.package.plugins; [

--- a/nixos/modules/services/misc/dwm-status.nix
+++ b/nixos/modules/services/misc/dwm-status.nix
@@ -66,7 +66,7 @@ in
           };
         };
         description = ''
-          Config options for dwm-status, see https://github.com/Gerschtli/dwm-status#configuration
+          Config options for dwm-status, see <https://github.com/Gerschtli/dwm-status#configuration>
           for available options.
         '';
       };

--- a/nixos/modules/services/misc/radicle.nix
+++ b/nixos/modules/services/misc/radicle.nix
@@ -199,7 +199,7 @@ in
         };
       settings = lib.mkOption {
         description = ''
-          See https://app.radicle.xyz/nodes/seed.radicle.garden/rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5/tree/radicle/src/node/config.rs#L275
+          See <https://app.radicle.xyz/nodes/seed.radicle.garden/rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5/tree/radicle/src/node/config.rs#L275>
         '';
         default = { };
         example = lib.literalExpression ''

--- a/nixos/modules/services/misc/renovate.nix
+++ b/nixos/modules/services/misc/renovate.nix
@@ -75,7 +75,7 @@ in
         Extra environment variables to export to the Renovate process
         from the systemd unit configuration.
 
-        See https://docs.renovatebot.com/config-overview for available environment variables.
+        See <https://docs.renovatebot.com/config-overview> for available environment variables.
       '';
       example = {
         LOG_LEVEL = "debug";
@@ -104,7 +104,7 @@ in
         Renovate's global configuration.
         If you want to pass secrets to renovate, please use {option}`services.renovate.credentials` for that.
 
-        See https://docs.renovatebot.com/config-overview for available settings.
+        See <https://docs.renovatebot.com/config-overview> for available settings.
       '';
     };
   };

--- a/nixos/modules/services/misc/tabby.nix
+++ b/nixos/modules/services/misc/tabby.nix
@@ -70,7 +70,7 @@ in
           $ sudo chown -R tabby:tabby /var/lib/tabby/models/
 
           See for Model Options:
-          > https://github.com/TabbyML/registry-tabby
+          > <https://github.com/TabbyML/registry-tabby>
         '';
       };
 
@@ -114,7 +114,7 @@ in
           Enable sending anonymous usage data.
 
           See for more details:
-          > https://tabby.tabbyml.com/docs/configuration#usage-collection
+          > <https://tabby.tabbyml.com/docs/configuration#usage-collection>
         '';
       };
     };

--- a/nixos/modules/services/monitoring/glpi-agent.nix
+++ b/nixos/modules/services/monitoring/glpi-agent.nix
@@ -45,7 +45,7 @@ in
         default = { };
         description = ''
           GLPI Agent configuration options.
-          See https://glpi-agent.readthedocs.io/en/latest/configuration.html for all available options.
+          See <https://glpi-agent.readthedocs.io/en/latest/configuration.html> for all available options.
 
           The 'server' option is mandatory and must point to your GLPI server.
         '';

--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -1904,7 +1904,7 @@ in
       default = null;
       description = ''
         Specifies which file should be used as web.config.file and be passed on startup.
-        See https://prometheus.io/docs/prometheus/latest/configuration/https/ for valid options.
+        See <https://prometheus.io/docs/prometheus/latest/configuration/https/> for valid options.
       '';
     };
 

--- a/nixos/modules/services/monitoring/prometheus/exporters/ecoflow.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/ecoflow.nix
@@ -29,7 +29,7 @@ in
       type = types.path;
       default = /etc/ecoflow-access-key;
       description = ''
-        Path to the file with your personal api access string from the Ecoflow development website https://developer-eu.ecoflow.com.
+        Path to the file with your personal api access string from the Ecoflow development website <https://developer-eu.ecoflow.com>.
         Do to share or commit your plaintext scecrets to a public repo use: agenix or soaps.
       '';
     };
@@ -37,7 +37,7 @@ in
       type = types.path;
       default = /etc/ecoflow-secret-key;
       description = ''
-        Path to the file with your personal api secret string from the Ecoflow development website https://developer-eu.ecoflow.com.
+        Path to the file with your personal api secret string from the Ecoflow development website <https://developer-eu.ecoflow.com>.
         Do to share or commit your plaintext scecrets to a public repo use: agenix or soaps.
       '';
     };

--- a/nixos/modules/services/monitoring/prometheus/exporters/pgbouncer.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/pgbouncer.nix
@@ -82,7 +82,7 @@ in
         needs to have read access to files owned by the PgBouncer process. Depends on
         the availability of /proc.
 
-        https://prometheus.io/docs/instrumenting/writing_clientlibs/#process-metrics.
+        <https://prometheus.io/docs/instrumenting/writing_clientlibs/#process-metrics>.
 
       '';
     };

--- a/nixos/modules/services/monitoring/prometheus/exporters/pve.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/pve.nix
@@ -38,7 +38,7 @@ in
 
         The environment file should NOT be stored in /nix/store as it contains passwords and/or keys in plain text.
 
-        Environment reference: https://github.com/prometheus-pve/prometheus-pve-exporter#authentication
+        Environment reference: <https://github.com/prometheus-pve/prometheus-pve-exporter#authentication>
       '';
     };
 
@@ -53,7 +53,7 @@ in
 
         If both configFile and environmentFile are provided, the configFile option will be ignored.
 
-        Configuration reference: https://github.com/prometheus-pve/prometheus-pve-exporter/#authentication
+        Configuration reference: <https://github.com/prometheus-pve/prometheus-pve-exporter/#authentication>
       '';
     };
 

--- a/nixos/modules/services/monitoring/prometheus/exporters/tibber.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/tibber.nix
@@ -16,7 +16,7 @@ in
       default = null;
       description = ''
         Add here the path to your personal Tibber API Token ('Bearer Token') File.
-        Get your personal Tibber API Token here: https://developer.tibber.com
+        Get your personal Tibber API Token here: <https://developer.tibber.com>
         Do not share your personal plaintext Tibber API Token via github. (see: ryantm/agenix, mic92/sops)
       '';
     };

--- a/nixos/modules/services/network-filesystems/ipfs-cluster.nix
+++ b/nixos/modules/services/network-filesystems/ipfs-cluster.nix
@@ -26,7 +26,7 @@ in
           "raft"
           "crdt"
         ];
-        description = "Consensus protocol - 'raft' or 'crdt'. https://cluster.ipfs.io/documentation/guides/consensus/";
+        description = "Consensus protocol - 'raft' or 'crdt'. <https://cluster.ipfs.io/documentation/guides/consensus/>";
       };
 
       dataDir = lib.mkOption {
@@ -44,7 +44,7 @@ in
       openSwarmPort = lib.mkOption {
         type = lib.types.bool;
         default = false;
-        description = "Open swarm port, secured by the cluster secret. This does not expose the API or proxy. https://cluster.ipfs.io/documentation/guides/security/";
+        description = "Open swarm port, secured by the cluster secret. This does not expose the API or proxy. <https://cluster.ipfs.io/documentation/guides/security/>";
       };
 
       secretFile = lib.mkOption {

--- a/nixos/modules/services/network-filesystems/xtreemfs.nix
+++ b/nixos/modules/services/network-filesystems/xtreemfs.nix
@@ -186,7 +186,7 @@ in
           description = ''
             Configuration of XtreemFS DIR service.
             WARNING: configuration is saved as plaintext inside nix store.
-            For more options: https://www.xtreemfs.org/xtfs-guide-1.5.1/index.html
+            For more options: <https://www.xtreemfs.org/xtfs-guide-1.5.1/index.html>
           '';
         };
         replication = {
@@ -228,7 +228,7 @@ in
             description = ''
               Configuration of XtreemFS DIR replication plugin.
               WARNING: configuration is saved as plaintext inside nix store.
-              For more options: https://www.xtreemfs.org/xtfs-guide-1.5.1/index.html
+              For more options: <https://www.xtreemfs.org/xtfs-guide-1.5.1/index.html>
             '';
           };
         };
@@ -335,7 +335,7 @@ in
           description = ''
             Configuration of XtreemFS MRC service.
             WARNING: configuration is saved as plaintext inside nix store.
-            For more options: https://www.xtreemfs.org/xtfs-guide-1.5.1/index.html
+            For more options: <https://www.xtreemfs.org/xtfs-guide-1.5.1/index.html>
           '';
         };
         replication = {
@@ -377,7 +377,7 @@ in
             description = ''
               Configuration of XtreemFS MRC replication plugin.
               WARNING: configuration is saved as plaintext inside nix store.
-              For more options: https://www.xtreemfs.org/xtfs-guide-1.5.1/index.html
+              For more options: <https://www.xtreemfs.org/xtfs-guide-1.5.1/index.html>
             '';
           };
         };
@@ -454,7 +454,7 @@ in
           description = ''
             Configuration of XtreemFS OSD service.
             WARNING: configuration is saved as plaintext inside nix store.
-            For more options: https://www.xtreemfs.org/xtfs-guide-1.5.1/index.html
+            For more options: <https://www.xtreemfs.org/xtfs-guide-1.5.1/index.html>
           '';
         };
       };

--- a/nixos/modules/services/network-filesystems/yandex-disk.nix
+++ b/nixos/modules/services/network-filesystems/yandex-disk.nix
@@ -26,7 +26,7 @@ in
         type = lib.types.bool;
         default = false;
         description = ''
-          Whether to enable Yandex-disk client. See https://disk.yandex.ru/
+          Whether to enable Yandex-disk client. See <https://disk.yandex.ru/>
         '';
       };
 

--- a/nixos/modules/services/networking/aria2.nix
+++ b/nixos/modules/services/networking/aria2.nix
@@ -85,7 +85,7 @@ in
         example = "/run/secrets/aria2-rpc-token.txt";
         description = ''
           A file containing the RPC secret authorization token.
-          Read https://aria2.github.io/manual/en/html/aria2c.html#rpc-auth to know how this option value is used.
+          Read <https://aria2.github.io/manual/en/html/aria2c.html#rpc-auth> to know how this option value is used.
         '';
       };
       downloadDirPermission = lib.mkOption {
@@ -121,7 +121,7 @@ in
           Generates the `aria2.conf` file. Refer to [the documentation][0] for
           all possible settings.
 
-          [0]: https://aria2.github.io/manual/en/html/aria2c.html#synopsis
+          [0]: <https://aria2.github.io/manual/en/html/aria2c.html#synopsis>
         '';
         default = { };
         type = lib.types.submodule {

--- a/nixos/modules/services/networking/crab-hole.nix
+++ b/nixos/modules/services/networking/crab-hole.nix
@@ -43,7 +43,7 @@ in
       };
 
       settings = lib.mkOption {
-        description = "Crab-holes config. See big example https://github.com/LuckyTurtleDev/crab-hole/blob/main/example-config.toml";
+        description = "Crab-holes config. See big example <https://github.com/LuckyTurtleDev/crab-hole/blob/main/example-config.toml>";
 
         example = {
           downstream = [

--- a/nixos/modules/services/networking/doh-server.md
+++ b/nixos/modules/services/networking/doh-server.md
@@ -69,4 +69,4 @@ in
 }
 ```
 
-See a full configuration in https://github.com/m13253/dns-over-https/blob/master/doh-server/doh-server.conf.
+See a full configuration in <https://github.com/m13253/dns-over-https/blob/master/doh-server/doh-server.conf>.

--- a/nixos/modules/services/networking/doh-server.nix
+++ b/nixos/modules/services/networking/doh-server.nix
@@ -116,7 +116,7 @@ in
         listen = [ ":8153" ];
         upstream = [ "udp:127.0.0.1:53" ];
       };
-      description = "Configuration of doh-server in toml. See example in https://github.com/m13253/dns-over-https/blob/master/doh-server/doh-server.conf";
+      description = "Configuration of doh-server in toml. See example in <https://github.com/m13253/dns-over-https/blob/master/doh-server/doh-server.conf>";
     };
 
     useACMEHost = lib.mkOption {

--- a/nixos/modules/services/networking/mihomo.nix
+++ b/nixos/modules/services/networking/mihomo.nix
@@ -31,13 +31,13 @@ in
 
         You can also use the following website:
         - metacubexd:
-          - https://d.metacubex.one
-          - https://metacubex.github.io/metacubexd
-          - https://metacubexd.pages.dev
+          - <https://d.metacubex.one>
+          - <https://metacubex.github.io/metacubexd>
+          - <https://metacubexd.pages.dev>
         - yacd:
-          - https://yacd.haishan.me
+          - <https://yacd.haishan.me>
         - clash-dashboard:
-          - https://clash.razord.top
+          - <https://clash.razord.top>
       '';
     };
 

--- a/nixos/modules/services/networking/monero.nix
+++ b/nixos/modules/services/networking/monero.nix
@@ -80,7 +80,7 @@ in
           Path to a text file containing IPs to block.
           Useful to prevent DDoS/deanonymization attacks.
 
-          https://github.com/monero-project/meta/issues/1124
+          <https://github.com/monero-project/meta/issues/1124>
         '';
         example = lib.literalExpression ''
           builtins.fetchurl {
@@ -222,7 +222,7 @@ in
         default = false;
         description = ''
           Whether to prune the blockchain.
-          https://www.getmonero.org/resources/moneropedia/pruning.html
+          <https://www.getmonero.org/resources/moneropedia/pruning.html>
         '';
       };
 

--- a/nixos/modules/services/networking/morty.nix
+++ b/nixos/modules/services/networking/morty.nix
@@ -21,7 +21,7 @@ in
 
     services.morty = {
 
-      enable = mkEnableOption "Morty proxy server. See https://github.com/asciimoo/morty";
+      enable = mkEnableOption "Morty proxy server. See <https://github.com/asciimoo/morty>";
 
       ipv6 = mkOption {
         type = types.bool;

--- a/nixos/modules/services/networking/mycelium.nix
+++ b/nixos/modules/services/networking/mycelium.nix
@@ -49,7 +49,7 @@ in
       type = lib.types.bool;
       default = true;
       description = ''
-        Adds the hosted peers from https://github.com/threefoldtech/mycelium#hosted-public-nodes.
+        Adds the hosted peers from <https://github.com/threefoldtech/mycelium#hosted-public-nodes>.
       '';
     };
     extraArgs = lib.mkOption {

--- a/nixos/modules/services/networking/newt.nix
+++ b/nixos/modules/services/networking/newt.nix
@@ -44,7 +44,7 @@ in
         type = with lib.types; nullOr path;
         default = null;
         description = ''
-          Path to a file containing sensitive environment variables for Newt. See https://docs.fossorial.io/Newt/overview#cli-args
+          Path to a file containing sensitive environment variables for Newt. See <https://docs.fossorial.io/Newt/overview#cli-args>
           These will overwrite anything defined in the config.
           The file should contain environment-variable assignments like:
           NEWT_ID=2ix2t8xk22ubpfy

--- a/nixos/modules/services/networking/nghttpx/backend-submodule.nix
+++ b/nixos/modules/services/networking/nghttpx/backend-submodule.nix
@@ -28,7 +28,7 @@
       description = ''
         List of nghttpx backend patterns.
 
-        Please see https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx-b
+        Please see <https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx-b>
         for more information on the pattern syntax and nghttpxs behavior.
       '';
     };

--- a/nixos/modules/services/networking/nghttpx/frontend-params-submodule.nix
+++ b/nixos/modules/services/networking/nghttpx/frontend-params-submodule.nix
@@ -11,7 +11,7 @@
         Enable or disable TLS. If true (enabled) the key and
         certificate must be configured for nghttpx.
 
-        Please see https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx-f
+        Please see <https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx-f>
         for more detail.
       '';
     };
@@ -24,7 +24,7 @@
         name received from the client is used instead of the request
         host. See --backend option about the pattern match.
 
-        Please see https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx-f
+        Please see <https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx-f>
         for more detail.
       '';
     };
@@ -37,7 +37,7 @@
         dynamically modify nghttpx at run-time therefore this feature
         is disabled by default and should be turned on with care.
 
-        Please see https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx-f
+        Please see <https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx-f>
         for more detail.
       '';
     };
@@ -49,7 +49,7 @@
         Make this frontend a health monitor endpoint. Any request
         received on this frontend is responded to with a 200 OK.
 
-        Please see https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx-f
+        Please see <https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx-f>
         for more detail.
       '';
     };
@@ -60,7 +60,7 @@
       description = ''
         Accept PROXY protocol version 1 on frontend connection.
 
-        Please see https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx-f
+        Please see <https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx-f>
         for more detail.
       '';
     };

--- a/nixos/modules/services/networking/nghttpx/nghttpx-options.nix
+++ b/nixos/modules/services/networking/nghttpx/nghttpx-options.nix
@@ -77,7 +77,7 @@
         is used. In the single process mode, the signal handling
         feature is disabled.
 
-        Please see https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx--single-process
+        Please see <https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx--single-process>
       '';
     };
 
@@ -87,7 +87,7 @@
       description = ''
         Listen backlog size.
 
-        Please see https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx--backlog
+        Please see <https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx--backlog>
       '';
     };
 
@@ -104,7 +104,7 @@
         only IPv4 address is considered. If "IPv6" is given, only IPv6
         address is considered.
 
-        Please see https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx--backend-address-family
+        Please see <https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx--backend-address-family>
       '';
     };
 
@@ -114,7 +114,7 @@
       description = ''
         Set the number of worker threads.
 
-        Please see https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx-n
+        Please see <https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx-n>
       '';
     };
 
@@ -127,7 +127,7 @@
         the platforms which lack thread support. If threading is
         disabled, this option is always enabled.
 
-        Please see https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx--single-thread
+        Please see <https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx--single-thread>
       '';
     };
 
@@ -138,7 +138,7 @@
         Set maximum number of open files (RLIMIT_NOFILE) to \<N\>. If 0
         is given, nghttpx does not set the limit.
 
-        Please see https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx--rlimit-nofile
+        Please see <https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx--rlimit-nofile>
       '';
     };
   };

--- a/nixos/modules/services/networking/nm-file-secret-agent.nix
+++ b/nixos/modules/services/networking/nm-file-secret-agent.nix
@@ -84,7 +84,7 @@ in
                   The NetworkManager configuration settings reference roughly corresponds to connection types.
                   More might be available on your system depending on the installed plugins.
 
-                  https://networkmanager.dev/docs/api/latest/ch01.html
+                  <https://networkmanager.dev/docs/api/latest/ch01.html>
                 '';
                 type = lib.types.nullOr lib.types.str;
                 default = null;

--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -43,7 +43,7 @@ in
           Enable Docker support. Needed for Nomad's docker driver.
 
           Note that the docker group membership is effectively equivalent
-          to being root, see https://github.com/moby/moby/issues/9976.
+          to being root, see <https://github.com/moby/moby/issues/9976>.
         '';
       };
 

--- a/nixos/modules/services/networking/openconnect.nix
+++ b/nixos/modules/services/networking/openconnect.nix
@@ -81,7 +81,7 @@ let
           Extra config to be appended to the interface config. It should
           contain long-format options as would be accepted on the command
           line by `openconnect`
-          (see https://www.infradead.org/openconnect/manual.html).
+          (see <https://www.infradead.org/openconnect/manual.html>).
           Non-key-value options like `deflate` can be used by
           declaring them as booleans, i. e. `deflate = true;`.
         '';

--- a/nixos/modules/services/networking/pdns-recursor.nix
+++ b/nixos/modules/services/networking/pdns-recursor.nix
@@ -181,7 +181,7 @@ in
       default = "validate";
       description = ''
         Controls the level of DNSSEC processing done by the PowerDNS Recursor.
-        See https://doc.powerdns.com/md/recursor/dnssec/ for a detailed explanation.
+        See <https://doc.powerdns.com/md/recursor/dnssec/> for a detailed explanation.
       '';
     };
 

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -763,7 +763,7 @@ in
           Force certificate authentication for server-to-server connections?
           This provides ideal security, but requires servers you communicate
           with to support encryption AND present valid, trusted certificates.
-          For more information see https://prosody.im/doc/s2s#security
+          For more information see <https://prosody.im/doc/s2s#security>
         '';
       };
 

--- a/nixos/modules/services/networking/sing-box.nix
+++ b/nixos/modules/services/networking/sing-box.nix
@@ -30,7 +30,7 @@ in
         };
         default = { };
         description = ''
-          The sing-box configuration, see https://sing-box.sagernet.org/configuration/ for documentation.
+          The sing-box configuration, see <https://sing-box.sagernet.org/configuration/> for documentation.
 
           Options containing secret data should be set to an attribute set
           containing the attribute `_secret` - a string pointing to a file

--- a/nixos/modules/services/networking/sunshine.nix
+++ b/nixos/modules/services/networking/sunshine.nix
@@ -60,7 +60,7 @@ in
       description = ''
         Settings to be rendered into the configuration file. If this is set, no configuration is possible from the web UI.
 
-        See https://docs.lizardbyte.dev/projects/sunshine/en/latest/about/advanced_usage.html#configuration for syntax.
+        See <https://docs.lizardbyte.dev/projects/sunshine/en/latest/about/advanced_usage.html#configuration for syntax>.
       '';
       example = literalExpression ''
         {
@@ -73,7 +73,7 @@ in
           type = port;
           default = defaultPort;
           description = ''
-            Base port -- others used are offset from this one, see https://docs.lizardbyte.dev/projects/sunshine/en/latest/about/advanced_usage.html#port for details.
+            Base port -- others used are offset from this one, see <https://docs.lizardbyte.dev/projects/sunshine/en/latest/about/advanced_usage.html#port> for details.
           '';
         };
       });

--- a/nixos/modules/services/networking/tailscale.nix
+++ b/nixos/modules/services/networking/tailscale.nix
@@ -104,7 +104,7 @@ in
       default = { };
       description = ''
         Extra parameters to pass after the auth key.
-        See https://tailscale.com/kb/1215/oauth-clients#registering-new-nodes-using-oauth-credentials
+        See <https://tailscale.com/kb/1215/oauth-clients#registering-new-nodes-using-oauth-credentials>
       '';
     };
 

--- a/nixos/modules/services/networking/umurmur.nix
+++ b/nixos/modules/services/networking/umurmur.nix
@@ -164,7 +164,7 @@ in
           };
         };
         default = { };
-        description = "Settings of uMurmur. For reference see https://github.com/umurmur/umurmur/blob/master/umurmur.conf.example";
+        description = "Settings of uMurmur. For reference see <https://github.com/umurmur/umurmur/blob/master/umurmur.conf.example>";
       };
 
       configFile = lib.mkOption rec {

--- a/nixos/modules/services/networking/zerobin.nix
+++ b/nixos/modules/services/networking/zerobin.nix
@@ -72,7 +72,7 @@ in
         '';
         description = ''
           Extra configuration to be appended to the 0bin config file
-          (see https://0bin.readthedocs.org/en/latest/en/options.html)
+          (see <https://0bin.readthedocs.org/en/latest/en/options.html>)
         '';
       };
     };

--- a/nixos/modules/services/scheduling/prefect.nix
+++ b/nixos/modules/services/scheduling/prefect.nix
@@ -123,7 +123,7 @@ in
     baseUrl = lib.mkOption {
       type = nullOr str;
       default = null;
-      description = "external url when served by a reverse proxy, e.g. https://example.com/prefect";
+      description = "external url when served by a reverse proxy, e.g. `https://example.com/prefect`";
     };
   };
 

--- a/nixos/modules/services/security/authelia.nix
+++ b/nixos/modules/services/security/authelia.nix
@@ -48,7 +48,7 @@ let
             as the values will be preserved in your nix store.
             This attribute allows you to configure the location of secret files to be loaded at runtime.
 
-            https://www.authelia.com/configuration/methods/secrets/
+            <https://www.authelia.com/configuration/methods/secrets/>
           '';
           default = { };
           type = types.submodule {
@@ -117,7 +117,7 @@ let
             If you are providing secrets please consider the options under {option}`services.authelia.<instance>.secrets`
             or make sure you use the `_FILE` suffix.
             If you provide the raw secret rather than the location of a secret file that secret will be preserved in the nix store.
-            For more details: https://www.authelia.com/configuration/methods/secrets/
+            For more details: <https://www.authelia.com/configuration/methods/secrets/>
           '';
           default = { };
         };
@@ -128,7 +128,7 @@ let
             There are several values that are defined and documented in nix such as `default_2fa_method`,
             but additional items can also be included.
 
-            https://github.com/authelia/authelia/blob/master/config.template.yml
+            <https://github.com/authelia/authelia/blob/master/config.template.yml>
           '';
           default = { };
           example = ''
@@ -284,7 +284,7 @@ in
         Multi-domain protection currently requires multiple instances of Authelia.
         If you don't require multiple instances of Authelia you can define just the one.
 
-        https://www.authelia.com/roadmap/active/multi-domain-protection/
+        <https://www.authelia.com/roadmap/active/multi-domain-protection/>
       '';
       example = ''
         {

--- a/nixos/modules/services/security/bitwarden-directory-connector-cli.nix
+++ b/nixos/modules/services/security/bitwarden-directory-connector-cli.nix
@@ -150,7 +150,7 @@ in
             overwriteExisting = mkOption {
               type = types.bool;
               default = false;
-              description = "Remove and re-add users/groups, See https://bitwarden.com/help/user-group-filters/#overwriting-syncs for more details.";
+              description = "Remove and re-add users/groups, See <https://bitwarden.com/help/user-group-filters/#overwriting-syncs> for more details.";
             };
 
             largeImport = mkOption {

--- a/nixos/modules/services/system/cachix-agent/default.nix
+++ b/nixos/modules/services/system/cachix-agent/default.nix
@@ -11,7 +11,7 @@ in
   meta.maintainers = [ lib.maintainers.domenkozar ];
 
   options.services.cachix-agent = {
-    enable = lib.mkEnableOption "Cachix Deploy Agent: https://docs.cachix.org/deploy/";
+    enable = lib.mkEnableOption "Cachix Deploy Agent: <https://docs.cachix.org/deploy/>";
 
     name = lib.mkOption {
       type = lib.types.str;

--- a/nixos/modules/services/system/cachix-watch-store.nix
+++ b/nixos/modules/services/system/cachix-watch-store.nix
@@ -14,7 +14,7 @@ in
   ];
 
   options.services.cachix-watch-store = {
-    enable = lib.mkEnableOption "Cachix Watch Store: https://docs.cachix.org";
+    enable = lib.mkEnableOption "Cachix Watch Store: <https://docs.cachix.org>";
 
     cacheName = lib.mkOption {
       type = lib.types.str;

--- a/nixos/modules/services/system/kerberos/kerberos-server.md
+++ b/nixos/modules/services/system/kerberos/kerberos-server.md
@@ -53,11 +53,11 @@ To enable a Kerberos server:
 
 ## Upstream Documentation {#module-services-kerberos-server-upstream-documentation}
 
-- MIT Kerberos homepage: https://web.mit.edu/kerberos
-- MIT Kerberos docs: https://web.mit.edu/kerberos/krb5-latest/doc/index.html
+- MIT Kerberos homepage: <https://web.mit.edu/kerberos>
+- MIT Kerberos docs: <https://web.mit.edu/kerberos/krb5-latest/doc/index.html>
 
-- Heimdal Kerberos GitHub wiki: https://github.com/heimdal/heimdal/wiki
-- Heimdal kerberos doc manpages (Debian unstable): https://manpages.debian.org/unstable/heimdal-docs/index.html
-- Heimdal Kerberos kdc manpages (Debian unstable): https://manpages.debian.org/unstable/heimdal-kdc/index.html
+- Heimdal Kerberos GitHub wiki: <https://github.com/heimdal/heimdal/wiki>
+- Heimdal kerberos doc manpages (Debian unstable): <https://manpages.debian.org/unstable/heimdal-docs/index.html>
+- Heimdal Kerberos kdc manpages (Debian unstable): <https://manpages.debian.org/unstable/heimdal-kdc/index.html>
 
 Note the version number in the URLs, it may be different for the latest version.

--- a/nixos/modules/services/system/zram-generator.nix
+++ b/nixos/modules/services/system/zram-generator.nix
@@ -25,7 +25,7 @@ in
       default = { };
       description = ''
         Configuration for zram-generator,
-        see https://github.com/systemd/zram-generator for documentation.
+        see <https://github.com/systemd/zram-generator> for documentation.
       '';
     };
   };

--- a/nixos/modules/services/torrent/opentracker.nix
+++ b/nixos/modules/services/torrent/opentracker.nix
@@ -17,7 +17,7 @@ in
       type = lib.types.separatedString " ";
       description = ''
         Configuration Arguments for opentracker
-        See https://erdgeist.org/arts/software/opentracker/ for all params
+        See <https://erdgeist.org/arts/software/opentracker/> for all params
       '';
       default = "";
     };

--- a/nixos/modules/services/video/frigate.nix
+++ b/nixos/modules/services/video/frigate.nix
@@ -190,8 +190,8 @@ in
 
         See also:
 
-        - https://docs.frigate.video/configuration/hardware_acceleration
-        - https://docs.frigate.video/configuration/ffmpeg_presets#hwaccel-presets
+        - <https://docs.frigate.video/configuration/hardware_acceleration>
+        - <https://docs.frigate.video/configuration/ffmpeg_presets#hwaccel-presets>
       '';
     };
 
@@ -217,7 +217,7 @@ in
             description = ''
               Attribute set of cameras configurations.
 
-              https://docs.frigate.video/configuration/cameras
+              <https://docs.frigate.video/configuration/cameras>
             '';
           };
 

--- a/nixos/modules/services/video/wivrn.nix
+++ b/nixos/modules/services/video/wivrn.nix
@@ -126,7 +126,7 @@ in
             Like upstream, the application option is a list including the application and it's flags. In the case of the NixOS module however, the first element of the list must be a package. The module will assert otherwise.
             The application can be set to a single package because it gets passed to lib.toList, though this will not allow for flags to be passed.
 
-            See https://github.com/WiVRn/WiVRn/blob/master/docs/configuration.md
+            See <https://github.com/WiVRn/WiVRn/blob/master/docs/configuration.md>
           '';
           default = { };
           example = literalExpression ''

--- a/nixos/modules/services/web-apps/castopod.md
+++ b/nixos/modules/services/web-apps/castopod.md
@@ -4,7 +4,7 @@ Castopod is an open-source hosting platform made for podcasters who want to enga
 
 ## Quickstart {#module-services-castopod-quickstart}
 
-Configure ACME (https://nixos.org/manual/nixos/unstable/#module-security-acme).
+Configure ACME (<https://nixos.org/manual/nixos/unstable/#module-security-acme>).
 Use the following configuration to start a public instance of Castopod on `castopod.example.com` domain:
 
 ```nix

--- a/nixos/modules/services/web-apps/haven.nix
+++ b/nixos/modules/services/web-apps/haven.nix
@@ -48,9 +48,9 @@ in
 
     settings = lib.mkOption {
       default = defaultSettings;
-      defaultText = "See https://github.com/bitvora/haven/blob/master/.env.example";
+      defaultText = "See <https://github.com/bitvora/haven/blob/master/.env.example>";
       apply = lib.recursiveUpdate defaultSettings;
-      description = "See https://github.com/bitvora/haven for documentation.";
+      description = "See <https://github.com/bitvora/haven> for documentation.";
       example = lib.literalExpression ''
         {
           RELAY_URL = "relay.example.com";
@@ -63,7 +63,7 @@ in
       type = lib.types.nullOr lib.types.path;
       default = null;
       description = ''
-        Path to a file containing sensitive environment variables. See https://github.com/bitvora/haven for documentation.
+        Path to a file containing sensitive environment variables. See <https://github.com/bitvora/haven> for documentation.
         The file should contain environment-variable assignments like:
         S3_SECRET_KEY=mysecretkey
         S3_ACCESS_KEY_ID=myaccesskey

--- a/nixos/modules/services/web-apps/karakeep.nix
+++ b/nixos/modules/services/web-apps/karakeep.nix
@@ -34,7 +34,7 @@ in
           Environment variables to pass to Karakaeep. This is how most settings
           can be configured. Changing DATA_DIR is possible but not supported.
 
-          See https://docs.karakeep.app/configuration/
+          See <https://docs.karakeep.app/configuration/>
         '';
         type = lib.types.attrsOf lib.types.str;
         default = { };

--- a/nixos/modules/services/web-apps/lasuite-docs.nix
+++ b/nixos/modules/services/web-apps/lasuite-docs.nix
@@ -194,7 +194,7 @@ in
         description = ''
           Configuration options of collaboration server.
 
-          See https://github.com/suitenumerique/docs/blob/v${cfg.collaborationServer.package.version}/docs/env.md
+          See <https://github.com/suitenumerique/docs/blob/v${cfg.collaborationServer.package.version}/docs/env.md>
         '';
       };
     };
@@ -327,7 +327,7 @@ in
       description = ''
         Configuration options of docs.
 
-        See https://github.com/suitenumerique/docs/blob/v${cfg.backendPackage.version}/docs/env.md
+        See <https://github.com/suitenumerique/docs/blob/v${cfg.backendPackage.version}/docs/env.md>
 
         `REDIS_URL` and `CELERY_BROKER_URL` are set if `services.lasuite-docs.redis.createLocally` is true.
         `DB_HOST` is set if `services.lasuite-docs.postgresql.createLocally` is true.

--- a/nixos/modules/services/web-apps/nextjs-ollama-llm-ui.nix
+++ b/nixos/modules/services/web-apps/nextjs-ollama-llm-ui.nix
@@ -37,7 +37,7 @@ in
 
           Note: You should keep it at 127.0.0.1 and only serve to the local
           network or internet from a (home) server behind a reverse-proxy and secured encryption.
-          See https://wiki.nixos.org/wiki/Nginx for instructions on how to set up a reverse-proxy.
+          See <https://wiki.nixos.org/wiki/Nginx> for instructions on how to set up a reverse-proxy.
         '';
       };
 

--- a/nixos/modules/services/web-apps/nostr-rs-relay.nix
+++ b/nixos/modules/services/web-apps/nostr-rs-relay.nix
@@ -40,7 +40,7 @@ in
     settings = lib.mkOption {
       inherit (settingsFormat) type;
       default = { };
-      description = "See https://git.sr.ht/~gheartsfield/nostr-rs-relay/#configuration for documentation.";
+      description = "See <https://git.sr.ht/~gheartsfield/nostr-rs-relay/#configuration> for documentation.";
     };
   };
 

--- a/nixos/modules/services/web-apps/outline.nix
+++ b/nixos/modules/services/web-apps/outline.nix
@@ -297,9 +297,9 @@ in
     discordAuthentication = lib.mkOption {
       description = ''
         To configure Discord auth, you'll need to create an application at
-        https://discord.com/developers/applications/
+        <https://discord.com/developers/applications/>
 
-        See https://docs.getoutline.com/s/hosting/doc/discord-g4JdWFFub6
+        See <https://docs.getoutline.com/s/hosting/doc/discord-g4JdWFFub6>
         for details on setting up your Discord app.
       '';
       default = null;

--- a/nixos/modules/services/web-apps/peertube-runner.nix
+++ b/nixos/modules/services/web-apps/peertube-runner.nix
@@ -53,7 +53,7 @@ in
       description = ''
         Configuration for peertube-runner.
 
-        See available configuration options at https://docs.joinpeertube.org/maintain/tools#configuration.
+        See available configuration options at <https://docs.joinpeertube.org/maintain/tools#configuration>.
       '';
     };
     instancesToRegister = lib.mkOption {
@@ -72,7 +72,7 @@ in
               description = ''
                 Path to a file containing a registration token for the PeerTube instance.
 
-                See how to generate registration tokens at https://docs.joinpeertube.org/admin/remote-runners#manage-remote-runners.
+                See how to generate registration tokens at <https://docs.joinpeertube.org/admin/remote-runners#manage-remote-runners>.
               '';
             };
             runnerName = lib.mkOption {

--- a/nixos/modules/services/web-apps/pixelfed.nix
+++ b/nixos/modules/services/web-apps/pixelfed.nix
@@ -173,7 +173,7 @@ in
           default = "mysql";
           description = ''
             Database engine to use.
-            Note that PGSQL is not well supported: https://github.com/pixelfed/pixelfed/issues/2727
+            Note that PGSQL is not well supported: <https://github.com/pixelfed/pixelfed/issues/2727>
           '';
         };
 

--- a/nixos/modules/services/web-apps/porn-vault/default.nix
+++ b/nixos/modules/services/web-apps/porn-vault/default.nix
@@ -55,7 +55,7 @@ in
         description = ''
           Configuration for Porn-Vault. The attributes are serialized to JSON in config.json.
 
-          See https://gitlab.com/porn-vault/porn-vault/-/blob/dev/config.example.json
+          See <https://gitlab.com/porn-vault/porn-vault/-/blob/dev/config.example.json>
         '';
         default = defaultConfig;
         apply = lib.recursiveUpdate defaultConfig;

--- a/nixos/modules/services/web-apps/reposilite.nix
+++ b/nixos/modules/services/web-apps/reposilite.nix
@@ -116,7 +116,7 @@ let
         type = lib.types.nullOr lib.types.str;
         description = ''
           Database connection string. Please use {option}`services.reposilite.database` instead.
-          See https://reposilite.com/guide/general#local-configuration for valid values.
+          See <https://reposilite.com/guide/general#local-configuration> for valid values.
         '';
         default = null;
       };
@@ -141,7 +141,7 @@ let
           Path to the .jsk KeyStore or paths to the PKCS#8 certificate and private key, separated by a space (see example).
           You can use `''${WORKING_DIRECTORY}` to refer to paths relative to Reposilite's working directory.
           If you are using a Java KeyStore, don't forget to specify the password via the {var}`REPOSILITE_LOCAL_KEYPASSWORD` environment variable.
-          See https://reposilite.com/guide/ssl for more information on how to set SSL up.
+          See <https://reposilite.com/guide/ssl> for more information on how to set SSL up.
         '';
         default = null;
         example = "\${WORKING_DIRECTORY}/cert.pem \${WORKING_DIRECTORY}/key.pem";
@@ -354,7 +354,7 @@ in
         assertion = cfg.settings.sslEnabled -> cfg.settings.keyPath != null;
         message = ''
           Reposilite was configured to enable SSL, but no valid paths to certificate files were provided via `settings.keyPath`.
-          Read more about SSL certificates here: https://reposilite.com/guide/ssl
+          Read more about SSL certificates here: <https://reposilite.com/guide/ssl>
         '';
       }
       {

--- a/nixos/modules/services/web-apps/sharkey.nix
+++ b/nixos/modules/services/web-apps/sharkey.nix
@@ -33,7 +33,7 @@ in
           List of paths to files containing environment variables for Sharkey to use at runtime.
 
           This is useful for keeping secrets out of the Nix store. See
-          https://docs.joinsharkey.org/docs/install/configuration/ for how to configure Sharkey using environment
+          <https://docs.joinsharkey.org/docs/install/configuration/> for how to configure Sharkey using environment
           variables.
         '';
       };
@@ -57,7 +57,7 @@ in
           You need to ensure `services.meilisearch.masterKeyFile` is correctly configured for a working
           Meilisearch setup. You also need to configure Sharkey to use an API key obtained from Meilisearch with the
           `MK_CONFIG_MEILISEARCH_APIKEY` environment variable, and set `services.sharkey.settings.meilisearch.index` to
-          the created index. See https://docs.joinsharkey.org/docs/customisation/search/meilisearch/ for how to create
+          the created index. See <https://docs.joinsharkey.org/docs/customisation/search/meilisearch/> for how to create
           an API key and index.
         '';
       };
@@ -141,7 +141,7 @@ in
                 Which provider to use for full text search.
 
                 All options other than `sqlLike` require extra setup - see the comments in
-                https://activitypub.software/TransFem-org/Sharkey/-/blob/develop/.config/example.yml for details.
+                <https://activitypub.software/TransFem-org/Sharkey/-/blob/develop/.config/example.yml> for details.
 
                 If `sqlPgroonga` is set, and `services.sharkey.setupPostgres` is `true`, the pgroonga extension will
                 automatically be setup. You still need to create an index manually.
@@ -172,7 +172,7 @@ in
         description = ''
           Configuration options for Sharkey.
 
-          See https://activitypub.software/TransFem-org/Sharkey/-/blob/develop/.config/example.yml for a list of all
+          See <https://activitypub.software/TransFem-org/Sharkey/-/blob/develop/.config/example.yml> for a list of all
           available configuration options.
         '';
       };

--- a/nixos/modules/services/web-apps/stash.nix
+++ b/nixos/modules/services/web-apps/stash.nix
@@ -221,7 +221,7 @@ let
       dangerous_allow_public_without_auth = mkOption {
         type = types.bool;
         default = false;
-        description = "Learn more at https://docs.stashapp.cc/networking/authentication-required-when-accessing-stash-from-the-internet/";
+        description = "Learn more at <https://docs.stashapp.cc/networking/authentication-required-when-accessing-stash-from-the-internet/>";
       };
       gallery_cover_regex = mkOption {
         type = types.str;
@@ -276,7 +276,7 @@ let
       security_tripwire_accessed_from_public_internet = mkOption {
         type = types.nullOr types.str;
         default = "";
-        description = "Learn more at https://docs.stashapp.cc/networking/authentication-required-when-accessing-stash-from-the-internet/";
+        description = "Learn more at <https://docs.stashapp.cc/networking/authentication-required-when-accessing-stash-from-the-internet/>";
       };
       sequential_scanning = mkOption {
         type = types.bool;

--- a/nixos/modules/services/web-apps/strfry.nix
+++ b/nixos/modules/services/web-apps/strfry.nix
@@ -92,7 +92,7 @@ in
       type = settingsFormat.type;
       default = defaultSettings;
       apply = lib.recursiveUpdate defaultSettings;
-      description = "Configuration options to set for the Strfry service. See https://github.com/hoytech/strfry for documentation.";
+      description = "Configuration options to set for the Strfry service. See <https://github.com/hoytech/strfry> for documentation.";
       example = lib.literalExpression ''
         dbParams = {
           maxreaders = 256;

--- a/nixos/modules/services/web-apps/youtrack.md
+++ b/nixos/modules/services/web-apps/youtrack.md
@@ -15,7 +15,7 @@ You can find this token in the log of the `youtrack` service. The log line looks
 
 Starting with YouTrack 2023.1, JetBrains no longer distributes it as as JAR.
 The new distribution with the JetBrains Launcher as a ZIP changed the basic data structure and also some configuration parameters.
-Check out https://www.jetbrains.com/help/youtrack/server/YouTrack-Java-Start-Parameters.html for more information on the new configuration options.
+Check out <https://www.jetbrains.com/help/youtrack/server/YouTrack-Java-Start-Parameters.html> for more information on the new configuration options.
 When upgrading to YouTrack 2023.1 or higher, a migration script will move the old state directory to `/var/lib/youtrack/2022_3` as a backup.
 A one-time manual update is required:
 

--- a/nixos/modules/services/web-servers/garage.nix
+++ b/nixos/modules/services/web-servers/garage.nix
@@ -74,7 +74,7 @@ in
             type = with types; either path (listOf attrs);
             description = ''
               The directory in which Garage will store the data blocks of objects. This folder can be placed on an HDD.
-              Since v0.9.0, Garage supports multiple data directories, refer to https://garagehq.deuxfleurs.fr/documentation/reference-manual/configuration/#data_dir for the exact format.
+              Since v0.9.0, Garage supports multiple data directories, refer to <https://garagehq.deuxfleurs.fr/documentation/reference-manual/configuration/#data_dir> for the exact format.
             '';
           };
         };

--- a/nixos/modules/services/web-servers/mighttpd2.nix
+++ b/nixos/modules/services/web-servers/mighttpd2.nix
@@ -50,7 +50,7 @@ in
       type = types.lines;
       description = ''
         Verbatim config file to use
-        (see https://kazu-yamamoto.github.io/mighttpd2/config.html)
+        (see <https://kazu-yamamoto.github.io/mighttpd2/config.html>)
       '';
     };
 
@@ -84,7 +84,7 @@ in
       type = types.lines;
       description = ''
         Verbatim routing file to use
-        (see https://kazu-yamamoto.github.io/mighttpd2/config.html)
+        (see <https://kazu-yamamoto.github.io/mighttpd2/config.html>)
       '';
     };
 

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -240,7 +240,7 @@ with lib;
         IP address / port.
         If there is one server block configured to enable http2, then it is
         enabled for all server blocks on this IP.
-        See https://stackoverflow.com/a/39466948/263061.
+        See <https://stackoverflow.com/a/39466948/263061>.
       '';
     };
 
@@ -254,7 +254,7 @@ with lib;
         and activate the QUIC transport protocol
         `services.nginx.virtualHosts.<name>.quic = true;`.
         Note that HTTP/3 support is experimental and *not* yet recommended for production.
-        Read more at https://quic.nginx.org/
+        Read more at <https://quic.nginx.org/>
         HTTP/3 availability must be manually advertised, preferably in each location block.
       '';
     };
@@ -269,7 +269,7 @@ with lib;
         and activate the QUIC transport protocol
         `services.nginx.virtualHosts.<name>.quic = true;`.
         Note that special application protocol support is experimental and *not* yet recommended for production.
-        Read more at https://quic.nginx.org/
+        Read more at <https://quic.nginx.org/>
       '';
     };
 
@@ -282,7 +282,7 @@ with lib;
         which can be achieved by setting `services.nginx.package = pkgs.nginxQuic;`.
         Note that QUIC support is experimental and
         *not* yet recommended for production.
-        Read more at https://quic.nginx.org/
+        Read more at <https://quic.nginx.org/>
       '';
     };
 

--- a/nixos/modules/services/web-servers/send.nix
+++ b/nixos/modules/services/web-servers/send.nix
@@ -27,8 +27,8 @@ in
             ])
           );
         description = ''
-          All the available config options and their defaults can be found here: https://github.com/timvisee/send/blob/master/server/config.js,
-          some descriptions can found here: https://github.com/timvisee/send/blob/master/docs/docker.md#environment-variables
+          All the available config options and their defaults can be found here: <https://github.com/timvisee/send/blob/master/server/config.js>,
+          some descriptions can found here: <https://github.com/timvisee/send/blob/master/docs/docker.md#environment-variables>
 
           Values under {option}`services.send.environment` will override the predefined values in the Send service.
             - Time/duration should be in seconds

--- a/nixos/modules/services/web-servers/unit/default.nix
+++ b/nixos/modules/services/web-servers/unit/default.nix
@@ -76,7 +76,7 @@ in
             }
           }
         '';
-        description = "Unit configuration in JSON format. More details here https://unit.nginx.org/configuration";
+        description = "Unit configuration in JSON format. More details here <https://unit.nginx.org/configuration>";
       };
     };
   };

--- a/nixos/modules/system/boot/binfmt.nix
+++ b/nixos/modules/system/boot/binfmt.nix
@@ -185,7 +185,7 @@ in
 
         description = ''
           Extra binary formats to register with the kernel.
-          See https://www.kernel.org/doc/html/latest/admin-guide/binfmt-misc.html for more details.
+          See <https://www.kernel.org/doc/html/latest/admin-guide/binfmt-misc.html> for more details.
         '';
 
         type = types.attrsOf (

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -172,7 +172,7 @@ in
       description = ''
         Whether to enable the systemd-boot (formerly gummiboot) EFI boot manager.
         For more information about systemd-boot:
-        https://www.freedesktop.org/wiki/Software/systemd/systemd-boot/
+        <https://www.freedesktop.org/wiki/Software/systemd/systemd-boot/>
       '';
     };
 
@@ -182,7 +182,7 @@ in
       description = ''
         The sort key used for the NixOS bootloader entries.
         This key determines sorting relative to non-NixOS entries.
-        See also https://uapi-group.org/specifications/specs/boot_loader_specification/#sorting
+        See also <https://uapi-group.org/specifications/specs/boot_loader_specification/#sorting>
 
         This option can also be used to control the sorting of NixOS specialisations.
 
@@ -384,7 +384,7 @@ in
 
         To control the ordering of the entry in the boot menu, use the sort-key
         field, see
-        https://uapi-group.org/specifications/specs/boot_loader_specification/#sorting
+        <https://uapi-group.org/specifications/specs/boot_loader_specification/#sorting>
         and {option}`boot.loader.systemd-boot.sortKey`.
       '';
     };

--- a/nixos/modules/system/boot/zram-as-tmp.nix
+++ b/nixos/modules/system/boot/zram-as-tmp.nix
@@ -36,7 +36,7 @@ in
             then the zram device will have 256 MiB.
             Fractions in the range 0.1–0.5 are recommended
 
-            See: https://github.com/systemd/zram-generator/blob/main/zram-generator.conf.example
+            See: <https://github.com/systemd/zram-generator/blob/main/zram-generator.conf.example>
           '';
         };
 
@@ -47,7 +47,7 @@ in
           description = ''
             The compression algorithm to use for the zram device.
 
-            See: https://github.com/systemd/zram-generator/blob/main/zram-generator.conf.example
+            See: <https://github.com/systemd/zram-generator/blob/main/zram-generator.conf.example>
           '';
         };
 
@@ -58,7 +58,7 @@ in
           description = ''
             The file system to put on the device.
 
-            See: https://github.com/systemd/zram-generator/blob/main/zram-generator.conf.example
+            See: <https://github.com/systemd/zram-generator/blob/main/zram-generator.conf.example>
           '';
         };
 
@@ -70,7 +70,7 @@ in
             by setting "discard".
             Setting this to the empty string clears the option.
 
-            See: https://github.com/systemd/zram-generator/blob/main/zram-generator.conf.example
+            See: <https://github.com/systemd/zram-generator/blob/main/zram-generator.conf.example>
           '';
         };
       };

--- a/nixos/modules/virtualisation/docker-rootless.nix
+++ b/nixos/modules/virtualisation/docker-rootless.nix
@@ -45,7 +45,7 @@ in
       };
       description = ''
         Configuration for docker daemon. The attributes are serialized to JSON used as daemon.conf.
-        See https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file
+        See <https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file>
       '';
     };
 

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -78,7 +78,7 @@ in
       };
       description = ''
         Configuration for docker daemon. The attributes are serialized to JSON used as daemon.conf.
-        See https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file
+        See <https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file>
       '';
     };
 

--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -150,7 +150,7 @@ let
         description = ''
           Hooks that will be placed under /var/lib/libvirt/hooks/daemon.d/
           and called for daemon start/shutdown/SIGHUP events.
-          Please see https://libvirt.org/hooks.html for documentation.
+          Please see <https://libvirt.org/hooks.html> for documentation.
         '';
       };
 
@@ -160,7 +160,7 @@ let
         description = ''
           Hooks that will be placed under /var/lib/libvirt/hooks/qemu.d/
           and called for qemu domains begin/end/migrate events.
-          Please see https://libvirt.org/hooks.html for documentation.
+          Please see <https://libvirt.org/hooks.html> for documentation.
         '';
       };
 
@@ -170,7 +170,7 @@ let
         description = ''
           Hooks that will be placed under /var/lib/libvirt/hooks/lxc.d/
           and called for lxc domains begin/end events.
-          Please see https://libvirt.org/hooks.html for documentation.
+          Please see <https://libvirt.org/hooks.html> for documentation.
         '';
       };
 
@@ -180,7 +180,7 @@ let
         description = ''
           Hooks that will be placed under /var/lib/libvirt/hooks/libxl.d/
           and called for libxl-handled xen domains begin/end events.
-          Please see https://libvirt.org/hooks.html for documentation.
+          Please see <https://libvirt.org/hooks.html> for documentation.
         '';
       };
 
@@ -190,7 +190,7 @@ let
         description = ''
           Hooks that will be placed under /var/lib/libvirt/hooks/network.d/
           and called for networks begin/end events.
-          Please see https://libvirt.org/hooks.html for documentation.
+          Please see <https://libvirt.org/hooks.html> for documentation.
         '';
       };
     };
@@ -205,7 +205,7 @@ let
           This option enables the older libvirt NSS module. This method uses
           DHCP server records, therefore is dependent on the hostname provided
           by the guest.
-          Please see https://libvirt.org/nss.html for more information.
+          Please see <https://libvirt.org/nss.html> for more information.
         '';
       };
 
@@ -215,7 +215,7 @@ let
         description = ''
           This option enables the newer libvirt_guest NSS module. This module
           uses the libvirt guest name instead of the hostname of the guest.
-          Please see https://libvirt.org/nss.html for more information.
+          Please see <https://libvirt.org/nss.html> for more information.
         '';
       };
     };

--- a/nixos/modules/virtualisation/lxd.nix
+++ b/nixos/modules/virtualisation/lxd.nix
@@ -68,7 +68,7 @@ in
           running containers requiring many file operations.
           Fixes errors like "Too many open files" or
           "neighbour: ndisc_cache: neighbor table overflow!".
-          See https://lxd.readthedocs.io/en/latest/production-setup/
+          See <https://lxd.readthedocs.io/en/latest/production-setup/>
           for details.
         '';
       };

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -729,7 +729,7 @@ in
                   so that no overlapping UID/GID ranges are assigned to multiple containers.
                   This is the recommanded option as it enhances container security massively and operates fully automatically in most cases.
 
-                  See https://www.freedesktop.org/software/systemd/man/latest/systemd-nspawn.html#--private-users= for details.
+                  See <https://www.freedesktop.org/software/systemd/man/latest/systemd-nspawn.html#--private-users=> for details.
                 '';
               };
 

--- a/nixos/modules/virtualisation/podman/network-socket.nix
+++ b/nixos/modules/virtualisation/podman/network-socket.nix
@@ -29,7 +29,7 @@ in
         This allows Docker clients to connect with the equivalents of the Docker
         CLI `-H` and `--tls*` family of options.
 
-        For certificate setup, see https://docs.docker.com/engine/security/protect-access/
+        For certificate setup, see <https://docs.docker.com/engine/security/protect-access/>
 
         This option is independent of [](#opt-virtualisation.podman.dockerSocket.enable).
       '';

--- a/nixos/modules/virtualisation/virtualbox-host.nix
+++ b/nixos/modules/virtualisation/virtualbox-host.nix
@@ -98,7 +98,7 @@ in
 
         This option is incompatible with `addNetworkInterface`.
 
-        Note: This is experimental. Please check https://github.com/cyberus-technology/virtualbox-kvm/issues.
+        Note: This is experimental. Please check <https://github.com/cyberus-technology/virtualbox-kvm/issues>.
       '';
     };
   };

--- a/nixos/modules/virtualisation/waagent.nix
+++ b/nixos/modules/virtualisation/waagent.nix
@@ -257,7 +257,7 @@ in
       type = settingsType;
       default = { };
       description = ''
-        The waagent.conf configuration, see https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/agent-linux for documentation.
+        The waagent.conf configuration, see <https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/agent-linux> for documentation.
       '';
     };
   };


### PR DESCRIPTION
This fixes links that are not turned into proper hyperlinks in the nixos module documentation. No other links are touched, no formatting has changed, the only thing is that links are properly shown now, which helps the user experience.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
