### PR TITLE
python3Packages.pygelf: update disabled tests

### DIFF
--- a/pkgs/development/python-modules/pygelf/default.nix
+++ b/pkgs/development/python-modules/pygelf/default.nix
@@ -28,17 +28,16 @@ buildPythonPackage rec {
     requests
   ];
 
-  disabledTests = [
-    # ConnectionRefusedError: [Errno 111] Connection refused
-    "test_static_fields"
-    "test_dynamic_fields"
-  ];
-
   disabledTestPaths = [
-    # These tests requires files that are stripped off by Pypi packaging
-    "tests/test_queuehandler_support.py"
-    "tests/test_debug_mode.py"
+    # The fixtures in these files fail to evaluate due to missing files `tests/config/cert.pem` and
+    # `tests/config/key.pem`. It suffices to replace them with any self-signed certificate e.g. from
+    # `nixos/tests/common/acme/server/snakeoil-certs.nix`, but after resolving that, all of the
+    # tests fail anyway with “ConnectionRefusedError: [Errno 111] Connection refused”.
     "tests/test_common_fields.py"
+    "tests/test_debug_mode.py"
+    "tests/test_dynamic_fields.py"
+    "tests/test_queuehandler_support.py"
+    "tests/test_static_fields.py"
   ];
 
   meta = {


### PR DESCRIPTION
Following #431074, `python3Packages.pygelf` checks fail with:

```
ERROR tests/test_dynamic_fields.py - FileNotFoundError: [Errno 2] No such file or directory
ERROR tests/test_static_fields.py - FileNotFoundError: [Errno 2] No such file or directory
```

I briefly tried providing the missing files, but this was pointless as the tests subsequently failed for attempting networking.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
