### PR TITLE
tectonic: fix build with rustc 1.89

### DIFF
--- a/pkgs/by-name/te/tectonic-unwrapped/package.nix
+++ b/pkgs/by-name/te/tectonic-unwrapped/package.nix
@@ -47,6 +47,7 @@ buildRustPackage rec {
       url = "https://github.com/tectonic-typesetting/tectonic/commit/fbb145cd079497b8c88197276f92cb89685b4d54.patch";
       hash = "sha256-6FW5MFkOWnqzYX8Eg5DfmLaEhVWKYVZwodE4SGXHKV0=";
     })
+    ./tectonic-0.15-fix-dangerous_implicit_autorefs.patch
   ];
 
   cargoPatches = [

--- a/pkgs/by-name/te/tectonic-unwrapped/tectonic-0.15-fix-dangerous_implicit_autorefs.patch
+++ b/pkgs/by-name/te/tectonic-unwrapped/tectonic-0.15-fix-dangerous_implicit_autorefs.patch
@@ -1,0 +1,13 @@
+diff --git a/crates/engine_bibtex/src/xbuf.rs b/crates/engine_bibtex/src/xbuf.rs
+index 8f3949e7..c216eb4d 100644
+--- a/crates/engine_bibtex/src/xbuf.rs
++++ b/crates/engine_bibtex/src/xbuf.rs
+@@ -52,7 +52,7 @@ pub unsafe fn xrealloc_zeroed<T: SafelyZero>(
+     old: *mut [T],
+     new_len: usize,
+ ) -> Option<&'static mut [T]> {
+-    let old_len = (*old).len();
++    let old_len = (&(*old)).len();
+     let new_size = new_len * mem::size_of::<T>();
+     // SAFETY: realloc can be called with any size, even 0, that will just deallocate and return null
+     let ptr = unsafe { xrealloc(old.cast(), new_size) }.cast::<T>();


### PR DESCRIPTION
Rust 1.89 made the `dangerous_implicit_autorefs` lint deny-by-default which breaks the current `tectonic` release: https://hydra.nixos.org/build/305689807/nixlog/1/tail. This issue has been fixed upstream but there hasn't been a new release in a while.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
