### PR TITLE
high-tide: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/by-name/hi/high-tide/package.nix
+++ b/pkgs/by-name/hi/high-tide/package.nix
@@ -13,20 +13,21 @@
   gst_all_1,
   libsecret,
   libportal,
+  alsa-utils,
   pipewire,
   nix-update-script,
 }:
 
 python313Packages.buildPythonApplication rec {
   pname = "high-tide";
-  version = "1.0.0";
+  version = "1.1.0";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "Nokse22";
     repo = "high-tide";
     tag = "v${version}";
-    hash = "sha256-lvfEqXXlDuW+30iTQ0FddcnAMZRM0BYeuxLN4++xs/0=";
+    hash = "sha256-AHdv2eazUnxgw5D4SlIzWm/wnC26zedwiAGT0OzjdZs=";
   };
 
   nativeBuildInputs = [
@@ -51,13 +52,16 @@ python313Packages.buildPythonApplication rec {
     libsecret
   ]);
 
-  dependencies = with python313Packages; [
+  dependencies = [
+    alsa-utils
+  ]
+  ++ (with python313Packages; [
     pygobject3
     tidalapi
     requests
     mpd2
     pypresence
-  ];
+  ]);
 
   dontWrapGApps = true;
 


### PR DESCRIPTION
A new dependency is required (alsa-utils) for exclusive ALSA access. Tested the exclusive device access, definitely took exclusive access and played audio.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
