### PR TITLE
maintainers: drop various / fix github handles

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7484,12 +7484,6 @@
     githubId = 1365692;
     name = "Will Fancher";
   };
-  elysasrc = {
-    name = "Elysa";
-    github = "ElysaSrc";
-    githubId = 101974839;
-    email = "elysasrc@proton.me";
-  };
   emantor = {
     email = "rouven+nixos@czerwinskis.de";
     github = "Emantor";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5616,7 +5616,7 @@
   dandellion = {
     email = "daniel@dodsorf.as";
     matrix = "@dandellion:dodsorf.as";
-    github = "dali99";
+    github = "D4ndellion";
     githubId = 990767;
     name = "Daniel Olsen";
   };
@@ -6031,7 +6031,7 @@
   declan = {
     name = "Declan Rixon";
     email = "declan.fraser.rixon@gmail.com";
-    github = "DeclanBaggins";
+    github = "MadelineBaggins";
     githubId = 57464835;
   };
   deeengan = {
@@ -7438,7 +7438,7 @@
   ElliottSullingeFarrall = {
     name = "Elliott Sullinge-Farrall";
     email = "elliott.chalford@gmail.com";
-    github = "ElliottSullingeFarrall";
+    github = "elliott-farrall";
     githubId = 108588212;
   };
   elliottvillars = {
@@ -8911,7 +8911,7 @@
   fxttr = {
     name = "Florian Büstgens";
     email = "fb@fx-ttr.de";
-    github = "fxttr";
+    github = "fmarl";
     githubId = 16306293;
   };
   fzakaria = {
@@ -9016,7 +9016,7 @@
   };
   gangaram = {
     email = "Ganga.Ram@tii.ae";
-    github = "gangaram-tii";
+    github = "gngram";
     githubId = 131853076;
     name = "Ganga Ram";
   };
@@ -9035,7 +9035,7 @@
   gardspirito = {
     name = "gardspirito";
     email = "nyxoroso@gmail.com";
-    github = "gardspirito";
+    github = "luna-spirito";
     githubId = 29687558;
   };
   garrison = {
@@ -9315,7 +9315,7 @@
   };
   gilice = {
     email = "gilice@proton.me";
-    github = "gilice";
+    github = "algorithmiker";
     githubId = 104317939;
     name = "gilice";
   };
@@ -13274,7 +13274,7 @@
   };
   keyzox = {
     email = "nixpkgs@adjoly.fr";
-    github = "keyzox71";
+    github = "Keyzox";
     matrix = "@keyzox:matrix.org";
     githubId = 18579667;
     name = "Adam J.";
@@ -13415,7 +13415,7 @@
   };
   kinzoku = {
     email = "kinzoku@the-nebula.xyz";
-    github = "kinzoku-dev";
+    github = "kinzokudev";
     githubId = 140647311;
     name = "Ayman Hamza";
   };
@@ -14222,7 +14222,7 @@
     name = "Jacob LeCoq";
     email = "lecoqjacob@gmail.com";
     githubId = 9278174;
-    github = "bayou-brogrammer";
+    github = "HexSleeves";
     keys = [ { fingerprint = "C505 1E8B 06AC 1776 6875  1B60 93AF DAD0 10B3 CB8D"; } ];
   };
   ledif = {
@@ -15227,7 +15227,7 @@
   };
   ma9e = {
     email = "sean@lfo.team";
-    github = "furrycatherder";
+    github = "sphaugh";
     githubId = 36235154;
     name = "Sean Haugh";
   };
@@ -16763,7 +16763,7 @@
   };
   minizilla = {
     email = "m.billyzaelani@gmail.com";
-    github = "minizilla";
+    github = "smoothprogrammer";
     githubId = 20436235;
     name = "Billy Zaelani Malik";
   };
@@ -17045,7 +17045,7 @@
     name = "Mon Aaraj";
     email = "owo69uwu69@gmail.com";
     matrix = "@mon:tchncs.de";
