### PR TITLE
font-bh{,-lucidatypewriter}-{100,75}dpi: refactor, move to pkgs/by-name & rename from xorg namespace

### DIFF
--- a/pkgs/by-name/fo/font-bh-100dpi/package.nix
+++ b/pkgs/by-name/fo/font-bh-100dpi/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  font-util,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-bh-100dpi";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-bh-100dpi-${finalAttrs.version}.tar.xz";
+    hash = "sha256-/Y9e/oSR+qvdJ0SAjT1Or9rlyD5hcBfH/d0nFtBJqx4=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    bdftopcf
+    font-util
+    mkfontscale
+  ];
+
+  buildInputs = [ font-util ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Luxi 100dpi pcf fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/bh-100dpi";
+    license = lib.licenses.unfreeRedistributable;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-bh-100dpi/package.nix
+++ b/pkgs/by-name/fo/font-bh-100dpi/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ font-util ];
 
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+  configureFlags = [ "--with-fontrootdir=$(out)/share/fonts/X11" ];
 
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''

--- a/pkgs/by-name/fo/font-bh-75dpi/package.nix
+++ b/pkgs/by-name/fo/font-bh-75dpi/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ font-util ];
 
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+  configureFlags = [ "--with-fontrootdir=$(out)/share/fonts/X11" ];
 
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''

--- a/pkgs/by-name/fo/font-bh-75dpi/package.nix
+++ b/pkgs/by-name/fo/font-bh-75dpi/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  font-util,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-bh-75dpi";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-bh-75dpi-${finalAttrs.version}.tar.xz";
+    hash = "sha256-YCbYwHNWPdPLtIeNAHbu2XDeur0hQjs7Yd2QRBuefNo=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    bdftopcf
+    font-util
+    mkfontscale
+  ];
+
+  buildInputs = [ font-util ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Luxi 75dpi pcf fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/bh-75dpi";
+    license = lib.licenses.unfreeRedistributable;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-bh-lucidatypewriter-100dpi/package.nix
+++ b/pkgs/by-name/fo/font-bh-lucidatypewriter-100dpi/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  font-util,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-bh-lucidatypewriter-100dpi";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-bh-lucidatypewriter-100dpi-${finalAttrs.version}.tar.xz";
+    hash = "sha256-duwJ7aQJSinUe5HPWcProinI99HKa64qu7P5JeM96PI=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    bdftopcf
+    font-util
+    mkfontscale
+  ];
+
+  buildInputs = [ font-util ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Lucida Sans Typewriter 100dpi pcf fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/bh-lucidatypewriter-100dpi";
+    # no license just a copyright notice
+    license = lib.licenses.unfree;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-bh-lucidatypewriter-100dpi/package.nix
+++ b/pkgs/by-name/fo/font-bh-lucidatypewriter-100dpi/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ font-util ];
 
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+  configureFlags = [ "--with-fontrootdir=$(out)/share/fonts/X11" ];
 
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''

--- a/pkgs/by-name/fo/font-bh-lucidatypewriter-75dpi/package.nix
+++ b/pkgs/by-name/fo/font-bh-lucidatypewriter-75dpi/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ font-util ];
 
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+  configureFlags = [ "--with-fontrootdir=$(out)/share/fonts/X11" ];
 
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''

