### PR TITLE
modules/image/repart: repart.imageFile(Basename) -> image.baseName

### DIFF
--- a/nixos/modules/image/repart-image.nix
+++ b/nixos/modules/image/repart-image.nix
@@ -30,7 +30,7 @@
   # arguments
   name,
   version,
-  imageFileBasename,
+  baseName,
   compression,
   fileSystems,
   finalPartitions,
@@ -205,7 +205,7 @@ stdenvNoCC.mkDerivation (
       echo "Building image with systemd-repart..."
       unshare --map-root-user fakeroot systemd-repart \
         ''${systemdRepartFlags[@]} \
-        ${imageFileBasename}.raw \
+        ${baseName}.raw \
         | tee repart-output.json
 
       runHook postBuild
@@ -220,14 +220,14 @@ stdenvNoCC.mkDerivation (
     # separate derivation to allow users to save disk space. Disk images are
     # already very space intensive so we want to allow users to mitigate this.
     + lib.optionalString compression.enable ''
-      for f in ${imageFileBasename}*; do
+      for f in ${baseName}*; do
         echo "Compressing $f with ${compression.algorithm}..."
         # Keep the original file when compressing and only delete it afterwards
         ${compressionCommand} $f && rm $f
       done
     ''
     + ''
-      mv -v repart-output.json ${imageFileBasename}* $out
+      mv -v repart-output.json ${baseName}* $out
 
       runHook postInstall
     '';

--- a/nixos/modules/image/repart-verity-store.nix
+++ b/nixos/modules/image/repart-verity-store.nix
@@ -194,8 +194,8 @@ in
                   | assert_uki_repart_match.py "${config.system.build.intermediateImage}/repart-output.json"
 
                 # copy the uncompressed intermediate image, so that systemd-repart picks it up
-                cp -v ${config.system.build.intermediateImage}/${config.image.repart.imageFileBasename}.raw .
-                chmod +w ${config.image.repart.imageFileBasename}.raw
+                cp -v ${config.system.build.intermediateImage}/${config.image.baseName}.raw .
+                chmod +w ${config.image.baseName}.raw
               '';
 
               # replace "TBD" with the original roothash values

--- a/nixos/modules/image/repart.nix
+++ b/nixos/modules/image/repart.nix
@@ -391,7 +391,7 @@ in
         mkfsEnv = mkfsOptionsToEnv cfg.mkfsOptions;
         val = pkgs.callPackage ./repart-image.nix {
           systemd = cfg.package;
-          imageFileBasename = config.image.baseName;
+          inherit (config.image) baseName;
           inherit (cfg)
             name
             version


### PR DESCRIPTION
Rename remaining uses of renamed option repart.imageFileBasename to image.baseName.

Follow up to https://github.com/NixOS/nixpkgs/pull/401872 Removes a warning when using repart-verity-store.nix.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
