### PR TITLE
nixos/photoprism: add run config options

### DIFF
--- a/nixos/modules/services/web-apps/photoprism.nix
+++ b/nixos/modules/services/web-apps/photoprism.nix
@@ -81,6 +81,18 @@ in
       '';
     };
 
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "photoprism";
+      description = "User under which photoprism runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "photoprism";
+      description = "Group under which photoprism runs.";
+    };
+
     package = lib.mkPackageOption pkgs "photoprism" { };
 
     settings = lib.mkOption {
@@ -102,11 +114,11 @@ in
 
       serviceConfig = {
         Restart = "on-failure";
-        User = "photoprism";
-        Group = "photoprism";
+        User = cfg.user;
+        Group = cfg.group;
         DynamicUser = true;
         StateDirectory = "photoprism";
-        WorkingDirectory = "/var/lib/photoprism";
+        WorkingDirectory = cfg.storagePath;
         RuntimeDirectory = "photoprism";
         ReadWritePaths = [
           cfg.originalsPath


### PR DESCRIPTION
Added photoprism service config options for the user and group, and fixed serviceConfig to use the user specified path.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
