### PR TITLE
python3Packages.tellcore-net: init at 0.4

### DIFF
--- a/pkgs/development/python-modules/tellcore-net/default.nix
+++ b/pkgs/development/python-modules/tellcore-net/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "tellcore-net";
+  version = "0.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "home-assistant-libs";
+    repo = "tellcore-net";
+    tag = version;
+    hash = "sha256-yMNAu8iSFB2UDqJR3u2XFelpGRKzi/3HyuEbrZK6v8g=";
+  };
+
+  build-system = [ setuptools ];
+
+  # Module has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "tellcorenet" ];
+
+  meta = {
+    description = "Python module that allows to run tellcore over TCP/IP";
+    homepage = "https://github.com/home-assistant-libs/tellcore-net";
+    changelog = "https://github.com/home-assistant-libs/tellcore-net/releases/tag/${version}";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+}

--- a/pkgs/development/python-modules/tellcore-py/default.nix
+++ b/pkgs/development/python-modules/tellcore-py/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "tellcore-py";
+  version = "1.1.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "erijo";
+    repo = "tellcore-py";
+    tag = "v${version}";
+    hash = "sha256-AcdYMzd3Ln65PZ+weSxyR+CwXmdi2A+wSE6B/4hepE0=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "tellcore" ];
+
+  meta = {
+    description = "Python wrapper for Telldus' home automation library";
+    homepage = "https://github.com/erijo/tellcore-py";
+    changelog = "https://github.com/erijo/tellcore-py/releases/tag/v${version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -5927,7 +5927,9 @@
       ];
     "tellstick" =
       ps: with ps; [
-      ]; # missing inputs: tellcore-net tellcore-py
+        tellcore-net
+        tellcore-py
+      ];
     "telnet" =
       ps: with ps; [
       ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17909,6 +17909,8 @@ self: super: with self; {
 
   tellcore-net = callPackage ../development/python-modules/tellcore-net { };
 
+  tellcore-py = callPackage ../development/python-modules/tellcore-py { };
+
   tellduslive = callPackage ../development/python-modules/tellduslive { };
 
   temescal = callPackage ../development/python-modules/temescal { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17907,6 +17907,8 @@ self: super: with self; {
 
   telfhash = callPackage ../development/python-modules/telfhash { };
 
+  tellcore-net = callPackage ../development/python-modules/tellcore-net { };
+
   tellduslive = callPackage ../development/python-modules/tellduslive { };
 
   temescal = callPackage ../development/python-modules/temescal { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://pypi.org/project/tellcore-net/
- https://github.com/home-assistant-libs/tellcore-net
- https://pypi.org/project/tellcore-py/
- https://github.com/erijo/tellcore-py
- https://www.home-assistant.io/integrations/tellstick/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
