### PR TITLE
vale-ls: 0.3.8 -> 0.4.0

### DIFF
--- a/pkgs/by-name/va/vale-ls/package.nix
+++ b/pkgs/by-name/va/vale-ls/package.nix
@@ -49,12 +49,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --suffix PATH : ${lib.makeBinPath [ vale ]}
   '';
 
-  meta = with lib; {
+  meta = {
     description = "LSP implementation for the Vale command-line tool";
     homepage = "https://github.com/errata-ai/vale-ls";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "vale-ls";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       foo-dogsquared
       jansol
     ];

--- a/pkgs/by-name/va/vale-ls/package.nix
+++ b/pkgs/by-name/va/vale-ls/package.nix
@@ -9,15 +9,15 @@
   vale,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "vale-ls";
-  version = "0.3.8";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "errata-ai";
     repo = "vale-ls";
-    tag = "v${version}";
-    hash = "sha256-+2peLqj3/ny0hDwJVKEp2XS68VO50IvpCB2fvZoEdJo=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lRRKRQTxgXF4E+XghJ5AOp+mtWtiCT13EcsPVydn4Uo=";
   };
 
   nativeBuildInputs = [
@@ -59,4 +59,4 @@ rustPlatform.buildRustPackage rec {
       jansol
     ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/errata-ai/vale-ls/releases/tag/v0.4.0
https://github.com/errata-ai/vale-ls/compare/v0.3.8...v0.4.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
