### PR TITLE
rocmPackages.rocminfo: don't propagate python3

### DIFF
--- a/pkgs/development/python-modules/torch/source/default.nix
+++ b/pkgs/development/python-modules/torch/source/default.nix
@@ -1,7 +1,6 @@
 {
   stdenv,
   lib,
-  pkgs,
   fetchFromGitHub,
   fetchFromGitLab,
   fetchpatch2,
@@ -251,9 +250,6 @@ let
     "Magma cudaPackages does not match cudaPackages" =
       cudaSupport
       && (effectiveMagma.cudaPackages.cudaMajorMinorVersion != cudaPackages.cudaMajorMinorVersion);
-    # Should be fixed by WIP https://github.com/NixOS/nixpkgs/pull/438399
-    "ROCm support on non-default python versions is temporarily broken" =
-      rocmSupport && (pkgs.python3.version != python.version);
   };
 
   unroll-src = writeShellScript "unroll-src" ''

--- a/pkgs/development/rocm-modules/6/composable_kernel/base.nix
+++ b/pkgs/development/rocm-modules/6/composable_kernel/base.nix
@@ -8,6 +8,7 @@
   rocm-merged-llvm,
   clr,
   rocminfo,
+  python3,
   hipify,
   gitMinimal,
   gtest,
@@ -69,6 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     clr
     hipify
     zstd
+    python3
   ];
 
   buildInputs = [

--- a/pkgs/development/rocm-modules/6/hiprt/default.nix
+++ b/pkgs/development/rocm-modules/6/hiprt/default.nix
@@ -5,6 +5,7 @@
   cmake,
   clr,
   gcc,
+  python3,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -25,6 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     gcc # required for replacing easy-encryption binary
     cmake
+    python3
   ];
 
   buildInputs = [

--- a/pkgs/development/rocm-modules/6/rccl/default.nix
+++ b/pkgs/development/rocm-modules/6/rccl/default.nix
@@ -11,6 +11,7 @@
   mscclpp,
   perl,
   hipify,
+  python3,
   gtest,
   chrpath,
   rocprofiler,
@@ -62,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     clr
     perl
     hipify
+    python3
     autoPatchelfHook # ASAN doesn't add rpath without this
   ];
 

--- a/pkgs/development/rocm-modules/6/rocminfo/default.nix
+++ b/pkgs/development/rocm-modules/6/rocminfo/default.nix
@@ -30,13 +30,15 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-fQPtO5TNbCbaZZ7VtGkkqng5QZ+FcScdh1opWr5YkLU=";
   };
 
+  strictDeps = true;
+
   nativeBuildInputs = [
     cmake
     rocm-cmake
+    python3
   ];
 
   buildInputs = [ rocm-runtime ];
-  propagatedBuildInputs = [ python3 ];
   cmakeFlags = [ "-DROCRTST_BLD_TYPE=Release" ];
 
   prePatch = ''

--- a/pkgs/development/rocm-modules/6/rocminfo/default.nix
+++ b/pkgs/development/rocm-modules/6/rocminfo/default.nix
@@ -58,6 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "ROCm Application for Reporting System Info";
     homepage = "https://github.com/ROCm/rocminfo";
     license = licenses.ncsa;
+    mainProgram = "rocminfo";
     maintainers = with maintainers; [ lovesegfault ];
     teams = [ teams.rocm ];
     platforms = platforms.linux;


### PR DESCRIPTION
Fixes incorrect python version leaking into deps of rocminfo / clr, potentially causing confusing errors about python packages not being found.

~~needs further iterations before I can mark ready for review; I expect some parts of the rocm package set are inadvertently relying on `clr` -> `rocminfo` providing a python3.~~ Sorted now!


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
