### PR TITLE
skrooge: switch to qt6

### DIFF
--- a/pkgs/applications/office/skrooge/default.nix
+++ b/pkgs/applications/office/skrooge/default.nix
@@ -1,35 +1,35 @@
 {
-  mkDerivation,
+  stdenv,
   lib,
   fetchurl,
   cmake,
   extra-cmake-modules,
+  pkg-config,
   qtwebengine,
-  qtscript,
+  qt5compat,
   grantlee,
-  qtxmlpatterns,
+  wrapQtAppsHook,
   kxmlgui,
   kwallet,
   kparts,
   kdoctools,
   kjobwidgets,
-  kdesignerplugin,
   kiconthemes,
   knewstuff,
   sqlcipher,
-  qca-qt5,
-  kactivities,
+  qca,
+  plasma-activities,
   karchive,
   kguiaddons,
   knotifyconfig,
   krunner,
+  ktexttemplate,
   kwindowsystem,
   libofx,
   shared-mime-info,
-  qtquickcontrols2,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "skrooge";
   version = "25.4.0";
 
@@ -41,32 +41,32 @@ mkDerivation rec {
   nativeBuildInputs = [
     cmake
     extra-cmake-modules
+    pkg-config
     kdoctools
     shared-mime-info
+    wrapQtAppsHook
   ];
 
   buildInputs = [
     qtwebengine
-    qtscript
+    qt5compat
     grantlee
     kxmlgui
     kwallet
     kparts
-    qtxmlpatterns
     kjobwidgets
-    kdesignerplugin
     kiconthemes
     knewstuff
     sqlcipher
-    qca-qt5
-    kactivities
+    qca
+    plasma-activities
     karchive
     kguiaddons
     knotifyconfig
     krunner
+    ktexttemplate
     kwindowsystem
     libofx
-    qtquickcontrols2
   ];
 
   # SKG_DESIGNER must be used to generate the needed library for QtDesigner.
@@ -76,6 +76,7 @@ mkDerivation rec {
     "-DSKG_DESIGNER=OFF"
     "-DSKG_WEBENGINE=ON"
     "-DSKG_WEBKIT=OFF"
+    "-DBUILD_WITH_QT6=ON"
     "-DBUILD_TESTS=ON"
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13073,7 +13073,7 @@ with pkgs;
 
   super-slicer-latest = super-slicer.latest;
 
-  skrooge = libsForQt5.callPackage ../applications/office/skrooge { };
+  skrooge = kdePackages.callPackage ../applications/office/skrooge { };
 
   soci = callPackage ../development/libraries/soci { };
 


### PR DESCRIPTION
Switch from qt5 to qt6. Fixes depending on the insecure qt5 qtwebengine.

I tested that opening, editing and saving a file still works.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
