### PR TITLE
pyroaring: Override Cython version for tests/build

### DIFF
--- a/pkgs/development/python-modules/pyroaring/default.nix
+++ b/pkgs/development/python-modules/pyroaring/default.nix
@@ -21,7 +21,16 @@ buildPythonPackage rec {
   };
 
   build-system = [
-    cython
+    (cython.overrideAttrs (rec {
+      name = "cython";
+      version = "3.0.12";
+      src = fetchFromGitHub {
+        owner = "cython";
+        repo = "cython";
+        tag = version;
+        hash = "sha256-clJXjQb6rVECirKRUGX0vD5a6LILzPwNo7+6KKYs2pI=";
+      };
+    }))
     setuptools
   ];
 


### PR DESCRIPTION
- `pyroaring` upstream have a constraint against `cython` v3.1.x, which means we need to stick to `cython` v3.0.12.
   - This is due to a few tests failing with newer `cython` versions.

- It affects `buildstream` and `python3Packages.buildstream-plugins` in Nixpkgs, which is why I have implemented this quick workaround to make `pyroaring` use a older version of `cython`.

See: https://github.com/NixOS/nixpkgs/pull/436489 and `nixpkgs-review` output for that PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
