### PR TITLE
_010editor: 16.0 -> 16.0.1

### DIFF
--- a/pkgs/by-name/_0/_010editor/package.nix
+++ b/pkgs/by-name/_0/_010editor/package.nix
@@ -7,13 +7,14 @@
   makeWrapper,
   makeDesktopItem,
   cups,
-  qt5,
+  qt6,
   undmg,
+  xorg,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "010editor";
-  version = "16.0";
+  version = "16.0.1";
 
   src = finalAttrs.passthru.srcs.${stdenv.hostPlatform.system};
 
@@ -27,14 +28,15 @@ stdenv.mkDerivation (finalAttrs: {
     lib.optionals stdenv.hostPlatform.isLinux [
       autoPatchelfHook
       makeWrapper
-      qt5.wrapQtAppsHook
+      qt6.wrapQtAppsHook
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ undmg ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     cups
-    qt5.qtbase
-    qt5.qtwayland
+    qt6.qtbase
+    qt6.qtwayland
+    xorg.xkeyboardconfig
   ];
 
   installPhase =
@@ -47,12 +49,12 @@ stdenv.mkDerivation (finalAttrs: {
       linuxInstall = ''
         mkdir -p $out/opt && cp -ar source/* $out/opt
 
-        # Use makeWrapper to clean environment and force xcb
+        # Wrap binary: clean env, fix XKB lookup
         makeWrapper $out/opt/010editor $out/bin/010editor \
           --unset QT_PLUGIN_PATH \
-          --set QT_QPA_PLATFORM xcb
+          --set XKB_CONFIG_ROOT ${xorg.xkeyboardconfig}/share/X11/xkb
 
-        # Copy the icon and generated desktop file
+        # Install icon + desktop entry
         install -D $out/opt/010_icon_128x128.png $out/share/icons/hicolor/128x128/apps/010.png
         install -D $desktopItem/share/applications/* -t $out/share/applications/
       '';
@@ -89,17 +91,17 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.srcs = {
     x86_64-linux = fetchzip {
       url = "https://download.sweetscape.com/010EditorLinux64Installer${finalAttrs.version}.tar.gz";
-      hash = "sha256-DK+AIk90AC/KjZR0yBMHaRF7ajuX+UvT8rqDVdL678M=";
+      hash = "sha256-fPQCVA9VrpNBTA7PiOsHwIiaZLKKoK817PtWNX8uHBQ=";
     };
 
     x86_64-darwin = fetchurl {
       url = "https://download.sweetscape.com/010EditorMac64Installer${finalAttrs.version}.dmg";
-      hash = "sha256-TWatSVqm9a+bVLXtJjiWAtkcB7qZqoeJ7Gmr62XUVz4=";
+      hash = "sha256-q/lfe4IWYJbxoGVBQju+t/w13UI3XHaVNPdTjnIQFw8=";
     };
 
     aarch64-darwin = fetchurl {
       url = "https://download.sweetscape.com/010EditorMacARM64Installer${finalAttrs.version}.dmg";
-      hash = "sha256-CtExBuu6EL8ilq3+gtwjNwnMxXkKgPdrk34tYvjN2ps=";
+      hash = "sha256-kBrYSxTNz01pPaRfKZWE6dDoACgs5tlfb+M6A7R0Vo4=";
     };
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog :
Fixed in the Check Sum dialog, the Ignore Byte Ranges checkbox was not visible.
Fixed a problem on Linux systems starting Wayland on certain Linux systems.
Fixed holding down shift and page down could cause the cursor to go off the end of the screen in some cases.
Fixed a bug drawing struct outlining on the last line of the hex editor.
Fixed a problem on Linux with the i3 window manager when drawing shadows.
Fixed a race condition running multiple templates at the same that contain a size function.
Added a warning to the installer about not supporting Windows versions before Window 10.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
