### PR TITLE
python31{2,3}Packages.mkdocs-swagger-ui-tag: fix build

### DIFF
--- a/pkgs/development/python-modules/mkdocs-swagger-ui-tag/default.nix
+++ b/pkgs/development/python-modules/mkdocs-swagger-ui-tag/default.nix
@@ -1,10 +1,11 @@
 {
-  lib,
   beautifulsoup4,
   buildPythonPackage,
   fetchFromGitHub,
+  hatchling,
+  lib,
   mkdocs,
-  pathspec,
+  playwright,
   pytestCheckHook,
   pythonOlder,
 }:
@@ -12,7 +13,7 @@
 buildPythonPackage rec {
   pname = "mkdocs-swagger-ui-tag";
   version = "0.7.1";
-  format = "setuptools";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
@@ -24,12 +25,13 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    mkdocs
     beautifulsoup4
+    hatchling
+    mkdocs
   ];
 
   nativeCheckInputs = [
-    pathspec
+    playwright
     pytestCheckHook
   ];
 
@@ -40,6 +42,8 @@ buildPythonPackage rec {
     "test_material"
     "test_material_dark_scheme_name"
     "test_template"
+    "test_mkdocs_screenshot"
+    "test_no_console_errors"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

By updated done in https://github.com/NixOS/nixpkgs/pull/431074 the build of this package bricked.

This is caused by upstream  [migrated to uv and pyproject.toml for development and building](https://github.com/blueswen/mkdocs-swagger-ui-tag/blob/v0.7.1/CHANGELOG#L8C1-L8C69).

Some (newly?) introduced tests could not succeed - they are ignored for now, as I have no time to investigate it further.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
