### PR TITLE
[Backport release-25.05] linuxPackages.rtw88: 0-unstable-2025-05-08 -> 0-unstable-2025-08-09

### DIFF
--- a/pkgs/os-specific/linux/rtw88/default.nix
+++ b/pkgs/os-specific/linux/rtw88/default.nix
@@ -12,13 +12,13 @@ let
 in
 stdenv.mkDerivation {
   pname = "rtw88";
-  version = "0-unstable-2025-06-26";
+  version = "0-unstable-2025-07-13";
 
   src = fetchFromGitHub {
     owner = "lwfinger";
     repo = "rtw88";
-    rev = "b89af8cd40d9528b0cdb9a6251efe49d8a69bfc6";
-    hash = "sha256-gzWVfb8nAN0mmOpiats+VDG/6iwdrxcQHEsDgC7eFZU=";
+    rev = "fa96fd4c014fa528d1fa50318e97aa71bf4f473c";
+    hash = "sha256-KFozxbpw6HJhbL5QLnGkKEBAbeEiHrhSJUMAcbM+lX4=";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;

--- a/pkgs/os-specific/linux/rtw88/default.nix
+++ b/pkgs/os-specific/linux/rtw88/default.nix
@@ -12,13 +12,13 @@ let
 in
 stdenv.mkDerivation {
   pname = "rtw88";
-  version = "0-unstable-2025-07-13";
+  version = "0-unstable-2025-08-09";
 
   src = fetchFromGitHub {
     owner = "lwfinger";
     repo = "rtw88";
-    rev = "fa96fd4c014fa528d1fa50318e97aa71bf4f473c";
-    hash = "sha256-KFozxbpw6HJhbL5QLnGkKEBAbeEiHrhSJUMAcbM+lX4=";
+    rev = "52072d874840f28c247b27f5d799f2c5c88a7e61";
+    hash = "sha256-Lu3ol0iKfM9/SJ5lieh4A28h02Stc971ZypfiB2BWJ0=";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;

--- a/pkgs/os-specific/linux/rtw88/default.nix
+++ b/pkgs/os-specific/linux/rtw88/default.nix
@@ -12,13 +12,13 @@ let
 in
 stdenv.mkDerivation {
   pname = "rtw88";
-  version = "0-unstable-2025-05-08";
+  version = "0-unstable-2025-06-26";
 
   src = fetchFromGitHub {
     owner = "lwfinger";
     repo = "rtw88";
-    rev = "461b696b51317ba4ca585a4ddb32f2e72cd4efc9";
-    hash = "sha256-PBAON2s7gKvpO40vppahEtkWJ4HIjbOjfUz+fx87gIA=";
+    rev = "b89af8cd40d9528b0cdb9a6251efe49d8a69bfc6";
+    hash = "sha256-gzWVfb8nAN0mmOpiats+VDG/6iwdrxcQHEsDgC7eFZU=";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;


### PR DESCRIPTION
Manual backport of #422679, #425160, #429895 to `release-25.05`.

- [x] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
  