### PR TITLE
warp-plus: 1.2.6 -> 1.2.6-unstable-2025-08-13

### DIFF
--- a/pkgs/by-name/wa/warp-plus/fix-endpoints.patch
+++ b/pkgs/by-name/wa/warp-plus/fix-endpoints.patch
@@ -1,0 +1,95 @@
+From b1bc81051810899189b071349443d82fdc1caebe Mon Sep 17 00:00:00 2001
+From: NImaism <nima.gholamyy@gmail.com>
+Date: Sat, 16 Aug 2025 22:20:15 +0330
+Subject: [PATCH] fix: warp endpoints issues
+
+---
+ app/app.go               | 18 ++++++++++++++----
+ cmd/warp-plus/rootcmd.go | 10 ----------
+ 2 files changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/app/app.go b/app/app.go
+index 770c58b536e11be3ebdb098c54cf74228139cb51..0197655d681539ed1dd1915ed65107cb7c007b17 100644
+--- a/app/app.go
++++ b/app/app.go
+@@ -56,6 +56,16 @@ func RunWarp(ctx context.Context, l *slog.Logger, opts WarpOptions) error {
+ 		return errors.New("must provide country for psiphon")
+ 	}
+ 
++	if opts.Endpoint == "" {
++		ident, err := warp.LoadOrCreateIdentity(l, path.Join(opts.CacheDir, "primary"), opts.License)
++		if err != nil {
++			l.Error("failed to load or create primary warp identity")
++			return err
++		}
++
++		opts.Endpoint = ident.Config.Peers[0].Endpoint.V4[:len(ident.Config.Peers[0].Endpoint.V4)-2] + ":500"
++	}
++
+ 	// Decide Working Scenario
+ 	endpoints := []string{opts.Endpoint, opts.Endpoint}
+ 
+@@ -96,7 +106,7 @@ func RunWarp(ctx context.Context, l *slog.Logger, opts WarpOptions) error {
+ 	case opts.Gool:
+ 		l.Info("running in warp-in-warp (gool) mode")
+ 		// run warp in warp
+-		warpErr = runWarpInWarp(ctx, l, opts, endpoints)
++		warpErr = runWarpInWarp(ctx, l, opts, endpoints[0])
+ 	default:
+ 		l.Info("running in normal warp mode")
+ 		// just run primary warp on bindAddress
+@@ -237,7 +247,7 @@ func runWarp(ctx context.Context, l *slog.Logger, opts WarpOptions, endpoint str
+ 	return nil
+ }
+ 
+-func runWarpInWarp(ctx context.Context, l *slog.Logger, opts WarpOptions, endpoints []string) error {
++func runWarpInWarp(ctx context.Context, l *slog.Logger, opts WarpOptions, endpoint string) error {
+ 	// make primary identity
+ 	ident1, err := warp.LoadOrCreateIdentity(l, path.Join(opts.CacheDir, "primary"), opts.License)
+ 	if err != nil {
+@@ -254,7 +264,7 @@ func runWarpInWarp(ctx context.Context, l *slog.Logger, opts WarpOptions, endpoi
+ 
+ 	// Enable trick and keepalive on all peers in config
+ 	for i, peer := range conf.Peers {
+-		peer.Endpoint = endpoints[0]
++		peer.Endpoint = endpoint
+ 		peer.Trick = true
+ 		peer.KeepAlive = 5
+ 
+@@ -297,7 +307,7 @@ func runWarpInWarp(ctx context.Context, l *slog.Logger, opts WarpOptions, endpoi
+ 	}
+ 
+ 	// Create a UDP port forward between localhost and the remote endpoint
+-	addr, err := wiresocks.NewVtunUDPForwarder(ctx, netip.MustParseAddrPort("127.0.0.1:0"), endpoints[0], tnet1, singleMTU)
++	addr, err := wiresocks.NewVtunUDPForwarder(ctx, netip.MustParseAddrPort("127.0.0.1:0"), endpoint, tnet1, singleMTU)
+ 	if err != nil {
+ 		return err
+ 	}
+diff --git a/cmd/warp-plus/rootcmd.go b/cmd/warp-plus/rootcmd.go
+index 87642c3708d5084d89771808c0ff7e96f6da1014..87eec817a35390cae4b66ad51fd152fce55670f6 100644
+--- a/cmd/warp-plus/rootcmd.go
++++ b/cmd/warp-plus/rootcmd.go
+@@ -13,7 +13,6 @@ import (
+ 	"github.com/adrg/xdg"
+ 	"github.com/bepass-org/warp-plus/app"
+ 	p "github.com/bepass-org/warp-plus/psiphon"
+-	"github.com/bepass-org/warp-plus/warp"
+ 	"github.com/bepass-org/warp-plus/wiresocks"
+ 	"github.com/peterbourgon/ff/v4"
+ 	"github.com/peterbourgon/ff/v4/ffval"
+@@ -205,15 +204,6 @@ func (c *rootConfig) exec(ctx context.Context, args []string) error {
+ 		opts.Scan = &wiresocks.ScanOptions{V4: c.v4, V6: c.v6, MaxRTT: c.rtt}
+ 	}
+ 
+-	// If the endpoint is not set, choose a random warp endpoint
+-	if opts.Endpoint == "" {
+-		addrPort, err := warp.RandomWarpEndpoint(c.v4, c.v6)
+-		if err != nil {
+-			fatal(l, err)
+-		}
+-		opts.Endpoint = addrPort.String()
+-	}
+-
+ 	go func() {
+ 		if err := app.RunWarp(ctx, l, opts); err != nil {
+ 			fatal(l, err)

--- a/pkgs/by-name/wa/warp-plus/package.nix
+++ b/pkgs/by-name/wa/warp-plus/package.nix
@@ -10,16 +10,16 @@
 
 buildGoModule rec {
   pname = "warp-plus";
-  version = "1.2.6";
+  version = "1.2.6-unstable-2025-08-13";
 
   src = fetchFromGitHub {
     owner = "bepass-org";
     repo = "warp-plus";
-    rev = "v${version}";
-    hash = "sha256-Zi428QI0DBIPEywXPi0TwDQWJuQyQcB6N5nqtYkkpHk=";
+    rev = "08d43e9e4c079534e47ba19fb2965c968c9621b2";
+    hash = "sha256-MHz8b1whSzUJO0YogxMPuXMaQRfR+xxSYhFxq412EmE=";
   };
 
-  vendorHash = "sha256-cCMbda2dVZypGqy9zoh0D3lVHWw/HNbCaSe0Nj5wL6s=";
+  vendorHash = "sha256-GmxiQk50iQoH2J/qUVvl9RBz6aIQp8RURqTzrl6NdCY=";
 
   ldflags = [
     "-s"
@@ -27,10 +27,16 @@ buildGoModule rec {
     "-X main.version=${version}"
   ];
 
+  patches = [
+    # https://github.com/bepass-org/warp-plus/pull/291
+    ./fix-endpoints.patch
+  ];
+
   checkFlags =
     let
       # Skip tests that require network access
       skippedTests = [
+        "TestStdNetBindReceiveFuncAfterClose"
         "TestConcurrencySafety"
         "TestNoiseHandshake"
         "TestTwoDevicePing"
@@ -39,8 +45,11 @@ buildGoModule rec {
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   passthru = {
-    updateScript = nix-update-script { };
-    tests.version = testers.testVersion { package = warp-plus; };
+    updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+    tests.version = testers.testVersion {
+      package = warp-plus;
+      command = "warp-plus version";
+    };
   };
 
   meta = {

--- a/pkgs/by-name/wa/warp-plus/package.nix
+++ b/pkgs/by-name/wa/warp-plus/package.nix
@@ -56,10 +56,7 @@ buildGoModule rec {
     description = "Warp + Psiphon, an anti censorship utility for Iran";
     homepage = "https://github.com/bepass-org/warp-plus";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ phanirithvij ];
     mainProgram = "warp-plus";
-    # Doesn't work with Go toolchain >1.22, runtime error:
-    # 'panic: tls.ConnectionState doesn't match'
-    broken = true;
   };
 }


### PR DESCRIPTION
fixes build
closes #437829

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