-    github = "ribosomerocker";
+    github = "subterfugue";
     githubId = 46468162;
   };
   moni = {
@@ -17132,7 +17132,7 @@
   };
   MostafaKhaled = {
     email = "mostafa.khaled.5422@gmail.com";
-    github = "mostafa-khaled775";
+    github = "m04f";
     githubId = 112074172;
     name = "Mostafa Khaled";
   };
@@ -18474,7 +18474,7 @@
     name = "Syd Lightyear";
     email = "norpol+nixpkgs@exaple.org";
     matrix = "@phileas:asra.gr";
-    github = "norpol";
+    github = "norpl";
     githubId = 98636020;
   };
   nosewings = {
@@ -18486,7 +18486,7 @@
   not-my-segfault = {
     email = "michal@tar.black";
     matrix = "@michal:tar.black";
-    github = "not-my-segfault";
+    github = "ihatethefrench";
     githubId = 30374463;
     name = "Michal S.";
   };
@@ -18500,7 +18500,7 @@
   notbandali = {
     name = "Amin Bandali";
     email = "bandali@gnu.org";
-    github = "bandali0";
+    github = "bandali";
     githubId = 1254858;
     keys = [ { fingerprint = "BE62 7373 8E61 6D6D 1B3A  08E8 A21A 0202 4881 6103"; } ];
   };
@@ -19142,7 +19142,7 @@
   };
   ornxka = {
     email = "ornxka@littledevil.sh";
-    github = "ornxka";
+    github = "warmdarksea";
     githubId = 52086525;
     name = "ornxka";
   };
@@ -19355,7 +19355,7 @@
   };
   pagedMov = {
     email = "kylerclay@proton.me";
-    github = "pagedMov";
+    github = "your-github-username";
     githubId = 19557376;
     name = "Kyler Clay";
     keys = [ { fingerprint = "784B 3623 94E7 8F11 0B9D AE0F 56FD CFA6 2A93 B51E"; } ];
@@ -20383,7 +20383,7 @@
   poopsicles = {
     name = "Fumnanya";
     email = "fmowete@outlook.com";
-    github = "poopsicles";
+    github = "dibenzepin";
     githubId = 87488715;
   };
   PopeRigby = {
@@ -21537,7 +21537,7 @@
   };
   rgri = {
     name = "shortcut";
-    github = "rgri";
+    github = "yliceee";
     githubId = 45253749;
   };
   rgrinberg = {
@@ -21868,7 +21868,7 @@
   };
   robertrichter = {
     email = "robert.richter@rrcomtech.com";
-    github = "rrcomtech";
+    github = "judgeNotFound";
     githubId = 50635122;
     name = "Robert Richter";
   };
@@ -22141,7 +22141,7 @@
   };
   rsrohitsingh682 = {
     email = "rsrohitsingh682@gmail.com";
-    github = "rsrohitsingh682";
+    github = "sinrohit";
     githubId = 45477585;
     name = "Rohit Singh";
   };
@@ -23220,7 +23220,7 @@
   };
   shadows_withal = {
     email = "shadows@with.al";
-    github = "shadows-withal";
+    github = "manyinsects";
     githubId = 6445316;
     name = "liv";
   };
