### PR TITLE
python3Packages.unsloth 2025.8.1 -> 2025.8.9 and dependency update

### DIFF
--- a/pkgs/development/python-modules/cut-cross-entropy/default.nix
+++ b/pkgs/development/python-modules/cut-cross-entropy/default.nix
@@ -24,7 +24,7 @@
 
 buildPythonPackage {
   pname = "cut-cross-entropy";
-  version = "25.5.1";
+  version = "25.7.2";
   pyproject = true;
 
   # The `ml-cross-entropy` Pypi comes from a third-party.
@@ -32,8 +32,8 @@ buildPythonPackage {
   src = fetchFromGitHub {
     owner = "apple";
     repo = "ml-cross-entropy";
-    rev = "b616b222976b235647790a16d0388338b9e18941"; # no tags
-    hash = "sha256-BVPon+T7chkpozX/IZU3KZMw1zRzlYVvF/22JWKjT2Y=";
+    rev = "b19a424ed30a05b8261cfa84d83b2601a9454c67"; # no tags
+    hash = "sha256-AwUqKiI7XjEOZ7ofjQCOsqvxHyTFD4RZ70odPyxxntc=";
   };
 
   build-system = [
@@ -64,6 +64,10 @@ buildPythonPackage {
   };
 
   nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTests = [
+    "test_vocab_parallel" # Requires CUDA but does not use pytest.skip
+  ];
 
   pythonImportsCheck = [
     "cut_cross_entropy"

--- a/pkgs/development/python-modules/trl/default.nix
+++ b/pkgs/development/python-modules/trl/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "trl";
-  version = "0.20.0";
+  version = "0.21.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = "trl";
     tag = "v${version}";
-    hash = "sha256-z14refdNySnKcfFq54l+slsi4SLe5FG8UNoAKxfmAy0=";
+    hash = "sha256-9jbbbiGa/2NqHKe9rxDRyzfaWyy7tsoeHaMlpg0Oxk0=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/unsloth/default.nix
+++ b/pkgs/development/python-modules/unsloth/default.nix
@@ -31,14 +31,14 @@
 
 buildPythonPackage rec {
   pname = "unsloth";
-  version = "2025.8.1";
+  version = "2025.8.9";
   pyproject = true;
 
   # Tags on the GitHub repo don't match
   src = fetchPypi {
     pname = "unsloth";
     inherit version;
-    hash = "sha256-hkE+f6apgilrE0lFTWRe8PEvRQ71YuoHpQgzd/R/FaI=";
+    hash = "sha256-XKYKEJCiOucuGfout8+FiTfO3KXvkucaduwWnZR5OwA=";
   };
 
   build-system = [
@@ -72,6 +72,7 @@ buildPythonPackage rec {
   # but it is not used.
   # Upstream issue: https://github.com/unslothai/unsloth-zoo/pull/68
   pythonRelaxDeps = [
+    "datasets"
     "protobuf"
     "transformers"
     "torch"


### PR DESCRIPTION
Due to Unsloth requiring an Nvidia GPU, I am bumping its dependencies together and testing everything at once:

```
python3Packages.cut-cross-entropy: 25.5.1 -> 25.7.2
python3Packages.trl: 0.20.0 -> 0.21.0
python3Packages.unsloth-zoo: 2025.8.1 -> 2025.8.9
python3Packages.unsloth: 2025.8.1 -> 2025.8.9
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
