### PR TITLE
nixos/sqm: Add smart queue management scripts

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4916,6 +4916,12 @@
     githubId = 9336788;
     name = "Claes Hallström";
   };
+  clarkadamp = {
+    email = "clark.adam.p@gmail.com";
+    github = "clarkadamp";
+    githubId = 6720621;
+    name = "Adam Clark";
+  };
   clebs = {
     email = "borja.clemente@gmail.com";
     github = "clebs";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1364,6 +1364,7 @@
   ./services/networking/spacecookie.nix
   ./services/networking/speedify.nix
   ./services/networking/spiped.nix
+  ./services/networking/sqm.nix
   ./services/networking/squid.nix
   ./services/networking/ssh/sshd.nix
   ./services/networking/sslh.nix

--- a/nixos/modules/services/networking/sqm.nix
+++ b/nixos/modules/services/networking/sqm.nix
@@ -1,0 +1,220 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    attrNames
+    attrsets
+    concatStringsSep
+    literalExpression
+    mkEnableOption
+    mkIf
+    mkOption
+    nameValuePair
+    lists
+    types
+    ;
+  inherit (builtins)
+    attrValues
+    catAttrs
+    hashString
+    ;
+in
+{
+  options = {
+    networking.sqm = {
+      enable = mkEnableOption ''
+        Smart Queue Management (SQM).
+
+        SQM provides a network a simplified Quality of Service (QoS) setup to help
+        reduce jitter an latency of smaller, usually interactive flows,
+        over larger flows which attempt to consume available bandwidth.
+
+        SQM moves the point of congestion control away from upstream network
+        devices such as modems, network termination unit or service provider traffic
+        enforcement queuing. In essence, sacrificing a small percentage of your
+        bandwidth to make your overall experience better.
+
+        Enabling this really only makes sense when the host terminates
+        one or more internet connections.
+
+        See <https://github.com/tohojo/sqm-scripts> for configuration options.
+
+        Configuration defaults from <https://github.com/tohojo/sqm-scripts/blob/main/src/defaults.sh>
+      '';
+      package = mkOption {
+        type = types.package;
+        default = pkgs.sqm-scripts;
+        defaultText = literalExpression "pkgs.sqm-scripts";
+        description = "The package containing the sqm-scripts";
+      };
+      kernelModules = mkOption {
+        type = types.listOf types.str;
+        default = [
+          "sch_ingress"
+          "act_mirred"
+          "cls_fw"
+          "cls_flow"
+          "cls_u32"
+          "sch_htb"
+        ];
+        description = "Required kernel modules, see src/default.sh";
+      };
+      settings = mkOption {
+        type = types.attrsOf types.str;
+        default = { };
+        example = {
+          TARGET = "5ms";
+        };
+        description = ''
+          Global configuraion that will be applied to all interfaces that can
+          be superceeded by interface specific settings.
+        '';
+      };
+      interfaces = mkOption {
+        type = types.attrsOf (
+          types.submodule {
+            options = {
+              enable = mkEnableOption "SQM for this interface";
+              uplinkKbps = mkOption {
+                type = types.ints.positive;
+                default = 1000;
+                description = ''
+                  Uplink/egress/upload bandwidth in kbps to shape at.
+                  This should be set slightly lower (5% or so) than your available upload rate.
+                '';
+              };
+              downlinkKbps = mkOption {
+                type = types.ints.positive;
+                default = 85000;
+                description = ''
+                  Downlink/ingress/download bandwidth in kbps to shape at.
+                  This should be set slightly lower (5% or so) than your available download rate
+                '';
+              };
+              script = mkOption {
+                type = types.str;
+                example = "layer_cake.qos";
+                default = "piece_of_cake.qos";
+                description = ''
+                  The QoS scheme to use, under most circumstances piece_of_cake.qos is sufficient
+                '';
+              };
+              queingDiscipline = mkOption {
+                type = types.str;
+                example = "fq_codel";
+                default = "cake";
+                description = "The queing strategy to use";
+              };
+              settings = mkOption {
+                type = types.attrsOf types.str;
+                default = { };
+                example = {
+                  TARGET = "5ms";
+                };
+                description = "Interface specific configuration";
+              };
+            };
+          }
+        );
+        default = { };
+        description = "Interfaces to enable SQM on";
+      };
+    };
+  };
+  config =
+    let
+      cfg = config.networking.sqm;
+
+      kernelModules =
+        map (qdisc: "sch_${qdisc}") (lists.unique (catAttrs "queingDiscipline" (attrValues cfg.interfaces)))
+        ++ cfg.kernelModules;
+
+      envVarScript =
+        # Simple ENVVAR="value" translation
+        values:
+        concatStringsSep "\n" (attrsets.mapAttrsToList (name: value: ''${name}="${value}"'') values);
+
+      configFiles = {
+        "sqm/default.conf" = {
+          text = concatStringsSep "\n" [
+            (builtins.readFile "${cfg.package}/etc/sqm/default.conf")
+            (envVarScript cfg.settings)
+          ];
+          mode = "0444";
+        };
+        "sqm/sqm.conf" = {
+          text = concatStringsSep "\n" [
+            (builtins.readFile "${cfg.package}/etc/sqm/sqm.conf")
+            (envVarScript {
+              SQM_LIB_DIR = "${cfg.package}/lib/sqm";
+            })
+          ];
+          mode = "0444";
+        };
+      }
+      // (attrsets.mapAttrs' (
+        ifaceName: options:
+        nameValuePair "sqm/${ifaceName}.iface.conf" {
+          text = (
+            envVarScript (
+              options.settings
+              // {
+                ALL_MODULES = concatStringsSep " " ([ "sch_${options.queingDiscipline}" ] ++ kernelModules);
+                DOWNLINK = toString options.downlinkKbps;
+                ENABLED = if options.enable then "1" else "0";
+                IFACE = ifaceName;
+                QDISC = options.queingDiscipline;
+                SCRIPT = options.script;
+                UPLINK = toString options.uplinkKbps;
+              }
+            )
+          );
+          mode = "0444";
+        }
+      ) cfg.interfaces);
+
+      interfaceUnits = map (interfaceName: "sqm@${interfaceName}.service") (attrNames cfg.interfaces);
+
+    in
+    mkIf cfg.enable {
+      boot.kernelModules = kernelModules;
+      environment = {
+        etc = configFiles;
+        systemPackages = [ cfg.package ];
+      };
+      systemd = {
+        packages = [ cfg.package ];
+        services."sqm@" = {
+          # Overrides for upstream unit file
+          overrideStrategy = "asDropin";
+          path = [
+            config.networking.firewall.package
+            pkgs.iproute2
+            pkgs.gawk
+          ];
+          # trigger service restarts on any configuration changes
+          restartTriggers = map (file: (hashString "sha256" file.text)) (attrValues configFiles);
+          serviceConfig = {
+            ExecStart = [
+              ""
+              "${cfg.package}/lib/sqm/start-sqm"
+            ];
+            ExecStop = [
+              ""
+              "${cfg.package}/lib/sqm/stop-sqm"
+            ];
+          };
+        };
+        targets = {
+          network.wants = interfaceUnits;
+          # multi-user to avoid needing a reboot
+          multi-user.wants = interfaceUnits;
+        };
+        tmpfiles.packages = [ cfg.package ];
+      };
+    };
+}

