### PR TITLE
nixos/cloudprober: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -35,6 +35,8 @@
 
 - Options under [networking.getaddrinfo](#opt-networking.getaddrinfo.enable) are now allowed to declaratively configure address selection and sorting behavior of `getaddrinfo` in dual-stack networks.
 
+- [Cloudprober](https://cloudprober.org/), an open-source active monitoring tool designed to detect failures in software systems and services in real-time.
+
 - [Homebridge](https://github.com/homebridge/homebridge), a lightweight Node.js server you can run on your home network that emulates the iOS HomeKit API. Available as [services.homebridge](#opt-services.homebridge.enable).
 
 - [LACT](https://github.com/ilya-zlobintsev/LACT), a GPU monitoring and configuration tool, can now be enabled through [services.lact.enable](#opt-services.lact.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -963,6 +963,7 @@
   ./services/monitoring/bosun.nix
   ./services/monitoring/cadvisor.nix
   ./services/monitoring/certspotter.nix
+  ./services/monitoring/cloudprober.nix
   ./services/monitoring/cockpit.nix
   ./services/monitoring/collectd.nix
   ./services/monitoring/das_watchdog.nix

--- a/nixos/modules/services/monitoring/cloudprober.nix
+++ b/nixos/modules/services/monitoring/cloudprober.nix
@@ -1,0 +1,100 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+let
+  inherit (lib)
+    filterAttrsRecursive
+    getExe
+    maintainers
+    mkEnableOption
+    mkIf
+    mkPackageOption
+    mkOption
+    types
+    ;
+  inherit (utils) escapeSystemdExecArgs;
+  cfg = config.services.cloudprober;
+  settingsFormat = pkgs.formats.yaml { };
+in
+{
+  options.services.cloudprober = {
+    enable = mkEnableOption "cloudprober";
+
+    package = mkPackageOption pkgs "cloudprober" { };
+
+    extraArgs = mkOption {
+      description = ''
+        Extra arguments passed to cloudprober.";
+      '';
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "--logfmt=json" ];
+    };
+
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = settingsFormat.type;
+      };
+      description = ''
+        Configuration for cloudprober.
+        See the official documentation for details: <https://cloudprober.org/docs/config/latest/overview/>
+        or take a look at the examples at <https://github.com/cloudprober/cloudprober/tree/main/examples>
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.cloudprober = {
+      description = "Cloudprober: Reliable System Monitoring, Simplified!";
+      documentation = [ "https://cloudprober.org/docs/" ];
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      serviceConfig = {
+        Type = "exec";
+        ExecStart = escapeSystemdExecArgs (
+          [
+            (getExe cfg.package)
+            "--config_file=${
+              settingsFormat.generate "cloudprober.yaml" (filterAttrsRecursive (n: v: v != null) cfg.settings)
+            }"
+          ]
+          ++ cfg.extraArgs
+        );
+        Restart = "on-failure";
+        CapabilityBoundingSet = [ "" ];
+        DynamicUser = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        StateDirectory = "cloudprober";
+        SystemCallArchitectures = "native";
+        SystemCallErrorNumber = "EPERM";
+        SystemCallFilter = "@system-service";
+        UMask = "0027";
+      };
+    };
+  };
+
+  meta.maintainers = with maintainers; [ xgwq ];
+}


### PR DESCRIPTION
Add module to setup Cloudprober.
https://cloudprober.org/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
