### PR TITLE
Revert "ci: add myself as a reviewer on anything in maintainers that's otherwise not maintained"

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -19,7 +19,6 @@
 /.github/workflows                      @NixOS/nixpkgs-ci
 /ci                                     @NixOS/nixpkgs-ci
 /ci/OWNERS                              @infinisil @philiptaron
-/maintainers                            @philiptaron
 
 # Development support
 /.editorconfig @Mic92 @zowoq


### PR DESCRIPTION
Reverts NixOS/nixpkgs#436001

Everyone was right. It is too much.