### PR TITLE
python3Packages.pyling-square: fix build, cleanup

### DIFF
--- a/pkgs/development/python-modules/pylink-square/default.nix
+++ b/pkgs/development/python-modules/pylink-square/default.nix
@@ -2,12 +2,17 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   setuptools,
-  mock,
+
+  # dependencies
   psutil,
-  pytestCheckHook,
-  pythonOlder,
   six,
+
+  # tests
+  mock,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -15,14 +20,17 @@ buildPythonPackage rec {
   version = "1.6.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
-
   src = fetchFromGitHub {
     owner = "square";
     repo = "pylink";
     tag = "v${version}";
     hash = "sha256-rkkdnpkl9UHcBDjp6lsFXR1zNn7tH1KeTQ7wV+yJ3m0=";
   };
+
+  patches = [
+    # ERROR: /build/source/setup.cfg:16: unexpected value continuation
+    ./fix-setup-cfg-syntax.patch
+  ];
 
   build-system = [ setuptools ];
 
@@ -45,11 +53,11 @@ buildPythonPackage rec {
     "test_set_log_file_success"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Python interface for the SEGGER J-Link";
     homepage = "https://github.com/square/pylink";
     changelog = "https://github.com/square/pylink/blob/${src.tag}/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ dump_stack ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ dump_stack ];
   };
 }

--- a/pkgs/development/python-modules/pylink-square/fix-setup-cfg-syntax.patch
+++ b/pkgs/development/python-modules/pylink-square/fix-setup-cfg-syntax.patch
@@ -1,0 +1,24 @@
+diff --git a/setup.cfg b/setup.cfg
+index 22f5e1c..fcad35f 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -11,19 +11,3 @@ universal = 1
+ [behave]
+ color = True
+ summary = True
+-
+-[options.extras_require]
+-  dev =
+-    behave==1.2.5
+-    coverage==4.4.1
+-    psutil>=5.2.2
+-    pycodestyle>=2.3.1
+-    setuptools>=70.2.0
+-    six
+-    sphinx==1.4.8
+-    sphinx-argparse==0.1.15
+-    sphinx_rtd_theme==0.2.4
+-    sphinxcontrib-napoleon==0.5.3
+-    wheel
+-  test =
+-    mock==2.0.0


### PR DESCRIPTION
## Things done

Fixes:
```
ERROR: /build/source/setup.cfg:16: unexpected value continuation
```

cc @jollheef

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
