### PR TITLE
font-{cronyx-cyrillic,{isas,micro}-misc,misc-{cyrillic,ethiopic}}: refactor, move to pkgs/by-name & rename from xorg namespace

### DIFF
--- a/pkgs/by-name/fo/font-cronyx-cyrillic/package.nix
+++ b/pkgs/by-name/fo/font-cronyx-cyrillic/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-cronyx-cyrillic";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-cronyx-cyrillic-${finalAttrs.version}.tar.xz";
+    hash = "sha256-3AeBzg3L/9v2quGgAXOhNAP5Kw3pJbylqeEX5OLWt4k=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    bdftopcf
+    mkfontscale
+  ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Cronyx pcf fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/cronyx-cyrillic";
+    license = lib.licenses.cronyx;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-cronyx-cyrillic/package.nix
+++ b/pkgs/by-name/fo/font-cronyx-cyrillic/package.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation (finalAttrs: {
     mkfontscale
   ];
 
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''
       #!/usr/bin/env nix-shell

--- a/pkgs/by-name/fo/font-isas-misc/package.nix
+++ b/pkgs/by-name/fo/font-isas-misc/package.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation (finalAttrs: {
     mkfontscale
   ];
 
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''
       #!/usr/bin/env nix-shell

--- a/pkgs/by-name/fo/font-isas-misc/package.nix
+++ b/pkgs/by-name/fo/font-isas-misc/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-isas-misc";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-isas-misc-${finalAttrs.version}.tar.xz";
+    hash = "sha256-R+WVu+baREufb8qiZTmrx7oZieI6+mzcSeIuSEzEOPw=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    bdftopcf
+    mkfontscale
+  ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Isas Fangsong ti & Song ti pcf fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/isas-misc";
+    license = lib.licenses.hpnd;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-micro-misc/package.nix
+++ b/pkgs/by-name/fo/font-micro-misc/package.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation (finalAttrs: {
     mkfontscale
   ];
 
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''
       #!/usr/bin/env nix-shell

--- a/pkgs/by-name/fo/font-micro-misc/package.nix
+++ b/pkgs/by-name/fo/font-micro-misc/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-micro-misc";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-micro-misc-${finalAttrs.version}.tar.xz";
+    hash = "sha256-LuC51r166Emv8b2C76tEobazaPu14R0S/38BWj32+UM=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    bdftopcf
+    mkfontscale
+  ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Micro pcf font";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/micro-misc";
+    license = lib.licenses.publicDomain;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-misc-cyrillic/package.nix
+++ b/pkgs/by-name/fo/font-misc-cyrillic/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-misc-cyrillic";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-misc-cyrillic-${finalAttrs.version}.tar.xz";
+    hash = "sha256-dgIaf1MGQAGRSlf9CO+uV/draPCiTcqKsbJFR07o6ZM=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    bdftopcf
+    mkfontscale
+  ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Misc Cyrillic pcf fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/misc-cyrillic";
+    license = with lib.licenses; [
+      publicDomain
+      cronyx
+      # misc free
+      # "May be distributed and modified without restrictions."
+      free
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-misc-cyrillic/package.nix
+++ b/pkgs/by-name/fo/font-misc-cyrillic/package.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation (finalAttrs: {
     mkfontscale
   ];
 
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''
       #!/usr/bin/env nix-shell

--- a/pkgs/by-name/fo/font-misc-ethiopic/package.nix
+++ b/pkgs/by-name/fo/font-misc-ethiopic/package.nix
@@ -18,8 +18,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ mkfontscale ];
 
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''
       #!/usr/bin/env nix-shell

--- a/pkgs/by-name/fo/font-misc-ethiopic/package.nix
+++ b/pkgs/by-name/fo/font-misc-ethiopic/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-misc-ethiopic";
+  version = "1.0.5";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-misc-ethiopic-${finalAttrs.version}.tar.xz";
+    hash = "sha256-R0mn5uGh7vbJH8yaBOixwO0CfUDBWZ5abJMnDYRpthI=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ mkfontscale ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Ge'ez Frontiers Foundation's Zemen OpenType and TrueType fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/misc-ethiopic";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -14,6 +14,7 @@
   font-encodings,
   font-isas-misc,
   font-micro-misc,
+  font-misc-cyrillic,
   font-mutt-misc,
   font-util,
   gccmakedep,
@@ -146,6 +147,7 @@ self: with self; {
   fontcronyxcyrillic = font-cronyx-cyrillic;
   fontisasmisc = font-isas-misc;
   fontmicromisc = font-micro-misc;
+  fontmisccyrillic = font-misc-cyrillic;
   fontmuttmisc = font-mutt-misc;
   fontutil = font-util;
   libAppleWM = libapplewm;
@@ -854,46 +856,6 @@ self: with self; {
       src = fetchurl {
         url = "mirror://xorg/individual/font/font-jis-misc-1.0.4.tar.xz";
         sha256 = "1l7spyq93rhydsdnsh46alcfbn2irz664vd209lamxviqkvfzlbq";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontmisccyrillic = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-misc-cyrillic";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-misc-cyrillic-1.0.4.tar.xz";
-        sha256 = "14z9x174fidjn65clkd2y1l6pxspmvphizap9a8h2h06adzil0kn";
       };
       hardeningDisable = [
         "bindnow"

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -13,6 +13,7 @@
   font-cronyx-cyrillic,
   font-encodings,
   font-isas-misc,
+  font-micro-misc,
   font-mutt-misc,
   font-util,
   gccmakedep,
@@ -144,6 +145,7 @@ self: with self; {
   fontbhtype1 = font-bh-type1;
   fontcronyxcyrillic = font-cronyx-cyrillic;
   fontisasmisc = font-isas-misc;
+  fontmicromisc = font-micro-misc;
   fontmuttmisc = font-mutt-misc;
   fontutil = font-util;
   libAppleWM = libapplewm;
@@ -852,46 +854,6 @@ self: with self; {
       src = fetchurl {
         url = "mirror://xorg/individual/font/font-jis-misc-1.0.4.tar.xz";
         sha256 = "1l7spyq93rhydsdnsh46alcfbn2irz664vd209lamxviqkvfzlbq";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontmicromisc = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-micro-misc";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-micro-misc-1.0.4.tar.xz";
-        sha256 = "0hzryqyml0bzzw91vqdmzdlb7dm18jmyz0mxy6plks3sppbbkq1f";
       };
       hardeningDisable = [
         "bindnow"

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -12,6 +12,7 @@
   font-bh-type1,
   font-cronyx-cyrillic,
   font-encodings,
+  font-isas-misc,
   font-mutt-misc,
   font-util,
   gccmakedep,
@@ -142,6 +143,7 @@ self: with self; {
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
   fontcronyxcyrillic = font-cronyx-cyrillic;
+  fontisasmisc = font-isas-misc;
   fontmuttmisc = font-mutt-misc;
   fontutil = font-util;
   libAppleWM = libapplewm;
@@ -819,46 +821,6 @@ self: with self; {
       strictDeps = true;
       nativeBuildInputs = [
         pkg-config
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontisasmisc = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-isas-misc";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-isas-misc-1.0.4.tar.xz";
-        sha256 = "1z1qqi64hbp297f6ryiswa4ikfn7mcwnb8nadyglni6swsxrbra7";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
         mkfontscale
       ];
       buildInputs = [ fontutil ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -10,6 +10,7 @@
   font-alias,
   font-bh-ttf,
   font-bh-type1,
+  font-cronyx-cyrillic,
   font-encodings,
   font-mutt-misc,
   font-util,
@@ -140,6 +141,7 @@ self: with self; {
   fontalias = font-alias;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
+  fontcronyxcyrillic = font-cronyx-cyrillic;
   fontmuttmisc = font-mutt-misc;
   fontutil = font-util;
   libAppleWM = libapplewm;
@@ -659,46 +661,6 @@ self: with self; {
       strictDeps = true;
       nativeBuildInputs = [
         pkg-config
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontcronyxcyrillic = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-cronyx-cyrillic";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-cronyx-cyrillic-1.0.4.tar.xz";
-        sha256 = "12dpsvif85z1m6jvq9g91lmzj0rll5rh3871mbvdpzyb1p7821yw";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
         mkfontscale
       ];
       buildInputs = [ fontutil ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -15,6 +15,7 @@
   font-isas-misc,
   font-micro-misc,
   font-misc-cyrillic,
+  font-misc-ethiopic,
   font-mutt-misc,
   font-util,
   gccmakedep,
@@ -148,6 +149,7 @@ self: with self; {
   fontisasmisc = font-isas-misc;
   fontmicromisc = font-micro-misc;
   fontmisccyrillic = font-misc-cyrillic;
+  fontmiscethiopic = font-misc-ethiopic;
   fontmuttmisc = font-mutt-misc;
   fontutil = font-util;
   libAppleWM = libapplewm;
@@ -865,44 +867,6 @@ self: with self; {
       nativeBuildInputs = [
         pkg-config
         bdftopcf
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontmiscethiopic = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-misc-ethiopic";
-      version = "1.0.5";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-misc-ethiopic-1.0.5.tar.xz";
-        sha256 = "04mnd620s9wkdid9wnf181yh5vf0n7l096nc3z4zdvm1w7kafja7";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
         mkfontscale
       ];
       buildInputs = [ fontutil ];

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -330,6 +330,7 @@ print OUT <<EOF;
   font-encodings,
   font-isas-misc,
   font-micro-misc,
+  font-misc-cyrillic,
   font-mutt-misc,
   font-util,
   gccmakedep,
@@ -462,6 +463,7 @@ self: with self; {
   fontcronyxcyrillic = font-cronyx-cyrillic;
   fontisasmisc = font-isas-misc;
   fontmicromisc = font-micro-misc;
+  fontmisccyrillic = font-misc-cyrillic;
   fontmuttmisc = font-mutt-misc;
   fontutil = font-util;
   libAppleWM = libapplewm;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -329,6 +329,7 @@ print OUT <<EOF;
   font-cronyx-cyrillic,
   font-encodings,
   font-isas-misc,
+  font-micro-misc,
   font-mutt-misc,
   font-util,
   gccmakedep,
@@ -460,6 +461,7 @@ self: with self; {
   fontbhtype1 = font-bh-type1;
   fontcronyxcyrillic = font-cronyx-cyrillic;
   fontisasmisc = font-isas-misc;
+  fontmicromisc = font-micro-misc;
   fontmuttmisc = font-mutt-misc;
   fontutil = font-util;
   libAppleWM = libapplewm;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -328,6 +328,7 @@ print OUT <<EOF;
   font-bh-type1,
   font-cronyx-cyrillic,
   font-encodings,
+  font-isas-misc,
   font-mutt-misc,
   font-util,
   gccmakedep,
@@ -458,6 +459,7 @@ self: with self; {
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
   fontcronyxcyrillic = font-cronyx-cyrillic;
+  fontisasmisc = font-isas-misc;
   fontmuttmisc = font-mutt-misc;
   fontutil = font-util;
   libAppleWM = libapplewm;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -331,6 +331,7 @@ print OUT <<EOF;
   font-isas-misc,
   font-micro-misc,
   font-misc-cyrillic,
+  font-misc-ethiopic,
   font-mutt-misc,
   font-util,
   gccmakedep,
@@ -464,6 +465,7 @@ self: with self; {
   fontisasmisc = font-isas-misc;
   fontmicromisc = font-micro-misc;
   fontmisccyrillic = font-misc-cyrillic;
+  fontmiscethiopic = font-misc-ethiopic;
   fontmuttmisc = font-mutt-misc;
   fontutil = font-util;
   libAppleWM = libapplewm;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -326,6 +326,7 @@ print OUT <<EOF;
   font-alias,
   font-bh-ttf,
   font-bh-type1,
+  font-cronyx-cyrillic,
   font-encodings,
   font-mutt-misc,
   font-util,
@@ -456,6 +457,7 @@ self: with self; {
   fontalias = font-alias;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
+  fontcronyxcyrillic = font-cronyx-cyrillic;
   fontmuttmisc = font-mutt-misc;
   fontutil = font-util;
   libAppleWM = libapplewm;

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -102,7 +102,6 @@ mirror://xorg/individual/font/font-daewoo-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-dec-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-ibm-type1-1.0.4.tar.xz
 mirror://xorg/individual/font/font-jis-misc-1.0.4.tar.xz
-mirror://xorg/individual/font/font-misc-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-ethiopic-1.0.5.tar.xz
 mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -101,7 +101,6 @@ mirror://xorg/individual/font/font-cursor-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-daewoo-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-dec-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-ibm-type1-1.0.4.tar.xz
-mirror://xorg/individual/font/font-isas-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-jis-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-micro-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-cyrillic-1.0.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -102,7 +102,6 @@ mirror://xorg/individual/font/font-daewoo-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-dec-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-ibm-type1-1.0.4.tar.xz
 mirror://xorg/individual/font/font-jis-misc-1.0.4.tar.xz
-mirror://xorg/individual/font/font-misc-ethiopic-1.0.5.tar.xz
 mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz
 mirror://xorg/individual/font/font-schumacher-misc-1.1.3.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -102,7 +102,6 @@ mirror://xorg/individual/font/font-daewoo-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-dec-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-ibm-type1-1.0.4.tar.xz
 mirror://xorg/individual/font/font-jis-misc-1.0.4.tar.xz
-mirror://xorg/individual/font/font-micro-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-ethiopic-1.0.5.tar.xz
 mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -97,7 +97,6 @@ mirror://xorg/individual/font/font-bitstream-75dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bitstream-100dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bitstream-speedo-1.0.2.tar.gz
 mirror://xorg/individual/font/font-bitstream-type1-1.0.4.tar.xz
-mirror://xorg/individual/font/font-cronyx-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-cursor-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-daewoo-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-dec-misc-1.0.4.tar.xz


### PR DESCRIPTION
<details>
<summary>this is the script i use to get the packages that don't depend on other xorg packages:</summary>

```nix
let
  inherit (import <nixpkgs> { }) lib;

  done = import ./pkgs/servers/x11/xorg/default.nix |> lib.functionArgs |> lib.attrNames;

  pkgs =
    (import ./default.nix { }).xorg
    |> lib.filterAttrs (
      n: v:
      lib.isAttrs v
      && v ? pname
      && !lib.elem n done
      && !lib.elem n (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem v.pname done
      && !lib.elem v.pname (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem (lib.toLower n) done
      && !lib.elem (lib.toLower n) (map (lib.replaceStrings [ "-" ] [ "" ]) done)
    );

  pnames = lib.mapAttrsToList (_: v: v.pname) pkgs;

  filteredPkgs =
    pkgs
    |> lib.filterAttrs (
      n: v:
      true
      # && !v.meta.unfree
      # && !v.meta.broken
      # && !v.meta.unsupported
      # && !lib.hasPrefix "font" n
      && !lib.hasPrefix "xf86" n
    );
in
filteredPkgs
# get deps
|> lib.mapAttrs (
  _: v:
  v.buildInputs ++ v.nativeBuildInputs ++ v.propagatedBuildInputs ++ v.propagatedNativeBuildInputs
)
# filter deps for xorg packages
|> lib.mapAttrs (_: v: lib.filter (x: x ? pname && lib.elem x.pname pnames) v)
# map deps to list and count
|> lib.mapAttrsToList (
  name: value: {
    inherit name;
    deps = map (x: x.pname or "error") value |> lib.unique;
    count = lib.length value;
  }
)
# sort
|> lib.sort (
  x: y: x.count < y.count || (x.count == y.count && (lib.toLower x.name) > (lib.toLower y.name))
)
|> lib.reverseList
# represent as string
|> map (x: "${toString x.count} - ${toString x.name}: ${lib.concatStringsSep " " x.deps}")
```

you can call it like this to get a nice output:

```sh
nix eval --json --file ./xorg-nodepends.nix | jq .[] --raw-output
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Build for platform:
  - [x] x86_64-linux
  - [x] x86_64-linux static
  - [x] aarch64-multiplatform
  - [x] aarch64-multiplatform-musl
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] ran passthru.updateScript
- [x] ran nix-check-deps
- [x] ran nixpkgs-hammer
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc