### PR TITLE
vobsub2srt: fix missing tesseract data

### DIFF
--- a/pkgs/by-name/vo/vobsub2srt/package.nix
+++ b/pkgs/by-name/vo/vobsub2srt/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   cmake,
   libtiff,
+  makeWrapper,
   pkg-config,
   tesseract3,
 }:
@@ -24,9 +25,13 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     cmake
     pkg-config
+    makeWrapper
   ];
   buildInputs = [ libtiff ];
   propagatedBuildInputs = [ tesseract3 ];
+  postInstall = ''
+    wrapProgram $out/bin/vobsub2srt --add-flags "--tesseract-data ${tesseract3}/share/tessdata"
+  '';
 
   meta = {
     homepage = "https://github.com/ruediger/VobSub2SRT";


### PR DESCRIPTION
Fixes #428887.

Adds a wrapper which adds a `--tesseract-data` flag so that the program can find necessary Tesseract OCR data in order to actually run. I wasn't able to get `--set-default TESSDATA_PREFIX` to work, but this unbreaks the package.

CC @ttuegel, the maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
