### PR TITLE
osgqt: add Qt6 support

### DIFF
--- a/pkgs/by-name/os/osgqt/package.nix
+++ b/pkgs/by-name/os/osgqt/package.nix
@@ -1,12 +1,18 @@
 {
   cmake,
   fetchFromGitHub,
+  fetchpatch,
   lib,
   libsForQt5,
+  qt6Packages,
   openscenegraph,
   stdenv,
-}:
 
+  qt6Support ? false,
+}:
+let
+  qt = if qt6Support then qt6Packages else libsForQt5;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "osgQt";
   version = "3.5.7-unstable-2025-10-08";
@@ -18,17 +24,38 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-+rjy2a266p755Mbfk6jRApiERpOL8axHklK0cYokX40=";
   };
 
-  buildInputs = [ libsForQt5.qtbase ];
+  patches = lib.optionals qt6Support [
+    (fetchpatch {
+      url = "https://github.com/DeadParrot/osgQt/commit/c4d48d1f05fda1dcb210418b89c75edf2157d85b.patch";
+      hash = "sha256-oq6R7BwXagXhxz3ClkD4qVSaNyfKawU5JK4Pq3QBKvU=";
+    })
+    (fetchpatch {
+      url = "https://github.com/DeadParrot/osgQt/commit/acbcdbec0026ad4b3979b6fa9311a1576f06b2cc.patch";
+      hash = "sha256-OJSITx/Lr4DwWM9vrLUiKh/cXZW+3jSAyNXLeyHPm3k=";
+    })
+  ];
+
+  postPatch = lib.optionalString qt6Support ''
+    mv include/osgQOpenGL/GraphicsWindowEx{,.h}
+    mv include/osgQOpenGL/OSGRenderer{,.h}
+    mv include/osgQOpenGL/RenderStageEx{,.h}
+    mv include/osgQOpenGL/StateEx{,.h}
+    mv include/osgQOpenGL/osgQOpenGLWidget{,.h}
+    mv include/osgQOpenGL/osgQOpenGLWindow{,.h}
+  '';
+
+  buildInputs = [ qt.qtbase ];
 
   nativeBuildInputs = [
     cmake
-    libsForQt5.wrapQtAppsHook
+    qt.wrapQtAppsHook
   ];
 
   propagatedBuildInputs = [ openscenegraph ];
 
   cmakeFlags = [
-    "-DDESIRED_QT_VERSION=5"
+    "-DBUILD_OSG_EXAMPLES=OFF"
+    "-DDESIRED_QT_VERSION=${if qt6Support then "6" else "5"}"
     "-DOpenGL_GL_PREFERENCE=GLVND"
   ];
 

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -138,6 +138,8 @@ makeScopeWithSplicing' {
           qt = qt5;
         };
 
+        osgqt = pkgs.osgqt.override { qt6Support = false; };
+
         phonon = callPackage ../development/libraries/phonon { };
 
         phonon-backend-gstreamer = callPackage ../development/libraries/phonon/backends/gstreamer.nix { };

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -82,6 +82,8 @@ makeScopeWithSplicing' {
 
       maplibre-native-qt = callPackage ../development/libraries/maplibre-native-qt { };
 
+      osgqt = pkgs.osgqt.override { qt6Support = true; };
+
       qca = callPackage ../development/libraries/qca {
         inherit (qt6) qtbase qt5compat;
       };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
