### PR TITLE
python3Packages.typer-slim: expose from typer package

### DIFF
--- a/pkgs/development/python-modules/typer/default.nix
+++ b/pkgs/development/python-modules/typer/default.nix
@@ -21,10 +21,13 @@
   pytestCheckHook,
   writableTmpDirAsHomeHook,
   procps,
+
+  # typer or typer-slim
+  package ? "typer",
 }:
 
 buildPythonPackage rec {
-  pname = "typer";
+  pname = package;
   version = "0.16.0";
   pyproject = true;
 
@@ -35,15 +38,17 @@ buildPythonPackage rec {
     hash = "sha256-WB9PIxagTHutfk3J+mNTVK8bC7TMDJquu3GLBQgaras=";
   };
 
+  env.TIANGOLO_BUILD_PACKAGE = package;
+
   build-system = [ pdm-backend ];
 
   dependencies = [
     click
     typing-extensions
-    # Build includes the standard optional by default
-    # https://github.com/tiangolo/typer/blob/0.12.3/pyproject.toml#L71-L72
   ]
-  ++ optional-dependencies.standard;
+  # typer includes the standard optional by default
+  # https://github.com/tiangolo/typer/blob/0.12.3/pyproject.toml#L71-L72
+  ++ lib.optionals (package == "typer") optional-dependencies.standard;
 
   optional-dependencies = {
     standard = [
@@ -51,6 +56,8 @@ buildPythonPackage rec {
       shellingham
     ];
   };
+
+  doCheck = package == "typer"; # tests expect standard dependencies
 
   nativeCheckInputs = [
     coverage # execs coverage in tests

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18683,6 +18683,8 @@ self: super: with self; {
 
   typer-shell = callPackage ../development/python-modules/typer-shell { };
 
+  typer-slim = self.typer.override { package = "typer-slim"; };
+
   types-aiobotocore = callPackage ../development/python-modules/types-aiobotocore { };
 
   inherit (callPackage ../development/python-modules/types-aiobotocore-packages { })


### PR DESCRIPTION
This is the slim variant, that is more lightweight, because it does not depend on rich and shellingham.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
