### PR TITLE
python3Packages.plyer: Fix FTBFS, take up maintenance

### DIFF
--- a/pkgs/development/python-modules/plyer/default.nix
+++ b/pkgs/development/python-modules/plyer/default.nix
@@ -81,6 +81,8 @@ buildPythonPackage rec {
     description = "Plyer is a platform-independent api to use features commonly found on various platforms";
     homepage = "https://github.com/kivy/plyer";
     license = licenses.mit;
-    maintainers = with maintainers; [ rski ];
+    teams = [
+      lib.teams.ngi
+    ];
   };
 }

--- a/pkgs/development/python-modules/plyer/default.nix
+++ b/pkgs/development/python-modules/plyer/default.nix
@@ -3,8 +3,8 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   keyring,
-  mock,
   pytestCheckHook,
 }:
 
@@ -20,6 +20,30 @@ buildPythonPackage rec {
     sha256 = "sha256-7Icb2MVj5Uit86lRHxal6b7y9gIJ3UT2HNqpA9DYWVE=";
   };
 
+  patches = [
+    # Fix compatibility with Python 3.13
+    (fetchpatch {
+      name = "0001-plyer-Use-unittest-mock.patch";
+      url = "https://github.com/kivy/plyer/commit/c9e73f395e2b51d46ada68119abfae2973591c00.patch";
+      hash = "sha256-rWak2GOGnsw+GhEtdob9h1c39aa6Z1yU7vH9kdGjHO0=";
+    })
+    (fetchpatch {
+      name = "0002-plyer-Remove-whitespace-error-during-self.assertEqual-function-call.patch";
+      url = "https://github.com/kivy/plyer/commit/8393c61dfd3a7aa0362d3bf530ba9ca052878c1a.patch";
+      hash = "sha256-omjpQJQ+vZ6T12vL6LvKOuRSihiHfLdEZ1pDat8VuiM=";
+    })
+    (fetchpatch {
+      name = "0003-plyer-Replace obj.__doc__-with-getdoc-obj-to-automatically-remove-new-lines.patch";
+      url = "https://github.com/kivy/plyer/commit/675750f31e9f98cd5de2df732afe34648f343d3e.patch";
+      hash = "sha256-Lb7MbbcIjwbfnR8U6t9j0c+bqU7kK3/xEt13pSF8G6M=";
+    })
+    (fetchpatch {
+      name = "0004-plyer-Remove-newline-and-indentation-comparisons-during-self.assertEqual-function-call.patch";
+      url = "https://github.com/kivy/plyer/commit/31e96f689771cd43f0a925463a59fcbc49f58e46.patch";
+      hash = "sha256-ZYYftI4w+21Q6oKm1wku7NJg3xfkIpkjN+PvZY0YjyY=";
+    })
+  ];
+
   postPatch = ''
     rm -r examples
     # remove all the wifi stuff. Depends on a python wifi module that has not been updated since 2016
@@ -34,7 +58,6 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ keyring ];
 
   nativeCheckInputs = [
-    mock
     pytestCheckHook
   ];
 


### PR DESCRIPTION
Closes #418869

NGIpkgs needs it for its Libervia packaging. In the above issue, the current maintainer (CC @rski) mentioned that they have no motivation to further maintain this package, so the NGI team will be picking it up.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
