### PR TITLE
[Backport release-25.05] ci: replace nix_2_24 with nix_2_28

### DIFF
--- a/ci/default.nix
+++ b/ci/default.nix
@@ -147,7 +147,7 @@ rec {
   parse = pkgs.lib.recurseIntoAttrs {
     latest = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.latest; };
     lix = pkgs.callPackage ./parse.nix { nix = pkgs.lix; };
-    nix_2_24 = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.nix_2_24; };
+    nix_2_28 = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.nix_2_28; };
   };
   shell = import ../shell.nix { inherit nixpkgs system; };
   tarball = import ../pkgs/top-level/make-tarball.nix {

--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -16,7 +16,7 @@
   pkgsBB ? pkgs.pkgsBuildBuild,
   nix ? pkgs-nixVersions.stable,
   nixVersions ? [
-    pkgs-nixVersions.nix_2_24
+    pkgs-nixVersions.nix_2_28
     nix
     pkgs-nixVersions.latest
   ],


### PR DESCRIPTION
## Summary
Backport of CI-related changes from #437039 to release-25.05

This is a partial backport containing only the CI testing changes that update the tested nix versions from nix_2_24 to nix_2_28.

## Original PR
- #437039: Nix 2.24 removal

## Changes
- Updated `ci/default.nix` to test nix_2_28 instead of nix_2_24
- Updated `lib/tests/release.nix` to use nix_2_28 in nixVersions list