### PR TITLE
nixVersions.nix_2_31: init at 2.31.0

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1035,7 +1035,10 @@ in
   nix-config = runTest ./nix-config.nix;
   nix-ld = runTest ./nix-ld.nix;
   nix-misc = handleTest ./nix/misc.nix { };
-  nix-upgrade = handleTest ./nix/upgrade.nix { inherit (pkgs) nixVersions; };
+  nix-upgrade = handleTest ./nix/upgrade.nix {
+    inherit (pkgs) nixVersions;
+    inherit system;
+  };
   nix-required-mounts = runTest ./nix-required-mounts;
   nix-serve = runTest ./nix-serve.nix;
   nix-serve-ssh = runTest ./nix-serve-ssh.nix;

--- a/nixos/tests/nix/upgrade.nix
+++ b/nixos/tests/nix/upgrade.nix
@@ -1,10 +1,15 @@
-{ pkgs, nixVersions, ... }:
+{
+  pkgs,
+  nixVersions,
+  system,
+  ...
+}:
 let
   lib = pkgs.lib;
 
   fallback-paths-external = pkgs.writeTextDir "fallback-paths.nix" ''
     {
-      ${pkgs.system} = "${nixVersions.latest}";
+      ${system} = "${nixVersions.latest}";
     }'';
 
   nixos-module = builtins.toFile "nixos-module.nix" ''
