### PR TITLE
spidermonkey_91: drop

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -33,6 +33,8 @@
 
 - `kbd` package's `outputs` now include a `man` and `scripts` outputs. The `unicode_start` and `unicode_stop` Bash scripts are now part of the `scripts` output, allowing most usages of the `kbd` package to not pull in `bash`.
 
+- `spidermonkey_91` has been removed, as it has been EOL since September 2022.
+
 - `cudaPackages.cudatoolkit-legacy-runfile` has been removed.
 
 - `conduwuit` was removed due to upstream ceasing development and deleting their repository. For existing data, a migration to `matrix-conduit`, `matrix-continuwuity` or `matrix-tuwunel` may be possible.

--- a/nixos/modules/services/misc/gotenberg.nix
+++ b/nixos/modules/services/misc/gotenberg.nix
@@ -115,7 +115,7 @@ in
         autoStart = mkOption {
           type = types.bool;
           default = false;
-          description = "Automatically start chromium when Gotenberg starts. If false, Chromium will start on the first conversion request that uses it.";
+          description = "Automatically start Chromium when Gotenberg starts. If false, Chromium will start on the first conversion request that uses it.";
         };
 
         disableJavascript = mkOption {
@@ -172,7 +172,7 @@ in
         autoStart = mkOption {
           type = types.bool;
           default = false;
-          description = "Automatically start LibreOffice when Gotenberg starts. If false, Chromium will start on the first conversion request that uses it.";
+          description = "Automatically start LibreOffice when Gotenberg starts. If false, LibreOffice will start on the first conversion request that uses it.";
         };
 
         disableRoutes = mkOption {

--- a/nixos/modules/services/misc/gotenberg.nix
+++ b/nixos/modules/services/misc/gotenberg.nix
@@ -303,6 +303,7 @@ in
       };
       serviceConfig = {
         Type = "simple";
+        # NOTE: disable to debug chromium crashes or otherwise no coredump is created and forbidden syscalls are not being logged
         DynamicUser = true;
         ExecStart = "${lib.getExe cfg.package} ${lib.escapeShellArgs args}";
 
@@ -340,6 +341,7 @@ in
           "@sandbox"
           "@system-service"
           "@chown"
+          "@pkey" # required by chromium or it crashes
         ];
         SystemCallArchitectures = "native";
 

--- a/nixos/modules/services/misc/gotenberg.nix
+++ b/nixos/modules/services/misc/gotenberg.nix
@@ -342,6 +342,7 @@ in
           "@system-service"
           "@chown"
           "@pkey" # required by chromium or it crashes
+          "mincore"
         ];
         SystemCallArchitectures = "native";
 

--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -598,7 +598,7 @@ in
 
         services.gotenberg = lib.mkIf cfg.configureTika {
           enable = true;
-          # https://github.com/paperless-ngx/paperless-ngx/blob/v2.15.3/docker/compose/docker-compose.sqlite-tika.yml#L64-L69
+          # https://github.com/paperless-ngx/paperless-ngx/blob/v2.18.2/docker/compose/docker-compose.sqlite-tika.yml#L60-L65
           chromium.disableJavascript = true;
           extraArgs = [ "--chromium-allow-list=file:///tmp/.*" ];
         };

--- a/nixos/tests/gotenberg.nix
+++ b/nixos/tests/gotenberg.nix
@@ -7,6 +7,9 @@
   nodes.machine = {
     services.gotenberg = {
       enable = true;
+      # fail the service if any of those does not come up
+      chromium.autoStart = true;
+      libreoffice.autoStart = true;
     };
   };
 

--- a/pkgs/applications/video/obs-studio/plugins/obs-vkcapture.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-vkcapture.nix
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "obs-vkcapture";
-  version = "1.5.2";
+  version = "1.5.3";
 
   src = fetchFromGitHub {
     owner = "nowrep";
     repo = "obs-vkcapture";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-ghfRST7J3bipQnOZnYMtmDggET+Etq/ngHs+zQ0bm1w=";
+    hash = "sha256-zra7fwYnUfPKS4AA6Z9FIPP3p/uR5O1wB6Z76aivtZI=";
   };
 
   cmakeFlags = lib.optionals stdenv.hostPlatform.isi686 [

--- a/pkgs/applications/virtualization/docker/buildx.nix
+++ b/pkgs/applications/virtualization/docker/buildx.nix
@@ -6,13 +6,13 @@
 
 buildGoModule rec {
   pname = "docker-buildx";
-  version = "0.26.1";
+  version = "0.27.0";
 
   src = fetchFromGitHub {
     owner = "docker";
     repo = "buildx";
     rev = "v${version}";
-    hash = "sha256-+ubv/8UdejxY7u3RdgS7L18hZHohlqGu9E3L0bTAmLY=";
+    hash = "sha256-SY7pf6bHvX6tezTYpOu/pqda3IsIqaR5g7JZS+eEEZw=";
   };
 
   doCheck = false;

--- a/pkgs/by-name/_1/_1password-gui/sources.json
+++ b/pkgs/by-name/_1/_1password-gui/sources.json
@@ -29,15 +29,15 @@
   },
   "beta": {
     "linux": {
-      "version": "8.11.8-32.BETA",
+      "version": "8.11.8-39.BETA",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/linux/tar/beta/x86_64/1password-8.11.8-32.BETA.x64.tar.gz",
-          "hash": "sha256-FlJ7uXtqavcOUs/DRGCMR0ImX9mlQBYGxFzM45DByBg="
+          "url": "https://downloads.1password.com/linux/tar/beta/x86_64/1password-8.11.8-39.BETA.x64.tar.gz",
+          "hash": "sha256-8KokDe9Vnr2lL5NileTcs+ncpqOcoRs5/N8hmrVv33U="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/linux/tar/beta/aarch64/1password-8.11.8-32.BETA.arm64.tar.gz",
-          "hash": "sha256-Dqy9keq6aRrFp2zKGOpV9kmI4CZQFZpf8ey9n9OKy8A="
+          "url": "https://downloads.1password.com/linux/tar/beta/aarch64/1password-8.11.8-39.BETA.arm64.tar.gz",
+          "hash": "sha256-fWLFshduzdbYgoSIeMKPd3SsbLh62O2lPFXqwqk/DTQ="
         }
       }
     },

