### PR TITLE
librespot: 0.6.0 -> 0.7.0

### DIFF
--- a/pkgs/applications/audio/librespot/default.nix
+++ b/pkgs/applications/audio/librespot/default.nix
@@ -18,20 +18,21 @@
   withMDNS ? true,
   withDNS-SD ? false,
   avahi-compat,
+  tlsBackend ? "native-tls", # "native-tls" "rustls-tls-native-roots" "rustls-tls-webpki-roots"
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "librespot";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "librespot-org";
     repo = "librespot";
     rev = "v${version}";
-    sha256 = "sha256-dGQDRb7fgIkXelZKa+PdodIs9DxbgEMlVGJjK/hU3Mo=";
+    hash = "sha256-IsHyYH4RDMRqXLNv6RZNzRTl3+zxan0TM/bjHoZC8YA=";
   };
 
-  cargoHash = "sha256-SqvJSHkyd1IicT6c4pE96dBJNNodULhpyG14HRGVWCk=";
+  cargoHash = "sha256-1Jc7gfnrsvk3Lcrvq0jV78IMKAnMDsW3nDr1W34PVmE=";
 
   nativeBuildInputs = [
     pkg-config
@@ -50,14 +51,16 @@ rustPlatform.buildRustPackage rec {
   ++ lib.optional withPulseAudio libpulseaudio;
 
   buildNoDefaultFeatures = true;
-  buildFeatures =
-    lib.optional withRodio "rodio-backend"
-    ++ lib.optional withMDNS "with-libmdns"
-    ++ lib.optional withDNS-SD "with-dns-sd"
-    ++ lib.optional withALSA "alsa-backend"
-    ++ lib.optional withAvahi "with-avahi"
-    ++ lib.optional withPortAudio "portaudio-backend"
-    ++ lib.optional withPulseAudio "pulseaudio-backend";
+  buildFeatures = [
+    tlsBackend
+  ]
+  ++ lib.optional withRodio "rodio-backend"
+  ++ lib.optional withMDNS "with-libmdns"
+  ++ lib.optional withDNS-SD "with-dns-sd"
+  ++ lib.optional withALSA "alsa-backend"
+  ++ lib.optional withAvahi "with-avahi"
+  ++ lib.optional withPortAudio "portaudio-backend"
+  ++ lib.optional withPulseAudio "pulseaudio-backend";
 
   postFixup = lib.optionalString withALSA ''
     wrapProgram "$out/bin/librespot" \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update librespot to v0.7.0.
Add support for the new TLS backend selection.
[Changelog](https://github.com/librespot-org/librespot/blob/v0.7.0/CHANGELOG.md)

cc @bennofs 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
