### PR TITLE
vivictpp: 1.1.0 -> 1.3.0

### DIFF
--- a/pkgs/by-name/vi/vivictpp/package.nix
+++ b/pkgs/by-name/vi/vivictpp/package.nix
@@ -16,18 +16,22 @@
   ffmpeg,
   cacert,
   zlib,
+  writeShellScript,
+  nix-update,
 }:
 
 let
-  version = "1.1.0";
+  version = "1.3.0";
   withSubprojects = stdenv.mkDerivation {
-    name = "sources-with-subprojects";
+    pname = "sources-with-subprojects";
+    inherit version;
 
     src = fetchFromGitHub {
       owner = "vivictorg";
       repo = "vivictpp";
-      rev = "v${version}";
-      hash = "sha256-ScuCOmcK714YXEHncizwj6EWdiNIJA1xRMn5gfmg4K4=";
+      tag = "v${version}";
+      fetchSubmodules = true;
+      hash = "sha256-yzUgLZbqEzyJINWQUTC/j33XbjSXP1vpDlgiKv6Jx9Q=";
     };
 
     nativeBuildInputs = [
@@ -45,7 +49,7 @@ let
     '';
 
     outputHashMode = "recursive";
-    outputHash = "sha256-/6nuTKjQEXfJlHkTkeX/A4PeGb8SOk6Q801gjx1SB6M=";
+    outputHash = "sha256-PtOb47QOffGje1U8Tle9AQon7ZCgMp/lITPAfM9/wr4=";
   };
 in
 stdenv.mkDerivation {
@@ -76,6 +80,11 @@ stdenv.mkDerivation {
 
   preConfigure = ''
     patchShebangs .
+  '';
+
+  passthru.updateScript = writeShellScript "update-vivictpp" ''
+    ${lib.getExe nix-update} vivictpp.src
+    ${lib.getExe nix-update} vivictpp --version skip
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/vi/vivictpp/package.nix
+++ b/pkgs/by-name/vi/vivictpp/package.nix
@@ -87,12 +87,12 @@ stdenv.mkDerivation {
     ${lib.getExe nix-update} vivictpp --version skip
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Easy to use tool for subjective comparison of the visual quality of different encodings of the same video source";
     homepage = "https://github.com/vivictorg/vivictpp";
-    license = licenses.gpl2Plus;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ tilpner ];
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ tilpner ];
     mainProgram = "vivictpp";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/vivictorg/vivictpp/blob/main/CHANGELOG.md#130---2025-06-28
https://github.com/vivictorg/vivictpp/releases/tag/v1.3.0
https://github.com/vivictorg/vivictpp/compare/v1.1.0...v1.3.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
