### PR TITLE
ceph: Use full path to mount(8) when remounting FUSE fs

### DIFF
--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -498,6 +498,11 @@ rec {
         --replace "/sbin/modprobe" "${kmod}/bin/modprobe" \
         --replace "/bin/grep" "${gnugrep}/bin/grep"
 
+      # Patch remount to use full path to mount(8), otherwise ceph-fuse fails when run
+      # from a systemd unit for example.
+      substituteInPlace src/client/fuse_ll.cc \
+        --replace-fail "mount -i -o remount" "${util-linux}/bin/mount -i -o remount"
+
       # The install target needs to be in PYTHONPATH for "*.pth support" check to succeed
       export PYTHONPATH=$PYTHONPATH:$lib/${sitePackages}:$out/${sitePackages}
       patchShebangs src/


### PR DESCRIPTION
Before, using ceph-fuse in a systemd unit, it failed to remount and exited.
```
ceph-fuse[74399]:   -257> 2025-08-30T01:19:31.420+0000 7f0fce7f46c0 -1 client.740614836 failed to remount (to trim kernel dentries): return code = 127
ceph-fuse[74399]:   -256> 2025-08-30T01:19:31.420+0000 7f0fce7f46c0 -1 client.740614836 failed to remount for kernel dentry trimming; quitting!
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
