### PR TITLE
python3Packages.vdirsyncer: fix test

### DIFF
--- a/pkgs/development/python-modules/vdirsyncer/default.nix
+++ b/pkgs/development/python-modules/vdirsyncer/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  fetchpatch,
   pythonOlder,
   click,
   click-log,
@@ -37,6 +38,18 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-5DeFH+uYXew1RGVPj5z23RCbCwP34ZlWCGYDCS/+so8=";
   };
+
+  patches = [
+    (
+      # Fix event_loop missing
+      # TODO: remove it after vdirsyncer release 0.19.4
+      fetchpatch {
+        # https://github.com/pimutils/vdirsyncer/pull/1185
+        url = "https://github.com/pimutils/vdirsyncer/commit/164559ad7a95ed795ce4ae8d9b287bd27704742d.patch";
+        hash = "sha256-nUGvkBnHr8nVPpBuhQ5GjaRs3QSxokdZUEIsOrQ+lpo=";
+      }
+    )
+  ];
 
   nativeBuildInputs = [
     setuptools


### PR DESCRIPTION
vdirsyncer fails to build due to pytest-asyncio 1.1.0. This PR fixes it. This PR also fixes khal's build since khal depends on vdirsyncer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
