### PR TITLE
python3Packages: fix subliminal, add knowit

### DIFF
--- a/pkgs/development/python-modules/knowit/default.nix
+++ b/pkgs/development/python-modules/knowit/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  babelfish,
+  enzyme,
+  pymediainfo,
+  pyyaml,
+  trakit,
+  pint,
+}:
+
+# TODO(@sandarukasa): it would be nice to provide ffmpeg here
+buildPythonPackage rec {
+  pname = "knowit";
+  version = "0.5.11";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ratoaq2";
+    repo = "knowit";
+    rev = version;
+    hash = "sha256-JqzCLdXEWZyvqXpeTJRW0zhY+wVcHLuBYrJbuSqfgkg=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    babelfish
+    enzyme
+    pymediainfo
+    pyyaml
+    trakit
+  ];
+
+  pythonImportsCheck = [
+    "knowit"
+  ];
+
+  meta = {
+    description = "Know better your media files";
+    homepage = "https://github.com/ratoaq2/knowit";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sandarukasa ];
+  };
+}

--- a/pkgs/development/python-modules/subliminal/default.nix
+++ b/pkgs/development/python-modules/subliminal/default.nix
@@ -9,22 +9,23 @@
   chardet,
   click,
   click-option-group,
+  defusedxml,
   dogpile-cache,
-  enzyme,
   guessit,
-  srt,
-  pysubs2,
-  rarfile,
-  requests,
+  knowit,
   platformdirs,
-  setuptools,
-  stevedore,
-  tomli,
+  pysubs2,
+  requests,
+  srt,
+  tomlkit,
 
+  hatchling,
+  hatch-vcs,
+
+  colorama,
+  pypandoc,
   pytestCheckHook,
-  pytest-cov-stub,
   pytest-xdist,
-  mypy,
   sympy,
   vcrpy,
 }:
@@ -43,7 +44,10 @@ buildPythonPackage rec {
     hash = "sha256-eAXzD6diep28wCZjWLOZpOX1bnakEldhs2LX5CPu5OI=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
 
   propagatedBuildInputs = [
     babelfish
@@ -51,23 +55,22 @@ buildPythonPackage rec {
     chardet
     click
     click-option-group
+    defusedxml
     dogpile-cache
-    enzyme
     guessit
-    srt
-    pysubs2
-    rarfile
-    requests
+    knowit
     platformdirs
-    stevedore
-    tomli
+    pysubs2
+    requests
+    srt
+    tomlkit
   ];
 
   nativeCheckInputs = [
+    colorama
+    pypandoc
     pytestCheckHook
-    pytest-cov-stub
     pytest-xdist
-    mypy
     sympy
     vcrpy
   ];
@@ -76,9 +79,13 @@ buildPythonPackage rec {
 
   disabledTests = [
     # Tests require network access
+    "cli_cache"
+    "cli_download"
+    "opensubtitles"
+    "test_archives"
+    "test_hash"
     "test_refine"
     "test_scan"
-    "test_hash"
   ];
 
   meta = {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7814,6 +7814,8 @@ self: super: with self; {
 
   knot-floer-homology = callPackage ../development/python-modules/knot-floer-homology { };
 
+  knowit = callPackage ../development/python-modules/knowit { };
+
   knx-frontend = callPackage ../development/python-modules/knx-frontend { };
 
   kokoro = callPackage ../development/python-modules/kokoro { };


### PR DESCRIPTION
Fixes #437998

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