--- a/pkgs/by-name/_1/_1password-gui/sources.json
+++ b/pkgs/by-name/_1/_1password-gui/sources.json
@@ -1,28 +1,28 @@
 {
   "stable": {
     "linux": {
-      "version": "8.11.6",
+      "version": "8.11.8",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.11.6.x64.tar.gz",
-          "hash": "sha256-OjyJDesweUhLHuBeLCEvNOloDZO8/D6Z1FquLyapQ4Q="
+          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.11.8.x64.tar.gz",
+          "hash": "sha256-gidi2lnKFxcSxi6lekWODp9TJNGofWFp72Bp30KoRfY="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.11.6.arm64.tar.gz",
-          "hash": "sha256-sspmxX6xeVHvEww4D41PZTM2YftbILx06aMuDbAay74="
+          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.11.8.arm64.tar.gz",
+          "hash": "sha256-pZqhWd2K+5+B3eK52OZNSPh3Jx4MKBy+hAnC5tihzhM="
         }
       }
     },
     "darwin": {
-      "version": "8.11.6",
+      "version": "8.11.8",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.11.6-x86_64.zip",
-          "hash": "sha256-HMwb22/4Dw3M3B1nrdURSQzMGAZxsVG6t8E+MUmRmjg="
+          "url": "https://downloads.1password.com/mac/1Password-8.11.8-x86_64.zip",
+          "hash": "sha256-MYyWof17KLVRtnPqSICnny24f8YoXJWeGwErWFrb6C4="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.11.6-aarch64.zip",
-          "hash": "sha256-SrB4tUk2GroUOptdQlJsC9tFssYXduyLR1TqH7aU2N4="
+          "url": "https://downloads.1password.com/mac/1Password-8.11.8-aarch64.zip",
+          "hash": "sha256-wii983COooBCXyiV2a2MC7SKnFJLp1JashsOzT3+ZRA="
         }
       }
     }

