### PR TITLE
python3Packages.coverage: 7.10.2 -> 7.10.5

### DIFF
--- a/pkgs/development/python-modules/coverage/default.nix
+++ b/pkgs/development/python-modules/coverage/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "coverage";
-  version = "7.10.2";
+  version = "7.10.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nedbat";
     repo = "coveragepy";
     tag = version;
-    hash = "sha256-OXi5FCLcfhseNDerwHdsVHF31Jy+ZSz2RU05vqPxQis=";
+    hash = "sha256-jsocpziOu0fSmFn075vj2u1SCZkG7M/kuRujaJ1OeH4=";
   };
 
   build-system = [ setuptools ];
@@ -47,23 +47,17 @@ buildPythonPackage rec {
   '';
 
   disabledTests = [
-    "test_all_our_source_files"
     "test_doctest"
     "test_files_up_one_level"
     "test_get_encoded_zip_files"
-    "test_metadata"
-    "test_more_metadata"
     "test_multi"
     "test_no_duplicate_packages"
-    "test_xdist_sys_path_nuttiness_is_fixed"
     "test_zipfile"
-  ]
-  ++ lib.optionals (isPy312 && stdenv.hostPlatform.system == "x86_64-darwin") [
-    # substring that may not be in string is part of the pytest output hash, which appears in the string
-    "test_nothing_specified"
-    "test_omit"
-    "test_omit_2"
-    "test_omit_as_string"
+    # tests expect coverage source to be there
+    "test_all_our_source_files"
+    "test_metadata"
+    "test_more_metadata"
+    "test_real_code_regions"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
Diff: https://github.com/nedbat/coveragepy/compare/7.10.2...7.10.5

Changelog: https://github.com/nedbat/coveragepy/blob/7.10.5/CHANGES.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
