### PR TITLE
gst_all_1.gst-plugins-rs: add test patch from upstream and re-enable tests

### DIFF
--- a/pkgs/development/libraries/gstreamer/rs/default.nix
+++ b/pkgs/development/libraries/gstreamer/rs/default.nix
@@ -189,6 +189,11 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # Related to https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/issues/723
     ./ignore-tests.patch
+    (fetchpatch {
+      name = "x264enc-test-fix.patch";
+      url = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/commit/c0c9888d66e107f9e0b6d96cd3a85961c7e97d9a.diff";
+      hash = "sha256-/ILdPDjI20k5l9Qf/klglSuhawmFUs9mR+VhBnQqsWw=";
+    })
   ];
 
   strictDeps = true;

--- a/pkgs/development/libraries/gstreamer/rs/ignore-tests.patch
+++ b/pkgs/development/libraries/gstreamer/rs/ignore-tests.patch
@@ -1,23 +1,3 @@
-diff --git a/mux/mp4/tests/tests.rs b/mux/mp4/tests/tests.rs
-index 52b91f59..c5875554 100644
---- a/mux/mp4/tests/tests.rs
-+++ b/mux/mp4/tests/tests.rs
-@@ -1339,6 +1339,7 @@ fn test_taic_encode_cannot_sync(video_enc: &str) {
-     );
- }
- 
-+#[ignore = "Unknown failure"]
- #[test]
- fn test_taic_x264() {
-     init();
-@@ -1359,6 +1360,7 @@ fn test_taic_stai_x264_not_enabled() {
-     test_taic_stai_encode("x264enc", false);
- }
- 
-+#[ignore = "Unknown failure"]
- #[test]
- fn test_taic_x264_no_sync() {
-     init();
 diff --git a/utils/uriplaylistbin/tests/uriplaylistbin.rs b/utils/uriplaylistbin/tests/uriplaylistbin.rs
 index 3489eaa8..569635d6 100644
 --- a/utils/uriplaylistbin/tests/uriplaylistbin.rs


### PR DESCRIPTION
Context:
- 40ab1553c4fac2dafb3ab18b4710670282cbaade ( https://github.com/NixOS/nixpkgs/pull/436518 )
- https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/issues/723#note_3071525


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
