### PR TITLE
toot: 0.47.1 -> 0.50.1

### DIFF
--- a/pkgs/by-name/to/toot/package.nix
+++ b/pkgs/by-name/to/toot/package.nix
@@ -7,14 +7,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "toot";
-  version = "0.47.1";
+  version = "0.50.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ihabunek";
     repo = "toot";
     tag = version;
-    hash = "sha256-cdlLZL3XZDgEXbac3Kgm9o61SOpoZzWD6C1DDwj6eNo=";
+    hash = "sha256-qcxJeUDRYVFcyrvecG5xGy02O7otj1fg0HgBMuGS1d4=";
   };
 
   nativeCheckInputs = with python3Packages; [ pytest ];
@@ -25,11 +25,11 @@ python3Packages.buildPythonApplication rec {
   ];
 
   dependencies = with python3Packages; [
+    python-dateutil
     requests
     beautifulsoup4
     wcwidth
     urwid
-    urwidgets
     tomlkit
     click
     pillow


### PR DESCRIPTION
Latest release and the ones between:

- [0.50.1](https://github.com/ihabunek/toot/releases/tag/0.50.1)
- [0.50.0](https://github.com/ihabunek/toot/releases/tag/0.50.0)
- [0.49.0](https://github.com/ihabunek/toot/releases/tag/0.49.0)
- [0.48.0](https://github.com/ihabunek/toot/releases/tag/0.48.0)

Upstream [vendored urwidgets](https://github.com/ihabunek/toot/pull/541), so it’s no longer needed as a dependency.

Build in master is broken due to urwidgets, this should also fix that problem.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
