### PR TITLE
python3Packages.rtslib-fb: fix build failures

### DIFF
--- a/pkgs/development/python-modules/rtslib-fb/default.nix
+++ b/pkgs/development/python-modules/rtslib-fb/default.nix
@@ -16,12 +16,6 @@ buildPythonPackage rec {
   version = "2.2.3";
   pyproject = true;
 
-  # TypeError: 'method' object does not support the context manager protocol
-  postPatch = ''
-    substituteInPlace rtslib/root.py \
-      --replace-fail "Path(restore_file).open" "Path(restore_file).open('r')"
-  '';
-
   src = fetchFromGitHub {
     owner = "open-iscsi";
     repo = "rtslib-fb";
@@ -37,10 +31,6 @@ buildPythonPackage rec {
   dependencies = [
     pyudev
   ];
-
-  postInstall = ''
-    install -Dm555 scripts/targetctl -t $out/bin
-  '';
 
   # No tests
   doCheck = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The `postInstall` in this derivation isn't necessary anymore, since the build system correctly sets up the binary in the new version. It was also causing build failures, since the location of that file moved in 2.2.3.

The `postPatch` step also seems to no longer be necessary, and leaving it causes the program to fail at runtime.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
