### PR TITLE
root: make rootcint and genreflex available again

### DIFF
--- a/pkgs/by-name/ro/root/Build-rootcint-and-genreflex-as-separate-targets.patch
+++ b/pkgs/by-name/ro/root/Build-rootcint-and-genreflex-as-separate-targets.patch
@@ -1,0 +1,108 @@
+From febb61a45a40a76bdbcd320f307dcd8f14cc532b Mon Sep 17 00:00:00 2001
+From: Jonas Rembser <jonas.rembser@cern.ch>
+Date: Thu, 28 Aug 2025 14:07:01 +0200
+Subject: [PATCH] [CMake] Build `rootcint` and `genreflex` as separate targets
+
+This makes the CMake code more robust.
+
+Right now, we use some `install(CODE "execute_process(COMMAND ln -f ...`
+solution on unix to install `rootcint` and `genreflex`. This does not
+work in all cases, either because of the usage of `\$ENV{DESTDIR}` when
+`DESTDIR` is not set, or because hard links are not allowed.
+
+Always copying `rootcling` - already in the build tree - would avoid
+that problem, but by copying we risk sidestepping the CMake mechanisms
+to set the RPath correctly when installing the copies, which are not
+actual targets.
+
+To make makes things simpler and more robust, this commit suggests to
+build the `rootcing` and `genreflex` executables as separate targets
+from the same source. The cost is very little cost in memory
+(`rootcling` is only 31K, so copying two times only increases the size
+of ROOTs `bin` directory by 1.5 %) and little in compile time (the extra
+compile time is less than a second, not noticable in parallel builds).
+---
+ main/CMakeLists.txt | 69 +++++++++++++++------------------------------
+ 1 file changed, 23 insertions(+), 46 deletions(-)
+
+diff --git a/main/CMakeLists.txt b/main/CMakeLists.txt
+index 7dfcd98e345..857f0df48d8 100644
+--- a/main/CMakeLists.txt
++++ b/main/CMakeLists.txt
+@@ -98,50 +98,27 @@ set_source_files_properties(src/rootcling.cxx PROPERTIES
+   VISIBILITY_INLINES_HIDDEN "ON"
+ )
+ 
+-ROOT_EXECUTABLE(rootcling src/rootcling.cxx LIBRARIES RIO Cling Core Rint)
+-
+-# rootcling includes the ROOT complex header which would build the complex
+-# dictionary with modules. To make sure that rootcling_stage1 builds this
+-# dict before we use it, we add a dependency here.
+-add_dependencies(rootcling complexDict)
+-
+-target_include_directories(rootcling PRIVATE
+-        ${CMAKE_SOURCE_DIR}/core/metacling/res
+-        ${CMAKE_SOURCE_DIR}/core/dictgen/res
+-        ${CMAKE_SOURCE_DIR}/io/rootpcm/res)
+-set_property(TARGET rootcling PROPERTY ENABLE_EXPORTS 1)
+-if(WIN32)
+-  set_target_properties(rootcling PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)
+-  set_property(TARGET rootcling APPEND_STRING PROPERTY LINK_FLAGS " -STACK:4000000")
+-endif()
+-
+-# Create aliases: rootcint, genreflex.
+-if(WIN32)
+-  add_custom_command(TARGET rootcling POST_BUILD
+-                     COMMAND copy /y rootcling.exe rootcint.exe
+-                     COMMAND copy /y rootcling.exe genreflex.exe
+-                     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+-else()
+-  add_custom_command(TARGET rootcling POST_BUILD
+-                     COMMAND ln -f rootcling rootcint
+-                     COMMAND ln -f rootcling genreflex
+-                     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+-endif()
+-set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES
+-                         "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rootcint;${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/genreflex")
+-
+-if(CMAKE_HOST_UNIX)
+-  install(CODE "execute_process(COMMAND ln -f rootcling rootcint WORKING_DIRECTORY \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})" COMPONENT applications)
+-  install(CODE "execute_process(COMMAND ln -f rootcling genreflex WORKING_DIRECTORY \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})" COMPONENT applications)
+-else()
+-  if(MSVC)
+-    install(PROGRAMS  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rootcling.exe DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT applications)
+-    install(PROGRAMS  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rootcint.exe DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT applications)
+-    install(PROGRAMS  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/genreflex.exe DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT applications)
+-  else()
+-    install(PROGRAMS  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rootcint
+-                      ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/genreflex
+-                      ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rlibmap
+-                      DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT applications)
++set(rootcling_exe_names rootcling genreflex rootcint)
++
++foreach(exe_name IN LISTS rootcling_exe_names)
++  ROOT_EXECUTABLE(${exe_name} src/rootcling.cxx LIBRARIES RIO Cling Core Rint)
++
++  # rootcling includes the ROOT complex header which would build the complex
++  # dictionary with modules. To make sure that rootcling_stage1 builds this
++  # dict before we use it, we add a dependency here.
++  add_dependencies(${exe_name} complexDict)
++
++  target_include_directories(${exe_name} PRIVATE
++          ${CMAKE_SOURCE_DIR}/core/metacling/res
++          ${CMAKE_SOURCE_DIR}/core/dictgen/res
++          ${CMAKE_SOURCE_DIR}/io/rootpcm/res)
++  set_property(TARGET ${exe_name} PROPERTY ENABLE_EXPORTS 1)
++  if(WIN32)
++    set_target_properties(${exe_name} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)
++    set_property(TARGET ${exe_name} APPEND_STRING PROPERTY LINK_FLAGS " -STACK:4000000")
+   endif()
+-endif()
++endforeach()
++
++# To inherit the dependencies from rootcling
++add_dependencies(genreflex rootcling)
++add_dependencies(rootcint rootcint)
+-- 
+2.50.1
+

--- a/pkgs/by-name/ro/root/package.nix
+++ b/pkgs/by-name/ro/root/package.nix
@@ -135,6 +135,8 @@ stdenv.mkDerivation rec {
       hash = "sha256-D7LZWJnGF9DtKcM8EF3KILU81cqTcZolW+HMe3fmXTw=";
       revert = true;
     })
+    # Will also be integrated to ROOT 6.38.00
+    ./Build-rootcint-and-genreflex-as-separate-targets.patch
   ];
 
   preConfigure = ''

--- a/pkgs/by-name/xf/xfitter/package.nix
+++ b/pkgs/by-name/xf/xfitter/package.nix
@@ -60,6 +60,12 @@ stdenv.mkDerivation {
   ]
   ++ lib.optional (stdenv.hostPlatform.libc == "glibc") libtirpc;
 
+  preConfigure = ''
+    substituteInPlace "CMakeLists.txt" \
+      --replace-fail 'cmake_minimum_required(VERSION 2.8.12.2)' \
+                     'cmake_minimum_required(VERSION 3.10)'
+  '';
+
   env.NIX_CFLAGS_COMPILE = lib.optionalString (
     stdenv.hostPlatform.libc == "glibc"
   ) "-I${libtirpc.dev}/include/tirpc";


### PR DESCRIPTION
The mechanism to install these binaries as hard links to `rootcling` was quite fragile. This commit suggests to just build them as separate CMake targets instead.

This fixes the compilation of `applgrid`, `apfelgrid`, and `xfitter` reported in https://github.com/NixOS/nixpkgs/pull/424032#discussion_r2305727437


FYI @veprbl

Upstream commit to ROOT:
  * https://github.com/root-project/root/pull/19769