### PR TITLE
ci/eval: allow local comparison with rebuilds

### DIFF
--- a/ci/eval/README.md
+++ b/ci/eval/README.md
@@ -2,25 +2,28 @@
 
 The code in this directory is used by the [eval.yml](../../.github/workflows/eval.yml) GitHub Actions workflow to evaluate the majority of Nixpkgs for all PRs, effectively making sure that when the development branches are processed by Hydra, no evaluation failures are encountered.
 
-Furthermore it also allows local evaluation using
+Furthermore it also allows local evaluation using:
+
 ```
-nix-build ci -A eval.full \
-  --max-jobs 4 \
-  --cores 2 \
-  --arg chunkSize 10000 \
-  --arg evalSystems '["x86_64-linux" "aarch64-darwin"]'
+nix-build ci -A eval.full
 ```
 
+The most important two arguments are:
+- `--arg evalSystems`: The set of systems for which `nixpkgs` should be evaluated.
+  Defaults to the four official platforms (`x86_64-linux`, `aarch64-linux`, `x86_64-darwin` and `aarch64-darwin`).
+  Example: `--arg evalSystems '["x86_64-linux" "aarch64-darwin"]'`
+- `--arg quickTest`: Enables testing a single chunk of the current system only for quick iteration.
+  Example: `--arg quickTest true`
+
+The following arguments can be used to fine-tune performance:
 - `--max-jobs`: The maximum number of derivations to run at the same time.
   Only each [supported system](../supportedSystems.json) gets a separate derivation, so it doesn't make sense to set this higher than that number.
 - `--cores`: The number of cores to use for each job.
   Recommended to set this to the amount of cores on your system divided by `--max-jobs`.
-- `chunkSize`: The number of attributes that are evaluated simultaneously on a single core.
+- `--arg chunkSize`: The number of attributes that are evaluated simultaneously on a single core.
   Lowering this decreases memory usage at the cost of increased evaluation time.
   If this is too high, there won't be enough chunks to process them in parallel, and will also increase evaluation time.
-- `evalSystems`: The set of systems for which `nixpkgs` should be evaluated.
-  Defaults to the four official platforms (`x86_64-linux`, `aarch64-linux`, `x86_64-darwin` and `aarch64-darwin`).
-
-A good default is to set `chunkSize` to 10000, which leads to about 3.6GB max memory usage per core, so suitable for fully utilising machines with 4 cores and 16GB memory, 8 cores and 32GB memory or 16 cores and 64GB memory.
+  The default is 5000.
+  Example: `--arg chunkSize 10000`
 
 Note that 16GB memory is the recommended minimum, while with less than 8GB memory evaluation time suffers greatly.

--- a/ci/eval/README.md
+++ b/ci/eval/README.md
@@ -5,7 +5,7 @@ The code in this directory is used by the [eval.yml](../../.github/workflows/eva
 Furthermore it also allows local evaluation using:
 
 ```
-nix-build ci -A eval.full
+nix-build ci -A eval.baseline
 ```
 
 The most important two arguments are:
@@ -27,3 +27,19 @@ The following arguments can be used to fine-tune performance:
   Example: `--arg chunkSize 10000`
 
 Note that 16GB memory is the recommended minimum, while with less than 8GB memory evaluation time suffers greatly.
+
+## Local eval with rebuilds / comparison
+
+To compare two commits locally, first run the following on the baseline commit:
+
+```
+BASELINE=$(nix-build ci -A eval.baseline --no-out-link)
+```
+
+Then, on the commit with your changes:
+
+```
+nix-build ci -A eval.full --arg baseline $BASELINE
+```
+
+Keep in mind to otherwise pass the same set of arguments for both commands (`evalSystems`, `quickTest`, `chunkSize`).

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -245,7 +245,7 @@ let
       # Whether to evaluate on a specific set of systems, by default all are evaluated
       evalSystems ? if quickTest then [ "x86_64-linux" ] else supportedSystems,
       # The number of attributes per chunk, see ./README.md for more info.
-      chunkSize,
+      chunkSize ? 5000,
       quickTest ? false,
     }:
     let

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -240,7 +240,7 @@ let
 
   compare = callPackage ./compare { };
 
-  full =
+  baseline =
     {
       # Whether to evaluate on a specific set of systems, by default all are evaluated
       evalSystems ? if quickTest then [ "x86_64-linux" ] else supportedSystems,
@@ -248,21 +248,36 @@ let
       chunkSize ? 5000,
       quickTest ? false,
     }:
+    symlinkJoin {
+      name = "nixpkgs-eval-baseline";
+      paths = map (
+        evalSystem:
+        singleSystem {
+          inherit quickTest evalSystem chunkSize;
+        }
+      ) evalSystems;
+    };
+
+  full =
+    {
+      # Whether to evaluate on a specific set of systems, by default all are evaluated
+      evalSystems ? if quickTest then [ "x86_64-linux" ] else supportedSystems,
+      # The number of attributes per chunk, see ./README.md for more info.
+      chunkSize ? 5000,
+      quickTest ? false,
+      baseline,
+    }:
     let
       diffs = symlinkJoin {
-        name = "diffs";
+        name = "nixpkgs-eval-diffs";
         paths = map (
           evalSystem:
-          let
-            eval = singleSystem {
-              inherit quickTest evalSystem chunkSize;
-            };
-          in
           diff {
             inherit evalSystem;
-            # Local "full" evaluation doesn't do a real diff.
-            beforeDir = eval;
-            afterDir = eval;
+            beforeDir = baseline;
+            afterDir = singleSystem {
+              inherit quickTest evalSystem chunkSize;
+            };
           }
         ) evalSystems;
       };
@@ -280,7 +295,8 @@ in
     combine
     compare
     # The above three are used by separate VMs in a GitHub workflow,
-    # while the below is intended for testing on a single local machine
+    # while the below are intended for testing on a single local machine
+    baseline
     full
     ;
 }


### PR DESCRIPTION
This allows running a full comparison between two commits locally.

What was previously `eval.full` is now called `eval.all`. The new `eval.full` takes a `baseline` argument for the comparison.

Fixes https://github.com/NixOS/nixpkgs/pull/437697#issuecomment-3233374732

@philiptaron could you give this a test-run? I only did some basic testing with "baseline == HEAD", but I think this should work with your example as well.

## Things done

- [x] Basic testing.
- [x] More testing by @philiptaron 
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
