### PR TITLE
maintainers: require GitHub handle (enforce via CI)

### DIFF
--- a/lib/tests/maintainer-module.nix
+++ b/lib/tests/maintainer-module.nix
@@ -7,20 +7,18 @@ in
     name = lib.mkOption {
       type = types.str;
     };
+    github = lib.mkOption {
+      type = types.str;
+    };
+    githubId = lib.mkOption {
+      type = types.ints.unsigned;
+    };
     email = lib.mkOption {
       type = types.nullOr types.str;
       default = null;
     };
     matrix = lib.mkOption {
       type = types.nullOr types.str;
-      default = null;
-    };
-    github = lib.mkOption {
-      type = types.nullOr types.str;
-      default = null;
-    };
-    githubId = lib.mkOption {
-      type = types.nullOr types.ints.unsigned;
       default = null;
     };
     keys = lib.mkOption {


### PR DESCRIPTION
At the scale of Nixpkgs, actively maintaining a package is only possible with integration into CI. To be able to be pinged for review requests, the maintainer must have a GitHub handle, which:
- leads to an invitation to the NixOS org, which comes with additional privileges,
- allows to request the maintainer for review as a member of this org, and
- automatically requests the maintainer for review in CI.

Currently, the GitHub handle is not strictly enforced. This leads to some new maintainers accidentally forgetting to set these. We can avoid these mistakes and enforce them via CI.

We currently have 3 maintainers without GitHub handle, according to my last run of `maintainers/scripts/fix-maintainers.pl`:
- https://github.com/NixOS/nixpkgs/pull/439407
- https://github.com/NixOS/nixpkgs/pull/437479
- https://github.com/NixOS/nixpkgs/pull/437480

These will have to be resolved first, before the tests will start passing.

*Note: I am aware of the closed [RFC 167](https://github.com/NixOS/rfcs/pull/167). I don't think we need an RFC for this nowadays, if somebody insists they could raise the issue to the SC.*

Closes #437407

## Things done

- Tested, as applicable:
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- ~~[ ] Adjust some of the contributing guidelines / comments in `maintainers-list.nix`.~~ #437469
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
