### PR TITLE
plowshare: upgrade spidermonkey dependency; modernize

### DIFF
--- a/pkgs/by-name/pl/plowshare/package.nix
+++ b/pkgs/by-name/pl/plowshare/package.nix
@@ -2,10 +2,10 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  makeWrapper,
+  makeBinaryWrapper,
   curl,
   recode,
-  spidermonkey_115,
+  spidermonkey_140,
 }:
 
 stdenv.mkDerivation rec {
@@ -17,10 +17,10 @@ stdenv.mkDerivation rec {
     owner = "mcrapet";
     repo = "plowshare";
     rev = "v${version}";
-    sha256 = "1p8s60dlzaldp006yj710s371aan915asyjhd99188vrj4jj1x79";
+    hash = "sha256-6fQgJZF5IxRSalB6rUpIVqlwhgbhSG8AuI2qTxswGt0=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeBinaryWrapper ];
 
   dontBuild = true;
 
@@ -32,16 +32,15 @@ stdenv.mkDerivation rec {
         lib.makeBinPath [
           curl
           recode
-          spidermonkey_115
+          spidermonkey_140
         ]
       }"
     done
   '';
 
   meta = {
-    description = ''
-      A command-line download/upload tool for popular file sharing websites
-    '';
+    description = "Command-line download/upload tool for popular file sharing websites";
+    homepage = "https://github.com/mcrapet/plowshare";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ aforemny ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
Spidermonkey 115 goes EOL in 3 weeks from this commit, so we want to upgrade all dependants before then in preparation. plowshare does not require a specific version, as it uses the CLI tool, so it's easy to upgrade. I also modernized the code, using makeBinaryWrapper instead of makeWrapper, and added a homepage for the package as well.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
