### PR TITLE
python-qt: disable vulnerable Qt5 webengine by default, add Qt6 support, clean, adopt

### DIFF
--- a/pkgs/by-name/ge/gepetto-viewer/package.nix
+++ b/pkgs/by-name/ge/gepetto-viewer/package.nix
@@ -121,6 +121,7 @@ let
       maintainers = [ lib.maintainers.nim65s ];
       mainProgram = "gepetto-gui";
       platforms = lib.platforms.unix;
+      broken = true;
     };
   });
 in

--- a/pkgs/development/libraries/python-qt/default.nix
+++ b/pkgs/development/libraries/python-qt/default.nix
@@ -36,6 +36,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     qmake
+  ];
+
+  buildInputs = [
+    python3
     qtdeclarative
     qtsvg
     qttools
@@ -47,8 +51,6 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals (!qt6Support) [
     qtxmlpatterns
   ];
-
-  buildInputs = [ python3 ];
 
   env.QTDIR = "${qtbase}"; # Used to find qtcoreversion.h
 

--- a/pkgs/development/libraries/python-qt/default.nix
+++ b/pkgs/development/libraries/python-qt/default.nix
@@ -7,6 +7,8 @@
   qtwebengine,
   qtxmlpatterns,
   qttools,
+
+  withWebengine ? false, # vulnerable, so disabled by default
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -24,6 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
     qmake
     qttools
     qtxmlpatterns
+  ]
+  ++ lib.optionals withWebengine [
     qtwebengine
   ];
 

--- a/pkgs/development/libraries/python-qt/default.nix
+++ b/pkgs/development/libraries/python-qt/default.nix
@@ -25,14 +25,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "python${lib.versions.majorMinor pyVersion}-qt${lib.versions.major qtVersion}";
-  version = "3.6.1-unstable-2025-11-20";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
     owner = "MeVisLab";
     repo = "pythonqt";
