### PR TITLE
filen-desktop: 3.0.41 -> 3.0.47, build from source not binary

### DIFF
--- a/pkgs/by-name/fi/filen-desktop/package.nix
+++ b/pkgs/by-name/fi/filen-desktop/package.nix
@@ -1,54 +1,115 @@
 {
   lib,
+  pkgs,
   stdenv,
-  fetchurl,
-  appimageTools,
+  buildNpmPackage,
+  fetchFromGitHub,
   makeDesktopItem,
+  desktopToDarwinBundle,
 }:
 let
-  pname = "filen-desktop";
-  version = "3.0.47";
-
-  arch = builtins.head (builtins.split "-" stdenv.hostPlatform.system);
-
-  src = fetchurl {
-    url = "https://github.com/FilenCloudDienste/filen-desktop/releases/download/v${version}/Filen_linux_${arch}.AppImage";
-    hash = "sha256-keaD5PUjkoFrFTCuap4DvmYq5X3Tjnq+njtiLgAZ9W8=";
-  };
-
+  packageName = "filen-desktop";
+  packageVersion = "3.0.47";
+  desktopName = "Filen Desktop";
   desktopItem = makeDesktopItem {
-    name = "filen-desktop";
-    desktopName = "Filen Desktop";
+    name = packageName;
+    exec = packageName;
+    icon = packageName;
+    startupWMClass = packageName;
+    desktopName = desktopName;
     comment = "Encrypted Cloud Storage";
-    icon = "filen-desktop";
-    exec = "filen-desktop %u";
-    categories = [ "Office" ];
+    categories = [
+      "Network"
+      "FileTransfer"
+      "Utility"
+    ];
+    keywords = [
+      "cloud"
+      "storage"
+      "encrypted"
+    ];
   };
 
-  appimageContents = appimageTools.extract { inherit pname version src; };
+  iconPrefix = if stdenv.hostPlatform.isDarwin then "darwin" else "linux";
+  iconSuffix = if stdenv.hostPlatform.isDarwin then "icns" else "png";
 in
-appimageTools.wrapType2 {
-  inherit pname version src;
+buildNpmPackage {
+  pname = packageName;
+  version = packageVersion;
+  makeCacheWritable = true;
 
-  extraInstallCommands = ''
-    mkdir -p $out/share
-    cp -rt $out/share ${desktopItem}/share/applications ${appimageContents}/usr/share/icons
-    chmod -R +w $out/share
-    find $out/share/icons -type f -iname "*.png" -execdir mv {} "$pname.png" \;
+  src = fetchFromGitHub {
+    owner = "FilenCloudDienste";
+    repo = packageName;
+    rev = "v${packageVersion}";
+    hash = "sha256-WS9JqErfsRtt6zF+LrKkpiscJ25MRXmRxmIm3GH6xf0=";
+  };
+
+  npmDepsHash = "sha256-+Ul2z6faZvAeCHq35janVTUNoqTQ5JNDeLbCV220nFU=";
+  npmBuildScript = "build";
+
+  ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+
+  nativeBuildInputs = [
+    pkgs.pkg-config
+    pkgs.electron
+    pkgs.makeWrapper
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    desktopToDarwinBundle
+  ];
+
+  buildInputs = [
+    pkgs.pixman
+    pkgs.cairo
+    pkgs.pango
+  ];
+
+  # Override package-lock.json electron version to use what's given by nixpkgs
+  postPatch = ''
+    substituteInPlace package.json \
+      --replace-fail '"electron": "^34.1.1"' '"electron": "*"'
+  '';
+
+  # Set up icon assets in path required by desktopItem
+  preInstall = ''
+    mkdir -p $out/share/pixmaps
+    cp $src/assets/icons/app/${iconPrefix}.${iconSuffix} $out/share/pixmaps/${packageName}.${iconSuffix}
+    cp $src/assets/icons/app/${iconPrefix}Notification.${iconSuffix} $out/share/pixmaps/${packageName}-notification.${iconSuffix}
+  '';
+
+  # Create binary wrapper and desktopItem
+  # desktopItem auto-creates the .app bundle for Darwin
+  postInstall = ''
+    makeWrapper ${pkgs.electron}/bin/electron $out/bin/${packageName} \
+      --set-default ELECTRON_IS_DEV 0 \
+      --add-flags $out/lib/node_modules/@filen/desktop/dist/index.js \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib ]}"
+
+    mkdir -p $out/share/applications
+    cp ${desktopItem}/share/applications/* $out/share/applications/
+  '';
+
+  # Write correct darwin icons to .app contents
+  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    cp -rf $out/share/pixmaps/* "$out/Applications/${desktopName}.app/Contents/Resources"
   '';
 
   meta = {
-    homepage = "https://filen.io/products/desktop";
-    downloadPage = "https://github.com/FilenCloudDienste/filen-desktop/releases/";
-    description = "Filen Desktop Client for Linux";
+    homepage = "https://filen.io/products";
+    downloadPage = "https://filen.io/products/desktop";
+    description = "Filen Desktop Client";
     longDescription = ''
       Encrypted Cloud Storage built for your Desktop.
-      Sync your data, mount network drives, collaborate with others and access files natively — powered by robust encryption and seamless integration.
+      Sync your data, mount network drives, collaborate with others and access files natively powered by robust encryption and seamless integration.
     '';
-    mainProgram = "filen-desktop";
-    platforms = [ "x86_64-linux" ];
+    mainProgram = packageName;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     license = lib.licenses.agpl3Only;
-    maintainers = with lib.maintainers; [ smissingham ];
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [
+      smissingham
+      kashw2
+    ];
   };
 }


### PR DESCRIPTION
Improvements:
- Build from npm source instead of unpacking binary
- Add support for Darwin
- Volume mount now works on both NixOS and Darwin
- Update minor version

Fixes: https://github.com/NixOS/nixpkgs/issues/412631 
Supersedes: https://github.com/NixOS/nixpkgs/pull/436090

Basic functions tested on:
- x86_64-linux: NixOS (Intel i9 13900k)
- aarch64-darwin: MacOS Sequoia 15.6.1 (Apple M4 Max)

Other testers appreciated, should work for other platforms.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
