### PR TITLE
kxstitch: migrate to by-name

### DIFF
--- a/pkgs/by-name/kx/kxstitch/package.nix
+++ b/pkgs/by-name/kx/kxstitch/package.nix
@@ -3,35 +3,40 @@
   lib,
   fetchgit,
   cmake,
-  extra-cmake-modules,
   imagemagick,
-  libsForQt5,
+  kdePackages,
+  pkg-config,
 }:
 
 stdenv.mkDerivation {
   pname = "kxstitch";
-  version = "unstable-2023-12-31";
+  version = "unstable-2025-08-16";
 
   src = fetchgit {
     url = "https://invent.kde.org/graphics/kxstitch.git";
-    rev = "4bb575dcb89e3c997e67409c8833e675962e101a";
-    hash = "sha256-pi+RpuT8YQYp1ogGtIgXpTPdYSFk19TUHTHDVyOcrMI=";
+    rev = "bfe934ffc2c2dfa1cc554bc4483a3285b027b00c";
+    hash = "sha256-B81nwInFWcQVDJU6VINII8crVPtV5zYBXADVVe+wCu4=";
   };
 
-  buildInputs = with libsForQt5; [
+  buildInputs = with kdePackages; [
     qtbase
     kconfig
     kconfigwidgets
     kcompletion
     kio
+    ktextwidgets
+    kxmlgui
   ];
 
   nativeBuildInputs = [
     cmake
-    extra-cmake-modules
     imagemagick
-    libsForQt5.wrapQtAppsHook
-  ];
+    pkg-config
+  ]
+  ++ (with kdePackages; [
+    extra-cmake-modules
+    wrapQtAppsHook
+  ]);
 
   postInstall = ''
     install -D $src/org.kde.kxstitch.desktop $out/share/applications/org.kde.kxstitch.desktop


### PR DESCRIPTION
Upgrade kxstitch to KDE6 and migrate to by-name
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
