### PR TITLE
oakctl: 0.11.0 -> 0.13.2

### DIFF
--- a/pkgs/by-name/oa/oakctl/package.nix
+++ b/pkgs/by-name/oa/oakctl/package.nix
@@ -9,26 +9,26 @@
 }:
 
 let
-  version = "0.11.0";
+  version = "0.13.2";
 
   # Note: Extracted from install script
   # https://oakctl-releases.luxonis.com/oakctl-installer.sh
   sources = {
     x86_64-linux = fetchurl {
       url = "https://oakctl-releases.luxonis.com/data/${version}/linux_x86_64/oakctl";
-      hash = "sha256-AJo1xFKWtjMZNsY9M2cENe+3y9Simv+mT/fLKOWeIys=";
+      hash = "sha256-uS7CUnj9+/kBwGaaZA9P6R2//vhZ1cJW+lhkQePZ0is=";
     };
     aarch64-linux = fetchurl {
       url = "https://oakctl-releases.luxonis.com/data/${version}/linux_aarch64/oakctl";
-      hash = "sha256-sRHfmv1cUWCWkQHARpzTgSns464RlAkgw/JOKPQk//8=";
+      hash = "sha256-+WFSV3TALeJtdcxkcduaN8tWGLCrOxvs3UV6cOr1xAI=";
     };
     aarch64-darwin = fetchurl {
       url = "https://oakctl-releases.luxonis.com/data/${version}/darwin_arm64/oakctl";
-      hash = "sha256-AgvV8rgVaD+TrjTDvWPGXVSBk9YUVmh7OK3j5mNU+0s=";
+      hash = "sha256-OgVmfYcRNVcLGjEbxdVUtsV45vICj+jKPQJ578aRwZs=";
     };
     x86_64-darwin = fetchurl {
       url = "https://oakctl-releases.luxonis.com/data/${version}/darwin_x86_64/oakctl";
-      hash = "sha256-AgvV8rgVaD+TrjTDvWPGXVSBk9YUVmh7OK3j5mNU+0s=";
+      hash = "sha256-KjJxwMRLs0XqiOTHjke+dSVKBftwBDYppjrqsbf0Qe8=";
     };
   };
 
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Note: The command 'oakctl self-update' won't work as the binary is located in the nix/store
   meta = {
     description = "Tool to interact with Luxonis OAK4 cameras";
-    homepage = "https://rvc4.docs.luxonis.com/software/tools/oakctl";
+    homepage = "https://docs.luxonis.com/software-v3/oak-apps/oakctl/";
     license = lib.licenses.unfree;
     platforms = [
       "x86_64-linux"


### PR DESCRIPTION
Update the tool to newer version and point to new website with the documentation.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
