### PR TITLE
npingler: unstable-2025-08-24 -> unstable-2025-08-26 

### DIFF
--- a/pkgs/by-name/np/npingler/package.nix
+++ b/pkgs/by-name/np/npingler/package.nix
@@ -25,12 +25,19 @@ rustPlatform.buildRustPackage {
 
   cargoHash = "sha256-71uqdWsXBd6qsplwI3cA2TxXoj6JOThEHxnv9u6iraQ=";
 
+  buildFeatures = [ "clap_mangen" ];
 
   nativeBuildInputs = [
     installShellFiles
   ];
 
   postInstall = lib.optionalString emulatorAvailable ''
+    manpages=$(mktemp -d)
+    ${emulator} $out/bin/npingler util generate-man-pages "$manpages"
+    for manpage in "$manpages"/*; do
+      installManPage "$manpage"
+    done
+
     installShellCompletion --cmd npingler \
       --bash <(${emulator} $out/bin/npingler util generate-completions bash) \
       --fish <(${emulator} $out/bin/npingler util generate-completions fish) \

--- a/pkgs/by-name/np/npingler/package.nix
+++ b/pkgs/by-name/np/npingler/package.nix
@@ -7,16 +7,16 @@
 
 rustPlatform.buildRustPackage {
   pname = "npingler";
-  version = "unstable-2025-08-24";
+  version = "unstable-2025-08-26";
 
   src = fetchFromGitHub {
     owner = "9999years";
     repo = "npingler";
-    rev = "b897098be1df890b669dc734edcb10bf8fc798cb";
-    hash = "sha256-mMwfonIP8fnJDNdl9ANhLmYlM8tPLtBCWNIPSRBT/D4=";
+    rev = "13781b1ee6a141dfebdaa4d885e153e1147a2312";
+    hash = "sha256-cWWzXsxvsETm3+91PuRnR27hSZZWVKnWU3YiTvB+t6A=";
   };
 
-  cargoHash = "sha256-VhMpgrNy0NauwBSCR+5vjod9H216HPC+rdQUIFVjnRg=";
+  cargoHash = "sha256-71uqdWsXBd6qsplwI3cA2TxXoj6JOThEHxnv9u6iraQ=";
 
   meta = {
     description = "Nix profile manager for use with npins";

--- a/pkgs/by-name/np/npingler/package.nix
+++ b/pkgs/by-name/np/npingler/package.nix
@@ -1,10 +1,17 @@
 {
   lib,
+  stdenv,
+  buildPackages,
   rustPlatform,
   fetchFromGitHub,
+  installShellFiles,
   nix-update-script,
 }:
 
+let
+  emulatorAvailable = stdenv.hostPlatform.emulatorAvailable buildPackages;
+  emulator = stdenv.hostPlatform.emulator buildPackages;
+in
 rustPlatform.buildRustPackage {
   pname = "npingler";
   version = "unstable-2025-08-26";
@@ -17,6 +24,18 @@ rustPlatform.buildRustPackage {
   };
 
   cargoHash = "sha256-71uqdWsXBd6qsplwI3cA2TxXoj6JOThEHxnv9u6iraQ=";
+
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = lib.optionalString emulatorAvailable ''
+    installShellCompletion --cmd npingler \
+      --bash <(${emulator} $out/bin/npingler util generate-completions bash) \
+      --fish <(${emulator} $out/bin/npingler util generate-completions fish) \
+      --zsh  <(${emulator} $out/bin/npingler util generate-completions zsh)
+  '';
 
   meta = {
     description = "Nix profile manager for use with npins";


### PR DESCRIPTION
This installs `man` pages and shell completions for `npingler`.

- Generate `man` pages: https://github.com/9999years/npingler/pull/29
- Generate shell completions: https://github.com/9999years/npingler/pull/28

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