@@ -25753,7 +25753,7 @@
   tirex = {
     email = "szymon@kliniewski.pl";
     name = "Szymon Kliniewski";
-    github = "NoneTirex";
+    github = "RealTirex";
     githubId = 26038207;
   };
   tirimia = {
@@ -27309,7 +27309,7 @@
   wenngle = {
     name = "Zeke Stephens";
     email = "zekestephens@gmail.com";
-    github = "wenngle";
+    github = "zekestephens";
     githubId = 63376671;
   };
   wentam = {
@@ -28304,7 +28304,7 @@
   yusdacra = {
     email = "y.bera003.06@protonmail.com";
     matrix = "@yusdacra:nixos.dev";
-    github = "yusdacra";
+    github = "90-008";
     githubId = 19897088;
     name = "Yusuf Bera Ertan";
     keys = [ { fingerprint = "9270 66BD 8125 A45B 4AC4 0326 6180 7181 F60E FCB2"; } ];
@@ -28550,7 +28550,7 @@
   ziguana = {
     name = "Zig Uana";
     email = "git@ziguana.dev";
-    github = "ziguana";
+    github = "nomadic-stare";
     githubId = 45833444;
   };
   zimbatm = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24136,12 +24136,6 @@
     githubId = 20484159;
     keys = [ { fingerprint = "F246 425A 7650 6F37 0552  BA8D DEA9 C405 09D9 65F5"; } ];
   };
-  srghma = {
-    email = "srghma@gmail.com";
-    github = "srghma";
-    githubId = 7573215;
-    name = "Sergei Khoma";
-  };
   srgom = {
     github = "SRGOM";
     githubId = 8103619;

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8997,14 +8997,6 @@
     githubId = 45048741;
     name = "Alwanga Oyango";
   };
-  galaxy = {
-    email = "galaxy@dmc.chat";
-    matrix = "@galaxy:mozilla.org";
-    name = "The Galaxy";
-    github = "ga1aksy";
-    githubId = 148551648;
-    keys = [ { fingerprint = "48CA 3873 9E9F CA8E 76A0  835A E3DE CF85 4212 E1EA"; } ];
-  };
   gale-username = {
     name = "gale";
     email = "git@galewebsite.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4656,11 +4656,6 @@
     name = "Christoph Jabs";
     keys = [ { fingerprint = "47D6 1FEB CD86 F3EC D2E3  D68A 83D0 74F3 48B2 FD9D"; } ];
   };
-  chrpinedo = {
-    github = "chrpinedo";
-    githubId = 2324630;
-    name = "Christian Pinedo";
-  };
   chuahou = {
     email = "human+github@chuahou.dev";
     github = "chuahou";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10224,12 +10224,6 @@
     github = "higebu";
     githubId = 733288;
   };
-  hikari = {
-    email = "HikariNee@protonmail.com";
-    github = "HikariNee";
-    githubId = 72349937;
-    name = "Hikari";
-  };
   hirenashah = {
     email = "hiren@hiren.io";
     github = "hirenashah";

--- a/pkgs/applications/graphics/image_optim/default.nix
+++ b/pkgs/applications/graphics/image_optim/default.nix
@@ -86,7 +86,6 @@ bundlerApp {
     homepage = "https://github.com/toy/image_optim";
     license = licenses.mit;
     maintainers = with maintainers; [
-      srghma
       nicknovitski
     ];
     platforms = platforms.all;

--- a/pkgs/by-name/ca/catppuccin-sddm/package.nix
+++ b/pkgs/by-name/ca/catppuccin-sddm/package.nix
@@ -74,7 +74,6 @@ stdenvNoCC.mkDerivation rec {
     description = "Soothing pastel theme for SDDM";
     homepage = "https://github.com/catppuccin/sddm";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ elysasrc ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/gu/guile-sjson/package.nix
+++ b/pkgs/by-name/gu/guile-sjson/package.nix
@@ -34,7 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "S-expression based json reader/writer for Guile";
     homepage = "https://gitlab.com/dustyweb/guile-sjson";
     license = licenses.lgpl3Plus;
-    maintainers = with maintainers; [ galaxy ];
     platforms = guile.meta.platforms;
   };
 })

--- a/pkgs/by-name/hu/hubstaff/package.nix
+++ b/pkgs/by-name/hu/hubstaff/package.nix
@@ -131,7 +131,6 @@ stdenv.mkDerivation {
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [
       michalrus
-      srghma
     ];
   };
 }

--- a/pkgs/by-name/i3/i3-volume/package.nix
+++ b/pkgs/by-name/i3/i3-volume/package.nix
@@ -54,7 +54,6 @@ stdenv.mkDerivation rec {
       Works with any window manager, such as [i3wm](https://i3wm.org/), [bspwm](https://github.com/baskerville/bspwm), and [KDE](https://kde.org/), as a standalone script, or with statusbars such as [polybar](https://github.com/polybar/polybar), [i3blocks](https://github.com/vivien/i3blocks), [i3status](https://github.com/i3/i3status), and more.
     '';
     homepage = "https://github.com/hastinbe/i3-volume";
-    maintainers = with lib.maintainers; [ srghma ];
     mainProgram = "i3-volume";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/jp/jpeg-archive/package.nix
+++ b/pkgs/by-name/jp/jpeg-archive/package.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation {
     description = "Utilities for archiving photos for saving to long term storage or serving over the web";
     homepage = "https://github.com/danielgtaylor/jpeg-archive";
     license = licenses.mit;
-    maintainers = [ maintainers.srghma ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/ko/konbucase/package.nix
+++ b/pkgs/by-name/ko/konbucase/package.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ryonakano/konbucase";
     description = "Case converting app suitable for coding or typing";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ galaxy ];
     platforms = lib.platforms.linux;
     mainProgram = "konbucase";
   };

--- a/pkgs/by-name/lu/lux/package.nix
+++ b/pkgs/by-name/lu/lux/package.nix
@@ -39,7 +39,6 @@ buildGoModule rec {
     homepage = "https://github.com/iawia002/lux";
     changelog = "https://github.com/iawia002/lux/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ galaxy ];
     mainProgram = "lux";
   };
 }

--- a/pkgs/by-name/pr/pricehist/package.nix
+++ b/pkgs/by-name/pr/pricehist/package.nix
@@ -38,6 +38,5 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://gitlab.com/chrisberkhout/pricehist";
     license = lib.licenses.mit;
     mainProgram = "pricehist";
-    maintainers = with lib.maintainers; [ chrpinedo ];
   };
 }

