### PR TITLE
qt6, python3Packages.pyside6: 6.9.1 -> 6.9.2

### DIFF
--- a/pkgs/development/libraries/qt-6/fetch.sh
+++ b/pkgs/development/libraries/qt-6/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.qt.io/official_releases/qt/6.9/6.9.1/submodules/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.qt.io/official_releases/qt/6.9/6.9.2/submodules/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/qt-6/modules/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase/default.nix
@@ -80,7 +80,6 @@
   libinput,
   # options
   qttranslations ? null,
-  fetchpatch,
 }:
 
 let
@@ -218,13 +217,6 @@ stdenv.mkDerivation rec {
     ./qmlimportscanner-import-path.patch
     # don't pass qtbase's QML directory to qmlimportscanner if it's empty
     ./skip-missing-qml-directory.patch
-
-    # Backport patch recommended by KDE to fix HTTP2 stream corruption issues
-    # FIXME: remove in 6.9.2
-    (fetchpatch {
-      url = "https://invent.kde.org/qt/qt/qtbase/-/commit/904aec2f372e2981af19bf762583a0ef42ec6bb9.diff";
-      hash = "sha256-bSf4TgYUk7Ariu37NHGQKv6wFArVpQLlnHCTbCFzAfI=";
-    })
   ];
 
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''

--- a/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
@@ -10,7 +10,6 @@
   lib,
   pkgsBuildBuild,
   replaceVars,
-  fetchpatch,
 }:
 
 qtModule {
@@ -38,11 +37,6 @@ qtModule {
     })
     # add version specific QML import path
     ./use-versioned-import-path.patch
-    # This should make it into the 6.9.2 release.
-    (fetchpatch {
-      url = "https://invent.kde.org/qt/qt/qtdeclarative/-/commit/672e6777e8e6a8fd.diff";
-      hash = "sha256-nPczX6SHZPcdg7AqpRIwPCrcS3PId+Ibb0iPSiHUdaw=";
-    })
   ];
 
   preConfigure =

