### PR TITLE
git-annex: Remove myself as a maintainer

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -435,8 +435,6 @@ package-maintainers:
     - hercules-ci-cnix-store
     - inline-c
     - inline-c-cpp
-  roosemberth:
-    - git-annex
   rvl:
     - taffybar
     - arbtt


### PR DESCRIPTION
I can not spend time to maintain this package.

I'm opening this PR against master since other than orphaning a package it has no impact in the current build status or distribution of git-annex. I also edited the generated file containing the actual derivation. If haskell-updates is not rebased or merged afterwards, this file will be overwritten when haskell-updates is merged on master. I'm not sure how that works anymore, so please let me know if I should target haskell-updates instead.