### PR TITLE
python3Packages.libapparmor: init from pkgs.libapparmor

### DIFF
--- a/pkgs/by-name/ap/apparmor-utils/package.nix
+++ b/pkgs/by-name/ap/apparmor-utils/package.nix
@@ -12,10 +12,12 @@
   buildPackages,
 
   # apparmor deps
-  libapparmor,
   apparmor-parser,
   apparmor-teardown,
 }:
+let
+  inherit (python3Packages) libapparmor;
+in
 python3Packages.buildPythonApplication {
   pname = "apparmor-utils";
   inherit (libapparmor) version src;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8081,6 +8081,12 @@ self: super: with self; {
 
   libais = callPackage ../development/python-modules/libais { };
 
+  libapparmor = toPythonModule (
+    pkgs.libapparmor.override {
+      python3Packages = self;
+    }
+  );
+
   libarchive-c = callPackage ../development/python-modules/libarchive-c {
     inherit (pkgs) libarchive;
   };


### PR DESCRIPTION
Without this, `libapparmor` will be built against the default python (currently python 3.13), even if the python used in `apparmor-utils` was overridden to e.g. 3.12. This causes unexpected import fails at runtime, because the `site-packages` directory for 3.12 would be missing from the `libapparmor` used.

Zero rebuild on actual apparmor, only adds rebuilds for the python312 version of libapparmor. Makes python overrides to `apparmor-utils` actually work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
