### PR TITLE
ipamjfont: init at 006.01

### DIFF
--- a/pkgs/by-name/ip/ipamjfont/package.nix
+++ b/pkgs/by-name/ip/ipamjfont/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  writeShellApplication,
+  curl,
+  gnugrep,
+  common-updater-scripts,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "ipamjfont";
+  version = "006.01";
+
+  src =
+    let
+      suffix = lib.strings.replaceString "." "" finalAttrs.version;
+    in
+    fetchzip {
+      url = "https://dforest.watch.impress.co.jp/library/i/ipamjfont/10750/ipamjm${suffix}.zip";
+      hash = "sha256-Rft8hmxm3D4hOaLaSYDfD14oarDIHUQkMZX+/ZDD4m0=";
+      stripRoot = false;
+    };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 *.ttf -t "$out/share/fonts/truetype/"
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = lib.getExe (writeShellApplication {
+      name = "${finalAttrs.pname}-updater";
+
+      runtimeInputs = [
+        curl
+        gnugrep
+        common-updater-scripts
+      ];
+
+      text = ''
+        suffix="$(
+          curl --fail --silent 'https://forest.watch.impress.co.jp/library/software/ipamjfont/download_10750.html' | \
+            grep --perl-regexp --only-matching 'meta.+?ipamjm\K[0-9]+'
+        )"
+        version="''${suffix:0:3}.''${suffix:3:2}"
+        update-source-version '${finalAttrs.pname}' "$version" --ignore-same-version --print-changes
+      '';
+    });
+  };
+
+  meta = {
+    description = "Japanese Mincho font implementing IVS compliant with Hanyo-Denshi collection";
+    downloadPage = "https://forest.watch.impress.co.jp/library/software/ipamjfont/";
+    homepage = "https://moji.or.jp/mojikiban/font/";
+    license = lib.licenses.ipa;
+    maintainers = with lib.maintainers; [
+      kachick
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Introducing [IPA MJ Mincho Font](https://moji.or.jp/mojikiban/font/).
This font can display special characters, especially those used in person's names, that are not included in the JIS standard.

- Other IPA fonts([ipafont](https://github.com/NixOS/nixpkgs/blob/a28903eb1a3cb9365a914b061d27ba7bfbd56fbe/pkgs/by-name/ip/ipafont/package.nix), [ipaexfont](https://github.com/NixOS/nixpkgs/blob/a28903eb1a3cb9365a914b061d27ba7bfbd56fbe/pkgs/by-name/ip/ipaexfont/package.nix)) are already in nixpkgs.
- The [official site](https://moji.or.jp/mojikiban/) delegates distribution to an [external site](https://forest.watch.impress.co.jp/).
- [AUR](https://gitlab.archlinux.org/archlinux/packaging/packages/otf-ipamjfont/-/blob/7d1b172066b2cae5c3834b0a7c6e0c85f38399d3/PKGBUILD) is a relevant example

I've placed the `*.ttf` file in `share/fonts/truetype`, while ipafont and ipaexfont use `share/fonts/opentype`.
This is because ipamjfont is a TrueType font, as confirmed by its `sfntVersion`.

```console
> fc-scan result/share/fonts/truetype/ipamjm.ttf | grep fontformat
        fontformat: "TrueType"(s)

> ttx -t cmap ./result/share/fonts/truetype/ipamjm.ttf -o - | grep sfntVersion
Dumping "./result/share/fonts/truetype/ipamjm.ttf" to "<stdout>"...
Dumping 'cmap' table...
<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.56">
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
