### PR TITLE
haskellPackages.postgrest: fix build; 13.04 -> 13.0.5

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2731,6 +2731,8 @@ with haskellLib;
           hasql-notifications = dontCheck super.hasql-notifications_0_2_2_2;
           hasql-pool = dontCheck super.hasql-pool_1_0_1;
           hasql-transaction = dontCheck super.hasql-transaction_1_1_0_1;
+          text-builder = super.text-builder_0_6_10;
+          text-builder-dev = super.text-builder-dev_0_3_10;
         }
       ))
       [

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2750,12 +2750,12 @@ with haskellLib;
         doJailbreak
         # 2022-12-02: Hackage release lags behind actual releases: https://github.com/PostgREST/postgrest/issues/2275
         (overrideSrc rec {
-          version = "13.0.4";
+          version = "13.0.5";
           src = pkgs.fetchFromGitHub {
             owner = "PostgREST";
             repo = "postgrest";
             rev = "v${version}";
-            hash = "sha256-Y9Nxfs2w3Iinx61Om7dd+R8TTsK12oWD+3vki3WUz9Y=";
+            hash = "sha256-5gBXQPU1pMwbpL+6DnWzAnilohH0JETNkES6sBP8tdM=";
           };
         })
       ];

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -121,6 +121,8 @@ extra-packages:
   - tar == 0.6.0.0                      # 2025-02-08: last version to not require os-string (which can't be built with GHC < 9.2)
   - tar == 0.6.3.0                      # 2025-08-17: last version to not require file-io and directory-ospath-streaming (for GHC < 9.6)
   - text == 2.0.2                       # 2023-09-14: Needed for elm (which is currently on ghc-8.10)
+  - text-builder < 1                    # 2025-08-27: Needed for building postgrest
+  - text-builder-dev < 0.4              # 2025-08-27: Needed for building postgrest
   - text-metrics < 0.3.3                # 2025-02-08: >= 0.3.3 uses GHC2021
   - versions < 6                        # 2024-04-22: required by spago-0.21
   - weeder == 2.2.*                     # 2022-02-21: preserve for GHC 8.10.7


### PR DESCRIPTION
`text-builder` had a major release v1, with many breaking changes. We already pin an older version of `hasql`, which is not going to be updated anymore, thus pinning older versions of `text-builder` as well.

text-builder 0.6.10 needs text-builder-dev < 0.4, so pinning that as well.

The build for `pkgsStatic` is failing due to a failure of `postgresql` / `libpq` in `pkgsStatic`. This is unlikely to be fixed soon, so out of scope for here.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
