### PR TITLE
spot: fix cross compilation

### DIFF
--- a/pkgs/by-name/sp/spot/package.nix
+++ b/pkgs/by-name/sp/spot/package.nix
@@ -40,6 +40,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-731aD+yJkyrNMmYtgKYzXIAyLegDBzTT2XqZs5usXiI=";
   };
 
+  postPatch = ''
+    substituteInPlace src/meson.build --replace-fail \
+      "cargo_output = 'src' / rust_target / meson.project_name()" \
+      "cargo_output = 'src' / '${stdenv.hostPlatform.rust.cargoShortTarget}' / rust_target / meson.project_name()"
+  '';
+
   nativeBuildInputs = [
     appstream-glib
     blueprint-compiler
@@ -70,6 +76,9 @@ stdenv.mkDerivation rec {
 
   # https://github.com/xou816/spot/issues/313
   mesonBuildType = "release";
+
+  # For https://github.com/xou816/spot/blob/21ee601f655caa4ca9cae1033a27459fe6289318/src/meson.build#L122
+  env.CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;
 
   passthru = {
     updateScript = nix-update-script { };


### PR DESCRIPTION
- fixes `nix-build -A pkgsCross.aarch64-multiplatform.spot`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - ~[ ] [NixOS tests] in [nixos/tests].~ (none available)
  - ~[ ] [Package tests] at `passthru.tests`.~ (none available)
  - ~[ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~ (not applicable)
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
