### PR TITLE
reoxide: init at 0.6.1-unstable-2025-08-27

### DIFF
--- a/pkgs/by-name/re/reoxide/package.nix
+++ b/pkgs/by-name/re/reoxide/package.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  python3,
+  fetchFromGitea,
+  cacert,
+  clang,
+  meson,
+  pkg-config,
+  cppzmq,
+  libclang,
+  libllvm,
+}:
+python3.pkgs.buildPythonApplication rec {
+  pname = "reoxide";
+  version = "0.6.1-unstable-2025-08-27";
+  pyproject = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "ReOxide";
+    repo = "reoxide";
+    rev = "0ba38caa8656aaf109f674c868bff708a7288bb0";
+    hash = "sha256-Pnqr4SuupGk0Fa9d5eJ/zWeJiE9gMxBeHvI2cZV60ew=";
+    nativeBuildInputs = [
+      meson
+      cacert
+    ];
+    postFetch = ''
+      pushd "$out"
+        for prj in subprojects/*.wrap; do
+          meson subprojects download "$(basename "$prj" .wrap)"
+          rm -rf subprojects/$(basename "$prj" .wrap)/.git
+        done
+      popd
+    '';
+  };
+
+  build-system = [
+    clang
+    pkg-config
+    python3.pkgs.meson
+    python3.pkgs.meson-python
+    python3.pkgs.ninja
+    python3.pkgs.setuptools
+  ];
+
+  dependencies = with python3.pkgs; [
+    cppzmq
+    libclang
+    libllvm
+    platformdirs
+    pyyaml
+    pyzmq
+  ];
+
+  mesonFlags = [
+    "-Db_ndebug=true"
+    "-Dextract-actions=enabled"
+  ];
+
+  postPatch = ''
+    # Replace version.py with a version that returns the package version
+    cat > scripts/version.py << 'EOF'
+    #! ${python3.interpreter}
+    import sys
+    if len(sys.argv) > 1 and sys.argv[1] == 'get-vcs':
+        print('${version}'.split('-')[0])
+    else:
+        exit(1)
+    EOF
+  '';
+
+  pythonImportsCheck = [
+    "reoxide"
+  ];
+
+  meta = {
+    description = "Plugin System for the Ghidra Decompiler";
+    homepage = "https://codeberg.org/ReOxide/reoxide";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      themadbit
+      eljamm
+    ];
+    teams = with lib.teams; [ ngi ];
+    mainProgram = "reoxide";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
