### PR TITLE
python313Packages.reqif: fix runtime dependency, minor cleanup

### DIFF
--- a/pkgs/development/python-modules/reqif/default.nix
+++ b/pkgs/development/python-modules/reqif/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  beautifulsoup4,
   buildPythonPackage,
   fetchFromGitHub,
   hatchling,
@@ -8,7 +7,6 @@
   lxml,
   pytestCheckHook,
   python,
-  pythonOlder,
   xmlschema,
 }:
 
@@ -16,8 +14,6 @@ buildPythonPackage rec {
   pname = "reqif";
   version = "0.0.46";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "strictdoc-project";
@@ -32,15 +28,15 @@ buildPythonPackage rec {
       "\"${placeholder "out"}/${python.sitePackages}/reqif\""
   '';
 
-  nativeBuildInputs = [
+  build-system = [
     hatchling
   ];
 
-  propagatedBuildInputs = [
-    beautifulsoup4
+  dependencies = with python.pkgs; [
     lxml
     jinja2
     xmlschema
+    openpyxl
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];


### PR DESCRIPTION
`reqif` is missing the runtime dependency `openpyxl`. Building it fails:

```
nix build .#pthon3Packages.reqif
       last 25 log lines:
       > Sourcing python-namespaces-hook
       > Sourcing python-catch-conflicts-hook.sh
       > Sourcing pytest-check-hook
       > Using pytestCheckPhase
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/ayqgfmdgq0pq57mdlb44bsqnxvp7if3h-source
       > source root is source
       > setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "source/tests/unit/reqif/test_reqif_bundle.py"
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > Executing pypaBuildPhase
       > Creating a wheel...
       > pypa build flags: --no-isolation --outdir dist/ --wheel
       > * Getting build dependencies for wheel...
       > * Building wheel...
       > Successfully built reqif-0.0.46-py3-none-any.whl
       > Finished creating a wheel...
       > Finished executing pypaBuildPhase
       > Running phase: pythonRuntimeDepsCheckHook
       > Executing pythonRuntimeDepsCheck
       > Checking runtime dependencies for reqif-0.0.46-py3-none-any.whl
       >   - openpyxl not installed
       For full logs, run 'nix log /nix/store/2mgcr8b4md9c8ck5n35359jxz35bpsz3-python3.13-reqif-0.0.46.drv'.
```

This PR adds the missing dependency.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
