### PR TITLE
nbcat: init at 1.0.0

### DIFF
--- a/pkgs/by-name/nb/nbcat/package.nix
+++ b/pkgs/by-name/nb/nbcat/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  python3Packages,
+  versionCheckHook,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonPackage rec {
+  pname = "nbcat";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "akopdev";
+    repo = "nbcat";
+    tag = "v${version}";
+    hash = "sha256-DD5/KPKdz1VgPWZqjal98UrbACoVvEls/LnMY1AYRdw=";
+  };
+
+  pyproject = true;
+
+  build-system = with python3Packages; [ hatchling ];
+
+  dependencies = with python3Packages; [
+    argcomplete
+    markdownify
+    pydantic
+    requests
+    rich
+    textual
+    textual-image
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "Preview Jupyter notebooks directly in your terminal. Like cat but for `.ipynb` files!";
+    homepage = "https://github.com/akopdev/nbcat";
+    mainProgram = "nbcat";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      Tygo-van-den-Hurk
+    ];
+  };
+}


### PR DESCRIPTION
[nbcat](https://github.com/akopdev/nbcat) let you preview Jupyter notebooks directly in your terminal. Think of it as `cat`, but for `.ipynb` files.

## Features

- Very fast and lightweight with minimal dependencies.
- Preview remote notebooks without downloading them.
- Enable paginated view mode with keyboard navigation (similar to `less`).
- Supports image rendering in high resolution
- Supports for all Jupyter notebook versions, including old legacy formats.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
