### PR TITLE
delfin: fix cross compilation

### DIFF
--- a/pkgs/by-name/de/delfin/package.nix
+++ b/pkgs/by-name/de/delfin/package.nix
@@ -37,6 +37,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-zZc2+0oskptpWZE4fyVcR4QHxqzpj71GXMXNXMK4an0=";
   };
 
+  postPatch = ''
+    substituteInPlace delfin/meson.build --replace-fail \
+      "'delfin' / rust_target / meson.project_name()" \
+      "'delfin' / '${stdenv.hostPlatform.rust.cargoShortTarget}' / rust_target / meson.project_name()"
+  '';
+
   nativeBuildInputs = [
     appstream
     desktop-file-utils
@@ -61,6 +67,9 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     (lib.mesonOption "profile" "release")
   ];
+
+  # For https://codeberg.org/avery42/delfin/src/commit/820b466bfd47f71c12e9b2cabb698e8f78942f41/delfin/meson.build#L47-L48
+  env.CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;
 
   passthru.updateScript = gitUpdater {
     rev-prefix = "v";


### PR DESCRIPTION
fixes `nix-build -A pkgsCross.aarch64-multiplatform.delfin`.

CC: @coolavery in case you might know a way to integrate this without patching... the issue is that `cargo build --target-dir $top` places things in `$top/$flavor/delfin`, but if we ask cargo to build for a specific architecture, e.g. `--target aarch64-unknown-linux-gnu`, then it places things in `$top/$arch/$flavor/$delfin` instead. I think an upstreamable solution might be to use `cargo install` instead of manually `cp`'ing out of the artifacts directory?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - ~[ ] [NixOS tests] in [nixos/tests].~ (none available)
  - ~[ ] [Package tests] at `passthru.tests`.~ (none available)
  - ~[ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~ (not applicable)
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
