### PR TITLE
linux-pam: disable audit when cross-compiling from darwin

### DIFF
--- a/pkgs/by-name/li/linux-pam/package.nix
+++ b/pkgs/by-name/li/linux-pam/package.nix
@@ -8,6 +8,7 @@
   gettext,
   ninja,
   audit,
+  linuxHeaders,
   libxcrypt,
   nixosTests,
   meson,
@@ -21,7 +22,10 @@
   docbook_xsl_ns,
   nix-update-script,
   withLogind ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
-  withAudit ? lib.meta.availableOn stdenv.hostPlatform audit,
+  withAudit ?
+    lib.meta.availableOn stdenv.hostPlatform audit
+    # cross-compilation only works from platforms with linux headers
+    && lib.meta.availableOn stdenv.buildPlatform linuxHeaders,
 }:
 
 stdenv.mkDerivation (finalAttrs: {


### PR DESCRIPTION
The `audit` package builds and executes a build-time program that requires linux headers. This obviously can't work on darwin.

There's also no way to mark the `audit` package as broken when cross-compiling from darwin. At least not in a way that would work with `lib.meta.availableOn`, so I think the best we can do is explicitly check for this.

This was broken by https://github.com/NixOS/nixpkgs/pull/432924

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
