### PR TITLE
ncps: 0.2.0 -> 0.3.0 with checkPhase fixes

### DIFF
--- a/pkgs/by-name/nc/ncps/package.nix
+++ b/pkgs/by-name/nc/ncps/package.nix
@@ -8,13 +8,13 @@
 let
   finalAttrs = {
     pname = "ncps";
-    version = "0.2.0";
+    version = "0.3.0";
 
     src = fetchFromGitHub {
       owner = "kalbasit";
       repo = "ncps";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-CjiPn5godd8lT3eE9e7MnZ0/2hOEq+CG0bpgRtLtwHo=";
+      hash = "sha256-mBiasGQgwP8dRQqtn7z+tLKECDd1p0JE2nvCYLru0Ts=";
     };
 
     ldflags = [
@@ -23,7 +23,7 @@ let
 
     subPackages = [ "." ];
 
-    vendorHash = "sha256-El3yvYYnase4ztG3u7xxcKE5ARy5Lvp/FVosBwOXzbU=";
+    vendorHash = "sha256-5QpzU+cy14cdR5Oi2vwA+BbMSTPMXlhyq9RpzbMsRZQ=";
     doCheck = true;
 
     nativeBuildInputs = [

--- a/pkgs/by-name/nc/ncps/package.nix
+++ b/pkgs/by-name/nc/ncps/package.nix
@@ -22,7 +22,9 @@ let
     ];
 
     vendorHash = "sha256-5QpzU+cy14cdR5Oi2vwA+BbMSTPMXlhyq9RpzbMsRZQ=";
+
     doCheck = true;
+    checkFlags = [ "-race" ];
 
     nativeBuildInputs = [
       dbmate # used for testing

--- a/pkgs/by-name/nc/ncps/package.nix
+++ b/pkgs/by-name/nc/ncps/package.nix
@@ -21,8 +21,6 @@ let
       "-X github.com/kalbasit/ncps/cmd.Version=v${finalAttrs.version}"
     ];
 
-    subPackages = [ "." ];
-
     vendorHash = "sha256-5QpzU+cy14cdR5Oi2vwA+BbMSTPMXlhyq9RpzbMsRZQ=";
     doCheck = true;
 


### PR DESCRIPTION
[ncps v0.3.0](https://github.com/kalbasit/ncps/releases/tag/v0.3.0)

I've also removed `subPackages` to allow checkPhase to test all subPackages (it's no-op for buildPhase) and I've enabled `-race` for the checkPhase.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
