### PR TITLE
wipefreespace: 2.6 -> 3.0

### DIFF
--- a/pkgs/by-name/wi/wipefreespace/package.nix
+++ b/pkgs/by-name/wi/wipefreespace/package.nix
@@ -37,12 +37,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  meta = with lib; {
+  meta = {
     description = "Program which will securely wipe the free space";
     homepage = "https://wipefreespace.sourceforge.io";
-    license = licenses.gpl2Plus;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ catap ];
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ catap ];
     mainProgram = "wipefreespace";
   };
 })

--- a/pkgs/by-name/wi/wipefreespace/package.nix
+++ b/pkgs/by-name/wi/wipefreespace/package.nix
@@ -1,48 +1,41 @@
 {
-  stdenv,
   lib,
-  fetchurl,
-  e2fsprogs,
-  ntfs3g,
-  xfsprogs,
-  reiser4progs,
-  libaal,
-  jfsutils,
-  libuuid,
+  stdenv,
+  fetchFromGitHub,
+  gettext,
   texinfo,
+  xfsprogs,
+  e2fsprogs,
+  libcap,
+  ntfs3g,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "wipefreespace";
-  version = "2.6";
+  version = "3.0";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/project/wipefreespace/wipefreespace/${version}/wipefreespace-${version}.tar.gz";
-    hash = "sha256-Pt6MDQ9wSJbL4tW/qckTpFsvE9FdXIkp/QmnYSlWR/M=";
+  src = fetchFromGitHub {
+    owner = "bogdro";
+    repo = "wipefreespace";
+    tag = finalAttrs.version;
+    hash = "sha256-zWjMCWQNPPly8xJ7jQraGHi4OLuNrnpNVQC2CRyHUlw=";
   };
 
   nativeBuildInputs = [
+    gettext
     texinfo
+    xfsprogs
   ];
 
   # missed: Reiser3 FAT12/16/32 MinixFS HFS+ OCFS
   buildInputs = [
     e2fsprogs
+    libcap
     ntfs3g
     xfsprogs
-    reiser4progs
-    libaal
-    jfsutils
-    libuuid
   ];
 
   strictDeps = true;
-
-  preConfigure = ''
-    export PATH=$PATH:${xfsprogs}/bin
-    export CFLAGS=-I${jfsutils}/include
-    export LDFLAGS="-L${jfsutils}/lib -L${reiser4progs}/lib"
-  '';
 
   meta = with lib; {
     description = "Program which will securely wipe the free space";
@@ -52,4 +45,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ catap ];
     mainProgram = "wipefreespace";
   };
-}
+})

--- a/pkgs/by-name/wi/wipefreespace/package.nix
+++ b/pkgs/by-name/wi/wipefreespace/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://wipefreespace.sourceforge.io";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ kyehn ];
     mainProgram = "wipefreespace";
   };
 })

--- a/pkgs/by-name/wi/wipefreespace/package.nix
+++ b/pkgs/by-name/wi/wipefreespace/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://wipefreespace.sourceforge.io";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ catap ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "wipefreespace";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/bogdro/wipefreespace/releases/tag/3.0
https://github.com/bogdro/wipefreespace/compare/2.6...3.0
https://github.com/bogdro/wipefreespace/blob/3.0/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
