### PR TITLE
amd-debug-tools: init at 0.2.8

### DIFF
--- a/pkgs/by-name/am/amd-debug-tools/package.nix
+++ b/pkgs/by-name/am/amd-debug-tools/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  fetchgit,
+  python3Packages,
+  acpica-tools,
+  ethtool,
+  libdisplay-info,
+}:
+
+let
+  version = "0.2.8";
+in
+python3Packages.buildPythonApplication {
+  pname = "amd-debug-tools";
+  inherit version;
+  pyproject = true;
+
+  build-system = with python3Packages; [
+    pyudev
+    setuptools
+    setuptools-git
+    setuptools-git-versioning
+  ];
+  dependencies = with python3Packages; [
+    acpica-tools
+    cysystemd
+    dbus-fast
+    ethtool
+    jinja2
+    libdisplay-info
+    matplotlib
+    pandas
+    pyudev
+    seaborn
+    tabulate
+  ];
+  src = fetchgit {
+    url = "https://git.kernel.org/pub/scm/linux/kernel/git/superm1/amd-debug-tools.git";
+    tag = version;
+    hash = "sha256-EmXsW7Q5WMFL32LWr29W3GnGpw5aj53wlp9KbFV1r0Q=";
+    leaveDotGit = true;
+  };
+
+  disabled = python3Packages.pythonOlder "3.7";
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail ', "setuptools-git-versioning>=2.0,<3"' ""
+  '';
+
+  pythonImportsCheck = [ "amd_debug" ];
+
+  meta = {
+    description = "Debug tools for AMD zen systems";
+    homepage = "https://git.kernel.org/pub/scm/linux/kernel/git/superm1/amd-debug-tools.git/";
+    changelog = "https://git.kernel.org/pub/scm/linux/kernel/git/superm1/amd-debug-tools.git/tag/?h=${version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/cysystemd/default.nix
+++ b/pkgs/development/python-modules/cysystemd/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  pkgs,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  cython,
+  pkg-config,
+  setuptools,
+}:
+
+let
+  version = "2.0.1";
+in
+buildPythonPackage {
+  pname = "cysystemd";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mosquito";
+    repo = "cysystemd";
+    tag = version;
+    hash = "sha256-K2SlTRPuFRvKUlWovWrS1BrbSBUF5FOI3aNC0FiCNfI=";
+  };
+
+  disabled = pythonOlder "3.6";
+
+  build-system = [
+    setuptools
+    cython
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [ pkgs.systemd ];
+
+  pythonImportsCheck = [ "cysystemd" ];
+
+  meta = {
+    description = "systemd wrapper on Cython";
+    homepage = "https://github.com/mosquito/cysystemd";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3278,6 +3278,8 @@ self: super: with self; {
 
   cysignals = callPackage ../development/python-modules/cysignals { };
 
+  cysystemd = callPackage ../development/python-modules/cysystemd { };
+
   cython = callPackage ../development/python-modules/cython { };
 
   cython-test-exception-raiser =


### PR DESCRIPTION
amd-debug-tools contains a set of scripts that can be used to test/debug behavior on machines with AMD processors. This extends to s2idle sleep, pstates, and BIOS debugging. The scripts are primary authored by AMD-employee Mario Limonciello.

https://git.kernel.org/pub/scm/linux/kernel/git/superm1/amd-debug-tools.git/about

I have used this to test s2idle on my laptop. It helps to confirm the laptop is actually reaching hardware sleep and it records how much energy was used during sleep. Example output:
```
$ doas amd-s2idle test --count 3 --duration 60 --format html --report-file ~/s2idle.html
How long to wait in between suspend cycles (seconds) (default 4)?
💻 AMD Ryzen 7 7840U w/ Radeon  780M Graphics (family 19 model 74)
💻 Framework Laptop 13 (AMD Ryzen 7040Series) (Laptop)
🐧 NixOS 25.11 (Xantusia)
🐧 Kernel 6.16.7
🔋 Battery BAT1 (NVT Framewo) is operating at 80.43% of design
✅ ASPM policy set to 'default'
✅ GPIO driver `pinctrl_amd` available
✅ PMC driver `amd_pmc` loaded (Program 0 Firmware 76.96.0)
✅ USB3 driver `xhci_hcd` bound to 0000:c1:00.3, 0000:c1:00.4, 0000:c3:00.3, 0000:c3:00.4
✅ USB4 driver `thunderbolt` bound to 0000:c3:00.5, 0000:c3:00.6
✅ System is configured for s2idle
✅ GPU driver `amdgpu` bound to 0000:c1:00.0
✅ PC6 and CC6 enabled
✅ SMT enabled
✅ ACPI FADT supports Low-power S0 idle
✅ LPS0 _DSM enabled
✅ WLAN driver `ath12k_pci` bound to 0000:01:00.0
🚦 Kernel is tainted: 4097
🗣️ Explanations for your system
🚦 Kernel is tainted
A tainted kernel may exhibit unpredictable bugs that are difficult for this script to characterize. If this is intended behavior run the tool with --force.
For more information on this failure see:https://gitlab.freedesktop.org/drm/amd/-/issues/3089
🗣️ Running 3 cycles (Test finish expected @ 2025-09-18 20:50:40.136995)
🗣️ Suspend cycle 1: Started at 2025-09-18 20:47:30.138448 (cycle finish expected @ 2025-09-18 20:48:34.335407)
🗣️ Results from last s2idle cycle
Summary
╒═════════════════════╤════════════╤══════════════════╤═════════════════╤═════════════════╤════════════════════╤════════════╤══════════════════╕
│ Start Time          │ Duration   │ Hardware Sleep   │ Battery Start   │ Battery Delta   │ Battery Ave Rate   │   Wake Pin │ Wake Interrupt   │
╞═════════════════════╪════════════╪══════════════════╪═════════════════╪═════════════════╪════════════════════╪════════════╪══════════════════╡
│ 2025-09-18 20:47:30 │ 0:01:03    │ 92.09%           │ 56.46%          │ -0.10%          │ -0.13W             │          6 │ ACPI SCI         │
╘═════════════════════╧════════════╧══════════════════╧═════════════════╧═════════════════╧════════════════════╧════════════╧══════════════════╛
💤 Hardware sleep cycle count: 1
💤 Notify devices ['DEV0', 'UBTC'] found during suspend
🗣️ Suspend cycle 2: Started at 2025-09-18 20:48:35.281752 (cycle finish expected @ 2025-09-18 20:49:39.369273)
🗣️ Results from last s2idle cycle
Summary
╒═════════════════════╤════════════╤══════════════════╤═════════════════╤═════════════════╤════════════════════╤════════════╤══════════════════╕
│ Start Time          │ Duration   │ Hardware Sleep   │ Battery Start   │ Battery Delta   │ Battery Ave Rate   │   Wake Pin │ Wake Interrupt   │
╞═════════════════════╪════════════╪══════════════════╪═════════════════╪═════════════════╪════════════════════╪════════════╪══════════════════╡
│ 2025-09-18 20:48:35 │ 0:01:03    │ 92.13%           │ 56.35%          │ -0.10%          │ -0.13W             │          6 │ ACPI SCI         │
╘═════════════════════╧════════════╧══════════════════╧═════════════════╧═════════════════╧════════════════════╧════════════╧══════════════════╛
💤 Hardware sleep cycle count: 1
💤 Notify devices ['DEV0', 'UBTC'] found during suspend
🗣️ Suspend cycle 3: Started at 2025-09-18 20:49:40.105101 (cycle finish expected @ 2025-09-18 20:50:44.192262)
🗣️ Results from last s2idle cycle
Summary
╒═════════════════════╤════════════╤══════════════════╤═════════════════╤═════════════════╤════════════════════╤════════════╤══════════════════╕
│ Start Time          │ Duration   │ Hardware Sleep   │ Battery Start   │ Battery Delta   │ Battery Ave Rate   │   Wake Pin │ Wake Interrupt   │
╞═════════════════════╪════════════╪══════════════════╪═════════════════╪═════════════════╪════════════════════╪════════════╪══════════════════╡
│ 2025-09-18 20:49:40 │ 0:01:03    │ 92.72%           │ 56.25%          │ -0.10%          │ -0.13W             │          6 │ ACPI SCI         │
╘═════════════════════╧════════════╧══════════════════╧═════════════════╧═════════════════╧════════════════════╧════════════╧══════════════════╛
💤 Hardware sleep cycle count: 1
💤 Notify devices ['DEV0', 'UBTC'] found during suspend
Authorization required, but no authorization protocol specified

Report written to /home/talexander/s2idle.html
```

I haven't used amd-pstate but here is the output on my laptop:
```
$ doas amd-pstate triage
🐧 NixOS 25.11 (Xantusia)
🐧 Kernel:	6.15.4
○ 'status':	active
○ 'prefcore':	enabled
🐧 ITMT:	Y
💻 CPU:		AMD Ryzen 7 7840U w/ Radeon  780M Graphics
🔋 Per-CPU sysfs files
+---------+----------------+----------------------+----------------+--------------------+--------------------+---------------------------------+------------+---------+
|   CPU # |   CPU Min Freq |   CPU Nonlinear Freq |   CPU Max Freq |   Scaling Min Freq |   Scaling Max Freq | Energy Performance Preference   |   Prefcore |   Boost |
|---------+----------------+----------------------+----------------+--------------------+--------------------+---------------------------------+------------+---------|
|       0 |         419175 |              1100334 |        3301000 |            1100334 |            3301000 | performance                     |        226 |       0 |
|       1 |         419175 |              1100334 |        3301000 |            1100334 |            3301000 | performance                     |        226 |       0 |
|       2 |         419175 |              1100334 |        3301000 |            1100334 |            3301000 | performance                     |        232 |       0 |
|       3 |         419175 |              1100334 |        3301000 |            1100334 |            3301000 | performance                     |        232 |       0 |
|       4 |         419175 |              1100334 |        3301000 |            1100334 |            3301000 | performance                     |        214 |       0 |
|       5 |         419175 |              1100334 |        3301000 |            1100334 |            3301000 | performance                     |        214 |       0 |
|       6 |         419175 |              1100334 |        3301000 |            1100334 |            3301000 | performance                     |        202 |       0 |
|       7 |         419175 |              1100334 |        3301000 |            1100334 |            3301000 | performance                     |        202 |       0 |
|       8 |         419175 |              1100334 |        3301000 |            1100334 |            3301000 | performance                     |        220 |       0 |
|       9 |         419175 |              1100334 |        3301000 |            1100334 |            3301000 | performance                     |        220 |       0 |
|      10 |         419175 |              1100334 |        3301000 |            1100334 |            3301000 | performance                     |        232 |       0 |
|      11 |         419175 |              1100334 |        3301000 |            1100334 |            3301000 | performance                     |        232 |       0 |
|      12 |         419175 |              1100334 |        3301000 |            1100334 |            3301000 | performance                     |        208 |       0 |
|      13 |         419175 |              1100334 |        3301000 |            1100334 |            3301000 | performance                     |        208 |       0 |
|      14 |         419175 |              1100334 |        3301000 |            1100334 |            3301000 | performance                     |        196 |       0 |
|      15 |         419175 |              1100334 |        3301000 |            1100334 |            3301000 | performance                     |        196 |       0 |
+---------+----------------+----------------------+----------------+--------------------+--------------------+---------------------------------+------------+---------+
🔋 CPPC MSRs
+---------+----------+----------+--------------------+---------+-----------+
|   CPU # |   Enable |   Status | Cap 1              | Cap 2   | Request   |
|---------+----------+----------+--------------------+---------+-----------|
|       0 |        1 |        0 | 0xe27e2a10e27e2a10 | 0x0     | 0x2b7e    |
|       1 |        1 |        0 | 0xe27e2a10         | 0x0     | 0x2b7e    |
|       2 |        1 |        0 | 0xe87e2a10e87e2a10 | 0x0     | 0x2b7e    |
|       3 |        1 |        0 | 0xe87e2a10         | 0x0     | 0x2b7e    |
|       4 |        1 |        0 | 0xd67e2a10d67e2a10 | 0x0     | 0x2b7e    |
|       5 |        1 |        0 | 0xd67e2a10         | 0x0     | 0x2b7e    |
|       6 |        1 |        0 | 0xca7e2a10ca7e2a10 | 0x0     | 0x2b7e    |
|       7 |        1 |        0 | 0xca7e2a10         | 0x0     | 0x2b7e    |
|       8 |        1 |        0 | 0xdc7e2a10dc7e2a10 | 0x0     | 0x2b7e    |
|       9 |        1 |        0 | 0xdc7e2a10         | 0x0     | 0x2b7e    |
|      10 |        1 |        0 | 0xe87e2a10e87e2a10 | 0x0     | 0x2b7e    |
|      11 |        1 |        0 | 0xe87e2a10         | 0x0     | 0x2b7e    |
|      12 |        1 |        0 | 0xd07e2a10d07e2a10 | 0x0     | 0x2b7e    |
|      13 |        1 |        0 | 0xd07e2a10         | 0x0     | 0x2b7e    |
|      14 |        1 |        0 | 0xc47e2a10c47e2a10 | 0x0     | 0x2b7e    |
|      15 |        1 |        0 | 0xc47e2a10         | 0x0     | 0x2b7e    |
+---------+----------+----------+--------------------+---------+-----------+
🔋 MSR_AMD_CPPC_CAP1 (decoded)
+---------+---------------+------------------+----------------+----------------+
|   CPU # |   Lowest Perf |   Nonlinear Perf |   Nominal Perf |   Highest Perf |
|---------+---------------+------------------+----------------+----------------|
|       0 |            16 |               42 |            126 |            226 |
|       1 |            16 |               42 |            126 |            226 |
|       2 |            16 |               42 |            126 |            232 |
|       3 |            16 |               42 |            126 |            232 |
|       4 |            16 |               42 |            126 |            214 |
|       5 |            16 |               42 |            126 |            214 |
|       6 |            16 |               42 |            126 |            202 |
|       7 |            16 |               42 |            126 |            202 |
|       8 |            16 |               42 |            126 |            220 |
|       9 |            16 |               42 |            126 |            220 |
|      10 |            16 |               42 |            126 |            232 |
|      11 |            16 |               42 |            126 |            232 |
|      12 |            16 |               42 |            126 |            208 |
|      13 |            16 |               42 |            126 |            208 |
|      14 |            16 |               42 |            126 |            196 |
|      15 |            16 |               42 |            126 |            196 |
+---------+---------------+------------------+----------------+----------------+
🔋 MSR_AMD_CPPC_REQ (decoded)
+---------+------------+------------+----------------+---------------------------+
|   CPU # |   Min Perf |   Max Perf |   Desired Perf |   Energy Performance Perf |
|---------+------------+------------+----------------+---------------------------|
|       0 |         43 |        126 |              0 |                         0 |
|       1 |         43 |        126 |              0 |                         0 |
|       2 |         43 |        126 |              0 |                         0 |
|       3 |         43 |        126 |              0 |                         0 |
|       4 |         43 |        126 |              0 |                         0 |
|       5 |         43 |        126 |              0 |                         0 |
|       6 |         43 |        126 |              0 |                         0 |
|       7 |         43 |        126 |              0 |                         0 |
|       8 |         43 |        126 |              0 |                         0 |
|       9 |         43 |        126 |              0 |                         0 |
|      10 |         43 |        126 |              0 |                         0 |
|      11 |         43 |        126 |              0 |                         0 |
|      12 |         43 |        126 |              0 |                         0 |
|      13 |         43 |        126 |              0 |                         0 |
|      14 |         43 |        126 |              0 |                         0 |
|      15 |         43 |        126 |              0 |                         0 |
+---------+------------+------------+----------------+---------------------------+
```

I also have not used amd-ttm but here is the output:
```
$ doas amd-ttm
💻 Current TTM pages limit: 12076552 pages (46.07 GB)
💻 Total system memory: 92.14 GB
```

and amd-bios provided too much output to include the full text here:
```
$ doas amd-bios parse
○ Linux version 6.15.4 (nixbld@localhost) (gcc (GCC) 14.3.0, GNU ld (GNU Binutils) 2.44) #1-NixOS SMP PREEMPT_DYNAMIC Fri Jun 27 10:13:43 UTC 2025
○ Command line: init=/nix/store/6fdfahb8rlyxlpz80gv2idpmz2w5wib0-nixos-system-odo-25.11.20250824.898678c/init ath12k.debug_mask=0xffffffff amdgpu.abmlevel=3 pcie_aspm=force nowatchdog nohibernate root=fstab loglevel=4 lsm=landlock,yama,bpf
○ BIOS-provided physical RAM map:
○ BIOS-e820: [mem 0x0000000000000000-0x000000000009efff] usable
○ BIOS-e820: [mem 0x000000000009f000-0x00000000000bffff] reserved
○ BIOS-e820: [mem 0x0000000000100000-0x0000000009afffff] usable
[...]
```

This would be my first contribution to nixpkgs so I don't yet know what I am doing. For example, I wasn't sure if the addition of cysystemd should be in a separate PR or included in this one since it was being added merely to serve as a dependency for amd-debug-tools. I kept the two in separate commits.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
