### PR TITLE
python3Packages.ansible-runner: skip failing tests

### DIFF
--- a/pkgs/development/python-modules/ansible-runner/default.nix
+++ b/pkgs/development/python-modules/ansible-runner/default.nix
@@ -17,6 +17,7 @@
   importlib-metadata,
 
   # tests
+  addBinToPathHook,
   ansible-core,
   glibcLocales,
   mock,
@@ -26,6 +27,7 @@
   pytest-xdist,
   pytestCheckHook,
   versionCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
@@ -60,6 +62,7 @@ buildPythonPackage rec {
   ++ lib.optionals (pythonOlder "3.10") [ importlib-metadata ];
 
   nativeCheckInputs = [
+    addBinToPathHook
     ansible-core # required to place ansible CLI onto the PATH in tests
     glibcLocales
     mock
@@ -69,12 +72,11 @@ buildPythonPackage rec {
     pytest-xdist
     pytestCheckHook
     versionCheckHook
+    writableTmpDirAsHomeHook
   ];
   versionCheckProgramArg = "--version";
 
   preCheck = ''
-    export HOME=$(mktemp -d)
-    export PATH="$PATH:$out/bin";
     # avoid coverage flags
     rm pytest.ini
   '';
@@ -90,8 +92,10 @@ buildPythonPackage rec {
     # Assertion error
     "test_callback_plugin_censoring_does_not_overwrite"
     "test_get_role_list"
+    "test_include_role_events"
     "test_include_role_from_collection_events"
     "test_module_level_no_log"
+    "test_output_when_given_invalid_playbook"
     "test_resolved_actions"
   ];
 


### PR DESCRIPTION
## Things done

Closes #438172

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
