### PR TITLE
python3Packages.subliminal: fix build, python3Packages.knowit: init at 0.5.11

### DIFF
--- a/pkgs/development/python-modules/knowit/default.nix
+++ b/pkgs/development/python-modules/knowit/default.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchzip,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
+  babelfish,
+  enzyme,
+  pymediainfo,
+  pyyaml,
+  trakit,
+  pint,
+
+  # nativeCheckInputs
+  pytestCheckHook,
+  ffmpeg,
+  mediainfo,
+  mkvtoolnix,
+  requests,
+}:
+
+buildPythonPackage rec {
+  pname = "knowit";
+  version = "0.5.11";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ratoaq2";
+    repo = "knowit";
+    tag = version;
+    hash = "sha256-JqzCLdXEWZyvqXpeTJRW0zhY+wVcHLuBYrJbuSqfgkg=";
+  };
+
+  matroska_test_zip = fetchzip {
+    url = "http://downloads.sourceforge.net/project/matroska/test_files/matroska_test_w1_1.zip";
+    hash = "sha256-X8gIfDj2iP043kjO3yqxuIgn8mZMX7XaqzhQ7CTLUhc=";
+    stripRoot = false;
+  };
+
+  postPatch = ''
+    mkdir -p tests/data/videos
+    cp ${matroska_test_zip}/*.mkv tests/data/videos/
+  '';
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    babelfish
+    enzyme
+    pymediainfo
+    pyyaml
+    trakit
+  ];
+
+  optional-dependencies = {
+    pint = [
+      pint
+    ];
+  };
+
+  pythonImportsCheck = [
+    "knowit"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    ffmpeg
+    mediainfo
+    mkvtoolnix
+    requests
+  ];
+
+  meta = {
+    changelog = "https://github.com/ratoaq2/knowit/releases/tag/${src.tag}";
+    description = "Extract metadata from media files";
+    homepage = "https://github.com/ratoaq2/knowit";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ iynaix ];
+    mainProgram = "knowit";
+  };
+}

--- a/pkgs/development/python-modules/subliminal/default.nix
+++ b/pkgs/development/python-modules/subliminal/default.nix
@@ -4,23 +4,33 @@
   fetchFromGitHub,
   pythonOlder,
 
+  # build-system
+  hatchling,
+  hatch-vcs,
+
+  # dependencies
   babelfish,
   beautifulsoup4,
   chardet,
   click,
   click-option-group,
+  defusedxml,
   dogpile-cache,
   enzyme,
   guessit,
+  knowit,
   srt,
   pysubs2,
   rarfile,
   requests,
   platformdirs,
-  setuptools,
   stevedore,
   tomli,
+  tomlkit,
 
+  # nativeCheckInputs
+  colorama,
+  pypandoc,
   pytestCheckHook,
   pytest-cov-stub,
   pytest-xdist,
@@ -43,7 +53,10 @@ buildPythonPackage rec {
     hash = "sha256-eAXzD6diep28wCZjWLOZpOX1bnakEldhs2LX5CPu5OI=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
 
   propagatedBuildInputs = [
     babelfish
@@ -51,9 +64,11 @@ buildPythonPackage rec {
     chardet
     click
     click-option-group
+    defusedxml
     dogpile-cache
     enzyme
     guessit
+    knowit
     srt
     pysubs2
     rarfile
@@ -61,9 +76,12 @@ buildPythonPackage rec {
     platformdirs
     stevedore
     tomli
+    tomlkit
   ];
 
   nativeCheckInputs = [
+    colorama
+    pypandoc
     pytestCheckHook
     pytest-cov-stub
     pytest-xdist
@@ -76,6 +94,10 @@ buildPythonPackage rec {
 
   disabledTests = [
     # Tests require network access
+    "integration"
+    "test_cli_cache"
+    "test_cli_download"
+    "test_is_supported_archive"
     "test_refine"
     "test_scan"
     "test_hash"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7850,6 +7850,8 @@ self: super: with self; {
 
   knot-floer-homology = callPackage ../development/python-modules/knot-floer-homology { };
 
+  knowit = callPackage ../development/python-modules/knowit { };
+
   knx-frontend = callPackage ../development/python-modules/knx-frontend { };
 
   kokoro = callPackage ../development/python-modules/kokoro { };


### PR DESCRIPTION
Updated the broken build for subliminal. It now uses a couple of new packages, including [knowit](https://github.com/ratoaq2/knowit), which I have also packaged for nixpkgs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
