### PR TITLE
python3Packages.asteroid-filterbanks: disable a failing test for all linux

### DIFF
--- a/pkgs/development/python-modules/asteroid-filterbanks/default.nix
+++ b/pkgs/development/python-modules/asteroid-filterbanks/default.nix
@@ -71,7 +71,7 @@ buildPythonPackage {
     "test_pcen_jit"
     "test_stateful_pcen_jit"
   ]
-  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     # Flaky: AssertionError: Tensor-likes are not close!
     "test_fb_def_and_forward_lowdim"
   ];


### PR DESCRIPTION
I'm seeing the same failure that originally got this test disabled on aarch64 on an x86_64 box with an EPYC.

It's a small floating point difference so I'm wondering if it's down to CPU features?

See #360116 for original PR which disabled this on aarch64.

```
       > FAILED tests/filterbanks_test.py::test_fb_def_and_forward_lowdim[fb_config3-ParamSincFB] - AssertionError: Tensor-likes are not close!
       >
       > Mismatched elements: 1 / 15961 (0.0%)
       > Greatest absolute difference: 2.6211142539978027e-05 at index (0, 0, 7810) (up to 1e-05 allowed)
       > Greatest relative difference: 0.0027774577029049397 at index (0, 0, 7810) (up to 0.0001
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
