### PR TITLE
python3Packages.opensearch-py: skip failing tests

### DIFF
--- a/pkgs/development/python-modules/opensearch-py/default.nix
+++ b/pkgs/development/python-modules/opensearch-py/default.nix
@@ -9,11 +9,11 @@
 
   # dependencies
   certifi,
+  events,
   python-dateutil,
   requests,
-  six,
+  # six,
   urllib3,
-  events,
 
   # optional-dependencies
   aiohttp,
@@ -22,6 +22,7 @@
   botocore,
   mock,
   pytest-asyncio,
+  pytest-cov-stub,
   pytest-mock,
   pytestCheckHook,
   pyyaml,
@@ -40,15 +41,15 @@ buildPythonPackage rec {
     hash = "sha256-IAEh+rB26Zqv7j5g2YIRZRCAtFbBngoh+w8Z4e2bY+M=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     certifi
+    events
     python-dateutil
     requests
-    six
+    # six
     urllib3
-    events
   ];
 
   optional-dependencies.async = [ aiohttp ];
@@ -57,10 +58,11 @@ buildPythonPackage rec {
     botocore
     mock
     pytest-asyncio
+    pytest-cov-stub
     pytest-mock
     pytestCheckHook
-    pyyaml
     pytz
+    pyyaml
   ]
   ++ optional-dependencies.async;
 
@@ -82,6 +84,12 @@ buildPythonPackage rec {
     # Failing tests, issue opened at https://github.com/opensearch-project/opensearch-py/issues/849
     "test_basicauth_in_request_session"
     "test_callable_in_request_session"
+
+    # fixture 'event_loop' not found
+    "test_sniff_after_n_seconds"
+    "test_sniff_on_start_close_unlocks_async_calls"
+    "test_sniff_on_start_error_if_no_sniffed_hosts"
+    "test_sniff_on_start_waits_for_sniff_to_complete"
   ]
   ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86) [
     # Flaky tests: OSError: [Errno 48] Address already in use


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

cc @mcwitt

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
