### PR TITLE
melos: 6.3.2 -> 7.1.0

### DIFF
--- a/pkgs/by-name/me/melos/add-generic-main.patch
+++ b/pkgs/by-name/me/melos/add-generic-main.patch
@@ -8,8 +8,13 @@ index 0db7013..218276f 100644
  import 'package:melos/src/command_runner.dart';
  
 -Future<void> main(List<String> arguments) async => launchExecutable(
--      arguments,
--      LaunchConfig(
+-  arguments,
+-  LaunchConfig(
+-    name: ExecutableName('melos'),
+-    launchFromSelf: false,
+-    entrypoint: melosEntryPoint,
+-  ),
+-);
 +Future<void> main(List<String> arguments) async {
 +  final melosYamlPath = findMelosYaml();
 +
@@ -24,13 +29,10 @@ index 0db7013..218276f 100644
 +    LaunchContext(
 +      directory: Directory.current,
 +      localInstallation: ExecutableInstallation(
-         name: ExecutableName('melos'),
--        launchFromSelf: false,
--        entrypoint: melosEntryPoint,
++        name: ExecutableName('melos'),
 +        isSelf: false,
 +        packageRoot: melosYamlPath,
-       ),
--    );
++      ),
 +    ),
 +  );
 +}

--- a/pkgs/by-name/me/melos/package.nix
+++ b/pkgs/by-name/me/melos/package.nix
@@ -5,12 +5,12 @@
 }:
 let
   pname = "melos";
-  version = "6.3.2";
+  version = "7.1.0";
   src = fetchFromGitHub {
     owner = "invertase";
     repo = "melos";
     rev = "melos-v${version}";
-    hash = "sha256-hD4UlQPFugRqtOZecyT/6wV3vFocoQ6OO5w+SZsYdO0=";
+    hash = "sha256-caX59w0uxy5VW1p1hgds73m3sIjEutz5ZUuOzjdIr4Q=";
   };
 in
 buildDartApplication {


### PR DESCRIPTION
## Things done

melos: 6.3.2 -> 7.1.0

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
