### PR TITLE
beamPackages.elixir-ls: 0.28.1 -> 0.29.3

### DIFF
--- a/pkgs/development/beam-modules/elixir-ls/default.nix
+++ b/pkgs/development/beam-modules/elixir-ls/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   elixir,
-  fetchpatch,
   fetchFromGitHub,
   makeWrapper,
   stdenv,
@@ -10,23 +9,16 @@
 
 stdenv.mkDerivation rec {
   pname = "elixir-ls";
-  version = "0.28.1";
+  version = "0.29.3";
 
   src = fetchFromGitHub {
     owner = "elixir-lsp";
     repo = "elixir-ls";
     rev = "v${version}";
-    hash = "sha256-r4P+3MPniDNdF3SG2jfBbzHsoxn826eYd2tsv6bJBoI=";
+    hash = "sha256-ikx0adlDrkUpMXPEbPtIsb2/1wcOt1jLwciVdBEKnss=";
   };
 
   patches = [
-    # fix elixir deterministic support https://github.com/elixir-lsp/elixir-ls/pull/1216
-    # remove > 0.28.1
-    (fetchpatch {
-      url = "https://github.com/elixir-lsp/elixir-ls/pull/1216.patch";
-      hash = "sha256-J1Q7XQXWYuCMq48e09deQU71DOElZ2zMTzrceZMky+0=";
-    })
-
     # patch wrapper script to remove elixir detection and inject necessary paths
     ./launch.sh.patch
   ];

--- a/pkgs/development/beam-modules/elixir-ls/launch.sh.patch
+++ b/pkgs/development/beam-modules/elixir-ls/launch.sh.patch
@@ -1,8 +1,8 @@
 diff --git c/scripts/launch.sh w/scripts/launch.sh
-index 21afbb1e..8bc5c382 100755
+index d9c33952..8bc5c382 100755
 --- c/scripts/launch.sh
 +++ w/scripts/launch.sh
-@@ -1,125 +1,4 @@
+@@ -1,114 +1,4 @@
 -#!/bin/sh
 -# Actual launcher. This does the hard work of figuring out the best way
 -# to launch the language server or the debug adapter.
@@ -102,25 +102,14 @@ index 21afbb1e..8bc5c382 100755
 -            export_stdlib_path "mise which elixir"
 -        else
 -            >&2 echo "mise not found"
--            >&2 echo "Looking for rtx executable"
+-            >&2 echo "Looking for vfox executable"
 -
--            # Look for rtx executable
--            if command -v rtx >/dev/null 2>&1; then
--                >&2 echo "rtx executable found at $(command -v rtx), activating"
--                eval "$($(command -v rtx) env -s "$preferred_shell")"
--                export_stdlib_path "rtx which elixir"
+-            if command -v vfox >/dev/null 2>&1; then
+-                >&2 echo "vfox executable found at $(command -v vfox), activating"
+-                eval "$( $(command -v vfox) activate "$preferred_shell" )"
 -            else
--                >&2 echo "rtx not found"
--                >&2 echo "Looking for vfox executable"
--
--                # Look for vfox executable
--                if command -v vfox >/dev/null 2>&1; then
--                    >&2 echo "vfox executable found at $(command -v vfox), activating"
--                    eval "$($(command -v vfox) activate "$preferred_shell")"
--                else
--                    >&2 echo "vfox not found"
--                    export_stdlib_path "which elixir"
--                fi
+-                >&2 echo "vfox not found"
+-                export_stdlib_path "which elixir"
 -            fi
 -        fi
 -    fi
@@ -129,7 +118,7 @@ index 21afbb1e..8bc5c382 100755
  
  # In case that people want to tweak the path, which Elixir to use, or
  # whatever prior to launching the language server or the debug adapter, we
-@@ -138,29 +17,22 @@ fi
+@@ -127,29 +17,22 @@ fi
  # script so we can correctly configure the Erlang library path to
  # include the local .ez files, and then do what we were asked to do.
  
@@ -151,9 +140,9 @@ index 21afbb1e..8bc5c382 100755
  default_erl_opts="-kernel standard_io_encoding latin1 +sbwt none +sbwtdcpu none +sbwtdio none"
  
 -if [ "$preferred_shell" = "bash" ]; then
--  source "$dirname/exec.bash"
+-  . "$dirname/exec.bash"
 -elif [ "$preferred_shell" = "zsh" ]; then
--  source "$dirname/exec.zsh"
+-  . "$dirname/exec.zsh"
 -else
 -  if [ -z "$ELS_ELIXIR_OPTS" ]
 -  then


### PR DESCRIPTION
https://github.com/elixir-lsp/elixir-ls/releases/tag/v0.29.0 
https://github.com/elixir-lsp/elixir-ls/releases/tag/v0.29.1 
https://github.com/elixir-lsp/elixir-ls/releases/tag/v0.29.2 
https://github.com/elixir-lsp/elixir-ls/releases/tag/v0.29.3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
