### PR TITLE
python3Packages.ueberzug: limit to Linux

### DIFF
--- a/pkgs/development/python-modules/ueberzug/default.nix
+++ b/pkgs/development/python-modules/ueberzug/default.nix
@@ -50,12 +50,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "ueberzug" ];
 
-  meta = with lib; {
+  meta = {
     description = "Alternative for w3mimgdisplay";
     homepage = "https://github.com/ueber-devel/ueberzug";
     changelog = "https://github.com/ueber-devel/ueberzug/releases/tag/${version}";
-    license = licenses.gpl3Only;
+    license = lib.licenses.gpl3Only;
     mainProgram = "ueberzug";
-    maintainers = with maintainers; [ Br1ght0ne ];
+    maintainers = with lib.maintainers; [ Br1ght0ne ];
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
Starting with 18.2.0, [one of ueberzug's headers `#errors` if `__linux__` isn't defined][1]. Set `meta.platforms` to reflect this.

[1]: https://github.com/ueber-devel/ueberzug/blob/c7c151aec4fe31574a5a42b8b18eb5f80212ac00/ueberzug/X/python.h#L4-L6


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
