### PR TITLE
glib: 2.84.4 -> 2.85.4; gjs: 1.84.2 -> 1.85.2

### DIFF
--- a/pkgs/by-name/gj/gjs/disable-introspection-test.patch
+++ b/pkgs/by-name/gj/gjs/disable-introspection-test.patch
@@ -2,7 +2,7 @@ diff --git a/installed-tests/js/meson.build b/installed-tests/js/meson.build
 index 07759690..43c87c59 100644
 --- a/installed-tests/js/meson.build
 +++ b/installed-tests/js/meson.build
-@@ -123,7 +123,6 @@ jasmine_tests = [
+@@ -34,7 +34,6 @@ jasmine_tests = [
      'GTypeClass',
      'Importer',
      'Importer2',

--- a/pkgs/by-name/gj/gjs/fix-paths.patch
+++ b/pkgs/by-name/gj/gjs/fix-paths.patch
@@ -2,7 +2,7 @@ diff --git a/installed-tests/debugger-test.sh b/installed-tests/debugger-test.sh
 index 0d118490..54c5507e 100755
 --- a/installed-tests/debugger-test.sh
 +++ b/installed-tests/debugger-test.sh
-@@ -3,7 +3,7 @@
+@@ -6,7 +6,7 @@
  if test "$GJS_USE_UNINSTALLED_FILES" = "1"; then
      gjs="$TOP_BUILDDIR/gjs-console"
  else

--- a/pkgs/by-name/gj/gjs/installed-tests-path.patch
+++ b/pkgs/by-name/gj/gjs/installed-tests-path.patch
@@ -11,7 +11,7 @@ index 98475f7d..942d9eca 100644
      ],
      include_directories: top_include,
      install: get_option('installed_tests'), install_dir: installed_tests_execdir)
-@@ -82,7 +82,7 @@ foreach test : jasmine_tests
+@@ -90,7 +90,7 @@ foreach test : jasmine_tests
  
      test_description_subst = {
          'name': 'test@0@.js'.format(test),
@@ -20,16 +20,16 @@ index 98475f7d..942d9eca 100644
      }
      configure_file(configuration: test_description_subst,
          input: '../minijasmine.test.in',
-@@ -125,7 +125,7 @@ foreach test : dbus_tests
+@@ -122,7 +122,7 @@ foreach test : dbus_tests
  
-     dbus_test_description_subst = {
-         'name': 'test@0@.js'.format(test),
--        'installed_tests_execdir': prefix / installed_tests_execdir,
-+        'installed_tests_execdir': installed_tests_execdir,
-     }
-     configure_file(
-         configuration: dbus_test_description_subst,
-@@ -163,7 +163,7 @@ foreach test : modules_tests
+ dbus_test_description_subst = {
+     'name': 'testGDBus.js',
+-    'installed_tests_execdir': prefix / installed_tests_execdir,
++    'installed_tests_execdir': installed_tests_execdir,
+ }
+ configure_file(
+     configuration: dbus_test_description_subst,
+@@ -159,7 +159,7 @@ foreach test : modules_tests
  
      esm_test_description_subst = {
          'name': 'test@0@.js'.format(test),
@@ -42,7 +42,7 @@ diff --git a/installed-tests/meson.build b/installed-tests/meson.build
 index 7a7c48ab..52508c2c 100644
 --- a/installed-tests/meson.build
 +++ b/installed-tests/meson.build
-@@ -30,7 +30,7 @@ foreach test : simple_tests
+@@ -34,7 +34,7 @@ foreach test : simple_tests
  
      test_description_subst = {
          'name': 'test@0@.sh'.format(test),
@@ -51,7 +51,7 @@ index 7a7c48ab..52508c2c 100644
      }
      configure_file(configuration: test_description_subst,
          input: 'script.test.in', output: 'test@0@.sh.test'.format(test),
-@@ -85,7 +85,7 @@ foreach test : debugger_tests
+@@ -123,7 +123,7 @@ foreach test : debugger_tests
  
      test_description_subst = {
          'name': '@0@.debugger'.format(test),

--- a/pkgs/by-name/gj/gjs/package.nix
+++ b/pkgs/by-name/gj/gjs/package.nix
@@ -11,7 +11,7 @@
   gtk4,
   atk,
   gobject-introspection,
-  spidermonkey_128,
+  spidermonkey_140,
   pango,
   cairo,
   readline,
@@ -41,7 +41,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gjs";
-  version = "1.84.2";
+  version = "1.85.2";
 
   outputs = [
     "out"
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gjs/${lib.versions.majorMinor finalAttrs.version}/gjs-${finalAttrs.version}.tar.xz";
-    hash = "sha256-NRQu3zRXBWNjACkew6fVg/FJaf8/rg/zD0qVseZ0AWY=";
+    hash = "sha256-C1yIXqS3BdGTD2aJx5hPxWrSQEovE7ZpCNHAigpdWwI=";
   };
 
   patches = [
@@ -84,7 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
     cairo
     readline
     libsysprof-capture
-    spidermonkey_128
+    spidermonkey_140
   ];
 
   nativeCheckInputs = [

--- a/pkgs/by-name/gl/glib/package.nix
+++ b/pkgs/by-name/gl/glib/package.nix
@@ -74,7 +74,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "glib";
-  version = "2.84.4";
+  version = "2.85.4";
 
   outputs = [
     "bin"
@@ -87,7 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/glib/${lib.versions.majorMinor finalAttrs.version}/glib-${finalAttrs.version}.tar.xz";
-    hash = "sha256-ip6hCUPDb8EX4lP4DJHkd7ZzUlrkV2KUKFiu9XYxu5A=";
+    hash = "sha256-Qy2EyORP5on/cKXYjattD3DV7890YLllrFYNusPGwYU=";
   };
 
   patches =


### PR DESCRIPTION
Primarily to upgrade gjs to use a non-EOL(in 3 weeks) version of spidermonkey. Current test failures as discussed on matrix, but this branch is here so folks can help debug that issue. 

Edit: Note that at this time, this is not ready to merge, as `gjs` fails to build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
