### PR TITLE
cargo-binutils: 0.3.6 -> 0.4.0

### DIFF
--- a/pkgs/by-name/ca/cargo-binutils/package.nix
+++ b/pkgs/by-name/ca/cargo-binutils/package.nix
@@ -6,19 +6,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-binutils";
-  version = "0.3.6";
+  version = "0.4.0";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-tRh3+X6QCdkkJE1O60ZRkDBRbznGZ1aB1AOmcz0EINI=";
+    hash = "sha256-AF1MRBH8ULnHNHT2FS/LxMH+b06QMTIZMIR8mmkn17c=";
   };
 
-  cargoHash = "sha256-QdW0HiVhKFuXj7hWZw1lkrFmvVIqbeMKRF2qnBX9wRI=";
+  cargoHash = "sha256-pK6pFgOxQdEc4hYFj6mLEiIuPhoutpM2h3OLZgYrf6Q=";
 
   meta = {
     description = "Cargo subcommands to invoke the LLVM tools shipped with the Rust toolchain";
     longDescription = ''
-      In order for this to work, you either need to run `rustup component add llvm-tools-preview` or install the `llvm-tools-preview` component using your Nix library (e.g. fenix or rust-overlay)
+      In order for this to work, you either need to run `rustup component add llvm-tools` or install the `llvm-tools` component using your Nix library (e.g. fenix or rust-overlay)
     '';
     homepage = "https://github.com/rust-embedded/cargo-binutils";
     changelog = "https://github.com/rust-embedded/cargo-binutils/blob/v${version}/CHANGELOG.md";

--- a/pkgs/by-name/ca/cargo-binutils/package.nix
+++ b/pkgs/by-name/ca/cargo-binutils/package.nix
@@ -29,6 +29,7 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [
       stupremee
       matthiasbeyer
+      newam
     ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I added myself as a maintainer too.

Changelog: https://github.com/rust-embedded/cargo-binutils/blob/966d6445e793dc5da527027f7d2a982922f8523e/CHANGELOG.md
diff: https://github.com/rust-embedded/cargo-binutils/compare/v0.3.6...966d6445e793dc5da527027f7d2a982922f8523e

Fixes: #437101 

Closes https://github.com/NixOS/nixpkgs/pull/437275

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
