### PR TITLE
rocmPackages.rocm-core: fix find_package(rocm-core)

### DIFF
--- a/pkgs/development/python-modules/torch/source/default.nix
+++ b/pkgs/development/python-modules/torch/source/default.nix
@@ -369,13 +369,6 @@ buildPythonPackage rec {
     substituteInPlace third_party/kineto/libkineto/CMakeLists.txt \
       --replace-fail "\''$ENV{ROCM_SOURCE_DIR}" "${rocmtoolkit_joined}"
 
-    # Workaround cmake error //include does not exist! in rocm-core-config.cmake
-    # Removing the call falls back to hip_version. Can likely be removed after ROCm 6.4 bump
-    substituteInPlace cmake/public/LoadHIP.cmake \
-      --replace-fail \
-        "find_package(rocm-core CONFIG)" \
-        ""
-
     # Use composable kernel as dependency, rather than built-in third-party
     substituteInPlace aten/src/ATen/CMakeLists.txt \
       --replace-fail "list(APPEND ATen_HIP_INCLUDE \''${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/composable_kernel/include)" "" \

--- a/pkgs/development/rocm-modules/6/rocm-core/default.nix
+++ b/pkgs/development/rocm-modules/6/rocm-core/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Test that the CMake config file can be included and sets expected vars
     ''
       mkdir test_project
-      cd test_project
+      pushd test_project
 
       echo '
         cmake_minimum_required(VERSION 3.16)
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
       ' > CMakeLists.txt
 
       CMAKE_PREFIX_PATH="$out" cmake .
-      cd ..
+      popd
 
       . $out/nix-support/setup-hook
       env | grep '^ROCM'

--- a/pkgs/development/rocm-modules/6/rocm-core/default.nix
+++ b/pkgs/development/rocm-modules/6/rocm-core/default.nix
@@ -7,6 +7,14 @@
   writeText,
 }:
 
+# rocm-core is used by most distros for a few purposes:
+# - meta package that all rocm packages depend so `apt-get remove rocm-core` removes all rocm packages
+# - provide overall ROCM_PATH
+# - provide rocm version info and path to rocm version headers
+# only the last usage makes sense in nixpkgs
+let
+  padIfSingle = s: if lib.stringLength s == 1 then "0${s}" else s;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-core";
   version = "6.3.3";
@@ -18,22 +26,55 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-UDnPGvgwzwv49CzF+Kt0v95CsxS33BZeqNcKw1K6jRI=";
   };
 
+  patches = [
+    ./env-rocm-path.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
-  # FIXME: What's the correct way to set this?
-  env.ROCM_LIBPATCH_VERSION = "${lib.versions.major finalAttrs.version}0${lib.versions.minor finalAttrs.version}0${lib.versions.patch finalAttrs.version}";
-  env.BUILD_ID = "nixos-${finalAttrs.env.ROCM_LIBPATCH_VERSION}";
-  env.ROCM_BUILD_ID = "release-${finalAttrs.env.BUILD_ID}";
+  env = {
+    ROCM_LIBPATCH_VERSION = "${lib.versions.major finalAttrs.version}${padIfSingle (lib.versions.minor finalAttrs.version)}${padIfSingle (lib.versions.patch finalAttrs.version)}";
+    BUILD_ID = "nixpkgs-${finalAttrs.env.ROCM_LIBPATCH_VERSION}";
+    ROCM_BUILD_ID = "${finalAttrs.env.BUILD_ID}";
+  };
   cmakeFlags = [
     "-DROCM_LIBPATCH_VERSION=${finalAttrs.env.ROCM_LIBPATCH_VERSION}"
     "-DROCM_VERSION=${finalAttrs.version}"
     "-DBUILD_ID=${finalAttrs.env.BUILD_ID}"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DCMAKE_INSTALL_BINDIR=bin"
   ];
 
   setupHook = writeText "setupHook.sh" ''
+    export ROCM_VERSION="${finalAttrs.version}"
     export ROCM_LIBPATCH_VERSION="${finalAttrs.env.ROCM_LIBPATCH_VERSION}"
-    export BUILD_ID="${finalAttrs.env.BUILD_ID}"
     export ROCM_BUILD_ID="${finalAttrs.env.ROCM_BUILD_ID}"
   '';
+
+  doInstallCheck = true;
+  preInstallCheck =
+    # Test that the CMake config file can be included and sets expected vars
+    ''
+      mkdir test_project
+      cd test_project
+
+      echo '
+        cmake_minimum_required(VERSION 3.16)
+        project(test_rocm_core)
+        find_package(rocm-core REQUIRED)
+        if(NOT DEFINED ROCM_CORE_INCLUDE_DIR)
+          message(FATAL_ERROR "ROCM_CORE_INCLUDE_DIR not set")
+        endif()
+        message(STATUS "Found ROCM_CORE_INCLUDE_DIR: ''${ROCM_CORE_INCLUDE_DIR}")
+        message(STATUS "Found ROCM_PATH: ''${ROCM_PATH}")
+      ' > CMakeLists.txt
+
+      CMAKE_PREFIX_PATH="$out" cmake .
+      cd ..
+
+      . $out/nix-support/setup-hook
+      env | grep '^ROCM'
+    '';
 
   passthru.ROCM_LIBPATCH_VERSION = finalAttrs.env.ROCM_LIBPATCH_VERSION;
   passthru.updateScript = rocmUpdateScript {

--- a/pkgs/development/rocm-modules/6/rocm-core/env-rocm-path.patch
+++ b/pkgs/development/rocm-modules/6/rocm-core/env-rocm-path.patch
@@ -1,0 +1,22 @@
+In FHS distros rocm-core expects to be installed colocated with a full set of ROCM packages.
+In nixpkgs contexts, we don't want rocm-core to be a ROCM_PATH root.
+diff --git a/cmake_modules/rocm-core-config.cmake.in b/cmake_modules/rocm-core-config.cmake.in
+index f5fe07c..9d72c9c 100644
+--- a/cmake_modules/rocm-core-config.cmake.in
++++ b/cmake_modules/rocm-core-config.cmake.in
+@@ -11,7 +11,14 @@ set_and_check(rocm_core_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+ set_and_check(ROCM_CORE_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+ set_and_check(rocm_core_LIB_DIR "@PACKAGE_LIB_INSTALL_DIR@")
+ set_and_check(ROCM_CORE_LIB_DIR "@PACKAGE_LIB_INSTALL_DIR@")
+-set_and_check(ROCM_PATH "${PACKAGE_PREFIX_DIR}")
++# Set ROCM_PATH with priority: existing value > environment variable > package prefix
++if(NOT DEFINED ROCM_PATH)
++    if(DEFINED ENV{ROCM_PATH})
++        set(ROCM_PATH "$ENV{ROCM_PATH}")
++    else()
++        set_and_check(ROCM_PATH "${PACKAGE_PREFIX_DIR}")
++    endif()
++endif()
+ 
+ get_filename_component(ROCM_CORE_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+ include("${ROCM_CORE_CMAKE_DIR}/rocmCoreTargets.cmake")


### PR DESCRIPTION
find_package(rocm-core) was failing because the generated `rocm-core-config.cmake` had broken paths.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
