### PR TITLE
bodoni-moda: init at 2.4-unstable-2024-02-18

### DIFF
--- a/pkgs/by-name/bo/bodoni-moda/package.nix
+++ b/pkgs/by-name/bo/bodoni-moda/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "bodoni-moda";
+  version = "2.4-unstable-2024-02-18";
+
+  src = fetchFromGitHub {
+    owner = "indestructible-type";
+    repo = "Bodoni";
+    rev = "30ce6cdc354ef179a3b72ba0f0e71826e599348c";
+    hash = "sha256-OQi+KKBM+BrmA2pDit6dib5krrQBba5dVCBd2/G5sIM=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/truetype
+    cp fonts/*/*.ttf $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://indestructibletype.com/Bodoni.html";
+    description = "Bodoni Moda a modern no-compromises Bodoni family by indestructible type*";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ gavink97 ];
+  };
+}


### PR DESCRIPTION
Added Bodoni* also known as Bodoni Moda typefaces

[homepage](https://indestructibletype.com/Bodoni.html)
[source](https://github.com/indestructible-type/Bodoni)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