-    # tag = "v${finalAttrs.version}";
-    rev = "fd97b4b2ca5fc94a3219b002aadfbe2e8c89f59d";
-    hash = "sha256-BAuvs23VBKt6g5gpAtMUPyikL+D3sMEpch1BLICUotc=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-toN8VOPvkDTHdGRXZsU5znQ4PhbdFTK3eLi3g29736A=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/python-qt/default.nix
+++ b/pkgs/development/libraries/python-qt/default.nix
@@ -24,7 +24,7 @@ let
   versions = "Qt${lib.versions.major qtVersion}-Python${lib.versions.majorMinor pyVersion}";
 in
 stdenv.mkDerivation (finalAttrs: {
-  pname = "python-qt";
+  pname = "python${lib.versions.majorMinor pyVersion}-qt${lib.versions.major qtVersion}";
   version = "3.6.1-unstable-2025-11-20";
 
   src = fetchFromGitHub {
@@ -54,6 +54,12 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   env.QTDIR = "${qtbase}"; # Used to find qtcoreversion.h
+
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace src/src.pro --replace-fail \
+      "QMAKE_APPLE_DEVICE_ARCHS = x86_64 arm64" \
+      "QMAKE_APPLE_DEVICE_ARCHS = ${stdenv.hostPlatform.darwinArch}"
+  '';
 
   # generated cpp is available for many Qt5 versions but not Qt6
   # ref. https://github.com/MeVisLab/pythonqt#binding-generator

--- a/pkgs/development/libraries/python-qt/default.nix
+++ b/pkgs/development/libraries/python-qt/default.nix
@@ -1,16 +1,28 @@
 {
   lib,
   stdenv,
+
   fetchFromGitHub,
+
   python3,
   qmake,
-  qtwebengine,
-  qtxmlpatterns,
-  qttools,
 
-  withWebengine ? false, # vulnerable, so disabled by default
+  qt5compat ? null,
+  qtbase,
+  qtdeclarative,
+  qtsvg,
+  qttools,
+  qtwebengine,
+  qtxmlpatterns ? null,
+
+  qt6Support ? false,
 }:
 
+let
+  qtVersion = lib.getVersion qtbase;
+  pyVersion = lib.getVersion python3;
+  versions = "Qt${lib.versions.major qtVersion}-Python${lib.versions.majorMinor pyVersion}";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "python-qt";
   version = "3.6.1";
@@ -24,18 +36,50 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     qmake
+    qtdeclarative
+    qtsvg
     qttools
-    qtxmlpatterns
   ]
-  ++ lib.optionals withWebengine [
-    qtwebengine
+  ++ lib.optionals qt6Support [
+    qt5compat
+    qtwebengine # optional and vulnerable in Qt5
+  ]
+  ++ lib.optionals (!qt6Support) [
+    qtxmlpatterns
   ];
 
   buildInputs = [ python3 ];
 
+  env.QTDIR = "${qtbase}"; # Used to find qtcoreversion.h
+
+  # generated cpp is available for many Qt5 versions but not Qt6
+  # ref. https://github.com/MeVisLab/pythonqt#binding-generator
+  preConfigure = lib.optionalString qt6Support (
+    let
+      includePaths = lib.concatMapStringsSep ":" (p: "${p}/include") [
+        qtbase
+        qtdeclarative
+        qtsvg
+        qttools
+        qtwebengine
+      ];
+    in
+    ''
+      pushd generator
+      qmake $qmakeFlags CONFIG+=Release generator.pro
+      make -j $NIX_BUILD_CORES
+      ./pythonqt_generator \
+        --include-paths=${includePaths} \
+        --qt-version=${qtVersion} \
+        qtscript_masterinclude.h \
+        build_all.txt
+      popd
+    ''
+  );
+
   qmakeFlags = [
     "PYTHON_DIR=${python3}"
-    "PYTHON_VERSION=3.${python3.sourceVersion.minor}"
+    "PYTHON_VERSION=${lib.versions.majorMinor pyVersion}"
   ];
 
   dontWrapQtApps = true;
@@ -49,20 +93,20 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   preFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    install_name_tool -id \
-      $out/lib/libPythonQt-Qt5-Python3.${python3.sourceVersion.minor}.dylib \
-      $out/lib/libPythonQt-Qt5-Python3.${python3.sourceVersion.minor}.dylib
-    install_name_tool -change \
-               libPythonQt-Qt5-Python3.${python3.sourceVersion.minor}.3.dylib \
-      $out/lib/libPythonQt-Qt5-Python3.${python3.sourceVersion.minor}.3.dylib \
-      -id \
-      $out/lib/libPythonQt_QtAll-Qt5-Python3.${python3.sourceVersion.minor}.dylib \
-      $out/lib/libPythonQt_QtAll-Qt5-Python3.${python3.sourceVersion.minor}.dylib
+    install_name_tool \
+      -id $out/lib/libPythonQt-${versions}.dylib \
+          $out/lib/libPythonQt-${versions}.dylib
+
+    install_name_tool \
+      -change      libPythonQt-${versions}.3.dylib \
+          $out/lib/libPythonQt-${versions}.3.dylib \
+      -id $out/lib/libPythonQt_QtAll-${versions}.dylib \
+          $out/lib/libPythonQt_QtAll-${versions}.dylib
   '';
 
   meta = {
     description = "PythonQt is a dynamic Python binding for the Qt framework. It offers an easy way to embed the Python scripting language into your C++ Qt applications";
-    homepage = "https://pythonqt.sourceforge.net/";
+    homepage = "https://mevislab.github.io/pythonqt/";
     license = lib.licenses.lgpl21;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ hlolli ];

--- a/pkgs/development/libraries/python-qt/default.nix
+++ b/pkgs/development/libraries/python-qt/default.nix
@@ -111,7 +111,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://mevislab.github.io/pythonqt/";
     license = lib.licenses.lgpl21;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ hlolli ];
+    maintainers = with lib.maintainers; [
+      hlolli
+      nim65s
+    ];
     # ref. https://github.com/MeVisLab/pythonqt/issues/276
     broken = stdenv.hostPlatform.isDarwin && qt6Support;
   };

--- a/pkgs/development/libraries/python-qt/default.nix
+++ b/pkgs/development/libraries/python-qt/default.nix
@@ -25,13 +25,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "python-qt";
-  version = "3.6.1";
+  version = "3.6.1-unstable-2025-11-20";
 
   src = fetchFromGitHub {
     owner = "MeVisLab";
     repo = "pythonqt";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-OYFQtDGq+d32RQ0vChRKH//O9QgQPLMd1he8X3zCi+U=";
+    # tag = "v${finalAttrs.version}";
+    rev = "fd97b4b2ca5fc94a3219b002aadfbe2e8c89f59d";
+    hash = "sha256-BAuvs23VBKt6g5gpAtMUPyikL+D3sMEpch1BLICUotc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/python-qt/default.nix
+++ b/pkgs/development/libraries/python-qt/default.nix
@@ -110,5 +110,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl21;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ hlolli ];
+    # ref. https://github.com/MeVisLab/pythonqt/issues/276
+    broken = stdenv.hostPlatform.isDarwin && qt6Support;
   };
 })

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15403,6 +15403,8 @@ self: super: with self; {
 
   python-qt = toPythonModule (pkgs.python-qt.override { python3 = self.python; });
 
+  python-qt-qt6 = toPythonModule (pkgs.qt6Packages.python-qt.override { python3 = self.python; });
+
   python-rabbitair = callPackage ../development/python-modules/python-rabbitair { };
 
   python-rapidjson = callPackage ../development/python-modules/python-rapidjson { };

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -154,6 +154,8 @@ makeScopeWithSplicing' {
 
         pulseaudio-qt = callPackage ../development/libraries/pulseaudio-qt { };
 
+        python-qt = callPackage ../development/libraries/python-qt { };
+
         qca = callPackage ../development/libraries/qca {
           inherit (libsForQt5) qtbase;
         };

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -134,6 +134,10 @@ makeScopeWithSplicing' {
         suffix = "qt6";
       };
 
+      python-qt = callPackage ../development/libraries/python-qt {
+        qt6Support = true;
+      };
+
       sailfish-access-control-plugin =
         callPackage ../development/libraries/sailfish-access-control-plugin
           { };


### PR DESCRIPTION
webengine is optional:

```
extensions/PythonQt_QtAll/PythonQt_QtAll.pro
24:  qtHaveModule(webenginewidgets):CONFIG += PythonQtWebEngineWidgets
```

So disable it by default to fix build
following https://github.com/NixOS/nixpkgs/pull/435067

edit: while here, let's get a Qt6 version, where qtwebengine is still maintained.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
