### PR TITLE
[25.05] fix geph compilation issue and update to v0.2.82

### DIFF
--- a/pkgs/by-name/ge/geph/build-fix.patch
+++ b/pkgs/by-name/ge/geph/build-fix.patch
@@ -1,0 +1,24 @@
+diff --git a/binaries/geph5-broker/src/routes.rs b/binaries/geph5-broker/src/routes.rs
+index 5d8c244..daebc1b 100644
+--- a/binaries/geph5-broker/src/routes.rs
++++ b/binaries/geph5-broker/src/routes.rs
+@@ -82,8 +82,8 @@ pub async fn bridge_to_leaf_route(
+                     )
+                 });
+ 
+-                if let Ok(version) = semver::Version::parse(version) && 
+-                VersionReq::parse(">=0.2.72").unwrap().matches(&version) &&
++                if let Ok(version) = semver::Version::parse(version) {
++                    if VersionReq::parse(">=0.2.72").unwrap().matches(&version) &&
+                 bridge.pool.contains("ovh_de") && // only have one group do this
+                 (
+                     asn == 197207 || // hamrah-e avval
+@@ -94,7 +94,7 @@ pub async fn bridge_to_leaf_route(
+                     return anyhow::Ok(RouteDescriptor::Delay {
+                         milliseconds: delay_ms,
+                         lower: RouteDescriptor::Race(vec![RouteDescriptor::Delay{milliseconds: 10000, lower: meeklike_route!().await?.into()}, tls_route!().await?.into(), sosistab3_route!().await?.into()]).into(),
+-                    })
++                    })}
+                 }
+ 
+                 if asn == 9808 || asn == 56044 || asn == 56047 || asn == 58807 || asn == 56048 || asn == 56040 || asn == 56047 {

--- a/pkgs/by-name/ge/geph/package.nix
+++ b/pkgs/by-name/ge/geph/package.nix
@@ -24,16 +24,16 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "geph5";
-  version = "0.2.77";
+  version = "0.2.82";
 
   src = fetchFromGitHub {
     owner = "geph-official";
     repo = "geph5";
     rev = "geph5-client-v${finalAttrs.version}";
-    hash = "sha256-xm2eSCLIPYydR8iwMlZyc/M6bFrUZRqL5yZUXuYdk/k=";
+    hash = "sha256-z4f6XoMSjMmq+Uf8A/6M+aJs6oDJGdMffVflwc0Q2so=";
   };
 
-  cargoHash = "sha256-DNk4BQoY8m3OmglXMZzGstl9aC+LhZq9EN0OLW7sBrw=";
+  cargoHash = "sha256-PhLNS6DdCisQ8sOWm1V72UJpLZX4gVNkt1779mmMB1c=";
 
   postPatch = ''
     substituteInPlace binaries/geph5-client/src/vpn/*.sh \

--- a/pkgs/by-name/ge/geph/package.nix
+++ b/pkgs/by-name/ge/geph/package.nix
@@ -35,6 +35,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-PhLNS6DdCisQ8sOWm1V72UJpLZX4gVNkt1779mmMB1c=";
 
+  patches = [ ./build-fix.patch ];
+
   postPatch = ''
     substituteInPlace binaries/geph5-client/src/vpn/*.sh \
       --replace-fail 'PATH=' 'PATH=${binPath}:'


### PR DESCRIPTION
Fixed a bug that prevented compilation.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