--- a/pkgs/development/libraries/qt-6/modules/qtmqtt.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtmqtt.nix
@@ -6,13 +6,13 @@
 
 qtModule rec {
   pname = "qtmqtt";
-  version = "6.9.1";
+  version = "6.9.2";
 
   src = fetchFromGitHub {
     owner = "qt";
     repo = "qtmqtt";
     tag = "v${version}";
-    hash = "sha256-nyMsl07pL6mNpg1p7W3cn2NXGmEbm+y9tgMexp6+xYI=";
+    hash = "sha256-/qz93JmMkJW3+lzT+QKvb/VL+xmbg5H8kKaXK+XN2nE=";
   };
 
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
@@ -7,7 +7,6 @@
   buildPackages,
   bison,
   coreutils,
-  fetchpatch2,
   flex,
   gperf,
   ninja,
@@ -111,14 +110,6 @@ qtModule {
 
     # Reproducibility QTBUG-136068
     ./gn-object-sorted.patch
-
-    # https://chromium-review.googlesource.com/c/chromium/src/+/6445471
-    (fetchpatch2 {
-      url = "https://github.com/chromium/chromium/commit/f8f21fb4aa01f75acbb12abf5ea8c263c6817141.patch?full_index=1";
-      stripLen = 1;
-      extraPrefix = "src/3rdparty/chromium/";
-      hash = "sha256-wcby9uD8xb4re9+s+rdl1hcpxDcHxuI68vUNAC7Baas=";
-    })
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/qt-6/srcs.nix
+++ b/pkgs/development/libraries/qt-6/srcs.nix
@@ -4,315 +4,315 @@
 
 {
   qt3d = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qt3d-everywhere-src-6.9.1.tar.xz";
-      sha256 = "1127kkbrds6xsd28p47drs51py5x8gsv2rwbllkb6yqlc1x4jilw";
-      name = "qt3d-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qt3d-everywhere-src-6.9.2.tar.xz";
+      sha256 = "0ndn5fbsfj2vbcq3siq1gnk2rgblicd6ri2jrh9g41anicxh4vma";
+      name = "qt3d-everywhere-src-6.9.2.tar.xz";
     };
   };
   qt5compat = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qt5compat-everywhere-src-6.9.1.tar.xz";
-      sha256 = "0yli7mbsdhksx57n05axr3kkspf9nm56w6bm1rbl0p0d7yn2diwn";
-      name = "qt5compat-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qt5compat-everywhere-src-6.9.2.tar.xz";
+      sha256 = "0q2vly836wgs462czw7lg0ysf2h48iwbdy43wwf2gz49qq2rja6b";
+      name = "qt5compat-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtactiveqt = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtactiveqt-everywhere-src-6.9.1.tar.xz";
-      sha256 = "0lvd6566yycfid6nq66m5cl3aw5bfzfifbhcpnqangvq1vla2zpx";
-      name = "qtactiveqt-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtactiveqt-everywhere-src-6.9.2.tar.xz";
+      sha256 = "003vgfxswi6cpdp9i8kdzm1n34cbrbzlap4sg9h1ap0i9is51s1w";
+      name = "qtactiveqt-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtbase = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtbase-everywhere-src-6.9.1.tar.xz";
-      sha256 = "13pjmha1jpalpy5qc5gijny7i648clsmcc08c5cik6nchfzyvjj0";
-      name = "qtbase-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtbase-everywhere-src-6.9.2.tar.xz";
+      sha256 = "0h149x8l2ywfr5m034n20z6cjxnldary39x0vv22jhg0ryg9rgj4";
+      name = "qtbase-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtcharts = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtcharts-everywhere-src-6.9.1.tar.xz";
-      sha256 = "1ly3mq4hgl4b20grajqy9bw16cx50d4drjxr3ljfj5n8gbmip1xq";
-      name = "qtcharts-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtcharts-everywhere-src-6.9.2.tar.xz";
+      sha256 = "0jzzlh0jq5fidgs9r4aqpilyj0nan30r1d0pigp1hgz7cigz20cz";
+      name = "qtcharts-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtconnectivity = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtconnectivity-everywhere-src-6.9.1.tar.xz";
-      sha256 = "05qabslwr7dc7mfkgkr2ikqlb93c0dkfyg2vbvc5lk8h280yb229";
-      name = "qtconnectivity-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtconnectivity-everywhere-src-6.9.2.tar.xz";
+      sha256 = "0qq4d8hn6s8bb9r2gglb6gzq6isbb13knqh7n2s2wsnx8rqwdzwa";
+      name = "qtconnectivity-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtdatavis3d = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtdatavis3d-everywhere-src-6.9.1.tar.xz";
-      sha256 = "1irjbdm8ypm01zx18rwq8sp161fq9yjhbx01pcgfdix7y9sqnyac";
-      name = "qtdatavis3d-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtdatavis3d-everywhere-src-6.9.2.tar.xz";
+      sha256 = "0p6bvia085hx3jb1la06c2q48m9i897r1a1mf6bi2hbmm2hirzsx";
+      name = "qtdatavis3d-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtdeclarative = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtdeclarative-everywhere-src-6.9.1.tar.xz";
-      sha256 = "15zc9i9d3c9r2bqbcavqn77qk2vwcwlmp5kv73pdg681vxjldffc";
-      name = "qtdeclarative-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtdeclarative-everywhere-src-6.9.2.tar.xz";
+      sha256 = "0r16qima008y2999r1djvwry01l295nmwwhqg081d2fr1cn2szs7";
+      name = "qtdeclarative-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtdoc = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtdoc-everywhere-src-6.9.1.tar.xz";
-      sha256 = "1d8sdnwimvy8fi7cihkxzjllri5gsldy39rzqwyxv4nfwnxbw33f";
-      name = "qtdoc-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtdoc-everywhere-src-6.9.2.tar.xz";
+      sha256 = "0qng2lsqmrrj8n85aqh8vl4nlzc23va9hynvvf6gqr35anvbpniz";
+      name = "qtdoc-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtgraphs = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtgraphs-everywhere-src-6.9.1.tar.xz";
-      sha256 = "0i1lb7zdvhxyv51g9h667g7wq50h6x11w88v68x5mfyda98dqbgm";
-      name = "qtgraphs-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtgraphs-everywhere-src-6.9.2.tar.xz";
+      sha256 = "0wsa4iar52dhiilyl053j7lmsw3xdn47b0pjrylb5a0ij1izp057";
+      name = "qtgraphs-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtgrpc = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtgrpc-everywhere-src-6.9.1.tar.xz";
-      sha256 = "0l574fwlqszk3zny2mcbka8ipi8bhj8m67jsd7yv129j42g8ck63";
-      name = "qtgrpc-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtgrpc-everywhere-src-6.9.2.tar.xz";
+      sha256 = "0r1z6lbjcsgxhvzylpr8z8wl44ql14ajf99n1hfvf4gy4f43qgd4";
+      name = "qtgrpc-everywhere-src-6.9.2.tar.xz";
     };
   };
   qthttpserver = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qthttpserver-everywhere-src-6.9.1.tar.xz";
