### PR TITLE
Reapply "aider-chat: fix tree-sitter query"

### DIFF
--- a/pkgs/by-name/ai/aider-chat/fix-tree-sitter.patch
+++ b/pkgs/by-name/ai/aider-chat/fix-tree-sitter.patch
@@ -1,0 +1,21 @@
+diff --git a/aider/repomap.py b/aider/repomap.py
+index 23eee239..0a40f2e6 100644
+--- a/aider/repomap.py
++++ b/aider/repomap.py
+@@ -16,6 +16,7 @@ from grep_ast import TreeContext, filename_to_lang
+ from pygments.lexers import guess_lexer_for_filename
+ from pygments.token import Token
+ from tqdm import tqdm
++from tree_sitter import QueryCursor
+ 
+ from aider.dump import dump
+ from aider.special import filter_important_files
+@@ -286,7 +287,7 @@ class RepoMap:
+ 
+         # Run the tags queries
+         query = language.query(query_scm)
+-        captures = query.captures(tree.root_node)
++        captures = QueryCursor(query).captures(tree.root_node)
+ 
+         saw = set()
+         if USING_TSL_PACK:

--- a/pkgs/by-name/ai/aider-chat/package.nix
+++ b/pkgs/by-name/ai/aider-chat/package.nix
@@ -146,6 +146,8 @@ let
     ];
 
     patches = [
+      ./fix-tree-sitter.patch
+
       (replaceVars ./fix-flake8-invoke.patch {
         flake8 = lib.getExe python3Packages.flake8;
       })


### PR DESCRIPTION
This reverts commit b6554c9f0eafd8248986e43ae646c344631be30b. See #436883. 

Short version:
- tree-sitter Python package was updated from 0.24
- aider broke because of the update
- the build was patched (#425990)
- tree-sitter was planned to be reverted to 0.24
- the build fix was reverted (b6554c9f0eafd8248986e43ae646c344631be30b)
- tree-sitter was updated to 0.25
- aider broke again

This PR reapplies the original patched build.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
