### PR TITLE
[Backport release-25.05] opkssh: 0.6.1 -> 0.9.0

### DIFF
--- a/pkgs/by-name/op/opkssh/package.nix
+++ b/pkgs/by-name/op/opkssh/package.nix
@@ -8,18 +8,18 @@
 
 buildGoModule (finalAttrs: {
   pname = "opkssh";
-  version = "0.6.1";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "openpubkey";
     repo = "opkssh";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-BK34zw/VYv6mAn68U8tRoOU6Obz3P+6Hw12fsKBuUf8=";
+    hash = "sha256-8fbOhyrHgNG9ulu/DZvUHzIojvoHG/gb5+Ft/RmMHXk=";
   };
 
   ldflags = [ "-X main.Version=${finalAttrs.version}" ];
 
-  vendorHash = "sha256-6nTRiybsNtP/BiDaNrFEGEGM41BAjGpOyQ0AlQimSE4=";
+  vendorHash = "sha256-bkTQqtlZhZ2/WnQNRdZzfblkGKjaAS22RFl6I1O3/yA=";
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/by-name/op/opkssh/package.nix
+++ b/pkgs/by-name/op/opkssh/package.nix
@@ -8,18 +8,18 @@
 
 buildGoModule (finalAttrs: {
   pname = "opkssh";
-  version = "0.8.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "openpubkey";
     repo = "opkssh";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8CWxxhqgSgFVRNjAvJ0faHI4rsSPQNkcSqVSzTHRJY4=";
+    hash = "sha256-c7cs7qSq5fhJuMhgRWAZmc4yWt+B219P2D0niP2sXlM=";
   };
 
   ldflags = [ "-X main.Version=${finalAttrs.version}" ];
 
-  vendorHash = "sha256-0H7hST5Czd/1rDQ0nO2FAnbG2lN3AZULs5M17zKa9FY=";
+  vendorHash = "sha256-naQGvGjIRTy4BlXxM4bXnrBUWTUCFTDHOYEp91ss1wI=";
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/by-name/op/opkssh/package.nix
+++ b/pkgs/by-name/op/opkssh/package.nix
@@ -8,18 +8,18 @@
 
 buildGoModule (finalAttrs: {
   pname = "opkssh";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "openpubkey";
     repo = "opkssh";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8fbOhyrHgNG9ulu/DZvUHzIojvoHG/gb5+Ft/RmMHXk=";
+    hash = "sha256-8CWxxhqgSgFVRNjAvJ0faHI4rsSPQNkcSqVSzTHRJY4=";
   };
 
   ldflags = [ "-X main.Version=${finalAttrs.version}" ];
 
-  vendorHash = "sha256-bkTQqtlZhZ2/WnQNRdZzfblkGKjaAS22RFl6I1O3/yA=";
+  vendorHash = "sha256-0H7hST5Czd/1rDQ0nO2FAnbG2lN3AZULs5M17zKa9FY=";
 
   nativeInstallCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
Manual backport of #411816 #427178 #436743 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
  