### PR TITLE
scx.full: 1.0.14 -> 1.0.15

### DIFF
--- a/nixos/modules/services/scheduling/scx.nix
+++ b/nixos/modules/services/scheduling/scx.nix
@@ -39,6 +39,8 @@ in
     scheduler = lib.mkOption {
       type = lib.types.enum [
         "scx_bpfland"
+        "scx_chaos"
+        "scx_cosmos"
         "scx_central"
         "scx_flash"
         "scx_flatcg"
@@ -46,14 +48,18 @@ in
         "scx_layered"
         "scx_mitosis"
         "scx_nest"
+        "scx_p2dq"
         "scx_pair"
+        "scx_prev"
         "scx_qmap"
         "scx_rlfifo"
         "scx_rustland"
         "scx_rusty"
         "scx_sdt"
         "scx_simple"
+        "scx_tickless"
         "scx_userland"
+        "scx_wd40"
       ];
       default = "scx_rustland";
       example = "scx_bpfland";

--- a/nixos/modules/services/scheduling/scx.nix
+++ b/nixos/modules/services/scheduling/scx.nix
@@ -121,5 +121,7 @@ in
     ];
   };
 
-  meta.maintainers = with lib.maintainers; [ johnrtitor ];
+  meta = {
+    inherit (pkgs.scx.full.meta) maintainers;
+  };
 }

--- a/nixos/tests/scx/default.nix
+++ b/nixos/tests/scx/default.nix
@@ -12,7 +12,6 @@
 
     specialisation = {
       bpfland.configuration.services.scx.scheduler = "scx_bpfland";
-      central.configuration.services.scx.scheduler = "scx_central";
       cosmos.configuration.services.scx.scheduler = "scx_cosmos";
       flash.configuration.services.scx.scheduler = "scx_flash";
       flatcg.configuration.services.scx.scheduler = "scx_flatcg";
@@ -29,7 +28,6 @@
   testScript = ''
     specialisation = [
       "bpfland",
-      "central",
       "cosmos",
       "flash",
       "flatcg",

--- a/nixos/tests/scx/default.nix
+++ b/nixos/tests/scx/default.nix
@@ -13,10 +13,16 @@
     specialisation = {
       bpfland.configuration.services.scx.scheduler = "scx_bpfland";
       central.configuration.services.scx.scheduler = "scx_central";
+      cosmos.configuration.services.scx.scheduler = "scx_cosmos";
+      flash.configuration.services.scx.scheduler = "scx_flash";
+      flatcg.configuration.services.scx.scheduler = "scx_flatcg";
       lavd.configuration.services.scx.scheduler = "scx_lavd";
+      nest.configuration.services.scx.scheduler = "scx_nest";
+      p2dq.configuration.services.scx.scheduler = "scx_p2dq";
       rlfifo.configuration.services.scx.scheduler = "scx_rlfifo";
       rustland.configuration.services.scx.scheduler = "scx_rustland";
       rusty.configuration.services.scx.scheduler = "scx_rusty";
+      simple.configuration.services.scx.scheduler = "scx_simple";
     };
   };
 
@@ -24,10 +30,16 @@
     specialisation = [
       "bpfland",
       "central",
+      "cosmos",
+      "flash",
+      "flatcg",
       "lavd",
+      "nest",
+      "p2dq",
       "rlfifo",
       "rustland",
-      "rusty"
+      "rusty",
+      "simple"
     ]
 
     def activate_specialisation(name: str):

--- a/pkgs/os-specific/linux/scx/scx_cscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_cscheds.nix
@@ -58,10 +58,6 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     cp ${finalAttrs.fetchLibbpf} meson-scripts/fetch_libbpf
     substituteInPlace meson.build \
       --replace-fail '[build_bpftool' "['${lib.getExe bash}', build_bpftool"
-
-    # TODO: Remove in next release.
-    substituteInPlace lib/scxtest/overrides.h \
-      --replace-fail '#define __builtin_preserve_enum_value(x,y,z) 1' '#define __builtin_preserve_enum_value(x,y) 1'
   '';
 
   nativeBuildInputs = [
@@ -89,7 +85,6 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
       "systemd" = false;
       # not for nix
       "openrc" = false;
-      "libalpm" = false;
     })
     (lib.mapAttrsToList lib.mesonBool {
       # needed libs are already fetched as FOD
@@ -106,16 +101,8 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     "zerocallusedregs"
   ];
 
-  # We copy the compiled header files to the dev output
-  # These are needed for the rust schedulers
-  postFixup = ''
-    mkdir -p ${placeholder "dev"}
-    cp -r libbpf ${placeholder "dev"}
-  '';
-
   outputs = [
     "bin"
-    "dev"
     "out"
   ];
 

--- a/pkgs/os-specific/linux/scx/scx_rustscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_rustscheds.nix
@@ -7,7 +7,6 @@
   zlib,
   zstd,
   scx-common,
-  scx,
   protobuf,
   libseccomp,
 }:
