### PR TITLE
flac: build from tarball; always enable man pages

### DIFF
--- a/pkgs/by-name/fl/flac/package.nix
+++ b/pkgs/by-name/fl/flac/package.nix
@@ -1,7 +1,7 @@
 {
   cmake,
   doxygen,
-  fetchFromGitHub,
+  fetchurl,
   graphviz,
   lib,
   libogg,
@@ -10,17 +10,17 @@
   pkg-config,
   stdenv,
   versionCheckHook,
-  enableManpages ? buildPackages.pandoc.compiler.bootstrapAvailable,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "flac";
   version = "1.5.0";
 
-  src = fetchFromGitHub {
-    owner = "xiph";
-    repo = "flac";
-    tag = finalAttrs.version;
-    hash = "sha256-B6XRai5UOAtY/7JXNbI3YuBgazi1Xd2ZOs6vvLq9LIs=";
+  # Building from tarball instead of GitHub to include pre-built manpages.
+  # This prevents huge numbers of rebuilds for pandoc / haskell-updates.
+  # It also enables manpages for platforms where pandoc is not available.
+  src = fetchurl {
+    url = "http://downloads.xiph.org/releases/flac/flac-${finalAttrs.version}.tar.xz";
+    hash = "sha256-8sHHZZKoL//4QTujxKEpm2x6sGxzTe4D/YhjBIXCuSA=";
   };
 
   hardeningDisable = [ "trivialautovarinit" ];
@@ -30,18 +30,13 @@ stdenv.mkDerivation (finalAttrs: {
     doxygen
     graphviz
     pkg-config
-  ]
-  ++ lib.optional enableManpages buildPackages.pandoc;
+  ];
 
   buildInputs = [ libogg ];
 
-  cmakeFlags =
-    lib.optionals (!stdenv.hostPlatform.isStatic) [
-      "-DBUILD_SHARED_LIBS=ON"
-    ]
-    ++ lib.optionals (!enableManpages) [
-      "-DINSTALL_MANPAGES=OFF"
-    ];
+  cmakeFlags = lib.optionals (!stdenv.hostPlatform.isStatic) [
+    "-DBUILD_SHARED_LIBS=ON"
+  ];
 
   CFLAGS = [
     "-O3"
@@ -57,8 +52,6 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
     "doc"
     "out"
-  ]
-  ++ lib.optionals enableManpages [
     "man"
   ];
 


### PR DESCRIPTION
This reduces the number of rebuilds for pandoc / haskell-updates by up to 14k on linux and 8k on darwin.

Related: #427145

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
