### PR TITLE
clipcat: fix build

### DIFF
--- a/pkgs/by-name/cl/clipcat/dummy.patch
+++ b/pkgs/by-name/cl/clipcat/dummy.patch
@@ -1,0 +1,14 @@
+diff --git a/crates/server/src/notification/dummy.rs b/crates/server/src/notification/dummy.rs
+index f85dda0..7489f22 100644
+--- a/crates/server/src/notification/dummy.rs
++++ b/crates/server/src/notification/dummy.rs
+@@ -1,6 +1,9 @@
++#[cfg(test)]
+ use crate::notification::traits;
+ 
++#[cfg(test)]
+ #[derive(Clone, Copy, Debug, Default)]
+ pub struct Notification {}
+ 
++#[cfg(test)]
+ impl traits::Notification for Notification {}

--- a/pkgs/by-name/cl/clipcat/package.nix
+++ b/pkgs/by-name/cl/clipcat/package.nix
@@ -5,6 +5,7 @@
   rustPlatform,
   protobuf,
   installShellFiles,
+  writableTmpDirAsHomeHook,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -20,9 +21,20 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-UA+NTtZ2qffUPUmvCidnTHwFzD3WOPTlxHR2e2vKwPQ=";
 
+  patches = [
+    # Fix compilation errors caused by stricter restrictions on unused code in Rust 1.89.
+    # TODO: remove this patch after upstream fix it.
+    ./dummy.patch
+  ];
+
   nativeBuildInputs = [
     protobuf
     installShellFiles
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # fix following error on darwin:
+    # objc/notify.h:1:9: fatal error: could not build module 'Cocoa'
+    writableTmpDirAsHomeHook
   ];
 
   checkFlags = [


### PR DESCRIPTION
Clipcat fails to build due to rust 1.89. This PR fixes it.

This PR also mark darwin as bad platform since dependency `nofity` fails to build on it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
