### PR TITLE
python3Packages.syne-tune: init at 0.14.2

### DIFF
--- a/pkgs/development/python-modules/syne-tune/default.nix
+++ b/pkgs/development/python-modules/syne-tune/default.nix
@@ -1,0 +1,146 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  dill,
+  numpy,
+  pandas,
+  sortedcontainers,
+  typing-extensions,
+
+  # optional-dependencies
+  autograd,
+  botorch,
+  # configspace,
+  fastparquet,
+  h5py,
+  huggingface-hub,
+  matplotlib,
+  onnxruntime,
+  pymoo,
+  pyyaml,
+  scikit-learn,
+  scipy,
+  # smac,
+  statsmodels,
+  swig,
+  xgboost,
+  # yahpo-gym,
+
+  # tests
+  pytestCheckHook,
+  pytest-timeout,
+  ray,
+  writableTmpDirAsHomeHook,
+}:
+buildPythonPackage rec {
+  pname = "syne-tune";
+  version = "0.14.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "syne-tune";
+    repo = "syne-tune";
+    tag = "v${version}";
+    hash = "sha256-51QyfJ0XOcXTeE95YOhtUmhat23joaEYvUnk7hYfksY=";
+  };
+
+  postPatch = ''
+    substituteInPlace syne_tune/optimizer/schedulers/synchronous/hyperband.py \
+     --replace-fail 'metric_val=np.NAN' 'metric_val=np.nan'
+    substituteInPlace syne_tune/optimizer/schedulers/synchronous/dehb.py \
+     --replace-fail 'result_failed.metric_val = np.NAN' 'result_failed.metric_val = np.nan'
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  pythonRelaxDeps = [
+    "numpy"
+  ];
+
+  dependencies = [
+    dill
+    numpy
+    pandas
+    sortedcontainers
+    typing-extensions
+  ];
+
+  optional-dependencies = lib.fix (self: {
+    blackbox-repository = [
+      fastparquet
+      h5py
+      huggingface-hub
+      numpy
+      pandas
+      scikit-learn
+      xgboost
+    ];
+    bore = [
+      scikit-learn
+      xgboost
+    ];
+    botorch = [ botorch ];
+    gpsearchers = [
+      autograd
+      scipy
+    ];
+    kde = [ statsmodels ];
+    moo = [
+      pymoo
+      scipy
+    ];
+    sklearn = [ scikit-learn ];
+    # smac = [ smac swig ]; # smac unavailable on nixpkgs
+    visual = [ matplotlib ];
+    # yahpo = [ configspace onnxruntime pandas pyyaml yahpo-gym ]; # yahpo-gym unavailable on nixpkgs
+  });
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-timeout
+    ray
+    writableTmpDirAsHomeHook
+  ]
+  ++ ray.optional-dependencies.tune
+  ++ optional-dependencies.blackbox-repository
+  ++ optional-dependencies.bore
+  ++ optional-dependencies.botorch
+  ++ optional-dependencies.gpsearchers
+  ++ optional-dependencies.kde
+  ++ optional-dependencies.sklearn;
+
+  disabledTests = [
+    # NameError: name 'HV' is not defined
+    # these require pkg `pymoo` and adding `pymoo` raises:
+    # setuptools.errors.PackageDiscoveryError: Multiple top-level packages discovered in a flat-layout: ['cma', 'notebooks'].
+    "test_append_hypervolume_indicator"
+    "test_hypervolume"
+    "test_hypervolume_progress"
+    "test_hypervolume_simple"
+  ];
+
+  disabledTestPaths = [
+    # legacy test
+    "tst/schedulers/test_legacy_schedulers_api.py"
+  ];
+
+  pythonImportsCheck = [
+    "syne_tune"
+  ];
+
+  meta = {
+    description = "Large scale asynchronous hyperparameter and architecture optimization library";
+    homepage = "https://github.com/syne-tune/syne-tune";
+    changelog = "https://github.com/syne-tune/syne-tune/releases/tag/${src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ daspk04 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17740,6 +17740,8 @@ self: super: with self; {
     }
   );
 
+  syne-tune = callPackage ../development/python-modules/syne-tune { };
+
   synergy = callPackage ../development/python-modules/synergy { };
 
   synology-srm = callPackage ../development/python-modules/synology-srm { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Syne Tune is a python library for large-scale hyperparameter optimization (HPO).
Homepage: https://github.com/syne-tune/syne-tune
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
