### PR TITLE
maintainers/README.md: clarify maintainer removal

### DIFF
--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -34,15 +34,15 @@ In order to do so, add yourself to the [`maintainer-list.nix`](./maintainer-list
 If you're adding yourself as a maintainer as part of another PR (in which you become a maintainer of a package, for example), make your change to
 `maintainer-list.nix` in a separate commit titled `maintainers: add <name>`.
 
-### How to lose maintainer status
+### Losing maintainer status
 
-Maintainers who have become inactive on a given package can be removed.
+Maintainers who have become inactive can be removed.
 This helps us keep an accurate view of the state of maintenance in Nixpkgs.
 
 The inactivity measure is currently not strictly enforced.
 We would typically look at it if we notice that the author hasn't reacted to package-related notifications for more than 3 months.
 
-Removing the maintainer happens by making a PR on the package, adding that person as a reviewer, and then waiting a week for a reaction.
+Removing the maintainer happens by making a PR, adding that person as a reviewer, and then waiting a week for a reaction.
 
 The maintainer is welcome to come back at any time.
 

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1,5 +1,5 @@
 /*
-  List of NixOS maintainers.
+  List of active NixOS maintainers.
    ```nix
    handle = {
      # Required


### PR DESCRIPTION
The wording on how to lose maintainer status implied that this was per package. While this is true, we also follow the same procedure for entirely inactive maintainers, dropping them from all packages, including their maintainer handle.

I'm a friend of making things shorter, this should leave enough room for interpretation of both.

Came up in https://github.com/NixOS/nixpkgs/pull/437082#issuecomment-3226916678.

Do we need to make it clearer or is that OK?

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
