### PR TITLE
python3Packages.opensearch-py: disable failing async tests

### DIFF
--- a/pkgs/development/python-modules/opensearch-py/default.nix
+++ b/pkgs/development/python-modules/opensearch-py/default.nix
@@ -91,10 +91,13 @@ buildPythonPackage rec {
     "test_sniff_on_start_waits_for_sniff_to_complete"
     "test_sniff_on_start_close_unlocks_async_calls"
   ]
-  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86) [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Flaky tests: OSError: [Errno 48] Address already in use
     "test_redirect_failure_when_allow_redirect_false"
     "test_redirect_success_when_allow_redirect_true"
+
+    # Network access
+    "test_warns_if_using_non_default_ssl_kwargs_with_ssl_context"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/opensearch-py/default.nix
+++ b/pkgs/development/python-modules/opensearch-py/default.nix
@@ -54,6 +54,7 @@ buildPythonPackage rec {
   optional-dependencies.async = [ aiohttp ];
 
   nativeCheckInputs = [
+    aiohttp
     botocore
     mock
     pytest-asyncio
@@ -82,6 +83,13 @@ buildPythonPackage rec {
     # Failing tests, issue opened at https://github.com/opensearch-project/opensearch-py/issues/849
     "test_basicauth_in_request_session"
     "test_callable_in_request_session"
+
+    # Failing tests, issue opened at https://github.com/opensearch-project/opensearch-py/issues/949
+    # fixture 'event_loop' not found
+    "test_sniff_after_n_seconds"
+    "test_sniff_on_start_error_if_no_sniffed_hosts"
+    "test_sniff_on_start_waits_for_sniff_to_complete"
+    "test_sniff_on_start_close_unlocks_async_calls"
   ]
   ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86) [
     # Flaky tests: OSError: [Errno 48] Address already in use


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/305919617

Four tests fail with `fixture 'event_loop' not found`:

```sh
ERROR test_opensearchpy/test_async/test_transport.py::TestTransport::test_sniff_after_n_seconds
ERROR test_opensearchpy/test_async/test_transport.py::TestTransport::test_sniff_on_start_error_if_no_sniffed_hosts
ERROR test_opensearchpy/test_async/test_transport.py::TestTransport::test_sniff_on_start_waits_for_sniff_to_complete
ERROR test_opensearchpy/test_async/test_transport.py::TestTransport::test_sniff_on_start_close_unlocks_async_calls
```

Disabled these four and filed https://github.com/opensearch-project/opensearch-py/issues/949

**UPDATE**:  `event_loop` was deprecated in `pytest-asyncio` 0.23 and removed in 1.0.0. Upstream needs to fix their tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
