### PR TITLE
otree: 0.5.1 → 0.6.0

### DIFF
--- a/pkgs/by-name/ot/otree/package.nix
+++ b/pkgs/by-name/ot/otree/package.nix
@@ -6,19 +6,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "otree";
-  version = "0.5.1";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "fioncat";
     repo = "otree";
     tag = "v${version}";
-    hash = "sha256-nfRCqqOJl5tpKFyWAHa98Z1Q2lD61eFPD3O155mawf8=";
+    hash = "sha256-Pz9iAN5GMJeYYQ7T0QWUfRwvSfreRF8pJR8ctPVFAmA=";
   };
 
-  cargoHash = "sha256-+rBS9t743OwfNCy6v5dRdjWZRHA5GNniaWVnAtb5yaw=";
+  cargoHash = "sha256-Uz4oA8maAiUye+FRoVBRuMHoPytr5y8DUfPA4CuMSe4=";
 
   meta = {
-    description = "Command line tool to view objects (json/yaml/toml) in TUI tree widget";
+    description = "Command line tool to view objects (JSON/YAML/TOML/XML) in TUI tree widget";
     homepage = "https://github.com/fioncat/otree";
     changelog = "https://github.com/fioncat/otree/releases/tag/v${version}";
     license = lib.licenses.mit;


### PR DESCRIPTION
- https://github.com/fioncat/otree/releases/tag/v0.5.2
- https://github.com/fioncat/otree/releases/tag/v0.6.0

0.5.2 added XML support; update description to reflect that.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
