### PR TITLE
hyprqt6engine: init at 0.1.0

### DIFF
--- a/pkgs/by-name/hy/hyprqt6engine/package.nix
+++ b/pkgs/by-name/hy/hyprqt6engine/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  hyprlang,
+  hyprutils,
+  qt6Packages,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hyprqt6engine";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "hyprwm";
+    repo = "hyprqt6engine";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-WSUMQmfVlpz31o2Tgfue0jnVRCeTrRi3Cy6s2/o8hzQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    hyprlang
+    hyprutils
+    qt6Packages.qtbase
+  ];
+
+  dontWrapQtApps = true;
+
+  cmakeFlags = lib.mapAttrsToList lib.cmakeFeature {
+    PLUGINDIR = "${placeholder "out"}/lib/qt-6";
+  };
+
+  meta = {
+    homepage = "https://github.com/hyprwm/hyprqt6engine";
+    description = "Qt6 theme provider for Hyprland";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.kruziikrel13 ];
+    teams = [ lib.teams.hyprland ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added new Hyprland ecosystem plugin hyprqt6engine which serves as a stand in replacement for qt6ct. 
- Wiki page: https://wiki.hypr.land/Hypr-Ecosystem/hyprqt6engine/
- Repository: https://github.com/hyprwm/hyprqt6engine

Note the maintainers are not actually involved with this package... yet so I can remove them from the package meta if it's extraneous. However assumedly I've just jumped the gun in adding this to nixpkgs and they may have already planned on doing it.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
