### PR TITLE
zulip: 5.12.0 → 5.12.1

### DIFF
--- a/pkgs/by-name/zu/zulip/package.nix
+++ b/pkgs/by-name/zu/zulip/package.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   buildNpmPackage,
   python3,
-  electron_35,
+  electron_37,
   makeDesktopItem,
   makeShellWrapper,
   copyDesktopItems,
@@ -11,16 +11,17 @@
 
 buildNpmPackage rec {
   pname = "zulip";
-  version = "5.12.0";
+  version = "5.12.1";
 
   src = fetchFromGitHub {
     owner = "zulip";
     repo = "zulip-desktop";
     tag = "v${version}";
-    hash = "sha256-YDb69tJCR58DARssnZgdVxtRpR8vHsawCTv7kQ56y+8=";
+    hash = "sha256-YuiPf/ciSm0nBlF8U55EkPSTz+RI148QKOFv6FmYRD0=";
   };
 
-  npmDepsHash = "sha256-MKKN6prUdWaHm27GybdbswDMNJH0xVffXsT2ZwroOHI=";
+  npmDepsHash = "sha256-RNXhDV0b1FZglIS5UsTn6YboJ4Au1/CZVtRz1BvcP2E=";
+  makeCacheWritable = true;
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
@@ -37,8 +38,8 @@ buildNpmPackage rec {
     runHook preBuild
 
     npm run pack -- \
-      -c.electronDist=${electron_35}/libexec/electron \
-      -c.electronVersion=${electron_35.version}
+      -c.electronDist=${electron_37}/libexec/electron \
+      -c.electronVersion=${electron_37.version}
 
     runHook postBuild
   '';
@@ -51,7 +52,7 @@ buildNpmPackage rec {
 
     install -m 444 -D app/resources/zulip.png $out/share/icons/hicolor/512x512/apps/zulip.png
 
-    makeShellWrapper '${lib.getExe electron_35}' "$out/bin/zulip" \
+    makeShellWrapper '${lib.getExe electron_37}' "$out/bin/zulip" \
       --add-flags "$out/share/lib/zulip/app.asar" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-wayland-ime=true}}" \
       --inherit-argv0


### PR DESCRIPTION
Upgrade the Zulip Desktop app from 5.12.0 to 5.12.1.

- https://github.com/zulip/zulip-desktop/releases/tag/v5.12.1
- https://github.com/zulip/zulip-desktop/compare/v5.12.0...v5.12.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
