### PR TITLE
buildMix: support for MIX_TARGET

### DIFF
--- a/pkgs/development/beam-modules/build-mix.nix
+++ b/pkgs/development/beam-modules/build-mix.nix
@@ -25,6 +25,7 @@
   meta ? { },
   enableDebugInfo ? false,
   mixEnv ? "prod",
+  mixTarget ? "host",
   removeConfig ? true,
   # A config directory that is considered for all the dependencies of an app, typically in $src/config/
   # This was initially added, as some of Mobilizon's dependencies need to access the config at build time.
@@ -51,6 +52,8 @@ let
         inherit version src;
 
         MIX_ENV = mixEnv;
+        MIX_TARGET = mixTarget;
+        MIX_BUILD_PREFIX = (if mixTarget == "host" then "" else "${mixTarget}_") + "${mixEnv}";
         MIX_DEBUG = if enableDebugInfo then 1 else 0;
         HEX_OFFLINE = 1;
 
@@ -122,7 +125,7 @@ let
 
             # Some packages like db_connection will use _build/shared instead of
             # honoring the $MIX_ENV variable.
-            for reldir in _build/{$MIX_ENV,shared}/lib/${name}/{src,ebin,priv,include} ; do
+            for reldir in _build/{$MIX_BUILD_PREFIX,shared}/lib/${name}/{src,ebin,priv,include} ; do
               if test -d $reldir ; then
                 # Some builds produce symlinks (eg: phoenix priv dircetory). They must
                 # be followed with -H flag.

--- a/pkgs/development/beam-modules/fetch-mix-deps.nix
+++ b/pkgs/development/beam-modules/fetch-mix-deps.nix
@@ -16,6 +16,7 @@
   sha256 ? "",
   src,
   mixEnv ? "prod",
+  mixTarget ? "host",
   debug ? false,
   meta ? { },
   patches ? [ ],
@@ -53,6 +54,7 @@ stdenvNoCC.mkDerivation (
     ];
 
     MIX_ENV = mixEnv;
+    MIX_TARGET = mixTarget;
     MIX_DEBUG = if debug then 1 else 0;
     DEBUG = if debug then 1 else 0; # for rebar3
     # the api with `mix local.rebar rebar path` makes a copy of the binary

--- a/pkgs/development/beam-modules/mix-configure-hook.sh
+++ b/pkgs/development/beam-modules/mix-configure-hook.sh
@@ -2,13 +2,13 @@
 # this hook will symlink all dependencies found in ERL_LIBS
 # since Elixir 1.12.2 elixir does not look into ERL_LIBS for
 # elixir depencencies anymore, so those have to be symlinked to the _build directory
-mkdir -p _build/"$MIX_ENV"/lib
+mkdir -p _build/"$MIX_BUILD_PREFIX"/lib
 while read -r -d ':' lib; do
     for dir in "$lib"/*; do
     # Strip version number for directory name if it exists, so naming of
     # all libs matches what mix's expectation.
     dest=$(basename "$dir" | cut -d '-' -f1)
-    build_dir="_build/$MIX_ENV/lib/$dest"
+    build_dir="_build/$MIX_BUILD_PREFIX/lib/$dest"
     ((MIX_DEBUG == 1)) && echo "Linking $dir to $build_dir"
     # Symlink libs to _build so that mix can find them when compiling.
     # This is what allows mix to compile the package without searching

--- a/pkgs/development/beam-modules/mix-release.nix
+++ b/pkgs/development/beam-modules/mix-release.nix
@@ -27,6 +27,7 @@
   meta ? { },
   enableDebugInfo ? false,
   mixEnv ? "prod",
+  mixTarget ? "host",
   compileFlags ? [ ],
   # Build a particular named release.
   # see https://hexdocs.pm/mix/1.12/Mix.Tasks.Release.html#content
@@ -123,6 +124,8 @@ stdenv.mkDerivation (
     buildInputs = buildInputs ++ lib.optionals (escriptBinName != null) [ erlang ];
 
     MIX_ENV = mixEnv;
+    MIX_TARGET = mixTarget;
+    MIX_BUILD_PREFIX = (if mixTarget == "host" then "" else "${mixTarget}_") + "${mixEnv}";
     MIX_DEBUG = if enableDebugInfo then 1 else 0;
     HEX_OFFLINE = 1;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
`mixBuild` currently puts all packages under `_build/$MIX_ENV/lib` paths i.e. `_build/prod/lib` or `_build/dev/lib` etc.  However, if building a Mix project against a  [MIX_TARGET](https://hexdocs.pm/mix/main/Mix.html#module-targets) other than the default of "host" the correct path is actually `_build/MIX_TARGET_MIX_ENV/lib`.  For example: `_build/rpi3_prod/lib` or `_build/qemu_dev/lib`.  This adds a `mixTarget` argument to `buildMix` and `mixRelease` so they build packages correctly in the presence of a `MIX_TARGET`. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
