### PR TITLE
home-assistant-custom-components.xiaomi_home: init at 0.4.2

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/xiaomi_home/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/xiaomi_home/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  construct,
+  paho-mqtt,
+  numpy,
+  cryptography,
+  psutil-home-assistant,
+  nix-update-script,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "XiaoMi";
+  domain = "xiaomi_home";
+  version = "0.4.2";
+
+  src = fetchFromGitHub {
+    owner = "XiaoMi";
+    repo = "ha_xiaomi_home";
+    rev = "v${version}";
+    hash = "sha256-X8AP2pFGhkh4f72+pORXBB8yOqgIqJ+SLrQx5gwKxEg=";
+  };
+
+  dependencies = [
+    construct
+    paho-mqtt
+    numpy
+    cryptography
+    psutil-home-assistant
+  ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=^v([0-9.]+)$" ]; };
+
+  meta = {
+    changelog = "https://github.com/XiaoMi/ha_xiaomi_home/releases/tag/v${version}";
+    description = "Xiaomi Home Integration for Home Assistant";
+    longDescription = ''
+      Xiaomi Home Integration for Home Assistant depends on additional components, example how to setup in NixOS `configuration.nix`:
+
+      ```
+      { config, lib, pkgs, ... }:
+      {
+        services.home-assistant = {
+          customComponents = [ pkgs.home-assistant-custom-components.xiaomi_home ];
+          extraComponents = [ "ffmpeg" "zeroconf" ];
+        };
+        # OAuth2 Redirect URL is hardcoded as http://homeassistant.local:8123
+        # Make sure you can access HA via this URL with mDNS
+        services.avahi.hostName = "homeassistant";
+        networking.firewall.allowedTCPPorts = [ 8123 ];
+      }
+      ```
+    '';
+    homepage = "https://github.com/XiaoMi/ha_xiaomi_home";
+    maintainers = with lib.maintainers; [ MakiseKurisu ];
+    license = lib.licenses.unfree;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Official Xiaomi integration component.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
