### PR TITLE
snapcraft: 8.10.2 -> 8.11.2

### DIFF
--- a/pkgs/by-name/sn/snapcraft/package.nix
+++ b/pkgs/by-name/sn/snapcraft/package.nix
@@ -14,7 +14,7 @@
 
 python312Packages.buildPythonApplication rec {
   pname = "snapcraft";
-  version = "8.10.2";
+  version = "8.11.2";
 
   pyproject = true;
 
@@ -22,7 +22,7 @@ python312Packages.buildPythonApplication rec {
     owner = "canonical";
     repo = "snapcraft";
     tag = version;
-    hash = "sha256-klG+cT2vXo9v9tIJhJNCeGTiuV5C+oed0Vi9310PnqQ=";
+    hash = "sha256-Rc3OSRTTpYA7WKI/WEvCdq1SQnkO91FXzQscV2b93TI=";
   };
 
   patches = [
@@ -59,7 +59,9 @@ python312Packages.buildPythonApplication rec {
       --replace-fail 'arch_linker_path = Path(arch_config.dynamic_linker)' \
       'return str(Path("${glibc}/lib/ld-linux-x86-64.so.2"))'
 
-    substituteInPlace pyproject.toml --replace-fail 'gnupg' 'python-gnupg'
+    substituteInPlace pyproject.toml \
+      --replace-fail 'setuptools>=69.0,<80.9.0' 'setuptools' \
+      --replace-fail 'gnupg' 'python-gnupg'
   '';
 
   nativeBuildInputs = [ makeWrapper ];
@@ -113,6 +115,7 @@ python312Packages.buildPythonApplication rec {
   pythonRelaxDeps = [
     "click"
     "craft-parts"
+    "craft-providers"
     "cryptography"
     "docutils"
     "jsonschema"
@@ -175,6 +178,11 @@ python312Packages.buildPythonApplication rec {
     "test_snap_command_fallback"
     "test_validate_architectures_supported"
     "test_validate_architectures_unsupported"
+    # Disabled because we're uisng a later version of a library than
+    # specified which changes the behaviour in a non-breaking way, apart
+    # from when a test is looking for a specific error message
+    "test_esm_error[core]"
+    "test_esm_error[core18]"
   ]
   ++ lib.optionals stdenv.hostPlatform.isAarch64 [ "test_load_project" ];
 

--- a/pkgs/development/python-modules/craft-archives/default.nix
+++ b/pkgs/development/python-modules/craft-archives/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "craft-archives";
-  version = "2.1.0";
+  version = "2.2.0";
 
   pyproject = true;
 
@@ -26,15 +26,12 @@ buildPythonPackage rec {
     owner = "canonical";
     repo = "craft-archives";
     tag = version;
-    hash = "sha256-VjGoAsmdYyoU7ngU69HVNauEk2/vbcEz2tMCTmjheF4=";
+    hash = "sha256-NXMBaY4sZT47Qi3XS5yuiXJEMKENghiXkLXnXHHYpRI=";
   };
 
   postPatch = ''
     substituteInPlace craft_archives/__init__.py \
       --replace-fail "dev" "${version}"
-
-    substituteInPlace pyproject.toml \
-      --replace-fail "setuptools==67.7.2" "setuptools"
   '';
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/craft-grammar/default.nix
+++ b/pkgs/development/python-modules/craft-grammar/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "craft-grammar";
-  version = "2.1.0";
+  version = "2.2.0";
 
   pyproject = true;
 
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "canonical";
     repo = "craft-grammar";
     tag = version;
-    hash = "sha256-R1+8KuJmG12WhJyeOu5G43hcXPHBD6UOqcKRePQNiZM=";
+    hash = "sha256-URyc+N2WSXnjurqd1ieV2mN4Uf9m0zivupRuKmH6s8Q=";
   };
 
   build-system = [ setuptools-scm ];

--- a/pkgs/development/python-modules/craft-parts/default.nix
+++ b/pkgs/development/python-modules/craft-parts/default.nix
@@ -31,7 +31,7 @@
 
 buildPythonPackage rec {
   pname = "craft-parts";
-  version = "2.20.0";
+  version = "2.20.1";
 
   pyproject = true;
 
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     owner = "canonical";
     repo = "craft-parts";
     tag = version;
-    hash = "sha256-apuAV17IlxbkaQvCzyqEhQwTYvqHibwvWHUEPYUiCJQ=";
+    hash = "sha256-YTyoJzot7GkRp+szo+a3wx5mWWJcYj7ke7kcxri9n10=";
   };
 
   patches = [ ./bash-path.patch ];

--- a/pkgs/development/python-modules/craft-providers/default.nix
+++ b/pkgs/development/python-modules/craft-providers/default.nix
@@ -21,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "craft-providers";
-  version = "2.4.0";
+  version = "3.0.0";
 
   pyproject = true;
 
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     owner = "canonical";
     repo = "craft-providers";
     tag = version;
-    hash = "sha256-frcRv+19czsZ948SEKfYsMUP6n9MbJv6gxXUAdwFw4Y=";
+    hash = "sha256-8StnxyuvyK9HRl1smbhJFz1qZxyNOWnzELG0ku0dh8k=";
   };
 
   patches = [
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     # The urllib3 incompat: https://github.com/msabramo/requests-unixsocket/pull/69
     # This is already patched in nixpkgs.
     substituteInPlace pyproject.toml \
-      --replace-fail "setuptools==75.9.1" "setuptools"
+      --replace-fail "setuptools==80.9.0" "setuptools"
   '';
 
   pythonRelaxDeps = [ "requests" ];


### PR DESCRIPTION
## Things done

Bump to [latest snapcraft release](https://github.com/canonical/snapcraft/releases/tag/8.11.2) with associated craft library bumps.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
