### PR TITLE
dbx: fix build

### DIFF
--- a/pkgs/by-name/db/dbx/package.nix
+++ b/pkgs/by-name/db/dbx/package.nix
@@ -33,6 +33,12 @@ let
         # Tests require langchain-openai which is incompatible with pydantic_1
         doCheck = false;
       });
+
+      versioningit = super.versioningit.overridePythonAttrs (old: {
+        # Tests fail with pydantic_1
+        # AttributeError: type object 'CaseDetails' has no attribute 'model_validate_...
+        doCheck = false;
+      });
     };
   };
 in
@@ -129,8 +135,13 @@ python.pkgs.buildPythonApplication rec {
     # Fails because of dbfs CLI wrong call
     "test_dbfs_unknown_user"
     "test_dbfs_no_root"
+
     # Requires pylint, prospector, pydocstyle
     "test_python_basic_sanity_check"
+
+    # FileNotFoundError: [Errno 2] No such file or directory: '/build/tmph3veuluv...
+    "test_load_file"
+    "test_storage_serde"
   ];
 
   disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

cc @GuillaumeDesforges

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
