### PR TITLE
buildMozillaMach: restore MOZ_SYSTEM_DIR patch

### DIFF
--- a/pkgs/build-support/build-mozilla-mach/133-env-var-for-system-dir.patch
+++ b/pkgs/build-support/build-mozilla-mach/133-env-var-for-system-dir.patch
@@ -1,0 +1,22 @@
+diff --git a/toolkit/xre/nsXREDirProvider.cpp b/toolkit/xre/nsXREDirProvider.cpp
+index 6db876975187..5882c5d7f1d6 100644
+--- a/toolkit/xre/nsXREDirProvider.cpp
++++ b/toolkit/xre/nsXREDirProvider.cpp
+@@ -11,6 +11,7 @@
+ 
+ #include "jsapi.h"
+ #include "xpcpublic.h"
++#include "prenv.h"
+ #include "prprf.h"
+ 
+ #include "nsIAppStartup.h"
+@@ -297,7 +297,8 @@ static nsresult GetSystemParentDirectory(nsIFile** aFile) {
+       "/usr/lib/mozilla"_ns
+ #    endif
+       ;
+-  rv = NS_NewNativeLocalFile(dirname, getter_AddRefs(localDir));
++  const char* pathVar = PR_GetEnv("MOZ_SYSTEM_DIR");
++  rv = NS_NewNativeLocalFile((pathVar && *pathVar) ? nsDependentCString(pathVar) : reinterpret_cast<const nsCString&>(dirname), getter_AddRefs(localDir));
+ #  endif
+ 
+   if (NS_SUCCEEDED(rv)) {

--- a/pkgs/build-support/build-mozilla-mach/default.nix
+++ b/pkgs/build-support/build-mozilla-mach/default.nix
@@ -305,7 +305,10 @@ buildStdenv.mkDerivation {
   ];
 
   patches =
+    # Remove references to the build clsoure
     lib.optionals (lib.versionAtLeast version "136") [ ./136-no-buildconfig.patch ]
+    # Add MOZ_SYSTEM_DIR env var for native messaging host support
+    ++ lib.optionals (lib.versionAtLeast version "133") [ ./133-env-var-for-system-dir.patch ]
     ++ lib.optionals (lib.versionAtLeast version "139" && lib.versionOlder version "141") [
       # https://bugzilla.mozilla.org/show_bug.cgi?id=1955112
       # https://hg-edge.mozilla.org/mozilla-central/rev/aa8a29bd1fb9


### PR DESCRIPTION
Accidentally dropped while pruning obsolete patches.

cc #436667 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
