### PR TITLE
tageditor: switch to using Qt6

### DIFF
--- a/pkgs/by-name/ta/tageditor/package.nix
+++ b/pkgs/by-name/ta/tageditor/package.nix
@@ -7,8 +7,8 @@
   cpp-utilities,
   mp4v2,
   libid3tag,
-  libsForQt5,
-  qt5,
+  kdePackages,
+  qt6,
   tagparser,
 }:
 
@@ -26,19 +26,24 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     cmake
-    qt5.wrapQtAppsHook
+    qt6.wrapQtAppsHook
   ];
 
   buildInputs = [
     mp4v2
     libid3tag
-    qt5.qtbase
-    qt5.qttools
-    qt5.qtx11extras
-    qt5.qtwebengine
     cpp-utilities
-    libsForQt5.qtutilities
+    kdePackages.qtutilities
+    qt6.qtbase
+    qt6.qttools
+    qt6.qtwebengine
     tagparser
+  ];
+
+  cmakeFlags = [
+    "-DQT_PACKAGE_PREFIX=Qt6"
+    "-DQt6_DIR=${qt6.qtbase}/lib/cmake/Qt6"
+    "-DQt6WebEngineWidgets_DIR=${qt6.qtwebengine}/lib/cmake/Qt6WebEngineWidgets"
   ];
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''


### PR DESCRIPTION
tageditor supports both Qt5 and Qt6, but our package only uses Qt5, and the recent [QtWebEngine insecure deprecation][deprecation] means that it now fails to build.

[deprecation]: https://github.com/NixOS/nixpkgs/pull/435067

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
