### PR TITLE
video-trimmer: fix cross compilation

### DIFF
--- a/pkgs/by-name/vi/video-trimmer/package.nix
+++ b/pkgs/by-name/vi/video-trimmer/package.nix
@@ -35,6 +35,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-3ycc4jXneGsz9Jp9Arzf224JPAKM+PxUkitWcIXre8Y=";
   };
 
+  postPatch = ''
+    substituteInPlace build-aux/cargo.sh --replace-fail \
+      'cp "$CARGO_TARGET_DIR"/' \
+      'cp "$CARGO_TARGET_DIR"/${stdenv.hostPlatform.rust.cargoShortTarget}/'
+  '';
+
   nativeBuildInputs = [
     pkg-config
     meson
@@ -59,6 +65,9 @@ stdenv.mkDerivation (finalAttrs: {
     gst_all_1.gst-plugins-good # for scaletempo and webm
     gst_all_1.gst-plugins-bad
   ];
+
+  # For https://gitlab.gnome.org/YaLTeR/video-trimmer/-/blob/cf64e8dea345bcd991db29a3f862a9277c71fe81/build-aux/cargo.sh#L19
+  env.CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;
 
   doCheck = true;
 


### PR DESCRIPTION
- fixes `nix-build -A pkgsCross.aarch64-multiplatform.video-trimmer`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - ~[ ] [NixOS tests] in [nixos/tests].~ (none available)
  - ~[ ] [Package tests] at `passthru.tests`.~ (none available)
  - ~[ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~ (not applicable)
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
