### PR TITLE
albyhub: 1.18.5 -> 1.19.2

### DIFF
--- a/pkgs/by-name/al/albyhub/ldk-node-go/default.nix
+++ b/pkgs/by-name/al/albyhub/ldk-node-go/default.nix
@@ -7,13 +7,13 @@
 
 buildGoModule {
   pname = "ldk-node-go";
-  version = "0-unstable-2025-06-30";
+  version = "0-unstable-2025-08-22";
 
   src = fetchFromGitHub {
     owner = "getAlby";
     repo = "ldk-node-go";
-    rev = "fc4853954f5259762ec91e6627f371a7a1241b08";
-    hash = "sha256-M96Yx4jEIKa83gKx4ofWh19QZFUxSdwH2J8h1aIrbys=";
+    rev = "93af4d511ff81466ce547b42d0c7ea6adb724ad3";
+    hash = "sha256-hDRjYUkV4dVT+iuO+hUpXrFZLZ9eLU50gBLEKVdXPLE=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/al/albyhub/ldk-node/default.nix
+++ b/pkgs/by-name/al/albyhub/ldk-node/default.nix
@@ -8,18 +8,18 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ldk-node";
-  version = "0-unstable-2025-06-30";
+  version = "0-unstable-2025-08-21";
 
   src = fetchFromGitHub {
     owner = "getAlby";
     repo = "ldk-node";
-    rev = "b00326e36445312a55f9fb583a8b54cc5763b6bf";
-    hash = "sha256-SDuHM7aawLXGSUxsKMlU0iH5+xs35VULX4vDGkS6xMA=";
+    rev = "078a26fb3a79f1ef66443b773018a1cf917cb5da";
+    hash = "sha256-ZmeohMnIbJzJbo9U+t0AWKFqLSIzDL/G42cBSBCtj3Q=";
   };
 
   buildFeatures = [ "uniffi" ];
 
-  cargoHash = "sha256-ONlN5xMU4A7ZTF4+XRbs5qAv8xQVYuMsU0bnD8Eh2gE=";
+  cargoHash = "sha256-VLQohnbuEdnu2E+BXe2mDKFUnDVlSY09rIIvHMIQ+Hg=";
 
   # Skip tests because they download bitcoin-core and electrs zip files, and then fail
   doCheck = false;

--- a/pkgs/by-name/al/albyhub/package.nix
+++ b/pkgs/by-name/al/albyhub/package.nix
@@ -96,3 +96,4 @@ buildGoModule (finalAttrs: {
     mainProgram = "albyhub";
   };
 })
+# nixpkgs-update: no auto update

--- a/pkgs/by-name/al/albyhub/package.nix
+++ b/pkgs/by-name/al/albyhub/package.nix
@@ -23,16 +23,16 @@ in
 
 buildGoModule (finalAttrs: {
   pname = "albyhub";
-  version = "1.18.5";
+  version = "1.19.2";
 
   src = fetchFromGitHub {
     owner = "getAlby";
     repo = "hub";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-j918jzhQs3dnPQaG4UMmoit8UvC8/3Z5+IiAZqO3OSA=";
+    hash = "sha256-11mHu067/SLh83UT2AZaLfYGwbB/b+vsQSN2AxuI/p4=";
   };
 
-  vendorHash = "sha256-iMxxJQZLQOLl7v1SimtXSYH7wXFOdZcSJAaUAKDqvBY=";
+  vendorHash = "sha256-h1I0PwddDzOFlJphKfej+dXgDXgkBOjrKigGwqfXbTU=";
   proxyVendor = true; # needed for secp256k1-zkp CGO bindings
 
   nativeBuildInputs = [
@@ -49,7 +49,7 @@ buildGoModule (finalAttrs: {
 
   frontendYarnOfflineCache = fetchYarnDeps {
     yarnLock = finalAttrs.src + "/frontend/yarn.lock";
-    hash = "sha256-ttLhICDAsg8Cvqy2AJKgS2IJZgay1tMi3Qd8RccD1jI=";
+    hash = "sha256-ukLg+vK3yquRlWu8z3HtAaVFqtzWPR63oiK8e7b6Gg0=";
   };
 
   preBuild = ''


### PR DESCRIPTION
> adds on-chain and swaps to the wallet send and receive pages, redesigns the app store, adds routing statistics to the homepage, auto-swap to xpub, more seamless first channel flow with support to pay by credit card, and many bug fixes and minor improvements.

See the full [release notes](https://github.com/getAlby/hub/releases/tag/v1.19.2) for more details
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