--- a/pkgs/by-name/an/ansible-lint/package.nix
+++ b/pkgs/by-name/an/ansible-lint/package.nix
@@ -8,13 +8,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "ansible-lint";
-  version = "25.8.1";
+  version = "25.8.2";
   pyproject = true;
 
   src = fetchPypi {
     inherit version;
     pname = "ansible_lint";
-    hash = "sha256-BAWePPW2ROeW4h1EUARiHR4kVOOuto0e6gpJ9lDvMhk=";
+    hash = "sha256-Nd093RLYBjh2kVvy8GuaG4D9J6fLHKTOUcjOu4RpCSI=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/bl/blender/package.nix
+++ b/pkgs/by-name/bl/blender/package.nix
@@ -115,12 +115,12 @@ in
 
 stdenv'.mkDerivation (finalAttrs: {
   pname = "blender";
-  version = "4.5.1";
+  version = "4.5.2";
 
   src = fetchzip {
     name = "source";
     url = "https://download.blender.org/source/blender-${finalAttrs.version}.tar.xz";
-    hash = "sha256-x1zeBQ0aTBFUpB7c4XfP6b2p+ENRFEnTGa4m/7Pl24k=";
+    hash = "sha256-6blXwp3DeWNM5Q6M5gWj4O+K/gFxEOj41lzlc5biEYQ=";
   };
 
   postPatch =

--- a/pkgs/by-name/ch/chow-kick/package.nix
+++ b/pkgs/by-name/ch/chow-kick/package.nix
@@ -33,7 +33,6 @@
   sqlite,
   stdenv,
   util-linuxMinimal,
-  webkitgtk_4_0,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -82,7 +81,6 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     sqlite
     util-linuxMinimal
-    webkitgtk_4_0
   ];
 
   cmakeFlags = [

--- a/pkgs/by-name/ch/chow-tape-model/package.nix
+++ b/pkgs/by-name/ch/chow-tape-model/package.nix
@@ -33,7 +33,6 @@
   python3,
   sqlite,
   stdenv,
-  webkitgtk_4_0,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "chow-tape-model";
@@ -87,7 +86,6 @@ stdenv.mkDerivation (finalAttrs: {
     pcre2
     python3
     sqlite
-    webkitgtk_4_0
   ];
 
   # Link-time-optimization fails without these

--- a/pkgs/by-name/cp/cppcheck/package.nix
+++ b/pkgs/by-name/cp/cppcheck/package.nix
@@ -21,7 +21,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cppcheck";
-  version = "2.18.0";
+  version = "2.18.1";
 
   outputs = [
     "out"
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "danmar";
     repo = "cppcheck";
     tag = finalAttrs.version;
-    hash = "sha256-trbL2Me1VWmVMfL45H50xbR36izifFmoLHKQvte6oZQ=";
+    hash = "sha256-SWMjxMtdISAOxMWteouOzr8DeRpqn16OlPDhR0Yb3QQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fr/freerdp/package.nix
+++ b/pkgs/by-name/fr/freerdp/package.nix
@@ -63,13 +63,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "freerdp";
-  version = "3.16.0";
+  version = "3.17.0";
 
   src = fetchFromGitHub {
     owner = "FreeRDP";
     repo = "FreeRDP";
     rev = finalAttrs.version;
-    hash = "sha256-HF4Is3ak2nYD2Fq6HGHwyM5OTBVqYqbB22otOprzfiQ=";
+    hash = "sha256-86RbzRgC93ZOt3MHRKJIRklEuyCQs6tHff5jk++yFok=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/gi/gitui/package.nix
+++ b/pkgs/by-name/gi/gitui/package.nix
@@ -9,6 +9,7 @@
   cmake,
   xclip,
   nix-update-script,
+  fetchpatch,
 }:
 let
   pname = "gitui";
@@ -37,6 +38,16 @@ rustPlatform.buildRustPackage {
   ++ lib.optional stdenv.hostPlatform.isLinux xclip
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     libiconv
+  ];
+
+  patches = [
+    # Fixes the build for rust 1.89
+    # Upstream PR: https://github.com/gitui-org/gitui/pull/2663
+    # TOREMOVE for gitui > 0.27.0
+    (fetchpatch {
+      url = "https://github.com/gitui-org/gitui/commit/950e703cab1dd37e3d02e7316ec99cc0dc70513c.patch";
+      sha256 = "sha256-KDgOPLKGuJaF0Nc6rw9FPFmcI07I8Gyp/KNX8x6+2xw=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/by-name/go/gotenberg/package.nix
+++ b/pkgs/by-name/go/gotenberg/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  buildGoModule,
+  buildGo125Module,
   chromium,
   fetchFromGitHub,
   libreoffice,
@@ -22,18 +22,23 @@ let
   libreoffice' = "${libreoffice}/lib/libreoffice/program/soffice.bin";
   inherit (lib) getExe;
 in
-buildGoModule rec {
+buildGo125Module rec {
   pname = "gotenberg";
-  version = "8.21.1";
+  version = "8.22.0";
+
+  outputs = [
+    "out"
+    "hyphen"
+  ];
 
   src = fetchFromGitHub {
     owner = "gotenberg";
     repo = "gotenberg";
     tag = "v${version}";
-    hash = "sha256-2uILOK5u+HrdjqN+ZQjGv48QxSCrzSvnF+Ae6iCKCbU=";
+    hash = "sha256-LrkJlUkcvW8ky9e2Ltj13wxcL0rvaE4NfVJrcrgPHL4=";
   };
 
-  vendorHash = "sha256-sTcP/tyrCtvgYeOnsbqRFdBC1bbMAbA978t6LOTKFio=";
+  vendorHash = "sha256-JHsuCYx9Ec/w8LBT2R4LxlrfjYyYve0+4/Xq0U1sq5I=";
 
   postPatch = ''
     find ./pkg -name '*_test.go' -exec sed -i -e 's#/tests#${src}#g' {} \;
@@ -82,14 +87,20 @@ buildGoModule rec {
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
+  postInstall = ''
+    mkdir $hyphen
+    cp -r build/chromium-hyphen-data/*/* $hyphen/
+  '';
+
   preFixup = ''
     wrapProgram $out/bin/gotenberg \
+      --set CHROMIUM_HYPHEN_DATA_DIR_PATH "$hyphen" \
+      --set EXIFTOOL_BIN_PATH "${getExe exiftool}" \
+      --set JAVA_HOME "${jre'}" \
+      --set PDFCPU_BIN_PATH "${getExe pdfcpu}" \
       --set PDFTK_BIN_PATH "${getExe pdftk}" \
       --set QPDF_BIN_PATH "${getExe qpdf}" \
-      --set UNOCONVERTER_BIN_PATH "${getExe unoconv}" \
-      --set EXIFTOOL_BIN_PATH "${getExe exiftool}" \
-      --set PDFCPU_BIN_PATH "${getExe pdfcpu}" \
-      --set JAVA_HOME "${jre'}"
+      --set UNOCONVERTER_BIN_PATH "${getExe unoconv}"
   '';
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/li/libopenraw/package.nix
+++ b/pkgs/by-name/li/libopenraw/package.nix
@@ -40,6 +40,10 @@ stdenv.mkDerivation rec {
       -e "s,GDK_PIXBUF_DIR=.*,GDK_PIXBUF_DIR=$out/lib/gdk-pixbuf-2.0/2.10.0/loaders,"
   '';
 
+  configureFlags = [
+    "--with-boost=${lib.getDev boost}"
+  ];
+
   meta = with lib; {
     description = "RAW camerafile decoding library";
     homepage = "https://libopenraw.freedesktop.org";

--- a/pkgs/by-name/lu/lucida-downloader/package.nix
+++ b/pkgs/by-name/lu/lucida-downloader/package.nix
@@ -7,18 +7,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "lucida-downloader";
-  version = "0.2.0";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "jelni";
     repo = "lucida-downloader";
     tag = "v${version}";
-    hash = "sha256-9wXnxsgZZprUez3PggBWbTU/Vx7JFkNC7fuOiqWG87Y=";
+    hash = "sha256-/T3iB2DbcIbdwROzyB4UqXqrF7soRPCW7EUjZ8orhf4=";
   };
 
   passthru.updateScript = nix-update-script { };
 
-  cargoHash = "sha256-OfnCKFWUxpFu6NU4MNMCimXAbhspBf1n6Qz5ff7MHI4=";
+  cargoHash = "sha256-GHEGz7m/IDtPaynDPQQ9Zq3wDKe4BV+H+rrF6G4QA6s=";
 
   meta = {
     description = "Multithreaded client for downloading music for free with lucida";

--- a/pkgs/by-name/lu/lucida-downloader/package.nix
+++ b/pkgs/by-name/lu/lucida-downloader/package.nix
@@ -1,7 +1,7 @@
 {
   fetchFromGitHub,
-  gitUpdater,
   lib,
+  nix-update-script,
   rustPlatform,
 }:
 
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-9wXnxsgZZprUez3PggBWbTU/Vx7JFkNC7fuOiqWG87Y=";
   };
 
-  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+  passthru.updateScript = nix-update-script { };
 
   cargoHash = "sha256-OfnCKFWUxpFu6NU4MNMCimXAbhspBf1n6Qz5ff7MHI4=";
 

--- a/pkgs/by-name/mi/mirrord/manifest.json
+++ b/pkgs/by-name/mi/mirrord/manifest.json
@@ -1,21 +1,21 @@
 {
-  "version": "3.157.2",
+  "version": "3.159.0",
   "assets": {
     "x86_64-linux": {
-      "url": "https://github.com/metalbear-co/mirrord/releases/download/3.157.2/mirrord_linux_x86_64",
-      "hash": "sha256-H73Qrj/6BezHo/jF1rvbN2rsisbTvRUB8qyzE2OcleI="
+      "url": "https://github.com/metalbear-co/mirrord/releases/download/3.159.0/mirrord_linux_x86_64",
+      "hash": "sha256-QwoilxsUmUDaYbIJLOhERbRgrrCN/M1sp4BvJsMWtOQ="
     },
     "aarch64-linux": {
-      "url": "https://github.com/metalbear-co/mirrord/releases/download/3.157.2/mirrord_linux_aarch64",
-      "hash": "sha256-hh4JSuUVDv3Z+J97+ArgJFpsb1i+hW35SQFSps4+/FE="
+      "url": "https://github.com/metalbear-co/mirrord/releases/download/3.159.0/mirrord_linux_aarch64",
+      "hash": "sha256-/4VACn2xOwDBjKca8gO2syuw6foDQNyqZCECiPNeT2M="
     },
     "aarch64-darwin": {
-      "url": "https://github.com/metalbear-co/mirrord/releases/download/3.157.2/mirrord_mac_universal",
-      "hash": "sha256-ObypSr4R+a5MrpNwyqZQjnTD1mVv9VG8OZmMMNtJzQ0="
+      "url": "https://github.com/metalbear-co/mirrord/releases/download/3.159.0/mirrord_mac_universal",
+      "hash": "sha256-l/ZlUNzmp1/JBufNTbBD7yPUtHTCaU1gBOzX4GzHrq0="
     },
     "x86_64-darwin": {
-      "url": "https://github.com/metalbear-co/mirrord/releases/download/3.157.2/mirrord_mac_universal",
-      "hash": "sha256-ObypSr4R+a5MrpNwyqZQjnTD1mVv9VG8OZmMMNtJzQ0="
+      "url": "https://github.com/metalbear-co/mirrord/releases/download/3.159.0/mirrord_mac_universal",
+      "hash": "sha256-l/ZlUNzmp1/JBufNTbBD7yPUtHTCaU1gBOzX4GzHrq0="
     }
   }
 }

--- a/pkgs/by-name/ob/obsidian/package.nix
+++ b/pkgs/by-name/ob/obsidian/package.nix
@@ -12,7 +12,7 @@
 }:
 let
   pname = "obsidian";
-  version = "1.9.10";
+  version = "1.9.12";
   appname = "Obsidian";
   meta = with lib; {
     description = "Powerful knowledge base that works on top of a local folder of plain text Markdown files";
@@ -36,9 +36,9 @@ let
     url = "https://github.com/obsidianmd/obsidian-releases/releases/download/v${version}/${filename}";
     hash =
       if stdenv.hostPlatform.isDarwin then
-        "sha256-tUT50nGF2rua5Wm1nqwO4I83u8o+BwwrapIbxgaAi1Y="
+        "sha256-HIcnOY/Fn/3zJTKiLxzPKbvug/wf1nc3lG2zyep68Nw="
       else
-        "sha256-5d9x92Nu8dzAGCnTeYHmv5XQN6aWxRemRyjC6wN6lDQ=";
+        "sha256-qS4M9gvCs3B2kOlImH/ddm0zjsVa4Zrhu2VEBKYNuMo=";
   };
 
   icon = fetchurl {

--- a/pkgs/by-name/pc/pcb2gcode/package.nix
+++ b/pkgs/by-name/pc/pcb2gcode/package.nix
@@ -22,6 +22,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-c5YabBqZn6ilIkF3lifTsYyLZMsZN21jDj1hNu0PRAc=";
   };
 
+  configureFlags = [
+    (lib.withFeatureAs true "boost" boost.dev)
+  ];
+
   nativeBuildInputs = [
     autoreconfHook
     pkg-config

--- a/pkgs/by-name/ra/racket/manifest.json
+++ b/pkgs/by-name/ra/racket/manifest.json
@@ -1,11 +1,11 @@
 {
-  "version": "8.17",
+  "version": "8.18",
   "full": {
-    "filename": "racket-8.17-src.tgz",
-    "sha256": "44431395138f7b8c5e67d416ff063b8fb6ce056f4c4f0fda27b7b1ec58bfa33b"
+    "filename": "racket-8.18-src.tgz",
+    "sha256": "65477c71ec1a978a6ee4db582b9b47b1a488029d7a42e358906de154a6e5905c"
   },
   "minimal": {
-    "filename": "racket-minimal-8.17-src.tgz",
-    "sha256": "4acb365869290881fa07c69588cfa8b2dc1000bdc69955d70964b0b1e76b71ba"
+    "filename": "racket-minimal-8.18-src.tgz",
+    "sha256": "24b9cf8365254b43bac308192c782edfbd86363df1322c4e063b797ed0f7db66"
   }
 }

--- a/pkgs/by-name/ud/udiskie/package.nix
+++ b/pkgs/by-name/ud/udiskie/package.nix
@@ -17,7 +17,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "udiskie";
-  version = "2.5.7";
+  version = "2.5.8";
 
   pyproject = true;
 
@@ -25,7 +25,7 @@ python3Packages.buildPythonApplication rec {
     owner = "coldfix";
     repo = "udiskie";
     rev = "v${version}";
-    hash = "sha256-ndoTVeF6iTe4+aqFDRaLUEaBavgCWHzULXeG3Kj3ptY=";
+    hash = "sha256-FFp1+7cCfkMI74rEAez8aJsaplEUa3madoSx+lwplzE=";
   };
 
   patches = [

--- a/pkgs/by-name/vi/vintagestory/package.nix
+++ b/pkgs/by-name/vi/vintagestory/package.nix
@@ -21,11 +21,11 @@
 
 stdenv.mkDerivation rec {
   pname = "vintagestory";
-  version = "1.21.0-rc.7";
+  version = "1.21.0";
 
   src = fetchurl {
-    url = "https://cdn.vintagestory.at/gamefiles/unstable/vs_client_linux-x64_${version}.tar.gz";
-    hash = "sha256-uoQjsSzQQ/4JjhPCDp3VWV0NCQsM5lca7VKB8OnKtYA=";
+    url = "https://cdn.vintagestory.at/gamefiles/stable/vs_client_linux-x64_${version}.tar.gz";
+    hash = "sha256-90YQOur7UhXxDBkGLSMnXQK7iQ6+Z8Mqx9PEG6FEXBs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/interpreters/spidermonkey/91.nix
+++ b/pkgs/development/interpreters/spidermonkey/91.nix
@@ -1,4 +1,0 @@
-import ./common.nix {
-  version = "91.13.0";
-  hash = "sha512-OLTMUt4h521gYea6F14cv9iIoWBwqpUfWkQoPy251+lPJQRiHw2nj+rG5xSRptDnA49j3QrhEtytcA6wLpqlFg==";
-}

--- a/pkgs/development/interpreters/spidermonkey/common.nix
+++ b/pkgs/development/interpreters/spidermonkey/common.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches =
-    lib.optionals (lib.versionAtLeast version "102" && lib.versionOlder version "128") [
+    lib.optionals (lib.versionOlder version "128") [
       # use pkg-config at all systems
       ./always-check-for-pkg-config.patch
       ./allow-system-s-nspr-and-icu-on-bootstrapped-sysroot.patch
@@ -56,16 +56,9 @@ stdenv.mkDerivation (finalAttrs: {
       ./always-check-for-pkg-config-128.patch
       ./allow-system-s-nspr-and-icu-on-bootstrapped-sysroot-128.patch
     ]
-    ++ lib.optionals (lib.versionAtLeast version "91" && stdenv.hostPlatform.system == "i686-linux") [
+    ++ lib.optionals (stdenv.hostPlatform.system == "i686-linux") [
       # Fixes i686 build, https://bugzilla.mozilla.org/show_bug.cgi?id=1729459
       ./fix-float-i686.patch
-    ]
-    ++ lib.optionals (lib.versionAtLeast version "91" && lib.versionOlder version "102") [
-      # Fix 91 compatibility with python311
-      (fetchpatch {
-        url = "https://src.fedoraproject.org/rpms/mozjs91/raw/e3729167646775e60a3d8c602c0412e04f206baf/f/0001-Python-Build-Use-r-instead-of-rU-file-read-modes.patch";
-        hash = "sha256-WgDIBidB9XNQ/+HacK7jxWnjOF8PEUt5eB0+Aubtl48=";
-      })
     ]
     ++ lib.optionals (lib.versionAtLeast version "140") [
       # mozjs-140.pc does not contain -DXP_UNIX on Linux
@@ -81,9 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
     m4
     perl
     pkg-config
-    # 91 does not build with python 3.12: ModuleNotFoundError: No module named 'six.moves'
-    # 102 does not build with python 3.12: ModuleNotFoundError: No module named 'distutils'
-    (if lib.versionOlder version "115" then python311 else python3)
+    python3
     rustc
     rustc.llvmPackages.llvm # for llvm-objdump
     which
@@ -125,8 +116,6 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-readline"
     "--enable-release"
     "--enable-shared-js"
-  ]
-  ++ lib.optionals (lib.versionAtLeast version "91") [
     "--disable-debug"
   ]
   ++ lib.optionals (lib.versionAtLeast version "140") [
@@ -151,16 +140,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  postPatch = lib.optionalString (lib.versionOlder version "102") ''
-    # This patch is a manually applied fix of
-    #   https://bugzilla.mozilla.org/show_bug.cgi?id=1644600
-    # Once that bug is fixed, this can be removed.
-    # This is needed in, for example, `zeroad`.
-    substituteInPlace js/public/StructuredClone.h \
-         --replace "class SharedArrayRawBufferRefs {" \
-                   "class JS_PUBLIC_API SharedArrayRawBufferRefs {"
-  '';
-
   preConfigure =
     lib.optionalString (lib.versionAtLeast version "128") ''
       export MOZBUILD_STATE_PATH=$TMPDIR/mozbuild
@@ -168,24 +147,11 @@ stdenv.mkDerivation (finalAttrs: {
     + ''
       export LIBXUL_DIST=$out
       export PYTHON="${buildPackages.python3.interpreter}"
-    ''
-    + lib.optionalString (lib.versionAtLeast version "91") ''
       export M4=m4
       export AWK=awk
       export AS=$CC
       export AC_MACRODIR=$PWD/build/autoconf/
-
-    ''
-    + lib.optionalString (lib.versionAtLeast version "91" && lib.versionOlder version "115") ''
-      pushd js/src
-      sh ../../build/autoconf/autoconf.sh --localdir=$PWD configure.in > configure
-      chmod +x configure
-      popd
-    ''
-    + lib.optionalString (lib.versionAtLeast version "115") ''
       patchShebangs build/cargo-linker
-    ''
-    + ''
       # We can't build in js/src/, so create a build dir
       mkdir obj
       cd obj/
@@ -217,7 +183,6 @@ stdenv.mkDerivation (finalAttrs: {
       catap
       bobby285271
     ];
-    broken = stdenv.hostPlatform.isDarwin; # 91 is broken, >=115 requires SDK 13.3 (see #242666).
     platforms = platforms.unix;
   };
 })

--- a/pkgs/development/python-modules/bluecurrent-api/default.nix
+++ b/pkgs/development/python-modules/bluecurrent-api/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "bluecurrent-api";
-  version = "1.2.4";
+  version = "1.3.1";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "bluecurrent";
     repo = "HomeAssistantAPI";
     tag = "v${version}";
-    hash = "sha256-NirWs06CkiSE3HPomQwBmX+XFhBxsM6ffE72mvlfxoY=";
+    hash = "sha256-PX0pD7X0o7OVtlz4Q5KuDBH83jtTaIdMnuLvAMTP8+U=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/bx-py-utils/default.nix
+++ b/pkgs/development/python-modules/bx-py-utils/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "bx-py-utils";
-  version = "109";
+  version = "111";
 
   disabled = pythonOlder "3.10";
 
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     owner = "boxine";
     repo = "bx_py_utils";
     tag = "v${version}";
-    hash = "sha256-y1R48nGeTCpcBAzU3kqNQumRToKvQx9qst1kXPWDIlk=";
+    hash = "sha256-B+05yBjqfnBaVvRZo47Akqyap4W5do+Xsumi69Ez4iY=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/genie-partner-sdk/default.nix
+++ b/pkgs/development/python-modules/genie-partner-sdk/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "genie-partner-sdk";
-  version = "1.0.9";
+  version = "1.0.10";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit version;
     pname = "genie_partner_sdk";
-    hash = "sha256-9fnKbC/Kiu5DYF3Sz4EksOJbJzRG7C+H3Ku2uE3eTTY=";
+    hash = "sha256-wADTKmR/9p60VJtbK+chUfZuyHe8fYkDSzFHALpXApg=";
   };
 
   nativeBuildInputs = [ hatchling ];

--- a/pkgs/development/python-modules/kivy/default.nix
+++ b/pkgs/development/python-modules/kivy/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   pkg-config,
   cython,
   docutils,
@@ -33,6 +34,15 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-q8BoF/pUTW2GMKBhNsqWDBto5+nASanWifS9AcNRc8Q=";
   };
+
+  patches = [
+    # Fix compat with newer Cython
+    (fetchpatch {
+      name = "0001-kivy-Remove-old-Python-2-long.patch";
+      url = "https://github.com/kivy/kivy/commit/5a1b27d7d3bdee6cedb55440bfae9c4e66fb3c68.patch";
+      hash = "sha256-GDNYL8dC1Rh4KJ8oPiIjegOJGzRQ1CsgWQeAvx9+Rc8=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \

--- a/pkgs/development/python-modules/letpot/default.nix
+++ b/pkgs/development/python-modules/letpot/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "letpot";
-  version = "0.6.1";
+  version = "0.6.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jpelgrom";
     repo = "python-letpot";
     tag = "v${version}";
-    hash = "sha256-xcuBDygUpkPzwdGGG+GLQBaMPpkrj49Y/1KKh6w9jmA=";
+    hash = "sha256-aSnh1tCHAa5nLWkt0vmEXE0Dow6A5Zb6AkbTX15F6A0=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/msgraph-core/default.nix
+++ b/pkgs/development/python-modules/msgraph-core/default.nix
@@ -9,7 +9,7 @@
   microsoft-kiota-abstractions,
   microsoft-kiota-authentication-azure,
   microsoft-kiota-http,
-  requests,
+  microsoft-kiota-serialization-json,
   azure-identity,
   pytestCheckHook,
   responses,
@@ -36,11 +36,12 @@ buildPythonPackage rec {
     microsoft-kiota-abstractions
     microsoft-kiota-authentication-azure
     microsoft-kiota-http
-    requests
-  ];
+  ]
+  ++ httpx.optional-dependencies.http2;
 
   nativeCheckInputs = [
     azure-identity
+    microsoft-kiota-serialization-json
     pytestCheckHook
     python-dotenv
     responses

--- a/pkgs/development/python-modules/nipype/default.nix
+++ b/pkgs/development/python-modules/nipype/default.nix
@@ -9,8 +9,6 @@
   python-dateutil,
   etelemetry,
   filelock,
-  funcsigs,
-  future,
   looseversion,
   mock,
   networkx,
@@ -19,6 +17,7 @@
   packaging,
   prov,
   psutil,
+  puremagic,
   pybids,
   pydot,
   pytest,
@@ -42,7 +41,6 @@
 buildPythonPackage rec {
   pname = "nipype";
   version = "1.10.0";
-  disabled = pythonOlder "3.7";
   format = "setuptools";
 
   src = fetchPypi {
@@ -52,18 +50,16 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace nipype/interfaces/base/tests/test_core.py \
-      --replace "/usr/bin/env bash" "${bash}/bin/bash"
+      --replace-fail "/usr/bin/env bash" "${bash}/bin/bash"
   '';
 
   pythonRelaxDeps = [ "traits" ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     click
     python-dateutil
     etelemetry
     filelock
-    funcsigs
-    future
     looseversion
     networkx
     nibabel
@@ -71,6 +67,7 @@ buildPythonPackage rec {
     packaging
     prov
     psutil
+    puremagic
     pydot
     rdflib
     scipy
@@ -97,11 +94,12 @@ buildPythonPackage rec {
   '';
   pythonImportsCheck = [ "nipype" ];
 
-  meta = with lib; {
-    homepage = "https://nipy.org/nipype/";
+  meta = {
+    homepage = "https://nipy.org/nipype";
     description = "Neuroimaging in Python: Pipelines and Interfaces";
+    changelog = "https://github.com/nipy/nipype/releases/tag/${version}";
     mainProgram = "nipypecli";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ ashgillman ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ashgillman ];
   };
 }

--- a/pkgs/development/python-modules/rawpy/default.nix
+++ b/pkgs/development/python-modules/rawpy/default.nix
@@ -74,6 +74,7 @@ buildPythonPackage rec {
 
   disabledTests = [
     # rawpy._rawpy.LibRawFileUnsupportedError: b'Unsupported file format or not RAW file'
+    "testCropSizeSigma"
     "testFoveonFileOpenAndPostProcess"
     "testThumbExtractBitmap"
   ];

--- a/pkgs/development/python-modules/s3fs/default.nix
+++ b/pkgs/development/python-modules/s3fs/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "s3fs";
-  version = "2025.2.0";
+  version = "2025.7.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "fsspec";
     repo = "s3fs";
     tag = version;
-    hash = "sha256-nnfvccORDspj54sRxL3d0hn4MpzKYGKE2Kl0v/wLaNw=";
+    hash = "sha256-1e+Y4nY61+BwGNCuBlAlf0Lpxj95di0iDrbmxlyAjVI=";
   };
 
   build-system = [

--- a/pkgs/servers/http/couchdb/3.nix
+++ b/pkgs/servers/http/couchdb/3.nix
@@ -5,7 +5,6 @@
   erlang,
   icu,
   openssl,
-  spidermonkey_91,
   python3,
   nixosTests,
 }:
@@ -20,8 +19,6 @@ stdenv.mkDerivation rec {
   };
 
   postPatch = ''
-    substituteInPlace src/couch/rebar.config.script --replace '/usr/include/mozjs-91' "${spidermonkey_91.dev}/include/mozjs-91"
-    substituteInPlace configure --replace '/usr/include/''${SM_HEADERS}' "${spidermonkey_91.dev}/include/mozjs-91"
     patchShebangs bin/rebar
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
@@ -37,14 +34,14 @@ stdenv.mkDerivation rec {
   buildInputs = [
     icu
     openssl
-    spidermonkey_91
     (python3.withPackages (ps: with ps; [ requests ]))
   ];
 
   dontAddPrefix = "True";
 
   configureFlags = [
-    "--spidermonkey-version=91"
+    "--js-engine=quickjs"
+    "--disable-spidermonkey"
   ];
 
   buildFlags = [

--- a/pkgs/tools/text/mdcat/default.nix
+++ b/pkgs/tools/text/mdcat/default.nix
@@ -22,6 +22,10 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-j6BFXx5cyjE3+fo1gGKlqpsxrm3i9HfQ9tJGNNjjLwo=";
   };
 
+  patches = [
+    ./fix-clippy.diff
+  ];
+
   nativeBuildInputs = [
     pkg-config
     asciidoctor

--- a/pkgs/tools/text/mdcat/fix-clippy.diff
+++ b/pkgs/tools/text/mdcat/fix-clippy.diff
@@ -1,0 +1,14 @@
+diff --git a/pulldown-cmark-mdcat/src/terminal/osc.rs b/pulldown-cmark-mdcat/src/terminal/osc.rs
+index 8fa2db6..dc2a2da 100644
+--- a/pulldown-cmark-mdcat/src/terminal/osc.rs
++++ b/pulldown-cmark-mdcat/src/terminal/osc.rs
+@@ -20,9 +20,6 @@ pub fn write_osc<W: Write + ?Sized>(writer: &mut W, command: &str) -> Result<()>
+     Ok(())
+ }
+ 
+-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+-pub struct Osc8Links;
+-
+ /// Whether the given `url` needs to get an explicit host.
+ ///
+ /// [OSC 8] links require that `file://` URLs give an explicit hostname, as

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2171,6 +2171,7 @@ mapAliases {
   # spidermonkey is not ABI upwards-compatible, so only allow this for nix-shell
   spidermonkey = throw "'spidermonkey' has been renamed to/replaced by 'spidermonkey_91'"; # Converted to throw 2024-10-17
   spidermonkey_78 = throw "'spidermonkey_78' has been removed because it was unused."; # Added 2025-02-02
+  spidermonkey_91 = throw "'spidermoney_91 has been EOL since 2022/09"; # Added 2025-08-26
   spidermonkey_102 = throw "'spidermonkey_102' is EOL since 2023/03"; # Added 2024-08-07
   spotify-unwrapped = spotify; # added 2022-11-06
   spring-boot = throw "'spring-boot' has been renamed to/replaced by 'spring-boot-cli'"; # Converted to throw 2024-10-17

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6372,12 +6372,10 @@ with pkgs;
 
   inherit
     ({
-      spidermonkey_91 = callPackage ../development/interpreters/spidermonkey/91.nix { };
       spidermonkey_115 = callPackage ../development/interpreters/spidermonkey/115.nix { };
       spidermonkey_128 = callPackage ../development/interpreters/spidermonkey/128.nix { };
       spidermonkey_140 = callPackage ../development/interpreters/spidermonkey/140.nix { };
     })
-    spidermonkey_91
     spidermonkey_115
     spidermonkey_128
     spidermonkey_140


### PR DESCRIPTION
It has been EOL for several years now, and the last dependant(couchdb3) no longer requires it as of #436932.

I've also removed all conditionals in the common.nix build file that were for versions older than 115, since we no longer ship any versions older than that. I would like to remove 115 and 128 soon as well, since as of commit, they reach end of life in 3 weeks(in fact, 115 is EOL for all platforms we support afaik). Also, I removed the `meta.broken` attribute, since that only talks about versions lower than 115, our current minimum. If it turns out some packages are still broken on darwin, I would be glad to add it back for the versions that need it.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
