### PR TITLE
supernovas: init at 1.5.0

### DIFF
--- a/pkgs/by-name/su/supernovas/package.nix
+++ b/pkgs/by-name/su/supernovas/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  calceph,
+  withCalceph ? true,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "supernovas";
+  version = "1.5.0";
+
+  src = fetchFromGitHub {
+    owner = "smithsonian";
+    repo = "supernovas";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hv+OdLTzGp8y1yovZF+sSXiUi7bJx+a1V2ldsAHG9ME=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = lib.optionals withCalceph [ calceph ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "ENABLE_CALCEPH" withCalceph)
+    (lib.cmakeBool "BUILD_EXAMPLES" false)
+  ];
+
+  meta = {
+    description = "High-performance astrometry library for C/C++";
+    homepage = "https://smithsonian.github.io/SuperNOVAS/";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ kiranshila ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Initial packaging for [SuperNOVAS](https://github.com/Smithsonian/SuperNOVAS/) astrometry library for C/C++. Future PRs will include dependencies like [CALCEPH](https://www.imcce.fr/inpop/calceph/) for ephemeris integration.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
