### PR TITLE
dprint: Fix build failure with Rust ≥ 1.89.0

### DIFF
--- a/pkgs/by-name/dp/dprint/package.nix
+++ b/pkgs/by-name/dp/dprint/package.nix
@@ -24,7 +24,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-Lt6CzSzppu5ULhzYN5FTCWtWK3AA4/8jRzXgQkU4Tco=";
   };
 
-  cargoHash = "sha256-1opQaR3vbm/DpDY5oQ1VgA4nf0nCBknxfgOSPZQbtV4=";
+  cargoPatches = [
+    # Upgrade wasmer to 6.1.0-rc.3 to fix build failure with Rust ≥ 1.89.0
+    # https://github.com/dprint/dprint/pull/1021
+    ./upgrade-wasmer.patch
+  ];
+
+  cargoHash = "sha256-RUWyR1Yr9G2xBMigDa9+LQyaU5on85xkRQYTLH9JOPg=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/dp/dprint/upgrade-wasmer.patch
+++ b/pkgs/by-name/dp/dprint/upgrade-wasmer.patch
@@ -1,0 +1,161 @@
+From 379cf407bfc07380dad24aefb2db40f6852f32ed Mon Sep 17 00:00:00 2001
+From: Anders Kaseorg <andersk@mit.edu>
+Date: Mon, 25 Aug 2025 18:01:57 -0700
+Subject: [PATCH] Upgrade wasmer to 6.1.0-rc.3
+
+Signed-off-by: Anders Kaseorg <andersk@mit.edu>
+---
+ Cargo.lock               | 41 ++++++++++++++++++++--------------------
+ crates/dprint/Cargo.toml |  4 ++--
+ 2 files changed, 22 insertions(+), 23 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 9a1bc870..bff2c81b 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -455,9 +455,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+ 
+ [[package]]
+ name = "corosensei"
+-version = "0.2.1"
++version = "0.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ad067b451c08956709f8762dba86e049c124ea52858e3ab8d076ba2892caa437"
++checksum = "5d1ea1c2a2f898d2a6ff149587b8a04f41ee708d248c723f01ac2f0f01edc0b3"
+ dependencies = [
+  "autocfg",
+  "cfg-if",
+@@ -776,18 +776,18 @@ dependencies = [
+ 
+ [[package]]
+ name = "derive_more"
+-version = "1.0.0"
++version = "2.0.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
++checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+ dependencies = [
+  "derive_more-impl",
+ ]
+ 
+ [[package]]
+ name = "derive_more-impl"
+-version = "1.0.0"
++version = "2.0.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
++checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -3256,16 +3256,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasmer"
+-version = "6.0.1"
++version = "6.1.0-rc.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f25dccc6251837449135914ee1978731c2c3df9fc727088eb7e098736c0f15d1"
++checksum = "1e588d83a5ac7eb5e6af54ac4d34183442e4dd2a7358d2a11793b17c03b7df0b"
+ dependencies = [
+  "bindgen",
+  "bytes",
+  "cfg-if",
+  "cmake",
+- "derive_more 1.0.0",
+- "idna_adapter",
++ "derive_more 2.0.1",
+  "indexmap",
+  "js-sys",
+  "more-asserts",
+@@ -3278,7 +3277,6 @@ dependencies = [
+  "target-lexicon",
+  "thiserror 1.0.61",
+  "tracing",
+- "ureq",
+  "wasm-bindgen",
+  "wasmer-compiler",
+  "wasmer-compiler-cranelift",
+@@ -3292,9 +3290,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasmer-compiler"
+-version = "6.0.1"
++version = "6.1.0-rc.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6f35baeb0d5b20710b5b9c59477dbf813b1ac53da33ee46cb22f8c4190e3986e"
++checksum = "c9542eb21b9a0f7811101e26e40e360a9ac02d093e3089c8fa62dfa102478edb"
+ dependencies = [
+  "backtrace",
+  "bytes",
+@@ -3323,9 +3321,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasmer-compiler-cranelift"
+-version = "6.0.1"
++version = "6.1.0-rc.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6d657a96003ce3f54a3cbbf681fcd782b983f9362c97cfbbe243cbf66790e004"
++checksum = "a69f548bcccd4791b2647e0d748eb8ddd4d0856233778867c8b0db3781a82ca1"
+ dependencies = [
+  "cranelift-codegen",
+  "cranelift-entity",
+@@ -3343,9 +3341,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasmer-derive"
+-version = "6.0.1"
++version = "6.1.0-rc.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "62b57be80a67de03c2a02d697bfd763e097546b11f0020cf9930ebaa4f8cf965"
++checksum = "8db532c73814748214276f878b8382a8885769fdd86d0bee2792c438b0d28c62"
+ dependencies = [
+  "proc-macro-error2",
+  "proc-macro2",
+@@ -3355,9 +3353,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasmer-types"
+-version = "6.0.1"
++version = "6.1.0-rc.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1b8424d15f5c19a8df972fc9367d75ba3b87af63b279208d50a32e9a298d944b"
++checksum = "81b900743ecb272e8e8a760a42e069f19d158d9fd03c6ac256026407bdc91833"
+ dependencies = [
+  "bytecheck 0.6.11",
+  "enum-iterator",
+@@ -3375,9 +3373,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasmer-vm"
+-version = "6.0.1"
++version = "6.1.0-rc.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "faabfffefc6fc350bb5b07301f05ba604a18c3d2d97c6354183f15792577056d"
++checksum = "40956bcf167d5bed1a940649f638e2d610e5a066863b4ab6c1ab1341fef97a9a"
+ dependencies = [
+  "backtrace",
+  "cc",
+@@ -3394,6 +3392,7 @@ dependencies = [
+  "memoffset",
+  "more-asserts",
+  "region",
++ "rustversion",
+  "scopeguard",
+  "thiserror 1.0.61",
+  "wasmer-types",
+diff --git a/crates/dprint/Cargo.toml b/crates/dprint/Cargo.toml
+index 44d107d4..af733e83 100644
+--- a/crates/dprint/Cargo.toml
++++ b/crates/dprint/Cargo.toml
+@@ -58,8 +58,8 @@ webpki-roots = "=0.26.7"
+ # patch version increases of rkyv may cause panics when deserializing
+ # data serialized with older versions
+ rkyv = "=0.8.10"
+-wasmer = "=6.0.1"
+-wasmer-compiler = "=6.0.1"
++wasmer = "=6.1.0-rc.3"
++wasmer-compiler = "=6.1.0-rc.3"
+ 
+ [target.'cfg(windows)'.dependencies]
+ winreg = "=0.55.0"


### PR DESCRIPTION
- dprint/dprint#1021

Fix this build failure introduced by the Rust 1.89.0 upgrade (#431899):

```
error: linking with `/nix/store/bcw9f6r9v2fm3kv7d15fcrya0mf34xds-gcc-wrapper-14.3.0/bin/cc` failed: exit status: 1
  |
  = note:  "/nix/store/bcw9f6r9v2fm3kv7d15fcrya0mf34xds-gcc-wrapper-14.3.0/bin/cc" "-m64" "/build/rustcD4KBHq/symbols.o" "<17 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "/build/source/target/x86_64-unknown-linux-gnu/release/deps/{libureq-df58dc0a92c38810.rlib,libsocks-eb15862927a3d71c.rlib,libtwox_hash-c21f9310570f0a5c.rlib,librand-cf28947818cc9ea0.rlib,librand_chacha-b57e5006b0c26090.rlib,librand_core-4fce3dbb6f155ba0.rlib,libzip-82a16c625f06e55b.rlib,libxz2-36a7004cb8d7d4a0.rlib,liblzma_sys-15d68fa8cb123c0b.rlib,libdeflate64-5d48869d029f3c4b.rlib,libpbkdf2-85d5324017b801ba.rlib,libzstd-34993bb174b7d2d7.rlib,libzstd_safe-a012cc1c8ff1b422.rlib,libzstd_sys-279be0440c35acb5.rlib,libzopfli-b90d0f58d482c79f.rlib,libsimd_adler32-a96f2d3c6711d280.rlib,liblockfree_object_pool-38eff01eea372200.rlib,libbzip2-e6bd09c08ad13a83.rlib,libbzip2_sys-718ed1aa10a944f6.rlib,libtime-0ee163fc47a1d532.rlib,libtime_core-7c17e4373be7fe5e.rlib,libnum_conv-34c53af237eeb7cd.rlib,libderanged-d23668f966b9f0a6.rlib,libpowerfmt-dad5b05e4a9c73e4.rlib,liblzma_rs-52ad5a82a86714b2.rlib,libcrc-b51a44c4d06c06e3.rlib,libcrc_catalog-17e7dfa2d1ece673.rlib,libaes-0fd0ac1bf9ef1527.rlib,libcipher-9c30e8c94d39b04c.rlib,libinout-a17119daf1607d90.rlib,libsha1-11a8ad57409499f5.rlib,libhmac-ccd6061fc232b3a9.rlib,libconstant_time_eq-ecd422efd3ca28c8.rlib,librustls_native_certs-234cd5236ed4aeee.rlib,librustls_pemfile-0afd538d6cbb6fc0.rlib,libbase64-0fce6b2ccf1af553.rlib,libopenssl_probe-6e042266b7554b05.rlib,libwebpki_roots-10b2524068bcd8d2.rlib,libclap_complete-ae3d9a2ed866e8ad.rlib,libdunce-a48132b618ecc460.rlib,libdirs-2913fb88ce9cb5b6.rlib,libdirs_sys-277ef184673dc00b.rlib,liboption_ext-42a600ae1dc3257c.rlib,librand-bb0f48f8d937a41f.rlib,librand_chacha-76b2dc2949fc3bbe.rlib,libppv_lite86-2adf7d0a68b5de38.rlib,librand_core-82b3bdba55862150.rlib,libgetrandom-7aaf8451c131381c.rlib,libipnet-b9ed344ea3430030.rlib,libconsole_static_text-ff5ae2d035a5edbd.rlib,libvte-1bef998ef048acf8.rlib,libarrayvec-65b9dc3a7ca8649c.rlib,libunicode_width-e889f829d4ebc1f4.rlib,libfs3-801e4491e2e707f8.rlib,libignore-46b148b4ef684986.rlib,libwalkdir-88403ce4b4b9e2bf.rlib,libsame_file-badf80ca51c22acc.rlib,libglobset-d111d7b886983d31.rlib,libregex_automata-bfa3b89f53edaaf4.rlib,libregex_syntax-c2184b98fdd74506.rlib,libbstr-7bbd57d60176dc54.rlib,libaho_corasick-75b103e5cc603bb9.rlib,libsimilar-d2b82df97de5e76a.rlib,librustls-a00d16650bbe8ce8.rlib,libwebpki-72c62dbadf674b0b.rlib,libring-34499d669d1987e6.rlib,libgetrandom-6c8ec5e8419ce144.rlib,libspin-3d1686323fcb5b02.rlib,libuntrusted-22a716ed55576eed.rlib,librustls_pki_types-c2366437b53b3062.rlib,libzeroize-47c6e08b8506d0f4.rlib,libwasmer-b8da5aac119dbffe.rlib,libderive_more-9c6de7facd1a595e.rlib,libwat-04475dfa947cda34.rlib,libwast-6e01191abce56346.rlib,libwasm_encoder-9877da44e5354ea8.rlib,libleb128-7dfa5c12462a86a0.rlib,libwasmer_compiler_cranelift-d4e18928a441576c.rlib,libitertools-f11f12fbbcb76018.rlib,libcranelift_frontend-4aed8c891aa6bcb3.rlib,librayon-2b0224d3d56b4c12.rlib,librayon_core-94a0a56d76318411.rlib,libcrossbeam_deque-d1a8a225b80b41ee.rlib,libcrossbeam_epoch-127ea10fe53fc652.rlib,libeither-78a59d9ff78926da.rlib,libcranelift_codegen-e0a259e5d14f3a8a.rlib,libcranelift_codegen_shared-af505568f3d8212e.rlib,libregalloc2-f8e277aef491bc99.rlib,libslice_group_by-8da78e39f942a003.rlib,libhashbrown-b466d6778f70ed0b.rlib,librustc_hash-bf05aba13576b055.rlib,libgimli-4439b11f7e2786b5.rlib,libfallible_iterator-98564fc3bfe6192c.rlib,libcranelift_control-395d4097d04e4f08.rlib,libarbitrary-86bc3458deb6fc52.rlib,libcranelift_bforest-a16f07e5e0165aae.rlib,libcranelift_entity-ce72b859ceadbf1d.rlib,libcranelift_bitset-155f8124d7a6758e.rlib,libwasmer_compiler-bd2e77712a12f46b.rlib,libwasmparser-8134fad2ec64edad.rlib,libself_cell-a4e81fcf3b1cb8b7.rlib,libobject-b6d8662004d812b5.rlib,libruzstd-fa8da0e93a5dbd72.rlib,libtwox_hash-e3606258f653f47c.rlib,libstatic_assertions-942f93c0f8e8f2bb.rlib,libbyteorder-3c08410529163482.rlib,libflate2-6dc98a21757cc984.rlib,libcrc32fast-ebfcfe27944d7070.rlib,libshared_buffer-81aeb0c3e3d36f8f.rlib,libmemmap2-7ed582d8496eee32.rlib,libwasmer_vm-f7897bac3ab863e6.rlib,libcrossbeam_queue-a7c5850896d2865d.rlib,libregion-fb413fea2b7a0be8.rlib,liblibunwind-7e7630406674d1bc.rlib,libcorosensei-c1a65e92923d3a8f.rlib,libbacktrace-15e647c308484d26.rlib,libminiz_oxide-0aa8023c38a7b435.rlib,libadler2-dda18de57a4a107c.rlib,libobject-61309c0c29b3e4b0.rlib,libaddr2line-28ec2612585f6942.rlib,libgimli-620b2a8a9bae04a2.rlib,librustc_demangle-c73caacd78786942.rlib,libfnv-27f41406ed48be5f.rlib,libdashmap-6656561fb9589b91.rlib,libmemoffset-87a701f553606523.rlib,libwasmer_types-866f09b0630f9579.rlib,libxxhash_rust-3f59323723f19383.rlib,libhex-d4d9a49f44631e11.rlib,libmore_asserts-a141099de617b798.rlib,libtarget_lexicon-e6d764309e951784.rlib,libenumset-2fe848908f451ea5.rlib,libsha2-be22863a94d31124.rlib,libcpufeatures-4084e36f17d29212.rlib,libdigest-38d19fb56b99b525.rlib,libsubtle-861e4795971f4219.rlib,libblock_buffer-93f942a83aec1e41.rlib,libcrypto_common-0316627ccd649b1c.rlib,libgeneric_array-2a3075f6ee1a2388.rlib,libtypenum-10d308f2821c5f31.rlib,libenum_iterator-57e6cfa414d3f50e.rlib,librkyv-805bd3db9026c5a5.rlib,librend-cd3a8a235dbe213a.rlib,libmunge-ff5d7153ba131324.rlib,libbytecheck-d5ef1b292a9859e1.rlib,libsimdutf8-b9ca19cbbb755d37.rlib,librancor-0e1425a524d52612.rlib,libptr_meta-edab0dd4c4f3d664.rlib,libthiserror-676b31b900d9e9f4.rlib,libjsonc_parser-19338d21e466e472.rlib,libtext_size-18e289ccd953d7df.rlib,libdissimilar-873e455dff13d523.rlib,libtower_lsp-589ab1e32dfe8456.rlib,libhttparse-11a5a6d4d3f3c46f.rlib,libdashmap-05f418ef7e5fcb97.rlib,libhashbrown-7aefdd746245fddd.rlib,libahash-3bc936617a027a19.rlib,libzerocopy-4f87196595e19eaa.rlib,libtower-6262cffeca611b52.rlib,libpin_project-1d5bd1cffe365f44.rlib,libtower_service-a5bddbdea139132e.rlib,libtower_layer-cd2ef3504b160103.rlib,libtracing-1d7ddfe622ed0488.rlib,libtracing_core-ae7690a188a42cca.rlib,liblsp_types-f317ebe91226569f.rlib,libbitflags-a19d3a47845efab3.rlib,libcrossterm-0faac04cbc0a41fb.rlib,libbitflags-f99879113860e4e0.rlib,libsignal_hook_mio-b53e45567d54a351.rlib,libsignal_hook-0565bb2d837b2623.rlib,libsignal_hook_registry-0d617538c9f3cc0c.rlib,libmio-98792f72cd168b55.rlib,liblog-1cd4459db5994d57.rlib,liburl-9d0a39cc2313f33d.rlib,libidna-308432412a42aecc.rlib,libidna_adapter-d0da404e062dccc3.rlib,libicu_normalizer-ae39dff7124fc687.rlib,libicu_normalizer_data-8a6cb10c8116ed42.rlib,libwrite16-c097441d874ba27c.rlib,libutf8_iter-ad8ef99999b93bac.rlib,libutf16_iter-e3e2b8104f1f15d6.rlib,libicu_properties-bd1e004d982bac17.rlib,libicu_properties_data-2e69535f0b8fd499.rlib,libicu_locid_transform-04e740dc8d59962c.rlib,libicu_locid_transform_data-8fd05893bd927d8b.rlib,libicu_collections-6121bf3cd8e04975.rlib,libicu_provider-e6d24fbef2c31bfa.rlib,libicu_locid-38db7c671b35894b.rlib,liblitemap-ca8452f518b2599d.rlib,libtinystr-366579b96733c2f7.rlib,libzerovec-a3dbf308f72e675f.rlib,libwriteable-156e6edcd7a8b939.rlib,libyoke-f78078714047592f.rlib,libzerofrom-8f64e5b0c614ada5.rlib,libstable_deref_trait-d786002a43ff4fbb.rlib,libform_urlencoded-0717d33ac6d72c0a.rlib,libpercent_encoding-153d2004886e4713.rlib,libthiserror-3ec2fed47c1ec291.rlib,libclap-47a117a6c56c51c7.rlib,libclap_builder-00fc7adec97f5a3e.rlib,libstrsim-e4b41907842cdc4c.rlib,libanstream-a082c29f5ee3f8b3.rlib,libanstyle_query-4beb4e97e7a796c1.rlib,libis_terminal_polyfill-fc5af0ec8b76655f.rlib,libcolorchoice-d1cd3d1bc28c29b6.rlib,libanstyle_parse-35287d7d1fd0f84f.rlib,libutf8parse-d99d415c2c471e94.rlib,libclap_lex-b2e943cc3cc6aa10.rlib,libanstyle-227a4e3b39a250c3.rlib,libsysinfo-ec8570c97a387c49.rlib,libparking_lot-87dc8c45038a150a.rlib,libparking_lot_core-67d42b8bcb396e84.rlib,libcfg_if-e64a3922ec6f8bbd.rlib,libsmallvec-45deea74aba014eb.rlib,liblock_api-570b84d8621dc1fe.rlib,libscopeguard-59638ae6d167dcf0.rlib,libonce_cell-01f63d27710420a9.rlib,libdprint_core-217350301e3b9ada.rlib,libserde_json-9e0d14cfde35e5a3.rlib,libitoa-75f951db53a7b203.rlib,libryu-1a58f87ca09155d3.rlib,libbumpalo-0530220e00e50745.rlib,librustc_hash-460b262804683254.rlib,libunicode_width-061ca5157d67566e.rlib,libcrossbeam_channel-911ea3f1057795f6.rlib,libcrossbeam_utils-ff300a6949b20131.rlib,libfutures-096fc60e8da6e281.rlib,libfutures_executor-4a6d945091baab95.rlib,libfutures_util-3d13581345e7bc11.rlib,libmemchr-ea3286f920a3edc4.rlib,libfutures_io-ac0157e0fbb4ac7a.rlib,libslab-6510c529e280aef0.rlib,libfutures_channel-530cffca991ac6f4.rlib,libfutures_task-f5c64f755ec04f07.rlib,libpin_utils-1eeefc6fb70b939a.rlib,libtokio_util-d37250f495fa1eb3.rlib,libbytes-cc92e3f3d6cfc1d5.rlib,libfutures_core-134515d30b2f63d1.rlib,libfutures_sink-6e6523ec75598944.rlib,libtokio-863bc2c8d24f6ab7.rlib,libnum_cpus-0cfdf475f5e4e47d.rlib,liblibc-1f1fadd2f56a0405.rlib,libpin_project_lite-4e6364ea99a88192.rlib,libindexmap-38cd3f4823d192d9.rlib,libhashbrown-1617bad21d2af998.rlib,libfoldhash-9905c2d675e71c84.rlib,libequivalent-4c7f25e8972d3daf.rlib,liballocator_api2-7a3a5efaca4eb5fa.rlib,libserde-3bf3d6ee1a523875.rlib,libanyhow-43ca8a49b0debf87.rlib}.rlib" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,libcfg_if-*,liblibc-*,librustc_std_workspace_core-*,liballoc-*,libcore-*,libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "/build/rustcD4KBHq/raw-dylibs" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "/build/source/target/x86_64-unknown-linux-gnu/release/build/ring-0b66f95136e3adcc/out" "-L" "/build/source/target/x86_64-unknown-linux-gnu/release/build/bzip2-sys-ef8587c167e69a03/out/lib" "-L" "/build/source/target/x86_64-unknown-linux-gnu/release/build/lzma-sys-660bfbee05f7b2e0/out" "-L" "/build/source/target/x86_64-unknown-linux-gnu/release/build/zstd-sys-cd967a557357af35/out" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/build/source/target/x86_64-unknown-linux-gnu/release/deps/dprint-f8a267252aab3a3b" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-Wl,-O1" "-nodefaultlibs" "/build/source/target/x86_64-unknown-linux-gnu/release/deps/dprint_audit_data.o" "-Wl,--undefined=AUDITABLE_VERSION_INFO"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: /nix/store/xrwdb41dqi2ia6lr2s61w5bzfg2m71pi-binutils-2.44/bin/ld: /build/source/target/x86_64-unknown-linux-gnu/release/deps/libwasmer_vm-f7897bac3ab863e6.rlib(wasmer_vm-f7897bac3ab863e6.wasmer_vm.89c64a112e719ed7-cgu.03.rcgu.o): in function `wasmer_vm::libcalls::function_pointer':
          wasmer_vm.89c64a112e719ed7-cgu.03:(.text._ZN9wasmer_vm8libcalls16function_pointer17h526f50769b841e4bE+0x126): undefined reference to `__rust_probestack'
          collect2: error: ld returned 1 exit status
          
  = note: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
  = note: use the `-l` flag to specify native libraries to link
  = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-lib)

warning: `dprint` (bin "dprint") generated 5 warnings
error: could not compile `dprint` (bin "dprint") due to 1 previous error; 5 warnings emitted
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
