### PR TITLE
rv: init at 0.1.0

### DIFF
--- a/pkgs/by-name/rv/rv/package.nix
+++ b/pkgs/by-name/rv/rv/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rv";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "spinel-coop";
+    repo = "rv";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DldUsSaVya5LD+0AHSlZXbJ05SNcew+7ryM3PlAMZEk=";
+  };
+
+  cargoHash = "sha256-yg9zW2keIQwdi0ky0JQ2MnKb+7GqYLUzbHM4ckAQVDQ=";
+
+  cargoBuildFlags = [
+    "--all-features"
+  ];
+
+  cargoTestFlags = [
+    "--all-features"
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  # Skip integration tests requiring pre-built Ruby executables.
+  checkFlags = [
+    "--skip=ruby::find_test::"
+    "--skip=ruby::list_test::"
+    "--skip=shell::env_test::"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Ruby version manager";
+    homepage = "https://github.com/spinel-coop/rv";
+    changelog = "https://github.com/spinel-coop/rv/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = with lib.licenses; [
+      mit # or
+      asl20
+    ];
+    maintainers = with lib.maintainers; [
+      kachick
+    ];
+    mainProgram = "rv";
+  };
+})


### PR DESCRIPTION
Introducing [rv](https://github.com/spinel-coop/rv) for ruby tooling, it is inspired by [uv](https://github.com/astral-sh/uv)

This tool downloads pre-built Ruby binaries from https://github.com/spinel-coop/rv-ruby, so it does not work on NixOS out-of-the-box.
I have confirmed its behavior with Nix on Ubuntu.

blog: https://andre.arko.net/2025/08/25/rv-a-new-kind-of-ruby-management-tool/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
