### PR TITLE
clickhouse: 25.7.4.11 → 25.7.5.34

### DIFF
--- a/pkgs/by-name/cl/clickhouse/generic.nix
+++ b/pkgs/by-name/cl/clickhouse/generic.nix
@@ -155,7 +155,7 @@ llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
   requiredSystemFeatures = [ "big-parallel" ];
 
   passthru = {
-    tests.clickhouse = if lts then nixosTests.clickhouse-lts else nixosTests.clickhouse;
+    tests = if lts then nixosTests.clickhouse-lts else nixosTests.clickhouse;
 
     updateScript = nix-update-script {
       extraArgs = nixUpdateExtraArgs;

--- a/pkgs/by-name/cl/clickhouse/package.nix
+++ b/pkgs/by-name/cl/clickhouse/package.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "25.7.4.11-stable";
-  hash = "sha256-SKDnnBdl9Rwc+ONH1chXAOFIwRmVG2l5cPEwpaDogzU=";
+  version = "25.7.5.34-stable";
+  hash = "sha256-0+e2QPsn6EZ28j3HE2TYOpJBN9jSl19Ytbvj+124viw=";
   lts = false;
   nixUpdateExtraArgs = [
     "--version-regex"


### PR DESCRIPTION
* https://github.com/ClickHouse/ClickHouse/compare/v25.7.4.11-stable...v25.7.5.34-stable

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