-      sha256 = "0lrby1ii7ic0m3wnv1hvb5izzwrk5ryqvbi723qnbhxvw88vbixz";
-      name = "qthttpserver-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qthttpserver-everywhere-src-6.9.2.tar.xz";
+      sha256 = "06a0f7j1b309xffw3rwydz8lpzxnf5jg67savswskzbd3lfzlhqk";
+      name = "qthttpserver-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtimageformats = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtimageformats-everywhere-src-6.9.1.tar.xz";
-      sha256 = "0z2py4x0shdn29l9656r63xc8gzk9bgxlgi3qx9bg6xgv8wg5sgb";
-      name = "qtimageformats-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtimageformats-everywhere-src-6.9.2.tar.xz";
+      sha256 = "0fciahs4i0nn5z0j624gkfncqg6byxswj45bw81drpjp5xz3y0la";
+      name = "qtimageformats-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtlanguageserver = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtlanguageserver-everywhere-src-6.9.1.tar.xz";
-      sha256 = "1v486kb11mg65bvg88mm306nvq55kg6glnqiwfv9n2vn28v3a5ya";
-      name = "qtlanguageserver-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtlanguageserver-everywhere-src-6.9.2.tar.xz";
+      sha256 = "1vlb0qn53y1b4zf7zkpxdvdh5ikr1cidq5gv8blvf6pyw6pnw6vq";
+      name = "qtlanguageserver-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtlocation = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtlocation-everywhere-src-6.9.1.tar.xz";
-      sha256 = "0mzg4z0zra13czgygaxim8wn4a2lzndly3w0ymcxwzh4gs8fis60";
-      name = "qtlocation-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtlocation-everywhere-src-6.9.2.tar.xz";
+      sha256 = "1ybk3ig69p6zyrxabcfkb4pcyc251gy1m2brkf4q52cmcwcysias";
+      name = "qtlocation-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtlottie = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtlottie-everywhere-src-6.9.1.tar.xz";
-      sha256 = "18lbl6pxvfiwl84y92xwnm4cayxs8rdfgmvrq44n3jbk0wp8rs4f";
-      name = "qtlottie-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtlottie-everywhere-src-6.9.2.tar.xz";
+      sha256 = "1iiigsb4p1zwkxm1x9c4pbx5rgwz35krdqi3vkql4nawvp997px4";
+      name = "qtlottie-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtmultimedia = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtmultimedia-everywhere-src-6.9.1.tar.xz";
-      sha256 = "079r0wp4nwyp4a5cannz3vf99aj4dvydwydvwbw5bvhqjm2kcplm";
-      name = "qtmultimedia-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtmultimedia-everywhere-src-6.9.2.tar.xz";
+      sha256 = "04mbwl1mg4rjgai027chldslpjnqrx52c3jxn20j2hx7ayda3y3v";
+      name = "qtmultimedia-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtnetworkauth = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtnetworkauth-everywhere-src-6.9.1.tar.xz";
-      sha256 = "1jrrfcw3aa93xaq95xhy0iyigldmvgamy5452mpm8d926xdv3bbz";
-      name = "qtnetworkauth-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtnetworkauth-everywhere-src-6.9.2.tar.xz";
+      sha256 = "114c65gyg56v70byyl3if1q7mzhp5kkv1g8sp4y9zaxqirbdjr91";
+      name = "qtnetworkauth-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtpositioning = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtpositioning-everywhere-src-6.9.1.tar.xz";
-      sha256 = "09pz0sbzcvhcaag7g7pidcnyvrx2kaxsxr73y2iqq949955p6qkh";
-      name = "qtpositioning-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtpositioning-everywhere-src-6.9.2.tar.xz";
+      sha256 = "06mwzlyprwz11ks6fsvzh03ilk5fxy3scr1gqqb4p85xzw0ri6j8";
+      name = "qtpositioning-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtquick3d = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtquick3d-everywhere-src-6.9.1.tar.xz";
-      sha256 = "0xwr5kdz1yn0arby4jipbh0j8z1x8ppiqhswddyipmdzizd005pn";
-      name = "qtquick3d-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtquick3d-everywhere-src-6.9.2.tar.xz";
+      sha256 = "002888xfnkxmvn8413fllidl3mm2fcwc4gbzdnbvpjlysaq9f3ig";
+      name = "qtquick3d-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtquick3dphysics = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtquick3dphysics-everywhere-src-6.9.1.tar.xz";
-      sha256 = "0kx2vj6qwwp05iizfnsmbn2337w70crah4zcdm1ah2f4p1g3ds36";
-      name = "qtquick3dphysics-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtquick3dphysics-everywhere-src-6.9.2.tar.xz";
+      sha256 = "12yc0lswcmyaw19yyxzy73j95ncgqw8mlx8svhrwsllgcf2n9z47";
+      name = "qtquick3dphysics-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtquickeffectmaker = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtquickeffectmaker-everywhere-src-6.9.1.tar.xz";
-      sha256 = "0caxs6xcm5c7g85xyln5jjvz4b4g6flww7kq9vsl9fs20v21gdir";
-      name = "qtquickeffectmaker-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtquickeffectmaker-everywhere-src-6.9.2.tar.xz";
+      sha256 = "1yfq1pp0k2d6438x8pn2y73y29bqwg45bjh6msiy64fldr4z31br";
+      name = "qtquickeffectmaker-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtquicktimeline = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtquicktimeline-everywhere-src-6.9.1.tar.xz";
-      sha256 = "153ji60xg55m85zg0px5nq1wbpkn61xf0whkjghf8y41rbkxpgvq";
-      name = "qtquicktimeline-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtquicktimeline-everywhere-src-6.9.2.tar.xz";
+      sha256 = "09n51qw0y8v1q83xs1ybwwm4a49j2qhshqrasdkzz25mij6nhrdw";
+      name = "qtquicktimeline-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtremoteobjects = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtremoteobjects-everywhere-src-6.9.1.tar.xz";
-      sha256 = "040a5s6sx5y0vpxjdmvici63yxr4rn9qisigpbjc4wlggfg0fgr7";
-      name = "qtremoteobjects-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtremoteobjects-everywhere-src-6.9.2.tar.xz";
+      sha256 = "09lby6dqc2sfig1krcszg6fkypgxlz2r7hgjjfi95g7g9gqlwqnz";
+      name = "qtremoteobjects-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtscxml = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtscxml-everywhere-src-6.9.1.tar.xz";
-      sha256 = "10274n4gslgh59sagyijllnskp204i16zm7bdpx58fmk4chdwcqc";
-      name = "qtscxml-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtscxml-everywhere-src-6.9.2.tar.xz";
+      sha256 = "1dpb687zbw4akx42kfpbb5cpdlq3hcqn8l3l0x7sd5i9061z2sp0";
+      name = "qtscxml-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtsensors = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtsensors-everywhere-src-6.9.1.tar.xz";
-      sha256 = "0v4w815698zgxhmk681ygfsjlbp1y4gqdmbb0pz2vm6gr8d16jzh";
-      name = "qtsensors-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtsensors-everywhere-src-6.9.2.tar.xz";
+      sha256 = "0qj4674vim2p34mq3kp99spjyf82qvs75w625namzqp274pshk4n";
+      name = "qtsensors-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtserialbus = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtserialbus-everywhere-src-6.9.1.tar.xz";
-      sha256 = "1mq4mghn19m7m0mkbn6llwiprabr4ym8rpd9ks05spsnhd2ww7j9";
-      name = "qtserialbus-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtserialbus-everywhere-src-6.9.2.tar.xz";
+      sha256 = "0xia9xcz7sjrbf1c4m63qnhz3ggdxr06pycslmsnqizlzb10f7lm";
+      name = "qtserialbus-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtserialport = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtserialport-everywhere-src-6.9.1.tar.xz";
-      sha256 = "047z7vchc01rki445i7qh5mqy3xh0i6ww1l34s4swx0c719fv3w0";
-      name = "qtserialport-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtserialport-everywhere-src-6.9.2.tar.xz";
+      sha256 = "0sz2dkas4qjdd6lkfb9g89vi94q18aiq9xdchlqb2yn0qbqb544b";
+      name = "qtserialport-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtshadertools = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtshadertools-everywhere-src-6.9.1.tar.xz";
-      sha256 = "0x2b7dpkgdngpbv1g5qc6ffa4lwq4d8g3r3vdi5zp1q8rr6d47jf";
-      name = "qtshadertools-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtshadertools-everywhere-src-6.9.2.tar.xz";
+      sha256 = "158lpzb1nqspwm0n48d3nfr81q85zka1igrjp6xj8cjlv7wqlrqp";
+      name = "qtshadertools-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtspeech = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtspeech-everywhere-src-6.9.1.tar.xz";
-      sha256 = "0a0lgjxkdfisczkaw7njs87a9qffigygn311chgqzvz2ragza1v8";
-      name = "qtspeech-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtspeech-everywhere-src-6.9.2.tar.xz";
+      sha256 = "1cc8l2h1frlraay0m40r5a91nsc7b53n6vksa52pwqqia4vngdmj";
+      name = "qtspeech-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtsvg = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtsvg-everywhere-src-6.9.1.tar.xz";
-      sha256 = "1mdvk8y7dfi8ibv36ccvfbmnsvm2y6dm27l6v6pz47w9zpjmvz1d";
-      name = "qtsvg-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtsvg-everywhere-src-6.9.2.tar.xz";
+      sha256 = "1985asvnkd2ar30nh2zyi490qz0vkz6z1f752lfald33yawcm16r";
+      name = "qtsvg-everywhere-src-6.9.2.tar.xz";
     };
   };
   qttools = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qttools-everywhere-src-6.9.1.tar.xz";