@@ -16,12 +15,6 @@ rustPlatform.buildRustPackage {
   inherit (scx-common) version src;
 
   inherit (scx-common.versionInfo.scx) cargoHash;
-
-  # Copy compiled headers and libs from scx.cscheds
-  postPatch = ''
-    mkdir libbpf
-    cp -r ${scx.cscheds.dev}/libbpf/* libbpf/
-  '';
 
   nativeBuildInputs = [
     pkg-config
@@ -37,18 +30,6 @@ rustPlatform.buildRustPackage {
 
   env = {
     BPF_CLANG = lib.getExe llvmPackages.clang;
-    BPF_EXTRA_CFLAGS_PRE_INCL = lib.concatStringsSep " " [
-      "-I${scx.cscheds.dev}/libbpf/src/usr/include"
-      "-I${scx.cscheds.dev}/libbpf/include/uapi"
-      "-I${scx.cscheds.dev}/libbpf/include/linux"
-    ];
-    RUSTFLAGS = lib.concatStringsSep " " [
-      "-C relocation-model=pic"
-      "-C link-args=-lelf"
-      "-C link-args=-lz"
-      "-C link-args=-lzstd"
-      "-L ${scx.cscheds.dev}/libbpf/src"
-    ];
   };
 
   hardeningDisable = [
@@ -63,6 +44,7 @@ rustPlatform.buildRustPackage {
     "--skip=compat::tests::test_struct_has_field"
     "--skip=cpumask"
     "--skip=topology"
+    "--skip=proc_data::tests::test_thread_operations"
   ];
 
   meta = scx-common.meta // {

--- a/pkgs/os-specific/linux/scx/scx_rustscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_rustscheds.nix
@@ -30,6 +30,12 @@ rustPlatform.buildRustPackage {
 
   env = {
     BPF_CLANG = lib.getExe llvmPackages.clang;
+    RUSTFLAGS = lib.concatStringsSep " " [
+      "-C relocation-model=pic"
+      "-C link-args=-lelf"
+      "-C link-args=-lz"
+      "-C link-args=-lzstd"
+    ];
   };
 
   hardeningDisable = [

--- a/pkgs/os-specific/linux/scx/version.json
+++ b/pkgs/os-specific/linux/scx/version.json
@@ -1,15 +1,15 @@
 {
   "scx": {
-    "version": "1.0.14",
-    "hash": "sha256-Wh+8vaQO93Erj+z8S2C633UDmUrFjQc3Bg+Nm7EML0E=",
-    "cargoHash": "sha256-6uiDx2/5ZcYkz8x8vuOTEUclIttzxVMvh1Q6QHg9N6E="
+    "version": "1.0.15",
+    "hash": "sha256-HZIcJVWb0prkCjoSw7hd4JKve+unWFnfz9bGXZaF6EA=",
+    "cargoHash": "sha256-CRk8vLwSylNM5M9j0iwRbAmzAREUOJAl28BdY2o1zGs="
   },
   "bpftool": {
     "rev": "183e7010387d1fc9f08051426e9a9fbd5f8d409e",
     "hash": "sha256-ZZly6csVWOmtLmld1fhSDUqyRgZx2gSMGXTaSASGv7c="
   },
   "libbpf": {
-    "rev": "c5f22aca0f3aa855daa159b2777472b35e721804",
-    "hash": "sha256-ggGVqAkdZt28KAx+LztVIYGxj0j79hKcPKmUy8TrJy8="
+    "rev": "b4fa3e39a77fd65574fb5f899486795fc3d89bd9",
+    "hash": "sha256-wlymVgcLlGCUOC92CkYU6QZZnqx8nidSfhr1pTiS8aM="
   }
 }


### PR DESCRIPTION
https://github.com/sched-ext/scx/releases/tag/v1.0.15
https://github.com/sched-ext/scx/compare/v1.0.14...v1.0.15

Removed the `libalpm` flag since it has been removed upstream.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
