### PR TITLE
juce: build Projucer and add projucerHook

### DIFF
--- a/doc/hooks/juce.section.md
+++ b/doc/hooks/juce.section.md
@@ -1,0 +1,33 @@
+# `juce.projucerHook` {#juce-projucer-hook}
+
+[Projucer](https://juce.com/tutorials/tutorial_new_projucer_project/) is a graphical project management utility and build system for the [JUCE](https://juce.com/) audio programming framework. It is available in nixpkgs under the `juce` package.
+
+The `juce.projucerHook` setup hook overrides the configure and install phases. It is only supported on Linux and requires your project's `.jucer` file to contain a `LinuxMakefile` exporter.
+
+## Example {#juce-projucer-hook-example}
+
+```nix
+{
+  juce,
+  stdenv,
+}:
+stdenv.mkDerivation {
+  # ...
+  nativeBuildInputs = [ juce.projucerHook ];
+
+  jucerFile = "Microbiome.jucer";
+
+  dontUseProjucerInstall = true;
+  # ...
+}
+```
+
+## Variables controlling `juce.projucerHook` {#juce-projucer-hook-variables}
+
+### `dontUseProjucerConfigure`
+
+Disables `projucerConfigurePhase`
+
+### `dontUseProjucerInstall`
+
+Disables `projucerInstallPhase`

--- a/pkgs/by-name/ju/juce/cmake_extras_projucer_only.patch
+++ b/pkgs/by-name/ju/juce/cmake_extras_projucer_only.patch
@@ -1,0 +1,14 @@
+diff --git a/extras/CMakeLists.txt b/extras/CMakeLists.txt
+index 21f61d0d18..db359dbbec 100644
+--- a/extras/CMakeLists.txt
++++ b/extras/CMakeLists.txt
+@@ -31,9 +31,4 @@
+ # ==============================================================================
+ 
+ set(CMAKE_FOLDER extras)
+-add_subdirectory(AudioPerformanceTest)
+-add_subdirectory(AudioPluginHost)
+-add_subdirectory(BinaryBuilder)
+-add_subdirectory(NetworkGraphicsDemo)
+ add_subdirectory(Projucer)
+-add_subdirectory(UnitTestRunner)

--- a/pkgs/by-name/ju/juce/projucer-hook.sh
+++ b/pkgs/by-name/ju/juce/projucer-hook.sh
@@ -1,0 +1,49 @@
+# shellcheck disable=SC2034
+
+set -e
+
+projucerConfigurePhase() {
+  runHook preConfigure
+
+  Projucer --set-global-search-path linux defaultJuceModulePath @src@/modules
+  if [ -n "${jucerUserModules-}" ]; then
+    Projucer --set-global-search-path linux defaultUserModulePath "$jucerUserModules"
+  fi
+  Projucer --resave "${jucerFile:-$pname.jucer}"
+
+  runHook postConfigure
+}
+
+projucerInstallPhase() {
+  runHook preInstall
+
+  find build -maxdepth 1 -executable -type f -not -name "juce_*" | while IFS= read -r -d '' f; do
+    # shellcheck disable=SC2154
+    mkdir -p "$out"/bin
+    cp "$f" "$out"/bin
+  done
+
+  runHook postInstall
+}
+
+projucerPreBuild() {
+  # setting the makefile attribute screws up paths
+  cd Builds/LinuxMakefile
+}
+
+if [ -z "${dontUseProjucerConfigure-}" ] && [ -z "${configurePhase-}" ]; then
+  configurePhase=projucerConfigurePhase
+  preBuildHooks+=(projucerPreBuild)
+  makeFlags+=(
+    all
+    "Config=Release"
+    "JUCE_VST3DESTDIR=$out/lib/vst3"
+    "JUCE_VSTDESTDIR=$out/lib/vst"
+    "JUCE_LV2DESTDIR=$out/lib/lv2"
+  )
+  enableParallelBuilding=true
+fi
+
+if [ -z "${dontUseProjucerInstall-}" ] && [ -z "${installPhase-}" ]; then
+  installPhase=projucerInstallPhase
+fi

--- a/pkgs/by-name/ju/juce/projucerHook.nix
+++ b/pkgs/by-name/ju/juce/projucerHook.nix
@@ -1,0 +1,10 @@
+{
+  makeSetupHook,
+  lib,
+  callPackage,
+}:
+makeSetupHook {
+  name = "projucer-hook";
+  propagatedBuildInputs = [ (callPackage ./package.nix { }) ];
+  meta.platforms = lib.platforms.linux;
+} ./projucer-hook.sh


### PR DESCRIPTION
From the hook's documentation:

> [Projucer](https://juce.com/tutorials/tutorial_new_projucer_project/) is a graphical project management utility and build system for the [JUCE](https://juce.com/) audio programming framework. It is available in nixpkgs under the `juce` package.

The hook is taken from https://github.com/bandithedoge/nur-packages/blob/master/pkgs/projucer/setupHook.sh.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