-      sha256 = "0k2b7z7g41pkq0bccvmwpalmn2ryhl0ccd4zv4zh9zfcyiiabi4h";
-      name = "qttools-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qttools-everywhere-src-6.9.2.tar.xz";
+      sha256 = "12d4czfwvh9rfjwnkpsiwzrpx4ga69c6vz85aabhpk3hx7lggdyq";
+      name = "qttools-everywhere-src-6.9.2.tar.xz";
     };
   };
   qttranslations = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qttranslations-everywhere-src-6.9.1.tar.xz";
-      sha256 = "0hd707fpsij9bzl143615a4ags6y0nkwdplzlzmwsizlanjs2qcp";
-      name = "qttranslations-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qttranslations-everywhere-src-6.9.2.tar.xz";
+      sha256 = "1mky3xj2yhcsrmpz8m28v7pky6ryn7hvdcglakww0rfk3qlbcfy7";
+      name = "qttranslations-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtvirtualkeyboard = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtvirtualkeyboard-everywhere-src-6.9.1.tar.xz";
-      sha256 = "07r87pg50drrv2z3b6ldlrvz8261xmq6jfcja9wg0dmqplw9l1c0";
-      name = "qtvirtualkeyboard-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtvirtualkeyboard-everywhere-src-6.9.2.tar.xz";
+      sha256 = "1qqizh7kyqbqqnrm1mmlf2709rm1rnflbqdl1bi75yms07d00hbv";
+      name = "qtvirtualkeyboard-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtwayland = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtwayland-everywhere-src-6.9.1.tar.xz";
-      sha256 = "0gifjc4l85ilr1gb0p9dy2s2aypskjp8c7wskfqyp03id07fl8bx";
-      name = "qtwayland-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtwayland-everywhere-src-6.9.2.tar.xz";
+      sha256 = "10bpxwpam56gvymz9vjxkppbqsj1369ddzl3k4pz2s2maq39imya";
+      name = "qtwayland-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtwebchannel = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtwebchannel-everywhere-src-6.9.1.tar.xz";
-      sha256 = "1h7rzjsim2rxdw25sks4yz8r03llr6q8kcc081n43z0a47ch3d0r";
-      name = "qtwebchannel-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtwebchannel-everywhere-src-6.9.2.tar.xz";
+      sha256 = "0rcf7i1wamdf1qynq3yi88r77ch5dg1jinxywlfjlb2dmlvn72l7";
+      name = "qtwebchannel-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtwebengine = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtwebengine-everywhere-src-6.9.1.tar.xz";
-      sha256 = "0v62j4zzya6yf91630ii6y4m62md69zfs1r21xi6v3rl5gigszbq";
-      name = "qtwebengine-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtwebengine-everywhere-src-6.9.2.tar.xz";
+      sha256 = "1aq35nkgbvhlsmglnjizbkavr7kb0ymf5n3kkllrpqy2mf90gjwr";
+      name = "qtwebengine-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtwebsockets = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtwebsockets-everywhere-src-6.9.1.tar.xz";
-      sha256 = "1xa8yx1v5xk1zn2wc4gssali0k2l0yn6w2ywxsccq0kz7f38rglq";
-      name = "qtwebsockets-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtwebsockets-everywhere-src-6.9.2.tar.xz";
+      sha256 = "1vh82w96436pqrp4daf324mqs2zjvn51z78b3ksc5mnqgrk3z0xy";
+      name = "qtwebsockets-everywhere-src-6.9.2.tar.xz";
     };
   };
   qtwebview = {
-    version = "6.9.1";
+    version = "6.9.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.1/submodules/qtwebview-everywhere-src-6.9.1.tar.xz";
-      sha256 = "19ar1pmf9q39mqvnjkfrxrblgl1vn65zigj194n098ppp3xx96n2";
-      name = "qtwebview-everywhere-src-6.9.1.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtwebview-everywhere-src-6.9.2.tar.xz";
+      sha256 = "1w8z3d7w7z2xjfb5l15gb37v9w6pa7d71jalkrqda8l2wr5d3ksc";
+      name = "qtwebview-everywhere-src-6.9.2.tar.xz";
     };
   };
 }

