### PR TITLE
kdePackages.breeze-icons: sort generated qrc for reproducibility

### DIFF
--- a/pkgs/kde/frameworks/breeze-icons/default.nix
+++ b/pkgs/kde/frameworks/breeze-icons/default.nix
@@ -12,6 +12,12 @@ mkKdeDerivation {
     libxml2
   ];
 
+  patches = [
+    # https://bugs.kde.org/show_bug.cgi?id=508718
+    # https://invent.kde.org/frameworks/breeze-icons/-/merge_requests/496
+    ./reproducible-builds.patch
+  ];
+
   # This package contains an SVG icon theme and an API forcing its use
   extraPropagatedBuildInputs = [
     qtsvg

--- a/pkgs/kde/frameworks/breeze-icons/reproducible-builds.patch
+++ b/pkgs/kde/frameworks/breeze-icons/reproducible-builds.patch
@@ -1,0 +1,61 @@
+diff --git a/src/tools/qrcAlias.cpp b/src/tools/qrcAlias.cpp
+index 86b648ba..ac34a168 100644
+--- a/src/tools/qrcAlias.cpp
++++ b/src/tools/qrcAlias.cpp
+@@ -136,16 +136,10 @@ static QString resolveWindowsGitLink(const QString &path, const QString &fileNam
+  */
+ static void generateQRCAndCheckInputs(const QStringList &indirs, const QString &outfile)
+ {
+-    QFile out(outfile);
+-    if (!out.open(QIODevice::WriteOnly)) {
+-        qFatal() << "Failed to create" << outfile;
+-    }
+-    out.write("<!DOCTYPE RCC><RCC version=\"1.0\">\n");
+-    out.write("<qresource>\n");
+-
+     // loop over the inputs, remember if we do look at generated stuff for checks
+     bool generatedIcons = false;
+     QSet<QString> checkedFiles, filesInResource;
++    QList<QString> lines;
+     bool themeFileFound = false, icons24Seen = false;
+     for (const auto &indir : indirs) {
+         // go to input dir to have proper relative paths
+@@ -155,7 +149,7 @@ static void generateQRCAndCheckInputs(const QStringList &indirs, const QString &
+ 
+         // we look at all interesting files in the indir and create a qrc with resolved symlinks
+         // we need QDir::System to get broken links for checking
+-        QDirIterator it(QStringLiteral("."), {QStringLiteral("*.theme"), QStringLiteral("*.svg")}, QDir::Files | QDir::System, QDirIterator::Subdirectories);
++	QDirIterator it(QStringLiteral("."), {QStringLiteral("*.theme"), QStringLiteral("*.svg")}, QDir::Files | QDir::System, QDirIterator::Subdirectories);
+         while (it.hasNext()) {
+             // ensure nice path without ./ and Co.
+             const auto file = QDir::current().relativeFilePath(it.next());
+@@ -217,8 +211,7 @@ static void generateQRCAndCheckInputs(const QStringList &indirs, const QString &
+                 themeFileFound = true;
+             }
+ 
+-            // write the one alias to file entry
+-            out.write(QStringLiteral("    <file alias=\"%1\">%2</file>\n").arg(file, fullPath).toUtf8());
++            lines.append(QStringLiteral("    <file alias=\"%1\">%2</file>\n").arg(file, fullPath));
+ 
+             // remember for checks below
+             filesInResource.insert(file);
+@@ -231,6 +224,19 @@ static void generateQRCAndCheckInputs(const QStringList &indirs, const QString &
+         generatedIcons = true;
+     }
+ 
++    // Write the resource file
++    QFile out(outfile);
++    if (!out.open(QIODevice::WriteOnly)) {
++        qFatal() << "Failed to create" << outfile;
++    }
++    out.write("<!DOCTYPE RCC><RCC version=\"1.0\">\n");
++    out.write("<qresource>\n");
++
++    std::sort(lines.begin(), lines.end());
++    for (const auto &line : lines) {
++        out.write(line.toUtf8());
++    }
++
+     out.write("</qresource>\n");
+     out.write("</RCC>\n");
+ 


### PR DESCRIPTION
Fixes #409153

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
