### PR TITLE
luci-go: 0-unstable-2024-10-31 -> 0-unstable-2025-08-26

### DIFF
--- a/pkgs/by-name/lu/luci-go/package.nix
+++ b/pkgs/by-name/lu/luci-go/package.nix
@@ -2,22 +2,27 @@
   buildGoModule,
   fetchFromGitiles,
   lib,
+  git,
 }:
 let
-  commit = "500493c154652d6986a34b341e98df244ae1ad0d";
+  commit = "b6bffbd35b309667f3716491c3fa51fae5b6f169";
   git-repo = "https://chromium.googlesource.com/infra/luci/luci-go";
 in
 buildGoModule {
   pname = "luci-go";
-  version = "0-unstable-2024-10-31";
+  version = "0-unstable-2025-08-26";
 
   src = fetchFromGitiles {
     url = git-repo;
     rev = commit;
-    hash = "sha256-HP4Aizt5FJA3IAlqs7gylw8/xUbBwsmReGaR8jIkmrk=";
+    hash = "sha256-vKASbHcu50l/kAUI5yAjOssjRKjsx0VxKQB7b3HprSI=";
   };
 
-  vendorHash = "sha256-FMqbEls6MivPeReZTADrfcAvxo8o0Gy7bq9xG6WN38k=";
+  vendorHash = "sha256-4BiC5LI7mG7jCz2dt+Wj+MTqzif68C+TAf/0JNExuYg=";
+
+  preCheck = ''
+    export PATH="${git}/bin:$PATH"
+  '';
 
   checkFlags =
     let
@@ -31,6 +36,9 @@ buildGoModule {
         # require filesystem access
         "TestPythonBasic"
         "TestPythonFromPath"
+
+        # incompatible with our sandbox
+        "TestFindRoot"
       ];
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
@@ -40,7 +48,7 @@ buildGoModule {
     longDescription = ''
       LUCI services and tools in Go. This is part of Chromium infra and
       provides facilities useful for packaging software from the Chromium
-      ecosystem.
+      ecosystem. Provides cipd.
     '';
     homepage = "${git-repo}/";
     changelog = "${git-repo}/+log?s=${commit}";


### PR DESCRIPTION
Bumped to a new commit. @wolfgangwalther seems to urgently need an upgrade, and requested it off-band. Please check whether it suits you.

Closes #437435

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
