### PR TITLE
nuspell: build man pages in separate derivation

### DIFF
--- a/pkgs/development/libraries/nuspell/default.nix
+++ b/pkgs/development/libraries/nuspell/default.nix
@@ -7,7 +7,6 @@
   pkg-config,
   icu,
   catch2_3,
-  enableManpages ? buildPackages.pandoc.compiler.bootstrapAvailable,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -24,9 +23,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
-  ]
-  ++ lib.optionals enableManpages [
-    buildPackages.pandoc
   ];
 
   buildInputs = [ catch2_3 ];
@@ -35,8 +31,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DBUILD_TESTING=YES"
-  ]
-  ++ lib.optionals (!enableManpages) [
     "-DBUILD_DOCS=OFF"
   ];
 
@@ -47,6 +41,22 @@ stdenv.mkDerivation (finalAttrs: {
     "lib"
     "dev"
   ];
+
+  passthru = lib.optionalAttrs buildPackages.pandoc.compiler.bootstrapAvailable {
+    man = stdenv.mkDerivation {
+      pname = "${finalAttrs.pname}-man";
+      inherit (finalAttrs) version src meta;
+      sourceRoot = "${finalAttrs.src.name}/docs";
+      nativeBuildInputs = [
+        cmake
+        buildPackages.pandoc
+      ];
+      cmakeFlags = [
+        "-DBUILD_MAN=YES"
+        "-DBUILD_TOOLS=YES"
+      ];
+    };
+  };
 
   meta = {
     description = "Free and open source C++ spell checking library";

--- a/pkgs/development/libraries/nuspell/default.nix
+++ b/pkgs/development/libraries/nuspell/default.nix
@@ -10,14 +10,14 @@
   enableManpages ? buildPackages.pandoc.compiler.bootstrapAvailable,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "nuspell";
   version = "5.1.6";
 
   src = fetchFromGitHub {
     owner = "nuspell";
     repo = "nuspell";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-U/lHSxpKsBnamf4ikE2aIjEPSU5fxjtuSmhZR0jxMAI=";
   };
 
@@ -55,6 +55,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ fpletz ];
     license = licenses.lgpl3Plus;
-    changelog = "https://github.com/nuspell/nuspell/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/nuspell/nuspell/blob/${finalAttrs.src.tag}/CHANGELOG.md";
   };
-}
+})

--- a/pkgs/development/libraries/nuspell/default.nix
+++ b/pkgs/development/libraries/nuspell/default.nix
@@ -48,13 +48,13 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Free and open source C++ spell checking library";
     mainProgram = "nuspell";
     homepage = "https://nuspell.github.io/";
-    platforms = platforms.all;
-    maintainers = with maintainers; [ fpletz ];
-    license = licenses.lgpl3Plus;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ fpletz ];
+    license = lib.licenses.lgpl3Plus;
     changelog = "https://github.com/nuspell/nuspell/blob/${finalAttrs.src.tag}/CHANGELOG.md";
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8623,6 +8623,7 @@ with pkgs;
   nssTools = nss.tools;
 
   nuspell = callPackage ../development/libraries/nuspell { };
+  nuspell-man = nuspell.man;
   nuspellWithDicts =
     dicts: callPackage ../development/libraries/nuspell/wrapper.nix { inherit dicts; };
 


### PR DESCRIPTION
This reduces the number of rebuilds for pandoc / haskell-updates by up to 700 linux packages.

I tested `nix-shell -p nuspell` and then `man nuspell` - this still works. Seems like `.man` doesn't need to be an output, but could also be a separate derivation. Not sure whether that would lead to complications anywhere else, though.

Related: https://github.com/NixOS/nixpkgs/issues/427145

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested basic functionality of `man` in `nix-shell`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
