### PR TITLE
lctime: init at 0.0.26

### DIFF
--- a/pkgs/by-name/lc/lctime/package.nix
+++ b/pkgs/by-name/lc/lctime/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  stdenv,
+  python3Packages,
+  fetchFromGitea,
+  runCommand,
+  lctime,
+  ngspice,
+  writableTmpDirAsHomeHook,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "lctime";
+  version = "0.0.26";
+  pyproject = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "librecell";
+    repo = "lctime";
+    tag = version;
+    hash = "sha256-oNmeV8r1dtO2y27jAJnlx4mKGjhzL07ad2yBdOLwgF0=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    joblib
+    klayout
+    liberty-parser
+    matplotlib
+    networkx
+    numpy
+    pyspice
+    scipy
+    sympy
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    ngspice
+  ];
+
+  enabledTestPaths = [
+    "src/lctime/*/*.py"
+  ];
+
+  disabledTestPaths = [
+    # hangs indefinitely
+    "src/lctime/characterization/test_ngspice_subprocess.py::test_ngspice_interactive_simple"
+    "src/lctime/characterization/test_ngspice_subprocess.py::test_ngspice_subprocess_class"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # causes python to abort
+    "src/lctime/characterization/test_ngspice_subprocess.py::test_simple_simulation"
+    # broken pipe
+    "src/lctime/characterization/test_ngspice_subprocess.py::test_interactive_subprocess"
+  ];
+
+  pythonImportsCheck = [
+    "lctime"
+  ];
+
+  passthru = {
+    tests =
+      runCommand "lctime-tests"
+        {
+          nativeBuildInputs = [
+            lctime
+            ngspice
+            writableTmpDirAsHomeHook
+          ];
+        }
+        ''
+          cd "$HOME"
+
+          cp -R "${src}/tests/"* .
+          patchShebangs *.sh
+
+          mkdir -p $out
+          ./run_tests.sh &> $out/result.log
+        '';
+  };
+
+  meta = {
+    description = "Characterization tool for CMOS digital standard-cells";
+    homepage = "https://codeberg.org/librecell/lctime";
+    license = with lib.licenses; [
+      agpl3Plus
+      asl20
+      cc-by-sa-40
+      cc0
+    ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+    mainProgram = "lctime";
+  };
+}

--- a/pkgs/development/python-modules/liberty-parser/default.nix
+++ b/pkgs/development/python-modules/liberty-parser/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitea,
+  setuptools,
+  lark,
+  numpy,
+  sympy,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "liberty-parser";
+  version = "0.0.25";
+  pyproject = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "tok";
+    repo = "liberty-parser";
+    tag = version;
+    hash = "sha256-Nl+FRG93DeP1ctDphaTKZqkukEywmGprj6JORJQTunw=";
+  };
+
+  # Tests try to write to /tmp directly. use $TMPDIR instead.
+  postPatch = ''
+    substituteInPlace src/liberty/parser.py \
+      --replace-fail "/tmp" "$TMPDIR"
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    lark
+    numpy
+    sympy
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  enabledTestPaths = [
+    "src/liberty/*.py"
+  ];
+
+  pythonImportsCheck = [
+    "liberty.parser"
+  ];
+
+  meta = {
+    description = "Liberty parser for Python";
+    homepage = "https://codeberg.org/tok/liberty-parser";
+    license = with lib.licenses; [
+      asl20
+      cc-by-sa-40
+      cc0
+      gpl3Plus
+    ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8123,6 +8123,8 @@ self: super: with self; {
 
   libear = callPackage ../development/python-modules/libear { };
 
+  liberty-parser = callPackage ../development/python-modules/liberty-parser { };
+
   libevdev = callPackage ../development/python-modules/libevdev { };
 
   libfdt = toPythonModule (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
