### PR TITLE
maintainers: drop gm6k

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9434,10 +9434,6 @@
     githubId = 47015416;
     name = "globule655";
   };
-  gm6k = {
-    email = "nix@quidecco.pl";
-    name = "Isidor Zeuner";
-  };
   gmacon = {
     name = "George Macon";
     matrix = "@gmacon:matrix.org";

--- a/pkgs/by-name/al/alsa-lib-with-plugins/package.nix
+++ b/pkgs/by-name/al/alsa-lib-with-plugins/package.nix
@@ -19,7 +19,6 @@ runCommand "${alsa-lib.pname}-${alsa-lib.version}"
       description = "Wrapper to ease access to ALSA plugins";
       mainProgram = "aserver";
       platforms = platforms.linux;
-      maintainers = with maintainers; [ gm6k ];
     };
     outputs = alsa-lib.outputs;
   }

--- a/pkgs/by-name/lu/luci-go/package.nix
+++ b/pkgs/by-name/lu/luci-go/package.nix
@@ -45,6 +45,5 @@ buildGoModule {
     homepage = "${git-repo}/";
     changelog = "${git-repo}/+log?s=${commit}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ gm6k ];
   };
 }

--- a/pkgs/by-name/mi/minetest-mapserver/package.nix
+++ b/pkgs/by-name/mi/minetest-mapserver/package.nix
@@ -27,6 +27,5 @@ buildGoModule rec {
       cc-by-sa-30
     ];
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ gm6k ];
   };
 }

--- a/pkgs/development/python-modules/pyldavis/default.nix
+++ b/pkgs/development/python-modules/pyldavis/default.nix
@@ -43,7 +43,6 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/bmabey/pyLDAvis";
     description = "Python library for interactive topic model visualization";
-    maintainers = with lib.maintainers; [ gm6k ];
     license = licenses.bsd3;
     sourceProvenance = with sourceTypes; [ fromSource ];
     platforms = platforms.all;


### PR DESCRIPTION
`gm6k` is not actively maintaining his packages. While there is [*some* current activity on GitHub and in the Nixpkgs repo](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr%20is%3Aopen%20involves%3Azeuner), none of that is related to maintaining the packages he's listed for.

The contribution guidelines say:

> We would typically look at it if we notice that the author hasn't reacted to package-related notifications for more than 3 months.

Since Isidor can't be requested for review by CI without GitHub handle, we'd have to look at a different metric.

There has been no activity on the [5 update PRs to `minetest-mapserver`](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr%20minetest-mapserver%20in%3Atitle%20is%3Aclosed%20-involves%3Azeuner). [`luci-go`](https://github.com/luci/luci-go) is [10 months outdated](https://github.com/NixOS/nixpkgs/blob/bbc5202a255afc92285b6266bf67e00ca911fc0d/pkgs/by-name/lu/luci-go/package.nix#L12), with [a lot of activity upstream](https://github.com/luci/luci-go/commits/main/) and [failing to build since March this year](https://hydra.nixos.org/job/nixpkgs/trunk/luci-go.x86_64-linux/all).

I'd argue, you are not actively *maintaining*, @zeuner. Thus, I propose to drop your maintainer handle according to the [contribution guidelines](https://github.com/NixOS/nixpkgs/tree/master/maintainers#how-to-lose-maintainer-status).

If you'd like to stay a maintainer, please respond within a week, according to the guidelines. It would also be great to let us know *how* you intend to actively maintain your packages despite the inability to be requested for review from CI.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
