### PR TITLE
python3Packages.dbt-common: 1.23.0-unstable-2025-04-21 -> 1.28.0-unstable-2025-08-14

### DIFF
--- a/pkgs/development/python-modules/dbt-adapters/default.nix
+++ b/pkgs/development/python-modules/dbt-adapters/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "dbt-adapters";
-  version = "1.16.3";
+  version = "1.16.5";
   pyproject = true;
 
   # missing tags on GitHub
   src = fetchPypi {
     pname = "dbt_adapters";
     inherit version;
-    hash = "sha256-1J0+V776ujbt8Anm/gAdld0MkC5apmeN8IEtzZBSWf8=";
+    hash = "sha256-OAPGC88WvBy/3sGyDO4pAHLYYe2+k7l7PpKpNcV+IdM=";
   };
 
   build-system = [ hatchling ];

--- a/pkgs/development/python-modules/dbt-common/default.nix
+++ b/pkgs/development/python-modules/dbt-common/default.nix
@@ -7,6 +7,7 @@
   hatchling,
 
   # dependencies
+  dbt-protos,
   agate,
   colorama,
   deepdiff,
@@ -28,14 +29,14 @@
 
 buildPythonPackage rec {
   pname = "dbt-common";
-  version = "1.23.0-unstable-2025-04-21";
+  version = "1.28.0-unstable-2025-08-14";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dbt-labs";
     repo = "dbt-common";
-    rev = "03e09c01f20573975e8e17776a4b7c9088b3f212"; # They don't tag releases
-    hash = "sha256-KqnwlFZZRYuWRflMzjrqCPBnzY9q/pPhceM2DGqz5bw=";
+    rev = "dd34e0a0565620863ff70c0b02421d84fcee8a02"; # They don't tag releases
+    hash = "sha256-hG6S+IIAR3Cu69oFapQUVoCdaiEQYeMQ/ekBuAXxPrI=";
   };
 
   build-system = [ hatchling ];
@@ -50,6 +51,7 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
+    dbt-protos
     agate
     colorama
     deepdiff
@@ -81,7 +83,7 @@ buildPythonPackage rec {
   meta = {
     description = "Shared common utilities for dbt-core and adapter implementations use";
     homepage = "https://github.com/dbt-labs/dbt-common";
-    changelog = "https://github.com/dbt-labs/dbt-common/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/dbt-labs/dbt-common/blob/main/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/dbt-core/default.nix
+++ b/pkgs/development/python-modules/dbt-core/default.nix
@@ -37,14 +37,14 @@
 
 buildPythonPackage rec {
   pname = "dbt-core";
-  version = "1.10.6";
+  version = "1.10.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dbt-labs";
     repo = "dbt-core";
     tag = "v${version}";
-    hash = "sha256-tMrtn5NYkRpok6mv4/CBXGPQuHWpL/raejPXyagj7Bs=";
+    hash = "sha256-4K00EVTOTTUHWwTpBlXKoHGof/s/H2acoWZPJ9FmBuk=";
   };
 
   sourceRoot = "${src.name}/core";

--- a/pkgs/development/python-modules/dbt-extractor/default.nix
+++ b/pkgs/development/python-modules/dbt-extractor/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "dbt-extractor";
-  version = "0.5.1";
+  version = "0.6.0";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -18,12 +18,12 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "dbt_extractor";
     inherit version;
-    hash = "sha256-zV2VV2qN6kGQJAqvmTajf9dLS3kTymmjw2j8RHK7fhM=";
+    hash = "sha256-1s8I7Hk7i8K9biYO+BgjCuaKT3FDb6SJ8I19saUuL/4=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-luPAuRl+yrHinLs6H0ZRVnce2zz1DUrniVOCa1hu1S4=";
+    hash = "sha256-6Y4zfqhj1/IeEX+Ve49jblxeW565Q2ypNClb/Ej0xoc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/dbt-semantic-interfaces/default.nix
+++ b/pkgs/development/python-modules/dbt-semantic-interfaces/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "dbt-semantic-interfaces";
-  version = "0.8.5";
+  version = "0.9.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     owner = "dbt-labs";
     repo = "dbt-semantic-interfaces";
     tag = "v${version}";
-    hash = "sha256-fe+0W08XfBzimQZugCpphrHYcDaoUUYkA+FYa2lS3Uo=";
+    hash = "sha256-I/bMpqTaAHs0XnYOYjFRgXv3qB06LItkaSxtRjk55js=";
   };
 
   pythonRelaxDeps = [ "importlib-metadata" ];

--- a/pkgs/development/python-modules/dbt-snowflake/default.nix
+++ b/pkgs/development/python-modules/dbt-snowflake/default.nix
@@ -2,25 +2,29 @@
   lib,
   buildPythonPackage,
   dbt-core,
-  fetchFromGitHub,
+  fetchPypi,
   pytestCheckHook,
-  setuptools,
+  hatchling,
   snowflake-connector-python,
 }:
 
 buildPythonPackage rec {
   pname = "dbt-snowflake";
-  version = "1.9.1";
+  version = "1.10.0";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "dbt-labs";
-    repo = "dbt-snowflake";
-    tag = "v${version}";
-    hash = "sha256-oPzSdAQgb2fKES3YcSGYjILFqixxxjdLCNVytVPecTg=";
+  # missing tags on GitHub
+  src = fetchPypi {
+    pname = "dbt_snowflake";
+    inherit version;
+    hash = "sha256-Y5H7ATm8bntl4YaF5l9DZiRhHt2q2/XaICp+PR9ywIw=";
   };
 
-  build-system = [ setuptools ];
+  pythonRelaxDeps = [
+    "certifi"
+  ];
+
+  build-system = [ hatchling ];
 
   dependencies = [
     dbt-core
@@ -32,12 +36,17 @@ buildPythonPackage rec {
 
   enabledTestPaths = [ "tests/unit" ];
 
+  pytestFlagsArray = [
+    # pyproject.toml specifies -n auto which only pytest-xdist understands
+    "--override-ini addopts=''"
+  ];
+
   pythonImportsCheck = [ "dbt.adapters.snowflake" ];
 
   meta = {
     description = "Plugin enabling dbt to work with Snowflake";
-    homepage = "https://github.com/dbt-labs/dbt-snowflake";
-    changelog = "https://github.com/dbt-labs/dbt-snowflake/blob/${src.tag}/CHANGELOG.md";
+    homepage = "https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-snowflake";
+    changelog = "https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-snowflake/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ tjni ];
   };


### PR DESCRIPTION
* closes https://github.com/NixOS/nixpkgs/pull/436818
* closes https://github.com/NixOS/nixpkgs/pull/436347
* fixes a bunch of build failures on hydra

----

- **python3Packages.dbt-semantic-interfaces: 0.8.5 -> 0.9.0**
- **python3Packages.dbt-common: 1.23.0-unstable-2025-04-21 -> 1.28.0-unstable-2025-08-14**
- **python3Packages.dbt-adapters: 1.16.3 -> 1.16.5**
- **python3Packages.dbt-core: 1.10.6 -> 1.10.9**
- **python3Packages.dbt-extractor: 0.5.1 -> 0.6.0**
- **python3Packages.dbt-snowflake: 1.9.1 -> 1.10.0**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
