### PR TITLE
rcu: 4.0.24 -> 4.0.26

### DIFF
--- a/pkgs/by-name/rc/rcu/Port-to-paramiko-4.x.patch
+++ b/pkgs/by-name/rc/rcu/Port-to-paramiko-4.x.patch
@@ -1,17 +1,15 @@
-From aad61b320d65953fddec10b019a186fc67f57a5d Mon Sep 17 00:00:00 2001
-From: OPNA2608 <opna2608@protonmail.com>
-Date: Sat, 10 Feb 2024 12:20:29 +0100
-Subject: [PATCH] src/model/transport.py: Port to paramiko 3.x
-
----
- src/model/transport.py | 19 +++++++++----------
- 1 file changed, 9 insertions(+), 10 deletions(-)
-
-diff --git a/src/model/transport.py b/src/model/transport.py
-index 0c2ee16..5a2bd22 100644
---- a/src/model/transport.py
-+++ b/src/model/transport.py
-@@ -117,7 +117,6 @@ from paramiko.kex_gss import KexGSSGex, KexGSSGroup1, KexGSSGroup14
+diff '--color=auto' -ruN a/src/model/transport.py b/src/model/transport.py
+--- a/src/model/transport.py	2025-08-27 17:12:23.761436314 +0200
++++ b/src/model/transport.py	2025-08-27 17:17:35.723006746 +0200
+@@ -105,7 +105,6 @@
+     MSG_NAMES,
+ )
+ from paramiko.compress import ZlibCompressor, ZlibDecompressor
+-from paramiko.dsskey import DSSKey
+ from paramiko.ed25519key import Ed25519Key
+ from paramiko.kex_curve25519 import KexCurve25519
+ from paramiko.kex_gex import KexGex, KexGexSHA256
+@@ -117,7 +116,6 @@
  from paramiko.message import Message
  from paramiko.packet import Packetizer, NeedRekeyException
  from paramiko.primes import ModulusPack
@@ -19,7 +17,7 @@ index 0c2ee16..5a2bd22 100644
  from paramiko.rsakey import RSAKey
  from paramiko.ecdsakey import ECDSAKey
  from paramiko.server import ServerInterface
-@@ -128,7 +127,7 @@ from paramiko.ssh_exception import (
+@@ -128,7 +126,7 @@
      ChannelException,
      ProxyCommandFailure,
  )
@@ -28,7 +26,24 @@ index 0c2ee16..5a2bd22 100644
  
  
  # for thread cleanup
