### PR TITLE
forge-mtg: improve update script and patch handling

### DIFF
--- a/pkgs/by-name/fo/forge-mtg/no-launch4j.patch
+++ b/pkgs/by-name/fo/forge-mtg/no-launch4j.patch
@@ -1,12 +1,10 @@
 diff --git a/forge-gui-desktop/pom.xml b/forge-gui-desktop/pom.xml
-index dfe902e6b9..6fe3382f27 100644
 --- a/forge-gui-desktop/pom.xml
 +++ b/forge-gui-desktop/pom.xml
-@@ -70,62 +70,6 @@
-                     </execution>
+@@ -71,62 +71,6 @@
                  </executions>
              </plugin>
--            <plugin>
+             <plugin>
 -                <groupId>com.akathist.maven.plugins.launch4j</groupId>
 -                <artifactId>launch4j-maven-plugin</artifactId>
 -                <version>2.5.1</version>
@@ -62,18 +60,17 @@ index dfe902e6b9..6fe3382f27 100644
 -                    </execution>
 -                </executions>
 -            </plugin>
-             <plugin>
+-            <plugin>
                  <groupId>com.google.code.maven-replacer-plugin</groupId>
                  <artifactId>replacer</artifactId>
+                 <version>1.5.3</version>
 diff --git a/forge-gui-mobile-dev/pom.xml b/forge-gui-mobile-dev/pom.xml
-index 168ecba1dc..748dbf47b7 100644
 --- a/forge-gui-mobile-dev/pom.xml
 +++ b/forge-gui-mobile-dev/pom.xml
-@@ -60,57 +60,6 @@
-                     <target>17</target>
+@@ -61,57 +61,6 @@
                  </configuration>
              </plugin>
--            <plugin>
+             <plugin>
 -                <groupId>com.akathist.maven.plugins.launch4j</groupId>
 -                <artifactId>launch4j-maven-plugin</artifactId>
 -                <version>2.5.1</version>
@@ -124,6 +121,8 @@ index 168ecba1dc..748dbf47b7 100644
 -                    <!--extra-->
 -                </executions>
 -            </plugin>
-             <plugin>
+-            <plugin>
                  <groupId>com.google.code.maven-replacer-plugin</groupId>
                  <artifactId>replacer</artifactId>
+                 <version>1.5.3</version>
+

