### PR TITLE
vivify: init at 0.8.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23823,6 +23823,12 @@
     githubId = 617130;
     keys = [ { fingerprint = "C4F7 46C7 B560 38D8 210F  0288 5877 DEE9 7428 557F"; } ];
   };
+  skohtv = {
+    name = "Skoh";
+    email = "contact@skoh.dev";
+    github = "skohtv";
+    githubId = 101289702;
+  };
   skovati = {
     github = "skovati";
     githubId = 49844593;

--- a/pkgs/by-name/vi/vivify/package.nix
+++ b/pkgs/by-name/vi/vivify/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenv,
+  fetchYarnDeps,
+  fetchFromGitHub,
+  yarnConfigHook,
+  npmHooks,
+  nodejs,
+  zip,
+  file,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vivify";
+  version = "0.8.2";
+
+  src = fetchFromGitHub {
+    owner = "jannis-baum";
+    repo = "Vivify";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2lxf21T9y4GMFlk0+qbaJJ/twRffYEBoBXZXe/NRDQk=";
+  };
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/yarn.lock";
+    hash = "sha256-mOgfwetiLMTDquw3f3+U1iEhBbvf0OC5lkNJHdrRSK0=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    yarn install
+
+    substituteInPlace node_modules/.bin/tsc \
+      --replace-fail '/usr/bin/env node' '${lib.getExe nodejs}'
+
+    substituteInPlace node_modules/.bin/webpack \
+      --replace-fail '/usr/bin/env node' '${lib.getExe nodejs}'
+
+    substituteInPlace node_modules/.bin/postject \
+      --replace-fail '/usr/bin/env node' '${lib.getExe nodejs}'
+
+    make linux
+
+    mkdir -p $out/bin
+    install -Dm755 ./build/linux/viv $out/bin/viv
+    install -Dm755 ./build/linux/vivify-server $out/bin/vivify-server
+
+    wrapProgram $out/bin/viv \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          nodejs
+          file
+        ]
+      }
+  '';
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    npmHooks.npmInstallHook
+    zip
+
+    nodejs
+    file
+  ];
+
+  # Stripping 'unneeded symbols' causes vivify-server executable to break
+  # (segmentation fault)
+  dontStrip = true;
+
+  meta = {
+    description = "Live Markdown viewer";
+    longDescription = ''
+      Vivify brings your files to life in the browser!
+      Vivify is primarily made to render Markdown and Jupyter Notebooks, but will also
+      serve as a directory browser and let you view code files with syntax highlighting.
+    '';
+    homepage = "https://github.com/jannis-baum/Vivify";
+    changelog = "https://github.com/jannis-baum/Vivify/releases/tag/v${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ skohtv ];
+    platforms = lib.platforms.linux;
+    mainProgram = "viv";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

[Vivify](https://github.com/jannis-baum/Vivify) is a live markdown viewer in the browser.
The build process seems slightly different on `darwin` and I don't have the hardware to test it, so for now `platforms = platforms.linux`.
And cheers to @tuurep who maintains the [AUR package](https://aur.archlinux.org/packages/vivify) and figured out the `dontStrip = true` https://github.com/jannis-baum/Vivify/issues/52#issuecomment-1839186782.



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
