### PR TITLE
spidermonkey_91: drop

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -42,6 +42,8 @@
 
 - `kbd` package's `outputs` now include a `man` and `scripts` outputs. The `unicode_start` and `unicode_stop` Bash scripts are now part of the `scripts` output, allowing most usages of the `kbd` package to not pull in `bash`.
 
+- `spidermonkey_91` has been removed, as it has been EOL since September 2022.
+
 - `cudaPackages.cudatoolkit-legacy-runfile` has been removed.
 
 - `conduwuit` was removed due to upstream ceasing development and deleting their repository. For existing data, a migration to `matrix-conduit`, `matrix-continuwuity` or `matrix-tuwunel` may be possible.

--- a/pkgs/development/interpreters/spidermonkey/140-relax-apple-sdk.patch
+++ b/pkgs/development/interpreters/spidermonkey/140-relax-apple-sdk.patch
@@ -1,0 +1,13 @@
+diff --git a/build/moz.configure/toolchain.configure b/build/moz.configure/toolchain.configure
+index 37c00230c853..dd89bea24392 100644
+--- a/build/moz.configure/toolchain.configure
++++ b/build/moz.configure/toolchain.configure
+@@ -233,7 +233,7 @@ with only_when(host_is_osx | target_is_osx):
+     )
+ 
+     def mac_sdk_min_version():
+-        return "15.5"
++        return "15.2"
+ 
+     @depends(
+         "--with-macos-sdk",

--- a/pkgs/development/interpreters/spidermonkey/91.nix
+++ b/pkgs/development/interpreters/spidermonkey/91.nix
@@ -1,4 +1,0 @@
-import ./common.nix {
-  version = "91.13.0";
-  hash = "sha512-OLTMUt4h521gYea6F14cv9iIoWBwqpUfWkQoPy251+lPJQRiHw2nj+rG5xSRptDnA49j3QrhEtytcA6wLpqlFg==";
-}

--- a/pkgs/development/interpreters/spidermonkey/common.nix
+++ b/pkgs/development/interpreters/spidermonkey/common.nix
@@ -187,6 +187,8 @@ stdenv.mkDerivation (finalAttrs: {
       catap
       bobby285271
     ];
+    # ERROR: Failed to find an adequate linker
+    broken = lib.versionOlder version "128" && stdenv.hostPlatform.isDarwin;
     platforms = platforms.unix;
   };
 })

--- a/pkgs/development/interpreters/spidermonkey/common.nix
+++ b/pkgs/development/interpreters/spidermonkey/common.nix
@@ -8,13 +8,14 @@
   fetchpatch,
 
   # build time
+  apple-sdk_14,
+  apple-sdk_15,
   buildPackages,
   cargo,
   m4,
   perl,
   pkg-config,
   python3,
-  python311,
   rust-cbindgen,
   rustPlatform,
   rustc,
