### PR TITLE
facetimehd-calibration: fix build

### DIFF
--- a/pkgs/by-name/fa/facetimehd-calibration/builder.sh
+++ b/pkgs/by-name/fa/facetimehd-calibration/builder.sh
@@ -1,0 +1,22 @@
+# Described on https://github.com/patjak/facetimehd/wiki/Extracting-the-sensor-calibration-files
+#
+# The whole download is 518MB; the deflate stream we're interested in is 1.2MB.
+urlRoot="https://download.info.apple.com/Mac_OS_X/031-30890-20150812-ea191174-4130-11e5-a125-930911ba098f"
+curl --insecure -o bootcamp.zip "$urlRoot/bootcamp$version.zip" -r 2338085-3492508
+
+# Add appropriate headers and footers so that zcat extracts cleanly
+
+{ printf '\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x00'
+  cat bootcamp.zip
+  printf '\x51\x1f\x86\x78\xcf\x5b\x12\x00'
+} | zcat > AppleCamera64.exe
+unrar x AppleCamera64.exe AppleCamera.sys
+
+# These offsets and sizes are from the wiki also
+dd bs=1 skip=1663920 count=33060 if=AppleCamera.sys of=9112_01XX.dat
+dd bs=1 skip=1644880 count=19040 if=AppleCamera.sys of=1771_01XX.dat
+dd bs=1 skip=1606800 count=19040 if=AppleCamera.sys of=1871_01XX.dat
+dd bs=1 skip=1625840 count=19040 if=AppleCamera.sys of=1874_01XX.dat
+
+mkdir -p "$out/lib/firmware/facetimehd"
+cp -a *.dat "$out/lib/firmware/facetimehd"

--- a/pkgs/by-name/fa/facetimehd-calibration/package.nix
+++ b/pkgs/by-name/fa/facetimehd-calibration/package.nix
@@ -1,98 +1,36 @@
 {
   lib,
   stdenvNoCC,
-  fetchurl,
+  curl,
   unrar-wrapper,
-  pkgs,
 }:
 
-let
-
+stdenvNoCC.mkDerivation {
+  pname = "facetimehd-calibration";
   version = "5.1.5769";
 
-  # Described on https://github.com/patjak/facetimehd/wiki/Extracting-the-sensor-calibration-files
+  # This is a special sort of fixed-output derivation
+  outputHash = "sha256-KQBIlpa68wjQNgBiEnLtl6iEYseNrTlSdq9wiNni16k=";
+  outputHashMode = "recursive";
 
-  # From the wiki page, range extracted with binwalk:
-  zipUrl = "https://download.info.apple.com/Mac_OS_X/031-30890-20150812-ea191174-4130-11e5-a125-930911ba098f/bootcamp${version}.zip";
-  zipRange = "2338085-3492508"; # the whole download is 518MB, this deflate stream is 1.2MB
+  __structuredAttrs = true;
+  builder = ./builder.sh;
 
-  # CRC and length from the ZIP entry header (not strictly necessary, but makes it extract cleanly):
-  gzFooter = ''\x51\x1f\x86\x78\xcf\x5b\x12\x00'';
-
-  # Also from the wiki page:
-  calibrationFiles = [
-    {
-      file = "1771_01XX.dat";
-      offset = "1644880";
-      size = "19040";
-    }
-    {
-      file = "1871_01XX.dat";
-      offset = "1606800";
-      size = "19040";
-    }
-    {
-      file = "1874_01XX.dat";
-      offset = "1625840";
-      size = "19040";
-    }
-    {
-      file = "9112_01XX.dat";
-      offset = "1663920";
-      size = "33060";
-    }
+  nativeBuildInputs = [
+    curl
+    unrar-wrapper
   ];
 
-in
-
-stdenvNoCC.mkDerivation {
-
-  pname = "facetimehd-calibration";
-  inherit version;
-  src = fetchurl {
-    url = zipUrl;
-    sha256 = "1dzyv457fp6d8ly29sivqn6llwj5ydygx7p8kzvdnsp11zvid2xi";
-    curlOpts = "-r ${zipRange}";
-  };
-
-  dontUnpack = true;
-  dontInstall = true;
-
-  nativeBuildInputs = [ unrar-wrapper ];
-
-  buildPhase = ''
-    { printf '\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x00'
-      cat $src
-      printf '${gzFooter}'
-    } | zcat > AppleCamera64.exe
-    unrar x AppleCamera64.exe AppleCamera.sys
-
-    mkdir -p $out/lib/firmware/facetimehd
-  ''
-  + lib.concatMapStrings (
-    {
-      file,
-      offset,
-      size,
-    }:
-    ''
-      dd bs=1 skip=${offset} count=${size} if=AppleCamera.sys of=$out/lib/firmware/facetimehd/${file}
-    ''
-  ) calibrationFiles;
-
-  meta = with lib; {
+  meta = {
     description = "facetimehd calibration";
     homepage = "https://support.apple.com/kb/DL1837";
-    license = licenses.unfree;
-    maintainers = with maintainers; [
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [
       alexshpilkin
       womfoo
       grahamc
     ];
-    platforms = [
-      "i686-linux"
-      "x86_64-linux"
-    ];
+    platforms = lib.platforms.all;
+    sourceProvenance = with lib.sourceTypes; [ binaryFirmware ];
   };
-
 }


### PR DESCRIPTION
Resolves #430685

This was the only user of `fetchurl` which was using `-r`, which is incompatible with `--continue-at -` from 4d7a4fbd9f634d0c2f1e660d3981e965b3513466. Rather than engineer a way to pass range options to `fetchurl`, let's just make a custom builder for this derivation. It actually makes the whole thing more clear.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test