### PR TITLE
h2o: 2.3.0-rolling-2025-08-22 → 2.3.0-rolling-2025-09-05

### DIFF
--- a/pkgs/by-name/h2/h2o/package.nix
+++ b/pkgs/by-name/h2/h2o/package.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "h2o";
-  version = "2.3.0-rolling-2025-09-04";
+  version = "2.3.0-rolling-2025-09-05";
 
   src = fetchFromGitHub {
     owner = "h2o";
     repo = "h2o";
-    rev = "295033e0b0daa5b481530f00c49759d50f0346a3";
-    hash = "sha256-7yhkLKvGXSc0S3ekC//zo7MZi+MILUp/nPSbKmoTIKQ=";
+    rev = "3b9b6a53cac8bcc6a25fb28df81ad295fc5f9402";
+    hash = "sha256-GJdZxGHQ6FWznY/PO3YN0yyfQ7RX8ilgEzXA4XciOqk=";
   };
 
   outputs = [

--- a/pkgs/by-name/h2/h2o/package.nix
+++ b/pkgs/by-name/h2/h2o/package.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "h2o";
-  version = "2.3.0-rolling-2025-08-29";
+  version = "2.3.0-rolling-2025-09-04";
 
   src = fetchFromGitHub {
     owner = "h2o";
     repo = "h2o";
-    rev = "bf5a9b6aceffb92082009a2e889e420de0ed2b3d";
-    hash = "sha256-0FAmqC4ytsA7/LOAbkLjMPHDxVXfznqEeROHgzqNNh0=";
+    rev = "295033e0b0daa5b481530f00c49759d50f0346a3";
+    hash = "sha256-7yhkLKvGXSc0S3ekC//zo7MZi+MILUp/nPSbKmoTIKQ=";
   };
 
   outputs = [

--- a/pkgs/by-name/h2/h2o/package.nix
+++ b/pkgs/by-name/h2/h2o/package.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "h2o";
-  version = "2.3.0-rolling-2025-08-28";
+  version = "2.3.0-rolling-2025-08-29";
 
   src = fetchFromGitHub {
     owner = "h2o";
     repo = "h2o";
-    rev = "42e4a8cedc867cfe08cb0bc4741372214a95c063";
-    hash = "sha256-X3L0Dph2bfDoe5QhPGSMb5abWbnpV8CrL2qS0rYL+Y4=";
+    rev = "bf5a9b6aceffb92082009a2e889e420de0ed2b3d";
+    hash = "sha256-0FAmqC4ytsA7/LOAbkLjMPHDxVXfznqEeROHgzqNNh0=";
   };
 
   outputs = [

--- a/pkgs/by-name/h2/h2o/package.nix
+++ b/pkgs/by-name/h2/h2o/package.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "h2o";
-  version = "2.3.0-rolling-2025-08-22";
+  version = "2.3.0-rolling-2025-08-26";
 
   src = fetchFromGitHub {
     owner = "h2o";
     repo = "h2o";
-    rev = "6476496bd544c3c7f601d7ab2b07e378e8310e11";
-    hash = "sha256-ZSBYg1HCuYifTyDmHyNIjEWab5N1TT+q/4m62mFFDJ0=";
+    rev = "5be9443086fb39a24538d23175b01348553904fc";
+    hash = "sha256-ckudEKFcZy3ouCF7F6UtW8GaoohYzw7ifjEfxuxRb9Y=";
   };
 
   outputs = [

--- a/pkgs/by-name/h2/h2o/package.nix
+++ b/pkgs/by-name/h2/h2o/package.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "h2o";
-  version = "2.3.0-rolling-2025-08-26";
+  version = "2.3.0-rolling-2025-08-27";
 
   src = fetchFromGitHub {
     owner = "h2o";
     repo = "h2o";
-    rev = "5be9443086fb39a24538d23175b01348553904fc";
-    hash = "sha256-ckudEKFcZy3ouCF7F6UtW8GaoohYzw7ifjEfxuxRb9Y=";
+    rev = "ac9d8dde95f73d384a42e6d378b360ceea47c2c1";
+    hash = "sha256-jateBWAlsJnr9e6pjdS+SWsunyvZ+9c+nFF/QhEo/+I=";
   };
 
   outputs = [

--- a/pkgs/by-name/h2/h2o/package.nix
+++ b/pkgs/by-name/h2/h2o/package.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "h2o";
-  version = "2.3.0-rolling-2025-08-27";
+  version = "2.3.0-rolling-2025-08-28";
 
   src = fetchFromGitHub {
     owner = "h2o";
     repo = "h2o";
-    rev = "ac9d8dde95f73d384a42e6d378b360ceea47c2c1";
-    hash = "sha256-jateBWAlsJnr9e6pjdS+SWsunyvZ+9c+nFF/QhEo/+I=";
+    rev = "42e4a8cedc867cfe08cb0bc4741372214a95c063";
+    hash = "sha256-X3L0Dph2bfDoe5QhPGSMb5abWbnpV8CrL2qS0rYL+Y4=";
   };
 
   outputs = [


### PR DESCRIPTION
Rolling bump

<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
