### PR TITLE
ffmpeg: small refactor

### DIFF
--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -15,9 +15,11 @@
   # NOTICE: Always use this argument to override the version. Do not use overrideAttrs.
   version, # ffmpeg ABI version. Also declare this if you're overriding the source.
   hash ? "", # hash of the upstream source for the given ABI version
-  source ? fetchgit {
-    url = "https://git.ffmpeg.org/ffmpeg.git";
-    rev = "n${version}";
+  source ? fetchFromGitea {
+    domain = "code.ffmpeg.org";
+    owner = "FFmpeg";
+    repo = "FFmpeg";
+    tag = "n${version}";
     inherit hash;
   },
 
@@ -40,7 +42,7 @@
   # instead.
   withFullDeps ? ffmpegVariant == "full",
 
-  fetchgit,
+  fetchFromGitea,
   fetchpatch2,
 
   # Feature flags

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -827,7 +827,7 @@ stdenv.mkDerivation (
       pkg-config
     ]
     # 8.0 is only compatible with nasm, and we don't want to rebuild all older ffmpeg builds at this moment.
-    ++ (if versionOlder version "8.0" then [ yasm ] else [ nasm ])
+    ++ optionals stdenv.hostPlatform.isx86 (if versionOlder version "8.0" then [ yasm ] else [ nasm ])
     # Texinfo version 7.1 introduced breaking changes, which older versions of ffmpeg do not handle.
     ++ (if versionOlder version "5" then [ texinfo6 ] else [ texinfo ])
     ++ optionals withCudaLLVM [ clang ]

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -9,7 +9,6 @@
   perl,
   texinfo,
   texinfo6,
-  yasm,
   nasm,
 
   # You can fetch any upstream version using this derivation by specifying version and hash
@@ -826,8 +825,7 @@ stdenv.mkDerivation (
       perl
       pkg-config
     ]
-    # 8.0 is only compatible with nasm, and we don't want to rebuild all older ffmpeg builds at this moment.
-    ++ optionals stdenv.hostPlatform.isx86 (if versionOlder version "8.0" then [ yasm ] else [ nasm ])
+    ++ optionals stdenv.hostPlatform.isx86 [ nasm ]
     # Texinfo version 7.1 introduced breaking changes, which older versions of ffmpeg do not handle.
     ++ (if versionOlder version "5" then [ texinfo6 ] else [ texinfo ])
     ++ optionals withCudaLLVM [ clang ]


### PR DESCRIPTION
- Swap over to using nasm instead of yasm
- switch to the new upstream repo
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
