### PR TITLE
qtcreator: added function to compose package with plugins

### DIFF
--- a/pkgs/development/libraries/qodeassist-plugin/default.nix
+++ b/pkgs/development/libraries/qodeassist-plugin/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  runCommand,
   cmake,
   pkg-config,
   qttools,
@@ -49,6 +50,15 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [ ];
 
   installPhase = "mkdir -p $out; cp -R lib $out/";
+
+  passthru.tests = {
+    test-version = runCommand "${finalAttrs.pname}-test" { } ''
+      QT_QPA_PLATFORM="offscreen" ${
+        lib.getExe (qtcreator.withPackages [ finalAttrs.finalPackage ])
+      } --version > $out
+      cat $out | grep 'qodeassist ${finalAttrs.version}'
+    '';
+  };
 
   meta = {
     description = "AI-powered coding assistant plugin for Qt Creator";

--- a/pkgs/development/libraries/qodeassist-plugin/default.nix
+++ b/pkgs/development/libraries/qodeassist-plugin/default.nix
@@ -72,6 +72,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/Palm1r/QodeAssist";
     license = lib.licenses.gpl3Only;
     maintainers = [ lib.maintainers.zatm8 ];
-    platforms = lib.platforms.linux;
+    platforms = qtcreator.meta.platforms;
   };
 })

--- a/pkgs/development/tools/qtcreator/default.nix
+++ b/pkgs/development/tools/qtcreator/default.nix
@@ -27,6 +27,7 @@
   rustc-demangle,
   elfutils,
   perf,
+  callPackage,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -103,6 +104,10 @@ stdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     substituteInPlace ''${!outputDev}/lib/cmake/QtCreator/QtCreatorConfig.cmake --replace "$out/" ""
   '';
+
+  passthru = {
+    withPackages = callPackage ./with-plugins.nix { };
+  };
 
   meta = {
     description = "Cross-platform IDE tailored to the needs of Qt developers";

--- a/pkgs/development/tools/qtcreator/with-plugins.nix
+++ b/pkgs/development/tools/qtcreator/with-plugins.nix
@@ -1,0 +1,23 @@
+{
+  pkgs,
+  lib,
+  qtcreator,
+  ...
+}:
+f:
+let
+  plugins_arg = builtins.foldl' (
+    acc: val: acc + "-pluginpath ${val.outPath}/lib/qtcreator/plugins/"
+  ) "" f;
+  qtcreator_runner = pkgs.writeShellScriptBin "qtcreator" ''
+    exec ${lib.getExe qtcreator} ${plugins_arg} "$@"
+  '';
+in
+pkgs.symlinkJoin {
+  inherit (qtcreator) version meta;
+  name = "qtcreator-with-plugins";
+  paths = [
+    qtcreator_runner
+    qtcreator
+  ];
+}


### PR DESCRIPTION
Added QtCreator compose function to make able to utilize external QtC plug-ins. The way it's been implemented (by creating a script which will pass plug-ins directories as arguments) is because there is no environment variable to pass into IDE and it will read plug-ins only where a package have been installed (dereferencing symlinks).
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
