### PR TITLE
python3Packages.ziggo-mediabox-xl: init at 1.1.0

### DIFF
--- a/pkgs/development/python-modules/ziggo-mediabox-xl/default.nix
+++ b/pkgs/development/python-modules/ziggo-mediabox-xl/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  requests,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "ziggo-mediabox-xl";
+  version = "1.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "b10m";
+    repo = "ziggo_mediabox_xl";
+    tag = version;
+    hash = "sha256-ElULsHfZXYTZ1cFEdAjhURWGOmJw2uJWMy49whGAV7g=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ requests ];
+
+  # Tests require network access
+  doCheck = false;
+
+  pythonImportsCheck = [ "ziggo_mediabox_xl" ];
+
+  meta = {
+    description = "Python interface to Ziggo's Mediabox XL";
+    homepage = "https://github.com/b10m/ziggo_mediabox_xl";
+    changelog = "https://github.com/b10m/ziggo_mediabox_xl/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -6881,7 +6881,8 @@
       ];
     "ziggo_mediabox_xl" =
       ps: with ps; [
-      ]; # missing inputs: ziggo-mediabox-xl
+        ziggo-mediabox-xl
+      ];
     "zimi" =
       ps: with ps; [
         zcc-helper

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20354,6 +20354,8 @@ self: super: with self; {
 
   zict = callPackage ../development/python-modules/zict { };
 
+  ziggo-mediabox-xl = callPackage ../development/python-modules/ziggo-mediabox-xl { };
+
   zigpy = callPackage ../development/python-modules/zigpy { };
 
   zigpy-cc = callPackage ../development/python-modules/zigpy-cc { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://pypi.org/project/ziggo-mediabox-xl/
- https://github.com/b10m/ziggo_mediabox_xl
- https://www.home-assistant.io/integrations/ziggo_mediabox_xl/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
