### PR TITLE
nixos/anubis: add support for a dedicated RuntimeDirectory per instance

### DIFF
--- a/nixos/modules/services/networking/anubis.md
+++ b/nixos/modules/services/networking/anubis.md
@@ -8,6 +8,34 @@ between a reverse proxy and the service to be protected.
 This module is designed to use Unix domain sockets as the socket paths can be automatically configured for multiple
 instances, but TCP sockets are also supported.
 
+Configuring multiple instances may look like the following.
+
+Notes:
+
+- Each instance as its runtime directory set to `anubis/anubis-<instance name>`.
+- When a single instance is declared with unix sockets, the runtime directory `anubis` is allowed for backward
+  compatibility.
+
+```nix
+{
+  services.anubis.instances."instance-1" = {
+    # Runtime directory: "anubis/anubis-instance-1".
+    settings = {
+      BIND = "/run/anubis/anubis-instance-1/anubis.sock";
+      TARGET = "http://localhost:8001";
+    };
+  };
+
+  services.anubis.instances."instance-2" = {
+    # Runtime directory: "anubis/anubis-instance-2".
+    settings = {
+      BIND = "/run/anubis/anubis-instance-2/anubis.sock";
+      TARGET = "http://localhost:8002";
+    };
+  };
+}
+```
+
 A minimal configuration with [nginx](#opt-services.nginx.enable) may look like the following:
 
 ```nix

--- a/nixos/tests/anubis.nix
+++ b/nixos/tests/anubis.nix
@@ -1,4 +1,36 @@
 { lib, ... }:
+let
+  legacyBotPolicyJSON = ''
+    {
+      "bots": [
+        {
+          "import": "(data)/bots/_deny-pathological.yaml"
+        },
+        {
+          "import": "(data)/meta/ai-block-aggressive.yaml"
+        },
+        {
+          "import": "(data)/crawlers/_allow-good.yaml"
+        },
+        {
+          "import": "(data)/bots/aggressive-brazilian-scrapers.yaml"
+        },
+        {
+          "import": "(data)/common/keep-internet-working.yaml"
+        },
+        {
+          "name": "generic-browser",
+          "user_agent_regex": "Mozilla|Opera",
+          "action": "CHALLENGE"
+        }
+      ],
+      "dnsbl": false,
+      "status_codes": {
+        "CHALLENGE": 200,
+        "DENY": 200
+      }
+    }'';
+in
 {
   name = "anubis";
   meta.maintainers = with lib.maintainers; [
@@ -7,57 +39,75 @@
     ryand56
   ];
 
-  nodes.machine =
+  nodes.machineLegacy =
     { config, pkgs, ... }:
     {
       services.anubis = {
         defaultOptions = {
-          # Get default botPolicy
-          botPolicy = lib.importJSON "${config.services.anubis.package.src}/data/botPolicies.json";
+          botPolicy = builtins.fromJSON legacyBotPolicyJSON;
           settings = {
             DIFFICULTY = 3;
             USER_DEFINED_DEFAULT = true;
           };
         };
-        instances = {
-          "".settings = {
+
+        instances."".settings = {
+          TARGET = "http://localhost:8080";
+          DIFFICULTY = 5;
+          USER_DEFINED_INSTANCE = true;
+        };
+
+        instances."tcp" = {
+          user = "anubis-tcp";
+          group = "anubis-tcp";
+          settings = {
             TARGET = "http://localhost:8080";
-            DIFFICULTY = 5;
-            USER_DEFINED_INSTANCE = true;
-          };
-
-          "tcp" = {
-            user = "anubis-tcp";
-            group = "anubis-tcp";
-            settings = {
-              TARGET = "http://localhost:8080";
-              BIND = ":9000";
-              BIND_NETWORK = "tcp";
-              METRICS_BIND = ":9001";
-              METRICS_BIND_NETWORK = "tcp";
-            };
-          };
-
-          "unix-upstream" = {
-            group = "nginx";
-            settings.TARGET = "unix:///run/nginx/nginx.sock";
-          };
-
-          "botPolicy-default" = {
-            botPolicy = null;
-            settings.TARGET = "http://localhost:8080";
-          };
-
-          "botPolicy-file" = {
-            settings = {
-              TARGET = "http://localhost:8080";
-              POLICY_FNAME = "/etc/anubis-botPolicy.json";
-            };
+            BIND = "127.0.0.1:9000";
+            BIND_NETWORK = "tcp";
+            METRICS_BIND = "127.0.0.1:9001";
+            METRICS_BIND_NETWORK = "tcp";
           };
         };
       };
 
-      # Empty json for testing
+      users.users.nginx.extraGroups = [ config.users.groups.anubis.name ];
+      services.nginx = {
+        enable = true;
+        recommendedProxySettings = true;
+        virtualHosts."basic.localhost".locations = {
+          "/".proxyPass = "http://unix:${config.services.anubis.instances."".settings.BIND}";
+          "/metrics".proxyPass = "http://unix:${config.services.anubis.instances."".settings.METRICS_BIND}";
+        };
+
+        virtualHosts."tcp.localhost".locations = {
+          "/".proxyPass = "http://${config.services.anubis.instances."tcp".settings.BIND}";
+          "/metrics".proxyPass = "http://${config.services.anubis.instances."tcp".settings.METRICS_BIND}";
+        };
+
+        # emulate an upstream with nginx, listening on tcp and unix sockets.
+        virtualHosts."upstream.localhost" = {
+          default = true; # make nginx match this vhost for `localhost`
+          listen = [
+            { addr = "unix:/run/nginx/nginx.sock"; }
+            {
+              addr = "localhost";
+              port = 8080;
+            }
+          ];
+          locations."/" = {
+            tryFiles = "$uri $uri/index.html =404";
+            root = pkgs.runCommand "anubis-test-upstream" { } ''
+              mkdir $out
+              echo "it works" >> $out/index.html
+            '';
+          };
+        };
+      };
+    };
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
       environment.etc."anubis-botPolicy.json".text = lib.generators.toJSON { } {
         bots = [
           {
@@ -68,8 +118,73 @@
         ];
       };
 
+      services.anubis = {
+        defaultOptions = {
+          botPolicy = builtins.fromJSON legacyBotPolicyJSON;
+          settings = {
+            DIFFICULTY = 3;
+            USER_DEFINED_DEFAULT = true;
+          };
+        };
+
+        instances."".settings = {
+          TARGET = "http://localhost:8080";
+          DIFFICULTY = 5;
+          USER_DEFINED_INSTANCE = true;
+          BIND = "/run/anubis/anubis/anubis.sock";
+          METRICS_BIND = "/run/anubis/anubis/anubis-metrics.sock";
+        };
+
+        instances."tcp" = {
+          user = "anubis-tcp";
+          group = "anubis-tcp";
+          settings = {
+            TARGET = "http://localhost:8080";
+            BIND = "127.0.0.1:9000";
+            BIND_NETWORK = "tcp";
+            METRICS_BIND = "127.0.0.1:9001";
+            METRICS_BIND_NETWORK = "tcp";
+          };
+        };
+
+        instances."another-unix-listen" = {
+          settings = {
+            TARGET = "http://localhost:8080";
+            BIND = "/run/anubis/anubis-another-unix-listen/anubis.sock";
+            METRICS_BIND = "/run/anubis/anubis-another-unix-listen/anubis-metrics.sock";
+          };
+        };
+
+        instances."unix-upstream" = {
+          group = "nginx";
+          settings = {
+            BIND = "/run/anubis/anubis-unix-upstream/anubis.sock";
+            METRICS_BIND = "/run/anubis/anubis-unix-upstream/anubis-metrics.sock";
+            TARGET = "unix:///run/nginx/nginx.sock";
+          };
+        };
+
+        instances."botPolicy-default" = {
+          botPolicy = null;
+          settings = {
+            TARGET = "http://localhost:8080";
+            BIND = "/run/anubis/anubis-botPolicy-default/anubis.sock";
+            METRICS_BIND = "/run/anubis/anubis-botPolicy-default/anubis-metrics.sock";
+          };
+        };
+
+        instances."botPolicy-file" = {
+          settings = {
+            TARGET = "http://localhost:8080";
+            POLICY_FNAME = "/etc/anubis-botPolicy.json";
+            BIND = "/run/anubis/anubis-botPolicy-file/anubis.sock";
+            METRICS_BIND = "/run/anubis/anubis-botPolicy-file/anubis-metrics.sock";
+          };
+        };
+      };
+
       # support
-      users.users.nginx.extraGroups = [ config.services.anubis.defaultOptions.group ];
+      users.users.nginx.extraGroups = [ config.users.groups.anubis.name ];
       services.nginx = {
         enable = true;
         recommendedProxySettings = true;
@@ -79,12 +194,21 @@
         };
 
         virtualHosts."tcp.localhost".locations = {
-          "/".proxyPass = "http://localhost:9000";
-          "/metrics".proxyPass = "http://localhost:9001";
+          "/".proxyPass = "http://${config.services.anubis.instances."tcp".settings.BIND}";
+          "/metrics".proxyPass = "http://${config.services.anubis.instances."tcp".settings.METRICS_BIND}";
+        };
+
+        virtualHosts."another-unix-listen".locations = {
+          "/".proxyPass = "http://unix:${
+            config.services.anubis.instances."another-unix-listen".settings.BIND
+          }";
+          "/metrics".proxyPass = "http://unix:${
+            config.services.anubis.instances."another-unix-listen".settings.METRICS_BIND
+          }";
         };
 
         virtualHosts."unix.localhost".locations = {
-          "/".proxyPass = "http://unix:${config.services.anubis.instances.unix-upstream.settings.BIND}";
+          "/".proxyPass = "http://unix:${config.services.anubis.instances."unix-upstream".settings.BIND}";
         };
 
         # emulate an upstream with nginx, listening on tcp and unix sockets.
@@ -109,43 +233,61 @@
     };
 
   testScript = ''
-    for unit in ["nginx", "anubis", "anubis-tcp", "anubis-unix-upstream"]:
-      machine.wait_for_unit(unit + ".service")
+    with subtest("Legacy anubis service configuration: supports only a single RuntimeDirectory"):
+      for unit in ["nginx", "anubis", "anubis-tcp"]:
+        machineLegacy.wait_for_unit(unit + ".service")
 
-    for port in [9000, 9001]:
-      machine.wait_for_open_port(port)
+      machineLegacy.wait_for_open_unix_socket("/run/anubis/anubis.sock")
+      machineLegacy.wait_for_open_unix_socket("/run/anubis/anubis-metrics.sock")
 
-    for instance in ["anubis", "anubis-unix-upstream"]:
-      machine.wait_for_open_unix_socket(f"/run/anubis/{instance}.sock")
-      machine.wait_for_open_unix_socket(f"/run/anubis/{instance}-metrics.sock")
+      # Default unix socket mode with 1 instance listening on unix sockets.
+      machineLegacy.succeed('curl -f http://localhost:8080 | grep "it works"')
+      machineLegacy.succeed('curl -f http://basic.localhost | grep "it works"')
+      machineLegacy.succeed('curl -f http://basic.localhost -H "User-Agent: Mozilla" | grep anubis')
+      machineLegacy.succeed('curl -f http://basic.localhost/metrics | grep anubis_challenges_issued')
 
-    # Default unix socket mode
-    machine.succeed('curl -f http://basic.localhost | grep "it works"')
-    machine.succeed('curl -f http://basic.localhost -H "User-Agent: Mozilla" | grep anubis')
-    machine.succeed('curl -f http://basic.localhost/metrics | grep anubis_challenges_issued')
+      # TCP mode.
+      machineLegacy.succeed('curl -f http://tcp.localhost -H "User-Agent: Mozilla" | grep anubis')
+      machineLegacy.succeed('curl -f http://tcp.localhost/metrics | grep anubis_challenges_issued')
 
-    # TCP mode
-    machine.succeed('curl -f http://tcp.localhost -H "User-Agent: Mozilla" | grep anubis')
-    machine.succeed('curl -f http://tcp.localhost/metrics | grep anubis_challenges_issued')
+    with subtest("Dedicated RuntimeDirectory"):
+      for unit in ["nginx", "anubis", "anubis-another-unix-listen", "anubis-tcp", "anubis-unix-upstream"]:
+        machine.wait_for_unit(unit + ".service")
 
-    # Upstream is a unix socket mode
-    machine.succeed('curl -f http://unix.localhost/index.html | grep "it works"')
+      for port in [9000, 9001]:
+        machine.wait_for_open_port(port)
 
-    # Default user-defined environment variables
-    machine.succeed('cat /run/current-system/etc/systemd/system/anubis.service | grep "USER_DEFINED_DEFAULT"')
-    machine.succeed('cat /run/current-system/etc/systemd/system/anubis-tcp.service | grep "USER_DEFINED_DEFAULT"')
+      machine.wait_for_open_unix_socket("/run/anubis/anubis/anubis.sock")
+      machine.wait_for_open_unix_socket("/run/anubis/anubis/anubis-metrics.sock")
+      for instance in ["another-unix-listen", "unix-upstream"]:
+        machine.wait_for_open_unix_socket(f"/run/anubis/anubis-{instance}/anubis.sock")
+        machine.wait_for_open_unix_socket(f"/run/anubis/anubis-{instance}/anubis-metrics.sock")
 
-    # Instance-specific user-specified environment variables
-    machine.succeed('cat /run/current-system/etc/systemd/system/anubis.service | grep "USER_DEFINED_INSTANCE"')
-    machine.fail('cat /run/current-system/etc/systemd/system/anubis-tcp.service | grep "USER_DEFINED_INSTANCE"')
+      machine.succeed('curl -f http://basic.localhost | grep "it works"')
+      machine.succeed('curl -f http://basic.localhost -H "User-Agent: Mozilla" | grep anubis')
+      machine.succeed('curl -f http://basic.localhost/metrics | grep anubis_challenges_issued')
 
-    # Make sure defaults don't overwrite themselves
-    machine.succeed('cat /run/current-system/etc/systemd/system/anubis.service | grep "DIFFICULTY=5"')
-    machine.succeed('cat /run/current-system/etc/systemd/system/anubis-tcp.service | grep "DIFFICULTY=3"')
+      machine.succeed('curl -f http://another-unix-listen.localhost -H "User-Agent: Mozilla" | grep anubis')
+      machine.succeed('curl -f http://another-unix-listen.localhost/metrics | grep anubis_challenges_issued')
 
-    # Check correct BotPolicy settings are applied
-    machine.succeed('cat /run/current-system/etc/systemd/system/anubis.service | grep "POLICY_FNAME=/nix/store"')
-    machine.fail('cat /run/current-system/etc/systemd/system/anubis-botPolicy-default.service | grep "POLICY_FNAME="')
-    machine.succeed('cat /run/current-system/etc/systemd/system/anubis-botPolicy-file.service | grep "POLICY_FNAME=/etc/anubis-botPolicy.json"')
+      # Upstream is a unix socket mode.
+      machine.succeed('curl -f http://unix.localhost/index.html | grep "it works"')
+
+      # Default user-defined environment variables.
+      machine.succeed('cat /run/current-system/etc/systemd/system/anubis.service | grep "USER_DEFINED_DEFAULT"')
+      machine.succeed('cat /run/current-system/etc/systemd/system/anubis-tcp.service | grep "USER_DEFINED_DEFAULT"')
+
+      # Instance-specific user-specified environment variables.
+      machine.succeed('cat /run/current-system/etc/systemd/system/anubis.service | grep "USER_DEFINED_INSTANCE"')
+      machine.fail('cat /run/current-system/etc/systemd/system/anubis-tcp.service | grep "USER_DEFINED_INSTANCE"')
+
+      # Make sure defaults don't overwrite themselves.
+      machine.succeed('cat /run/current-system/etc/systemd/system/anubis.service | grep "DIFFICULTY=5"')
+      machine.succeed('cat /run/current-system/etc/systemd/system/anubis-tcp.service | grep "DIFFICULTY=3"')
+
+      # Check correct BotPolicy settings are applied
+      machine.succeed('cat /run/current-system/etc/systemd/system/anubis.service | grep "POLICY_FNAME=/nix/store"')
+      machine.fail('cat /run/current-system/etc/systemd/system/anubis-botPolicy-default.service | grep "POLICY_FNAME="')
+      machine.succeed('cat /run/current-system/etc/systemd/system/anubis-botPolicy-file.service | grep "POLICY_FNAME=/etc/anubis-botPolicy.json"')
   '';
 }


### PR DESCRIPTION
Set `RuntimeDirectory` to `anubis/<instance name>`.  
At the moment each instance of `services.anubis` is using `RuntimeDirectory = "anubis"`.  
This prevents to run multiple instances listening on unix sockets.  

A temporary fix is to overwrite `RuntimeDirectory` per instance, for example:

```nix
  systemd.services."<instance 1>".serviceConfig = {
    RuntimeDirectory = lib.mkForce "anubis-<instance 1>";
  };
  systemd.services."<instance 2>".serviceConfig = {
    RuntimeDirectory = lib.mkForce "anubis-<instance 2>";
  };
```

With this fix, `RuntimeDirectory` is now `anubis/anubis-<instance name>` (or `anubis/anubis` when the instance name is empty).  
For backward compatibility when a single instance uses unix sockets which are not using the new runtime directory prefix, `RuntimeDirectory` is preserved as `anubis`.

New checks:

- `nixos-rebuild` logs a warning for the user to migrate their `BIND` and `METRICS_BIND` accordingly.
- `nixos-rebuild` asserts `BIND` and `METRICS_BIND` are located in the runtime directory of their instance.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
