### PR TITLE
raccoin: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27316,6 +27316,11 @@
     githubId = 51289041;
     name = "Vuks";
   };
+  vv01f = {
+    github = "vv01f";
+    githubId = 3034896;
+    name = "Wolf";
+  };
   vyorkin = {
     email = "vasiliy.yorkin@gmail.com";
     github = "vyorkin";

--- a/pkgs/by-name/ra/raccoin/package.nix
+++ b/pkgs/by-name/ra/raccoin/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  makeWrapper,
+  libxkbcommon,
+  wayland,
+  cairo,
+  pango,
+  harfbuzz,
+  fontconfig,
+  freetype,
+  alsa-lib,
+  libGL,
+  xorg,
+  openssl,
+  nix-update-script,
+  withWayland ? true,
+  withX11 ? true,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "raccoin";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "bjorn";
+    repo = "raccoin";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6BwRFU8qU6K0KqKdK+soKcWU2LPxkKKPOcn2gupunGg=";
+  };
+  cargoHash = "sha256-pz3dwIIBQZIwTammiI/UQwM0Iy1ZgC9ntK+qNGv3s24=";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+  buildInputs = [
+    cairo
+    pango
+    harfbuzz
+    fontconfig
+    freetype
+    alsa-lib
+    libGL
+    openssl
+    libxkbcommon
+  ]
+  ++ lib.optionals withWayland [
+    wayland
+  ]
+  ++ lib.optionals withX11 [
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXi
+    xorg.libXrandr
+  ];
+
+  # upstream has no tests
+  doCheck = false;
+  # alternatively when tests are added later
+  #doCheck = true;
+  #checkPhase = ''
+  #  cargo test --lib -- --nocapture
+  #'';
+  #passthru.tests.version = testers.testVersion { package = raccoin; };
+
+  postFixup = ''
+    patchelf --set-rpath "${
+      lib.makeLibraryPath (
+        [
+          fontconfig
+          libxkbcommon
+          openssl
+        ]
+        ++ lib.optional withX11 xorg.libX11
+      )
+    }" \
+      $out/bin/raccoin
+  '';
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Crypto portfolio & capital-gains reporting tool (Rust + Slint)";
+    longDescription = ''
+      This GUI Tool enables accounting with the quite basic principle
+      "first in, first out" (FIFO) in multiple wallets. It is for
+      e.g. bitcoiners that actually use the currency and want
+      reports on their holdings.
+    '';
+    homepage = "https://raccoin.org";
+    changelog = "https://github.com/bjorn/raccoin/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "raccoin";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ vv01f ];
+  };
+})


### PR DESCRIPTION
## Things done

Simply packaging <https://github.com/bjorn/raccoin> with requirement for Flakes.
Website: <https://raccoin.org/>

The Tool enables to do accounting with the principle "first in, first out" for the likes of e.g. bitcoin users that actually use the currency and want to get regular reports on their holdings.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
