### PR TITLE
nixos/sshwifty: init module and test

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -120,6 +120,8 @@
 
 - `services.libvirtd.autoSnapshot`, a backup service for libvirt managed vms.
 
+- [Sshwifty](https://github.com/nirui/sshwifty), a Telnet and SSH client for your browser. Available as [services.sshwifty](#opt-services.sshwifty.enable).
+
 ## Backward Incompatibilities {#sec-release-25.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1694,6 +1694,7 @@
   ./services/web-apps/snipe-it.nix
   ./services/web-apps/snips-sh.nix
   ./services/web-apps/sogo.nix
+  ./services/web-apps/sshwifty.nix
   ./services/web-apps/stash.nix
   ./services/web-apps/stirling-pdf.nix
   ./services/web-apps/strfry.nix

--- a/nixos/modules/services/web-apps/sshwifty.nix
+++ b/nixos/modules/services/web-apps/sshwifty.nix
@@ -1,0 +1,128 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.sshwifty;
+  format = pkgs.formats.json { };
+  settings = format.generate "sshwifty.json" cfg.settings;
+in
+{
+  options.services.sshwifty = {
+    enable = lib.mkEnableOption "Sshwifty";
+    package = lib.mkPackageOption pkgs "sshwifty" { };
+    settings = lib.mkOption {
+      type = format.type;
+      description = ''
+        Configuration for Sshwifty. See
+        [the Sshwifty documentation](https://github.com/nirui/sshwifty/tree/master?tab=readme-ov-file#configuration)
+        for possible options.
+      '';
+    };
+    sharedKeyFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "Path to a file containing the shared key.";
+    };
+    socks5PasswordFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "Path to a file containing the SOCKS5 password.";
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    systemd.services.sshwifty = {
+      description = "Sshwifty";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      script = ''
+        ${lib.optionalString (cfg.sharedKeyFile != null || cfg.socks5PasswordFile != null) (
+          lib.concatStringsSep " " [
+            (lib.getExe pkgs.jq)
+            "-s"
+            "'.[0] * .[1]"
+            (lib.optionalString (cfg.sharedKeyFile != null && cfg.socks5PasswordFile != null) "* .[2]")
+            "'"
+            settings
+            (lib.optionalString (
+              cfg.sharedKeyFile != null
+            ) "<(echo \"{\\\"SharedKey\\\":\\\"$(cat $CREDENTIALS_DIRECTORY/sharedkey)\\\"}\")")
+            (lib.optionalString (
+              cfg.socks5PasswordFile != null
+            ) "<(echo \"{\\\"Socks5Password\\\":\\\"$(cat $CREDENTIALS_DIRECTORY/socks5pass)\\\"}\")")
+            "> /run/sshwifty/sshwifty.json"
+          ]
+        )}
+        ${lib.optionalString (
+          cfg.sharedKeyFile != null || cfg.socks5PasswordFile != null
+        ) "export SSHWIFTY_CONFIG=/run/sshwifty/sshwifty.json"}
+        ${lib.optionalString (
+          cfg.sharedKeyFile == null && cfg.socks5PasswordFile == null
+        ) "export SSHWIFTY_CONFIG=${settings}"}
+        exec ${lib.getExe cfg.package}
+      '';
+      serviceConfig = {
+        DynamicUser = true;
+        RuntimeDirectory = "sshwifty";
+        RuntimeDirectoryMode = "0750";
+        LoadCredential =
+          [ ]
+          ++ lib.optionals (cfg.sharedKeyFile != null) [ "sharedkey:${cfg.sharedKeyFile}" ]
+          ++ lib.optionals (cfg.socks5PasswordFile != null) [ "socks5pass:${cfg.socks5PasswordFile}" ];
+        # Hardening
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        RemoveIPC = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        CapabilityBoundingSet = "CAP_NET_BIND_SERVICE";
+        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
+        PrivateTmp = "disconnected";
+        ProcSubset = "pid";
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = [
+          "~cgroup"
+          "~ipc"
+          "~mnt"
+          "~net"
+          "~pid"
+          "~user"
+          "~uts"
+        ];
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "~@clock"
+          "~@cpu-emulation"
+          "~@debug"
+          "~@module"
+          "~@mount"
+          "~@obsolete"
+          "~@privileged"
+          "~@raw-io"
+          "~@reboot"
+          "~@resources"
+          "~@swap"
+        ];
+        UMask = "0077";
+      };
+    };
+  };
+  meta.maintainers = [ lib.maintainers.ungeskriptet ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1373,6 +1373,7 @@ in
   sslh = handleTest ./sslh.nix { };
   ssh-agent-auth = runTest ./ssh-agent-auth.nix;
   ssh-audit = runTest ./ssh-audit.nix;
+  sshwifty = runTest ./web-apps/sshwifty/default.nix;
   sssd = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./sssd.nix { };
   sssd-ldap = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./sssd-ldap.nix { };
   stalwart-mail = runTest ./stalwart/stalwart-mail.nix;

--- a/nixos/tests/web-apps/sshwifty/default.nix
+++ b/nixos/tests/web-apps/sshwifty/default.nix
@@ -1,0 +1,32 @@
+{ lib, pkgs, ... }:
+{
+  name = "sshwifty";
+
+  nodes.machine =
+    { ... }:
+    {
+      services.sshwifty = {
+        enable = true;
+        sharedKeyFile = pkgs.writeText "sharedkey" "rpz2E4QI6uPMLr";
+        settings = {
+          HostName = "localhost";
+          Servers = [
+            {
+              ListenInterface = "::1";
+              ListenPort = 80;
+              ServerMessage = "NixOS test";
+            }
+          ];
+        };
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("sshwifty.service")
+    machine.wait_for_open_port(80)
+    machine.wait_until_succeeds("curl --fail -6 http://localhost/", timeout=60)
+    machine.wait_until_succeeds("${lib.getExe pkgs.nodejs} ${./sshwifty-test.js}", timeout=60)
+  '';
+
+  meta.maintainers = [ lib.maintainers.ungeskriptet ];
+}

--- a/nixos/tests/web-apps/sshwifty/sshwifty-test.js
+++ b/nixos/tests/web-apps/sshwifty/sshwifty-test.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/* Based on ui/app.js from Sshwifty. */
+const { subtle } = require('node:crypto')
+const sshwiftyURL = 'http://localhost/sshwifty/socket/verify'
+const sharedKey = 'rpz2E4QI6uPMLr'
+const serverMessage = 'NixOS test'
+
+async function hmac512(secret, data) {
+  const key = await subtle.importKey(
+    'raw',
+    secret,
+    { name: 'HMAC', hash: { name: 'SHA-512' } },
+    false,
+    ['sign', 'verify'],
+  )
+  return subtle.sign(key.algorithm, key, data)
+}
+
+async function getSocketAuthKey(privateKey) {
+  const enc = new TextEncoder(),
+    rTime = Number(Math.trunc(Date.now() / 100000))
+  return new Uint8Array(
+    await hmac512(enc.encode(privateKey), enc.encode(rTime)),
+  ).slice(0, 32)
+}
+
+async function requestAuth(privateKey) {
+  const authKey = await getSocketAuthKey(privateKey)
+  const h = await fetch(sshwiftyURL, {
+    headers: { 'X-Key': btoa(String.fromCharCode.apply(null, authKey)) },
+  })
+  const serverDate = h.headers.get('Date')
+  return {
+    result: h.status,
+    date: serverDate ? new Date(serverDate) : null,
+    text: await h.text(),
+  }
+}
+
+async function tryInitialAuth() {
+  try {
+    const result = await requestAuth(sharedKey)
+    if (result.date) {
+      const serverRespondTime = result.date,
+        serverRespondTimestamp = serverRespondTime.getTime(),
+        clientCurrent = new Date(),
+        clientTimestamp = clientCurrent.getTime(),
+        timeDiff = Math.abs(serverRespondTimestamp - clientTimestamp)
+      if (timeDiff > 30000) {
+        console.log('Time difference between client and server too big.')
+        process.exit(1)
+      }
+    }
+    switch (result.result) {
+      case 200:
+        if (result.text.includes(serverMessage)) {
+          console.log('All good.')
+          process.exit()
+        } else {
+          console.log('Server message not found')
+          process.exit(1)
+        }
+        break
+      case 403:
+        console.log('We need auth.')
+        process.exit(1)
+        break
+      case 0:
+        console.log('Timeout?')
+        process.exit(1)
+        break
+      default:
+        console.log('wghat')
+        process.exit(1)
+    }
+  } catch {
+    console.log('Something went horribly wrong, ouch.')
+    process.exit(1)
+  }
+}
+
+console.log('Testing Sshwifty')
+tryInitialAuth()

--- a/pkgs/by-name/ss/sshwifty/package.nix
+++ b/pkgs/by-name/ss/sshwifty/package.nix
@@ -4,6 +4,7 @@
   buildNpmPackage,
   fetchFromGitHub,
   versionCheckHook,
+  nixosTests,
   nix-update-script,
   go_1_25,
 }:
@@ -52,7 +53,10 @@ buildGo125Module (finalAttrs: {
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests = { inherit (nixosTests) sshwifty; };
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "WebSSH & WebTelnet client";


### PR DESCRIPTION
Add a module and test for Sshwifty.

Unfortunately Sshwifty prefers the JSON config over the environment variables, which is why we have to merge the JSON config generated by Nix with a little JSON snippet that sets up the shared key and SOCKS5 password for us in ExecStart=.

## Things done
- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
