### PR TITLE
nixos: fixes for disabling containers by default

### DIFF
--- a/nixos/doc/manual/administration/imperative-containers.section.md
+++ b/nixos/doc/manual/administration/imperative-containers.section.md
@@ -2,7 +2,7 @@
 
 We'll cover imperative container management using `nixos-container`
 first. Be aware that container management is currently only possible as
-`root`.
+`root`, and that you need to enable [](#opt-boot.enableContainers) explicitly.
 
 You create a container with identifier `foo` as follows:
 

--- a/nixos/modules/profiles/minimal.nix
+++ b/nixos/modules/profiles/minimal.nix
@@ -30,9 +30,6 @@ in
     fish.generateCompletions = mkDefault false;
   };
 
-  # This pulls in nixos-containers which depends on Perl.
-  boot.enableContainers = mkDefault false;
-
   services = {
     logrotate.enable = mkDefault false;
     udisks2.enable = mkDefault false;

--- a/nixos/modules/profiles/perlless.nix
+++ b/nixos/modules/profiles/perlless.nix
@@ -11,7 +11,6 @@
   system.tools.nixos-generate-config.enable = lib.mkDefault false;
   programs.less.lessopen = lib.mkDefault null;
   programs.command-not-found.enable = lib.mkDefault false;
-  boot.enableContainers = lib.mkDefault false;
   boot.loader.grub.enable = lib.mkDefault false;
   environment.defaultPackages = lib.mkDefault [ ];
   documentation.info.enable = lib.mkDefault false;

--- a/nixos/tests/containers-imperative.nix
+++ b/nixos/tests/containers-imperative.nix
@@ -19,6 +19,8 @@
     {
       imports = [ ../modules/installer/cd-dvd/channel.nix ];
 
+      boot.enableContainers = true;
+
       # XXX: Sandbox setup fails while trying to hardlink files from the host's
       #      store file system into the prepared chroot directory.
       nix.settings.sandbox = false;

--- a/nixos/tests/disable-installer-tools.nix
+++ b/nixos/tests/disable-installer-tools.nix
@@ -11,7 +11,6 @@
     { pkgs, lib, ... }:
     {
       system.disableInstallerTools = true;
-      boot.enableContainers = false;
       environment.defaultPackages = [ ];
     };
 


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/427001

Need to actually test this.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
