### PR TITLE
nss_esr: 3.101.2 -> 3.112.1

### DIFF
--- a/pkgs/development/libraries/nss/esr.nix
+++ b/pkgs/development/libraries/nss/esr.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "3.101.2";
-  hash = "sha256-i5K47pzQYOiD4vFHBN6VeqXEdPBOM7U1oSK0qSi2M2Y=";
+  version = "3.112.1";
+  hash = "sha256-NpvE/WH+oY231uDKxXJptDojfU4rNsXySpOduWszzjQ=";
   filename = "esr.nix";
-  versionRegex = "NSS_(3)_(101)(?:_(\\d+))?_RTM";
+  versionRegex = "NSS_(3)_(112)(?:_(\\d+))?_RTM";
 }


### PR DESCRIPTION
https://github.com/nss-dev/nss/blob/master/doc/rst/releases/nss_3_103.rst
https://github.com/nss-dev/nss/blob/master/doc/rst/releases/nss_3_104.rst 
https://github.com/nss-dev/nss/blob/master/doc/rst/releases/nss_3_105.rst 
https://github.com/nss-dev/nss/blob/master/doc/rst/releases/nss_3_106.rst 
https://github.com/nss-dev/nss/blob/master/doc/rst/releases/nss_3_107.rst 
https://github.com/nss-dev/nss/blob/master/doc/rst/releases/nss_3_108.rst
https://github.com/nss-dev/nss/blob/master/doc/rst/releases/nss_3_109.rst 
https://github.com/nss-dev/nss/blob/master/doc/rst/releases/nss_3_110.rst 
https://github.com/nss-dev/nss/blob/master/doc/rst/releases/nss_3_111.rst 
https://github.com/nss-dev/nss/blob/master/doc/rst/releases/nss_3_112.rst 
https://github.com/nss-dev/nss/blob/master/doc/rst/releases/nss_3_112_1.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