--- a/pkgs/development/python-modules/pyside6/default.nix
+++ b/pkgs/development/python-modules/pyside6/default.nix
@@ -36,6 +36,7 @@ let
     qtsvg
     qtwebchannel
     qtwebsockets
+    qtwebview
     qtpositioning
     qtlocation
     qtshadertools

--- a/pkgs/development/python-modules/shiboken6/default.nix
+++ b/pkgs/development/python-modules/shiboken6/default.nix
@@ -13,11 +13,11 @@ let
 in
 stdenv'.mkDerivation (finalAttrs: {
   pname = "shiboken6";
-  version = "6.9.1";
+  version = "6.9.2";
 
   src = fetchurl {
     url = "mirror://qt/official_releases/QtForPython/pyside6/PySide6-${finalAttrs.version}-src/pyside-setup-everywhere-src-${finalAttrs.version}.tar.xz";
-    hash = "sha256-BMcSxbkjSt0Nm1qjwBoMrt5kpVtJYSd1H11SojDP90g=";
+    hash = "sha256-nsCHRlNCvcnb5JKjDlj9u8VEhlXerPWYKg/nEj9ZIi0=";
   };
 
   sourceRoot = "pyside-setup-everywhere-src-${finalAttrs.version}/sources/shiboken6";


### PR DESCRIPTION
https://code.qt.io/cgit/qt/qtreleasenotes.git/about/qt/6.9.2/release-note.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
