### PR TITLE
valkey: make compatible with `services.redis` module

### DIFF
--- a/nixos/tests/redis.nix
+++ b/nixos/tests/redis.nix
@@ -10,7 +10,7 @@ let
   mkTestName =
     pkg: "${pkg.pname}_${builtins.replaceStrings [ "." ] [ "" ] (lib.versions.majorMinor pkg.version)}";
   redisPackages = {
-    inherit (pkgs) redis keydb;
+    inherit (pkgs) redis keydb valkey;
   };
   makeRedisTest =
     {

--- a/pkgs/by-name/va/valkey/package.nix
+++ b/pkgs/by-name/va/valkey/package.nix
@@ -6,6 +6,7 @@
   lua,
   jemalloc,
   pkg-config,
+  nixosTests,
   tcl,
   which,
   ps,
@@ -116,7 +117,10 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postCheck
   '';
 
-  passthru.serverBin = "valkey-server";
+  passthru = {
+    tests.redis = nixosTests.redis;
+    serverBin = "valkey-server";
+  };
 
   meta = with lib; {
     homepage = "https://valkey.io/";

--- a/pkgs/by-name/va/valkey/package.nix
+++ b/pkgs/by-name/va/valkey/package.nix
@@ -116,6 +116,8 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postCheck
   '';
 
+  passthru.serverBin = "valkey-server";
+
   meta = with lib; {
     homepage = "https://valkey.io/";
     description = "High-performance data structure server that primarily serves key/value workloads";


### PR DESCRIPTION
The `services.redis` NixOS module has a `package` option that lets you override the redis server package with a package that has a `serverBin` passthru attribute.

This PR:

- Adds a `passthru.serverBin` attribute to the `valkey` package.
- Adds `valkey` to the `nixosTests.redis` test suite.
- Adds `nixosTests.redis` to the `valkey` passtru tests (as has been done for the `redis` and `keydb` packages).

Tested locally by running:

```console
nix build .#valkey.tests.redis.valkey
```

Related: 

- #315557

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
