### PR TITLE
lyra: 1.6.1 -> 1.7.0

### DIFF
--- a/pkgs/by-name/ly/lyra/package.nix
+++ b/pkgs/by-name/ly/lyra/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lyra";
-  version = "1.6.1";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "bfgroup";
     repo = "lyra";
     rev = version;
-    sha256 = "sha256-tS2SPLiKaL8C35AmOXyJPstFUfynkE/A53rurqiySbI=";
+    sha256 = "sha256-X8wJwSfOo7v2SKYrKJ4RhpEmOdEkS8lPHIqCxP46VF4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sy/sycl-info/fix-lyra-message.patch
+++ b/pkgs/by-name/sy/sycl-info/fix-lyra-message.patch
@@ -1,0 +1,12 @@
+diff '--color=auto' -u -r old/sycl-info/cli_config.hpp new/sycl-info/cli_config.hpp
+--- old/sycl-info/cli_config.hpp	2025-08-28 01:01:14.403357414 +0800
++++ new/sycl-info/cli_config.hpp	2025-08-28 01:02:11.256702715 +0800
+@@ -42,7 +42,7 @@
+     auto cli = make_cli();
+     auto result = cli.parse(lyra::args(argc, argv));
+     if (!result) {
+-      raise_error(result.errorMessage(), cli);
++      raise_error(result.message(), cli);
+     }
+   }
+ 

--- a/pkgs/by-name/sy/sycl-info/package.nix
+++ b/pkgs/by-name/sy/sycl-info/package.nix
@@ -23,6 +23,11 @@ stdenv.mkDerivation {
     sha256 = "0fy0y1rcfb11p3vijd8wym6xkaicav49pv2bv2l18rma929n1m1m";
   };
 
+  patches = [
+    # fix error caused by upgrading lyra from 1.6.1 to 1.7.0
+    ./fix-lyra-message.patch
+  ];
+
   buildInputs = [
     nlohmann_json
     ronn


### PR DESCRIPTION
This PR upgrade lyra and fix compilation error caused by this update.

Close https://github.com/NixOS/nixpkgs/pull/431858.

@wegank .

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
