### PR TITLE
sqlite: enable limit-on-update/delete

### DIFF
--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -83,6 +83,8 @@ stdenv.mkDerivation rec {
     "--includedir=${placeholder "dev"}/include"
     "--libdir=${placeholder "out"}/lib"
     (if stdenv.hostPlatform.isStatic then "--disable-tcl" else "--with-tcl=${lib.getLib tcl}/lib")
+    # Enabling limit-on-update/delete by adding -DSQLITE_ENABLE_UPDATE_DELETE_LIMIT to NIX_CFLAGS_COMPILE does not work: the lemon parser generator (built early in buildPhase) doesn't receive the flag when it's invoked, as it's not been wrapped with Nix magic.
+    "--enable-update-limit"
   ]
   ++ lib.optional (!interactive) "--disable-readline"
   # autosetup only looks up readline.h in predefined set of directories.


### PR DESCRIPTION
Limit-on-update/delete is useful for, amongst other things, bounding the  amount of work done in a single SQL statement. It is not enabled by  upstream by default, but Debian does enable it.

The 'amalgamation'/autoconf distribution from upstream includes  pregenerated parser files. Enabling limit-on-update requires changes to  the parser, so rather than the provided amalgamation we have to go for  the original source files to get the parser generator to run.  Conveniently, the pristine source is already used as an input to  tools.nix, so it might even save a download in some cases!

Because the parser generator doesn't receive NIX_CFLAGS_COMPILE, the  setting has to go through the --enable-update-limit configure flag.  Maybe in the future, if this derivation moves to e.g. CFLAGS, this  feature enablement can be made uniform with the others.

## Things not done yet but which might need doing

- [x] I'm anticipating needing to retarget staging, but I'll at least have a look what the damage is like first.
- [ ] Is this too minor for a release note? Currently thinking 'yes, too minor', but willing to be told otherwise.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
