### PR TITLE
lib/types: fix either lazy value regression in case of non-matching v…

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -177,7 +177,13 @@
 ### Deprecations {#sec-nixpkgs-release-25.11-lib-deprecations}
 
 - Create the first release note entry in this section!
+- `types.either` silently accepted mismatching types when used in `freeformType`. Module maintainers should fix the used type
+  In most cases wrapping `either` with `attrsOf` should be sufficient.
 
+  Since types.either was used to bootstrap other types. This also affects the following types:
+  - `oneOf`
+  - `number`
+  - `numbers.*`
 
 ### Additions and Improvements {#sec-nixpkgs-release-25.11-lib-additions-improvements}
 

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -257,6 +257,10 @@ checkConfigError 'A definition for option .* is not of type.*between.*-21 and 43
 # types.either
 checkConfigOutput '^42$' config.value ./declare-either.nix ./define-value-int-positive.nix
 checkConfigOutput '^"24"$' config.value ./declare-either.nix ./define-value-string.nix
+
+# Check regression detected in https://github.com/NixOS/nixpkgs/issues/438459
+# Can be removed after 26.05 release.
+checkConfigOutput '^"bar"$' config.foo ./freeform-either.nix
 # types.oneOf
 checkConfigOutput '^42$' config.value ./declare-oneOf.nix ./define-value-int-positive.nix
 checkConfigOutput '^\[\]$' config.value ./declare-oneOf.nix ./define-value-list.nix

--- a/lib/tests/modules/freeform-either.nix
+++ b/lib/tests/modules/freeform-either.nix
@@ -1,0 +1,7 @@
+{ lib, ... }:
+{
+  # Proper type would be attrsOf (either int str)
+  # This checks backwards compatibility for the incorrect usage of either
+  freeformType = lib.types.either lib.types.int lib.types.str;
+  foo = "bar";
+}


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/438459 a regression introduced by #391544

cc @eclairevoyant feel free to test and approve if this solves your problem.

Example of the warning

```nix-repl
nix-repl> nixos.config.services.printing.cups-pdf.instances.pdf.settings
evaluation warning: See https://github.com/NixOS/nixpkgs/issues/438825. If you are the maintainer of this module please fix the followin issue:
                    The option `services.printing.cups-pdf.instances.pdf.settings` is neither a value of type `signed integer or string or absolute path` nor `package`, Definition values:
                    - In `example.nix':
                        {
                          UserUMask = "0033";
                        }
{
  AnonDirName = "/var/spool/cups-pdf-pdf/anonymous";
  Anonuser = "root";
  GhostScript = "/nix/store/lin169x3s56razcp2j6z31nic7h1m07s-ghostscript-with-X-10.05.1/bin/gs";
  Out = "/var/spool/cups-pdf-pdf/users/\${USER}";
  Spool = "/var/spool/cups-pdf-pdf/spool";
  UserUMask = "0033";
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
