### PR TITLE
[Backport release-25.05] img4tool: init at 217; libgeneral: init at 85

### DIFF
--- a/pkgs/by-name/im/img4tool/configure-version.patch
+++ b/pkgs/by-name/im/img4tool/configure-version.patch
@@ -1,0 +1,27 @@
+diff --git a/configure.ac b/configure.ac
+index 66da2bd..86278ec 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1,5 +1,5 @@
+ AC_PREREQ([2.69])
+-AC_INIT([img4tool], m4_esyscmd([git rev-list --count HEAD | tr -d '\n']), [tihmstar@gmail.com])
++AC_INIT([img4tool], [tihmstar@gmail.com])
+ 
+ AC_CANONICAL_SYSTEM
+ AC_CANONICAL_HOST
+@@ -9,11 +9,10 @@ AM_INIT_AUTOMAKE([subdir-objects])
+ AC_CONFIG_HEADERS([config.h])
+ AC_CONFIG_MACRO_DIRS([m4])
+ 
+-
+-AC_DEFINE([VERSION_COMMIT_COUNT], "m4_esyscmd([git rev-list --count HEAD | tr -d '\n'])", [Git commit count])
+-AC_DEFINE([VERSION_COMMIT_SHA], "m4_esyscmd([git rev-parse HEAD | tr -d '\n'])", [Git commit sha])
+-AC_SUBST([VERSION_COMMIT_COUNT], ["m4_esyscmd([git rev-list --count HEAD | tr -d '\n'])"])
+-AC_SUBST([VERSION_COMMIT_SHA], ["m4_esyscmd([git rev-parse HEAD | tr -d '\n'])"])
++AC_ARG_WITH([version-commit-count], [],
++  [VERSION_COMMIT_COUNT="$withval"])
++AC_DEFINE([VERSION_COMMIT_COUNT], ["$VERSION_COMMIT_COUNT"], [Git commit count])
++AC_SUBST([VERSION_COMMIT_COUNT], ["$VERSION_COMMIT_COUNT"])
+ 
+ # Checks for programs.
+ AC_PROG_CXX

--- a/pkgs/by-name/im/img4tool/package.nix
+++ b/pkgs/by-name/im/img4tool/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  clangStdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  libgeneral,
+  libplist,
+  openssl,
+  lzfse,
+  git,
+}:
+clangStdenv.mkDerivation (finalAttrs: {
+  pname = "img4tool";
+  version = "217";
+
+  src = fetchFromGitHub {
+    owner = "tihmstar";
+    repo = "img4tool";
+    tag = finalAttrs.version;
+    hash = "sha256-67Xfq4jEK9juyaSIgVdWygAePZuyb4Yp8mY+6V66+Aw=";
+  };
+
+  # Do not depend on git to calculate version, instead
+  # pass version via configureFlag
+  patches = [ ./configure-version.patch ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    libgeneral
+    libplist
+    lzfse
+    openssl
+  ];
+
+  configureFlags = [
+    "--with-version-commit-count=${finalAttrs.version}"
+  ];
+
+  strictDeps = true;
+
+  meta = {
+    description = "Socket daemon to multiplex connections from and to iOS devices";
+    homepage = "https://github.com/tihmstar/img4tool";
+    license = lib.licenses.lgpl3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ onny ];
+    mainProgram = "img4tool";
+  };
+})

--- a/pkgs/by-name/li/libgeneral/configure-version.patch
+++ b/pkgs/by-name/li/libgeneral/configure-version.patch
@@ -1,0 +1,26 @@
+diff --git a/configure.ac b/configure.ac
+index c214ccd..ab0cdd7 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1,5 +1,5 @@
+ AC_PREREQ([2.69])
+-AC_INIT([libgeneral], m4_esyscmd([git rev-list --count HEAD | tr -d '\n']), [tihmstar@gmail.com])
++AC_INIT([libgeneral], [tihmstar@gmail.com])
+ 
+ AC_CANONICAL_SYSTEM
+ AC_CANONICAL_HOST
+@@ -9,10 +9,10 @@ AM_INIT_AUTOMAKE([subdir-objects])
+ AC_CONFIG_HEADERS([config.h])
+ AC_CONFIG_MACRO_DIRS([m4])
+ 
+-AC_DEFINE([VERSION_COMMIT_COUNT], "m4_esyscmd([git rev-list --count HEAD | tr -d '\n'])", [Git commit count])
+-AC_DEFINE([VERSION_COMMIT_SHA], "m4_esyscmd([git rev-parse HEAD | tr -d '\n'])", [Git commit sha])
+-AC_SUBST([VERSION_COMMIT_COUNT], ["m4_esyscmd([git rev-list --count HEAD | tr -d '\n'])"])
+-AC_SUBST([VERSION_COMMIT_SHA], ["m4_esyscmd([git rev-parse HEAD | tr -d '\n'])"])
++AC_ARG_WITH([version-commit-count], [],
++  [VERSION_COMMIT_COUNT="$withval"])
++AC_DEFINE([VERSION_COMMIT_COUNT], ["$VERSION_COMMIT_COUNT"], [Git commit count])
++AC_SUBST([VERSION_COMMIT_COUNT], ["$VERSION_COMMIT_COUNT"])
+ 
+ # Checks for programs.
+ AC_PROG_CXX([clang++])

--- a/pkgs/by-name/li/libgeneral/package.nix
+++ b/pkgs/by-name/li/libgeneral/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  clangStdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  libimobiledevice,
+  libusb1,
+  avahi,
+}:
+clangStdenv.mkDerivation (finalAttrs: {
+  pname = "libgeneral";
+  version = "84";
+
+  src = fetchFromGitHub {
+    owner = "tihmstar";
+    repo = "libgeneral";
+    tag = finalAttrs.version;
+    hash = "sha256-D6S7Ha7SQvWDGwiJuKh2Y9YOsw2ytxn70ia3llKC034=";
+  };
+
+  # Do not depend on git to calculate version, instead
+  # pass version via configureFlag
+  patches = [ ./configure-version.patch ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  configureFlags = [
+    "--with-version-commit-count=${finalAttrs.version}"
+  ];
+
+  strictDeps = true;
+
+  meta = {
+    description = "Helper library used by usbmuxd2";
+    homepage = "https://github.com/tihmstar/libgeneral";
+    license = lib.licenses.lgpl21;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ onny ];
+  };
+})

--- a/pkgs/by-name/li/libgeneral/package.nix
+++ b/pkgs/by-name/li/libgeneral/package.nix
@@ -10,13 +10,13 @@
 }:
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "libgeneral";
-  version = "84";
+  version = "85";
 
   src = fetchFromGitHub {
     owner = "tihmstar";
     repo = "libgeneral";
     tag = finalAttrs.version;
-    hash = "sha256-D6S7Ha7SQvWDGwiJuKh2Y9YOsw2ytxn70ia3llKC034=";
+    hash = "sha256-bCaAx1PVqT7Fl8IoefupIb6UuHD43clmdtnomF5Vycs=";
   };
 
   # Do not depend on git to calculate version, instead

--- a/pkgs/by-name/us/usbmuxd2/package.nix
+++ b/pkgs/by-name/us/usbmuxd2/package.nix
@@ -9,34 +9,8 @@
   avahi,
   clang,
   git,
+  libgeneral,
 }:
-let
-
-  libgeneral = clangStdenv.mkDerivation rec {
-    pname = "libgeneral";
-    version = "74";
-    src = fetchFromGitHub {
-      owner = "tihmstar";
-      repo = "libgeneral";
-      rev = "refs/tags/${version}";
-      hash = "sha256-6aowcIYssc1xqH6kTi/cpH2F7rgc8+lGC8HgZWYH2w0=";
-      # Leave DotGit so that autoconfigure can read version from git tags
-      leaveDotGit = true;
-    };
-    nativeBuildInputs = [
-      autoreconfHook
-      git
-      pkg-config
-    ];
-    meta = with lib; {
-      description = "Helper library used by usbmuxd2";
-      homepage = "https://github.com/tihmstar/libgeneral";
-      license = licenses.lgpl21;
-      platforms = platforms.all;
-    };
-  };
-
-in
 clangStdenv.mkDerivation {
   pname = "usbmuxd2";
   version = "unstable-2023-12-12";
@@ -83,12 +57,12 @@ clangStdenv.mkDerivation {
     "sbindir=${placeholder "out"}/bin"
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/tihmstar/usbmuxd2";
     description = "Socket daemon to multiplex connections from and to iOS devices";
-    license = licenses.lgpl3;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ onny ];
+    license = lib.licenses.lgpl3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ onny ];
     mainProgram = "usbmuxd";
   };
 }

--- a/pkgs/by-name/us/usbmuxd2/package.nix
+++ b/pkgs/by-name/us/usbmuxd2/package.nix
@@ -72,6 +72,8 @@ clangStdenv.mkDerivation rec {
     libusb1
   ];
 
+  doInstallCheck = true;
+
   configureFlags = [
     "--with-udevrulesdir=${placeholder "out"}/lib/udev/rules.d"
     "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"

--- a/pkgs/by-name/us/usbmuxd2/package.nix
+++ b/pkgs/by-name/us/usbmuxd2/package.nix
@@ -17,7 +17,7 @@ let
     version = "74";
     src = fetchFromGitHub {
       owner = "tihmstar";
-      repo = pname;
+      repo = "libgeneral";
       rev = "refs/tags/${version}";
       hash = "sha256-6aowcIYssc1xqH6kTi/cpH2F7rgc8+lGC8HgZWYH2w0=";
       # Leave DotGit so that autoconfigure can read version from git tags
@@ -37,13 +37,13 @@ let
   };
 
 in
-clangStdenv.mkDerivation rec {
+clangStdenv.mkDerivation {
   pname = "usbmuxd2";
   version = "unstable-2023-12-12";
 
   src = fetchFromGitHub {
     owner = "tihmstar";
-    repo = pname;
+    repo = "usbmuxd2";
     rev = "2ce399ddbacb110bd5a83a6b8232d42c9a9b6e84";
     hash = "sha256-UVLLE73XuWTgGlpTMxUDykFmiBDqz6NCRO2rpRAYfow=";
     # Leave DotGit so that autoconfigure can read version from git tags


### PR DESCRIPTION
Manual backport of #426901, #435606, and two treewides to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.