--- a/pkgs/by-name/sq/sqm-scripts/package.nix
+++ b/pkgs/by-name/sq/sqm-scripts/package.nix
@@ -1,0 +1,29 @@
+{
+  pkgs,
+  lib,
+  stdenv,
+  ...
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sqm-scripts";
+  version = "1.6.0";
+  src = pkgs.fetchFromGitHub {
+    owner = "tohojo";
+    repo = "sqm-scripts";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-GjboEi4AOYAkzMCSTEmLKNuowSbUgeRDukL87Q6xCw4=";
+  };
+  installFlags = [
+    "DESTDIR=$(out)"
+    "PREFIX="
+  ];
+  meta = {
+    description = "Set of scripts using the Linux qdisc mechanism to configure traffic shaping and scheduling";
+    homepage = "https://github.com/tohojo/sqm-scripts";
+    changelog = "https://github.com/tohojo/sqm-scripts/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.clarkadamp ];
+    mainProgram = "sqm";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
This change adds a new `networking.sqm` service which enables runs the [sqm-scripts](https://github.com/tohojo/sqm-scripts) developed for [OpenWRT](https://openwrt.org/docs/guide-user/network/traffic-shaping/sqm).

`sqm-scripts` hooks into the `tc` command within `iproute2` enabling alternative queing and congestion management setup to improve how the network performs under time of congestion.  

This is useful if someone is using NixOS as an internet gateway, as I am.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
I have been using this for a few months and I get A+ ratings on the [bufferbloat](https://www.waveform.com/tools/bufferbloat) speed tests.

This is my sqm.nix config for my 500/50Mbps internet connection.
```
{...}: {
  networking.sqm = {
    enable = true;
    interfaces.wan = {
      enable = true;
      uplinkKbps = 49000;
      downlinkKbps = 490000;
    };
  };
}
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
