### PR TITLE
pwdsphinx: init at 2.0.3

### DIFF
--- a/pkgs/by-name/pw/pwdsphinx/package.nix
+++ b/pkgs/by-name/pw/pwdsphinx/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  installShellFiles,
+  pandoc,
+  writableTmpDirAsHomeHook,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "pwdsphinx";
+  version = "2.0.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "stef";
+    repo = "pwdsphinx";
+    tag = "v${version}";
+    hash = "sha256-COSfA5QqIGWEnahmo5klFECK7XjyabGs1nG9vyhj/DM=";
+  };
+
+  postPatch = ''
+    substituteInPlace ./setup.py \
+      --replace-fail 'zxcvbn-python' 'zxcvbn'
+  '';
+
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies = with python3Packages; [
+    cbor2
+    pyequihash
+    pyoprf
+    pysodium
+    qrcodegen
+    securestring
+    zxcvbn
+  ];
+
+  # for man pages
+  nativeBuildInputs = [
+    installShellFiles
+    pandoc
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share/doc/pwdsphinx/
+    cp -r ./configs $out/share/doc/pwdsphinx/
+    installManPage man/*.1
+  '';
+
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  preCheck = ''
+    mkdir -p ~/.config/sphinx
+    cp ${src}/configs/config ~/.config/sphinx/config
+    # command fails without key but the command generates the key, so always pass
+    $out/bin/sphinx init || true
+  '';
+
+  pythonImportsCheck = [ "pwdsphinx" ];
+
+  meta = {
+    description = "Native backend for web-extensions for Sphinx-based password storage";
+    homepage = "https://www.ctrlc.hu/~stef/blog/posts/sphinx.html";
+    downloadPage = "https://github.com/stef/pwdsphinx";
+    changelog = "https://github.com/stef/pwdsphinx/releases/tag/v${version}";
+    teams = [ lib.teams.ngi ];
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "sphinx";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Closes: https://github.com/ngi-nix/projects/issues/1695

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
