### PR TITLE
signal-desktop: fix darwin build

### DIFF
--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -105,9 +105,11 @@ stdenv.mkDerivation (finalAttrs: {
     pnpmConfigHook
     pnpm
     makeWrapper
-    copyDesktopItems
     python3
     jq
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    copyDesktopItems
   ];
   buildInputs = (lib.optional (!withAppleEmojis) noto-fonts-color-emoji-png);
 
@@ -134,6 +136,17 @@ stdenv.mkDerivation (finalAttrs: {
     # https://github.com/signalapp/Signal-Desktop/issues/7667
     substituteInPlace ts/util/version.std.ts \
       --replace-fail 'isAdhoc(version)' 'true'
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Nix builds do not need upstream release hooks (notarization and
+    # language-pack postprocessing), and they expect a different macOS
+    # app layout than nixpkgs' Electron provides.
+    substituteInPlace package.json \
+      --replace-fail '"artifactBuildCompleted": "ts/scripts/artifact-build-completed.node.js",' "" \
+      --replace-fail '"afterSign": "ts/scripts/after-sign.node.js",' "" \
+      --replace-fail '"afterPack": "ts/scripts/after-pack.node.js",' "" \
+      --replace-fail '"sign": "./ts/scripts/sign-macos.node.js",' "" \
+      --replace-fail '"afterAllArtifactBuild": "ts/scripts/after-all-artifact-build.node.js",' ""
   '';
 
   pnpmDeps = fetchPnpmDeps {
@@ -156,6 +169,10 @@ stdenv.mkDerivation (finalAttrs: {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     SIGNAL_ENV = "production";
     SOURCE_DATE_EPOCH = 1770853842;
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    # Disable code signing during local macOS builds.
+    CSC_IDENTITY_AUTO_DISCOVERY = "false";
   };
 
   preBuild = ''
@@ -200,6 +217,30 @@ stdenv.mkDerivation (finalAttrs: {
 
     rm -r node_modules/@signalapp/sqlcipher
     cp -r ${signal-sqlcipher} node_modules/@signalapp/sqlcipher
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # fs-xattr is required at runtime by preload.wrapper.js,
+    # but with npmRebuild disabled its native binding is missing.
+    # Build it explicitly against Electron headers ahead of packaging.
+    export npm_config_nodedir=${electron.headers}
+    pushd node_modules/fs-xattr
+    pnpm exec node-gyp rebuild
+    popd
+    test -f node_modules/fs-xattr/build/Release/xattr.node
+
+    # These hooks expect upstream release/signing layout and can fail in
+    # nixpkgs builds. Drop them from the effective electron-builder config.
+    jq '
+      .build
+      |= del(
+        .artifactBuildCompleted,
+        .afterSign,
+        .afterPack,
+        .afterAllArtifactBuild
+      ) |
+      .build.mac |= del(.sign)
+    ' package.json > package.json.tmp
+    mv package.json.tmp package.json
   '';
 
   buildPhase = ''
@@ -212,19 +253,31 @@ stdenv.mkDerivation (finalAttrs: {
 
     pnpm run generate
     pnpm exec electron-builder \
-      --linux "dir:${stdenv.hostPlatform.node.arch}" \
+      ${
+        if stdenv.hostPlatform.isDarwin then "--mac" else "--linux"
+      } "dir:${stdenv.hostPlatform.node.arch}" \
       --config.extraMetadata.environment=$SIGNAL_ENV \
       -c.electronDist=electron-dist \
-      -c.electronVersion=${electron.version}
+      -c.electronVersion=${electron.version} \
+      ${lib.optionalString stdenv.hostPlatform.isDarwin "-c.npmRebuild=false"} \
+      ${lib.optionalString stdenv.hostPlatform.isDarwin "-c.mac.identity=null"}
 
     runHook postBuild
   '';
 
   installPhase = ''
     runHook preInstall
-
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/{Applications,bin}
+    cp -r dist/mac*/Signal.app $out/Applications
+    makeWrapper "$out/Applications/Signal.app/Contents/MacOS/Signal" "$out/bin/signal-desktop" \
+      --add-flags ${lib.escapeShellArg commandLineArgs}
+  ''
+  + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     mkdir -p $out/share/
-    cp -r dist/*-unpacked/resources $out/share/signal-desktop
+    mkdir -p $out/share/signal-desktop
+    cp -r dist/*-unpacked/resources/* $out/share/signal-desktop
 
     for icon in build/icons/png/*
     do
@@ -236,7 +289,8 @@ stdenv.mkDerivation (finalAttrs: {
       --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --add-flags ${lib.escapeShellArg commandLineArgs}
-
+  ''
+  + ''
     runHook postInstall
   '';
 
@@ -300,6 +354,8 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
     ];
   };
 })

--- a/pkgs/by-name/si/signal-desktop/signal-sqlcipher.nix
+++ b/pkgs/by-name/si/signal-desktop/signal-sqlcipher.nix
@@ -10,6 +10,8 @@
   cargo,
   dump_syms,
   python3,
+  xcodebuild,
+  cctools,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "node-sqlcipher";
@@ -45,6 +47,10 @@ stdenv.mkDerivation (finalAttrs: {
     cargo
     dump_syms
     python3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    xcodebuild
+    cctools.libtool
   ];
 
   buildPhase = ''
@@ -75,6 +81,6 @@ stdenv.mkDerivation (finalAttrs: {
       # deps/sqlcipher
       bsd3
     ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/si/signal-desktop/webrtc.nix
+++ b/pkgs/by-name/si/signal-desktop/webrtc.nix
@@ -12,6 +12,9 @@
   writeShellScriptBin,
   gclient2nix,
   rustc,
+  apple-sdk,
+  xcodebuild,
+  llvmPackages,
 }:
 
 let
@@ -49,12 +52,22 @@ stdenv.mkDerivation (finalAttrs: {
     rustc
     pkg-config
     gclient2nix.gclientUnpackHook
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    apple-sdk
+    xcodebuild
   ];
 
   buildInputs = [
     glib
-    alsa-lib
     pulseaudio
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    llvmPackages.clang
+    llvmPackages.compiler-rt
+  ]
+  ++ lib.optionals stdenv.isLinux [
+    alsa-lib
   ];
 
   postPatch = ''
@@ -64,6 +77,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace modules/audio_device/linux/pulseaudiosymboltable_linux.cc \
       --replace-fail "libpulse.so.0" "${pulseaudio}/lib/libpulse.so.0"
+    substituteInPlace build/config/compiler/BUILD.gn \
+      --replace-fail 'clang_rt_library_dir = ""' 'clang_rt_library_dir="${llvmPackages.compiler-rt}/lib/clang/${llvmPackages.clang.version}/lib/darwin"'
+  ''
+  + lib.optionalString stdenv.isLinux ''
     substituteInPlace modules/audio_device/linux/alsasymboltable_linux.cc \
       --replace-fail "libasound.so.2" "${alsa-lib}/lib/libasound.so.2"
   '';
@@ -73,46 +90,58 @@ stdenv.mkDerivation (finalAttrs: {
     echo "generate_location_tags = true" >> build/config/gclient_args.gni
   '';
 
-  gnFlags = [
-    # webrtc uses chromium's `src/build/BUILDCONFIG.gn`. many of these flags
-    # are copied from pkgs/applications/networking/browsers/chromium/common.nix.
-    ''target_os="linux"''
-    ''target_cpu="${chromiumRosettaStone.cpu stdenv.hostPlatform}"''
-    ''pkg_config="${stdenv.cc.targetPrefix}pkg-config"''
-    "use_sysroot=false"
-    "is_clang=false"
-    "treat_warnings_as_errors=false"
-    "use_llvm_libatomic=false"
-    "use_custom_libcxx=false"
+  gnFlags =
+    lib.optionals stdenv.isLinux [
+      # webrtc uses chromium's `src/build/BUILDCONFIG.gn`. many of these flags
+      # are copied from pkgs/applications/networking/browsers/chromium/common.nix.
+      ''target_os="linux"''
+      ''target_cpu="${chromiumRosettaStone.cpu stdenv.hostPlatform}"''
+      ''pkg_config="${stdenv.cc.targetPrefix}pkg-config"''
+      "use_sysroot=false"
+      "is_clang=false"
+      "treat_warnings_as_errors=false"
+      "use_llvm_libatomic=false"
+      "use_custom_libcxx=false"
 
-    # https://github.com/signalapp/ringrtc/blob/main/bin/build-desktop
-    "rtc_build_examples=false"
-    "rtc_build_tools=false"
-    "rtc_use_x11=false"
-    "rtc_enable_sctp=false"
-    "rtc_libvpx_build_vp9=true"
-    "rtc_disable_metrics=true"
-    "rtc_disable_trace_events=true"
-    "is_debug=false"
-    "symbol_level=1"
-    "rtc_include_tests=false"
-    "rtc_enable_protobuf=false"
-
-    ''rust_sysroot_absolute="${buildPackages.rustc}"''
-
-    # Build using the system toolchain (for Linux distributions):
-    #
-    # What you would expect to be called "target_toolchain" is
-    # actually called either "default_toolchain" or "custom_toolchain",
-    # depending on which part of the codebase you are in; see:
-    # https://chromium.googlesource.com/chromium/src/build/+/3c4595444cc6d514600414e468db432e0f05b40f/config/BUILDCONFIG.gn#17
-    ''custom_toolchain="//build/toolchain/linux/unbundle:default"''
-    ''host_toolchain="//build/toolchain/linux/unbundle:default"''
-  ]
-  ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-    ''host_toolchain="//build/toolchain/linux/unbundle:host"''
-    ''v8_snapshot_toolchain="//build/toolchain/linux/unbundle:host"''
-  ];
+      # Build using the system toolchain (for Linux distributions):
+      #
+      # What you would expect to be called "target_toolchain" is
+      # actually called either "default_toolchain" or "custom_toolchain",
+      # depending on which part of the codebase you are in; see:
+      # https://chromium.googlesource.com/chromium/src/build/+/3c4595444cc6d514600414e468db432e0f05b40f/config/BUILDCONFIG.gn#17
+      ''custom_toolchain="//build/toolchain/linux/unbundle:default"''
+      ''host_toolchain="//build/toolchain/linux/unbundle:default"''
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      ''target_os="mac"''
+      ''target_cpu="${chromiumRosettaStone.cpu stdenv.hostPlatform}"''
+      "use_sysroot=true"
+      "is_clang=true"
+      ''clang_base_path="${llvmPackages.clang}/bin"''
+      ''custom_toolchain="//build/toolchain/mac:clang_x64"''
+      "treat_warnings_as_errors=false"
+      "use_llvm_libatomic=false"
+      "use_custom_libcxx=false"
+    ]
+    ++ [
+      # https://github.com/signalapp/ringrtc/blob/main/bin/build-desktop
+      "rtc_build_examples=false"
+      "rtc_build_tools=false"
+      "rtc_use_x11=false"
+      "rtc_enable_sctp=false"
+      "rtc_libvpx_build_vp9=true"
+      "rtc_disable_metrics=true"
+      "rtc_disable_trace_events=true"
+      "is_debug=false"
+      "symbol_level=1"
+      "rtc_include_tests=false"
+      "rtc_enable_protobuf=false"
+      ''rust_sysroot_absolute="${buildPackages.rustc}"''
+    ]
+    ++ lib.optionals (stdenv.isLinux && stdenv.buildPlatform != stdenv.hostPlatform) [
+      ''host_toolchain="//build/toolchain/linux/unbundle:host"''
+      ''v8_snapshot_toolchain="//build/toolchain/linux/unbundle:host"''
+    ];
   ninjaFlags = [ "webrtc" ];
 
   installPhase = ''
@@ -128,6 +157,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/SignalApp/webrtc";
     license = lib.licenses.bsd3;
     maintainers = [ ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/si/signal-desktop/webrtc.nix
+++ b/pkgs/by-name/si/signal-desktop/webrtc.nix
@@ -4,6 +4,7 @@
   buildPackages,
   ninja,
   gn,
+  symlinkJoin,
   python3,
   pkg-config,
   glib,
@@ -18,6 +19,14 @@
 }:
 
 let
+  llvmCcAndBintools = symlinkJoin {
+    name = "signal-webrtc-llvm-cc-and-bintools";
+    paths = [
+      buildPackages.rustc.llvmPackages.llvm
+      buildPackages.rustc.llvmPackages.stdenv.cc
+    ];
+  };
+
   chromiumRosettaStone = {
     cpu =
       platform:
@@ -41,6 +50,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   gclientDeps = gclient2nix.importGclientDeps ./webrtc-sources.json;
   sourceRoot = "src";
+
+  # Chromium's Darwin toolchain defines _LIBCPP_HARDENING_MODE itself; keep
+  # cc-wrapper from injecting a conflicting default.
+  hardeningDisable = lib.optionals stdenv.isDarwin [
+    "libcxxhardeningfast"
+    "libcxxhardeningextensive"
+  ];
 
   nativeBuildInputs = [
     gn
@@ -77,8 +93,15 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace modules/audio_device/linux/pulseaudiosymboltable_linux.cc \
       --replace-fail "libpulse.so.0" "${pulseaudio}/lib/libpulse.so.0"
-    substituteInPlace build/config/compiler/BUILD.gn \
-      --replace-fail 'clang_rt_library_dir = ""' 'clang_rt_library_dir="${llvmPackages.compiler-rt}/lib/clang/${llvmPackages.clang.version}/lib/darwin"'
+  ''
+  + lib.optionalString stdenv.isDarwin ''
+    substituteInPlace build/config/clang/BUILD.gn \
+      --replace-fail '_clang_lib_dir = "$clang_base_path/lib/clang/$clang_version/lib"' '_clang_lib_dir = "${llvmPackages.compiler-rt}/lib"'
+
+    # Keep target triple aligned with nix cc-wrapper expectations to avoid
+    # arm64-apple-macos vs arm64-apple-darwin warning spam.
+    substituteInPlace build/config/mac/BUILD.gn \
+      --replace-fail "apple-macos" "apple-darwin"
   ''
   + lib.optionalString stdenv.isLinux ''
     substituteInPlace modules/audio_device/linux/alsasymboltable_linux.cc \
@@ -117,8 +140,11 @@ stdenv.mkDerivation (finalAttrs: {
       ''target_cpu="${chromiumRosettaStone.cpu stdenv.hostPlatform}"''
       "use_sysroot=true"
       "is_clang=true"
-      ''clang_base_path="${llvmPackages.clang}/bin"''
-      ''custom_toolchain="//build/toolchain/mac:clang_x64"''
+      "clang_use_chrome_plugins=false"
+      "clang_use_raw_ptr_plugin=false"
+      "use_clang_modules=false"
+      ''clang_base_path="${llvmCcAndBintools}"''
+      ''custom_toolchain="//build/toolchain/mac:clang_${chromiumRosettaStone.cpu stdenv.hostPlatform}"''
       "treat_warnings_as_errors=false"
       "use_llvm_libatomic=false"
       "use_custom_libcxx=false"


### PR DESCRIPTION
## Things done

Getting the darwin port started, so that we can deprecate the binary package (if we want). For details see #436458

## TODOs
- [x] `nix build .#signal-desktop.libsignal-node`
- [x] `nix build .#signal-desktop.signal-sqlcipher`
- [x] `nix build .#signal-desktop.sticker-creator`
- [x] `nix develop .#signal-desktop.webrtc`
- [x] `nix build .#signal-desktop.ringrtc`
- [x] `nix build .#signal-desktop`

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
