### PR TITLE
gemini-cli: fix darwin build, drop node-pty

### DIFF
--- a/pkgs/by-name/ge/gemini-cli/package.nix
+++ b/pkgs/by-name/ge/gemini-cli/package.nix
@@ -21,7 +21,7 @@ buildNpmPackage (finalAttrs: {
     ./restore-missing-dependencies-fields.patch
   ];
 
-  npmDepsHash = "sha256-0j6kXlnWg7N23cnmMialZVqyZTAzgPn0VGAqSeYIVZM=";
+  npmDepsHash = "sha256-i4Z/zM4jRf9Orisu0xHHa3yJsDjYSmHieF2WIKU/1iY=";
 
   preConfigure = ''
     mkdir -p packages/generated

--- a/pkgs/by-name/ge/gemini-cli/restore-missing-dependencies-fields.patch
+++ b/pkgs/by-name/ge/gemini-cli/restore-missing-dependencies-fields.patch
@@ -1,18 +1,36 @@
-From c1aef417d559237bf4d147c584449b74d6fbc1f8 Mon Sep 17 00:00:00 2001
-From: ljxfstorm <ljxf.storm@live.cn>
-Date: Fri, 1 Aug 2025 10:23:11 +0800
-Subject: [PATCH] build(deps): restore missing `resolved` and `integrity` of
- some dependencies
-
----
- package-lock.json | 12 ++++++++++++
- 1 file changed, 12 insertions(+)
-
 diff --git a/package-lock.json b/package-lock.json
-index 3938c5e32b..99590b8a9b 100644
+index 74cfbfef..4131aa2b 100644
 --- a/package-lock.json
 +++ b/package-lock.json
-@@ -11738,6 +11738,8 @@
+@@ -58,8 +58,7 @@
+         "@lydell/node-pty-darwin-x64": "1.1.0",
+         "@lydell/node-pty-linux-x64": "1.1.0",
+         "@lydell/node-pty-win32-arm64": "1.1.0",
+-        "@lydell/node-pty-win32-x64": "1.1.0",
+-        "node-pty": "^1.0.0"
++        "@lydell/node-pty-win32-x64": "1.1.0"
+       }
+     },
+     "node_modules/@alcalzone/ansi-tokenize": {
+@@ -8604,17 +8603,6 @@
+         "url": "https://opencollective.com/node-fetch"
+       }
+     },
+-    "node_modules/node-pty": {
+-      "version": "1.0.0",
+-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.0.0.tgz",
+-      "integrity": "sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==",
+-      "hasInstallScript": true,
+-      "license": "MIT",
+-      "optional": true,
+-      "dependencies": {
+-        "nan": "^2.17.0"
+-      }
+-    },
+     "node_modules/normalize-package-data": {
+       "version": "6.0.2",
+       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+@@ -12535,6 +12523,8 @@
      },
      "packages/cli/node_modules/@testing-library/dom": {
        "version": "10.4.0",
@@ -21,7 +39,7 @@ index 3938c5e32b..99590b8a9b 100644
        "dev": true,
        "license": "MIT",
        "peer": true,
-@@ -11773,6 +11775,8 @@
+@@ -12570,6 +12560,8 @@
      },
      "packages/cli/node_modules/@testing-library/react": {
        "version": "16.3.0",
@@ -30,7 +48,7 @@ index 3938c5e32b..99590b8a9b 100644
        "dev": true,
        "license": "MIT",
        "dependencies": {
-@@ -11824,6 +11828,8 @@
+@@ -12621,6 +12613,8 @@
      },
      "packages/cli/node_modules/aria-query": {
        "version": "5.3.0",
@@ -39,7 +57,7 @@ index 3938c5e32b..99590b8a9b 100644
        "dev": true,
        "license": "Apache-2.0",
        "peer": true,
-@@ -11833,6 +11839,8 @@
+@@ -12630,6 +12624,8 @@
      },
      "packages/cli/node_modules/emoji-regex": {
        "version": "10.4.0",
@@ -48,7 +66,7 @@ index 3938c5e32b..99590b8a9b 100644
        "license": "MIT"
      },
      "packages/cli/node_modules/react-is": {
-@@ -11845,6 +11853,8 @@
+@@ -12642,6 +12638,8 @@
      },
      "packages/cli/node_modules/string-width": {
        "version": "7.2.0",
@@ -57,7 +75,17 @@ index 3938c5e32b..99590b8a9b 100644
        "license": "MIT",
        "dependencies": {
          "emoji-regex": "^10.3.0",
-@@ -11942,6 +11952,8 @@
+@@ -12715,8 +12713,7 @@
+         "@lydell/node-pty-darwin-x64": "1.1.0",
+         "@lydell/node-pty-linux-x64": "1.1.0",
+         "@lydell/node-pty-win32-arm64": "1.1.0",
+-        "@lydell/node-pty-win32-x64": "1.1.0",
+-        "node-pty": "^1.0.0"
++        "@lydell/node-pty-win32-x64": "1.1.0"
+       }
+     },
+     "packages/core/node_modules/ajv": {
+@@ -12751,6 +12748,8 @@
      },
      "packages/core/node_modules/ignore": {
        "version": "7.0.5",
@@ -66,4 +94,16 @@ index 3938c5e32b..99590b8a9b 100644
        "license": "MIT",
        "engines": {
          "node": ">= 4"
-
+diff --git a/package.json b/package.json
+index aba2aa98..57c79274 100644
+--- a/package.json
++++ b/package.json
+@@ -100,7 +100,6 @@
+     "@lydell/node-pty-darwin-x64": "1.1.0",
+     "@lydell/node-pty-linux-x64": "1.1.0",
+     "@lydell/node-pty-win32-arm64": "1.1.0",
+-    "@lydell/node-pty-win32-x64": "1.1.0",
+-    "node-pty": "^1.0.0"
++    "@lydell/node-pty-win32-x64": "1.1.0"
+   }
+ }


### PR DESCRIPTION
node-pty doesn't build on darwin

useTty is false by default https://github.com/google-gemini/gemini-cli/blob/001009d350b757278898d8e486b0752cb4d89766/docs/cli/configuration.md?plain=1#L195

node-pty is not first choice implementation
https://github.com/google-gemini/gemini-cli/blob/001009d350b757278898d8e486b0752cb4d89766/packages/core/src/utils/getPty.ts#L20

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
