### PR TITLE
consul-alerts: fix meta description

### DIFF
--- a/pkgs/by-name/co/consul-alerts/package.nix
+++ b/pkgs/by-name/co/consul-alerts/package.nix
@@ -25,7 +25,7 @@ buildGoModule rec {
 
   meta = with lib; {
     mainProgram = "consul-alerts";
-    description = "A highly available daemon for sending notifications and reminders based on Consul health checks";
+    description = "Highly available daemon for sending notifications and reminders based on Consul health checks";
     homepage = "https://github.com/AcalephStorage/consul-alerts";
     # As per README
     platforms = platforms.linux ++ platforms.freebsd ++ platforms.darwin;

--- a/pkgs/by-name/co/consul-alerts/package.nix
+++ b/pkgs/by-name/co/consul-alerts/package.nix
@@ -25,7 +25,7 @@ buildGoModule rec {
 
   meta = with lib; {
     mainProgram = "consul-alerts";
-    description = "Extendable open source continuous integration server";
+    description = "A highly available daemon for sending notifications and reminders based on Consul health checks";
     homepage = "https://github.com/AcalephStorage/consul-alerts";
     # As per README
     platforms = platforms.linux ++ platforms.freebsd ++ platforms.darwin;


### PR DESCRIPTION
Updated description in consul-alerts meta as it had been copied from [jenkins](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/je/jenkins/package.nix#L78) and did not properly describe the package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
