### PR TITLE
python3Packages.tyro: 0.9.27 -> 0.9.28

### DIFF
--- a/pkgs/development/python-modules/tyro/default.nix
+++ b/pkgs/development/python-modules/tyro/default.nix
@@ -18,6 +18,7 @@
   flax,
   jax,
   ml-collections,
+  msgspec,
   omegaconf,
   pydantic,
   pytestCheckHook,
@@ -26,14 +27,14 @@
 
 buildPythonPackage rec {
   pname = "tyro";
-  version = "0.9.27";
+  version = "0.9.28";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "brentyi";
     repo = "tyro";
     tag = "v${version}";
-    hash = "sha256-2duLVdBwNpGWCV+WgtzyXjoVhukVjUUhIWXVBEk4QIA=";
+    hash = "sha256-dxciOLNxOjTTIm7P1XTRMgW1a6Sdbnfnqc0EEfyq7IM=";
   };
 
   build-system = [ hatchling ];
@@ -51,6 +52,7 @@ buildPythonPackage rec {
     flax
     jax
     ml-collections
+    msgspec
     omegaconf
     pydantic
     pytestCheckHook

--- a/pkgs/development/python-modules/unsloth-zoo/default.nix
+++ b/pkgs/development/python-modules/unsloth-zoo/default.nix
@@ -27,20 +27,21 @@
 
 buildPythonPackage rec {
   pname = "unsloth-zoo";
-  version = "2025.8.1";
+  version = "2025.8.8";
   pyproject = true;
 
   # no tags on GitHub
   src = fetchPypi {
     pname = "unsloth_zoo";
     inherit version;
-    hash = "sha256-AkAfd+dJb8A9cUYK/VH30Q5xN2BW/x4zyndnIyN9y14=";
+    hash = "sha256-Njezsl9+oxAyiRF87AXQJbLjNz/lco0j8JG8RnTiZAE=";
   };
 
   # pyproject.toml requires an obsolete version of protobuf,
   # but it is not used.
   # Upstream issue: https://github.com/unslothai/unsloth-zoo/pull/68
   pythonRelaxDeps = [
+    "datasets"
     "protobuf"
     "transformers"
     "torch"

--- a/pkgs/development/python-modules/unsloth-zoo/dont-require-unsloth.patch
+++ b/pkgs/development/python-modules/unsloth-zoo/dont-require-unsloth.patch
@@ -1,9 +1,9 @@
 diff --git a/unsloth_zoo/__init__.py b/unsloth_zoo/__init__.py
-index a629854..06014b1 100644
+index 2332907..2eed5e9 100644
 --- a/unsloth_zoo/__init__.py
 +++ b/unsloth_zoo/__init__.py
-@@ -17,8 +17,6 @@
- __version__ = "2025.5.11"
+@@ -64,8 +64,6 @@ pass
+ 
  
  from importlib.util import find_spec
 -if find_spec("unsloth") is None:
@@ -11,7 +11,7 @@ index a629854..06014b1 100644
  pass
  del find_spec
  
-@@ -28,13 +26,14 @@ def get_device_type():
+@@ -75,12 +73,13 @@ def get_device_type():
          return "cuda"
      elif hasattr(torch, "xpu") and torch.xpu.is_available():
          return "xpu"
@@ -22,7 +22,6 @@ index a629854..06014b1 100644
  pass
  DEVICE_TYPE : str = get_device_type()
  
- import os
 -if not ("UNSLOTH_IS_PRESENT" in os.environ):
 -    raise ImportError("Please install Unsloth via `pip install unsloth`!")
  pass


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/brentyi/tyro/compare/v0.9.27...v0.9.28
Changelog: https://github.com/brentyi/tyro/releases/tag/v0.9.28

cc @hoh


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc