### PR TITLE
lvm2: make manpage generation reproducible

### DIFF
--- a/pkgs/os-specific/linux/lvm2/common.nix
+++ b/pkgs/os-specific/linux/lvm2/common.nix
@@ -128,6 +128,8 @@ stdenv.mkDerivation rec {
       }
     ))
     ./fix-stdio-usage.patch
+    # https://gitlab.com/lvmteam/lvm2/-/merge_requests/33
+    ./fix-manpage-reproducibility.patch
   ];
 
   doCheck = false; # requires root

--- a/pkgs/os-specific/linux/lvm2/fix-manpage-reproducibility.patch
+++ b/pkgs/os-specific/linux/lvm2/fix-manpage-reproducibility.patch
@@ -1,0 +1,31 @@
+commit 950f219ed287358df8c128f7e22989177a8de47c
+Author: Arnout Engelen <arnout@bzzt.net>
+Date:   Mon Aug 25 15:55:44 2025 +0200
+
+    man: simplify vmautoactivation(7)
+    
+    Previously this was hard-coded to: "Autoactivation commands use a number
+    of temp files in /run/lvm (with the expectation that /run is cleared
+    between boots.)"
+    
+    Since c1bfc8737f08bf7558b2d788e9756f895cd9eaaa it was made more generic,
+    but on some systems this logic leads to "Autoactivation commands use a
+    number of temp files in /run/lvm (with the expectation that /var/run
+    is cleared between boots)." which I'd say adds more confusion than it
+    solves.
+
+diff --git a/man/lvmautoactivation.7_main b/man/lvmautoactivation.7_main
+index e55943b29..9d429055c 100644
+--- a/man/lvmautoactivation.7_main
++++ b/man/lvmautoactivation.7_main
+@@ -175,9 +175,7 @@ is reserved for udev output.)
+ .
+ Autoactivation commands use a number of temp files in
+ .I #DEFAULT_RUN_DIR#
+-(with the expectation that
+-.I #DEFAULT_PID_DIR#
+-is cleared between boots).
++(with the expectation that it is cleared between boots).
+ .
+ .TP
+ .B pvs_online


### PR DESCRIPTION
Fixes #434933

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