@@ -46,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches =
-    lib.optionals (lib.versionAtLeast version "102" && lib.versionOlder version "128") [
+    lib.optionals (lib.versionOlder version "128") [
       # use pkg-config at all systems
       ./always-check-for-pkg-config.patch
       ./allow-system-s-nspr-and-icu-on-bootstrapped-sysroot.patch
@@ -56,16 +57,9 @@ stdenv.mkDerivation (finalAttrs: {
       ./always-check-for-pkg-config-128.patch
       ./allow-system-s-nspr-and-icu-on-bootstrapped-sysroot-128.patch
     ]
-    ++ lib.optionals (lib.versionAtLeast version "91" && stdenv.hostPlatform.system == "i686-linux") [
+    ++ lib.optionals (stdenv.hostPlatform.system == "i686-linux") [
       # Fixes i686 build, https://bugzilla.mozilla.org/show_bug.cgi?id=1729459
       ./fix-float-i686.patch
-    ]
-    ++ lib.optionals (lib.versionAtLeast version "91" && lib.versionOlder version "102") [
-      # Fix 91 compatibility with python311
-      (fetchpatch {
-        url = "https://src.fedoraproject.org/rpms/mozjs91/raw/e3729167646775e60a3d8c602c0412e04f206baf/f/0001-Python-Build-Use-r-instead-of-rU-file-read-modes.patch";
-        hash = "sha256-WgDIBidB9XNQ/+HacK7jxWnjOF8PEUt5eB0+Aubtl48=";
-      })
     ]
     ++ lib.optionals (lib.versionAtLeast version "140") [
       # mozjs-140.pc does not contain -DXP_UNIX on Linux
@@ -81,9 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
     m4
     perl
     pkg-config
-    # 91 does not build with python 3.12: ModuleNotFoundError: No module named 'six.moves'
-    # 102 does not build with python 3.12: ModuleNotFoundError: No module named 'distutils'
-    (if lib.versionOlder version "115" then python311 else python3)
+    python3
     rustc
     rustc.llvmPackages.llvm # for llvm-objdump
     which
@@ -105,6 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     libiconv
+    (if (lib.versionAtLeast version "140") then apple-sdk_15 else apple-sdk_14)
   ];
 
   depsBuildBuild = [
@@ -125,8 +118,6 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-readline"
     "--enable-release"
     "--enable-shared-js"
-  ]
-  ++ lib.optionals (lib.versionAtLeast version "91") [
     "--disable-debug"
   ]
   ++ lib.optionals (lib.versionAtLeast version "140") [
@@ -151,16 +142,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  postPatch = lib.optionalString (lib.versionOlder version "102") ''
-    # This patch is a manually applied fix of
-    #   https://bugzilla.mozilla.org/show_bug.cgi?id=1644600
-    # Once that bug is fixed, this can be removed.
-    # This is needed in, for example, `zeroad`.
-    substituteInPlace js/public/StructuredClone.h \
-         --replace "class SharedArrayRawBufferRefs {" \
-                   "class JS_PUBLIC_API SharedArrayRawBufferRefs {"
-  '';
-
   preConfigure =
     lib.optionalString (lib.versionAtLeast version "128") ''
       export MOZBUILD_STATE_PATH=$TMPDIR/mozbuild
@@ -168,24 +149,11 @@ stdenv.mkDerivation (finalAttrs: {
     + ''
       export LIBXUL_DIST=$out
       export PYTHON="${buildPackages.python3.interpreter}"
-    ''
-    + lib.optionalString (lib.versionAtLeast version "91") ''
       export M4=m4
       export AWK=awk
       export AS=$CC
       export AC_MACRODIR=$PWD/build/autoconf/
-
-    ''
-    + lib.optionalString (lib.versionAtLeast version "91" && lib.versionOlder version "115") ''
-      pushd js/src
-      sh ../../build/autoconf/autoconf.sh --localdir=$PWD configure.in > configure
-      chmod +x configure
-      popd
-    ''
-    + lib.optionalString (lib.versionAtLeast version "115") ''
       patchShebangs build/cargo-linker
-    ''
-    + ''
       # We can't build in js/src/, so create a build dir
       mkdir obj
       cd obj/
@@ -217,7 +185,6 @@ stdenv.mkDerivation (finalAttrs: {
       catap
       bobby285271
     ];
-    broken = stdenv.hostPlatform.isDarwin; # 91 is broken, >=115 requires SDK 13.3 (see #242666).
     platforms = platforms.unix;
   };
 })

--- a/pkgs/development/interpreters/spidermonkey/common.nix
+++ b/pkgs/development/interpreters/spidermonkey/common.nix
@@ -68,6 +68,9 @@ stdenv.mkDerivation (finalAttrs: {
         url = "https://src.fedoraproject.org/rpms/mozjs140/raw/49492baa47bc1d7b7d5bc738c4c81b4661302f27/f/9aa8b4b051dd539e0fbd5e08040870b3c712a846.patch";
         hash = "sha256-SsyO5g7wlrxE7y2+VTHfmUDamofeZVqge8fv2y0ZhuU=";
       })
+    ]
+    ++ lib.optionals (lib.versionAtLeast version "140" && stdenv.hostPlatform.isDarwin) [
+      ./140-relax-apple-sdk.patch
     ];
 
   nativeBuildInputs = [

--- a/pkgs/development/interpreters/spidermonkey/common.nix
+++ b/pkgs/development/interpreters/spidermonkey/common.nix
@@ -68,8 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
         url = "https://src.fedoraproject.org/rpms/mozjs140/raw/49492baa47bc1d7b7d5bc738c4c81b4661302f27/f/9aa8b4b051dd539e0fbd5e08040870b3c712a846.patch";
         hash = "sha256-SsyO5g7wlrxE7y2+VTHfmUDamofeZVqge8fv2y0ZhuU=";
       })
-    ]
-    ++ lib.optionals (lib.versionAtLeast version "140" && stdenv.hostPlatform.isDarwin) [
+      # SDK 15.5 is not available in nixpkgs yet
       ./140-relax-apple-sdk.patch
     ];
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2181,6 +2181,7 @@ mapAliases {
   # spidermonkey is not ABI upwards-compatible, so only allow this for nix-shell
   spidermonkey = throw "'spidermonkey' has been renamed to/replaced by 'spidermonkey_91'"; # Converted to throw 2024-10-17
   spidermonkey_78 = throw "'spidermonkey_78' has been removed because it was unused."; # Added 2025-02-02
+  spidermonkey_91 = throw "'spidermonkey_91 is EOL since 2022/09"; # Added 2025-08-26
   spidermonkey_102 = throw "'spidermonkey_102' is EOL since 2023/03"; # Added 2024-08-07
   spotify-unwrapped = spotify; # added 2022-11-06
   spring-boot = throw "'spring-boot' has been renamed to/replaced by 'spring-boot-cli'"; # Converted to throw 2024-10-17

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6357,12 +6357,10 @@ with pkgs;
 
   inherit
     ({
-      spidermonkey_91 = callPackage ../development/interpreters/spidermonkey/91.nix { };
       spidermonkey_115 = callPackage ../development/interpreters/spidermonkey/115.nix { };
       spidermonkey_128 = callPackage ../development/interpreters/spidermonkey/128.nix { };
       spidermonkey_140 = callPackage ../development/interpreters/spidermonkey/140.nix { };
     })
-    spidermonkey_91
     spidermonkey_115
     spidermonkey_128
     spidermonkey_140


### PR DESCRIPTION
Fixed up version of #437376

It has been EOL for several years now, and the last dependant(couchdb3) no longer requires it as of #436932.

I've also removed all conditionals in the common.nix build file that were for versions older than 115, since we no longer ship any versions older than that. I would like to remove 115 and 128 soon as well, since as of commit, they reach end of life in 3 weeks(in fact, 115 is EOL for all platforms we support afaik). Also, I removed the `meta.broken` attribute, since that only talks about versions lower than 115, our current minimum. If it turns out some packages are still broken on darwin, I would be glad to add it back for the versions that need it.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
