### PR TITLE
emacs: replace fetchFromSavannah with mirror

### DIFF
--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -13,7 +13,7 @@ lib.makeScope pkgs.newScope (
       inherit lib;
       inherit (pkgs)
         fetchFromBitbucket
-        fetchFromSavannah
+        fetchzip
         ;
     };
 

--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -13,7 +13,7 @@ lib.makeScope pkgs.newScope (
       inherit lib;
       inherit (pkgs)
         fetchFromBitbucket
-        fetchurl
+        fetchFromSavannah
         ;
     };
 

--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -69,7 +69,7 @@
   # Boolean flags
   withNativeCompilation ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
   noGui ? false,
-  srcRepo ? true,
+  srcRepo ? false,
   withAcl ? false,
   withAlsaLib ? false,
   withAthena ? false,
@@ -202,6 +202,11 @@ mkDerivation (finalAttrs: {
   postPatch = lib.concatStringsSep "\n" [
     (lib.optionalString srcRepo ''
       rm -fr .git
+    '')
+
+    # See: https://github.com/NixOS/nixpkgs/issues/170426
+    (lib.optionalString (!srcRepo) ''
+      find . -type f \( -name "*.elc" -o -name "*loaddefs.el" \) -exec rm {} \;
     '')
 
     # Add the name of the wrapped gvfsd

--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -69,6 +69,7 @@
   # Boolean flags
   withNativeCompilation ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
   noGui ? false,
+  srcRepo ? true,
   withAcl ? false,
   withAlsaLib ? false,
   withAthena ? false,
@@ -199,11 +200,9 @@ mkDerivation (finalAttrs: {
     ];
 
   postPatch = lib.concatStringsSep "\n" [
-
-    # See: https://github.com/NixOS/nixpkgs/issues/170426
-    ''
-      find . -type f \( -name "*.elc" -o -name "*loaddefs.el" \) -exec rm {} \;
-    ''
+    (lib.optionalString srcRepo ''
+      rm -fr .git
+    '')
 
     # Add the name of the wrapped gvfsd
     # This used to be carried as a patch but it often got out of sync with
@@ -248,6 +247,11 @@ mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeWrapper
     pkg-config
+  ]
+  ++ lib.optionals (variant == "macport") [
+    texinfo
+  ]
+  ++ lib.optionals srcRepo [
     autoreconfHook
     texinfo
   ]

--- a/pkgs/applications/editors/emacs/sources.nix
+++ b/pkgs/applications/editors/emacs/sources.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromBitbucket,
-  fetchFromSavannah,
+  fetchzip,
 }:
 
 let
@@ -26,9 +26,9 @@ let
       src =
         {
           "mainline" = (
-            fetchFromSavannah {
-              repo = "emacs";
-              inherit rev hash;
+            fetchzip {
+              url = "mirror://gnu/emacs/${rev}.tar.xz";
+              inherit hash;
             }
           );
           "macport" = (
@@ -107,8 +107,8 @@ in
     pname = "emacs";
     version = "30.2";
     variant = "mainline";
-    rev = "30.2";
-    hash = "sha256-3Lfb3HqdlXqSnwJfxe7npa4GGR9djldy8bKRpkQCdSA=";
+    rev = "emacs-30.2";
+    hash = "sha256-W2eZ+cNQhi/fMeRkwOqSKU7Vzvp43WUOpiwaLLNEXtg=";
     patches = fetchpatch: [
       (builtins.path {
         name = "inhibit-lexical-cookie-warning-67916.patch";

--- a/pkgs/applications/editors/emacs/sources.nix
+++ b/pkgs/applications/editors/emacs/sources.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromBitbucket,
-  fetchurl,
+  fetchFromSavannah,
 }:
 
 let
@@ -26,9 +26,9 @@ let
       src =
         {
           "mainline" = (
-            fetchurl {
-              url = "mirror://gnu/emacs/emacs-${rev}.tar.xz";
-              inherit hash;
+            fetchFromSavannah {
+              repo = "emacs";
+              inherit rev hash;
             }
           );
           "macport" = (
@@ -108,7 +108,7 @@ in
     version = "30.2";
     variant = "mainline";
     rev = "30.2";
-    hash = "sha256-s/NvGKbdJxVxM3AWYlfeL64B+dOM/oeM7Zsebe1b79k=";
+    hash = "sha256-3Lfb3HqdlXqSnwJfxe7npa4GGR9djldy8bKRpkQCdSA=";
     patches = fetchpatch: [
       (builtins.path {
         name = "inhibit-lexical-cookie-warning-67916.patch";


### PR DESCRIPTION
Revert and re-apply a019344338d84d8e6a79ab0a5a1ede443234e331 with
fixes and minor improvements.

Refs: #427024 #435964
Co-authored-by: Lin Jian <me@linj.tech>

- [x] I need to do some tests

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
