### PR TITLE
python3Packages.torch: backport a triton 2.4 support patch

### DIFF
--- a/pkgs/development/python-modules/torch/source/default.nix
+++ b/pkgs/development/python-modules/torch/source/default.nix
@@ -294,6 +294,12 @@ buildPythonPackage rec {
   patches = [
     ./clang19-template-warning.patch
   ]
+  ++ lib.optionals tritonSupport [
+    # Manual backport of [inductor] Fix usage of launch_enter_hook/launch_exit_hook
+    # to fix AttributeError: type object 'CompiledKernel' has no attribute 'launch_enter_hook'
+    # https://github.com/pytorch/pytorch/pull/152457
+    ./triton-2.4-compat.patch
+  ]
   ++ lib.optionals cudaSupport [ ./fix-cmake-cuda-toolkit.patch ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     # Propagate CUPTI to Kineto by overriding the search path with environment variables.

--- a/pkgs/development/python-modules/torch/source/triton-2.4-compat.patch
+++ b/pkgs/development/python-modules/torch/source/triton-2.4-compat.patch
@@ -1,0 +1,81 @@
+From c90e23eb73212186b7eb9a98ba69e6309d864c67 Mon Sep 17 00:00:00 2001
+From: Dan Zimmerman <danzimm@meta.com>
+Date: Wed, 30 Apr 2025 13:22:16 +0000
+Subject: [PATCH] [inductor] Fix usage of launch_enter_hook/launch_exit_hook
+ (#152457)
+
+In https://github.com/triton-lang/triton/pull/6467 I moved where `launch_enter_hook`/`launch_exit_hook` are specified (from the kernel class to a config). This PR updates the usages to use the config module if it exists to support tip of main triton.
+
+In https://github.com/triton-lang/triton/pull/6641 I renamed `triton.config` to `triton.knobs`, hence the second commit in this PR.
+
+Test Plan: Setup OSS PT with tip of main triton (namely including https://github.com/triton-lang/triton/pull/6641) and run `python test/inductor/test_pad_mm.py`
+
+Pull Request resolved: https://github.com/pytorch/pytorch/pull/152457
+Approved by: https://github.com/jamesjwu
+---
+ torch/_inductor/runtime/static_cuda_launcher.py | 15 ++++++++++-----
+ torch/_inductor/runtime/triton_compat.py        |  7 +++++++
+ torch/_inductor/runtime/triton_heuristics.py    | 12 ++++++++++--
+ 3 files changed, 27 insertions(+), 7 deletions(-)
+diff --git a/torch/_inductor/runtime/triton_compat.py b/torch/_inductor/runtime/triton_compat.py
+index d6e45b72ce498..e244ecbee635f 100644
+--- a/torch/_inductor/runtime/triton_compat.py
++++ b/torch/_inductor/runtime/triton_compat.py
+@@ -69,5 +69,10 @@ def _log2(x: Any) -> Any:
+             raise NotImplementedError
+ 
++
++    try:
++        from triton import knobs
++    except ImportError:
++        knobs = None
+ else:
+ 
+     def _raise_error(*args: Any, **kwargs: Any) -> Any:
+@@ -88,6 +93,7 @@ class PTXASError(Exception):  # type: ignore[no-redef]
+     _log2 = _raise_error
+     libdevice = None
+     math = None
++    knobs = None
+ 
+     class triton:  # type: ignore[no-redef]
+         @staticmethod
+@@ -138,4 +144,5 @@ class autograd_profiler:  # type: ignore[no-redef]
+     "math",
+     "triton",
+     "cc_warp_size",
++    "knobs",
+ ]
+diff --git a/torch/_inductor/runtime/triton_heuristics.py b/torch/_inductor/runtime/triton_heuristics.py
+index 93fb36e12bbae..ac79ecd7af467 100644
+--- a/torch/_inductor/runtime/triton_heuristics.py
++++ b/torch/_inductor/runtime/triton_heuristics.py
+@@ -73,6 +73,7 @@
+     GPUTarget,
+     HAS_WARP_SPEC,
+     KernelInterface,
++    knobs,
+     OutOfResources,
+     PTXASError,
+     triton,
+@@ -1423,11 +1424,18 @@ def make_launcher(self) -> LauncherType:
+             binary.shared if hasattr(binary, "shared") else binary.metadata.shared
+         )
+ 
++        if knobs is None:
++            launch_enter = binary.__class__.launch_enter_hook
++            launch_exit = binary.__class__.launch_exit_hook
++        else:
++            launch_enter = knobs.runtime.launch_enter_hook
++            launch_exit = knobs.runtime.launch_exit_hook
++
+         scope = {
+             "grid_meta": cfg.kwargs,
+             "bin": binary,
+-            "launch_enter_hook": binary.__class__.launch_enter_hook,
+-            "launch_exit_hook": binary.__class__.launch_exit_hook,
++            "launch_enter_hook": launch_enter,
++            "launch_exit_hook": launch_exit,
+             "metadata": (
+                 binary.packed_metadata
+                 if hasattr(binary, "packed_metadata")


### PR DESCRIPTION
Fixes an error which occurs after triton was bumped from 2.3.1 to 2.4 in 1a3d391c99f91411d86189b9413053d7d5eb72e0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
