### PR TITLE
_86Box: fixed missing libgcrypt dep for VNC renderer

### DIFF
--- a/pkgs/by-name/_8/_86Box/package.nix
+++ b/pkgs/by-name/_8/_86Box/package.nix
@@ -28,6 +28,7 @@
   libvorbis,
   libopus,
   libmpg123,
+  libgcrypt,
 
   enableDynarec ? with stdenv.hostPlatform; isx86 || isAarch,
   enableNewDynarec ? enableDynarec && stdenv.hostPlatform.isAarch,
@@ -87,7 +88,10 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional stdenv.hostPlatform.isLinux alsa-lib
   ++ lib.optional enableWayland wayland
-  ++ lib.optional enableVncRenderer libvncserver;
+  ++ lib.optionals enableVncRenderer [
+    libvncserver
+    libgcrypt
+  ];
 
   cmakeFlags =
     lib.optional stdenv.hostPlatform.isDarwin "-DCMAKE_MACOSX_BUNDLE=OFF"


### PR DESCRIPTION
Fixes #437267.

Test (`x86-64-linux`):

```bash
NIXPKGS_ALLOW_UNFREE=1 nix-shell --pure \
  -I nixpkgs=https://github.com/matteo-pacini/nixpkgs/archive/4635e6fd36d6e85f6a293e51aff2e15ae52d74d8.tar.gz \
  -p '_86Box-with-roms.override({ enableVncRenderer = true; })' \
  --keep XDG_RUNTIME_DIR \
  --keep WAYLAND_DISPLAY \
  --keep DISPLAY \
  --keep DBUS_SESSION_BUS_ADDRESS \
  --run 'QT_QPA_PLATFORM=wayland 86Box'
  ```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
