### PR TITLE
taisei: 1.4.2 -> 1.4.4

### DIFF
--- a/pkgs/by-name/ta/taisei/package.nix
+++ b/pkgs/by-name/ta/taisei/package.nix
@@ -12,32 +12,30 @@
   openssl,
   gamemode,
   shaderc,
-  ensureNewerSourcesForZipFilesHook,
   # Runtime depends
   glfw,
-  SDL2,
+  sdl3,
   SDL2_mixer,
   cglm,
   freetype,
   libpng,
   libwebp,
-  libzip,
   zlib,
   zstd,
   spirv-cross,
+  mimalloc,
 
   gamemodeSupport ? stdenv.hostPlatform.isLinux,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "taisei";
-  version = "1.4.2";
+  version = "1.4.4";
 
   src = fetchFromGitHub {
     owner = "taisei-project";
     repo = "taisei";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rThLz8o6IYhIBUc0b1sAQi2aF28btajcM1ScTv+qn6c=";
+    hash = "sha256-Cs66kyNSVjUZUH+ddZGjFwSUQtwqX4uuGQh+ZLv6N6o=";
     fetchSubmodules = true;
   };
 
@@ -48,24 +46,23 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     python3Packages.python
     python3Packages.zstandard
-    ensureNewerSourcesForZipFilesHook
     shaderc
   ];
 
   buildInputs = [
     glfw
-    SDL2
+    sdl3
     SDL2_mixer
     cglm
     freetype
     libpng
     libwebp
-    libzip
     zlib
     zstd
     opusfile
     openssl
     spirv-cross
+    mimalloc
   ]
   ++ lib.optional gamemodeSupport gamemode;
 
@@ -74,7 +71,10 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonEnable "install_macos_bundle" false)
     (lib.mesonEnable "install_relocatable" false)
     (lib.mesonEnable "shader_transpiler" false)
+    (lib.mesonEnable "shader_transpiler_dxbc" false)
     (lib.mesonEnable "gamemode" gamemodeSupport)
+    (lib.mesonEnable "package_data" false)
+    (lib.mesonEnable "vfs_zip" false)
   ];
 
   preConfigure = ''

--- a/pkgs/by-name/ta/taisei/package.nix
+++ b/pkgs/by-name/ta/taisei/package.nix
@@ -12,6 +12,7 @@
   openssl,
   gamemode,
   shaderc,
+  makeWrapper,
   # Runtime depends
   glfw,
   sdl3,
@@ -47,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.python
     python3Packages.zstandard
     shaderc
+    makeWrapper
   ];
 
   buildInputs = [
@@ -79,6 +81,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   preConfigure = ''
     patchShebangs .
+  '';
+
+  postInstall = lib.optionalString gamemodeSupport ''
+    wrapProgram $out/bin/taisei \
+      --set LD_LIBRARY_PATH ${lib.makeLibraryPath [ gamemode ]}
   '';
 
   strictDeps = true;


### PR DESCRIPTION
1.4.3 changelog: https://github.com/taisei-project/taisei/releases/tag/v1.4.3
1.4.4 changelog: https://github.com/taisei-project/taisei/releases/tag/v1.4.4
Diff: https://github.com/taisei-project/taisei/compare/v1.4.2...v1.4.4

- Use `sdl3` which is now required over `SDL2`
- Added `mimalloc` as it's now preferred
- Removed `libzip` and disable `package_data` and `vfs_zip` meson options to prevent a crash when loading a new game:
```
4873  {taskmgr:global/5}  WARNING  vfs/zippath vfs_zippath_open: Opening compressed file '/nix/store/azsg6dv4q4md9g1awmfpyq706r07p9ms-taisei-1.4.4/share/taisei/00-taisei.zip/models/hud.iqm' in seekable mode, this is suboptimal. Consider storing this file without compression  [vfs/zippath.c:87]
4873  {taskmgr:global/5}  ERROR  resource/iqm_loader/iqm_loader iqm_load_stream: res/models/hud.iqm: mesh 0: vertices out of range  [resource/iqm_loader/iqm_loader.c:391]
4873  {taskmgr:global/5}  FATAL  resource load_resource_finish: Required model 'hud' couldn't be loaded from '/nix/store/azsg6dv4q4md9g1awmfpyq706r07p9ms-taisei-1.4.4/share/taisei/00-taisei.zip/models/hud.iqm'  [resource/resource.c:1425]
```
- Added `gamemode` to `LD_LIBRARY_PATH`, gamemode doesn't automatically start as expected without this
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
