### PR TITLE
xen: fix script shebangs

### DIFF
--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -43,6 +43,7 @@
   pandoc,
 
   # Scripts
+  bash,
   bridge-utils,
   coreutils,
   diffutils,
@@ -223,6 +224,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]);
 
   buildInputs = [
+    bash
     bzip2
     e2fsprogs.dev
     libnl


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR fixes #437878 by ensuring `bash` is in the buildInputs for the `xen` package.
Not having `bash` in `buildInputs` meant it was not present in `HOST_PATH` during the fixup stage, so `patchShebangs` could not computer the correct store path for bash on the target system, and the shebangs were left unpatched. Per the linked issue, this was most notably causing `xenstored` to not be able to start, which is a key service required for dom0 operation and normal Xen functionality.

I have validated these changes both locally by building the package and confirming the scripts have correctly patched shebangs, but also by building and deploying on my test Xen host, and can confirm this PR restores normal operation of `xenstored` and related Xen operations (such as using `xl` to administer Xen guests).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
