### PR TITLE
nixos/networkmanager: fix serializing an invalid `wifi.powersave=null`

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -684,13 +684,7 @@ in
         networkmanager.connectionConfig = {
           "ethernet.cloned-mac-address" = cfg.ethernet.macAddress;
           "wifi.cloned-mac-address" = cfg.wifi.macAddress;
-          "wifi.powersave" =
-            if cfg.wifi.powersave == null then
-              null
-            else if cfg.wifi.powersave then
-              3
-            else
-              2;
+          "wifi.powersave" = lib.mkIf (cfg.wifi.powersave != null) (if cfg.wifi.powersave then 3 else 2);
         };
       }
     ];

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -144,7 +144,9 @@ in
 {
 
   meta = {
-    maintainers = teams.freedesktop.members;
+    maintainers = teams.freedesktop.members ++ [
+      lib.maintainers.frontear
+    ];
   };
 
   ###### interface


### PR DESCRIPTION
NetworkManager does not define `null` as a valid value for `wifi.powersave`. It defines "ignore" (1), "disable" (2), and "enable" (3). There is another value "default" (0), which is only relevant for per-connection profiles.

Originally, the serialization of this option was protected via an `optionalString` (see [here](https://github.com/NixOS/nixpkgs/pull/118308/files#diff-0a708e7b053cf5df7620b5262936553af2242d2ce9dabde5bbeba221ece0a021L45-L46)), but this was replaced with a standard `if then else` Nix conditional expression (see [here](https://github.com/NixOS/nixpkgs/pull/118308/files#diff-0a708e7b053cf5df7620b5262936553af2242d2ce9dabde5bbeba221ece0a021R528-R531)). The PR which introduced these changes was https://github.com/NixOS/nixpkgs/pull/118308.

Since then, `/etc/NetworkManager/NetworkManager.conf` has always serialized `.wifi.powersave=null`, which is an ill-defined value. Strangely, I don't see NetworkManager complaining about it, but it's still technically invalid and should not be used. NetworkManager defines the lack of this value to imply `wifi.powersave=ignore`, which leaves the responsibility of enabling power saving to the kernel or any other external tool (such as `iwconfig` via `sudo iwconfig <interface> power off`). From my testing this seems to be what NetworkManager is already doing with `wifi.powersave=null`, so this shouldn't be a breaking change in any capacity for existing users.

### Follow-up

As a follow-up change, I want to refactor the module to drop `connctionConfig` entirely and replace its usage with `settings.connection`. This would constitute a bigger change, hence why I'm not adding it as part of this PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
