### PR TITLE
couchdb: use quickjs instead of spidermonkey

### DIFF
--- a/pkgs/servers/http/couchdb/3.nix
+++ b/pkgs/servers/http/couchdb/3.nix
@@ -5,7 +5,6 @@
   erlang,
   icu,
   openssl,
-  spidermonkey_91,
   python3,
   nixosTests,
 }:
@@ -20,8 +19,6 @@ stdenv.mkDerivation rec {
   };
 
   postPatch = ''
-    substituteInPlace src/couch/rebar.config.script --replace '/usr/include/mozjs-91' "${spidermonkey_91.dev}/include/mozjs-91"
-    substituteInPlace configure --replace '/usr/include/''${SM_HEADERS}' "${spidermonkey_91.dev}/include/mozjs-91"
     patchShebangs bin/rebar
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
@@ -37,14 +34,14 @@ stdenv.mkDerivation rec {
   buildInputs = [
     icu
     openssl
-    spidermonkey_91
     (python3.withPackages (ps: with ps; [ requests ]))
   ];
 
   dontAddPrefix = "True";
 
   configureFlags = [
-    "--spidermonkey-version=91"
+    "--js-engine=quickjs"
+    "--disable-spidermonkey"
   ];
 
   buildFlags = [


### PR DESCRIPTION
Allows us to drop `spidermonkey_91`, which reached EOL years ago. We won't switch to the latest supported spidermonkey version for couchdb(128) because as of commit time its support ends in 3 weeks, so there would be no use trying to update it again after this. Better to just switch now and avoid pain in the future. Note, the `spidermonkey_91` drop will be in a followup PR, unless it would be better to do it here. Also, this should maintain compatability afaik, so I don't believe this needs a breaking change notification, but I would be glad to put on in just to be safe, if desired.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
