### PR TITLE
mir: 2.21.1 -> 2.22.0

### DIFF
--- a/pkgs/by-name/mi/miracle-wm/package.nix
+++ b/pkgs/by-name/mi/miracle-wm/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  unstableGitUpdater,
   nixosTests,
   boost,
   cmake,
@@ -31,20 +31,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "miracle-wm";
-  version = "0.6.2";
+  version = "0.6.2-unstable-2025-08-27";
 
   src = fetchFromGitHub {
     owner = "miracle-wm-org";
     repo = "miracle-wm";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-zUqW21gZC7J/E0cld11N6OyclpgKCh4F7m/soBi3N1E=";
+    rev = "0a55a023adf511b042f922aeba666744805be988";
+    hash = "sha256-yf7knY1tNFeCwePsfTAMAxIma+ZeZUvqpMJe7ABahEw=";
   };
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace-fail 'DESTINATION /usr/lib' 'DESTINATION ''${CMAKE_INSTALL_LIBDIR}' \
       --replace-fail '-march=native' '# -march=native' \
-      --replace-fail '-flto' '# -flto'
   ''
   + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
     substituteInPlace CMakeLists.txt \
@@ -89,13 +88,17 @@ stdenv.mkDerivation (finalAttrs: {
   checkInputs = [ gtest ];
 
   cmakeFlags = [
+    (lib.cmakeBool "ENABLE_LTO" true)
     (lib.cmakeBool "SYSTEMD_INTEGRATION" true)
+    (lib.cmakeBool "END_TO_END_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   checkPhase = ''
     runHook preCheck
+
+    export XDG_RUNTIME_DIR=$TMP
 
     ./tests/miracle-wm-tests
 
@@ -115,7 +118,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    updateScript = gitUpdater { rev-prefix = "v"; };
+    updateScript = unstableGitUpdater { tagPrefix = "v"; };
     providedSessions = [ "miracle-wm" ];
     tests.vm = nixosTests.miracle-wm;
   };

--- a/pkgs/by-name/wl/wlcs/package.nix
+++ b/pkgs/by-name/wl/wlcs/package.nix
@@ -3,7 +3,6 @@
   lib,
   gitUpdater,
   fetchFromGitHub,
-  fetchpatch,
   testers,
   cmake,
   pkg-config,
@@ -15,23 +14,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wlcs";
-  version = "1.7.0";
+  version = "1.8.1";
 
   src = fetchFromGitHub {
     owner = "MirServer";
     repo = "wlcs";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-BQPRymkbGu4YvTYXTaTMuyP5fHpqMWI4xPwjDRHZNEQ=";
+    hash = "sha256-W4/a7neFcaqdPIAWDk5TcIuIWZ76rC7xCk3beJVqE/E=";
   };
-
-  patches = [
-    # Remove when version > 1.7.0
-    (fetchpatch {
-      name = "0001-wlcs-Fix-GCC14-compat.patch";
-      url = "https://github.com/canonical/wlcs/commit/5c812e560052e2cbff4c6d26439935020ddee52f.patch";
-      hash = "sha256-8YrVKhgpTYZi8n4dZ4pRWJoAcZtr9eaFMv0NNV7/kWU=";
-    })
-  ];
 
   strictDeps = true;
 

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -5,15 +5,8 @@ let
 in
 {
   mir = common {
-    version = "2.21.1";
-    hash = "sha256-FDZ40LiuvMuyWQQGjgOHTm+J3i7yczKMzL3dZ1jsz/E=";
-    patches = [
-      (fetchpatch {
-        name = "0001-Fix-gtest-nodiscard-error.patch";
-        url = "https://github.com/canonical/mir/commit/60dab2b197deb159087e44865e7314ad2865b79d.patch";
-        hash = "sha256-fB49E+Wjm2zJnie9Ws+tP0d6lxcG3V/C/UDfy/4iuFU=";
-      })
-    ];
+    version = "2.22.0";
+    hash = "sha256-46FxyS4Anm1id63GUUCzn9ubTQIvs1+HrXKgZki6fQw=";
   };
 
   mir_2_15 = common {

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -37,6 +37,24 @@ in
         hash = "sha256-QuVZBcHSn/DK+xbjM36Y89+w22vk7NRV4MkbjgvS28A=";
       })
 
+      # Exclude known-flaky tests
+      # Remove when version > 2.15.0
+      (fetchpatch {
+        name = "0004-mir-exclude-tests-surfaces_with_exclusive_zone_set_to_negative_one_do_not_respect_other_exclusive_zones-1.patch";
+        url = "https://github.com/canonical/mir/commit/967d872daab50d845adce389c0672edfd18b90c9.patch";
+        hash = "sha256-XfTWQj+fmPpC1hIqt7ELGU6Yq2wJSO+FQ8bsikI5h0I=";
+      })
+      (fetchpatch {
+        name = "0005-mir-exclude-tests-surfaces_with_exclusive_zone_set_to_negative_one_do_not_respect_other_exclusive_zones-2.patch";
+        url = "https://github.com/canonical/mir/commit/932d8744852bca9830668018474890bce0c5f6d6.patch";
+        hash = "sha256-+udEt6pF5VLSBtRgo9r1YdVsinARWLAL4AeEG01DV68=";
+      })
+      (fetchpatch {
+        name = "0006-mir-exclude-tests-surfaces_with_exclusive_zone_set_to_negative_one_do_not_respect_other_exclusive_zones-3.patch";
+        url = "https://github.com/canonical/mir/commit/fbad5e50be02992f6cf1f41f928950532f3f62c5.patch";
+        hash = "sha256-J0YEhXf8sAWEHHxU7QKSJjOoHiXsYqotBfgGm79X6GA=";
+      })
+
       # Fix ignored return value of std::lock_guard
       # Remove when version > 2.15.0
       # Was changed as part of the big platform API change, no individual upstream commit with this fix


### PR DESCRIPTION
https://github.com/canonical/mir/releases/tag/v2.22.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
