### PR TITLE
pulumi: 3.190.0 -> 3.192.0

### DIFF
--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -156,18 +156,17 @@ buildGoModule rec {
         version = "v${version}";
         command = "PULUMI_SKIP_UPDATE_CHECK=1 pulumi version";
       };
+
       # Test building packages that reuse our version and src.
       inherit (pulumiPackages) pulumi-go pulumi-nodejs pulumi-python;
-      # Pulumi currently requires protobuf4, but Nixpkgs defaults to a newer
-      # version. Test that we can actually build the package with protobuf4.
-      # https://github.com/pulumi/pulumi/issues/16828
-      # https://github.com/NixOS/nixpkgs/issues/351751#issuecomment-2462163436
-      pythonPackage =
+      pythonPackage = python3Packages.pulumi;
+      pythonPackageProtobuf5 =
         (python3Packages.overrideScope (
           final: _: {
-            protobuf = final.protobuf4;
+            protobuf = final.protobuf5;
           }
         )).pulumi;
+
       pulumiTestHookShellcheck = testers.shellcheck {
         name = "pulumi-test-hook-shellcheck";
         src = ./extra/pulumi-test-hook.sh;

--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -17,18 +17,18 @@
 }:
 buildGoModule rec {
   pname = "pulumi";
-  version = "3.190.0";
+  version = "3.192.0";
 
   src = fetchFromGitHub {
     owner = "pulumi";
     repo = "pulumi";
     tag = "v${version}";
-    hash = "sha256-n4YjJJZNPRjvR5WuDO3+bCvKxDrmK7VBbS6E6RP0C84=";
+    hash = "sha256-rcDXC+xlUa67afuXvmEv8UNsYWBvQQ0P4httdtdcrh4=";
     # Some tests rely on checkout directory name
     name = "pulumi";
   };
 
-  vendorHash = "sha256-ewVZNgnW7JbX0VOU14Ipo7EBkj8evOoXWjf9yLOmJF8=";
+  vendorHash = "sha256-BaFw8EnPd2GPA/p9wm8XpVy/iE8gqbteRnMQC8Z4NHQ=";
 
   sourceRoot = "${src.name}/pkg";
 
@@ -68,6 +68,10 @@ buildGoModule rec {
         # Seems to require TTY.
         "TestProgressEvents"
 
+        # Flaky; upstream “fixed” it by increasing timeout.
+        # https://github.com/pulumi/pulumi/pull/20116
+        "TestAnalyzerCancellation"
+
         # Tries to clone repo: https://github.com/pulumi/test-repo.git
         "TestValidateRelativeDirectory"
         "TestRepoLookup"
@@ -83,6 +87,8 @@ buildGoModule rec {
         "TestPulumiNewWithoutTemplateSupport"
         "TestGeneratingProjectWithAIPromptSucceeds"
         "TestPulumiNewWithRegistryTemplates"
+        "TestRunNewYesNoTemplate"
+        "TestRunNewYesWithTemplate"
 
         # Connects to https://api.pulumi.com/…
         "TestGetLatestPluginIncludedVersion"

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-go/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-go/package.nix
@@ -9,7 +9,7 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/sdk/go/pulumi-language-go";
 
-  vendorHash = "sha256-SfnGZyHuhgj277DrRqr8TkKE+ZwnPKBFu/7EcPS4OhE=";
+  vendorHash = "sha256-jwsdMSLDn2PNJFIIVhqwBLH7acFTOFLPgVNMKbI5DZE=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-nodejs/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-nodejs/package.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/sdk/nodejs/cmd/pulumi-language-nodejs";
 
-  vendorHash = "sha256-Mf/SsRRDlm/TuSOksLV8f7H7xiT6fkHWyH6fJFo5fCc=";
+  vendorHash = "sha256-Q5Pk2f3EAiM4oit1vhc+PMEuMxdbrKAue3e0pnrZw2c=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-python/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-python/package.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/sdk/python/cmd/pulumi-language-python";
 
-  vendorHash = "sha256-cpmB1Vmi8JAh+OKzoZ/x/AxB4uxH95laSo0uBGrj3FQ=";
+  vendorHash = "sha256-BfkjDesPdPDV2uILYaMJFIvaEBKT15ukwaReAL3yziw=";
 
   ldflags = [
     "-s"

--- a/pkgs/development/python-modules/pulumi/default.nix
+++ b/pkgs/development/python-modules/pulumi/default.nix
@@ -54,6 +54,7 @@ buildPythonPackage {
   ];
 
   pythonRelaxDeps = [
+    "protobuf"
     "grpcio"
     "pip"
     "semver"
@@ -66,11 +67,20 @@ buildPythonPackage {
     pulumi-python
   ];
 
+  disabledTestPaths = [
+    # TODO: remove disabledTestPaths once the test is fixed upstream.
+    # https://github.com/pulumi/pulumi/pull/19080#discussion_r2309611222
+    "lib/test/provider/experimental/test_property_value.py::test_nesting"
+  ];
+
   # https://github.com/pulumi/pulumi/blob/0acaf8060640fdd892abccf1ce7435cd6aae69fe/sdk/python/scripts/test_fast.sh#L10-L11
   # https://github.com/pulumi/pulumi/blob/0acaf8060640fdd892abccf1ce7435cd6aae69fe/sdk/python/scripts/test_fast.sh#L16
   installCheckPhase = ''
     runHook preInstallCheck
-    ${python.executable} -m pytest --junit-xml= --ignore=lib/test/automation lib/test
+    declare -a _disabledTestPathsArray
+    concatTo _disabledTestPathsArray disabledTestPaths
+    ${python.executable} -m pytest --junit-xml= --ignore=lib/test/automation lib/test \
+      "''${_disabledTestPathsArray[@]/#/--deselect=}"
     pushd lib/test_with_mocks
     ${python.executable} -m pytest --junit-xml=
     popd
@@ -86,8 +96,6 @@ buildPythonPackage {
     description = "Modern Infrastructure as Code. Any cloud, any language";
     homepage = "https://www.pulumi.com";
     license = lib.licenses.asl20;
-    # https://github.com/pulumi/pulumi/issues/16828
-    broken = lib.versionAtLeast protobuf.version "5";
     maintainers = with lib.maintainers; [
       teto
       tie


### PR DESCRIPTION
https://github.com/pulumi/pulumi/compare/v3.190.0...v3.192.0

Also fixes Python package that works with protobuf5 after [v3.190.0](https://github.com/NixOS/nixpkgs/pull/430029) (see https://github.com/pulumi/pulumi/issues/16828).

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