--- a/pkgs/by-name/fo/forge-mtg/package.nix
+++ b/pkgs/by-name/fo/forge-mtg/package.nix
@@ -123,9 +123,7 @@ maven.buildMavenPackage {
     done
   '';
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [ "--version-regex=forge-(.*)" ];
-  };
+  passthru.updateScript = ./update.sh;
 
   meta = with lib; {
     description = "Magic: the Gathering card game with rules enforcement";

--- a/pkgs/by-name/fo/forge-mtg/update.sh
+++ b/pkgs/by-name/fo/forge-mtg/update.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env nix-shell
+#!nix-shell --pure -i bash -p curl cacert nix-update jq gnused git
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+get_latest_version() {
+    local repo="$1"
+    curl -sfS ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} https://api.github.com/repos/$repo/releases/latest | jq -r .tag_name
+}
+
+download_and_extract_source() {
+    local repo="$1"
+    local version="$2"
+    local temp_dir=$(mktemp -d)
+
+    curl -sfSL "https://github.com/$repo/archive/$version.tar.gz" | tar -xz -C "$temp_dir"
+
+    echo $temp_dir
+}
+
+check_plugin_in_pom() {
+    local pom_file="$1"
+    local plugin_name="$2"
+    if [[ -f "$pom_file" ]]; then
+        grep -q "<artifactId>$plugin_name</artifactId>" "$pom_file" 2>/dev/null
+    else
+        return 1
+    fi
+}
+
+remove_plugin_from_pom() {
+    local pom_file="$1"
+    local plugin_name="$2"
+
+    if [[ ! -f "$pom_file" ]]; then
+        echo "Error: $pom_file does not exist" >&2
+        return 1
+    fi
+
+    awk -v plugin="$plugin_name" '
+    /<plugin>/ {
+        plugin_block = $0 "\n"
+        in_plugin = 1
+        skip = 0
+        next
+    }
+    in_plugin && /<\/plugin>/ {
+        plugin_block = plugin_block $0 "\n"
+        if (!skip) {
+            printf "%s", plugin_block
+        }
+        in_plugin = 0
+        plugin_block = ""
+        next
+    }
+    in_plugin {
+        plugin_block = plugin_block $0 "\n"
+        if (/<artifactId>/ && index($0, plugin) > 0) {
+            skip = 1
+        }
+        next
+    }
+    !in_plugin { print }
+    ' "$pom_file" > "$pom_file.tmp" && mv "$pom_file.tmp" "$pom_file"
+
+    echo "Removed plugin blocks with artifactId '$plugin_name' from $pom_file"
+}
+
+update_patch() {
+    local source_dir="$1"
+    local plugin_name="$2"
+    local patch_file="$3"
+
+    if [[ ! -d "$source_dir" ]]; then
+        echo "Source directory $source_dir does not exist!"
+        exit 1
+    fi
+
+    local temp_dir=$(mktemp -d)
+    local plugin_found=false
+    local patch_content=""
+
+    echo "Checking for $plugin_name in pom.xml files..."
+
+    # Find all pom.xml files that contain the specified plugin
+    while IFS= read -r -d '' pom_file; do
+        if check_plugin_in_pom "$pom_file" "$plugin_name"; then
+            plugin_found=true
+            echo "Found $plugin_name in: $pom_file"
+
+            # Generate patch content for this file
+            local relative_path=$(echo "$pom_file" | sed "s|^$source_dir/||")
+            local temp_original="$temp_dir/original_$(basename "$pom_file")"
+            local temp_patched="$temp_dir/patched_$(basename "$pom_file")"
+
+            cp "$pom_file" "$temp_original"
+            cp "$pom_file" "$temp_patched"
+
+            remove_plugin_from_pom "$temp_patched" "$plugin_name"
+
+            # Generate diff for this file
+            if ! cmp -s "$temp_original" "$temp_patched"; then
+                local file_diff=$(diff -u "$temp_original" "$temp_patched" | sed "s|$temp_original|a/$relative_path|g; s|$temp_patched|b/$relative_path|g" | sed '1,2s/\t.*$//')
+                if [[ -n "$file_diff" ]]; then
+                    patch_content+='diff --git a/'"$relative_path"' b/'"$relative_path"''$'\n'
+                    patch_content+="$file_diff"$'\n'
+                fi
+            fi
+        fi
+    done < <(find "$source_dir" -name "pom.xml" -print0)
+
+    if [[ "$plugin_found" == "true" && -n "$patch_content" ]]; then
+        echo "Updating $patch_file..."
+        echo "$patch_content" > "$SCRIPT_DIR/$patch_file"
+        echo "Patch updated successfully!"
+        rm -rf "$temp_dir"
+    else
+        echo "No $plugin_name found on any pom.xml file. Patch not updated."
+        rm -rf "$temp_dir"
+        exit 1
+    fi
+}
+
+echo "Updating forge-mtg package..."
+
+version=$(get_latest_version "Card-Forge/forge")
+
+source_dir=$(download_and_extract_source "Card-Forge/forge" $version)/forge-$version
+
+update_patch "$source_dir" "launch4j-maven-plugin" "no-launch4j.patch"
+
+rm -rf "$(dirname "$source_dir")"
+
+nix-update --version-regex=forge-'(.*)' forge-mtg


### PR DESCRIPTION
* Add update.sh script

* ensuring "no-launch4j.patch" is regenerated when update.sh is triggered

* using the auto generated "no-launch4j.path" file


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
