### PR TITLE
easyloggingpp: fix build, cleanup, run checks

### DIFF
--- a/pkgs/by-name/ea/easyloggingpp/package.nix
+++ b/pkgs/by-name/ea/easyloggingpp/package.nix
@@ -22,11 +22,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ gtest ];
+  nativeCheckInputs = [ gtest ];
 
-  cmakeFlags = [ (lib.cmakeBool "test" true) ];
+  cmakeFlags = [ (lib.cmakeBool "test" finalAttrs.doCheck) ];
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isLinux " -pthread";
+
+  doCheck = true;
+
+  env.GTEST_FILTER =
+    # https://github.com/abumq/easyloggingpp/issues/816
+    "-CommandLineArgsTest.LoggingFlagsArg";
 
   meta = {
     description = "C++ logging library";

--- a/pkgs/by-name/ea/easyloggingpp/package.nix
+++ b/pkgs/by-name/ea/easyloggingpp/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ gtest ];
   cmakeFlags = [ "-Dtest=ON" ];
-  env.NIX_CFLAGS_COMPILE = "-std=c++14" + lib.optionalString stdenv.hostPlatform.isLinux " -pthread";
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isLinux " -pthread";
   postInstall = ''
     mkdir -p $out/include
     cp ../src/easylogging++.cc $out/include

--- a/pkgs/by-name/ea/easyloggingpp/package.nix
+++ b/pkgs/by-name/ea/easyloggingpp/package.nix
@@ -8,25 +8,32 @@
   cmake,
   gtest,
 }:
-stdenv.mkDerivation rec {
+
+stdenv.mkDerivation (finalAttrs: {
   pname = "easyloggingpp";
   version = "9.97.1";
+
   src = fetchFromGitHub {
-    owner = "amrayn";
+    owner = "abumq";
     repo = "easyloggingpp";
-    rev = "v${version}";
-    sha256 = "sha256-R4NdwsUywgJoK5E/OdZXFds6iBKOsMa0E+2PDdQbV6E=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-R4NdwsUywgJoK5E/OdZXFds6iBKOsMa0E+2PDdQbV6E=";
   };
 
   nativeBuildInputs = [ cmake ];
+
   buildInputs = [ gtest ];
-  cmakeFlags = [ "-Dtest=ON" ];
+
+  cmakeFlags = [ (lib.cmakeBool "test" true) ];
+
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isLinux " -pthread";
+
   meta = {
     description = "C++ logging library";
-    homepage = "https://github.com/amrayn/easyloggingpp";
+    homepage = "https://github.com/abumq/easyloggingpp";
+    changelog = "https://github.com/abumq/easyloggingpp/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ acowley ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/ea/easyloggingpp/package.nix
+++ b/pkgs/by-name/ea/easyloggingpp/package.nix
@@ -22,10 +22,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ gtest ];
   cmakeFlags = [ "-Dtest=ON" ];
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isLinux " -pthread";
-  postInstall = ''
-    mkdir -p $out/include
-    cp ../src/easylogging++.cc $out/include
-  '';
   meta = {
     description = "C++ logging library";
     homepage = "https://github.com/amrayn/easyloggingpp";


### PR DESCRIPTION
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `d6cfed8704295245cf82c2592dfa71f09182bd4d`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>easyloggingpp</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc