### PR TITLE
ci/eval/compare: ping maintainers of removed packages

### DIFF
--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -77,6 +77,7 @@ let
   # - values: lists of `packagePlatformPath`s
   diffAttrs = builtins.fromJSON (builtins.readFile "${combinedDir}/combined-diff.json");
 
+  changedPackagePlatformAttrs = convertToPackagePlatformAttrs diffAttrs.changed;
   rebuildsPackagePlatformAttrs = convertToPackagePlatformAttrs diffAttrs.rebuilds;
   removedPackagePlatformAttrs = convertToPackagePlatformAttrs diffAttrs.removed;
 
@@ -116,7 +117,7 @@ let
     );
 
   maintainers = callPackage ./maintainers.nix { } {
-    changedattrs = lib.attrNames (lib.groupBy (a: a.name) rebuildsPackagePlatformAttrs);
+    changedattrs = lib.attrNames (lib.groupBy (a: a.name) changedPackagePlatformAttrs);
     changedpathsjson = touchedFilesJson;
     removedattrs = lib.attrNames (lib.groupBy (a: a.name) removedPackagePlatformAttrs);
     inherit byName;

--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -78,6 +78,7 @@ let
   diffAttrs = builtins.fromJSON (builtins.readFile "${combinedDir}/combined-diff.json");
 
   rebuildsPackagePlatformAttrs = convertToPackagePlatformAttrs diffAttrs.rebuilds;
+  removedPackagePlatformAttrs = convertToPackagePlatformAttrs diffAttrs.removed;
 
   changed-paths =
     let
@@ -117,6 +118,7 @@ let
   maintainers = callPackage ./maintainers.nix { } {
     changedattrs = lib.attrNames (lib.groupBy (a: a.name) rebuildsPackagePlatformAttrs);
     changedpathsjson = touchedFilesJson;
+    removedattrs = lib.attrNames (lib.groupBy (a: a.name) removedPackagePlatformAttrs);
     inherit byName;
   };
 in

--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -28,7 +28,7 @@ let
   }) (changedattrs ++ removedattrs);
 
   attrsWithPackages = builtins.map (
-    pkg: pkg // { package = lib.attrsets.attrByPath pkg.path null pkgs; }
+    pkg: pkg // { package = lib.getAttrFromPath pkg.path pkgs; }
   ) enrichedAttrs;
 
   attrsWithMaintainers = builtins.map (

--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -27,25 +27,9 @@ let
     name = name;
   }) (changedattrs ++ removedattrs);
 
-  validPackageAttributes = builtins.filter (
-    pkg:
-    if (lib.attrsets.hasAttrByPath pkg.path pkgs) then
-      (
-        let
-          value = lib.attrsets.attrByPath pkg.path null pkgs;
-        in
-        if (builtins.tryEval value).success then
-          if value != null then true else builtins.trace "${pkg.name} exists but is null" false
-        else
-          builtins.trace "Failed to access ${pkg.name} even though it exists" false
-      )
-    else
-      builtins.trace "Failed to locate ${pkg.name}." false
-  ) enrichedAttrs;
-
   attrsWithPackages = builtins.map (
     pkg: pkg // { package = lib.attrsets.attrByPath pkg.path null pkgs; }
-  ) validPackageAttributes;
+  ) enrichedAttrs;
 
   attrsWithMaintainers = builtins.map (
     pkg:

--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -5,6 +5,7 @@
 {
   changedattrs,
   changedpathsjson,
+  removedattrs,
   byName ? false,
 }:
 let
@@ -24,7 +25,7 @@ let
   enrichedAttrs = builtins.map (name: {
     path = lib.splitString "." name;
     name = name;
-  }) changedattrs;
+  }) (changedattrs ++ removedattrs);
 
   validPackageAttributes = builtins.filter (
     pkg:

--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -22,27 +22,18 @@ let
 
   anyMatchingFiles = files: builtins.any anyMatchingFile files;
 
-  enrichedAttrs = builtins.map (name: {
-    path = lib.splitString "." name;
-    name = name;
-  }) (changedattrs ++ removedattrs);
-
-  attrsWithPackages = builtins.map (
-    pkg: pkg // { package = lib.getAttrFromPath pkg.path pkgs; }
-  ) enrichedAttrs;
-
   attrsWithMaintainers = builtins.map (
-    pkg:
+    name:
     let
-      meta = pkg.package.meta or { };
+      package = lib.getAttrFromPath (lib.splitString "." name) pkgs;
     in
-    pkg
-    // {
+    {
+      inherit name package;
       # TODO: Refactor this so we can ping entire teams instead of the individual members.
       # Note that this will require keeping track of GH team IDs in "maintainers/teams.nix".
-      maintainers = meta.maintainers or [ ];
+      maintainers = package.meta.maintainers or [ ];
     }
-  ) attrsWithPackages;
+  ) (changedattrs ++ removedattrs);
 
   relevantFilenames =
     drv:


### PR DESCRIPTION
This change pings maintainers of actually removed packages, aka where the package's expression is deleted.

This will not ping maintainers of packages that become invisible, because a (transitive) dependency of them is marked as insecure or broken.

Followed up by a few refactors that should work by now, some because of #426629.

## Things done

- [x] Tested in my fork.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
