### PR TITLE
sommelier: add no-dmabuf-fixup patch to fix GPU support (and update 126.0 -> 138.0)

### DIFF
--- a/pkgs/by-name/so/sommelier/no-dmabuf-fixup.patch
+++ b/pkgs/by-name/so/sommelier/no-dmabuf-fixup.patch
@@ -1,0 +1,32 @@
+From f4e07c57e29bed05acc89cb028a693317b5e1b31 Mon Sep 17 00:00:00 2001
+From: Val Packett <val@invisiblethingslab.com>
+Date: Thu, 28 Aug 2025 03:46:26 -0300
+Subject: [PATCH] vm_tools: sommelier: avoid broken dmabuf "fixup" that depends
+ on CrOS kernel
+
+Reported as https://issuetracker.google.com/u/2/issues/441537635
+---
+ vm_tools/sommelier/compositor/sommelier-linux-dmabuf.cc | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/vm_tools/sommelier/compositor/sommelier-linux-dmabuf.cc b/vm_tools/sommelier/compositor/sommelier-linux-dmabuf.cc
+index 964c71643ec6..26bd06912403 100644
+--- a/compositor/sommelier-linux-dmabuf.cc
++++ b/compositor/sommelier-linux-dmabuf.cc
+@@ -176,11 +176,13 @@ bool sl_linux_dmabuf_fixup_plane0_params(gbm_device* gbm,
+     // Correct stride if we are able to get proper resource info.
+     if (!ret) {
+       is_virtgpu_buffer = true;
++#ifdef __THIS_SILENTLY_BREAKS_EVERYTHIHNG_ON_UPSTREAM_KERNELS__
+       if (info_arg.stride) {
+         *out_stride = info_arg.stride;
+         *out_modifier_hi = info_arg.format_modifier >> 32;
+         *out_modifier_lo = info_arg.format_modifier & 0xFFFFFFFF;
+       }
++#endif
+     }
+ 
+     // Always close the handle we imported.
+-- 
+2.49.0
+

--- a/pkgs/by-name/so/sommelier/package.nix
+++ b/pkgs/by-name/so/sommelier/package.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation {
   pname = "sommelier";
-  version = "126.0";
+  version = "138.0";
 
   src = fetchzip rec {
     url = "https://chromium.googlesource.com/chromiumos/platform2/+archive/${passthru.rev}/vm_tools/sommelier.tar.gz";
-    passthru.rev = "fd3798efe23f2edbc48f86f2fbd82ba5059fd875";
+    passthru.rev = "85a947e4c5cf8cb006e9db619484db11b567f0fe";
     stripRoot = false;
-    sha256 = "BmWZnMcK7IGaEAkVPulyb3hngsmuI0D1YtQEbqMjV5c=";
+    sha256 = "r75LHH1PRa2uhIUviE1MjD/m3HxyeDz9iVuZ/MHEXgk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/so/sommelier/package.nix
+++ b/pkgs/by-name/so/sommelier/package.nix
@@ -43,6 +43,10 @@ stdenv.mkDerivation {
     xorg.libxcb
   ];
 
+  patches = [
+    ./no-dmabuf-fixup.patch
+  ];
+
   preConfigure = ''
     patchShebangs gen-shim.py
   '';


### PR DESCRIPTION
hi @alyssais!

I have discovered why sommelier was so broken for everyone outside of CrOS: [b:441537635](https://issuetracker.google.com/u/2/issues/441537635) :exploding_head: 

Let's add a straightforward patch here and hope upstream does something eventually (since VirGL support is gone in CrOS they might even decide to remove more code..?)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`. // at least for me, the tests were crashing before the update too, so not making it worse at least. could not yet figure out the fix for the test suite
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
