### PR TITLE
Partially fix cross compilation for Zig

### DIFF
--- a/doc/hooks/zig.section.md
+++ b/doc/hooks/zig.section.md
@@ -10,13 +10,13 @@ In Nixpkgs, `zig.hook` overrides the default build, check and install phases.
 {
   lib,
   stdenv,
-  zig,
+  pkgsBuildHost,
 }:
 
 stdenv.mkDerivation {
   # . . .
 
-  nativeBuildInputs = [ zig.hook ];
+  nativeBuildInputs = [ pkgsBuildHost.zig.hook ];
 
   zigBuildFlags = [ "-Dman-pages=true" ];
 

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -370,6 +370,22 @@ let
         # Handle Android SDK and NDK versions.
         androidSdkVersion = args.androidSdkVersion or null;
         androidNdkVersion = args.androidNdkVersion or null;
+
+        zigTarget =
+          let
+            cpu = final.parsed.cpu.name;
+            os =
+              if final.isMacOS then
+                "macos" # Instead of "darwin"
+              else
+                final.parsed.kernel.name;
+            abi =
+              {
+                "unknown" = "none"; # e.g. x86_64-macos-none
+              }
+              .${final.parsed.abi.name} or final.parsed.abi.name;
+          in
+          args.zigTarget or "${cpu}-${os}-${abi}";
       }
       // (
         let

--- a/pkgs/by-name/nc/ncdu/package.nix
+++ b/pkgs/by-name/nc/ncdu/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
   stdenv,
+  pkgsBuildHost,
   fetchurl,
   ncurses,
   pkg-config,
-  zig_0_14,
   zstd,
   installShellFiles,
   versionCheckHook,
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    zig_0_14.hook
+    pkgsBuildHost.zig_0_14.hook
     installShellFiles
     pkg-config
   ];
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
       defelo
       ryan4yin
     ];
-    inherit (zig_0_14.meta) platforms;
+    inherit (pkgsBuildHost.zig_0_14.meta) platforms;
     mainProgram = "ncdu";
   };
 })

--- a/pkgs/development/compilers/zig/hook.nix
+++ b/pkgs/development/compilers/zig/hook.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  targetPackages,
   makeSetupHook,
   zig,
   stdenv,
@@ -47,7 +48,12 @@ makeSetupHook {
           else
             "-Drelease-safe=true";
       in
-      [
+      lib.optionals (stdenv.hostPlatform.zigTarget != stdenv.targetPlatform.zigTarget) [
+        # FIXME: These break DT_RUNPATH for some reason
+        "-Dtarget=${stdenv.targetPlatform.zigTarget}"
+        "-Ddynamic-linker=$(echo ${targetPackages.stdenv.cc.bintools.dynamicLinker})" # Expands wildcard
+      ]
+      ++ [
         "-Dcpu=baseline"
         releaseType
       ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

See https://github.com/NixOS/nixpkgs/issues/414824#issuecomment-3229795367

- [ ] (Only did for ncdu) `nativeBuildInputs = [ zig_*.hook ];` oops splicing footgun #211340, need to change all of those to `pkgsBuildHost.zig_*.hook`
- [X] `zig_*.hook` should pass a proper `-Dtarget=...`
- [X] `zig_*.hook` should pass a proper `-Ddynamic-linker=...`
- [X] zig doesn't like `*-unknown-linux-{gnu,musl}` and insists on `*-linux-{gnu,musl}`, we need some sort of `*Platform.zigTarget`
- [ ] `darwinSdkVersion` in `zigTarget` or hook
- [ ] `glibc.version` (?) in `zigTarget` or hook
- [ ] `zig build -Dtarget=...` ignores `NIX_LDFLAGS` because it has its own linker? (gives us binaries with improper `DT_RUNPATH`)

This fixes `pkgsStatic.ncdu`, but not other cross (due to the `DT_RUNPATH` problem). It also isn't clean or complete, so marking as draft.

cc @andrewrk, zig team: @figsoda @RossComputerGuy 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
