### PR TITLE
ci/eval: add a shebang to the stats comparison script

### DIFF
--- a/ci/eval/compare/cmp-stats.py
+++ b/ci/eval/compare/cmp-stats.py
@@ -1,3 +1,6 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i "python3 -I" -p "python3.withPackages(ps: with ps; [ numpy pandas scipy ])"
+
 import json
 import os
 from scipy.stats import ttest_rel


### PR DESCRIPTION
This isn't for CI, just for humans. I didn't do anything fancy like ensure that I was using the correct CI pinned json, but it shouldn't matter: this is just to make it easier to run the script.

## Things done

- [x] Tested basic functionality by running `ci/eval/compare/cmp-stats.py` in Nixpkgs root
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md