### PR TITLE
vagrant: fix gem extension build warnings

### DIFF
--- a/pkgs/by-name/va/vagrant/package.nix
+++ b/pkgs/by-name/va/vagrant/package.nix
@@ -4,7 +4,7 @@
   fetchurl,
   buildRubyGem,
   bundlerEnv,
-  ruby,
+  ruby_3_4,
   libarchive,
   libguestfs,
   qemu,
@@ -19,6 +19,8 @@ let
   version = "2.4.8";
   url = "https://github.com/hashicorp/vagrant/archive/v${version}.tar.gz";
   hash = "sha256-AVagvZKbVT4RWrCJdskhABTunRM9tBb5+jovYM/VF+0=";
+
+  ruby = ruby_3_4;
 
   deps = bundlerEnv rec {
     name = "${pname}-${version}";
@@ -60,7 +62,7 @@ in
 buildRubyGem rec {
   name = "${gemName}-${version}";
   gemName = "vagrant";
-  inherit version;
+  inherit ruby version;
 
   doInstallCheck = true;
   dontBuild = false;


### PR DESCRIPTION
Same as https://github.com/NixOS/nixpkgs/pull/431923.

The problem is that every invocation of vagrant emits following warnings:
```
Ignoring debug-1.9.2 because its extensions are not built. Try: gem pristine debug --version 1.9.2
Ignoring racc-1.7.3 because its extensions are not built. Try: gem pristine racc --version 1.7.3
Ignoring rbs-3.4.0 because its extensions are not built. Try: gem pristine rbs --version 3.4.0
Ignoring debug-1.9.2 because its extensions are not built. Try: gem pristine debug --version 1.9.2
Ignoring racc-1.7.3 because its extensions are not built. Try: gem pristine racc --version 1.7.3
Ignoring rbs-3.4.0 because its extensions are not built. Try: gem pristine rbs --version 3.4.0
Ignoring debug-1.9.2 because its extensions are not built. Try: gem pristine debug --version 1.9.2
Ignoring racc-1.7.3 because its extensions are not built. Try: gem pristine racc --version 1.7.3
Ignoring rbs-3.4.0 because its extensions are not built. Try: gem pristine rbs --version 3.4.0
```
This problem is also mentioned at https://github.com/NixOS/nixpkgs/pull/434750#issuecomment-3206935995.

By using ruby 3.4, the warnings dissappear.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
    - on top of #437371
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
