### PR TITLE
invoiceplane: fix build

### DIFF
--- a/pkgs/by-name/in/invoiceplane/package.nix
+++ b/pkgs/by-name/in/invoiceplane/package.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   nixosTests,
   fetchYarnDeps,
-  nodejs,
+  applyPatches,
   php,
   yarnConfigHook,
   yarnBuildHook,
@@ -24,23 +24,26 @@ php.buildComposerProject2 (finalAttrs: {
   pname = "invoiceplane";
   inherit version;
 
-  src = fetchFromGitHub {
-    owner = "InvoicePlane";
-    repo = "InvoicePlane";
-    tag = "v${version}";
-    hash = "sha256-XNjdFWP5AEulbPZcMDXYSdDhaLWlgu3nnCSFnjUjGpk=";
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "InvoicePlane";
+      repo = "InvoicePlane";
+      tag = "v${version}";
+      hash = "sha256-XNjdFWP5AEulbPZcMDXYSdDhaLWlgu3nnCSFnjUjGpk=";
+    };
+    patches = [
+      # Fix composer.json validation
+      # See https://github.com/InvoicePlane/InvoicePlane/pull/1306
+      ./fix_composer_validation.patch
+    ];
   };
 
   patches = [
     # yarn.lock missing some resolved attributes and fails
     ./fix-yarn-lock.patch
-
-    # Fix composer.json validation
-    # See https://github.com/InvoicePlane/InvoicePlane/pull/1306
-    ./fix_composer_validation.patch
   ];
 
-  vendorHash = "sha256-qnWLcEabQpu0Yp4Q2NWQm4XFV4YW679cvXo6p/dDECI=";
+  vendorHash = "sha256-UCYAnECuIbIYg1T4I8I9maXVKXJc1zkyauBuIy5frTY=";
 
   nativeBuildInputs = [
     yarnConfigHook


### PR DESCRIPTION
Follow-up to: https://github.com/NixOS/nixpkgs/pull/431713. `applyPatches` needs to be used to patch `src` for `vendorHash` to pick up the changes to `composer.json` and `composer.lock`.

Fixes: https://github.com/NixOS/nixpkgs/issues/437054
Also see: https://github.com/NixOS/nixpkgs/pull/431713#issuecomment-3221649797, 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
