### PR TITLE
ma: 11 -> 13

### DIFF
--- a/pkgs/by-name/ma/ma/package.nix
+++ b/pkgs/by-name/ma/ma/package.nix
@@ -7,15 +7,15 @@
 
 stdenv.mkDerivation {
   pname = "ma";
-  version = "11";
+  version = "13";
 
   src = fetchurl {
-    url = "https://web.archive.org/web/20250511210225/http://call-with-current-continuation.org/ma/ma.tar.gz";
-    hash = "sha256-1UVxXbN2jSNm13BjyoN3jbKtkO3DUEEHaDOC2Ibbxf4=";
+    url = "https://web.archive.org/web/20250829110226/http://call-with-current-continuation.org/ma/ma.tar.gz";
+    hash = "sha256-QNt4ctcu4/xJY2eud+kp5paPUnLsRhK7D2nJ0LBIvIo=";
   };
 
   postPatch = ''
-    substituteInPlace ./build --replace-fail gcc ${lib.getExe stdenv.cc}
+    substituteInPlace ./build --replace-fail cc ${lib.getExe stdenv.cc}
   '';
 
   buildInputs = [
@@ -43,6 +43,7 @@ stdenv.mkDerivation {
     description = "Minimalistic variant of the Acme editor";
     homepage = "http://call-with-current-continuation.org/ma/ma.html";
     mainProgram = "ma";
+    maintainers = [ lib.maintainers.sternenseemann ];
     # Per the README:
     # > All of MA's source code is hereby placed in the public domain
     license = lib.licenses.publicDomain;


### PR DESCRIPTION
Upstream changelog (from README):

```
13
    - Fix quoting issue with plumbing (thanks to "sterni").

12
    - Selection of word under the mouse cursor does not include
      "," or ";".
    - Selecting an initial position when opening a fresh window
      tries harder to make the selection visible.
    - C-r selects to end of file.
    - ESC now records the position after a button press moves
      the insertion point (this is more according to how I
      understand the behaviour in sam/acme).
    - B3 on address that involves search starts the search at
      the insertion point, not at the start of the file.
```

~~For some reason, the B script has been removed. I've emailed the author about this.~~


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
