### PR TITLE
lofreq: init at 2.1.5

### DIFF
--- a/pkgs/by-name/lo/lofreq/package.nix
+++ b/pkgs/by-name/lo/lofreq/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  autoreconfHook,
+  htslib,
+  python3,
+  zlib,
+
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lofreq";
+  version = "2.1.5";
+
+  src = fetchFromGitHub {
+    owner = "CSB5";
+    repo = "lofreq";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dA2B3dCD6LbJ1hS87XVR442GJc2B4WhcO1PJV4fNWmM=";
+
+    postFetch = ''
+      # just .tar.gz'd tag archives -- too large for no use with keeping
+      rm -rf dist
+    '';
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+  buildInputs = [
+    htslib
+    python3
+    zlib
+  ];
+
+  configureFlags = [
+    # entirely optional -- extremely useful but:
+    # would depend on PyVCF which was removed in #232816 due to using 2to3
+    "--disable-tools"
+  ];
+
+  # does have tests, but those rely on some `data` directory i can't seem to find
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "lofreq";
+    description = "Sensitive variant calling from sequencing data";
+    homepage = "https://csb5.github.io/lofreq/";
+    license = lib.licenses.mit;
+
+    maintainers = with lib.maintainers; [
+      multisn8
+    ];
+  };
+})


### PR DESCRIPTION
Add new package `lofreq`, see https://csb5.github.io/lofreq/. Super useful for bio informatics.

NOTE: The Python parts are NOT packaged atm, as they would require packaging PyVCF first and are purely optional.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