@@ -71,7 +76,7 @@ pkgs.testers.nixosTest {
         if not match: raise Exception("Couldn't find new version in output: " + result)
 
     with subtest("nix-build-with-mismatch-daemon"):
-        machine.succeed("runuser -u alice -- nix build --expr 'derivation {name =\"test\"; system = \"${pkgs.system}\";builder = \"/bin/sh\"; args = [\"-c\" \"echo test > $out\"];}' --print-out-paths")
+        machine.succeed("runuser -u alice -- nix build --expr 'derivation {name =\"test\"; system = \"${system}\";builder = \"/bin/sh\"; args = [\"-c\" \"echo test > $out\"];}' --print-out-paths")
 
 
     with subtest("remove-new-nix"):
@@ -94,7 +99,7 @@ pkgs.testers.nixosTest {
         if not match: raise Exception("Couldn't find new version in output: " + result)
 
     with subtest("nix-build-with-new-daemon"):
-        machine.succeed("runuser -u alice -- nix build --expr 'derivation {name =\"test-new\"; system = \"${pkgs.system}\";builder = \"/bin/sh\"; args = [\"-c\" \"echo test > $out\"];}' --print-out-paths")
+        machine.succeed("runuser -u alice -- nix build --expr 'derivation {name =\"test-new\"; system = \"${system}\";builder = \"/bin/sh\"; args = [\"-c\" \"echo test > $out\"];}' --print-out-paths")
 
     with subtest("nix-collect-garbage-with-old-nix"):
         machine.succeed("${nixVersions.stable}/bin/nix-collect-garbage")

--- a/pkgs/by-name/bm/bmake/package.nix
+++ b/pkgs/by-name/bm/bmake/package.nix
@@ -57,12 +57,18 @@ stdenv.mkDerivation (finalAttrs: {
   # * opt-keep-going-indirect: not yet known
   # * varmod-localtime: musl doesn't support TZDIR and this test relies on
   #   impure, implicit paths
-  env.BROKEN_TESTS = builtins.concatStringsSep " " [
-    "directive-export"
-    "directive-export-gmake"
-    "opt-keep-going-indirect"
-    "varmod-localtime"
-  ];
+  # * interrupt-compat (fails on x86_64-linux building for i686-linux)
+  env.BROKEN_TESTS = lib.concatStringsSep " " (
+    [
+      "directive-export"
+      "directive-export-gmake"
+      "opt-keep-going-indirect"
+      "varmod-localtime"
+    ]
+    ++ lib.optionals stdenv.targetPlatform.is32bit [
+      "interrupt-compat"
+    ]
+  );
 
   strictDeps = true;
 

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -164,6 +164,20 @@ lib.makeExtensible (
 
       nix_2_30 = addTests "nix_2_30" self.nixComponents_2_30.nix-everything;
 
+      nixComponents_2_31 = nixDependencies.callPackage ./modular/packages.nix rec {
+        version = "2.31.0";
+        inherit (self.nix_2_30.meta) maintainers teams;
+        otherSplices = generateSplicesForNixComponents "nixComponents_2_31";
+        src = fetchFromGitHub {
+          owner = "NixOS";
+          repo = "nix";
+          tag = version;
+          hash = "sha256-5JYyijH2q/uQCDIZCCyQEBsZ0VPNP2SS1wgZ4+qeIWM=";
+        };
+      };
+
+      nix_2_31 = addTests "nix_2_31" self.nixComponents_2_31.nix-everything;
+
       nixComponents_git = nixDependencies.callPackage ./modular/packages.nix rec {
         version = "2.31pre20250712_${lib.substring 0 8 src.rev}";
         inherit maintainers teams;

--- a/pkgs/tools/package-management/nix/dependencies.nix
+++ b/pkgs/tools/package-management/nix/dependencies.nix
@@ -8,7 +8,20 @@ regular@{
 
 {
   scopeFunction = scope: {
-    boehmgc = regular.boehmgc.override { enableLargeConfig = true; };
+    boehmgc =
+      (regular.boehmgc.override {
+        enableLargeConfig = true;
+      }).overrideAttrs
+        (attrs: {
+          # Increase the initial mark stack size to avoid stack
+          # overflows, since these inhibit parallel marking (see
+          # GC_mark_some()). To check whether the mark stack is too
+          # small, run Nix with GC_PRINT_STATS=1 and look for messages
+          # such as `Mark stack overflow`, `No room to copy back mark
+          # stack`, and `Grew mark stack to ... frames`.
+          NIX_CFLAGS_COMPILE = "-DINITIAL_MARK_STACK_SIZE=1048576";
+        });
+
     aws-sdk-cpp =
       (regular.aws-sdk-cpp.override {
         apis = [

--- a/pkgs/tools/package-management/nix/modular/src/libfetchers-tests/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libfetchers-tests/package.nix
@@ -3,6 +3,7 @@
   buildPackages,
   stdenv,
   mkMesonExecutable,
+  writableTmpDirAsHomeHook,
 
   nix-fetchers,
   nix-fetchers-c,
@@ -47,18 +48,13 @@ mkMesonExecutable (finalAttrs: {
         runCommand "${finalAttrs.pname}-run"
           {
             meta.broken = !stdenv.hostPlatform.emulatorAvailable buildPackages;
+            buildInputs = [ writableTmpDirAsHomeHook ];
           }
-          (
-            lib.optionalString stdenv.hostPlatform.isWindows ''
-              export HOME="$PWD/home-dir"
-              mkdir -p "$HOME"
-            ''
-            + ''
-              export _NIX_TEST_UNIT_DATA=${resolvePath ./data}
-              ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
-              touch $out
-            ''
-          );
+          ''
+            export _NIX_TEST_UNIT_DATA=${resolvePath ./data}
+            ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
+            touch $out
+          '';
     };
   };
 

--- a/pkgs/tools/package-management/nix/modular/src/libflake-tests/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libflake-tests/package.nix
@@ -3,6 +3,7 @@
   buildPackages,
   stdenv,
   mkMesonExecutable,
+  writableTmpDirAsHomeHook,
 
   nix-flake,
   nix-flake-c,
@@ -41,12 +42,11 @@ mkMesonExecutable (finalAttrs: {
         runCommand "${finalAttrs.pname}-run"
           {
             meta.broken = !stdenv.hostPlatform.emulatorAvailable buildPackages;
+            buildInputs = [ writableTmpDirAsHomeHook ];
           }
           (''
             export _NIX_TEST_UNIT_DATA=${resolvePath ./data}
             export NIX_CONFIG="extra-experimental-features = flakes"
-            export HOME="$TMPDIR/home"
-            mkdir -p "$HOME"
             ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
             touch $out
           '');

--- a/pkgs/tools/package-management/nix/modular/src/libflake-tests/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libflake-tests/package.nix
@@ -42,18 +42,14 @@ mkMesonExecutable (finalAttrs: {
           {
             meta.broken = !stdenv.hostPlatform.emulatorAvailable buildPackages;
           }
-          (
-            lib.optionalString stdenv.hostPlatform.isWindows ''
-              export HOME="$PWD/home-dir"
-              mkdir -p "$HOME"
-            ''
-            + ''
-              export _NIX_TEST_UNIT_DATA=${resolvePath ./data}
-              export NIX_CONFIG="extra-experimental-features = flakes"
-              ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
-              touch $out
-            ''
-          );
+          (''
+            export _NIX_TEST_UNIT_DATA=${resolvePath ./data}
+            export NIX_CONFIG="extra-experimental-features = flakes"
+            export HOME="$TMPDIR/home"
+            mkdir -p "$HOME"
+            ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
+            touch $out
+          '');
     };
   };
 

--- a/pkgs/tools/package-management/nix/modular/src/libstore-tests/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libstore-tests/package.nix
@@ -67,6 +67,7 @@ mkMesonExecutable (finalAttrs: {
           }
           (''
             export _NIX_TEST_UNIT_DATA=${data + "/src/libstore-tests/data"}
+            export NIX_REMOTE=$HOME/store
             ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage} \
               --gtest_filter=-${lib.concatStringsSep ":" finalAttrs.excludedTestPatterns}
             touch $out

--- a/pkgs/tools/package-management/nix/modular/src/libstore-tests/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libstore-tests/package.nix
@@ -3,6 +3,7 @@
   buildPackages,
   stdenv,
   mkMesonExecutable,
+  writableTmpDirAsHomeHook,
 
   nix-store,
   nix-store-c,
@@ -62,11 +63,10 @@ mkMesonExecutable (finalAttrs: {
         runCommand "${finalAttrs.pname}-run"
           {
             meta.broken = !stdenv.hostPlatform.emulatorAvailable buildPackages;
+            buildInputs = [ writableTmpDirAsHomeHook ];
           }
           (''
             export _NIX_TEST_UNIT_DATA=${data + "/src/libstore-tests/data"}
-            export HOME="$TMPDIR/home"
-            mkdir -p "$HOME"
             ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage} \
               --gtest_filter=-${lib.concatStringsSep ":" finalAttrs.excludedTestPatterns}
             touch $out


### PR DESCRIPTION
Diff: https://github.com/NixOS/nix/compare/2.30.2...2.31.0

Changelog: https://discourse.nixos.org/t/nix-2-31-0-released/68465

Previous release PR:

- #423962

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test