### PR TITLE
sourceHanPackages: move packages to toplevel only

### DIFF
--- a/pkgs/data/fonts/source-han/default.nix
+++ b/pkgs/data/fonts/source-han/default.nix
@@ -86,7 +86,7 @@ let
     };
 in
 {
-  sans = makeSuperOTC {
+  source-han-sans = makeSuperOTC {
     family = "sans";
     description = "sans-serif";
     rev = "2.005R";
@@ -95,7 +95,7 @@ in
     prefix = "01_";
   };
 
-  serif = makeSuperOTC {
+  source-han-serif = makeSuperOTC {
     family = "serif";
     description = "serif";
     rev = "2.003R";
@@ -104,35 +104,35 @@ in
     prefix = "01_";
   };
 
-  mono = makeSuperOTC {
+  source-han-mono = makeSuperOTC {
     family = "mono";
     description = "monospaced";
     rev = "1.002";
     hash = "sha256-DBkkSN6QhI8R64M2h2iDqaNtxluJZeSJYAz8x6ZzWME=";
   };
 
-  sans-vf-otf = makeVariable {
+  source-han-sans-vf-otf = makeVariable {
     family = "sans";
     version = "2.005";
     hash = "sha256-7/THncqTE6IpPezcX14eYRRC8WR/xPv0XjfOPEfF8aU=";
     format = "otf";
   };
 
-  sans-vf-ttf = makeVariable {
+  source-han-sans-vf-ttf = makeVariable {
     family = "sans";
     version = "2.005";
     hash = "sha256-CL5kjZzCiNvdcwiFflTlarINpeYxvuqZH+4ayiIQdD8=";
     format = "ttf";
   };
 
-  serif-vf-otf = makeVariable {
+  source-han-serif-vf-otf = makeVariable {
     family = "serif";
     version = "2.003";
     hash = "sha256-a6295Ukha9QY5ByMr2FUy13j5gZ1itnezvfJWmJjqt0=";
     format = "otf";
   };
 
-  serif-vf-ttf = makeVariable {
+  source-han-serif-vf-ttf = makeVariable {
     family = "serif";
     version = "2.003";
     hash = "sha256-F+FUQunfyAEBVV10lZxC3dzGTWhHgHzpTO8CjC3n4WY=";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1384,6 +1384,13 @@ mapAliases {
   source-han-serif-korean = throw "'source-han-serif-korean' has been renamed to/replaced by 'source-han-serif'"; # Converted to throw 2025-10-27
   source-han-serif-simplified-chinese = throw "'source-han-serif-simplified-chinese' has been renamed to/replaced by 'source-han-serif'"; # Converted to throw 2025-10-27
   source-han-serif-traditional-chinese = throw "'source-han-serif-traditional-chinese' has been renamed to/replaced by 'source-han-serif'"; # Converted to throw 2025-10-27
+  sourceHanPackages.mono = warnAlias "'sourceHanPackages.mono' has been renamed to ''source-han-mono" source-han-mono; # Added 2025-11-03
+  sourceHanPackages.sans = warnAlias "'sourceHanPackages.sans' has been renamed to ''source-han-sans" source-han-sans; # Added 2025-11-03
+  sourceHanPackages.sans-vf-otf = warnAlias "'sourceHanPackages.sans-vf-otf' has been renamed to ''source-han-sans-vf-otf" source-han-sans-vf-otf; # Added 2025-11-03
+  sourceHanPackages.sans-vf-ttf = warnAlias "'sourceHanPackages.sans-vf-ttf' has been renamed to ''source-han-sans-vf-ttf" source-han-sans-vf-ttf; # Added 2025-11-03
+  sourceHanPackages.serif = warnAlias "'sourceHanPackages.serif' has been renamed to ''source-han-serif" source-han-serif; # Added 2025-11-03
+  sourceHanPackages.serif-vf-otf = warnAlias "'sourceHanPackages.serif-vf-otf' has been renamed to ''source-han-serif-vf-otf" source-han-serif-vf-otf; # Added 2025-11-03
+  sourceHanPackages.serif-vf-ttf = warnAlias "'sourceHanPackages.serif-vf-ttf' has been renamed to ''source-han-serif-vf-ttf" source-han-serif-vf-ttf; # Added 2025-11-03
   sourceHanSansPackages.japanese = throw "'sourceHanSansPackages.japanese' has been renamed to/replaced by 'source-han-sans'"; # Converted to throw 2025-10-27
   sourceHanSansPackages.korean = throw "'sourceHanSansPackages.korean' has been renamed to/replaced by 'source-han-sans'"; # Converted to throw 2025-10-27
   sourceHanSansPackages.simplified-chinese = throw "'sourceHanSansPackages.simplified-chinese' has been renamed to/replaced by 'source-han-sans'"; # Converted to throw 2025-10-27

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10596,14 +10596,15 @@ with pkgs;
     pretendard-std
     ;
 
-  sourceHanPackages = dontRecurseIntoAttrs (callPackage ../data/fonts/source-han { });
-  source-han-sans = sourceHanPackages.sans;
-  source-han-serif = sourceHanPackages.serif;
-  source-han-mono = sourceHanPackages.mono;
-  source-han-sans-vf-otf = sourceHanPackages.sans-vf-otf;
-  source-han-sans-vf-ttf = sourceHanPackages.sans-vf-ttf;
-  source-han-serif-vf-otf = sourceHanPackages.serif-vf-otf;
-  source-han-serif-vf-ttf = sourceHanPackages.serif-vf-ttf;
+  inherit (callPackage ../data/fonts/source-han { })
+    source-han-sans
+    source-han-serif
+    source-han-mono
+    source-han-sans-vf-otf
+    source-han-sans-vf-ttf
+    source-han-serif-vf-otf
+    source-han-serif-vf-ttf
+    ;
 
   tango-icon-theme = callPackage ../data/icons/tango-icon-theme {
     gtk = res.gtk2;

--- a/pkgs/top-level/packages-config.nix
+++ b/pkgs/top-level/packages-config.nix
@@ -12,7 +12,6 @@
     lib.mapAttrs (_: set: lib.recurseIntoAttrs set) {
       inherit (super)
         rPackages
-        sourceHanPackages
         ;
 
       # emacsPackages is an alias for emacs.pkgs


### PR DESCRIPTION
Split from #434501
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
