### PR TITLE
workflows/labels: prevent error on token creation for Test workflow

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Use a GitHub App, because it has much higher rate limits: 12,500 instead of 5,000 req / hour.
       - uses: actions/create-github-app-token@0f859bf9e69e887678d5bbfbee594437cb440ffe # v2.1.0
-        if: vars.NIXPKGS_CI_APP_ID
+        if: github.event_name != 'pull_request' && vars.NIXPKGS_CI_APP_ID
         id: app-token
         with:
           app-id: ${{ vars.NIXPKGS_CI_APP_ID }}

--- a/ci/github-script/run
+++ b/ci/github-script/run
@@ -49,7 +49,7 @@ program
   .option('--no-dry', 'Make actual modifications')
   .action(async (owner, repo, pr, options) => {
     const prepare = (await import('./prepare.js')).default
-    run(prepare, owner, repo, pr, options)
+    await run(prepare, owner, repo, pr, options)
   })
 
 program
@@ -61,7 +61,7 @@ program
   .option('--no-cherry-picks', 'Do not expect cherry-picks.')
   .action(async (owner, repo, pr, options) => {
     const commits = (await import('./commits.js')).default
-    run(commits, owner, repo, pr, options)
+    await run(commits, owner, repo, pr, options)
   })
 
 program
@@ -77,7 +77,7 @@ program
     try {
       process.env.GITHUB_WORKSPACE = tmp
       process.chdir(tmp)
-      run(labels, owner, repo, pr, options)
+      await run(labels, owner, repo, pr, options)
     } finally {
       rmSync(tmp, { recursive: true })
     }


### PR DESCRIPTION
This only happens when the label workflow runs in pull_request context *and* from within nixpkgs (not a fork). This is the case for dependabot updates, for example #436918.

Also fixed a bug in `ci/github-script/run`, which prevented the `labels` job from running locally.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
