### PR TITLE
_0xproto: 2.100 -> 2.500

### DIFF
--- a/pkgs/by-name/_0/_0xproto/package.nix
+++ b/pkgs/by-name/_0/_0xproto/package.nix
@@ -18,10 +18,12 @@ stdenvNoCC.mkDerivation rec {
       stripRoot = false;
     };
 
+  # Exclude files in ZxProto/. The fonts are identical, with only the filenames changed.:
+  # https://github.com/0xType/0xProto/pull/112
   installPhase = ''
     runHook preInstall
-    install -Dm644 -t $out/share/fonts/opentype/ *.otf
-    install -Dm644 -t $out/share/fonts/truetype/ *.ttf
+    install -Dm644 -t $out/share/fonts/opentype/ *.otf ./No-Ligatures/*-NL.otf
+    install -Dm644 -t $out/share/fonts/truetype/ *.ttf ./No-Ligatures/*-NL.ttf
     runHook postInstall
   '';
 

--- a/pkgs/by-name/_0/_0xproto/package.nix
+++ b/pkgs/by-name/_0/_0xproto/package.nix
@@ -6,7 +6,7 @@
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "0xproto";
-  version = "2.100";
+  version = "2.500";
 
   src =
     let
@@ -14,7 +14,8 @@ stdenvNoCC.mkDerivation rec {
     in
     fetchzip {
       url = "https://github.com/0xType/0xProto/releases/download/${version}/0xProto_${underscoreVersion}.zip";
-      hash = "sha256-hUQGCsktnun9924+k6ECQuQ1Ddl/qGmtuLWERh/vDpc=";
+      hash = "sha256-AmD5lUV341222gu/cCLnKWO87mjPn7gFkeklrV3OlOs=";
+      stripRoot = false;
     };
 
   installPhase = ''

--- a/pkgs/by-name/_0/_0xproto/package.nix
+++ b/pkgs/by-name/_0/_0xproto/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  nix-update-script,
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "0xproto";
@@ -22,6 +23,10 @@ stdenvNoCC.mkDerivation rec {
     install -Dm644 -t $out/share/fonts/truetype/ *.ttf
     runHook postInstall
   '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Free and Open-source font for programming";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR fixes the automatic updater.
Updates for this package stopped for one year.

- Last attempt: https://nixpkgs-update-logs.nix-community.org/_0xproto/2025-08-22.log
- Diff: https://github.com/0xType/0xProto/compare/2.100...2.500
- Changelog: https://github.com/0xType/0xProto/blob/2.500/CHANGELOG.md?plain=1#L3-L36

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

@EdSwordsmith

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
