### PR TITLE
matebook-applet: init at 3.1.0

### DIFF
--- a/pkgs/by-name/ma/matebook-applet/package.nix
+++ b/pkgs/by-name/ma/matebook-applet/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  pkg-config,
+  libayatana-appindicator,
+  gtk3,
+}:
+
+buildGoModule rec {
+  pname = "matebook-applet";
+  version = "3.1.0";
+
+  src = fetchFromGitHub {
+    owner = "nekr0z";
+    repo = "matebook-applet";
+    tag = "v${version}";
+    hash = "sha256-/ysxtYljp2B4CtVJxijsu6dykS0Gz3t02FFcB4E4jH4=";
+  };
+
+  vendorHash = "sha256-lnkU0FiEothUQyj5JQZLoh6IcovKeB9UACHx73siMcY=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libayatana-appindicator
+    gtk3
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  postInstall = ''
+    install -Dm644 matebook-applet.desktop -t "$out/share/applications/"
+    install -Dm644 assets/matebook-applet.png -t "$out/share/icons/hicolor/512x512/apps/"
+    install -Dm644 matebook-applet.1 -t "$out/share/man/man1/"
+  '';
+
+  meta = {
+    description = "System tray applet/control app for Huawei Matebook";
+    homepage = "https://github.com/nekr0z/matebook-applet";
+    changelog = "https://github.com/nekr0z/matebook-applet/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ sandarukasa ];
+    mainProgram = "matebook-applet";
+  };
+}


### PR DESCRIPTION
System tray applet/control app for Huawei Matebook
https://github.com/nekr0z/matebook-applet

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
