### PR TITLE
hedgedoc: add soft breaks setting

### DIFF
--- a/pkgs/by-name/he/hedgedoc/hedgedoc_soft_breaks_false_default.patch
+++ b/pkgs/by-name/he/hedgedoc/hedgedoc_soft_breaks_false_default.patch
@@ -1,0 +1,22 @@
+diff --git a/public/js/extra.js b/public/js/extra.js
+index d4d8ad7bf..ad631a822 100644
+--- a/public/js/extra.js
++++ b/public/js/extra.js
+@@ -187,7 +187,7 @@ export function isValidURL (str) {
+ export function parseMeta (md, edit, view, toc, tocAffix) {
+   let lang = null
+   let dir = null
+-  let breaks = true
++  let breaks = false
+   if (md && md.meta) {
+     const meta = md.meta
+     lang = meta.lang
+@@ -997,7 +997,7 @@ function highlightRender (code, lang) {
+ 
+ export const md = markdownit('default', {
+   html: true,
+-  breaks: true,
++  breaks: false,
+   langPrefix: '',
+   linkify: true,
+   typographer: true,

--- a/pkgs/by-name/he/hedgedoc/package.nix
+++ b/pkgs/by-name/he/hedgedoc/package.nix
@@ -10,6 +10,7 @@
   nixosTests,
   yarn-berry_4,
   writableTmpDirAsHomeHook,
+  enableSoftBreaks ? false,
 }:
 
 let
@@ -43,6 +44,8 @@ stdenv.mkDerivation {
   buildInputs = [
     nodejs # for shebangs
   ];
+
+  patches = [ ] ++ (if enableSoftBreaks then [ ./hedgedoc_soft_breaks_false_default.patch ] else [ ]);
 
   buildPhase = ''
     runHook preBuild


### PR DESCRIPTION
HedgeDoc defaults to hard breaks for its Markdown flavor (newline in source causes newline in presentation), with an option to add `breaks: false` in YAML header in each document. There is no global option. Upstream discussed this topic in a [GitHub issue][1] and a [Discourse discussion][2], and concluded no changes should be made. This PR adds an `enableSoftBreaks` override to `pkgs.hedgedoc` in Nixpkgs to apply a simple patch to change default `breaks` value from `true` to `false`.

```nix
{ pkgs, ... }:
{
  services.hedgedoc = {
    enable = true;
    package = pkgs.hedgedoc.override { enableSoftBreaks = true; }
  };
}
```

Soft breaks are popular and enabled by default in e.g. in [CommonMark][1], HTML and LaTeX. Soft breaks allow to decouple newline formatting (e.g. automated column wrap or manual [semantic breaks][2]) in source content from newline formatting in output HTML, improving interop when pasting content between HedgeDoc and e.g. Markdown in a GitHub repo rendered to HTML with an SSG.

[1]: https://spec.commonmark.org/0.31.2/#soft-line-breaks
[2]: https://sembr.org/
[3]: https://github.com/hedgedoc/hedgedoc/issues/59
[4]: https://community.hedgedoc.org/t/should-we-change-the-hedgedoc-default-for-breaks-from-true-to-false/298

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
