### PR TITLE
anki: fix build

### DIFF
--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -93,6 +93,7 @@ python3.pkgs.buildPythonApplication rec {
     ./patches/disable-auto-update.patch
     ./patches/remove-the-gl-library-workaround.patch
     ./patches/skip-formatting-python-code.patch
+    ./patches/i18n.patch
     # Used in with-addons.nix
     ./patches/allow-setting-addons-folder.patch
   ];

--- a/pkgs/games/anki/patches/i18n.patch
+++ b/pkgs/games/anki/patches/i18n.patch
@@ -1,0 +1,24 @@
+diff --git a/rslib/i18n/src/generated.rs b/rslib/i18n/src/generated.rs
+index f3526f79f..f3fa71ce8 100644
+--- a/rslib/i18n/src/generated.rs
++++ b/rslib/i18n/src/generated.rs
+@@ -4,6 +4,5 @@
+ // Include auto-generated content
+ 
+ #![allow(clippy::all)]
+-#![allow(text_direction_codepoint_in_literal)]
+ 
+ include!(concat!(env!("OUT_DIR"), "/strings.rs"));
+diff --git a/rslib/i18n/src/lib.rs b/rslib/i18n/src/lib.rs
+index bfd6f5ba2..b47c5b208 100644
+--- a/rslib/i18n/src/lib.rs
++++ b/rslib/i18n/src/lib.rs
+@@ -1,6 +1,8 @@
+ // Copyright: Ankitects Pty Ltd and contributors
+ // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+ 
++#![allow(text_direction_codepoint_in_literal)]
++
+ mod generated;
+ 
+ use std::borrow::Cow;


### PR DESCRIPTION
Currently anki fails to build due to rust 1.89. This PR fix it.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
