### PR TITLE
font-adobe-{100dpi,75dpi,utopia-{100dpi,75dpi,type1}}: refactor, move to pkgs/by-name & rename from xorg namespace

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -64,6 +64,11 @@ lib.mapAttrs mkLicense (
       free = false;
     };
 
+    adobeUtopia = {
+      fullName = "Adobe Utopia Font License";
+      spdxId = "Adobe-Utopia";
+    };
+
     afl20 = {
       spdxId = "AFL-2.0";
       fullName = "Academic Free License v2.0";

--- a/pkgs/by-name/fo/font-adobe-100dpi/package.nix
+++ b/pkgs/by-name/fo/font-adobe-100dpi/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  font-util,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-adobe-100dpi";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-adobe-100dpi-${finalAttrs.version}.tar.xz";
+    hash = "sha256-tnr/RF4FYyjVP5cy05iE9V3Y0wP8Ja89u6M6i6NanM8=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    bdftopcf
+    font-util
+    mkfontscale
+  ];
+
+  buildInputs = [ font-util ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/share/fonts/X11" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Adobe 100dpi pcf fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/adobe-100dpi";
+    license = lib.licenses.hpndSellVariant; # plus a trademark that doesn't change the license
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-adobe-75dpi/package.nix
+++ b/pkgs/by-name/fo/font-adobe-75dpi/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  font-util,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-adobe-75dpi";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-adobe-75dpi-${finalAttrs.version}.tar.xz";
+    hash = "sha256-EoGmLb7e0WnklcrhpbSH4fM28rTZcdkpEcWcEDmZuRE=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    bdftopcf
+    font-util
+    mkfontscale
+  ];
+
+  buildInputs = [ font-util ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/share/fonts/X11" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Adobe 75dpi pcf fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/adobe-75dpi";
+    license = lib.licenses.hpndSellVariant; # plus a trademark that doesn't change the license
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-adobe-utopia-100dpi/package.nix
+++ b/pkgs/by-name/fo/font-adobe-utopia-100dpi/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  font-util,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-adobe-utopia-100dpi";
+  version = "1.0.5";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-adobe-utopia-100dpi-${finalAttrs.version}.tar.xz";
+    hash = "sha256-+4TsKXqQaXNUjKWbfG2uqtISRL7F0/sefJPfXvQ7Aks=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    bdftopcf
+    font-util
+    mkfontscale
+  ];
+
+  buildInputs = [ font-util ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/share/fonts/X11" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Adobe Utopia 100dpi pcf fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/adobe-utopia-100dpi";
+    license = lib.licenses.adobeUtopia;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-adobe-utopia-75dpi/package.nix
+++ b/pkgs/by-name/fo/font-adobe-utopia-75dpi/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  font-util,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-adobe-utopia-75dpi";
+  version = "1.0.5";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-adobe-utopia-75dpi-${finalAttrs.version}.tar.xz";
+    hash = "sha256-pyYkWTLQck+gxTjJkoEdY9WX5fU5KPQEjpyvViN5d2A=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    bdftopcf
+    font-util
+    mkfontscale
+  ];
+
+  buildInputs = [ font-util ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/share/fonts/X11" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Adobe Utopia 75dpi pcf fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/adobe-utopia-75dpi";
+    license = lib.licenses.adobeUtopia;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-adobe-utopia-type1/package.nix
+++ b/pkgs/by-name/fo/font-adobe-utopia-type1/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-adobe-utopia-type1";
+  version = "1.0.5";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-adobe-utopia-type1-${finalAttrs.version}.tar.xz";
+    hash = "sha256-TLKAvEdpOwfF4A/Q5a1XIaq+vAVIw/BndOXMPLz3Vpc=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ mkfontscale ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Adobe Utopia PostScript Type 1 fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/adobe-utopia-type1";
+    license = lib.licenses.adobeUtopia;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xd/xdummy/package.nix
+++ b/pkgs/by-name/xd/xdummy/package.nix
@@ -30,7 +30,7 @@ let
       ModulePath "${xorg.xf86videodummy}/lib/xorg/modules"
       XkbDir "${xkeyboard_config}/share/X11/xkb"
       FontPath "${xorg.fontadobe75dpi}/share/fonts/X11/75dpi"
-      FontPath "${xorg.fontadobe100dpi}/lib/X11/fonts/100dpi"
+      FontPath "${xorg.fontadobe100dpi}/share/fonts/X11/100dpi"
       FontPath "${xorg.fontmiscmisc}/lib/X11/fonts/misc"
       FontPath "${xorg.fontcursormisc}/lib/X11/fonts/misc"
     ${lib.optionalString unfreeFonts ''

--- a/pkgs/by-name/xd/xdummy/package.nix
+++ b/pkgs/by-name/xd/xdummy/package.nix
@@ -29,7 +29,7 @@ let
       ModulePath "${xorg.xorgserver.out}/lib/xorg/modules"
       ModulePath "${xorg.xf86videodummy}/lib/xorg/modules"
       XkbDir "${xkeyboard_config}/share/X11/xkb"
-      FontPath "${xorg.fontadobe75dpi}/lib/X11/fonts/75dpi"
+      FontPath "${xorg.fontadobe75dpi}/share/fonts/X11/75dpi"
       FontPath "${xorg.fontadobe100dpi}/lib/X11/fonts/100dpi"
       FontPath "${xorg.fontmiscmisc}/lib/X11/fonts/misc"
       FontPath "${xorg.fontcursormisc}/lib/X11/fonts/misc"

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -2,6 +2,7 @@
 {
   lib,
   bdftopcf,
+  font-adobe-100dpi,
   font-adobe-75dpi,
   font-alias,
   font-bh-ttf,
@@ -118,6 +119,7 @@ self: with self; {
     xwud
     ;
   encodings = font-encodings;
+  fontadobe100dpi = font-adobe-100dpi;
   fontadobe75dpi = font-adobe-75dpi;
   fontalias = font-alias;
   fontbhttf = font-bh-ttf;
@@ -286,47 +288,6 @@ self: with self; {
         xorgproto
         libXt
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontadobe100dpi = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-adobe-100dpi";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-adobe-100dpi-1.0.4.tar.xz";
-        sha256 = "1kwwbaiqnfm3pcysy9gw0g9xhpgmhjcd6clp7zajhqq5br2gyymn";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
-        fontutil
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -2,6 +2,7 @@
 {
   lib,
   bdftopcf,
+  font-adobe-75dpi,
   font-alias,
   font-bh-ttf,
   font-bh-type1,
@@ -117,6 +118,7 @@ self: with self; {
     xwud
     ;
   encodings = font-encodings;
+  fontadobe75dpi = font-adobe-75dpi;
   fontalias = font-alias;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
@@ -310,47 +312,6 @@ self: with self; {
       src = fetchurl {
         url = "mirror://xorg/individual/font/font-adobe-100dpi-1.0.4.tar.xz";
         sha256 = "1kwwbaiqnfm3pcysy9gw0g9xhpgmhjcd6clp7zajhqq5br2gyymn";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
-        fontutil
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontadobe75dpi = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-adobe-75dpi";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-adobe-75dpi-1.0.4.tar.xz";
-        sha256 = "04drk4wi176524lxjwfrnkr3dwz1hysabqfajpj6klfypqnsd08j";
       };
       hardeningDisable = [
         "bindnow"

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -5,6 +5,7 @@
   font-adobe-100dpi,
   font-adobe-75dpi,
   font-adobe-utopia-100dpi,
+  font-adobe-utopia-75dpi,
   font-alias,
   font-bh-ttf,
   font-bh-type1,
@@ -123,6 +124,7 @@ self: with self; {
   fontadobe100dpi = font-adobe-100dpi;
   fontadobe75dpi = font-adobe-75dpi;
   fontadobeutopia100dpi = font-adobe-utopia-100dpi;
+  fontadobeutopia75dpi = font-adobe-utopia-75dpi;
   fontalias = font-alias;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
@@ -290,47 +292,6 @@ self: with self; {
         xorgproto
         libXt
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontadobeutopia75dpi = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-adobe-utopia-75dpi";
-      version = "1.0.5";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-adobe-utopia-75dpi-1.0.5.tar.xz";
-        sha256 = "0q3pg4imdbwwiq2g8a1rypjrgmb33n0r5j9qqnh4ywnh69cj89m7";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
-        fontutil
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -4,6 +4,7 @@
   bdftopcf,
   font-adobe-100dpi,
   font-adobe-75dpi,
+  font-adobe-utopia-100dpi,
   font-alias,
   font-bh-ttf,
   font-bh-type1,
@@ -121,6 +122,7 @@ self: with self; {
   encodings = font-encodings;
   fontadobe100dpi = font-adobe-100dpi;
   fontadobe75dpi = font-adobe-75dpi;
+  fontadobeutopia100dpi = font-adobe-utopia-100dpi;
   fontalias = font-alias;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
@@ -288,47 +290,6 @@ self: with self; {
         xorgproto
         libXt
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontadobeutopia100dpi = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-adobe-utopia-100dpi";
-      version = "1.0.5";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-adobe-utopia-100dpi-1.0.5.tar.xz";
-        sha256 = "0jq27gs5xpwkghggply5pr215lmamrnpr6x5iia76schg8lyr17v";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
-        fontutil
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -6,6 +6,7 @@
   font-adobe-75dpi,
   font-adobe-utopia-100dpi,
   font-adobe-utopia-75dpi,
+  font-adobe-utopia-type1,
   font-alias,
   font-bh-ttf,
   font-bh-type1,
@@ -125,6 +126,7 @@ self: with self; {
   fontadobe75dpi = font-adobe-75dpi;
   fontadobeutopia100dpi = font-adobe-utopia-100dpi;
   fontadobeutopia75dpi = font-adobe-utopia-75dpi;
+  fontadobeutopiatype1 = font-adobe-utopia-type1;
   fontalias = font-alias;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
@@ -292,44 +294,6 @@ self: with self; {
         xorgproto
         libXt
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontadobeutopiatype1 = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-adobe-utopia-type1";
-      version = "1.0.5";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-adobe-utopia-type1-1.0.5.tar.xz";
-        sha256 = "15snyyy3rk75fikz1hs80nybxai1aynybl0gw32hffv98yy81cjc";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -321,6 +321,7 @@ print OUT <<EOF;
   font-adobe-100dpi,
   font-adobe-75dpi,
   font-adobe-utopia-100dpi,
+  font-adobe-utopia-75dpi,
   font-alias,
   font-bh-ttf,
   font-bh-type1,
@@ -439,6 +440,7 @@ self: with self; {
   fontadobe100dpi = font-adobe-100dpi;
   fontadobe75dpi = font-adobe-75dpi;
   fontadobeutopia100dpi = font-adobe-utopia-100dpi;
+  fontadobeutopia75dpi = font-adobe-utopia-75dpi;
   fontalias = font-alias;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -318,6 +318,7 @@ print OUT <<EOF;
 {
   lib,
   bdftopcf,
+  font-adobe-100dpi,
   font-adobe-75dpi,
   font-alias,
   font-bh-ttf,
@@ -434,6 +435,7 @@ self: with self; {
     xwud
     ;
   encodings = font-encodings;
+  fontadobe100dpi = font-adobe-100dpi;
   fontadobe75dpi = font-adobe-75dpi;
   fontalias = font-alias;
   fontbhttf = font-bh-ttf;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -320,6 +320,7 @@ print OUT <<EOF;
   bdftopcf,
   font-adobe-100dpi,
   font-adobe-75dpi,
+  font-adobe-utopia-100dpi,
   font-alias,
   font-bh-ttf,
   font-bh-type1,
@@ -437,6 +438,7 @@ self: with self; {
   encodings = font-encodings;
   fontadobe100dpi = font-adobe-100dpi;
   fontadobe75dpi = font-adobe-75dpi;
+  fontadobeutopia100dpi = font-adobe-utopia-100dpi;
   fontalias = font-alias;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -318,6 +318,7 @@ print OUT <<EOF;
 {
   lib,
   bdftopcf,
+  font-adobe-75dpi,
   font-alias,
   font-bh-ttf,
   font-bh-type1,
@@ -433,6 +434,7 @@ self: with self; {
     xwud
     ;
   encodings = font-encodings;
+  fontadobe75dpi = font-adobe-75dpi;
   fontalias = font-alias;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -322,6 +322,7 @@ print OUT <<EOF;
   font-adobe-75dpi,
   font-adobe-utopia-100dpi,
   font-adobe-utopia-75dpi,
+  font-adobe-utopia-type1,
   font-alias,
   font-bh-ttf,
   font-bh-type1,
@@ -441,6 +442,7 @@ self: with self; {
   fontadobe75dpi = font-adobe-75dpi;
   fontadobeutopia100dpi = font-adobe-utopia-100dpi;
   fontadobeutopia75dpi = font-adobe-utopia-75dpi;
+  fontadobeutopiatype1 = font-adobe-utopia-type1;
   fontalias = font-alias;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1019,7 +1019,6 @@ self: super:
   let
     # unfree but redistributable
     redist = [
-      "fontadobeutopiatype1"
       "fontibmtype1"
       "fontbh100dpi"
       "fontbh75dpi"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1020,7 +1020,6 @@ self: super:
     # unfree but redistributable
     redist = [
       "fontadobeutopiatype1"
-      "fontadobeutopia75dpi"
       "fontibmtype1"
       "fontbh100dpi"
       "fontbh75dpi"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1020,7 +1020,6 @@ self: super:
     # unfree but redistributable
     redist = [
       "fontadobeutopiatype1"
-      "fontadobeutopia100dpi"
       "fontadobeutopia75dpi"
       "fontibmtype1"
       "fontbh100dpi"

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -93,7 +93,6 @@ mirror://xorg/individual/driver/xf86-video-vesa-2.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-vmware-13.4.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-wsfb-0.4.0.tar.bz2
-mirror://xorg/individual/font/font-adobe-utopia-type1-1.0.5.tar.xz
 mirror://xorg/individual/font/font-arabic-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bh-75dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bh-100dpi-1.0.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -93,7 +93,6 @@ mirror://xorg/individual/driver/xf86-video-vesa-2.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-vmware-13.4.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-wsfb-0.4.0.tar.bz2
-mirror://xorg/individual/font/font-adobe-utopia-75dpi-1.0.5.tar.xz
 mirror://xorg/individual/font/font-adobe-utopia-type1-1.0.5.tar.xz
 mirror://xorg/individual/font/font-arabic-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bh-75dpi-1.0.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -93,7 +93,6 @@ mirror://xorg/individual/driver/xf86-video-vesa-2.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-vmware-13.4.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-wsfb-0.4.0.tar.bz2
-mirror://xorg/individual/font/font-adobe-75dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-adobe-100dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-adobe-utopia-75dpi-1.0.5.tar.xz
 mirror://xorg/individual/font/font-adobe-utopia-100dpi-1.0.5.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -94,7 +94,6 @@ mirror://xorg/individual/driver/xf86-video-vmware-13.4.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-wsfb-0.4.0.tar.bz2
 mirror://xorg/individual/font/font-adobe-utopia-75dpi-1.0.5.tar.xz
-mirror://xorg/individual/font/font-adobe-utopia-100dpi-1.0.5.tar.xz
 mirror://xorg/individual/font/font-adobe-utopia-type1-1.0.5.tar.xz
 mirror://xorg/individual/font/font-arabic-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bh-75dpi-1.0.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -93,7 +93,6 @@ mirror://xorg/individual/driver/xf86-video-vesa-2.6.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-vmware-13.4.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-wsfb-0.4.0.tar.bz2
-mirror://xorg/individual/font/font-adobe-100dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-adobe-utopia-75dpi-1.0.5.tar.xz
 mirror://xorg/individual/font/font-adobe-utopia-100dpi-1.0.5.tar.xz
 mirror://xorg/individual/font/font-adobe-utopia-type1-1.0.5.tar.xz


### PR DESCRIPTION
<details>
<summary>this is the script i use to get the packages that don't depend on other xorg packages:</summary>

```nix
let
  inherit (import <nixpkgs> { }) lib;

  done = import ./pkgs/servers/x11/xorg/default.nix |> lib.functionArgs |> lib.attrNames;

  pkgs =
    (import ./default.nix { }).xorg
    |> lib.filterAttrs (
      n: v:
      lib.isAttrs v
      && v ? pname
      && !lib.elem n done
      && !lib.elem n (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem v.pname done
      && !lib.elem v.pname (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem (lib.toLower n) done
      && !lib.elem (lib.toLower n) (map (lib.replaceStrings [ "-" ] [ "" ]) done)
    );

  pnames = lib.mapAttrsToList (_: v: v.pname) pkgs;

  filteredPkgs =
    pkgs
    |> lib.filterAttrs (
      n: v:
      true
      # && !v.meta.unfree
      # && !v.meta.broken
      # && !v.meta.unsupported
      # && !lib.hasPrefix "font" n
      && !lib.hasPrefix "xf86" n
    );
in
filteredPkgs
# get deps
|> lib.mapAttrs (
  _: v:
  v.buildInputs ++ v.nativeBuildInputs ++ v.propagatedBuildInputs ++ v.propagatedNativeBuildInputs
)
# filter deps for xorg packages
|> lib.mapAttrs (_: v: lib.filter (x: x ? pname && lib.elem x.pname pnames) v)
# map deps to list and count
|> lib.mapAttrsToList (
  name: value: {
    inherit name;
    deps = map (x: x.pname or "error") value |> lib.unique;
    count = lib.length value;
  }
)
# sort
|> lib.sort (
  x: y: x.count < y.count || (x.count == y.count && (lib.toLower x.name) > (lib.toLower y.name))
)
|> lib.reverseList
# represent as string
|> map (x: "${toString x.count} - ${toString x.name}: ${lib.concatStringsSep " " x.deps}")
```

you can call it like this to get a nice output:

```sh
nix eval --json --file ./xorg-nodepends.nix | jq .[] --raw-output
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] x86_64-linux static 
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] ran passthru.updateScript
- [x] ran nixpkgs-hammer
- [x] ran nix-check-deps 
  - font-util gets detected as unused however pkg-config requires it (not sure for what)
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc