### PR TITLE
 [Backport release-25.05] grafanaPlugins.grafana-sentry-datasource: init at 2.2.1

### DIFF
--- a/pkgs/servers/monitoring/grafana/plugins/grafana-sentry-datasource/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-sentry-datasource/default.nix
@@ -9,10 +9,10 @@ grafanaPlugin {
     x86_64-darwin = "sha256-yHgF+XmJXnJjfPwabs1dsrnWvssTmYpeZUXUl+gQxfM=";
     aarch64-darwin = "sha256-ysLXSKG7q/u70NynYqKKRlYIl5rkYy0AMoza3sQSPNM=";
   };
-  meta = with lib; {
+  meta = {
     description = "Integrate Sentry data into Grafana";
-    license = licenses.asl20;
-    maintainers = [ ];
-    platforms = platforms.unix;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ arianvp ];
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/servers/monitoring/grafana/plugins/grafana-sentry-datasource/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-sentry-datasource/default.nix
@@ -1,0 +1,18 @@
+{ grafanaPlugin, lib }:
+
+grafanaPlugin {
+  pname = "grafana-sentry-datasource";
+  version = "2.2.1";
+  zipHash = {
+    x86_64-linux = "sha256-6pjBUqUHXLLgFzfal/OKsMBVlVXxuRglOj3XRnnduRY=";
+    aarch64-linux = "sha256-0kjxBnv34lRB5qeVOyik7qvlEsz7CYur9EyIDTe+AKM=";
+    x86_64-darwin = "sha256-yHgF+XmJXnJjfPwabs1dsrnWvssTmYpeZUXUl+gQxfM=";
+    aarch64-darwin = "sha256-ysLXSKG7q/u70NynYqKKRlYIl5rkYy0AMoza3sQSPNM=";
+  };
+  meta = with lib; {
+    description = "Integrate Sentry data into Grafana";
+    license = licenses.asl20;
+    maintainers = [ ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/servers/monitoring/grafana/plugins/plugins.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/plugins.nix
@@ -21,6 +21,7 @@
   grafana-opensearch-datasource = callPackage ./grafana-opensearch-datasource { };
   grafana-piechart-panel = callPackage ./grafana-piechart-panel { };
   grafana-polystat-panel = callPackage ./grafana-polystat-panel { };
+  grafana-sentry-datasource = callPackage ./grafana-sentry-datasource { };
   grafana-worldmap-panel = callPackage ./grafana-worldmap-panel { };
   marcusolsson-calendar-panel = callPackage ./marcusolsson-calendar-panel { };
   marcusolsson-csv-datasource = callPackage ./marcusolsson-csv-datasource { };


### PR DESCRIPTION
## Things done

Backport of https://github.com/NixOS/nixpkgs/pull/435972

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
