### PR TITLE
tic-80: use lua5_3_compat instead of lua5_3

### DIFF
--- a/pkgs/by-name/ti/tic-80/package.nix
+++ b/pkgs/by-name/ti/tic-80/package.nix
@@ -11,7 +11,7 @@
   libGLU,
   libX11,
   janet,
-  lua5_3,
+  lua5_3_compat,
   quickjs,
   SDL2,
   # Whether to build TIC-80's "Pro" version, which is an incentive to support the project financially,
@@ -85,7 +85,7 @@ stdenv.mkDerivation {
     libGLU
     libX11
     janet
-    (lua5_3.withPackages (ps: [ ps.fennel ]))
+    (lua5_3_compat.withPackages (ps: [ ps.fennel ]))
     quickjs
     SDL2
   ];


### PR DESCRIPTION
TIC-80 expects Lua 5.3 built with 5.1/5.2 backwards compatibility. Normally the TIC-80 build system ensures this by building a vendored lua with the requisite options enabled, but we build with `PREFER_SYSTEM_LIBRARIES` which bypasses this.

There may be similar incompatibilities in other language modes due to the use of `PREFER_SYSTEM_LIBRARIES`, but tracking those all down is a much bigger job and the only one I have first-hand experience with is Lua.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
