### PR TITLE
unityhub: 3.13.1 -> 3.14.0, disable auto updater

### DIFF
--- a/pkgs/by-name/un/unityhub/package.nix
+++ b/pkgs/by-name/un/unityhub/package.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation rec {
   pname = "unityhub";
-  version = "3.13.1";
+  version = "3.14.0";
 
   src = fetchurl {
     url = "https://hub-dist.unity3d.com/artifactory/hub-debian-prod-local/pool/main/u/unity/unityhub_amd64/unityhub-amd64-${version}.deb";
-    hash = "sha256-gBQrz6CNlUyhxeLmY6tNtxpaQJSEW00r7MGyIDtYdiY=";
+    hash = "sha256-pOtdvu7sVe+n2FzItM6SA2sFhOwE48Tk5L+cbK7TTq8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/un/unityhub/package.nix
+++ b/pkgs/by-name/un/unityhub/package.nix
@@ -139,6 +139,11 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/share/applications/unityhub.desktop \
       --replace-fail /opt/unityhub/unityhub $out/opt/unityhub/unityhub
 
+    # This file is used by auto updater to determine whether this install is
+    # a .deb, .rpm, etc. Remove this to disable the auto updater, which auto
+    # downloads the update, in addition to being useless.
+    rm $out/opt/unityhub/resources/package-type
+
     runHook postInstall
   '';
 


### PR DESCRIPTION
Fairly normal update, and also quick fix to disable auto updater. I think there are some possible other ways to do so, but this seems the easiest.

https://unity.com/unity-hub/release-notes#3.14.0

There's something that they mention about the license manager having the wrong perms? not sure.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
