### PR TITLE
python313Packages.llvmlite: 0.44.0 -> 0.45.0rc1; python313Packages.numba: 0.61.2 -> 0.62.0rc1

### DIFF
--- a/pkgs/development/python-modules/librosa/default.nix
+++ b/pkgs/development/python-modules/librosa/default.nix
@@ -49,6 +49,11 @@ buildPythonPackage rec {
     hash = "sha256-T58J/Gi3tHzelr4enbYJi1KmO46QxE5Zlhkc0+EgvRg=";
   };
 
+  patches = [
+    # <https://github.com/librosa/librosa/pull/1977>
+    ./fix-with-numba-0.62.0.patch
+  ];
+
   build-system = [ setuptools ];
 
   dependencies = [

--- a/pkgs/development/python-modules/librosa/fix-with-numba-0.62.0.patch
+++ b/pkgs/development/python-modules/librosa/fix-with-numba-0.62.0.patch
@@ -1,0 +1,27 @@
+From 902bcca8cfc84801cf93a6c3ca59da283072a79f Mon Sep 17 00:00:00 2001
+From: Emily <hello@emily.moe>
+Date: Wed, 27 Aug 2025 18:58:07 +0100
+Subject: [PATCH] Fix types in beat tracking code
+
+The development version of Numba 0.62.0 is unhappy about `range`
+being applied to floating point values here.
+---
+ librosa/beat.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/librosa/beat.py b/librosa/beat.py
+index 1a19005d..4ed9e945 100644
+--- a/librosa/beat.py
++++ b/librosa/beat.py
+@@ -582,7 +582,7 @@ def __beat_track_dp(localscore, frames_per_beat, tightness, backlink, cumscore):
+         # Search over all possible predecessors to find the best preceding beat
+         # NOTE: to provide time-varying tempo estimates, we replace
+         # frames_per_beat[0] by frames_per_beat[i] in this loop body.
+-        for loc in range(i - np.round(frames_per_beat[tv * i] / 2), i - 2 * frames_per_beat[tv * i] - 1, - 1):
++        for loc in range(i - round(frames_per_beat[tv * i] / 2), int(i - 2 * frames_per_beat[tv * i] - 1), - 1):
+             # Once we're searching past the start, break out
+             if loc < 0:
+                 break
+-- 
+2.50.1
+

--- a/pkgs/development/python-modules/llvmlite/default.nix
+++ b/pkgs/development/python-modules/llvmlite/default.nix
@@ -8,17 +8,25 @@
 
   setuptools,
 
+  cmake,
+  ninja,
+
+  llvm_20,
+  libxml2,
+
   # tests
   pytestCheckHook,
-  llvm,
-  libxml2,
 
   withStaticLLVM ? true,
 }:
 