--- a/pkgs/by-name/fo/font-bh-lucidatypewriter-75dpi/package.nix
+++ b/pkgs/by-name/fo/font-bh-lucidatypewriter-75dpi/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  font-util,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-bh-lucidatypewriter-75dpi";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-bh-lucidatypewriter-75dpi-${finalAttrs.version}.tar.xz";
+    hash = "sha256-hk4sOaxh8E9pP8LIqq7SSymMLNQCg87BLu5FnFY16PU=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    bdftopcf
+    font-util
+    mkfontscale
+  ];
+
+  buildInputs = [ font-util ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Lucida Sans Typewriter 75dpi pcf fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/bh-lucidatypewriter-75dpi";
+    # no license just a copyright notice
+    license = lib.licenses.unfree;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xd/xdummy/package.nix
+++ b/pkgs/by-name/xd/xdummy/package.nix
@@ -34,9 +34,9 @@ let
       FontPath "${xorg.fontmiscmisc}/lib/X11/fonts/misc"
       FontPath "${xorg.fontcursormisc}/lib/X11/fonts/misc"
     ${lib.optionalString unfreeFonts ''
-      FontPath "${xorg.fontbhlucidatypewriter75dpi}/lib/X11/fonts/75dpi"
-      FontPath "${xorg.fontbhlucidatypewriter100dpi}/lib/X11/fonts/100dpi"
-      FontPath "${xorg.fontbh100dpi}/lib/X11/fonts/100dpi"
+      FontPath "${xorg.fontbhlucidatypewriter75dpi}/share/fonts/X11/75dpi"
+      FontPath "${xorg.fontbhlucidatypewriter100dpi}/share/fonts/X11/100dpi"
+      FontPath "${xorg.fontbh100dpi}/share/fonts/X11/100dpi"
     ''}
     EndSection
 

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -4,6 +4,7 @@
   bdftopcf,
   font-alias,
   font-bh-100dpi,
+  font-bh-75dpi,
   font-bh-ttf,
   font-bh-type1,
   font-encodings,
@@ -120,6 +121,7 @@ self: with self; {
   encodings = font-encodings;
   fontalias = font-alias;
   fontbh100dpi = font-bh-100dpi;
+  fontbh75dpi = font-bh-75dpi;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
   fontmuttmisc = font-mutt-misc;
@@ -523,47 +525,6 @@ self: with self; {
       nativeBuildInputs = [
         pkg-config
         bdftopcf
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontbh75dpi = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-bh-75dpi";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-bh-75dpi-1.0.4.tar.xz";
-        sha256 = "1nkwkqdl946xc4xknhi1pnxdww6rxrv013c7nk5x6ganfg0dh9k0";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
-        fontutil
         mkfontscale
       ];
       buildInputs = [ fontutil ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -5,6 +5,7 @@
   font-alias,
   font-bh-100dpi,
   font-bh-75dpi,
+  font-bh-lucidatypewriter-100dpi,
   font-bh-ttf,
   font-bh-type1,
   font-encodings,
@@ -122,6 +123,7 @@ self: with self; {
   fontalias = font-alias;
   fontbh100dpi = font-bh-100dpi;
   fontbh75dpi = font-bh-75dpi;
+  fontbhlucidatypewriter100dpi = font-bh-lucidatypewriter-100dpi;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
   fontmuttmisc = font-mutt-misc;
@@ -525,47 +527,6 @@ self: with self; {
       nativeBuildInputs = [
         pkg-config
         bdftopcf
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontbhlucidatypewriter100dpi = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-bh-lucidatypewriter-100dpi";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-bh-lucidatypewriter-100dpi-1.0.4.tar.xz";
-        sha256 = "1wp87pijbydkpcmawsyas7vwhad2xg1mkkwigga2jjh9lknhkv3n";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
-        fontutil
         mkfontscale
       ];
       buildInputs = [ fontutil ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -3,6 +3,7 @@
   lib,
   bdftopcf,
   font-alias,
+  font-bh-100dpi,
   font-bh-ttf,
   font-bh-type1,
   font-encodings,
@@ -118,6 +119,7 @@ self: with self; {
     ;
   encodings = font-encodings;
   fontalias = font-alias;
+  fontbh100dpi = font-bh-100dpi;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
   fontmuttmisc = font-mutt-misc;
@@ -521,47 +523,6 @@ self: with self; {
       nativeBuildInputs = [
         pkg-config
         bdftopcf
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontbh100dpi = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-bh-100dpi";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-bh-100dpi-1.0.4.tar.xz";
-        sha256 = "07mb9781c9yxzp3ifw317v4fbnmg9qyqv0244zfspylihkz5x3zx";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
-        fontutil
         mkfontscale
       ];
       buildInputs = [ fontutil ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -6,6 +6,7 @@
   font-bh-100dpi,
   font-bh-75dpi,
   font-bh-lucidatypewriter-100dpi,
+  font-bh-lucidatypewriter-75dpi,
   font-bh-ttf,
   font-bh-type1,
   font-encodings,
@@ -124,6 +125,7 @@ self: with self; {
   fontbh100dpi = font-bh-100dpi;
   fontbh75dpi = font-bh-75dpi;
   fontbhlucidatypewriter100dpi = font-bh-lucidatypewriter-100dpi;
+  fontbhlucidatypewriter75dpi = font-bh-lucidatypewriter-75dpi;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
   fontmuttmisc = font-mutt-misc;
@@ -527,47 +529,6 @@ self: with self; {
       nativeBuildInputs = [
         pkg-config
         bdftopcf
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontbhlucidatypewriter75dpi = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-bh-lucidatypewriter-75dpi";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-bh-lucidatypewriter-75dpi-1.0.4.tar.xz";
-        sha256 = "1xg86mb9qigf5v0wx0q2shn8qaabsapamj627xllzw31mhwjqkl6";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
-        fontutil
         mkfontscale
       ];
       buildInputs = [ fontutil ];

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -321,6 +321,7 @@ print OUT <<EOF;
   font-alias,
   font-bh-100dpi,
   font-bh-75dpi,
+  font-bh-lucidatypewriter-100dpi,
   font-bh-ttf,
   font-bh-type1,
   font-encodings,
@@ -438,6 +439,7 @@ self: with self; {
   fontalias = font-alias;
   fontbh100dpi = font-bh-100dpi;
   fontbh75dpi = font-bh-75dpi;
+  fontbhlucidatypewriter100dpi = font-bh-lucidatypewriter-100dpi;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
   fontmuttmisc = font-mutt-misc;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -320,6 +320,7 @@ print OUT <<EOF;
   bdftopcf,
   font-alias,
   font-bh-100dpi,
+  font-bh-75dpi,
   font-bh-ttf,
   font-bh-type1,
   font-encodings,
@@ -436,6 +437,7 @@ self: with self; {
   encodings = font-encodings;
   fontalias = font-alias;
   fontbh100dpi = font-bh-100dpi;
+  fontbh75dpi = font-bh-75dpi;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
   fontmuttmisc = font-mutt-misc;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -322,6 +322,7 @@ print OUT <<EOF;
   font-bh-100dpi,
   font-bh-75dpi,
   font-bh-lucidatypewriter-100dpi,
+  font-bh-lucidatypewriter-75dpi,
   font-bh-ttf,
   font-bh-type1,
   font-encodings,
@@ -440,6 +441,7 @@ self: with self; {
   fontbh100dpi = font-bh-100dpi;
   fontbh75dpi = font-bh-75dpi;
   fontbhlucidatypewriter100dpi = font-bh-lucidatypewriter-100dpi;
+  fontbhlucidatypewriter75dpi = font-bh-lucidatypewriter-75dpi;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
   fontmuttmisc = font-mutt-misc;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -319,6 +319,7 @@ print OUT <<EOF;
   lib,
   bdftopcf,
   font-alias,
+  font-bh-100dpi,
   font-bh-ttf,
   font-bh-type1,
   font-encodings,
@@ -434,6 +435,7 @@ self: with self; {
     ;
   encodings = font-encodings;
   fontalias = font-alias;
+  fontbh100dpi = font-bh-100dpi;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
   fontmuttmisc = font-mutt-misc;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1023,7 +1023,6 @@ self: super:
       "fontadobeutopia100dpi"
       "fontadobeutopia75dpi"
       "fontibmtype1"
-      "fontbh75dpi"
 
       # Bigelow & Holmes fonts
       # https://www.x.org/releases/current/doc/xorg-docs/License.html#Bigelow_Holmes_Inc_and_URW_GmbH_Luxi_font_license

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1023,7 +1023,6 @@ self: super:
       "fontadobeutopia100dpi"
       "fontadobeutopia75dpi"
       "fontibmtype1"
-      "fontbh100dpi"
       "fontbh75dpi"
 
       # Bigelow & Holmes fonts

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1026,7 +1026,6 @@ self: super:
 
       # Bigelow & Holmes fonts
       # https://www.x.org/releases/current/doc/xorg-docs/License.html#Bigelow_Holmes_Inc_and_URW_GmbH_Luxi_font_license
-      "fontbhlucidatypewriter100dpi"
       "fontbhlucidatypewriter75dpi"
     ];
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1023,10 +1023,6 @@ self: super:
       "fontadobeutopia100dpi"
       "fontadobeutopia75dpi"
       "fontibmtype1"
-
-      # Bigelow & Holmes fonts
-      # https://www.x.org/releases/current/doc/xorg-docs/License.html#Bigelow_Holmes_Inc_and_URW_GmbH_Luxi_font_license
-      "fontbhlucidatypewriter75dpi"
     ];
 
     # unfree, possibly not redistributable

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -99,7 +99,6 @@ mirror://xorg/individual/font/font-adobe-utopia-75dpi-1.0.5.tar.xz
 mirror://xorg/individual/font/font-adobe-utopia-100dpi-1.0.5.tar.xz
 mirror://xorg/individual/font/font-adobe-utopia-type1-1.0.5.tar.xz
 mirror://xorg/individual/font/font-arabic-misc-1.0.4.tar.xz
-mirror://xorg/individual/font/font-bh-lucidatypewriter-75dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bitstream-75dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bitstream-100dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bitstream-speedo-1.0.2.tar.gz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -100,7 +100,6 @@ mirror://xorg/individual/font/font-adobe-utopia-100dpi-1.0.5.tar.xz
 mirror://xorg/individual/font/font-adobe-utopia-type1-1.0.5.tar.xz
 mirror://xorg/individual/font/font-arabic-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bh-75dpi-1.0.4.tar.xz
-mirror://xorg/individual/font/font-bh-100dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bh-lucidatypewriter-75dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bh-lucidatypewriter-100dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bitstream-75dpi-1.0.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -99,7 +99,6 @@ mirror://xorg/individual/font/font-adobe-utopia-75dpi-1.0.5.tar.xz
 mirror://xorg/individual/font/font-adobe-utopia-100dpi-1.0.5.tar.xz
 mirror://xorg/individual/font/font-adobe-utopia-type1-1.0.5.tar.xz
 mirror://xorg/individual/font/font-arabic-misc-1.0.4.tar.xz
-mirror://xorg/individual/font/font-bh-75dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bh-lucidatypewriter-75dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bh-lucidatypewriter-100dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bitstream-75dpi-1.0.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -100,7 +100,6 @@ mirror://xorg/individual/font/font-adobe-utopia-100dpi-1.0.5.tar.xz
 mirror://xorg/individual/font/font-adobe-utopia-type1-1.0.5.tar.xz
 mirror://xorg/individual/font/font-arabic-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bh-lucidatypewriter-75dpi-1.0.4.tar.xz
-mirror://xorg/individual/font/font-bh-lucidatypewriter-100dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bitstream-75dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bitstream-100dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bitstream-speedo-1.0.2.tar.gz


### PR DESCRIPTION
<details>
<summary>this is the script i use to get the packages that don't depend on other xorg packages:</summary>

```nix
let
  inherit (import <nixpkgs> { }) lib;

  done = import ./pkgs/servers/x11/xorg/default.nix |> lib.functionArgs |> lib.attrNames;

  pkgs =
    (import ./default.nix { }).xorg
    |> lib.filterAttrs (
      n: v:
      lib.isAttrs v
      && v ? pname
      && !lib.elem n done
      && !lib.elem n (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem v.pname done
      && !lib.elem v.pname (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem (lib.toLower n) done
      && !lib.elem (lib.toLower n) (map (lib.replaceStrings [ "-" ] [ "" ]) done)
    );

  pnames = lib.mapAttrsToList (_: v: v.pname) pkgs;

  filteredPkgs =
    pkgs
    |> lib.filterAttrs (
      n: v:
      true
      # && !v.meta.unfree
      # && !v.meta.broken
      # && !v.meta.unsupported
      # && !lib.hasPrefix "font" n
      && !lib.hasPrefix "xf86" n
    );
in
filteredPkgs
# get deps
|> lib.mapAttrs (
  _: v:
  v.buildInputs ++ v.nativeBuildInputs ++ v.propagatedBuildInputs ++ v.propagatedNativeBuildInputs
)
# filter deps for xorg packages
|> lib.mapAttrs (_: v: lib.filter (x: x ? pname && lib.elem x.pname pnames) v)
# map deps to list and count
|> lib.mapAttrsToList (
  name: value: {
    inherit name;
    deps = map (x: x.pname or "error") value |> lib.unique;
    count = lib.length value;
  }
)
# sort
|> lib.sort (
  x: y: x.count < y.count || (x.count == y.count && (lib.toLower x.name) > (lib.toLower y.name))
)
|> lib.reverseList
# represent as string
|> map (x: "${toString x.count} - ${toString x.name}: ${lib.concatStringsSep " " x.deps}")
```

you can call it like this to get a nice output:

```sh
nix eval --json --file ./xorg-nodepends.nix | jq .[] --raw-output
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] x86_64-linux static 
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] ran passthru.updateScript
- [x] ran nixpkgs-hammer
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc