### PR TITLE
brscan4: Make brsaneconfig4 -q functional

### DIFF
--- a/pkgs/by-name/br/brscan4/package.nix
+++ b/pkgs/by-name/br/brscan4/package.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
     done
     popd > /dev/null
 
-    # Generate an LD_PRELOAD wrapper to redirect execvp(), open() and open64()
+    # Generate an LD_PRELOAD wrapper to redirect various system
     # calls to `/opt/brother/scanner/brscan4`.
     preload=$out/libexec/brother/scanner/brscan4/libpreload.so
     mkdir -p $(dirname $preload)

--- a/pkgs/by-name/br/brscan4/preload.c
+++ b/pkgs/by-name/br/brscan4/preload.c
@@ -1,5 +1,5 @@
-/* Brgen4 search for configuration under `/etc/opt/brother/scanner/brscan4`. This
-   LD_PRELOAD library intercepts execvp(), open and open64 calls to redirect them to
+/* Brgen4 search for configuration under `/opt/brother/scanner/brscan4`. This
+   LD_PRELOAD library intercepts various calls to redirect them to
    the corresponding location in $out. Also support specifying an alternate
    file name for `brsanenetdevice4.cfg` which otherwise is invariable
    created at `/etc/opt/brother/scanner/brscan4`*/
@@ -16,7 +16,7 @@
 #include <string.h>
 #include <dirent.h>
 
-char origDir [] = "/etc/opt/brother/scanner/brscan4";
+char origDir [] = "/opt/brother/scanner/brscan4";
 char realDir [] = OUT "/opt/brother/scanner/brscan4";
 
 char devCfgFileNameEnvVar [] = "BRSANENETDEVICE4_CFG_FILENAME";
@@ -98,11 +98,11 @@ const char* rewriteSystemCall(const char* command, char* buf, unsigned maxBuf)
     return result;
 }
 
-int execvp(const char * path, char * const argv[])
+int execve(const char *path, char *const argv[], char *const envp[])
 {
-    int (*_execvp) (const char *, char * const argv[]) = dlsym(RTLD_NEXT, "execvp");
+    int (*_execve) (const char *, char *const argv[], char *const envp[]) = dlsym(RTLD_NEXT, "execve");
     char buf[PATH_MAX];
-    return _execvp(rewrite(path, buf), argv);
+    return _execve(rewrite(path, buf), argv, envp);
 }
 
 


### PR DESCRIPTION
Fix the LD_PRELOAD wrapper, patch all RPATHs and add a missing dependency so `brsaneconfig4 -q` runs successfully.

(It still doesn't find my scanner but I believe that is for regular proprietary driver reasons)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
