### PR TITLE
system.etc.overlay: handle case where bind mount is a symlink

### DIFF
--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -312,7 +312,9 @@ in
                   ${
                     if config.system.etc.overlay.mutable then
                       ''
-                        if [[ -f "$mountPoint" ]]; then
+                        if [[ -L "$mountPoint" ]]; then
+                          ln -s . "$tmpMountPoint"
+                        elif [[ -f "$mountPoint" ]]; then
                           touch "$tmpMountPoint"
                         elif [[ -d "$mountPoint" ]]; then
                           mkdir -p "$tmpMountPoint"
@@ -326,7 +328,7 @@ in
                         fi
                       ''
                   }
-                mount --bind "$mountPoint" "$tmpMountPoint"
+                mount --bind -o X-mount.nocanonicalize "$mountPoint" "$tmpMountPoint"
               done
 
               # Move the new temporary /etc mount underneath the current /etc mount.


### PR DESCRIPTION
util-linux now supports bind mounting symlinks over symlinks with mount --bind -o X-mount.nocanonicalize, so we should handle that as well.

This came out of my attempt to get timezone handling via bind mounts working.

## Things done

~~Still draft, because I didn't test this.~~
* Running my system with immutable etc and this patch

Ran the following tests successfully:
* nixosTests.activation-etc-overlay-mutable
* nixosTests.activation-etc-overlay-immutable


- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
