### PR TITLE
python3Packages.mpi4py: skip failing/hanging tests

### DIFF
--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -6,6 +6,7 @@
   setuptools,
   mpi,
   toPythonModule,
+  pytest-timeout,
   pytestCheckHook,
   mpiCheckPhaseHook,
 }:
@@ -43,7 +44,15 @@ buildPythonPackage rec {
     pytestCheckHook
     mpiCheckPhaseHook
   ];
-  disabledTestPaths = lib.optionals (mpi.pname == "mpich") [
+  disabledTestPaths = [
+    # mpi4py.MPI.Exception: MPI_ERR_UNKNOWN: unknown error
+    "test/test_spawn.py"
+
+    # Hang indefinitely
+    "demo/futures/test_futures.py"
+    "test/test_util_pool.py"
+  ]
+  ++ lib.optionals (mpi.pname == "mpich") [
     # These tests from some reason cause pytest to crash, and therefor it is
     # hard to debug them. Upstream mentions these tests to raise issues in
     # https://github.com/mpi4py/mpi4py/issues/418  but the workaround suggested


### PR DESCRIPTION
## Things done

cc @doronbehar @emilazy

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
