### PR TITLE
scx.cscheds: direct use of bash

### DIFF
--- a/pkgs/os-specific/linux/scx/scx_cscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_cscheds.nix
@@ -17,15 +17,6 @@
   libseccomp,
 }:
 
-let
-  # Fixes a bug with the meson build script where it specifies
-  # /bin/bash twice in the script
-  misbehaviorBash = writeShellScript "bash" ''
-    shift 1
-    exec ${lib.getExe bash} "$@"
-  '';
-
-in
 llvmPackages.stdenv.mkDerivation (finalAttrs: {
   pname = "scx_cscheds";
   inherit (scx-common) version src;
@@ -66,7 +57,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     cp ${finalAttrs.fetchBpftool} meson-scripts/fetch_bpftool
     cp ${finalAttrs.fetchLibbpf} meson-scripts/fetch_libbpf
     substituteInPlace meson.build \
-      --replace-fail '[build_bpftool' "['${misbehaviorBash}', build_bpftool"
+      --replace-fail '[build_bpftool' "['${lib.getExe bash}', build_bpftool"
 
     # TODO: Remove in next release.
     substituteInPlace lib/scxtest/overrides.h \


### PR DESCRIPTION
I didn't delve into why it originally worked; it appears that `shift` directly discarded `build_bpftool`, resulting in `jq` being treated as a script for execution.

Fixes #436580

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
