### PR TITLE
irsim: init at 9.7.119

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6323,6 +6323,12 @@
     githubId = 4951663;
     name = "Morgan Helton";
   };
+  dezash = {
+    email = "desmondmehta@gmail.com";
+    github = "dezash123";
+    githubId = 90272831;
+    name = "Desmond Mehta";
+  };
   dezgeg = {
     email = "tuomas.tynkkynen@iki.fi";
     github = "dezgeg";

--- a/pkgs/by-name/ir/irsim/package.nix
+++ b/pkgs/by-name/ir/irsim/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  git,
+  m4,
+  tcl,
+  tk,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "irsim";
+  version = "9.7.119";
+
+  src = fetchFromGitHub {
+    owner = "RTimothyEdwards";
+    repo = "irsim";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-XtmSxZfMknx13KXVo5pHPGIOUWU0x3AH608+6qVYqlQ=";
+  };
+
+  nativeBuildInputs = [
+    git
+  ];
+
+  buildInputs = [
+    m4
+    tcl
+    tk
+  ];
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "--with-tcl=${tcl}"
+    "--with-tk=${tk}"
+  ];
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration -Wno-implicit-int";
+
+  meta = {
+    description = "VLSI switch-level simulator";
+    homepage = "http://opencircuitdesign.com/irsim/";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ dezash ];
+  };
+})


### PR DESCRIPTION
add [irsim](http://opencircuitdesign.com/irsim/), an open-source switch-level simulator for VLSI
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
