### PR TITLE
lib.types.submoduleWith: add onlyDefinesConfig parameter

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -394,6 +394,11 @@ checkConfigOutput '^"pkgs\.\\"123\\"\.\\"with\\\\\\"quote\\"\.hello"$' options.p
 ## specialArgs should work
 checkConfigOutput '^"foo"$' config.submodule.foo ./declare-submoduleWith-special.nix
 
+## onlyDefinesConfig behaves as expected
+checkConfigOutput '^true$' config.submodule.config ./declare-submoduleWith-onlydefinesconfig.nix ./define-submoduleWith-onlydefinesconfig.nix
+checkConfigOutput '^true$' config.submodule.config ./declare-submoduleWith-onlydefinesconfig.nix ./define-submoduleWith-onlydefinesconfig-path.nix
+checkConfigError 'is not of type `boolean' config.submodule.config ./declare-submoduleWith-onlydefinesconfig.nix ./define-submoduleWith-noshorthand.nix
+
 ## shorthandOnlyDefinesConfig behaves as expected
 checkConfigOutput '^true$' config.submodule.config ./declare-submoduleWith-shorthand.nix ./define-submoduleWith-shorthand.nix
 checkConfigError 'is not of type `boolean' config.submodule.config ./declare-submoduleWith-shorthand.nix ./define-submoduleWith-noshorthand.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -394,7 +394,7 @@ checkConfigOutput '^"pkgs\.\\"123\\"\.\\"with\\\\\\"quote\\"\.hello"$' options.p
 ## specialArgs should work
 checkConfigOutput '^"foo"$' config.submodule.foo ./declare-submoduleWith-special.nix
 
-## shorthandOnlyDefines config behaves as expected
+## shorthandOnlyDefinesConfig behaves as expected
 checkConfigOutput '^true$' config.submodule.config ./declare-submoduleWith-shorthand.nix ./define-submoduleWith-shorthand.nix
 checkConfigError 'is not of type `boolean' config.submodule.config ./declare-submoduleWith-shorthand.nix ./define-submoduleWith-noshorthand.nix
 checkConfigError "In module ..*define-submoduleWith-shorthand.nix., you're trying to define a value of type \`bool'\n\s*rather than an attribute set for the option" config.submodule.config ./declare-submoduleWith-noshorthand.nix ./define-submoduleWith-shorthand.nix

--- a/lib/tests/modules/declare-submoduleWith-onlydefinesconfig.nix
+++ b/lib/tests/modules/declare-submoduleWith-onlydefinesconfig.nix
@@ -1,0 +1,21 @@
+{ lib, ... }:
+let
+  sub = {
+    # An option named `config`; reason to have `onlyDefinesConfig = true;`
+    options.config = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+    };
+    config._module.args.bar = true;
+  };
+in
+{
+  options.submodule = lib.mkOption {
+    type = lib.types.submoduleWith {
+      modules = [ sub ];
+      specialArgs.foo = true;
+      onlyDefinesConfig = true;
+    };
+    default = { };
+  };
+}

--- a/lib/tests/modules/define-submoduleWith-onlydefinesconfig-path-file.nix
+++ b/lib/tests/modules/define-submoduleWith-onlydefinesconfig-path-file.nix
@@ -1,0 +1,4 @@
+{ foo, bar, ... }:
+{
+  config = foo && bar;
+}

--- a/lib/tests/modules/define-submoduleWith-onlydefinesconfig-path.nix
+++ b/lib/tests/modules/define-submoduleWith-onlydefinesconfig-path.nix
@@ -1,0 +1,3 @@
+{
+  submodule = ./define-submoduleWith-onlydefinesconfig-path-file.nix;
+}

--- a/lib/tests/modules/define-submoduleWith-onlydefinesconfig.nix
+++ b/lib/tests/modules/define-submoduleWith-onlydefinesconfig.nix
@@ -1,0 +1,7 @@
+{
+  submodule =
+    { foo, bar, ... }:
+    {
+      config = foo && bar;
+    };
+}

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -251,7 +251,7 @@ Submodules are detailed in [Submodule](#section-option-types-submodule).
     options. This is equivalent to
     `types.submoduleWith { modules = toList o; shorthandOnlyDefinesConfig = true; }`.
 
-`types.submoduleWith` { *`modules`*, *`specialArgs`* ? {}, *`shorthandOnlyDefinesConfig`* ? false }
+`types.submoduleWith` { *`modules`*, *`specialArgs`* ? {}, *`onlyDefinesConfig`* ? false, *`shorthandOnlyDefinesConfig`* ? false }
 
 :   Like `types.submodule`, but more flexible and with better defaults.
     It has parameters
@@ -273,6 +273,12 @@ Submodules are detailed in [Submodule](#section-option-types-submodule).
         other problems. An example is overriding the `lib` argument,
         because `lib` itself is used to define `_module.args`, which
         makes using `_module.args` to define it impossible.
+
+    -   *`onlyDefinesConfig`* Whether definitions of this type should
+        always default to the `config` section of a module. In contrast to
+        `shorthandOnlyDefinesConfig`, this applies to all definition values,
+        including functions and paths. When a value is a function, it is invoked
+        with the same arguments as the module itself.
 
     -   *`shorthandOnlyDefinesConfig`* Whether definitions of this type
         should default to the `config` section of a module (see

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -290,6 +290,8 @@ Submodules are detailed in [Submodule](#section-option-types-submodule).
         With this option enabled, defining a non-`config` section
         requires using a function:
         `the-submodule = { ... }: { options = { ... }; }`.
+        Note that this behavior does *not* apply to [path values](https://nix.dev/manual/nix/latest/language/types.html#type-path),
+        similar to how it does not apply to [function values](https://nix.dev/manual/nix/latest/language/types.html#type-function).
 
 `types.deferredModule`
 


### PR DESCRIPTION
Added the `onlyDefinesConfig` parameter, which works like `shorthandOnlyDefinesConfig` but applies not only to `attrset` values, but also to `function` and `path` values. This is especially useful when a submodule has `specialArgs` and defines `options.{options, config}`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
