### PR TITLE
nixos/plymouth: fix theme == "breeze" breakage after removing Plasma 5

### DIFF
--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -67,6 +67,14 @@ let
     ${cfg.extraConfig}
   '';
 
+  checkIfThemeExists = ''
+    # Check if the actual requested theme is here
+    if [[ ! -d ${themesEnv}/share/plymouth/themes/${cfg.theme} ]]; then
+        echo "The requested theme: ${cfg.theme} is not provided by any of the packages in boot.plymouth.themePackages"
+        echo "The following themes exist: $(ls ${themesEnv}/share/plymouth/themes/)"
+        exit 1
+    fi
+  '';
 in
 
 {
@@ -188,50 +196,42 @@ in
         "/etc/plymouth/logo.png".source = cfg.logo;
         "/etc/plymouth/plymouthd.defaults".source = "${plymouth}/share/plymouth/plymouthd.defaults";
         # Directories
-        "/etc/plymouth/plugins".source = pkgs.runCommand "plymouth-initrd-plugins" { } ''
-          # Check if the actual requested theme is here
-          if [[ ! -d ${themesEnv}/share/plymouth/themes/${cfg.theme} ]]; then
-              echo "The requested theme: ${cfg.theme} is not provided by any of the packages in boot.plymouth.themePackages"
-              echo "The following themes exist: $(ls ${themesEnv}/share/plymouth/themes/)"
-              exit 1
-          fi
+        "/etc/plymouth/plugins".source = pkgs.runCommand "plymouth-initrd-plugins" { } (
+          checkIfThemeExists
+          + ''
+            moduleName="$(sed -n 's,ModuleName *= *,,p' ${themesEnv}/share/plymouth/themes/${cfg.theme}/${cfg.theme}.plymouth)"
 
-          moduleName="$(sed -n 's,ModuleName *= *,,p' ${themesEnv}/share/plymouth/themes/${cfg.theme}/${cfg.theme}.plymouth)"
-
-          mkdir -p $out/renderers
-          # module might come from a theme
-          cp ${themesEnv}/lib/plymouth/*.so $out
-          cp ${plymouth}/lib/plymouth/renderers/*.so $out/renderers
-          # useless in the initrd, and adds several megabytes to the closure
-          rm $out/renderers/x11.so
-        '';
-        "/etc/plymouth/themes".source = pkgs.runCommand "plymouth-initrd-themes" { } ''
-          # Check if the actual requested theme is here
-          if [[ ! -d ${themesEnv}/share/plymouth/themes/${cfg.theme} ]]; then
-              echo "The requested theme: ${cfg.theme} is not provided by any of the packages in boot.plymouth.themePackages"
-              echo "The following themes exist: $(ls ${themesEnv}/share/plymouth/themes/)"
-              exit 1
-          fi
-
-          mkdir -p $out/${cfg.theme}
-          cp -r ${themesEnv}/share/plymouth/themes/${cfg.theme}/* $out/${cfg.theme}
-          # Copy more themes if the theme depends on others
-          for theme in $(grep -hRo '/share/plymouth/themes/.*$' $out | xargs -n1 basename); do
-              if [[ -d "${themesEnv}/share/plymouth/themes/$theme" ]]; then
-                  if [[ ! -d "$out/$theme" ]]; then
-                    echo "Adding dependent theme: $theme"
-                    mkdir -p "$out/$theme"
-                    cp -r "${themesEnv}/share/plymouth/themes/$theme"/* "$out/$theme"
-                  fi
-              else
-                echo "Missing theme dependency: $theme"
-              fi
-          done
-          # Fixup references
-          for theme in $out/*/*.plymouth; do
-            sed -i "s,${builtins.storeDir}/.*/share/plymouth/themes,$out," "$theme"
-          done
-        '';
+            mkdir -p $out/renderers
+            # module might come from a theme
+            cp ${themesEnv}/lib/plymouth/*.so $out
+            cp ${plymouth}/lib/plymouth/renderers/*.so $out/renderers
+            # useless in the initrd, and adds several megabytes to the closure
+            rm $out/renderers/x11.so
+          ''
+        );
+        "/etc/plymouth/themes".source = pkgs.runCommand "plymouth-initrd-themes" { } (
+          checkIfThemeExists
+          + ''
+            mkdir -p $out/${cfg.theme}
+            cp -r ${themesEnv}/share/plymouth/themes/${cfg.theme}/* $out/${cfg.theme}
+            # Copy more themes if the theme depends on others
+            for theme in $(grep -hRo '/share/plymouth/themes/.*$' $out | xargs -n1 basename); do
+                if [[ -d "${themesEnv}/share/plymouth/themes/$theme" ]]; then
+                    if [[ ! -d "$out/$theme" ]]; then
+                      echo "Adding dependent theme: $theme"
+                      mkdir -p "$out/$theme"
+                      cp -r "${themesEnv}/share/plymouth/themes/$theme"/* "$out/$theme"
+                    fi
+                else
+                  echo "Missing theme dependency: $theme"
+                fi
+            done
+            # Fixup references
+            for theme in $out/*/*.plymouth; do
+              sed -i "s,${builtins.storeDir}/.*/share/plymouth/themes,$out," "$theme"
+            done
+          ''
+        );
 
         # Fonts
         "/etc/plymouth/fonts".source = pkgs.runCommand "plymouth-initrd-fonts" { } ''
@@ -285,63 +285,62 @@ in
       '')
     ];
 
