### PR TITLE
`lib.packagesFromDirectory`: restore `recurseIntoDirectory` argument

### DIFF
--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -293,11 +293,13 @@ in
     # Type
 
     ```
-    packagesFromDirectoryRecursive :: {
+    packagesFromDirectoryRecursive :: (args :: {
       callPackage :: Path -> {} -> a,
       newScope? :: AttrSet -> scope,
       directory :: Path,
-    } -> AttrSet
+      recurseIntoDirectory? :: (args -> AttrSet) -> args -> AttrSet,
+      recurseArgs? :: Any
+    }) -> AttrSet
     ```
 
     # Inputs
@@ -307,12 +309,35 @@ in
       It is typically the `callPackage` function, taken from either `pkgs` or a new scope corresponding to the `directory`.
 
     `newScope`
-    : If present, this function is used when recursing into a directory, to generate a new scope.
+    : If present, this function is used by the default `recurseIntoDirectory` to generate a new scope.
       The arguments are updated with the scope's `callPackage` and `newScope` functions, so packages can require
       anything in their scope, or in an ancestor of their scope.
+      This argument has no effect when `recurseIntoDirectory` is provided.
 
     `directory`
     : The directory to read package files from.
+
+    `recurseIntoDirectory`
+    : This argument is applied to the function which processes directories.
+    : Equivalently, this function takes `processDir` and `args`, and can modify arguments passed to `processDir`
+      (same as above) before calling it, as well as modify its output (which is then returned by `recurseIntoDirectory`).
+
+      :::{.note}
+      When `newScope` is set, the default `recurseIntoDirectory` is equivalent to:
+      ```nix
+      processDir: { newScope, ... }@args:
+        # create a new scope and mark it `recurseForDerivations`
+        lib.recurseIntoAttrs (lib.makeScope newScope (self:
+          # generate the attrset representing the directory, using the new scope's `callPackage` and `newScope`
+          processDir (args // {
+            inherit (self) callPackage newScope;
+          })
+        ))
+      ```
+      :::
+
+    `recurseArgs`
+    : Optional argument, which can be hold data used by `recurseIntoDirectory`
 
     # Examples
     :::{.example}
@@ -356,12 +381,43 @@ in
     `a.nix` cannot directly take as inputs packages defined in a child directory, such as `b1`.
     :::
     ::::
+
+    :::{.example}
+    ## Mark with `recurseIntoAttrs` when recursing into a directory
+    ```nix
+    packagesFromDirectoryRecursive {
+      inherit (pkgs) callPackage;
+      directory = ./my-packages;
+
+      recurseIntoDirectory = processDir: args: lib.recurseIntoAttrs (processDir args);
+    }
+    ```
+    :::
+
+    :::{.example}
+    ## Express custom recursion behaviour with `recurseIntoDirectory`
+    For instance, only mark attrsets produced by `packagesFromDirectoryRecursive` with `recurseForDerivations`
+    if they (transitively) contain derivations.
+
+    ```nix
+    packagesFromDirectoryRecursive {
+      inherit (pkgs) callPackage;
+      directory = ./my-packages;
+
+      recurseIntoDirectory = processDir: args: let
+        result = processDir args;
+      in result // {
+        recurseForDerivations =
+          lib.any (child: lib.isDerivation child || child.recurseForDerivations or false) result;
+      };
+    }
+    ```
+    :::
   */
   packagesFromDirectoryRecursive =
     let
       inherit (lib)
         concatMapAttrs
-        id
         makeScope
         recurseIntoAttrs
         removeSuffix
@@ -402,11 +458,38 @@ in
               lib.filesystem.packagesFromDirectoryRecursive: Unsupported file type ${type} at path ${toString path}
             ''
         ) (builtins.readDir directory);
