### PR TITLE
python313Packages.fints: fix build with sandbox

### DIFF
--- a/pkgs/development/python-modules/fints/default.nix
+++ b/pkgs/development/python-modules/fints/default.nix
@@ -37,6 +37,8 @@ buildPythonPackage rec {
     sepaxml
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   pythonImportsCheck = [ "fints" ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
```
python3.13-fints> _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ python3.13-fints> /nix/store/gkspnzkgarw4qvbl4670p3jcbgg6psrg-python3-3.13.6/lib/python3.13/socketserver.py:457: in __init__
python3.13-fints>     self.server_bind()
python3.13-fints> /nix/store/gkspnzkgarw4qvbl4670p3jcbgg6psrg-python3-3.13.6/lib/python3.13/http/server.py:136: in server_bind
python3.13-fints>     socketserver.TCPServer.server_bind(self)
python3.13-fints> _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
python3.13-fints>
python3.13-fints> self = <http.server.HTTPServer object at 0x10e9df4d0>
python3.13-fints>
python3.13-fints>     def server_bind(self):
python3.13-fints>         """Called by constructor to bind the socket.
python3.13-fints>
python3.13-fints>         May be overridden.
python3.13-fints>
python3.13-fints>         """
python3.13-fints>         if self.allow_reuse_address and hasattr(socket, "SO_REUSEADDR"):
python3.13-fints>             self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
python3.13-fints>         # Since Linux 6.12.9, SO_REUSEPORT is not allowed
python3.13-fints>         # on other address families than AF_INET/AF_INET6.
python3.13-fints>         if (
python3.13-fints>             self.allow_reuse_port and hasattr(socket, "SO_REUSEPORT")
python3.13-fints>             and self.address_family in (socket.AF_INET, socket.AF_INET6)
python3.13-fints>         ):
python3.13-fints>             self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
python3.13-fints> >       self.socket.bind(self.server_address)
python3.13-fints> E       PermissionError: [Errno 1] Operation not permitted
python3.13-fints>
python3.13-fints> /nix/store/gkspnzkgarw4qvbl4670p3jcbgg6psrg-python3-3.13.6/lib/python3.13/socketserver.py:478: PermissionError
python3.13-fints> =============================== warnings summary ===============================
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
