### PR TITLE
cargo-binutils: fix `mismatched_lifetime_syntaxes`

### DIFF
--- a/pkgs/by-name/ca/cargo-binutils/mismatched_lifetime_syntaxes.patch
+++ b/pkgs/by-name/ca/cargo-binutils/mismatched_lifetime_syntaxes.patch
@@ -1,0 +1,35 @@
+diff --git a/src/lib.rs b/src/lib.rs
+index ef4e6ab..ea05090 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -144,7 +144,7 @@ impl<'a> BuildType<'a> {
+     }
+ }
+ 
+-fn args(tool: Tool, examples: Option<&str>) -> ArgMatches {
++fn args(tool: Tool, examples: Option<&str>) -> ArgMatches<'_> {
+     let name = tool.name();
+     let about = format!(
+         "Proxy for the `llvm-{}` tool shipped with the Rust toolchain.",
+diff --git a/src/postprocess.rs b/src/postprocess.rs
+index 11eb8de..d2e0fad 100644
+--- a/src/postprocess.rs
++++ b/src/postprocess.rs
+@@ -7,7 +7,7 @@ use regex::{Captures, Regex};
+ // UTF-8 then we don't touch it.
+ 
+ // This pass demangles *all* the Rust symbols in the input
+-pub fn demangle(bytes: &[u8]) -> Cow<[u8]> {
++pub fn demangle(bytes: &[u8]) -> Cow<'_, [u8]> {
+     let re = Regex::new(r#"_Z.+?E\b"#).expect("BUG: Malformed Regex");
+ 
+     if let Ok(text) = str::from_utf8(bytes) {
+@@ -23,7 +23,7 @@ pub fn demangle(bytes: &[u8]) -> Cow<[u8]> {
+ }
+ 
+ // This pass turns the addresses in the output of `size -A` into hexadecimal format
+-pub fn size(bytes: &[u8]) -> Cow<[u8]> {
++pub fn size(bytes: &[u8]) -> Cow<'_, [u8]> {
+     if let Ok(text) = str::from_utf8(bytes) {
+         let mut s = text
+             .lines()

--- a/pkgs/by-name/ca/cargo-binutils/package.nix
+++ b/pkgs/by-name/ca/cargo-binutils/package.nix
@@ -15,6 +15,10 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-QdW0HiVhKFuXj7hWZw1lkrFmvVIqbeMKRF2qnBX9wRI=";
 
+  patches = [
+    ./mismatched_lifetime_syntaxes.patch
+  ];
+
   meta = {
     description = "Cargo subcommands to invoke the LLVM tools shipped with the Rust toolchain";
     longDescription = ''


### PR DESCRIPTION
Fixes #437101

Superseded by #437238

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
