### PR TITLE
healthchecks: 3.9 -> 3.11, drop phaer from maintainers

### DIFF
--- a/nixos/tests/web-apps/healthchecks.nix
+++ b/nixos/tests/web-apps/healthchecks.nix
@@ -36,9 +36,14 @@
 
     with subtest("Manage script works"):
         # "shell" sucommand should succeed, needs python in PATH.
-        assert "foo\n" == machine.succeed("echo 'print(\"foo\")' | sudo -u healthchecks healthchecks-manage shell")
-
+        t.assertIn(
+          "\nfoo\n",
+          machine.succeed("echo 'print(\"foo\")' | sudo -u healthchecks healthchecks-manage shell")
+        )
         # Shouldn't fail if not called by healthchecks user
-        assert "foo\n" == machine.succeed("echo 'print(\"foo\")' | healthchecks-manage shell")
+        t.assertIn(
+          "\nfoo\n",
+          machine.succeed("echo 'print(\"foo\")' | healthchecks-manage shell")
+        )
   '';
 }

--- a/pkgs/by-name/he/healthchecks/package.nix
+++ b/pkgs/by-name/he/healthchecks/package.nix
@@ -97,6 +97,6 @@ py.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/healthchecks/healthchecks";
     description = "Cron monitoring tool written in Python & Django";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ phaer ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/he/healthchecks/package.nix
+++ b/pkgs/by-name/he/healthchecks/package.nix
@@ -15,14 +15,14 @@ let
 in
 py.pkgs.buildPythonApplication rec {
   pname = "healthchecks";
-  version = "3.9";
+  version = "3.11";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "healthchecks";
     repo = "healthchecks";
     tag = "v${version}";
-    sha256 = "sha256-78Ku7yYhgIZ+uIMPKkExIXUOKmfiRMjEiBm2SugyD+s=";
+    sha256 = "sha256-s8qhCp+6d2rixgrduWXopiWEpBCLVKkoDjTYT0eLSN8=";
   };
 
   propagatedBuildInputs = with py.pkgs; [
@@ -38,6 +38,7 @@ py.pkgs.buildPythonApplication rec {
     psycopg2
     pycurl
     pydantic
+    pyjwt
     pyotp
     segno
     statsd


### PR DESCRIPTION
This updates a currently-broken-on-master services to the latest release and adds a new dependency on pyjwt.

We also update the `manage.py shell` tests to match expected output in current releases.

I don't personally use the self-hosted version of healthchecks.io, so I don't really want to maintain it going forward.

But I am happy to help if someone else wants to pick up! :)

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
