### PR TITLE
ent-go: Explicitly set runtime version

### DIFF
--- a/pkgs/by-name/en/ent-go/ent_version.patch
+++ b/pkgs/by-name/en/ent-go/ent_version.patch
@@ -1,0 +1,28 @@
+--- a/entc/gen/graph.go	2025-08-26 12:42:17.548313631 +0100
++++ b/entc/gen/graph.go	2025-08-26 12:43:32.398186157 +0100
+@@ -1008,22 +1008,10 @@
+ 
+ // ModuleInfo returns the entgo.io/ent version.
+ func (Config) ModuleInfo() (m debug.Module) {
+-	const pkg = "entgo.io/ent"
+-	info, ok := debug.ReadBuildInfo()
+-	if !ok {
+-		return
+-	}
+-	// Was running as a CLI (ent/cmd/ent).
+-	if info.Main.Path == pkg {
+-		return info.Main
+-	}
+-	// Or, as a main package (ent/entc).
+-	for _, dep := range info.Deps {
+-		if dep.Path == pkg {
+-			return *dep
+-		}
++	return debug.Module{
++		Version: "@version@",
++		Sum:     "@sum@",
+ 	}
+-	return
+ }
+ 
+ // FeatureEnabled reports if the given feature name is enabled.

--- a/pkgs/by-name/en/ent-go/package.nix
+++ b/pkgs/by-name/en/ent-go/package.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
+  replaceVars,
 }:
 
 buildGoModule rec {
@@ -17,6 +18,14 @@ buildGoModule rec {
   };
 
   vendorHash = "sha256-ec5tA9TsDKGnHVZWilLj7bdHrd46uQcNQ8YCK/s6UAY=";
+
+  patches = [
+    # patch in version information so we don't get "version = "(devel)";"
+    (replaceVars ./ent_version.patch {
+      inherit version;
+      sum = src.outputHash;
+    })
+  ];
 
   subPackages = [ "cmd/ent" ];
 


### PR DESCRIPTION
ent uses the runtime version to generate `runtime.go`. Without this patch, you get `version = "(devel)";` and no sha listed. This patch adds in the actual version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
