### PR TITLE
crystal: expose version 1.16

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4731,6 +4731,7 @@ with pkgs;
     crystal_1_11
     crystal_1_14
     crystal_1_15
+    crystal_1_16
     crystal_1_17
     crystal
     ;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The `crystal` package's default version is currently 1.16.

https://github.com/NixOS/nixpkgs/blob/77ae3f85d5e814698380c00ad3a867ebc3204cb1/pkgs/development/compilers/crystal/default.nix#L331

However, this version becomes unusable once [1.17](https://github.com/crystal-lang/crystal/releases/tag/1.17.0) or higher is introduced.
Additionally, we are unable to pin the specific version of crystal in other packages.

Follow-up: #399318

```console
> nix run nixpkgs#crystal -- --version
Crystal 1.16.3 (2025-05-12)

LLVM: 18.1.8
Default target: x86_64-unknown-linux-gnu

> nix run nixpkgs#crystal_1_15 -- --version
Crystal 1.15.1 (2025-02-04)

LLVM: 18.1.8
Default target: x86_64-unknown-linux-gnu

> nix run nixpkgs#crystal_1_16 -- --version
error: flake 'flake:nixpkgs' does not provide attribute 'apps.x86_64-linux.crystal_1_16', 'packages.x86_64-linux.crystal_1_16', 'legacyPackages.x86_64-linux.crystal_1_16' or 'crystal_1_16'
       Did you mean one of crystal_1_11, crystal_1_12, crystal_1_14, crystal_1_15 or crystal_1_2?
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

@david50407
@manveru
@peterhoeg
@donovanglover
@straight-shoota

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
