### PR TITLE
python3Packages.lsprotocol: split 2023/2025 and use 2023 by default

### DIFF
--- a/pkgs/development/python-modules/lsprotocol/2023.nix
+++ b/pkgs/development/python-modules/lsprotocol/2023.nix
@@ -9,26 +9,21 @@
   jsonschema,
   pyhamcrest,
   pytestCheckHook,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "lsprotocol";
-  version = "2025.0.0";
+  version = "2023.0.1";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "lsprotocol";
     tag = version;
-    hash = "sha256-DrWXHMgDZSQQ6vsmorThMrUTX3UQU+DajSEOdxoXrFQ=";
+    hash = "sha256-PHjLKazMaT6W4Lve1xNxm6hEwqE3Lr2m5L7Q03fqb68=";
   };
 
-  postPatch = ''
-    pushd packages/python
-  '';
+  sourceRoot = "${src.name}/packages/python";
 
   build-system = [
     flit-core
@@ -48,21 +43,26 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
+    # cattrs.errors.StructureHandlerNotFoundError: Unsupported type:
+    # typing.Union[str, lsprotocol.types.NotebookDocumentFilter_Type1,
+    # lsprotocol.types.NotebookDocumentFilter_Type2,
+    # lsprotocol.types.NotebookDocumentFilter_Type3, NoneType]. Register
+    # a structure hook for it.
     "test_notebook_sync_options"
   ];
 
   preCheck = ''
-    popd
+    cd ../../
   '';
 
   pythonImportsCheck = [ "lsprotocol" ];
 
-  meta = with lib; {
+  meta = {
     description = "Python implementation of the Language Server Protocol";
     homepage = "https://github.com/microsoft/lsprotocol";
     changelog = "https://github.com/microsoft/lsprotocol/releases/tag/${src.tag}";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       doronbehar
       fab
     ];

--- a/pkgs/development/python-modules/lsprotocol/2025.nix
+++ b/pkgs/development/python-modules/lsprotocol/2025.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  attrs,
+  buildPythonPackage,
+  cattrs,
+  fetchFromGitHub,
+  flit-core,
+  importlib-resources,
+  jsonschema,
+  pyhamcrest,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "lsprotocol";
+  version = "2025.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "lsprotocol";
+    tag = version;
+    hash = "sha256-DrWXHMgDZSQQ6vsmorThMrUTX3UQU+DajSEOdxoXrFQ=";
+  };
+
+  sourceRoot = "${src.name}/packages/python";
+
+  build-system = [
+    flit-core
+  ];
+
+  dependencies = [
+    attrs
+    cattrs
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  checkInputs = [
+    importlib-resources
+    jsonschema
+    pyhamcrest
+  ];
+
+  disabledTests = [
+    # cattrs.errors.StructureHandlerNotFoundError: Unsupported type:
+    # typing.Union[str, lsprotocol.types.NotebookDocumentFilter_Type1,
+    # lsprotocol.types.NotebookDocumentFilter_Type2,
+    # lsprotocol.types.NotebookDocumentFilter_Type3, NoneType]. Register
+    # a structure hook for it.
+    "test_notebook_sync_options"
+  ];
+
+  preCheck = ''
+    cd ../../
+  '';
+
+  pythonImportsCheck = [ "lsprotocol" ];
+
+  meta = {
+    description = "Python implementation of the Language Server Protocol";
+    homepage = "https://github.com/microsoft/lsprotocol";
+    changelog = "https://github.com/microsoft/lsprotocol/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      doronbehar
+      fab
+    ];
+  };
+}

--- a/pkgs/development/python-modules/pygls/default.nix
+++ b/pkgs/development/python-modules/pygls/default.nix
@@ -10,6 +10,7 @@
   pythonOlder,
   typeguard,
   websockets,
+  nix-update-script,
 }:
 
 buildPythonPackage rec {
@@ -58,6 +59,14 @@ buildPythonPackage rec {
   '';
 
   pythonImportsCheck = [ "pygls" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      # Skips pre-releases
+      "--version-regex"
+      "^v([0-9.]+)$"
+    ];
+  };
 
   meta = with lib; {
     description = "Pythonic generic implementation of the Language Server Protocol";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8727,7 +8727,11 @@ self: super: with self; {
 
   lsp-tree-sitter = callPackage ../development/python-modules/lsp-tree-sitter { };
 
-  lsprotocol = callPackage ../development/python-modules/lsprotocol { };
+  lsprotocol = lsprotocol_2023;
+
+  lsprotocol_2023 = callPackage ../development/python-modules/lsprotocol/2023.nix { };
+
+  lsprotocol_2025 = callPackage ../development/python-modules/lsprotocol/2025.nix { };
 
   ltpycld2 = callPackage ../development/python-modules/ltpycld2 { };
 


### PR DESCRIPTION
The 2025 release of lsprotocol breaks every package that depends on it. This adds back the 2023 variant as the default, but provides a 2025 variant for packages that will need it in the future.

The breaking changes were introduced in:
- lsprotocol: https://github.com/microsoft/lsprotocol/releases/tag/2024.0.0a2
- nixpkgs: #431074

The latest alpha release of pygls 2.0.0 supports 2025 (since https://github.com/openlawlibrary/pygls/pull/487), but then every other package that depends on pygls would have to refactored to use 2.0.0a6, so we'll hold that off until the official release.

Fixes #437024

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
