### PR TITLE
ncps: Update the module for ncps v0.3.0

### DIFF
--- a/nixos/modules/services/networking/ncps.nix
+++ b/nixos/modules/services/networking/ncps.nix
@@ -37,6 +37,7 @@ let
       "--cache-hostname='${cfg.cache.hostName}'"
       "--cache-data-path='${cfg.cache.dataPath}'"
       "--cache-database-url='${cfg.cache.databaseURL}'"
+      "--cache-temp-path='${cfg.cache.tempPath}'"
       "--server-addr='${cfg.server.addr}'"
     ]
     ++ (lib.optional cfg.cache.allowDeleteVerb "--cache-allow-delete-verb")
@@ -170,6 +171,14 @@ in
             empty to automatically generate a private/public key.
           '';
         };
+
+        tempPath = lib.mkOption {
+          type = lib.types.str;
+          default = "/tmp";
+          description = ''
+            The path to the temporary directory that is used by the cache to download NAR files
+          '';
+        };
       };
 
       server = {
@@ -219,7 +228,7 @@ in
     };
     users.groups.ncps = { };
 
-    systemd.services.ncps-create-datadirs = {
+    systemd.services.ncps-create-directories = {
       description = "Created required directories by ncps";
       serviceConfig = {
         Type = "oneshot";
@@ -236,6 +245,12 @@ in
           if ! test -d ${dbDir}; then
             mkdir -p ${dbDir}
             chown ncps:ncps ${dbDir}
+          fi
+        '')
+        + (lib.optionalString (cfg.cache.tempPath != "/tmp") ''
+          if ! test -d ${cfg.cache.tempPath}; then
+            mkdir -p ${cfg.cache.tempPath}
+            chown ncps:ncps ${cfg.cache.tempPath}
           fi
         '');
       wantedBy = [ "ncps.service" ];
@@ -277,6 +292,9 @@ in
         })
         (lib.mkIf (isSqlite && !lib.strings.hasPrefix "/var/lib/ncps" dbDir) {
           ReadWritePaths = [ dbDir ];
+        })
+        (lib.mkIf (cfg.cache.tempPath != "/tmp") {
+          ReadWritePaths = [ cfg.cache.tempPath ];
         })
 
         # Hardening

--- a/nixos/modules/services/networking/ncps.nix
+++ b/nixos/modules/services/networking/ncps.nix
@@ -27,6 +27,9 @@ let
         cfg.openTelemetry.grpcURL != null
       ) "--otel-grpc-url='${cfg.openTelemetry.grpcURL}'")
     ))
+    ++ (lib.optionals cfg.prometheus.enable [
+      "--prometheus-enabled"
+    ])
   );
 
   serveFlags = lib.concatStringsSep " " (
@@ -75,6 +78,8 @@ in
           '';
         };
       };
+
+      prometheus.enable = lib.mkEnableOption "Enable Prometheus metrics endpoint at /metrics";
 
       logLevel = lib.mkOption {
         type = lib.types.enum logLevels;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

ncps v0.3.0 introduces two new flags:
- `--prometheus-enabled` to enable Prometheus metrics at /metrics endpoint.
- `--cache-temp-path` to configure the path where ncps places temporary NAR files before saving them in the store.

Requires #438680 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
