### PR TITLE
nix-inspect: 0.1.2 -> 0.1.2-unstable-2025-08-14

### DIFF
--- a/pkgs/by-name/ni/nix-inspect/package.nix
+++ b/pkgs/by-name/ni/nix-inspect/package.nix
@@ -9,21 +9,22 @@
   meson,
   ninja,
   stdenv,
-  fetchpatch,
+  fetchpatch2,
 }:
 let
+  nixComponents = nixVersions.nixComponents_2_30;
   src = fetchFromGitHub {
     owner = "bluskript";
     repo = "nix-inspect";
-    rev = "c55921e1d1cf980ff6351273fde6cedd5d8fa320";
-    hash = "sha256-Upz+fnWJjzt5WokjO/iaiPbqiwSrqpWjrpcFOqQ4p0E=";
+    rev = "2938c8e94acca6a7f1569f478cac6ddc4877558e";
+    hash = "sha256-ArwdTtlIje7yOTblkZs4aQ1+HBtEwJKkfKOiA9tY8nA=";
   };
 
   workerPackage = stdenv.mkDerivation {
     inherit src;
 
     pname = "nix-inspect-worker";
-    version = "0.1.2";
+    version = "0.1.2-unstable-2025-08-14";
     postPatch = ''
       cd worker
     '';
@@ -34,18 +35,22 @@ let
       pkg-config
     ];
 
-    # TODO: Remove this patch when this pull request is merged and released: https://github.com/bluskript/nix-inspect/pull/18
     patches = [
-      (fetchpatch {
-        url = "https://github.com/bluskript/nix-inspect/commit/e1e05883d42ce0c7029a3d69dce14ae9d057aae6.patch";
-        sha256 = "sha256-bHo+sRc9pICK0ccdiWLRNNvr8QjNCrlcwMvmUHznAtg=";
+      # Upgrade to Nix 2.30 - https://github.com/bluskript/nix-inspect/pull/25
+      (fetchpatch2 {
+        url = "https://github.com/bluskript/nix-inspect/commit/af4dd48d69f399c7b7e3f07d5268ade606a91f22.patch";
+        hash = "sha256-ipyT/zr+CEZi8EPk6Tw8V58ukUdmrtXRn+H32Y7Csuw=";
       })
     ];
 
     buildInputs = [
       boost
       nlohmann_json
-      nixVersions.nix_2_24.dev
+      nixComponents.nix-main
+      nixComponents.nix-store
+      nixComponents.nix-expr
+      nixComponents.nix-cmd
+      nixComponents.nix-flake
     ];
 
     mesonBuildType = "release";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This is a preparation to migrate away from nix 2.24.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