-@@ -396,7 +395,7 @@ class Transport(threading.Thread, ClosingContextManager):
+@@ -192,7 +190,6 @@
+         "ecdsa-sha2-nistp384",
+         "ecdsa-sha2-nistp521",
+         "ssh-rsa",
+-        "ssh-dss",
+     )
+     _preferred_kex = (
+         "ecdh-sha2-nistp256",
+@@ -273,8 +270,6 @@
+     _key_info = {
+         "ssh-rsa": RSAKey,
+         "ssh-rsa-cert-v01@openssh.com": RSAKey,
+-        "ssh-dss": DSSKey,
+-        "ssh-dss-cert-v01@openssh.com": DSSKey,
+         "ecdsa-sha2-nistp256": ECDSAKey,
+         "ecdsa-sha2-nistp256-cert-v01@openssh.com": ECDSAKey,
+         "ecdsa-sha2-nistp384": ECDSAKey,
+@@ -396,7 +391,7 @@
          self.active = False
          self.hostname = None
  
@@ -37,7 +52,7 @@ index 0c2ee16..5a2bd22 100644
              # convert "host:port" into (host, port)
              hl = sock.split(":", 1)
              self.hostname = hl[0]
-@@ -419,7 +418,7 @@ class Transport(threading.Thread, ClosingContextManager):
+@@ -419,7 +414,7 @@
                      sock = socket.socket(af, socket.SOCK_STREAM)
                      sock.settimeout(1)
                      try:
@@ -46,7 +61,7 @@ index 0c2ee16..5a2bd22 100644
                      except socket.error as e:
                          reason = str(e)
                      else:
-@@ -542,7 +541,7 @@ class Transport(threading.Thread, ClosingContextManager):
+@@ -542,7 +537,7 @@
          """
          Returns a string representation of this object, for debugging.
          """
@@ -55,7 +70,31 @@ index 0c2ee16..5a2bd22 100644
          out = "<paramiko.Transport at {}".format(id_)
          if not self.active:
              out += " (unconnected)"
-@@ -1123,7 +1122,7 @@ class Transport(threading.Thread, ClosingContextManager):
+@@ -749,11 +744,11 @@
+         as a server, the host key is used to sign certain packets during the
+         SSH2 negotiation, so that the client can trust that we are who we say
+         we are.  Because this is used for signing, the key must contain private
+-        key info, not just the public half.  Only one key of each type (RSA or
+-        DSS) is kept.
++        key info, not just the public half.  Only one key of each type (i.e.
++        RSA) is kept.
+ 
+         :param .PKey key:
+-            the host key to add, usually an `.RSAKey` or `.DSSKey`.
++            the host key to add, usually an `.RSAKey`.
+         """
+         self.server_key_dict[key.get_name()] = key
+ 
+@@ -763,7 +758,7 @@
+         client, this method will return the negotiated host key.  If only one
+         type of host key was set with `add_server_key`, that's the only key
+         that will ever be returned.  But in cases where you have set more than
+-        one type of host key (for example, an RSA key and a DSS key), the key
++        one type of host key (for example, an RSA key and another key), the key
+         type will be negotiated by the client, and this method will return the
+         key of the type agreed on.  If the host key has not been negotiated
+         yet, ``None`` is returned.  In client mode, the behavior is undefined.
+@@ -1123,7 +1118,7 @@
          m = Message()
          m.add_byte(cMSG_IGNORE)
          if byte_count is None:
@@ -64,7 +103,7 @@ index 0c2ee16..5a2bd22 100644
          m.add_bytes(os.urandom(byte_count))
          self._send_user_message(m)
  
-@@ -1802,7 +1801,7 @@ class Transport(threading.Thread, ClosingContextManager):
+@@ -1802,7 +1797,7 @@
      def stop_thread(self):
          self.active = False
          self.packetizer.close()
@@ -73,7 +112,7 @@ index 0c2ee16..5a2bd22 100644
              # Original join logic; #520 doesn't appear commonly present under
              # Python 2.
              while self.is_alive() and self is not threading.current_thread():
-@@ -1909,7 +1908,7 @@ class Transport(threading.Thread, ClosingContextManager):
+@@ -1909,7 +1904,7 @@
          m = Message()
          m.add_mpint(self.K)
          m.add_bytes(self.H)
@@ -82,7 +121,7 @@ index 0c2ee16..5a2bd22 100644
          m.add_bytes(self.session_id)
          # Fallback to SHA1 for kex engines that fail to specify a hex
          # algorithm, or for e.g. transport tests that don't run kexinit.
-@@ -2037,14 +2036,14 @@ class Transport(threading.Thread, ClosingContextManager):
+@@ -2037,14 +2032,14 @@
  
          # active=True occurs before the thread is launched, to avoid a race
          _active_threads.append(self)
@@ -99,6 +138,3 @@ index 0c2ee16..5a2bd22 100644
                  self._log(
                      DEBUG,
                      "Local version/idstring: {}".format(self.local_version),
--- 
-2.42.0
-

--- a/pkgs/by-name/rc/rcu/package.nix
+++ b/pkgs/by-name/rc/rcu/package.nix
@@ -23,7 +23,7 @@ let
 in
 python3Packages.buildPythonApplication rec {
   pname = "rcu";
-  version = "4.0.25";
+  version = "4.0.26";
 
   format = "other";
 
@@ -31,7 +31,7 @@ python3Packages.buildPythonApplication rec {
     let
       src-tarball = requireFile {
         name = "rcu-${version}-source.tar.gz";
-        hash = "sha256-8xcYAQxUmY8beUrRYmOn5UeWibr0EUZLOG4pFfeeSdw=";
+        hash = "sha256-yY3OFZVHxhVurfjSEeR+UUNHQdpc08jhgaDEvMWRsLA=";
         url = "https://www.davisr.me/projects/rcu/";
       };
     in

--- a/pkgs/by-name/rc/rcu/package.nix
+++ b/pkgs/by-name/rc/rcu/package.nix
@@ -23,7 +23,7 @@ let
 in
 python3Packages.buildPythonApplication rec {
   pname = "rcu";
-  version = "4.0.24";
+  version = "4.0.25";
 
   format = "other";
 
@@ -31,7 +31,7 @@ python3Packages.buildPythonApplication rec {
     let
       src-tarball = requireFile {
         name = "rcu-${version}-source.tar.gz";
-        hash = "sha256-3rZiqg8Uuta3kI2m+2rBZ1XzN9bFds+emhivH5X7sJg=";
+        hash = "sha256-8xcYAQxUmY8beUrRYmOn5UeWibr0EUZLOG4pFfeeSdw=";
         url = "https://www.davisr.me/projects/rcu/";
       };
     in
@@ -42,7 +42,7 @@ python3Packages.buildPythonApplication rec {
     '';
 
   patches = [
-    ./Port-to-paramiko-3.x.patch
+    ./Port-to-paramiko-4.x.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
<img width="702" height="661" alt="image" src="https://github.com/user-attachments/assets/9bf2358f-19bb-4603-8bf8-73edb62256d9" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