+let
+  llvm = llvm_20;
+in
+
 buildPythonPackage rec {
   pname = "llvmlite";
-  version = "0.44.0";
+  version = "0.45.0rc1";
   pyproject = true;
 
   disabled = isPyPy || pythonAtLeast "3.14";
@@ -27,28 +35,28 @@ buildPythonPackage rec {
     owner = "numba";
     repo = "llvmlite";
     tag = "v${version}";
-    hash = "sha256-ZIA/JfK9ZP00Zn6SZuPus30Xw10hn3DArHCkzBZAUV0=";
+    hash = "sha256-wMTNtUuslCjopyfF6FAtfJAR0zuWjL8N8G16UKiplN0=";
   };
 
   build-system = [ setuptools ];
 
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
   buildInputs = [ llvm ] ++ lib.optionals withStaticLLVM [ libxml2.dev ];
 
-  postPatch = lib.optionalString withStaticLLVM ''
-    substituteInPlace ffi/build.py --replace-fail "--system-libs --libs all" "--system-libs --libs --link-static all"
-  '';
-
-  # Set directory containing llvm-config binary
-  env.LLVM_CONFIG = "${llvm.dev}/bin/llvm-config";
-
   nativeCheckInputs = [ pytestCheckHook ];
+
+  dontUseCmakeConfigure = true;
 
   # https://github.com/NixOS/nixpkgs/issues/255262
   preCheck = ''
     cd $out
   '';
 
-  __impureHostDeps = lib.optionals stdenv.hostPlatform.isDarwin [ "/usr/lib/libm.dylib" ];
+  env.LLVMLITE_SHARED = !withStaticLLVM;
 
   passthru = lib.optionalAttrs (!withStaticLLVM) { inherit llvm; };
 

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -33,7 +33,7 @@ let
   cudatoolkit = cudaPackages.cuda_nvcc;
 in
 buildPythonPackage rec {
-  version = "0.61.2";
+  version = "0.62.0rc1";
   pname = "numba";
   pyproject = true;
 
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     postFetch = ''
       sed -i 's/git_refnames = "[^"]*"/git_refnames = " (tag: ${src.tag})"/' $out/numba/_version.py
     '';
-    hash = "sha256-Qa2B5pOWrLb/1V3PSyiwS1x9ueXwDKRhDMDecBCAN+8=";
+    hash = "sha256-YnozYetRsrCl5+UvK4y1QQykUqSMshi9vcv/K5A0dts=";
   };
 
   postPatch = ''
@@ -59,14 +59,7 @@ buildPythonPackage rec {
       --replace-fail \
         "dldir = [" \
         "dldir = [ '${addDriverRunpath.driverLink}/lib', "
-
-    substituteInPlace setup.py \
-      --replace-fail 'max_numpy_run_version = "2.3"' 'max_numpy_run_version = "2.4"'
-    substituteInPlace numba/__init__.py \
-      --replace-fail "numpy_version > (2, 2)" "numpy_version > (2, 3)"
   '';
-
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-I${lib.getInclude stdenv.cc.libcxx}/include/c++/v1";
 
   build-system = [
     setuptools
@@ -80,21 +73,16 @@ buildPythonPackage rec {
 
   buildInputs = lib.optionals cudaSupport [ cudaPackages.cuda_cudart ];
 
-  pythonRelaxDeps = [ "numpy" ];
+  pythonRelaxDeps = [
+    "numpy"
+  ];
 
   dependencies = [
     numpy
     llvmlite
   ];
 
-  patches = [
-    (fetchpatch2 {
-      url = "https://github.com/numba/numba/commit/e2c8984ba60295def17e363a926d6f75e7fa9f2d.patch";
-      includes = [ "numba/core/bytecode.py" ];
-      hash = "sha256-HIVbp3GSmnq6W7zrRIirIbhGjJsFN3PNyHSfAE8fdDw=";
-    })
-  ]
-  ++ lib.optionals cudaSupport [
+  patches = lib.optionals cudaSupport [
     (replaceVars ./cuda_path.patch {
       cuda_toolkit_path = cudatoolkit;
       cuda_toolkit_lib_path = lib.getLib cudatoolkit;
@@ -111,12 +99,16 @@ buildPythonPackage rec {
     cd $out
   '';
 
-  enabledTestPaths = lib.optionals (!doFullCheck) [
-    # These are the most basic tests. Running all tests is too expensive, and
-    # some of them fail (also differently on different platforms), so it will
-    # be too hard to maintain such a `disabledTests` list.
-    "${python.sitePackages}/numba/tests/test_usecases.py"
-  ];
+  enabledTestPaths =
+    if doFullCheck then
+      null
+    else
+      [
+        # These are the most basic tests. Running all tests is too expensive, and
+        # some of them fail (also differently on different platforms), so it will
+        # be too hard to maintain such a `disabledTests` list.
+        "${python.sitePackages}/numba/tests/test_usecases.py"
+      ];
 
   disabledTests = lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
     # captured stderr: Fatal Python error: Segmentation fault

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8641,8 +8641,7 @@ self: super: with self; {
   llmx = callPackage ../development/python-modules/llmx { };
 
   llvmlite = callPackage ../development/python-modules/llvmlite {
-    # llvmlite always requires a specific version of llvm.
-    llvm = pkgs.llvm_16;
+    inherit (pkgs) cmake ninja;
   };
 
   lm-eval = callPackage ../development/python-modules/lm-eval { };


### PR DESCRIPTION
Nearing the end of the quest to delete old compilers for 25.11.

Upstream hasn’t cut tags for these release candidates yet, but the remaining blockers on [both](https://github.com/numba/llvmlite/issues/1254) [checklists](https://github.com/numba/numba/issues/10170) are documentation and release engineering work rather than code changes, so we can start testing this now, merge when everything looks good and the release candidate tags are cut, and bump to the final version once it’s out.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux *(with and without CUDA)*
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
