### PR TITLE
gcc: fix powerpc-linux cross compilers; lib.systems: add ppc32 target

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -45,6 +45,7 @@ let
     "mips64-linux"
     "mips64el-linux"
     "mipsel-linux"
+    "powerpc-linux"
     "powerpc64-linux"
     "powerpc64le-linux"
     "riscv32-linux"

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -36,6 +36,11 @@ rec {
     };
   };
 
+  ppc32 = {
+    config = "powerpc-unknown-linux-gnu";
+    rust.rustcTarget = "powerpc-unknown-linux-gnu";
+  };
+
   sheevaplug = {
     config = "armv5tel-unknown-linux-gnueabi";
   }

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -94,6 +94,7 @@ lib.runTests (
     ];
     testmmix = mseteq mmix [ "mmix-mmixware" ];
     testpower = mseteq power [
+      "powerpc-linux"
       "powerpc-netbsd"
       "powerpc-none"
       "powerpc64-linux"
@@ -174,6 +175,7 @@ lib.runTests (
       "mips64-linux"
       "mips64el-linux"
       "mipsel-linux"
+      "powerpc-linux"
       "powerpc64-linux"
       "powerpc64le-linux"
       "riscv32-linux"

--- a/pkgs/development/compilers/gcc/common/libgcc-buildstuff.nix
+++ b/pkgs/development/compilers/gcc/common/libgcc-buildstuff.nix
@@ -16,7 +16,7 @@ let
   # glibc.  At this early pre-glibc stage these files sometimes
   # have different names.
   crtstuff-ofiles =
-    if stdenv.targetPlatform.isPower then "ecrti.o ecrtn.o ncrti.o ncrtn.o" else "crti.o crtn.o";
+    if stdenv.targetPlatform.isPower64 then "ecrti.o ecrtn.o ncrti.o ncrtn.o" else "crti.o crtn.o";
 
   # Normally, `SHLIB_LC` is set to `-lc`, which means that
   # `libgcc_s.so` cannot be built until `libc.so` is available.
@@ -28,7 +28,7 @@ let
   # gcc-built `{e,n}crt{n,i}.o` instead of failing to find the
   # versions which have been repackaged in libc as `crt{n,i}.o`
   #
-  SHLIB_LC = lib.optionalString stdenv.targetPlatform.isPower "-mnewlib";
+  SHLIB_LC = lib.optionalString stdenv.targetPlatform.isPower64 "-mnewlib";
 
 in
 ''
@@ -47,11 +47,14 @@ in
 # https://www.openwall.com/lists/musl/2022/11/09/3
 #
 # 'parsed.cpu.family' won't be correct for every platform.
-+
-  lib.optionalString
-    (
-      stdenv.targetPlatform.isLoongArch64 || stdenv.targetPlatform.isS390 || stdenv.targetPlatform.isAlpha
-    )
-    ''
-      touch libgcc/config/${stdenv.targetPlatform.parsed.cpu.family}/crt{i,n}.S
-    ''
++ (lib.optionalString
+  (
+    stdenv.targetPlatform.isLoongArch64 || stdenv.targetPlatform.isS390 || stdenv.targetPlatform.isAlpha
+  )
+  ''
+    touch libgcc/config/${stdenv.targetPlatform.parsed.cpu.family}/crt{i,n}.S
+  ''
+)
++ lib.optionalString (stdenv.targetPlatform.isPower && !stdenv.targetPlatform.isPower64) ''
+  touch libgcc/config/rs6000/crt{i,n}.S
+''

--- a/pkgs/development/compilers/rust/binary.nix
+++ b/pkgs/development/compilers/rust/binary.nix
@@ -89,6 +89,7 @@ rec {
         "armv7l-linux"
         "i686-linux"
         "loongarch64-linux"
+        "powerpc-linux"
         "powerpc64-linux"
         "powerpc64le-linux"
         "riscv64-linux"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I'm not exactly sure why this differs between 32 and 64-Bit PowerPC, but this change makes 32-Bit PowerPC cross work.
Successfully built `pkgsCross.ppc32.hello` on x86_64-linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
