### PR TITLE
openboard: switch to qt6 and remove obsolete importer

### DIFF
--- a/pkgs/by-name/op/openboard/package.nix
+++ b/pkgs/by-name/op/openboard/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  libsForQt5,
+  qt6Packages,
   libGL,
   fontconfig,
   openssl,
@@ -27,28 +27,15 @@
 }:
 
 let
-  importer = stdenv.mkDerivation {
-    pname = "openboard-importer";
-    version = "0-unstable-2016-10-08";
-
-    src = fetchFromGitHub {
-      owner = "OpenBoard-org";
-      repo = "OpenBoard-Importer";
-      rev = "47927bda021b4f7f1540b794825fb0d601875e79";
-      sha256 = "19zhgsimy0f070caikc4vrrqyc8kv2h6rl37sy3iggks8z0g98gf";
-    };
-
-    nativeBuildInputs = [
-      libsForQt5.qmake
-      libsForQt5.wrapQtAppsHook
-    ];
-    buildInputs = [ libsForQt5.qtbase ];
-    dontWrapQtApps = true;
-
-    installPhase = ''
-      install -Dm755 OpenBoardImporter $out/bin/OpenBoardImporter
-    '';
-  };
+  inherit (qt6Packages)
+    qtbase
+    qttools
+    qtmultimedia
+    qtwebengine
+    qmake
+    wrapQtAppsHook
+    quazip
+    ;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "openboard";
@@ -76,14 +63,14 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
-    libsForQt5.wrapQtAppsHook
+    wrapQtAppsHook
   ];
 
   buildInputs = [
-    libsForQt5.qtbase
-    libsForQt5.qtxmlpatterns
-    libsForQt5.qttools
-    libsForQt5.qtwebengine
+    qtbase
+    qttools
+    qtwebengine
+    qtmultimedia
     libGL
     fontconfig
     openssl
@@ -101,12 +88,10 @@ stdenv.mkDerivation (finalAttrs: {
     lame
     fdk_aac
     libass
-    libsForQt5.quazip
+    quazip
     libXext
     libXfixes
   ];
-
-  propagatedBuildInputs = [ importer ];
 
   meta = with lib; {
     description = "Interactive whiteboard application";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

`qt5.qtwebengine` marked as [vulnerable](https://github.com/NixOS/nixpkgs/pull/435067). Switched to qt6 and removed the obsolete `openboard-importer`.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
