### PR TITLE
tuned: 2.25.1 -> 2.26.0

### DIFF
--- a/pkgs/by-name/tu/tuned/package.nix
+++ b/pkgs/by-name/tu/tuned/package.nix
@@ -48,16 +48,19 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs .
 
     substituteInPlace tuned-gui.py tuned.service tuned/ppd/tuned-ppd.service \
-      --replace-warn "/usr/sbin/" "$out/bin/"
-
-    substituteInPlace tuned-gui.py \
-      --replace-warn "/usr/share/" "$out/share/"
+      --replace-fail "/usr/sbin/" "$out/bin/"
 
     substituteInPlace tuned-gui.desktop \
-      --replace-warn "/usr/sbin/tuned-gui" "tuned-gui"
+      --replace-fail "/usr/sbin/tuned-gui" "tuned-gui"
 
     substituteInPlace experiments/powertop2tuned.py \
-      --replace-warn "/usr/sbin/powertop" "${lib.getExe powertop}"
+      --replace-fail "/usr/sbin/powertop" "${lib.getExe powertop}"
+
+    substituteInPlace \
+      tuned/{gtk/tuned_dialog.py,consts.py} tuned-gui.py tuned-adm.bash \
+      $(find profiles/ -type f -executable -name '*.sh') \
+      --replace-warn "/usr/share" "$out/share" \
+      --replace-warn "/usr/lib" "$out/lib"
   '';
 
   strictDeps = true;

--- a/pkgs/by-name/tu/tuned/package.nix
+++ b/pkgs/by-name/tu/tuned/package.nix
@@ -24,7 +24,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tuned";
-  version = "2.25.1";
+  version = "2.26.0";
 
   outputs = [
     "out"
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "redhat-performance";
     repo = "tuned";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-MMyYMgdvoAIeLCqUZMoQYsYYbgkXku47nZWq2aowPFg=";
+    hash = "sha256-tqr8o4rRhN75hXCdsIhFedfWvicmlIFuZjBNKLQgimQ=";
   };
 
   patches = [
@@ -82,15 +82,12 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   makeFlags = [
+    "DESTDIR=${placeholder "out"}"
     "PREFIX="
 
-    "DATADIR=/share"
-    "DESTDIR=${placeholder "out"}"
-    "KERNELINSTALLHOOKDIR=/lib/kernel/install.d"
     "PYTHON=${lib.getExe python3Packages.python}"
     "PYTHON_SITELIB=/${python3Packages.python.sitePackages}"
     "TMPFILESDIR=/lib/tmpfiles.d"
-    "TUNED_PROFILESDIR=/lib/tuned/profile"
     "UNITDIR=/lib/systemd/system"
   ];
 


### PR DESCRIPTION
Diff: https://github.com/redhat-performance/tuned/compare/v2.25.1...v2.26.0

Changelog: https://github.com/redhat-performance/tuned/releases/tag/v2.26.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
