### PR TITLE
python3packages.gitingest: move GitHub organization, fix dependencies

### DIFF
--- a/pkgs/development/python-modules/gitingest/default.nix
+++ b/pkgs/development/python-modules/gitingest/default.nix
@@ -5,11 +5,15 @@
 
   # Dependencies
   setuptools,
+  boto3,
   click,
   fastapi,
+  loguru,
   pathspec,
+  prometheus-client,
   pydantic,
   python-dotenv,
+  sentry-sdk,
   slowapi,
   starlette,
   tiktoken,
@@ -32,7 +36,7 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "cyclotruc";
+    owner = "coderamp-labs";
     repo = "gitingest";
     tag = "v${version}";
     hash = "sha256-drsncGneZyOCC2GJbrDM+bf4QGI2luacxMhrmdk03l4=";
@@ -43,11 +47,16 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
+    boto3
     click
     fastapi
+    httpx
+    loguru
     pathspec
+    prometheus-client
     pydantic
     python-dotenv
+    sentry-sdk
     slowapi
     starlette
     tiktoken
@@ -60,7 +69,6 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    httpx
     jinja2
     gitMinimal
     pytest-asyncio
@@ -77,16 +85,22 @@ buildPythonPackage rec {
     "test_cli_writes_file"
     "test_clone_specific_branch"
     "test_include_ignore_patterns"
+    "test_ingest_summary"
     "test_ingest_with_gitignore"
     "test_parse_query_with_branch"
     "test_parse_query_without_host"
+    "test_remote_repository_analysis"
+    "test_large_repository"
+    "test_concurrent_requests"
+    "test_large_file_handling"
+    "test_repository_with_patterns"
     "test_run_ingest_query"
   ];
 
   meta = {
-    changelog = "https://github.com/cyclotruc/gitingest/releases/tag/${src.tag}";
+    changelog = "https://github.com/coderamp-labs/gitingest/releases/tag/${src.tag}";
     description = "Replace 'hub' with 'ingest' in any github url to get a prompt-friendly extract of a codebase";
-    homepage = "https://github.com/cyclotruc/gitingest";
+    homepage = "https://github.com/coderamp-labs/gitingest";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ ];
     mainProgram = "gitingest";


### PR DESCRIPTION
GitHub org got named, the project is now at https://github.com/coderamp-labs/gitingest. Fix missing dependencies and blacklist network tests to fix build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
