### PR TITLE
acsccid: 1.1.8 -> 1.1.12

### DIFF
--- a/pkgs/by-name/ac/acsccid/package.nix
+++ b/pkgs/by-name/ac/acsccid/package.nix
@@ -1,8 +1,9 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
+  fetchurl,
   autoconf,
+  autoconf-archive,
   automake,
   libtool,
   gettext,
@@ -14,20 +15,19 @@
   libiconv,
 }:
 
-stdenv.mkDerivation rec {
-  version = "1.1.8";
+stdenv.mkDerivation (finalAttrs: {
+  version = "1.1.12";
   pname = "acsccid";
 
-  src = fetchFromGitHub {
-    owner = "acshk";
-    repo = "acsccid";
-    tag = "v${version}";
-    sha256 = "12aahrvsk21qgpjwcrr01s742ixs44nmjkvcvqyzhqb307x1rrn3";
+  src = fetchurl {
+    url = "mirror://sourceforge/acsccid/acsccid-${finalAttrs.version}.tar.bz2";
+    sha256 = "sha256-KPYHWlSUpWjOL9hmbEifb0pRWZtE+8k5Dh3bSNPMxb0=";
   };
 
   nativeBuildInputs = [
     pkg-config
     autoconf
+    autoconf-archive
     automake
     libtool
     gettext
@@ -50,17 +50,10 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   postPatch = ''
-    sed -e s_/bin/echo_echo_g -i src/Makefile.am
+    substituteInPlace src/Makefile.in \
+      --replace-fail '$(INSTALL_UDEV_RULE_FILE)' ""
     patchShebangs src/convert_version.pl
     patchShebangs src/create_Info_plist.pl
-  '';
-
-  preConfigure = ''
-    libtoolize --force
-    aclocal
-    autoheader
-    automake --force-missing --add-missing
-    autoconf
   '';
 
   meta = {
@@ -78,9 +71,9 @@ stdenv.mkDerivation rec {
         services.pcscd.enable = true;
         services.pcscd.plugins = [ pkgs.acsccid ];
     '';
-    homepage = src.meta.homepage;
+    homepage = "http://acsccid.sourceforge.net";
     license = lib.licenses.lgpl2Plus;
     maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
Supersedes https://github.com/NixOS/nixpkgs/pull/420911, which was closed without merging.
acsccid 1.1.8 in current nixpkgs does not build due to some autoconf errors.
this fixes the autoconf errors, changes from a downstream github to the upstream repo, and updates to the latest version, 1.1.12, of acsccid.

A changelog is available in the downstream github [here](https://raw.githubusercontent.com/acshk/acsccid/refs/heads/master/README).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
