### PR TITLE
voicevox: 0.24.2 -> 0.25.0

### DIFF
--- a/pkgs/by-name/vo/voicevox-core/onnxruntime.nix
+++ b/pkgs/by-name/vo/voicevox-core/onnxruntime.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "voicevox-onnxruntime";
+  version = "1.17.3";
+
+  src = finalAttrs.passthru.sources.${stdenv.hostPlatform.system};
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  buildInputs = [ stdenv.cc.cc.lib ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out"
+    cp -r ./lib "$out/lib"
+
+    runHook postInstall
+  '';
+
+  passthru.sources =
+    let
+      # Note: Only the prebuilt binaries are able to decrypt the encrypted voice models
+      fetchArtifact =
+        { id, hash }:
+        fetchurl {
+          url = "https://github.com/VOICEVOX/onnxruntime-builder/releases/download/voicevox_onnxruntime-${finalAttrs.version}/voicevox_onnxruntime-${id}-${finalAttrs.version}.tgz";
+          inherit hash;
+        };
+    in
+    {
+      "x86_64-linux" = fetchArtifact {
+        id = "linux-x64";
+        hash = "sha256-crUof91I3IM6mSn26eOCbnk7VM4SAhgb6T9jgjoiL1g=";
+      };
+      "aarch64-linux" = fetchArtifact {
+        id = "linux-arm64";
+        hash = "sha256-J27twAe2lDJPWbw1ws+QQXJOt4ZghDemSfCW7eo5Q6k=";
+      };
+      "x86_64-darwin" = fetchArtifact {
+        id = "osx-x86_64";
+        hash = "sha256-We3IYCUtu39kzC63K9SykEpt98NfM9yAgkNbnxWlBd8=";
+      };
+      "aarch64-darwin" = fetchArtifact {
+        id = "osx-arm64";
+        hash = "sha256-ltfqGSigoVSFSS03YhOH31D0CnkuKmgX1N9z7NGFcfI=";
+      };
+    };
+
+  meta = {
+    license = with lib.licenses; [
+      mit
+      {
+        name = "VOICEVOX ONNX Runtime Terms of Use";
+        url = "https://github.com/VOICEVOX/voicevox_resource/blob/main/onnxruntime/README.md";
+        free = false;
+        redistributable = true;
+      }
+    ];
+    maintainers = with lib.maintainers; [
+      tomasajt
+      eljamm
+    ];
+    platforms = lib.attrNames finalAttrs.passthru.sources;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/vo/voicevox-core/openjtalk.patch
+++ b/pkgs/by-name/vo/voicevox-core/openjtalk.patch
@@ -1,0 +1,12 @@
+diff --git a/build.rs b/build.rs
+index 3f1b971..72f722f 100644
+--- a/build.rs
++++ b/build.rs
+@@ -6,6 +6,7 @@ use std::{
+ };
+ fn main() {
+     let mut cmake_conf = cmake::Config::new("open_jtalk");
++    cmake_conf.define("FETCHCONTENT_SOURCE_DIR_OPENJTALK", "@openjtalk_src@");
+     let target = env::var("TARGET").unwrap();
+     let mut include_dirs: Vec<PathBuf> = Vec::new();
+     let cmake_conf = if target.starts_with("i686") {

--- a/pkgs/by-name/vo/voicevox-core/package.nix
+++ b/pkgs/by-name/vo/voicevox-core/package.nix
@@ -6,7 +6,9 @@
   rustPlatform,
   fetchFromGitHub,
   cmake,
+  pkg-config,
   python3,
+  openssl,
 }:
 
 let
@@ -19,17 +21,17 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "voicevox-core";
-  version = "0.16.1";
-  modelVersion = "0.16.0";
+  version = "0.16.2";
+  modelVersion = "0.16.1";
 
   src = fetchFromGitHub {
     owner = "VOICEVOX";
     repo = "voicevox_core";
     tag = finalAttrs.version;
-    hash = "sha256-LCczOvU4NzHXoHp3QN5TzJkr1oSJP+V8JYQHLH0ObWQ=";
+    hash = "sha256-aRy9x6IzFDwL4HjhCW705LpkZ13/SJ25h45XbbXciy0=";
   };
 
-  cargoHash = "sha256-VQSIR120aDxZAlELXP/pJp2P+29aJ/EFjmqn4Unax58=";
+  cargoHash = "sha256-8udiXUZGn3ZT7RvmZd/F5tLsCKi5QLPG3pzv7LFyLvQ=";
 
   postPatch = ''
     cp -r --no-preserve=all ${openjtalk-src} ./openjtalk
@@ -46,7 +48,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # setting this to anything disables trying to download onnxruntime
   env.ORT_LIB_LOCATION = "dummy";
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [ openssl ];
 
   doCheck = false;
 
@@ -60,7 +67,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       owner = "VOICEVOX";
       repo = "voicevox_vvm";
       tag = finalAttrs.modelVersion;
-      hash = "sha256-c8tTiNsXkSnEFYUtL+Q3ApZRasJVSKSBjsdsJ8wpJ+A=";
+      hash = "sha256-OY+xuvNjgmH/bxhL61XJZ3JVOxyec6kifkoGD4eN7HA=";
     };
 
     nativeBuildInputs = [ python3 ];

--- a/pkgs/by-name/vo/voicevox-engine/package.nix
+++ b/pkgs/by-name/vo/voicevox-engine/package.nix
@@ -73,7 +73,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   makeWrapperArgs = [
-    ''--add-flags "--voicelib_dir=${voicevox-core}/lib"''
+    ''--add-flags "--voicelib_dir=${voicevox-core.wrapped}/lib"''
   ];
 
   preCheck = ''

--- a/pkgs/by-name/vo/voicevox-engine/package.nix
+++ b/pkgs/by-name/vo/voicevox-engine/package.nix
@@ -7,14 +7,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "voicevox-engine";
-  version = "0.24.1";
+  version = "0.25.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "VOICEVOX";
     repo = "voicevox_engine";
     tag = version;
-    hash = "sha256-WoHTv4VjLFJPIi47WETMQM8JmgBctAWlue8yKmi1+6A=";
+    hash = "sha256-ZthTXHXzexbffWoi8AKJrgX9/gd7fmKbYpCwuZZiQWQ=";
   };
 
   patches = [
@@ -35,6 +35,7 @@ python3Packages.buildPythonApplication rec {
     kanalizer
     numpy
     platformdirs
+    psutil
     pydantic
     python-multipart
     pyworld
@@ -50,6 +51,10 @@ python3Packages.buildPythonApplication rec {
   pythonRemoveDeps = [
     # upstream wants fastapi-slim, but we provide fastapi instead
     "fastapi-slim"
+  ];
+
+  pythonRelaxDeps = [
+    "psutil" # at the time of writing, psutil has not reached version 7.1.1
   ];
 
   preConfigure = ''
@@ -98,7 +103,7 @@ python3Packages.buildPythonApplication rec {
       owner = "VOICEVOX";
       repo = "voicevox_resource";
       tag = version;
-      hash = "sha256-4D9b5MjJQq+oCqSv8t7CILgFcotbNBH3m2F/up12pPE=";
+      hash = "sha256-yj3bwEB1qeoXAf3Dr02FF/HB6g7toAd2VUmR2937yzc=";
     };
 
     pyopenjtalk = python3Packages.callPackage ./pyopenjtalk.nix { };

--- a/pkgs/by-name/vo/voicevox/hardcode-paths.patch
+++ b/pkgs/by-name/vo/voicevox/hardcode-paths.patch
@@ -11,15 +11,15 @@ index cc5e2b9..29140f8 100644
          "executionArgs": [],
          "host": "http://127.0.0.1:50021"
      }
-diff --git a/electron-builder.config.cjs b/electron-builder.config.cjs
-index d2a21b4..7b338c0 100644
---- a/electron-builder.config.cjs
-+++ b/electron-builder.config.cjs
-@@ -40,17 +40,6 @@ const isArm64 = process.arch === "arm64";
+diff --git a/build/electronBuilderConfig.ts b/build/electronBuilderConfig.ts
+index 83dcc10..114fb9d 100644
+--- a/build/electronBuilderConfig.ts
++++ b/build/electronBuilderConfig.ts
+@@ -45,17 +45,6 @@ const isArm64 = process.arch === "arm64";
  // cf: https://k-hyoda.hatenablog.com/entry/2021/10/23/000349#%E8%BF%BD%E5%8A%A0%E5%B1%95%E9%96%8B%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E5%85%88%E3%81%AE%E8%A8%AD%E5%AE%9A
  const extraFilePrefix = isMac ? "MacOS/" : "";
  
--const sevenZipFile = readdirSync(resolve(__dirname, "vendored", "7z")).find(
+-const sevenZipFile = readdirSync(path.join(rootDir, "vendored", "7z")).find(
 -  // Windows: 7za.exe, Linux: 7zzs, macOS: 7zz
 -  (fileName) => ["7za.exe", "7zzs", "7zz"].includes(fileName),
 -);
@@ -30,29 +30,29 @@ index d2a21b4..7b338c0 100644
 -  );
 -}
 -
- /** @type {import("electron-builder").Configuration} */
- const builderOptions = {
+ const builderOptions: ElectronBuilderConfiguration = {
    beforeBuild: async () => {
-@@ -91,14 +80,6 @@ const builderOptions = {
+     if (existsSync(path.join(rootDir, "dist_electron"))) {
+@@ -97,14 +86,6 @@ const builderOptions: ElectronBuilderConfiguration = {
        from: "build/README.txt",
        to: extraFilePrefix + "README.txt",
      },
 -    {
 -      from: VOICEVOX_ENGINE_DIR,
--      to: join(extraFilePrefix, "vv-engine"),
+-      to: path.join(extraFilePrefix, "vv-engine"),
 -    },
 -    {
--      from: resolve(__dirname, "vendored", "7z", sevenZipFile),
+-      from: path.join(rootDir, "vendored", "7z", sevenZipFile),
 -      to: extraFilePrefix + sevenZipFile,
 -    },
    ],
    // electron-builder installer
    productName: "VOICEVOX",
 diff --git a/src/backend/electron/vvppFile.ts b/src/backend/electron/vvppFile.ts
-index 7e152f1..1aaa8c4 100644
+index f649bf8..de2f3fa 100644
 --- a/src/backend/electron/vvppFile.ts
 +++ b/src/backend/electron/vvppFile.ts
-@@ -220,6 +220,7 @@ export class VvppFileExtractor {
+@@ -224,6 +224,7 @@ export class VvppFileExtractor {
    }
  
    private getSevenZipPath(): string {
@@ -60,3 +60,26 @@ index 7e152f1..1aaa8c4 100644
      let sevenZipPath = import.meta.env.VITE_7Z_BIN_NAME;
      if (!sevenZipPath) {
        throw new Error("7z path is not defined");
+diff --git a/vite.config.ts b/vite.config.ts
+index 3c9e029..c253a6a 100644
+--- a/vite.config.ts
++++ b/vite.config.ts
+@@ -5,7 +5,6 @@ import { rm } from "node:fs/promises";
+ import electronPlugin from "vite-plugin-electron/simple";
+ import tsconfigPaths from "vite-tsconfig-paths";
+ import vue from "@vitejs/plugin-vue";
+-import electronDefaultImport from "electron";
+ import checker from "vite-plugin-checker";
+ import { BuildOptions, defineConfig, loadEnv, Plugin } from "vite";
+ import { quasar } from "@quasar/vite-plugin";
+@@ -17,9 +16,7 @@ import {
+   SourceFile,
+ } from "./tools/checkSuspiciousImports.js";
+ 
+-// @ts-expect-error electronをelectron環境外からimportするとelectronのファイルパスが得られる。
+-// https://github.com/electron/electron/blob/a95180e0806f4adba8009f46124b6bb4853ac0a6/npm/index.js
+-const electronPath = electronDefaultImport as string;
++const electronPath = "@electron_path@";
+ 
+ const nodeTestPaths = ["../tests/unit/**/*.node.{test,spec}.ts"];
+ const browserTestPaths = ["../tests/unit/**/*.browser.{test,spec}.ts"];

--- a/pkgs/by-name/vo/voicevox/package.nix
+++ b/pkgs/by-name/vo/voicevox/package.nix
@@ -11,7 +11,7 @@
   makeWrapper,
   moreutils,
   nodejs,
-  pnpm_9,
+  pnpm_10,
 
   _7zz,
   electron,
@@ -19,21 +19,22 @@
 }:
 
 let
-  pnpm = pnpm_9;
+  pnpm = pnpm_10;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "voicevox";
-  version = "0.24.2";
+  version = "0.25.0";
 
   src = fetchFromGitHub {
     owner = "VOICEVOX";
     repo = "voicevox";
     tag = finalAttrs.version;
-    hash = "sha256-ploFrzxIseyUD7LINnFmshrg3QJV8KUkdbvDoJ/VkRk=";
+    hash = "sha256-s8+uHwqxK9my/850C52VT5kshlGrHOOHtopUlsowNeI=";
   };
 
   patches = [
     (replaceVars ./hardcode-paths.patch {
+      electron_path = lib.getExe electron;
       sevenzip_path = lib.getExe _7zz;
       voicevox_engine_path = lib.getExe voicevox-engine;
     })
@@ -41,11 +42,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     # unlock the overly specific pnpm package version pin
-    jq 'del(.packageManager)' package.json | sponge package.json
-
-    substituteInPlace package.json \
-      --replace-fail "999.999.999" "$version" \
-      --replace-fail ' && electron-builder --config electron-builder.config.cjs --publish never' ""
+    # and also set version to a proper value
+    jq "del(.packageManager) | .version = \"$version\"" package.json | sponge package.json
   '';
 
   pnpmDeps = pnpm.fetchDeps {
@@ -65,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     ];
 
     fetcherVersion = 1;
-    hash = "sha256-RKgqFmHQnjHS7yeUIbH9awpNozDOCCHplc/bmfxmMyg=";
+    hash = "sha256-no0oFhy7flet9QH4FEkPJdlwNq5YkjIx8Uat3M2ruKI=";
   };
 
   nativeBuildInputs = [
@@ -96,11 +94,11 @@ stdenv.mkDerivation (finalAttrs: {
     chmod -R u+w electron-dist
 
     # note: we patched out the call to electron-builder in postPatch
-    pnpm run electron:build
+    pnpm run electron:build:compile
 
     pnpm exec electron-builder \
       --dir \
-      --config electron-builder.config.cjs \
+      --config ./build/electronBuilderConfigLoader.cjs \
       -c.electronDist=electron-dist \
       -c.electronVersion=${electron.version}
 


### PR DESCRIPTION
The decryption logic of the voice models has been moved into VOICEVOX's custom fork of `onnxruntime`.
This means that `voicevox-core` can now be built from source, and also, it will now be built by Hydra as well.

The newly added passthru derivation `voicevox-core.wrapped` is now what `voicevox-core` used to be before this PR: the core library + onnxruntime + models.

The models are now downloaded from the `voicevox_vvm` repo.

The newly added custom `onnxruntime` is packaged just like how `voicevox-core` used to be packaged: different sources for each system.
This is the unfree component.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
