### PR TITLE
[Backport release-25.05] qmmp: 2.2.5 -> 2.2.8

### DIFF
--- a/pkgs/by-name/qm/qmmp/package.nix
+++ b/pkgs/by-name/qm/qmmp/package.nix
@@ -54,11 +54,11 @@
 
 stdenv.mkDerivation rec {
   pname = "qmmp";
-  version = "2.2.7";
+  version = "2.2.8";
 
   src = fetchurl {
     url = "https://qmmp.ylsoftware.com/files/qmmp/2.2/${pname}-${version}.tar.bz2";
-    hash = "sha256-3c/wthj0eQgC9tUtmnlrXzLLfQ8jyZGBuAT2FPq1+7I=";
+    hash = "sha256-cwqXoGOkmOs32p4vgZjf5XBpPmpsfyshDVgb2H27k4o=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/qm/qmmp/package.nix
+++ b/pkgs/by-name/qm/qmmp/package.nix
@@ -54,11 +54,11 @@
 
 stdenv.mkDerivation rec {
   pname = "qmmp";
-  version = "2.2.5";
+  version = "2.2.6";
 
   src = fetchurl {
     url = "https://qmmp.ylsoftware.com/files/qmmp/2.2/${pname}-${version}.tar.bz2";
-    hash = "sha256-WCEfMnrDhau8fXXmpdjdZLzbXMDxEZMp8pJ9FjEJfhg=";
+    hash = "sha256-Jw7Kb9co2aC8fxnpTg4OH2o8RNreZI3/pYoNu3OWy0s=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/qm/qmmp/package.nix
+++ b/pkgs/by-name/qm/qmmp/package.nix
@@ -54,11 +54,11 @@
 
 stdenv.mkDerivation rec {
   pname = "qmmp";
-  version = "2.2.6";
+  version = "2.2.7";
 
   src = fetchurl {
     url = "https://qmmp.ylsoftware.com/files/qmmp/2.2/${pname}-${version}.tar.bz2";
-    hash = "sha256-Jw7Kb9co2aC8fxnpTg4OH2o8RNreZI3/pYoNu3OWy0s=";
+    hash = "sha256-3c/wthj0eQgC9tUtmnlrXzLLfQ8jyZGBuAT2FPq1+7I=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Manual backport of #409522, #420979, #435733 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
