### PR TITLE
vscode-extensions.shader-slang.slang-language-extension: init at 2.0.1

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -4253,6 +4253,8 @@ let
         };
       };
 
+      shader-slang.slang-language-extension = callPackage ./shader-slang.slang-language-extension { };
+
       shardulm94.trailing-spaces = buildVscodeMarketplaceExtension {
         mktplcRef = {
           publisher = "shardulm94";

--- a/pkgs/applications/editors/vscode/extensions/shader-slang.slang-language-extension/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/shader-slang.slang-language-extension/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  shader-slang,
+  stdenv,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "slang-language-extension";
+    publisher = "shader-slang";
+    version = "2.0.1";
+    hash = "sha256-cMBFksLcEi3OmRpyuk/hMNo5HqsfGvWhheiLg6Dusn0=";
+  };
+
+  postInstall =
+    let
+      target =
+        {
+          "x86_64-linux" = "linux-x64";
+          "aarch64-linux" = "linux-arm64";
+          "x86_64-darwin" = "darwin-x64";
+          "aarch64-darwin" = "darwin-arm64";
+        }
+        .${stdenv.hostPlatform.system};
+    in
+    lib.concatLines (
+      [
+        "bin=$out/share/vscode/extensions/shader-slang.slang-language-extension/server/bin"
+        "rm -r $bin" # `bin/darwin-arm64` is present by default for some reason.
+        "mkdir -p $bin/${target}"
+      ]
+      # https://github.com/shader-slang/slang-vscode-extension/blob/v2.0.1/build_scripts/build-package.sh#L40-L43
+      ++ (map (path: "ln -s ${shader-slang}/${path} $bin/${target}/") [
+        "lib/libslang${stdenv.hostPlatform.extensions.library}"
+        "lib/libslang-glsl-module${stdenv.hostPlatform.extensions.library}"
+        "bin/slangd"
+      ])
+    );
+
+  meta = {
+    changelog = "https://marketplace.visualstudio.com/items/shader-slang.slang-language-extension/changelog";
+    description = "Extension for the Slang Shading Language";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=shader-slang.slang-language-extension";
+    homepage = "https://github.com/shader-slang/slang-vscode-extension";
+    license = with lib.licenses; [
+      asl20
+      llvm-exception
+    ];
+    maintainers = with lib.maintainers; [ samestep ];
+    platforms = with lib.platforms; linux ++ darwin;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR builds on #435962 by packaging the Slang v2025.14.3 binaries into [v2.0.1 of the Slang VS Code extension](https://github.com/shader-slang/slang-vscode-extension/tree/v2.0.1), which uses that same version upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
