### PR TITLE
maintainers.tomkoid: add github

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26049,6 +26049,8 @@
   };
   tomkoid = {
     email = "tomaszierl@outlook.com";
+    github = "tomkoid";
+    githubId = 67477750;
     name = "Tomkoid";
   };
   Tommimon = {


### PR DESCRIPTION
Once #437469 is merged, `github` / `githubId` will be required for maintainer entries.

`tomkoid` currently doesn't have one and we can fix it in two ways: Either add the github data or drop the maintainer. This PR implements *both* changes, please look at the individual commits, not the overall diff. I intend to drop either the first commit or the last commit before merge.

@tomkoid the decision is yours. Without feedback for 7 days, we'd drop your maintainer handle, because we shouldn't be adding data to it without your consent. Of course, even if that's the case, you can always be added again (with complete data ofc). So even if you'd miss this notification and only find out about it later, no problem.

Related: https://github.com/NixOS/nixpkgs/pull/261671#discussion_r2300534141

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
