### PR TITLE
xdg-desktop-portal-phosh: init at 0.0.4

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/phosh.nix
+++ b/nixos/modules/services/x11/desktop-managers/phosh.nix
@@ -145,6 +145,11 @@ let
 in
 
 {
+
+  meta = {
+    maintainers = with lib.maintainers; [ armelclo ];
+  };
+
   options = {
     services.xserver.desktopManager.phosh = {
       enable = lib.mkOption {
@@ -222,6 +227,16 @@ in
         XDG_SESSION_DESKTOP = "phosh";
         XDG_SESSION_TYPE = "wayland";
       };
+    };
+
+    xdg.portal = {
+      enable = true;
+      extraPortals = [
+        pkgs.xdg-desktop-portal-phosh
+        pkgs.xdg-desktop-portal-gnome
+        pkgs.xdg-desktop-portal-gtk
+      ];
+      configPackages = lib.mkDefault [ pkgs.phosh ];
     };
 
     environment.systemPackages = [

--- a/pkgs/by-name/xd/xdg-desktop-portal-phosh/cargo_lock_deps_version.patch
+++ b/pkgs/by-name/xd/xdg-desktop-portal-phosh/cargo_lock_deps_version.patch
@@ -1,0 +1,30 @@
+diff --git a/subprojects/pfs/Cargo.lock b/subprojects/pfs/Cargo.lock
+index efe74be..9b5f48e 100644
+--- a/subprojects/pfs/Cargo.lock
++++ b/subprojects/pfs/Cargo.lock
+@@ -458,9 +458,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+ 
+ [[package]]
+ name = "libadwaita"
+-version = "0.7.1"
++version = "0.7.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8611ee9fb85e7606c362b513afcaf5b59853f79e4d98caaaf581d99465014247"
++checksum = "500135d29c16aabf67baafd3e7741d48e8b8978ca98bac39e589165c8dc78191"
+ dependencies = [
+  "gdk4",
+  "gio",
+diff --git a/subprojects/pfs/Cargo.toml b/subprojects/pfs/Cargo.toml
+index ae3b519..6cf25dd 100644
+--- a/subprojects/pfs/Cargo.toml
++++ b/subprojects/pfs/Cargo.toml
+@@ -18,7 +18,7 @@ path = "src/examples/open/pfs_open.rs"
+ 
+ [dependencies]
+ gettext-rs = { version = "0.7", features = ["gettext-system"] }
+-glib-macros = "0.20.5"
++glib-macros = "0.20.12"
+ gtk = { version = "0.9", package = "gtk4", features = ["gnome_47"] }
+ 
+ [dependencies.adw]
+

--- a/pkgs/by-name/xd/xdg-desktop-portal-phosh/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-phosh/package.nix
@@ -1,0 +1,87 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  gnome-desktop,
+  libadwaita,
+  meson,
+  ninja,
+  pkg-config,
+  xdg-desktop-portal,
+  rustc,
+  desktop-file-utils,
+  cargo,
+  rustPlatform,
+  gettext,
+}:
+let
+  # Derived from subprojects/pfs.wrap
+  pfs = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "guidog";
+    repo = "pfs";
+    tag = "v0.0.4";
+    hash = "sha256-b0S/jNE03h26bGA76fb/qlyJ8/MifZeltTc16UX2h9w=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xdg-desktop-portal-phosh";
+  version = "0.49.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "guidog";
+    repo = "xdg-desktop-portal-phosh";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-VF+ZNUP5Y2xm2nlNN3QsLJh8yNRJH7d3k+kLJ+4eu9s=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-h+VQqtirReLIHlVByKSb6DpqR1FtCxSwQpjowHX1mcg=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    rustc
+    desktop-file-utils
+    cargo
+    rustPlatform.cargoSetupHook
+    gettext
+  ];
+
+  buildInputs = [
+    libadwaita
+    gnome-desktop
+    xdg-desktop-portal
+  ];
+
+  strictDeps = true;
+
+  prePatch = ''
+    cp -r ${pfs} subprojects/pfs
+    chmod +w -R subprojects/pfs # Allow patches for subprojects to work
+  '';
+
+  patches = [
+    # Patch that fixes the issue with two Rust package versions.
+    # For reasons that I don't understand, rustPlatform.fetchCargoVendor seems to not fetch the version inside the Cargo.lock file.
+    # Like with libadwaita, fetchCargoVendor download the version 0.7.2 but in the lock file specified 0.7.1 and in the toml file specified 0.7.
+    ./cargo_lock_deps_version.patch
+  ];
+
+  passthru = {
+    updateScript = lib.updateScript { };
+  };
+
+  meta = with lib; {
+    description = "A backend implementation for xdg-desktop-portal that is using GTK/GNOME/Phosh to provide interfaces that aren't provided by the GTK portal";
+    homepage = "https://gitlab.gnome.org/guidog/xdg-desktop-portal-phosh";
+    changelog = "https://gitlab.gnome.org/guidog/xdg-desktop-portal-phosh/-/blob/main/NEWS";
+    maintainers = with maintainers; [ armelclo ];
+    platforms = platforms.linux;
+    license = licenses.gpl3Only;
+  };
+})


### PR DESCRIPTION
Add xdg-desktop-portal-phosh to nix that add 2 xdg portals for phosh. 
Modify the phosh module to automatically enable this portal.

## Things done

For reviewers:
I had to use a patch to fix a rust package version issue. 
I don't like this, but I wasn't able to find any solution without a patch.
See code comment for more info.

<img width="715" height="1055" alt="image" src="https://github.com/user-attachments/assets/dce72a0d-7092-482d-abde-8661d86881b9" />

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
