### PR TITLE
buildArmTrustedFirmware: use lib.extendMkDerivation                                                                                                                     

### DIFF
--- a/pkgs/misc/arm-trusted-firmware/build-arm-trusted-firmware.nix
+++ b/pkgs/misc/arm-trusted-firmware/build-arm-trusted-firmware.nix
@@ -1,0 +1,128 @@
+{
+  buildPackages,
+  fetchFromGitHub,
+  lib,
+  openssl,
+  pkgsCross,
+  stdenv,
+
+  # Warning: this blob (hdcp.bin) runs on the main CPU (not the GPU) at
+  # privilege level EL3, which is above both the kernel and the
+  # hypervisor.
+  #
+  # This parameter applies only to platforms which are believed to use
+  # hdcp.bin. On all other platforms, or if unfreeIncludeHDCPBlob=false,
+  # hdcp.bin will be deleted before building.
+  unfreeIncludeHDCPBlob ? true,
+}:
+
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+
+  excludeDrvArgNames = [ "extraMeta" ];
+
+  extendDrvArgs =
+    finalAttrs:
+    {
+      filesToInstall,
+      installDir ? "$out",
+      platform ? null,
+      platformCanUseHDCPBlob ? false, # set this to true if the platform is able to use hdcp.bin
+      ...
+    }@args:
+
+    # delete hdcp.bin if either: the platform is thought to
+    # not need it or unfreeIncludeHDCPBlob is false
+    let
+      deleteHDCPBlobBeforeBuild = !platformCanUseHDCPBlob || !unfreeIncludeHDCPBlob;
+    in
+    {
+      pname = "arm-trusted-firmware${lib.optionalString (platform != null) "-${platform}"}";
+      version = args.version or "2.13.0";
+
+      src =
+        args.src or (fetchFromGitHub {
+          owner = "ARM-software";
+          repo = "arm-trusted-firmware";
+          tag = "v${finalAttrs.version}";
+          hash = "sha256-rxm5RCjT/MyMCTxiEC8jQeFMrCggrb2DRbs/qDPXb20=";
+        });
+
+      patches =
+        lib.optionals deleteHDCPBlobBeforeBuild [
+          # this is a rebased version of https://gitlab.com/vicencb/kevinboot/-/blob/master/atf.patch
+          ./remove-hdcp-blob.patch
+        ]
+        ++ args.patches or [ ];
+
+      postPatch =
+        lib.optionalString deleteHDCPBlobBeforeBuild ''
+          rm plat/rockchip/rk3399/drivers/dp/hdcp.bin
+        ''
+        + args.postPatch or "";
+
+      depsBuildBuild = [ buildPackages.stdenv.cc ] ++ args.depsBuildBuild or [ ];
+
+      nativeBuildInputs = [
+        pkgsCross.arm-embedded.stdenv.cc # For Cortex-M0 firmware in RK3399
+        openssl # For fiptool
+      ]
+      ++ args.nativeBuildInputs or [ ];
+
+      # Make the new toolchain guessing (from 2.11+) happy
+      # https://github.com/ARM-software/arm-trusted-firmware/blob/4ec2948fe3f65dba2f19e691e702f7de2949179c/make_helpers/toolchains/rk3399-m0.mk#L21-L22
+      rk3399-m0-oc = "${pkgsCross.arm-embedded.stdenv.cc.targetPrefix}objcopy";
+
+      buildInputs = [ openssl ] ++ args.buildInputs or [ ];
+
+      makeFlags = [
+        "HOSTCC=$(CC_FOR_BUILD)"
+        "M0_CROSS_COMPILE=${pkgsCross.arm-embedded.stdenv.cc.targetPrefix}"
+        "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+        # Make the new toolchain guessing (from 2.11+) happy
+        "CC=${stdenv.cc.targetPrefix}cc"
+        "LD=${stdenv.cc.targetPrefix}cc"
+        "AS=${stdenv.cc.targetPrefix}cc"
+        "OC=${stdenv.cc.targetPrefix}objcopy"
+        "OD=${stdenv.cc.targetPrefix}objdump"
+        # Passing OpenSSL path according to docs/design/trusted-board-boot-build.rst
+        "OPENSSL_DIR=${openssl}"
+      ]
+      ++ (lib.optional (platform != null) "PLAT=${platform}")
+      ++ args.makeFlags or [ ]
+      ++ (lib.warnIf (args ? extraMakeFlags)
+        "buildArmTrustedFirmware now accepts `makeFlags`, please switch from using `extraMakeFlags` to `makeFlags`"
+        args.extraMakeFlags or [ ]
+      );
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p ${installDir}
+        cp ${lib.concatStringsSep " " filesToInstall} ${installDir}
+
+        runHook postInstall
+      '';
+
+      hardeningDisable = [ "all" ];
+      dontStrip = true;
+
+      # breaks secondary CPU bringup on at least RK3588, maybe others
+      env.NIX_CFLAGS_COMPILE = "-fomit-frame-pointer";
+
+      meta = {
+        homepage = "https://github.com/ARM-software/arm-trusted-firmware";
+        description = "Reference implementation of secure world software for ARMv8-A";
+        license = [
+          lib.licenses.bsd3
+        ]
+        ++ lib.optionals (!deleteHDCPBlobBeforeBuild) [ lib.licenses.unfreeRedistributable ];
+        maintainers = [ lib.maintainers.lopsided98 ];
+      }
+      // (args.meta or { })
+      // (lib.warnIf (args ? extraMeta)
+        "buildArmTrustedFirmware now accepts `meta`, please switch from using `extraMeta` to `meta`"
+        args.extraMeta or { }
+      );
+    };
+}