-    boot.initrd.extraUtilsCommands = lib.mkIf (!config.boot.initrd.systemd.enable) ''
-      copy_bin_and_libs ${plymouth}/bin/plymouth
-      copy_bin_and_libs ${plymouth}/bin/plymouthd
+    boot.initrd.extraUtilsCommands = lib.mkIf (!config.boot.initrd.systemd.enable) (
+      ''
+        copy_bin_and_libs ${plymouth}/bin/plymouth
+        copy_bin_and_libs ${plymouth}/bin/plymouthd
 
-      # Check if the actual requested theme is here
-      if [[ ! -d ${themesEnv}/share/plymouth/themes/${cfg.theme} ]]; then
-          echo "The requested theme: ${cfg.theme} is not provided by any of the packages in boot.plymouth.themePackages"
-          echo "The following themes exist: $(ls ${themesEnv}/share/plymouth/themes/)"
-          exit 1
-      fi
+      ''
+      + checkIfThemeExists
+      + ''
 
-      moduleName="$(sed -n 's,ModuleName *= *,,p' ${themesEnv}/share/plymouth/themes/${cfg.theme}/${cfg.theme}.plymouth)"
+        moduleName="$(sed -n 's,ModuleName *= *,,p' ${themesEnv}/share/plymouth/themes/${cfg.theme}/${cfg.theme}.plymouth)"
 
-      mkdir -p $out/lib/plymouth/renderers
-      # module might come from a theme
-      cp ${themesEnv}/lib/plymouth/*.so $out/lib/plymouth
-      cp ${plymouth}/lib/plymouth/renderers/*.so $out/lib/plymouth/renderers
-      # useless in the initrd, and adds several megabytes to the closure
-      rm $out/lib/plymouth/renderers/x11.so
+        mkdir -p $out/lib/plymouth/renderers
+        # module might come from a theme
+        cp ${themesEnv}/lib/plymouth/*.so $out/lib/plymouth
+        cp ${plymouth}/lib/plymouth/renderers/*.so $out/lib/plymouth/renderers
+        # useless in the initrd, and adds several megabytes to the closure
+        rm $out/lib/plymouth/renderers/x11.so
 
-      mkdir -p $out/share/plymouth/themes
-      cp ${plymouth}/share/plymouth/plymouthd.defaults $out/share/plymouth
+        mkdir -p $out/share/plymouth/themes
+        cp ${plymouth}/share/plymouth/plymouthd.defaults $out/share/plymouth
 
-      # Copy themes into working directory for patching
-      mkdir themes
+        # Copy themes into working directory for patching
+        mkdir themes
 
-      # Use -L to copy the directories proper, not the symlinks to them.
-      # Copy all themes because they're not large assets, and bgrt depends on the ImageDir of
-      # the spinner theme.
-      cp -r -L ${themesEnv}/share/plymouth/themes/* themes
+        # Use -L to copy the directories proper, not the symlinks to them.
+        # Copy all themes because they're not large assets, and bgrt depends on the ImageDir of
+        # the spinner theme.
+        cp -r -L ${themesEnv}/share/plymouth/themes/* themes
 
-      # Patch out any attempted references to the theme or plymouth's themes directory
-      chmod -R +w themes
-      find themes -type f | while read file
-      do
-        sed -i "s,${builtins.storeDir}/.*/share/plymouth/themes,$out/share/plymouth/themes,g" $file
-      done
+        # Patch out any attempted references to the theme or plymouth's themes directory
+        chmod -R +w themes
+        find themes -type f | while read file
+        do
+          sed -i "s,${builtins.storeDir}/.*/share/plymouth/themes,$out/share/plymouth/themes,g" $file
+        done
 
-      # Install themes
-      cp -r themes/* $out/share/plymouth/themes
+        # Install themes
+        cp -r themes/* $out/share/plymouth/themes
 
-      # Install logo
-      mkdir -p $out/etc/plymouth
-      cp -r -L ${themesEnv}/etc/plymouth $out/etc
+        # Install logo
+        mkdir -p $out/etc/plymouth
+        cp -r -L ${themesEnv}/etc/plymouth $out/etc
 
-      # Setup font
-      mkdir -p $out/share/fonts
-      cp ${cfg.font} $out/share/fonts
-      mkdir -p $out/etc/fonts
-      cat > $out/etc/fonts/fonts.conf <<EOF
-      <?xml version="1.0"?>
-      <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
-      <fontconfig>
-          <dir>$out/share/fonts</dir>
-      </fontconfig>
-      EOF
-    '';
+        # Setup font
+        mkdir -p $out/share/fonts
+        cp ${cfg.font} $out/share/fonts
+        mkdir -p $out/etc/fonts
+        cat > $out/etc/fonts/fonts.conf <<EOF
+        <?xml version="1.0"?>
+        <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+        <fontconfig>
+            <dir>$out/share/fonts</dir>
+        </fontconfig>
+        EOF
+      ''
+    );
 
     boot.initrd.extraUtilsCommandsTest = mkIf (!config.boot.initrd.systemd.enable) ''
       $out/bin/plymouthd --help >/dev/null

--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -17,6 +17,13 @@ let
   cfg = config.boot.plymouth;
   opt = options.boot.plymouth;
 
+  nixosBreezePlymouth = pkgs.kdePackages.breeze-plymouth.override {
+    logoFile = cfg.logo;
+    logoName = "nixos";
+    osName = "NixOS";
+    osVersion = config.system.nixos.release;
+  };
+
   plymouthLogos = pkgs.runCommand "plymouth-logos" { inherit (cfg) logo; } ''
     mkdir -p $out
 
@@ -80,7 +87,12 @@ in
       };
 
       themePackages = mkOption {
-        default = [ ];
+        default = lib.optional (cfg.theme == "breeze") nixosBreezePlymouth;
+        defaultText = literalMD ''
+          A NixOS branded variant of the breeze theme when
+          `config.${opt.theme} == "breeze"`, otherwise
+          `[ ]`.
+        '';
         type = types.listOf types.package;
         description = ''
           Extra theme packages for plymouth.

--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -192,6 +192,7 @@ in
           # Check if the actual requested theme is here
           if [[ ! -d ${themesEnv}/share/plymouth/themes/${cfg.theme} ]]; then
               echo "The requested theme: ${cfg.theme} is not provided by any of the packages in boot.plymouth.themePackages"
+              echo "The following themes exist: $(ls ${themesEnv}/share/plymouth/themes/)"
               exit 1
           fi
 
@@ -208,6 +209,7 @@ in
           # Check if the actual requested theme is here
           if [[ ! -d ${themesEnv}/share/plymouth/themes/${cfg.theme} ]]; then
               echo "The requested theme: ${cfg.theme} is not provided by any of the packages in boot.plymouth.themePackages"
+              echo "The following themes exist: $(ls ${themesEnv}/share/plymouth/themes/)"
               exit 1
           fi
 
@@ -290,6 +292,7 @@ in
       # Check if the actual requested theme is here
       if [[ ! -d ${themesEnv}/share/plymouth/themes/${cfg.theme} ]]; then
           echo "The requested theme: ${cfg.theme} is not provided by any of the packages in boot.plymouth.themePackages"
+          echo "The following themes exist: $(ls ${themesEnv}/share/plymouth/themes/)"
           exit 1
       fi
 


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
