### PR TITLE
yaml2nix: init at 0.3.0

### DIFF
--- a/pkgs/by-name/ya/yaml2nix/package.nix
+++ b/pkgs/by-name/ya/yaml2nix/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  testers,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "yaml2nix";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "euank";
+    repo = "yaml2nix";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DkHWWpvBco2yodyOk40LjTNcoaJ1bFKf0JY9OwWgy5M=";
+  };
+
+  cargoHash = "sha256-3N0V/5lqiE2lTXu9oUsO3FOXhWqkNlomceqIVDGGuOM=";
+
+  passthru = {
+    tests.convert = testers.runCommand {
+      name = "${finalAttrs.pname}-convert-test";
+      nativeBuildInputs = [ finalAttrs.finalPackage ];
+      script = ''
+        cat <<EOF > test.yaml
+        foo: "bar"
+        baz:
+          - qux
+        EOF
+
+        cat <<EOF > expected.nix
+        { foo = "bar"; baz = [ "qux" ]; }
+        EOF
+
+        yaml2nix test.yaml > test.nix
+
+        diff test.nix expected.nix && touch $out
+      '';
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Command line tool to convert YAML into a Nix expression";
+    homepage = "https://github.com/euank/yaml2nix";
+    changelog = "https://github.com/euank/yaml2nix/releases/tag/${finalAttrs.src.tag}";
+    maintainers = with lib.maintainers; [
+      gepbird
+    ];
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.unix;
+    mainProgram = "yaml2nix";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This package allows you to convert YAML files to Nix code. It can be useful for example when converting YAML config files for various services and programs to NixOS/home-manager modules' `settings`

https://github.com/euank/yaml2nix

Fixes https://github.com/euank/yaml2nix/issues/1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