--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -1,134 +1,8 @@
+{ buildArmTrustedFirmware, stdenv }:
+
 {
-  lib,
-  stdenv,
-  fetchFromGitHub,
-  fetchFromGitLab,
-  openssl,
-  pkgsCross,
-  buildPackages,
-
-  # Warning: this blob (hdcp.bin) runs on the main CPU (not the GPU) at
-  # privilege level EL3, which is above both the kernel and the
-  # hypervisor.
-  #
-  # This parameter applies only to platforms which are believed to use
-  # hdcp.bin. On all other platforms, or if unfreeIncludeHDCPBlob=false,
-  # hdcp.bin will be deleted before building.
-  unfreeIncludeHDCPBlob ? true,
-}:
-
-let
-  buildArmTrustedFirmware = lib.makeOverridable (
-    {
-      filesToInstall,
-      installDir ? "$out",
-      platform ? null,
-      platformCanUseHDCPBlob ? false, # set this to true if the platform is able to use hdcp.bin
-      extraMakeFlags ? [ ],
-      extraMeta ? { },
-      ...
-    }@args:
-
-    # delete hdcp.bin if either: the platform is thought to
-    # not need it or unfreeIncludeHDCPBlob is false
-    let
-      deleteHDCPBlobBeforeBuild = !platformCanUseHDCPBlob || !unfreeIncludeHDCPBlob;
-    in
-
-    stdenv.mkDerivation (
-      rec {
-
-        pname = "arm-trusted-firmware${lib.optionalString (platform != null) "-${platform}"}";
-        version = "2.13.0";
-
-        src = fetchFromGitHub {
-          owner = "ARM-software";
-          repo = "arm-trusted-firmware";
-          tag = "v${version}";
-          hash = "sha256-rxm5RCjT/MyMCTxiEC8jQeFMrCggrb2DRbs/qDPXb20=";
-        };
-
-        patches = lib.optionals deleteHDCPBlobBeforeBuild [
-          # this is a rebased version of https://gitlab.com/vicencb/kevinboot/-/blob/master/atf.patch
-          ./remove-hdcp-blob.patch
-        ];
-
-        postPatch = lib.optionalString deleteHDCPBlobBeforeBuild ''
-          rm plat/rockchip/rk3399/drivers/dp/hdcp.bin
-        '';
-
-        depsBuildBuild = [ buildPackages.stdenv.cc ];
-
-        nativeBuildInputs = [
-          pkgsCross.arm-embedded.stdenv.cc # For Cortex-M0 firmware in RK3399
-          openssl # For fiptool
-        ];
-
-        # Make the new toolchain guessing (from 2.11+) happy
-        # https://github.com/ARM-software/arm-trusted-firmware/blob/4ec2948fe3f65dba2f19e691e702f7de2949179c/make_helpers/toolchains/rk3399-m0.mk#L21-L22
-        rk3399-m0-oc = "${pkgsCross.arm-embedded.stdenv.cc.targetPrefix}objcopy";
-
-        buildInputs = [ openssl ];
-
-        makeFlags = [
-          "HOSTCC=$(CC_FOR_BUILD)"
-          "M0_CROSS_COMPILE=${pkgsCross.arm-embedded.stdenv.cc.targetPrefix}"
-          "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
-          # Make the new toolchain guessing (from 2.11+) happy
-          "CC=${stdenv.cc.targetPrefix}cc"
-          "LD=${stdenv.cc.targetPrefix}cc"
-          "AS=${stdenv.cc.targetPrefix}cc"
-          "OC=${stdenv.cc.targetPrefix}objcopy"
-          "OD=${stdenv.cc.targetPrefix}objdump"
-          # Passing OpenSSL path according to docs/design/trusted-board-boot-build.rst
-          "OPENSSL_DIR=${openssl}"
-        ]
-        ++ (lib.optional (platform != null) "PLAT=${platform}")
-        ++ extraMakeFlags;
-
-        installPhase = ''
-          runHook preInstall
-
-          mkdir -p ${installDir}
-          cp ${lib.concatStringsSep " " filesToInstall} ${installDir}
-
-          runHook postInstall
-        '';
-
-        hardeningDisable = [ "all" ];
-        dontStrip = true;
-
-        # breaks secondary CPU bringup on at least RK3588, maybe others
-        env.NIX_CFLAGS_COMPILE = "-fomit-frame-pointer";
-
-        meta =
-          with lib;
-          {
-            homepage = "https://github.com/ARM-software/arm-trusted-firmware";
-            description = "Reference implementation of secure world software for ARMv8-A";
-            license = [
-              licenses.bsd3
-            ]
-            ++ lib.optionals (!deleteHDCPBlobBeforeBuild) [ licenses.unfreeRedistributable ];
-            maintainers = with maintainers; [ lopsided98 ];
-          }
-          // extraMeta;
-      }
-      // builtins.removeAttrs args [ "extraMeta" ]
-    )
-  );
-
-in
-{
-  inherit buildArmTrustedFirmware;
-
   armTrustedFirmwareTools = buildArmTrustedFirmware {
-    # Normally, arm-trusted-firmware builds the build tools for buildPlatform
-    # using CC_FOR_BUILD (or as it calls it HOSTCC). Since want to build them
-    # for the hostPlatform here, we trick it by overriding the HOSTCC setting
-    # and, to be safe, remove CC_FOR_BUILD from the environment.
-    depsBuildBuild = [ ];
-    extraMakeFlags = [
+    makeFlags = [
       "HOSTCC=${stdenv.cc.targetPrefix}gcc"
       "fiptool"
       "certtool"
@@ -143,67 +17,67 @@ in
     '';
   };
 
-  armTrustedFirmwareAllwinner = buildArmTrustedFirmware rec {
+  armTrustedFirmwareAllwinner = buildArmTrustedFirmware (finalAttrs: {
     platform = "sun50i_a64";
-    extraMeta.platforms = [ "aarch64-linux" ];
-    filesToInstall = [ "build/${platform}/release/bl31.bin" ];
-  };
+    meta.platforms = [ "aarch64-linux" ];
+    filesToInstall = [ "build/${finalAttrs.platform}/release/bl31.bin" ];
+  });
 
-  armTrustedFirmwareAllwinnerH616 = buildArmTrustedFirmware rec {
+  armTrustedFirmwareAllwinnerH616 = buildArmTrustedFirmware (finalAttrs: {
     platform = "sun50i_h616";
-    extraMeta.platforms = [ "aarch64-linux" ];
-    filesToInstall = [ "build/${platform}/release/bl31.bin" ];
-  };
+    meta.platforms = [ "aarch64-linux" ];
+    filesToInstall = [ "build/${finalAttrs.platform}/release/bl31.bin" ];
+  });
 
-  armTrustedFirmwareAllwinnerH6 = buildArmTrustedFirmware rec {
+  armTrustedFirmwareAllwinnerH6 = buildArmTrustedFirmware (finalAttrs: {
     platform = "sun50i_h6";
-    extraMeta.platforms = [ "aarch64-linux" ];
-    filesToInstall = [ "build/${platform}/release/bl31.bin" ];
-  };
+    meta.platforms = [ "aarch64-linux" ];
+    filesToInstall = [ "build/${finalAttrs.platform}/release/bl31.bin" ];
+  });
 
-  armTrustedFirmwareQemu = buildArmTrustedFirmware rec {
+  armTrustedFirmwareQemu = buildArmTrustedFirmware (finalAttrs: {
     platform = "qemu";
-    extraMeta.platforms = [ "aarch64-linux" ];
+    meta.platforms = [ "aarch64-linux" ];
     filesToInstall = [
-      "build/${platform}/release/bl1.bin"
-      "build/${platform}/release/bl2.bin"
-      "build/${platform}/release/bl31.bin"
+      "build/${finalAttrs.platform}/release/bl1.bin"
+      "build/${finalAttrs.platform}/release/bl2.bin"
+      "build/${finalAttrs.platform}/release/bl31.bin"
     ];
-  };
+  });
 
-  armTrustedFirmwareRK3328 = buildArmTrustedFirmware rec {
-    extraMakeFlags = [ "bl31" ];
+  armTrustedFirmwareRK3328 = buildArmTrustedFirmware (finalAttrs: {
+    makeFlags = [ "bl31" ];
     platform = "rk3328";
-    extraMeta.platforms = [ "aarch64-linux" ];
-    filesToInstall = [ "build/${platform}/release/bl31/bl31.elf" ];
-  };
+    meta.platforms = [ "aarch64-linux" ];
+    filesToInstall = [ "build/${finalAttrs.platform}/release/bl31/bl31.elf" ];
+  });
 
-  armTrustedFirmwareRK3399 = buildArmTrustedFirmware rec {
-    extraMakeFlags = [ "bl31" ];
+  armTrustedFirmwareRK3399 = buildArmTrustedFirmware (finalAttrs: {
+    makeFlags = [ "bl31" ];
     platform = "rk3399";
-    extraMeta.platforms = [ "aarch64-linux" ];
-    filesToInstall = [ "build/${platform}/release/bl31/bl31.elf" ];
+    meta.platforms = [ "aarch64-linux" ];
+    filesToInstall = [ "build/${finalAttrs.platform}/release/bl31/bl31.elf" ];
     platformCanUseHDCPBlob = true;
-  };
+  });
 
-  armTrustedFirmwareRK3568 = buildArmTrustedFirmware rec {
-    extraMakeFlags = [ "bl31" ];
+  armTrustedFirmwareRK3568 = buildArmTrustedFirmware (finalAttrs: {
+    makeFlags = [ "bl31" ];
     platform = "rk3568";
-    extraMeta.platforms = [ "aarch64-linux" ];
-    filesToInstall = [ "build/${platform}/release/bl31/bl31.elf" ];
-  };
+    meta.platforms = [ "aarch64-linux" ];
+    filesToInstall = [ "build/${finalAttrs.platform}/release/bl31/bl31.elf" ];
+  });
 
-  armTrustedFirmwareRK3588 = buildArmTrustedFirmware rec {
-    extraMakeFlags = [ "bl31" ];
+  armTrustedFirmwareRK3588 = buildArmTrustedFirmware (finalAttrs: {
+    makeFlags = [ "bl31" ];
     platform = "rk3588";
-    extraMeta.platforms = [ "aarch64-linux" ];
-    filesToInstall = [ "build/${platform}/release/bl31/bl31.elf" ];
-  };
+    meta.platforms = [ "aarch64-linux" ];
+    filesToInstall = [ "build/${finalAttrs.platform}/release/bl31/bl31.elf" ];
+  });
 
-  armTrustedFirmwareS905 = buildArmTrustedFirmware rec {
-    extraMakeFlags = [ "bl31" ];
+  armTrustedFirmwareS905 = buildArmTrustedFirmware (finalAttrs: {
+    makeFlags = [ "bl31" ];
     platform = "gxbb";
-    extraMeta.platforms = [ "aarch64-linux" ];
-    filesToInstall = [ "build/${platform}/release/bl31.bin" ];
-  };
+    meta.platforms = [ "aarch64-linux" ];
+    filesToInstall = [ "build/${finalAttrs.platform}/release/bl31.bin" ];
+  });
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10379,9 +10379,12 @@ with pkgs;
     fftw = fftwFloat;
   };
 
+  buildArmTrustedFirmware =
+    callPackage ../misc/arm-trusted-firmware/build-arm-trusted-firmware.nix
+      { };
+
   arm-trusted-firmware = callPackage ../misc/arm-trusted-firmware { };
   inherit (arm-trusted-firmware)
-    buildArmTrustedFirmware
     armTrustedFirmwareTools
     armTrustedFirmwareAllwinner
     armTrustedFirmwareAllwinnerH616


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

By switching to `lib.extendMkDerivation`, users can use the "finalAttrs" style when constructing their ATF builds. In addition, move buildArmTrustedFirmware to its own callPackage'd file, which allows for all arguments used to construct `buildArmTrustedFirmware` to be easily overridable. This was previously difficult and cumbersome to do due to the buildArmTrustedFirmware enclosing the function arguments in `pkgs/misc/arm-trusted-firmware/default.nix`, but not being available on the package-set to override said arguments.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
