### PR TITLE
ci/eval/compare: avoid CI failures on non-github maintainer records

### DIFF
--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -95,14 +95,20 @@ let
 
   attrsWithModifiedFiles = builtins.filter (pkg: anyMatchingFiles pkg.filenames) attrsWithFilenames;
 
+  # TODO: create ping lists for other contacts once non-GitHub ping
+  #  implementations get merged
   listToPing = lib.concatMap (
     pkg:
-    builtins.map (maintainer: {
-      id = maintainer.githubId;
-      inherit (maintainer) github;
-      packageName = pkg.name;
-      dueToFiles = pkg.filenames;
-    }) pkg.maintainers
+    builtins.map
+      (maintainer: {
+        id = maintainer.githubId;
+        inherit (maintainer) github;
+        packageName = pkg.name;
+        dueToFiles = pkg.filenames;
+      })
+      # TODO: If community consensus (e.g. an RFC) makes `githubId` mandatory,
+      #  simplify to `pkg.maintainers`
+      (builtins.filter (maintainer: maintainer ? githubId) pkg.maintainers)
   ) attrsWithModifiedFiles;
 
   byMaintainer = lib.groupBy (ping: toString ping.${if byName then "github" else "id"}) listToPing;


### PR DESCRIPTION
Filtering out maintainer records without a GitHub contact before computing the GitHub-specific ping list.

A well-formed maintainer records requires _either_ an e-mail, a matrix or a GitHub contact. However, the current CI implementation fails to evaluate if there is no GitHub contact, no matter whether the other contacts are present. This can lead to misleading CI messages (e.g. https://github.com/NixOS/nixpkgs/actions/runs/17257678120/job/48972816114?pr=437389) on a perfectly valid PR pointing to perfectly valid maintainer records. Inexperienced contributers might think they did something wrong, and inexperienced reviewers might think the PR is not worth looking at due to the CI failure.

This was already fixed in `ofborg` before (https://github.com/NixOS/ofborg/pull/665), but apparently the fix wasn't merged before the code was moved to `nixpkgs`.

Of course this does not replace the need to provide ping handlers for the other contact entry variants, which should be processed in separate PRs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