--- a/pkgs/by-name/sa/safeeyes/package.nix
+++ b/pkgs/by-name/sa/safeeyes/package.nix
@@ -81,7 +81,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "http://slgobinath.github.io/SafeEyes";
     description = "Protect your eyes from eye strain using this simple and beautiful, yet extensible break reminder. A Free and Open Source Linux alternative to EyeLeo";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ srghma ];
     platforms = platforms.linux;
     mainProgram = "safeeyes";
   };

--- a/pkgs/by-name/so/sozi/package.nix
+++ b/pkgs/by-name/so/sozi/package.nix
@@ -37,7 +37,6 @@ appimageTools.wrapType2 {
     homepage = "https://sozi.baierouge.fr/";
     license = lib.licenses.mpl20;
     mainProgram = "sozi";
-    maintainers = with lib.maintainers; [ srghma ];
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/te/textsnatcher/package.nix
+++ b/pkgs/by-name/te/textsnatcher/package.nix
@@ -61,7 +61,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://textsnatcher.rf.gd/";
     changelog = "https://github.com/RajSolai/TextSnatcher/releases/tag/v${finalAttrs.version}";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ galaxy ];
     mainProgram = "com.github.rajsolai.textsnatcher";
     platforms = platforms.linux;
   };

--- a/pkgs/by-name/yo/youtubeuploader/package.nix
+++ b/pkgs/by-name/yo/youtubeuploader/package.nix
@@ -35,7 +35,6 @@ buildGoModule rec {
     homepage = "https://github.com/porjo/youtubeuploader";
     changelog = "https://github.com/porjo/youtubeuploader/releases/tag/v${version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ srghma ];
     mainProgram = "youtubeuploader";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/development/python-modules/curlify/default.nix
+++ b/pkgs/development/python-modules/curlify/default.nix
@@ -23,6 +23,5 @@ buildPythonPackage {
     description = "Convert python requests request object to cURL command";
     homepage = "https://github.com/ofw/curlify";
     license = licenses.mit;
-    maintainers = with maintainers; [ chrpinedo ];
   };
 }


### PR DESCRIPTION
This was produced with `maintainers/scripts/fix-maintainers.pl`.

All the dropped maintainers have their GitHub account removed already.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
