### PR TITLE
nixos/systemd: introduce settingsToSections util, migrate existing rfc42 options to use settingsToSections, migrate oomd to rfc42

### DIFF
--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -349,6 +349,15 @@ rec {
       )
     );
 
+  settingsToSections =
+    settings:
+    concatStringsSep "\n" (
+      mapAttrsToList (section_name: section_attrs: ''
+        [${section_name}]
+        ${attrsToSection section_attrs}
+      '') settings
+    );
+
   generateUnits =
     {
       allowCollisions ? true,

--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -732,10 +732,7 @@ rec {
 
   commonUnitText =
     def: lines:
-    ''
-      [Unit]
-      ${attrsToSection def.unitConfig}
-    ''
+    (settingsToSections { Unit = def.unitConfig; })
     + lines
     + optionalString (def.wantedBy != [ ]) ''
 
@@ -753,10 +750,7 @@ rec {
       enable
       overrideStrategy
       ;
-    text = ''
-      [Unit]
-      ${attrsToSection def.unitConfig}
-    '';
+    text = (settingsToSections { Unit = def.unitConfig; });
   };
 
   serviceToUnit = def: {
@@ -840,10 +834,9 @@ rec {
       enable
       overrideStrategy
       ;
-    text = commonUnitText def ''
-      [Timer]
-      ${attrsToSection def.timerConfig}
-    '';
+    text = commonUnitText def (settingsToSections {
+      Timer = def.timerConfig;
+    });
   };
 
   pathToUnit = def: {
@@ -856,10 +849,9 @@ rec {
       enable
       overrideStrategy
       ;
-    text = commonUnitText def ''
-      [Path]
-      ${attrsToSection def.pathConfig}
-    '';
+    text = commonUnitText def (settingsToSections {
+      Path = def.pathConfig;
+    });
   };
 
   mountToUnit = def: {
@@ -872,10 +864,9 @@ rec {
       enable
       overrideStrategy
       ;
-    text = commonUnitText def ''
-      [Mount]
-      ${attrsToSection def.mountConfig}
-    '';
+    text = commonUnitText def (settingsToSections {
+      Mount = def.mountConfig;
+    });
   };
 
   automountToUnit = def: {
@@ -888,10 +879,9 @@ rec {
       enable
       overrideStrategy
       ;
-    text = commonUnitText def ''
-      [Automount]
-      ${attrsToSection def.automountConfig}
-    '';
+    text = commonUnitText def (settingsToSections {
+      Automount = def.automountConfig;
+    });
   };
 
   sliceToUnit = def: {
@@ -904,10 +894,9 @@ rec {
       enable
       overrideStrategy
       ;
-    text = commonUnitText def ''
-      [Slice]
-      ${attrsToSection def.sliceConfig}
-    '';
+    text = commonUnitText def (settingsToSections {
+      Slice = def.sliceConfig;
+    });
   };
 
   # Create a directory that contains systemd definition files from an attrset

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -24,7 +24,7 @@ let
     mountToUnit
     automountToUnit
     sliceToUnit
-    attrsToSection
+    settingsToSections
     ;
 
   upstreamSystemUnits = [
@@ -598,10 +598,7 @@ in
           upstreamWants = upstreamSystemWants;
         };
 
-        "systemd/system.conf".text = ''
-          [Manager]
-          ${attrsToSection cfg.settings.Manager}
-        '';
+        "systemd/system.conf".text = settingsToSections cfg.settings;
 
         "systemd/sleep.conf".text = ''
           [Sleep]

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -22,7 +22,7 @@ let
     timerToUnit
     mountToUnit
     automountToUnit
-    attrsToSection
+    settingsToSections
     ;
 
   cfg = config.boot.initrd.systemd;
@@ -485,10 +485,7 @@ in
         "/init".source = "${cfg.package}/lib/systemd/systemd";
         "/etc/systemd/system".source = stage1Units;
 
-        "/etc/systemd/system.conf".text = ''
-          [Manager]
-          ${attrsToSection cfg.settings.Manager}
-        '';
+        "/etc/systemd/system.conf".text = settingsToSections cfg.settings;
 
         # We can use either ! or * to lock the root account in the
         # console, but some software like OpenSSH won't even allow you

--- a/nixos/modules/system/boot/systemd/logind.nix
+++ b/nixos/modules/system/boot/systemd/logind.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   utils,
   ...
 }:
@@ -62,10 +61,8 @@
       "user-runtime-dir@.service"
     ];
 
-    environment.etc."systemd/logind.conf".text = ''
-      [Login]
-      ${utils.systemdUtils.lib.attrsToSection config.services.logind.settings.Login}
-    '';
+    environment.etc."systemd/logind.conf".text =
+      utils.systemdUtils.lib.settingsToSections config.services.logind.settings;
 
     # Restarting systemd-logind breaks X11
     # - upstream commit: https://cgit.freedesktop.org/xorg/xserver/commit/?id=dc48bd653c7e101

--- a/nixos/modules/system/boot/systemd/oomd.nix
+++ b/nixos/modules/system/boot/systemd/oomd.nix
@@ -36,20 +36,6 @@ in
       '';
       type = lib.types.submodule {
         freeformType = lib.types.attrsOf utils.systemdUtils.unitOptions.unitOption;
-        options.DefaultMemoryPressureDurationSec = lib.mkOption {
-          type = lib.types.nonEmptyStr;
-          default = "20s";
-          description = ''
-            Sets the amount of time a unit's control group needs to have exceeded memory pressure limits before systemd-oomd will take action.
-            A unit can override this value with ManagedOOMMemoryPressureDurationSec=.
-            Memory pressure limits are defined by DefaultMemoryPressureLimit= and ManagedOOMMemoryPressureLimit=.
-            Must be set to 0, or at least 1 second. Defaults to 30 seconds when unset or 0.
-
-            See {manpage}`oomd.conf(5)` for more details.
-
-            Set to default to 20s in NixOS following the default set by Fedora.
-          '';
-        };
       };
       default = { };
       example = {


### PR DESCRIPTION
- added `settingsToSections` util
- migrated existing unit serializers to use `settingsToSections` where applicable
- migrated `services.logind.settings`, `systemd.settings` and `boot.initrd.systemd.settings` to use `settingsToSections`
- migrated `systemd.oomd.extraConfig` to `systemd.oomd.settings.OOM`
  - uses `settingsToSections` for serialization
  - aligned `DefaultMemoryPressureDurationSec` default with upstream systemd
  - actually respects the systemd specifics instead of using ini writer

Verified by evaluating a couple systemd tests to ensure these changes are zero-test-rebuild.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
