### PR TITLE
git-branchless: fix build (broken by rust 1.89)

### DIFF
--- a/pkgs/by-name/gi/git-branchless/fix-esl01-indexedlog-for-rust-1_89.patch
+++ b/pkgs/by-name/gi/git-branchless/fix-esl01-indexedlog-for-rust-1_89.patch
@@ -1,0 +1,18 @@
+diff --git a/src/lock.rs b/src/lock.rs
+--- a/src/lock.rs
++++ b/src/lock.rs
+@@ -132,10 +132,10 @@ impl ScopedDirLock {
+ 
+         // Lock
+         match (opts.exclusive, opts.non_blocking) {
+-            (true, false) => file.lock_exclusive(),
+-            (true, true) => file.try_lock_exclusive(),
+-            (false, false) => file.lock_shared(),
+-            (false, true) => file.try_lock_shared(),
++            (true, false) => fs2::FileExt::lock_exclusive(&file),
++            (true, true) => fs2::FileExt::try_lock_exclusive(&file),
++            (false, false) => fs2::FileExt::lock_shared(&file),
++            (false, true) => fs2::FileExt::try_lock_shared(&file),
+         }
+         .context(&path, || {
+             format!(

--- a/pkgs/by-name/gi/git-branchless/package.nix
+++ b/pkgs/by-name/gi/git-branchless/package.nix
@@ -21,6 +21,20 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-8uv+sZRr06K42hmxgjrKk6FDEngUhN/9epixRYKwE3U=";
   };
 
+  # Patch the vendored esl01-indexedlog crate.
+  # This is necessary to fix the build for rust 1.89. See:
+  # - https://github.com/NixOS/nixpkgs/issues/437051
+  # - https://github.com/arxanas/git-branchless/issues/1585
+  # - https://github.com/facebook/sapling/issues/1119
+  # The patch is derived from:
+  # - https://github.com/facebook/sapling/commit/9e27acb84605079bf4e305afb637a4d6801831ac
+  postPatch = ''
+    (
+      cd ../git-branchless-*-vendor/esl01-indexedlog-*/
+      patch -p1 < ${./fix-esl01-indexedlog-for-rust-1_89.patch}
+    )
+  '';
+
   cargoHash = "sha256-i7KpTd4fX3PrhDjj3R9u98rdI0uHkpQCxSmEF+Gu7yk=";
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/437051.

Patch the vendored esl01-indexedlog crate, which is necessary to fix the build for rust 1.89. See:
- https://github.com/NixOS/nixpkgs/issues/437051
- https://github.com/arxanas/git-branchless/issues/1585
- https://github.com/facebook/sapling/issues/1119

The patch is derived from https://github.com/facebook/sapling/commit/9e27acb84605079bf4e305afb637a4d6801831ac. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
