### PR TITLE
bower: Migrate to fetchYarnDeps

### DIFF
--- a/pkgs/by-name/bo/bower/package.nix
+++ b/pkgs/by-name/bo/bower/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchYarnDeps,
+  yarnConfigHook,
+  yarnInstallHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bower";
+  version = "1.8.12";
+
+  src = fetchFromGitHub {
+    owner = "bower";
+    repo = "bower";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-ZjDq4ExQebGB855bbRZCX62YkrrClhZJqU+ipv5v7BM=";
+  };
+
+  patches = [
+    ./workspace-dependencies.patch
+  ];
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = finalAttrs.src + "/yarn.lock";
+    hash = "sha256-Y7tjFbyz3AKMvHAOB9U0KPdxmiO7tHPP+RdkSlSQJUc=";
+  };
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnInstallHook
+  ];
+
+  meta = {
+    changelog = "https://github.com/bower/bower/releases/tag/v${finalAttrs.version}";
+    description = "Package manager for the web";
+    homepage = "https://bower.io";
+    license = lib.licenses.mit;
+    mainProgram = "bower";
+  };
+})

--- a/pkgs/by-name/bo/bower/workspace-dependencies.patch
+++ b/pkgs/by-name/bo/bower/workspace-dependencies.patch
@@ -1,0 +1,28 @@
+--- a/package.json
++++ b/package.json
+@@ -16,6 +16,11 @@
+     "bower"
+   ],
+   "dependencies": {
++    "bower-config": "file:./packages/bower-config",
++    "bower-endpoint-parser": "file:./packages/bower-endpoint-parser",
++    "bower-json": "file:./packages/bower-json",
++    "bower-logger": "file:./packages/bower-logger",
++    "bower-registry-client": "file:./packages/bower-registry-client",
+     "abbrev": "^1.0.5",
+     "archy": "1.0.0",
+     "cardinal": "0.4.4",
+@@ -98,12 +103,5 @@
+   "resolutions": {
+     "deep-extend": "0.5.1",
+     "minimist": "0.2.1"
+-  },
+-  "workspaces": [
+-    "packages/bower-config",
+-    "packages/bower-endpoint-parser",
+-    "packages/bower-json",
+-    "packages/bower-logger",
+-    "packages/bower-registry-client"
+-  ]
++  }
+ }

--- a/pkgs/development/bower-modules/generic/default.nix
+++ b/pkgs/development/bower-modules/generic/default.nix
@@ -45,7 +45,7 @@ pkgs.stdenv.mkDerivation (
 
     buildInputs = buildInputs ++ [
       pkgs.git
-      pkgs.nodePackages.bower
+      pkgs.bower
     ];
   }
 )

--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -63,6 +63,7 @@ mapAliases {
   inherit (pkgs) bash-language-server; # added 2024-06-07
   bibtex-tidy = pkgs.bibtex-tidy; # added 2023-07-30
   bitwarden-cli = pkgs.bitwarden-cli; # added 2023-07-25
+  inherit (pkgs) bower; # added 2025-08-27
   inherit (pkgs) bower2nix; # added 2024-08-23
   inherit (pkgs) btc-rpc-explorer; # added 2023-08-17
   inherit (pkgs) carbon-now-cli; # added 2023-08-17

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -18,7 +18,6 @@
 , "audiosprite"
 , "aws-cdk"
 , "awesome-lint"
-, "bower"
 , "browserify"
 , "browser-sync"
 , "cdk8s-cli"

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -46557,24 +46557,6 @@ in
     bypassCache = true;
     reconstructLock = true;
   };
-  bower = nodeEnv.buildNodePackage {
-    name = "bower";
-    packageName = "bower";
-    version = "1.8.14";
-    src = fetchurl {
-      url = "https://registry.npmjs.org/bower/-/bower-1.8.14.tgz";
-      sha512 = "8Rq058FD91q9Nwthyhw0la9fzpBz0iwZTrt51LWl+w+PnJgZk9J+5wp3nibsJcIUPglMYXr4NRBaR+TUj0OkBQ==";
-    };
-    buildInputs = globalBuildInputs;
-    meta = {
-      description = "The browser package manager";
-      homepage = "http://bower.io";
-      license = "MIT";
-    };
-    production = true;
-    bypassCache = true;
-    reconstructLock = true;
-  };
   browserify = nodeEnv.buildNodePackage {
     name = "browserify";
     packageName = "browserify";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Migrate Bower to use fetchYarnDeps

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
