### PR TITLE
volk: 3.1.2 -> 3.2.0

### DIFF
--- a/pkgs/by-name/vo/volk/package.nix
+++ b/pkgs/by-name/vo/volk/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   python3,
   enableModTool ? true,
@@ -10,22 +9,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "volk";
-  version = "3.1.2";
+  version = "3.2.0";
 
   src = fetchFromGitHub {
     owner = "gnuradio";
     repo = "volk";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-R1FT5sbl0fAAl6YIX5aD5CiQ/AjZkCSDPPQPiuy4WBY=";
+    hash = "sha256-9bURoGyjdNoKCcgGvZL9VygQqUQxOrwthp154Was2/s=";
     fetchSubmodules = true;
   };
-  patches = [
-    # https://github.com/gnuradio/volk/pull/766
-    (fetchpatch {
-      url = "https://github.com/gnuradio/volk/commit/e46771a739658b5483c25ee1203587bf07468c4d.patch";
-      hash = "sha256-33V6lA4Ch50o2E7HPUMQ2NPqHXx/i6FUbz3vIaQa9Wc=";
-    })
-  ];
 
   cmakeFlags = [ (lib.cmakeBool "ENABLE_MODTOOL" enableModTool) ];
 


### PR DESCRIPTION
Diff: https://github.com/gnuradio/volk/compare/v3.1.2...v3.2.0

Closes #438486

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
