### PR TITLE
chromium,chromedriver: 139.0.7258.138 -> 139.0.7258.154

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "139.0.7258.138",
+    "version": "139.0.7258.154",
     "chromedriver": {
-      "version": "139.0.7258.139",
-      "hash_darwin": "sha256-EqKEyT/iEJkVASSAEP0/dNptDw3yr3AwoM2yUYbn1to=",
-      "hash_darwin_aarch64": "sha256-3H9CUsMDvD+PJ+n/YwCv22uEIxa80y+cMvL1PWOWQg0="
+      "version": "139.0.7258.155",
+      "hash_darwin": "sha256-9tHj/QSFz9fJTQ+xivOKbssqXsE53BHViy7uCZ4OMhc=",
+      "hash_darwin_aarch64": "sha256-fmflqWTiruKD/VtmNWllCA71tqaB0OIOUiXsmJOTJFI="
     },
     "deps": {
       "depot_tools": {
@@ -21,8 +21,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "884e54ea8d42947ed636779015c5b4815e069838",
-        "hash": "sha256-MCBHB1ms3H8AXqiIDHH7C+8/NDcgsn3pDx7mKtGdfbc=",
+        "rev": "9e0d6b2b47ffb17007b713429c9a302f9e43847f",
+        "hash": "sha256-L3cq3kx7hOv8bzwkQ+nyDM9VDzsvHaRzrSwrqwyCdHA=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -97,8 +97,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "96492b317e27ba4106ed00f5faa4534cfeaa0b8f",
-        "hash": "sha256-TE8vYLNnAzVkGQZ2ZYuNHnu8fwp2Qv4ANP0btgrKYSQ="
+        "rev": "d9fc4a372074b1079c193c422fc4a180e79b6636",
+        "hash": "sha256-owMOjZEXhjXkEwzKdNVUk6Uzqdfp8UQq4JLDSvbvyeA="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -582,8 +582,8 @@
       },
       "src/third_party/pdfium": {
         "url": "https://pdfium.googlesource.com/pdfium.git",
-        "rev": "849572b5c41e5bf59dc88bf54c41067faa9b5b00",
-        "hash": "sha256-lTUkzpzIskbEL7b2xBWT8s9YNyu1AZ235SBo5AfQtpg="
+        "rev": "bbdc38bc2d1693f56154f78eb5d4ff296d8ca3da",
+        "hash": "sha256-LYo73KuSVBEcRN1PqG0EBFeKaLy66UPtZ3DMHP5YVXM="
       },
       "src/third_party/perfetto": {
         "url": "https://chromium.googlesource.com/external/github.com/google/perfetto.git",
@@ -797,8 +797,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "4d36678284f92d381f411c7947588d7a09989ca4",
-        "hash": "sha256-X5k2R7/sS3/C2S5hC1ILSquWjnPol3Pk+xe1suzgnFs="
+        "rev": "a0a7886d6b3707be8d4b403e463fa82fdb3f216c",
+        "hash": "sha256-KjIBJw40hiBkcHNn96dD5iZs2n2HMWIkAJ6ND2+5JJQ="
       }
     }
   },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2025/08/stable-channel-update-for-desktop_26.html

This update includes 1 security fix.

CVEs:
CVE-2025-9478

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
