### PR TITLE
ptcpdump: init at 0.37.0

### DIFF
--- a/pkgs/by-name/pt/ptcpdump/package.nix
+++ b/pkgs/by-name/pt/ptcpdump/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  fetchFromGitHub,
+  versionCheckHook,
+  buildGoModule,
+  libpcap,
+}:
+
+buildGoModule (finalAttr: {
+  pname = "ptcpdump";
+  version = "0.37.0";
+
+  src = fetchFromGitHub {
+    owner = "mozillazg";
+    repo = "ptcpdump";
+    tag = "v${finalAttr.version}";
+    hash = "sha256-ouH7VFWSCOElbmbSWAkmM4dtNVp545mC/FnoNAFtaEw=";
+  };
+
+  vendorHash = null;
+
+  buildInputs = [ libpcap ];
+
+  tags = [ "dynamic" ];
+
+  ldflags = [
+    "-X github.com/mozillazg/ptcpdump/internal.Version=v${finalAttr.version}"
+  ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  checkFlags =
+    let
+      # Skip tests that require network access
+      skippedTests = [
+        "Test_loadSpecFromBTFHub"
+        "Test_loadSpecFromOpenanolis"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  meta = {
+    homepage = "https://github.com/mozillazg/ptcpdump/";
+    description = "Process-aware, eBPF-based tcpdump";
+    mainProgram = "ptcpdump";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ neilmayhew ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add a derivation for [ptcpdump](https://github.com/mozillazg/ptcpdump/), a "Process-aware, eBPF-based tcpdump". It's backwards compatible with the traditional `tcpdump` but adds some powerful new features.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

I wasn't able to run `nixpkgs-review` because it died with an infinite recursion in `bazel-build-jaxlib-0.4.28`.

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
