### PR TITLE
shader-slang: fix LLVM build

### DIFF
--- a/pkgs/by-name/sh/shader-slang/package.nix
+++ b/pkgs/by-name/sh/shader-slang/package.nix
@@ -10,7 +10,7 @@
   libxml2,
   libX11,
   glslang,
-  llvmPackages_13,
+  llvmPackages_14,
   versionCheckHook,
   gitUpdater,
 
@@ -78,10 +78,10 @@ stdenv.mkDerivation (finalAttrs: {
     libX11
   ]
   ++ lib.optionals withLLVM [
-    # Slang only supports LLVM 13:
-    # https://github.com/shader-slang/slang/blob/master/docs/building.md#llvm-support
-    llvmPackages_13.llvm
-    llvmPackages_13.libclang
+    # Slang only supports LLVM 14:
+    # https://github.com/shader-slang/slang/blob/v2025.14.3/docs/building.md#llvm-support
+    llvmPackages_14.llvm
+    llvmPackages_14.libclang
   ]
   ++ lib.optionals withGlslang [
     # SPIRV-tools is included in glslang.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9042,6 +9042,8 @@ with pkgs;
 
   sdr-j-fm = libsForQt5.callPackage ../applications/radio/sdr-j-fm { };
 
+  shader-slang-llvm = callPackage ../by-name/sh/shader-slang/package.nix { withLLVM = true; };
+
   sigdigger = libsForQt5.callPackage ../applications/radio/sigdigger { };
 
   sev-snp-measure = with python3Packages; toPythonApplication sev-snp-measure;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

While reviewing #435962, I forgot that this fix is necessary when using `withLLVM`, due to shader-slang/slang#8031.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
