### PR TITLE
gssdp_1_6: disable manpages

### DIFF
--- a/pkgs/development/libraries/gssdp/1.6.nix
+++ b/pkgs/development/libraries/gssdp/1.6.nix
@@ -7,8 +7,6 @@
   pkg-config,
   gobject-introspection,
   vala,
-  buildPackages,
-  enableManpages ? buildPackages.pandoc.compiler.bootstrapAvailable,
   gi-docgen,
   python3,
   libsoup_3,
@@ -44,8 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     vala
     gi-docgen
     python3
-  ]
-  ++ lib.optionals enableManpages [ buildPackages.pandoc ];
+  ];
 
   buildInputs = [
     libsoup_3
@@ -58,7 +55,8 @@ stdenv.mkDerivation (finalAttrs: {
   mesonFlags = [
     "-Dgtk_doc=true"
     "-Dsniffer=false"
-    (lib.mesonBool "manpages" enableManpages)
+    # This packages only has manpages for gssdp-device-sniffer, which we disabled above.
+    "-Dmanpages=false"
   ];
 
   # On Darwin: Failed to bind socket, Operation not permitted


### PR DESCRIPTION
Building these doesn't make sense, because the only tool they are available for - is disabled already. Building them is pointless.

This reduces rebuilds for pandoc / haskell-updates by up to 5k on Linux.

Related: #427145

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
