### PR TITLE
mitre-attack-navigator: init at 0-unstable-2025-08-25

### DIFF
--- a/pkgs/by-name/mi/mitre-attack-navigator/package.nix
+++ b/pkgs/by-name/mi/mitre-attack-navigator/package.nix
@@ -1,0 +1,65 @@
+{
+  rustPlatform,
+  lib,
+  fetchFromGitHub,
+  npmHooks,
+  fetchNpmDeps,
+  wrapGAppsHook3,
+  cargo-tauri,
+  nodejs,
+  pkg-config,
+  gtk3,
+  openssl,
+  webkitgtk_4_1,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "mitre-attack-navigator";
+  version = "0-unstable-2025-08-25";
+
+  src = fetchFromGitHub {
+    owner = "Athena-OS";
+    repo = "mitre-attack-navigator";
+    rev = "efb4c43ef4ce61d9a854974064ce137bbeef224e";
+    hash = "sha256-ZsERmodvTqA0Eh1rH+rPBRpYzb/T1ujpfPWys66PbRo=";
+    fetchSubmodules = true;
+  };
+
+  npmDeps = fetchNpmDeps {
+    inherit src;
+    hash = "sha256-k0xjXPQsgalIXtuNCFxMWL/qCvhSRp7i6db00Gwlq1Y=";
+  };
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = "src-tauri";
+
+  cargoHash = "sha256-/UnM7xyH5SUDLSPE1m3R0MAl47yWOa37YiSlL3AwZAg=";
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+    wrapGAppsHook3
+    cargo-tauri.hook
+    nodejs
+    npmHooks.npmConfigHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk3
+    openssl
+    webkitgtk_4_1
+  ];
+
+  postInstall = ''
+    rm -f $out/share/applications/*.desktop
+    install -Dm644 attack-navigator.desktop -t $out/share/applications
+  '';
+
+  meta = {
+    homepage = "https://github.com/Athena-OS/mitre-attack-navigator";
+    description = "A Tauri-based desktop app for MITRE's ATT&CK Navigator cybersecurity framework";
+    maintainers = with lib.maintainers; [ d3vil0p3r ];
+    mainProgram = "attack-navigator";
+    license = lib.licenses.gpl3Plus;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
