### PR TITLE
xbps: 0.59.2 -> 0.60.6

### DIFF
--- a/pkgs/by-name/xb/xbps/package.nix
+++ b/pkgs/by-name/xb/xbps/package.nix
@@ -45,11 +45,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/void-linux/xbps";
     description = "X Binary Package System";
-    platforms = platforms.linux; # known to not work on Darwin, at least
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ dtzWill ];
+    platforms = lib.platforms.linux; # known to not work on Darwin, at least
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ dtzWill ];
   };
 })

--- a/pkgs/by-name/xb/xbps/package.nix
+++ b/pkgs/by-name/xb/xbps/package.nix
@@ -9,15 +9,15 @@
   libarchive,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "xbps";
-  version = "0.59.2";
+  version = "0.60.5";
 
   src = fetchFromGitHub {
     owner = "void-linux";
     repo = "xbps";
-    rev = version;
-    hash = "sha256-3+LzFLDZ1zfRPBETMlpEn66zsfHRHQLlgeZPdMtmA14=";
+    tag = finalAttrs.version;
+    hash = "sha256-ht5hhaaE9QAsp+5xmOAYQE9fgL0GBuQvz0qB64z0cbs=";
   };
 
   nativeBuildInputs = [
@@ -37,24 +37,10 @@ stdenv.mkDerivation rec {
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error=unused-result -Wno-error=deprecated-declarations";
 
+  # Don't try to install keys to /var/db/xbps, put in $out/share for now
   postPatch = ''
-    # _BSD_SOURCE causes cpp warning
-    # https://github.com/void-linux/xbps/issues/576
-    substituteInPlace bin/xbps-fbulk/main.c lib/util.c lib/external/dewey.c lib/external/fexec.c \
-      --replace 'define _BSD_SOURCE' 'define _DEFAULT_SOURCE' \
-      --replace '# define _BSD_SOURCE' '#define _DEFAULT_SOURCE'
-
-    # fix calloc argument cause a build failure
-    substituteInPlace bin/xbps-fbulk/main.c \
-      --replace-fail 'calloc(sizeof(*depn), 1)' 'calloc(1UL, sizeof(*depn))'
-
-    # fix unprefixed ranlib (needed on cross)
-    substituteInPlace lib/Makefile \
-      --replace 'SILENT}ranlib ' 'SILENT}$(RANLIB) '
-
-    # Don't try to install keys to /var/db/xbps, put in $out/share for now
     substituteInPlace data/Makefile \
-      --replace '$(DESTDIR)/$(DBDIR)' '$(DESTDIR)/$(SHAREDIR)'
+      --replace-fail '$(DESTDIR)/$(DBDIR)' '$(DESTDIR)/$(SHAREDIR)'
   '';
 
   enableParallelBuilding = true;
@@ -66,4 +52,4 @@ stdenv.mkDerivation rec {
     license = licenses.bsd2;
     maintainers = with maintainers; [ dtzWill ];
   };
-}
+})

--- a/pkgs/by-name/xb/xbps/package.nix
+++ b/pkgs/by-name/xb/xbps/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xbps";
-  version = "0.60.5";
+  version = "0.60.6";
 
   src = fetchFromGitHub {
     owner = "void-linux";
     repo = "xbps";
     tag = finalAttrs.version;
-    hash = "sha256-ht5hhaaE9QAsp+5xmOAYQE9fgL0GBuQvz0qB64z0cbs=";
+    hash = "sha256-euV8oi1na+mfILnnUHK5S8Pi6+QuOUA8KhD0FHUqM70=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/void-linux/xbps/releases/tag/0.60.6
https://github.com/void-linux/xbps/compare/0.59.2...0.60.6

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
