### PR TITLE
nixos/postgresql-backup: do not enable assertions when module is disabled

### DIFF
--- a/nixos/modules/services/backup/postgresql-backup.nix
+++ b/nixos/modules/services/backup/postgresql-backup.nix
@@ -152,45 +152,48 @@ in
 
   };
 
-  config = lib.mkMerge [
-    {
-      assertions = [
-        {
-          assertion = cfg.backupAll -> cfg.databases == [ ];
-          message = "config.services.postgresqlBackup.backupAll cannot be used together with config.services.postgresqlBackup.databases";
-        }
-        {
-          assertion =
-            cfg.compression == "none"
-            || (cfg.compression == "gzip" && cfg.compressionLevel >= 1 && cfg.compressionLevel <= 9)
-            || (cfg.compression == "zstd" && cfg.compressionLevel >= 1 && cfg.compressionLevel <= 19);
-          message = "config.services.postgresqlBackup.compressionLevel must be set between 1 and 9 for gzip and 1 and 19 for zstd";
-        }
-      ];
-    }
-    (lib.mkIf cfg.enable {
-      systemd.tmpfiles.rules = [
-        "d '${cfg.location}' 0700 postgres - - -"
-      ];
-    })
-    (lib.mkIf (cfg.enable && cfg.backupAll) {
-      systemd.services.postgresqlBackup = postgresqlBackupService "all" "pg_dumpall ${cfg.pgdumpOptions}";
-    })
-    (lib.mkIf (cfg.enable && !cfg.backupAll) {
-      systemd.services = lib.listToAttrs (
-        map (
-          db:
-          let
-            cmd = "pg_dump ${cfg.pgdumpOptions} ${db}";
-          in
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        assertions = [
           {
-            name = "postgresqlBackup-${db}";
-            value = postgresqlBackupService db cmd;
+            assertion = cfg.backupAll -> cfg.databases == [ ];
+            message = "config.services.postgresqlBackup.backupAll cannot be used together with config.services.postgresqlBackup.databases";
           }
-        ) cfg.databases
-      );
-    })
-  ];
+          {
+            assertion =
+              cfg.compression == "none"
+              || (cfg.compression == "gzip" && cfg.compressionLevel >= 1 && cfg.compressionLevel <= 9)
+              || (cfg.compression == "zstd" && cfg.compressionLevel >= 1 && cfg.compressionLevel <= 19);
+            message = "config.services.postgresqlBackup.compressionLevel must be set between 1 and 9 for gzip and 1 and 19 for zstd";
+          }
+        ];
+
+        systemd.tmpfiles.rules = [
+          "d '${cfg.location}' 0700 postgres - - -"
+        ];
+      }
+
+      (lib.mkIf cfg.backupAll {
+        systemd.services.postgresqlBackup = postgresqlBackupService "all" "pg_dumpall ${cfg.pgdumpOptions}";
+      })
+
+      (lib.mkIf (!cfg.backupAll) {
+        systemd.services = lib.listToAttrs (
+          map (
+            db:
+            let
+              cmd = "pg_dump ${cfg.pgdumpOptions} ${db}";
+            in
+            {
+              name = "postgresqlBackup-${db}";
+              value = postgresqlBackupService db cmd;
+            }
+          ) cfg.databases
+        );
+      })
+    ]
+  );
 
   meta.maintainers = with lib.maintainers; [ Scrumplex ];
 }


### PR DESCRIPTION
This triggered in a config I managed where postgresqlBackup was not even enabled.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