+
+      defaultRecurse =
+        processDir: args:
+        if args ? newScope then
+          # Create a new scope and mark it `recurseForDerivations`.
+          # This lets the packages refer to each other.
+          # See:
+          #  [lib.makeScope](https://nixos.org/manual/nixpkgs/unstable/#function-library-lib.customisation.makeScope) and
+          #  [lib.recurseIntoAttrs](https://nixos.org/manual/nixpkgs/unstable/#function-library-lib.customisation.makeScope)
+          recurseIntoAttrs (
+            makeScope args.newScope (
+              self:
+              # generate the attrset representing the directory, using the new scope's `callPackage` and `newScope`
+              processDir (
+                args
+                // {
+                  inherit (self) callPackage newScope;
+                }
+              )
+            )
+          )
+        else
+          processDir args;
     in
     {
       callPackage,
       newScope ? throw "lib.packagesFromDirectoryRecursive: newScope wasn't passed in args",
       directory,
+      # recurseIntoDirectory can modify the function used when processing directory entries
+      #  and recurseArgs can (optionally) hold data for its use ; see function documentation
+      recurseArgs ? throw "lib.packagesFromDirectoryRecursive: recurseArgs wasn't passed in args",
+      recurseIntoDirectory ? defaultRecurse,
     }@args:
     let
       defaultPath = directory + "/package.nix";
@@ -414,26 +497,8 @@ in
     if pathExists defaultPath then
       # if `${directory}/package.nix` exists, call it directly
       callPackage defaultPath { }
-    else if args ? newScope then
-      # Create a new scope and mark it `recurseForDerivations`.
-      # This lets the packages refer to each other.
-      # See:
-      #  [lib.makeScope](https://nixos.org/manual/nixpkgs/unstable/#function-library-lib.customisation.makeScope) and
-      #  [lib.recurseIntoAttrs](https://nixos.org/manual/nixpkgs/unstable/#function-library-lib.customisation.makeScope)
-      recurseIntoAttrs (
-        makeScope newScope (
-          self:
-          # generate the attrset representing the directory, using the new scope's `callPackage` and `newScope`
-          processDir (
-            args
-            // {
-              inherit (self) callPackage newScope;
-            }
-          )
-        )
-      )
     else
-      processDir args;
+      recurseIntoDirectory processDir args;
 
   /**
     Append `/default.nix` if the passed path is a directory.

--- a/lib/tests/packages-from-directory/non-scope/a.nix
+++ b/lib/tests/packages-from-directory/non-scope/a.nix
@@ -1,0 +1,1 @@
+{ }: "a from non-scope"

--- a/lib/tests/packages-from-directory/non-scope/b.nix
+++ b/lib/tests/packages-from-directory/non-scope/b.nix
@@ -1,0 +1,1 @@
+{ }: "b from non-scope"

--- a/lib/tests/packages-from-directory/non-scope/my-group/b.nix
+++ b/lib/tests/packages-from-directory/non-scope/my-group/b.nix
@@ -1,0 +1,1 @@
+{ b }: "b from my-group, b from non-scope = ${b}"


### PR DESCRIPTION
This reverts commit 05d528b.

The `recurseIntoDirectory` argument was removed from the `packagesFromDirectoryRecursive` interface in #392800. The PR description said "Update `packagesFromDirectoryRecursive` to create nested scopes ... when `newScope` is given". However, the actual implementation as merged fully removed the `recurseIntoDirectory` argument without a release note or deprecation period. This was not remarked on in review, so I believe this was accidental.

In some cases (package sets, like `pythonPackages` or `haskellPackages`), the recursive `newScope` behavior is desired: you want your Python packages to be able to recieve other Python packages as arguments.

However, attributes can also be simply grouped together for organizational purposes. For example, I'd like to have an attrset of checks, where `checks.clippy` makes sure my repository passes `cargo clippy` and `checks.rustfmt` makes sure my repository passes `cargo fmt`. However, the naive approach is impossible with the implementation of `packagesFromDirectoryRecursive` after #392800; supplying a `checks/clippy.nix` like this results in an infinite recursion error, as the result of `checks/clippy.nix` is passed in as the `clippy` argument instead of `pkgs.clippy`:

```nix
{
  stdenv,
  cargo,
  clippy,
}

stdenv.mkDerivation {
  # ...
  checkInputs = [ cargo clippy ];
  checkPhase = ''
    cargo clippy
  '';
  # ...
}
```

See: #392800

cc @katexochen @nicoonoclaste



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
