### PR TITLE
python3Packages.sparklines: Switch to pyproject and switch license GPLv3+ -> MIT

### DIFF
--- a/pkgs/development/python-modules/sparklines/default.nix
+++ b/pkgs/development/python-modules/sparklines/default.nix
@@ -2,14 +2,15 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  future,
+  hatchling,
+  termcolor,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "sparklines";
   version = "0.7.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "deeplook";
@@ -18,17 +19,29 @@ buildPythonPackage rec {
     sha256 = "sha256-jiMrxZMWN+moap0bDH+uy66gF4XdGst9HJpnboJrQm4=";
   };
 
-  propagatedBuildInputs = [ future ];
+  propagatedBuildInputs = [
+    hatchling
+    termcolor
+  ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "sparklines" ];
 
+  postPatch = ''
+    export TMPDIR=$PWD/tmp
+    mkdir -p $TMPDIR
+    substituteInPlace tests/test_sparkline.py \
+      --replace-fail "/tmp/" "$TMPDIR/"
+  '';
+
   meta = with lib; {
     description = "This Python package implements Edward Tufte's concept of sparklines, but limited to text only";
     mainProgram = "sparklines";
     homepage = "https://github.com/deeplook/sparklines";
-    maintainers = with maintainers; [ rhoriguchi ];
-    license = licenses.gpl3Only;
+    maintainers = with maintainers; [
+      rhoriguchi
+    ];
+    license = licenses.mit;
   };
 }


### PR DESCRIPTION
This PR updates the `sparklines` derivation to switch to pyproject ([upstream PR](https://github.com/deeplook/sparklines/pull/40)) with updated dependencies and switches license from GPLv3+ to MIT ([upstream PR](https://github.com/deeplook/sparklines/pull/42)).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
