### PR TITLE
gdtoolkit_4: 4.3.3 -> 4.3.4

### DIFF
--- a/pkgs/by-name/gd/gdtoolkit_4/package.nix
+++ b/pkgs/by-name/gd/gdtoolkit_4/package.nix
@@ -27,14 +27,14 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "gdtoolkit";
-  version = "4.3.3";
+  version = "4.3.4";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "Scony";
     repo = "godot-gdscript-toolkit";
     tag = version;
-    hash = "sha256-GS1bCDOKtdJkzgP3+CSWEUeHQ9lUcAHDT09QmPOOeVc=";
+    hash = "sha256-D67iwGGF3CrdAi/XKGVkusZlFCsMPIKdVpKDwcVQMrI=";
   };
 
   disabled = python.pythonOlder "3.7";
@@ -43,6 +43,7 @@ python.pkgs.buildPythonApplication rec {
     docopt
     lark
     pyyaml
+    radon
     setuptools
   ];
 
@@ -62,12 +63,13 @@ python.pkgs.buildPythonApplication rec {
   # The tests are not working on NixOS
   disabledTestPaths = [
     "tests/generated/test_expression_parsing.py"
-    "tests/gdradon/test_executable.py"
   ];
 
   pythonImportsCheck = [
     "gdtoolkit"
     "gdtoolkit.formatter"
+    "gdtoolkit.gd2py"
+    "gdtoolkit.gdradon"
     "gdtoolkit.linter"
     "gdtoolkit.parser"
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/Scony/godot-gdscript-toolkit/compare/4.3.3...4.3.4
[Scony/godot-gdscript-toolkit@4.3.4/CHANGELOG.md](https://github.com/Scony/godot-gdscript-toolkit/blob/4.3.4/CHANGELOG.md)

Should resolve #437173.
- I had the same build issue on x86_64-linux and it is now gone. I am unable to test aarch64-darwin myself though :/

Closes #436617 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
