### PR TITLE
python313Packages.pandas-stubs: 2.2.3.250308 -> 2.3.0.250703-unstable-2025-08-25; fix build

### DIFF
--- a/pkgs/development/python-modules/pandas-stubs/default.nix
+++ b/pkgs/development/python-modules/pandas-stubs/default.nix
@@ -34,9 +34,9 @@
   xlsxwriter,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "pandas-stubs";
-  version = "2.2.3.250308";
+  version = "2.3.0.250703-unstable-2025-08-25";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -44,8 +44,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pandas-dev";
     repo = "pandas-stubs";
-    tag = "v${version}";
-    hash = "sha256-93XVzdb3A2S+Exk33v3U8HDMg9vPKAEkWjLZnBaXMWQ=";
+    rev = "3033eea474b754f7deabfa25a3377ed1efb85c15";
+    hash = "sha256-1RU18pP3rmKoemwk44B3RG0D5jiNkx2fxxcXwMBEngY=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/pandas-stubs/default.nix
+++ b/pkgs/development/python-modules/pandas-stubs/default.nix
@@ -99,10 +99,10 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "pandas" ];
 
-  meta = with lib; {
+  meta = {
     description = "Type annotations for Pandas";
     homepage = "https://github.com/pandas-dev/pandas-stubs";
-    license = licenses.mit;
-    maintainers = with maintainers; [ malo ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ malo ];
   };
 }

--- a/pkgs/development/python-modules/pandas-stubs/default.nix
+++ b/pkgs/development/python-modules/pandas-stubs/default.nix
@@ -77,24 +77,10 @@ buildPythonPackage {
     python-calamine
   ];
 
-  disabledTests = [
-    # Missing dependencies, error and warning checks
-    "test_all_read_without_lxml_dtype_backend" # pyarrow.orc
-    "test_orc" # pyarrow.orc
-    "test_plotting" # UserWarning: No artists with labels found to put in legend.
-    "test_spss" # FutureWarning: ChainedAssignmentError: behaviour will change in pandas 3.0!
-    "test_show_version"
-    # FutureWarning: In the future `np.bool` will be defined as the corresponding...
-    "test_timedelta_cmp"
-    "test_timestamp_cmp"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    "test_clipboard" # FileNotFoundError: [Errno 2] No such file or directory: 'pbcopy'
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
-    # Disable tests for types that are not supported on aarch64 in `numpy` < 2.0
-    "test_astype_float" # `f16` and `float128`
-    "test_astype_complex" # `c32` and `complex256`
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # FileNotFoundError: [Errno 2] No such file or directory: 'pbcopy'
+    "test_clipboard"
+    "test_all_read_without_lxml_dtype_backend"
   ];
 
   pythonImportsCheck = [ "pandas" ];


### PR DESCRIPTION
- **python313Packes.pandas-stubs: 2.2.3.250308 -> 2.3.0.250703-unstable-2025-08-25**
- **python313Packes.pandas-stubs: remove with lib;**
- **python313Packes.pandas-stubs: remove test skips**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
