### PR TITLE
python3Packages.fastmcp: 2.11.1 -> 2.11.3

### DIFF
--- a/pkgs/development/python-modules/fastmcp/default.nix
+++ b/pkgs/development/python-modules/fastmcp/default.nix
@@ -14,6 +14,7 @@
   exceptiongroup,
   httpx,
   mcp,
+  openapi-core,
   openapi-pydantic,
   pydantic,
   pyperclip,
@@ -57,6 +58,7 @@ buildPythonPackage rec {
     exceptiongroup
     httpx
     mcp
+    openapi-core
     openapi-pydantic
     pyperclip
     python-dotenv
@@ -87,6 +89,10 @@ buildPythonPackage rec {
     "test_keep_alive_starts_new_session_if_manually_closed"
     "test_keep_alive_maintains_session_if_reentered"
     "test_close_session_and_try_to_use_client_raises_error"
+    "test_run_mcp_config"
+    "test_uv_transport"
+    "test_uv_transport_module"
+    "test_github_api_schema_performance"
 
     # RuntimeError: Client failed to connect: Timed out while waiting for response
     "test_timeout"
@@ -94,20 +100,25 @@ buildPythonPackage rec {
 
     # assert 0 == 2
     "test_multi_client"
+    "test_canonical_multi_client_with_transforms"
 
     # fastmcp.exceptions.ToolError: Unknown tool
     "test_multi_client_with_logging"
     "test_multi_client_with_elicitation"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # RuntimeError: Server failed to start after 10 attempts
+    "test_unauthorized_access"
   ];
 
   disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
     # RuntimeError: Server failed to start after 10 attempts
-    "tests/auth/providers/test_bearer.py"
-    "tests/auth/test_oauth_client.py"
-    "tests/client/test_openapi.py"
+    "tests/client/auth/test_oauth_client.py"
+    "tests/client/test_openapi_experimental.py"
+    "tests/client/test_openapi_legacy.py"
     "tests/client/test_sse.py"
     "tests/client/test_streamable_http.py"
-    "tests/server/http/test_http_dependencies.py"
+    "tests/server/auth/test_jwt_provider.py"
     "tests/server/http/test_http_dependencies.py"
   ];
 

--- a/pkgs/development/python-modules/fastmcp/default.nix
+++ b/pkgs/development/python-modules/fastmcp/default.nix
@@ -31,14 +31,14 @@
 
 buildPythonPackage rec {
   pname = "fastmcp";
-  version = "2.11.1";
+  version = "2.11.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jlowin";
     repo = "fastmcp";
     tag = "v${version}";
-    hash = "sha256-Y71AJdWcRBDbq63p+lcQplqutz2UTQ3f+pTyhcolpuw=";
+    hash = "sha256-jIXrMyNnyPE2DUgg+sxT6LD4dTmKQglh4cFuaw179Z0=";
   };
 
   postPatch = ''


### PR DESCRIPTION
This PR started as a fix PR adding a dependency and addressing some test failures. 

When running the `nixpkgs-review` and addressing the errors in the darwin tests due to missing paths, it turned into a bump and fix PR.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
