### PR TITLE
makeself: 2.4.5 -> 2.5.0

### DIFF
--- a/pkgs/by-name/ma/makeself/package.nix
+++ b/pkgs/by-name/ma/makeself/package.nix
@@ -9,7 +9,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.4.5";
+  version = "2.5.0";
   pname = "makeself";
 
   src = fetchFromGitHub {
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     repo = "makeself";
     tag = "release-${version}";
     fetchSubmodules = true;
-    hash = "sha256-15lUtErGsbXF2Gn0f0rvA18mMuVMmkKrGO2poeYZU9g=";
+    hash = "sha256-QPisihCGnzG9gaZyb/bUroWdPAoC2GdQiz1tSkoScjs=";
   };
 
   nativeBuildInputs = [ installShellFiles ];
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     runHook preInstall
     installManPage makeself.1
     install -Dm555 makeself.sh $out/bin/makeself
-    install -Dm444 -t ${sharePath}/ makeself.lsm README.md makeself-header.sh
+    install -Dm444 -t ${sharePath}/ README.md makeself-header.sh
     runHook postInstall
   '';
 

--- a/pkgs/by-name/ma/makeself/package.nix
+++ b/pkgs/by-name/ma/makeself/package.nix
@@ -9,8 +9,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.5.0";
   pname = "makeself";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "megastep";


### PR DESCRIPTION
Bump Makeself version from 2.4.5 to 2.5.0.
Release notes: https://github.com/megastep/makeself/releases/tag/release-2.5.0

The new version removes the makeself.lsm file, so we also do not attempt to place it in the share directory anymore.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
