### PR TITLE
python313Packages.skops: update inputs, python313Packages.fastapi-mcp: use pytest-asyncio_0

### DIFF
--- a/pkgs/development/python-modules/fastapi-mcp/default.nix
+++ b/pkgs/development/python-modules/fastapi-mcp/default.nix
@@ -20,7 +20,7 @@
 
   # tests
   coverage,
-  pytest-asyncio,
+  pytest-asyncio_0,
   pytest-cov-stub,
   pytestCheckHook,
 }:
@@ -59,7 +59,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     coverage
-    pytest-asyncio
+    pytest-asyncio_0
     pytest-cov-stub
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/skops/default.nix
+++ b/pkgs/development/python-modules/skops/default.nix
@@ -1,16 +1,21 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
   hatchling,
-  pytestCheckHook,
-  pytest-cov-stub,
   huggingface-hub,
   matplotlib,
+  numpy,
+  packaging,
   pandas,
+  prettytable,
+  pytest-cov-stub,
+  pytestCheckHook,
+  pythonOlder,
+  pyyaml,
+  rich,
   scikit-learn,
-  stdenv,
   streamlit,
   tabulate,
 }:
@@ -30,7 +35,9 @@ buildPythonPackage rec {
   build-system = [ hatchling ];
 
   dependencies = [
-    huggingface-hub
+    numpy
+    packaging
+    prettytable
     scikit-learn
     tabulate
   ];
@@ -38,19 +45,22 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     matplotlib
     pandas
-    pytestCheckHook
     pytest-cov-stub
+    pytestCheckHook
+    pyyaml
     streamlit
   ];
+  optional-dependencies = {
+    rich = [ rich ];
+  };  
   enabledTestPaths = [ "skops" ];
   disabledTests = [
     # flaky
     "test_base_case_works_as_expected"
+    # fairlearn is not available in nixpkgs
+    "TestAddFairlearnMetricFrame"
   ];
   disabledTestPaths = [
-    # try to download data from Huggingface Hub:
-    "skops/hub_utils/tests"
-    "skops/card/tests"
     # minor output formatting issue
     "skops/card/_model_card.py"
   ]

--- a/pkgs/development/python-modules/skops/default.nix
+++ b/pkgs/development/python-modules/skops/default.nix
@@ -50,16 +50,20 @@ buildPythonPackage rec {
     pyyaml
     streamlit
   ];
+
   optional-dependencies = {
     rich = [ rich ];
-  };  
+  };
+
   enabledTestPaths = [ "skops" ];
+
   disabledTests = [
     # flaky
     "test_base_case_works_as_expected"
     # fairlearn is not available in nixpkgs
     "TestAddFairlearnMetricFrame"
   ];
+
   disabledTestPaths = [
     # minor output formatting issue
     "skops/card/_model_card.py"
@@ -68,19 +72,21 @@ buildPythonPackage rec {
     # Segfaults on darwin
     "skops/io/tests/test_persist.py"
   ];
+
   pytestFlags = [
     # Warning from scipy.optimize in skops/io/tests/test_persist.py::test_dump_and_load_with_file_wrapper
     # https://github.com/skops-dev/skops/issues/479
     "-Wignore::DeprecationWarning"
   ];
+
   pythonImportsCheck = [ "skops" ];
 
   meta = {
     description = "Library for saving/loading, sharing, and deploying scikit-learn based models";
-    mainProgram = "skops";
     homepage = "https://skops.readthedocs.io/en/stable";
     changelog = "https://github.com/skops-dev/skops/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.bcdarwin ];
+    mainProgram = "skops";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
