### PR TITLE
[Backport release-25.05] jetty_12: 12.0.21 -> 12.1.0

### DIFF
--- a/pkgs/servers/http/jetty/default.nix
+++ b/pkgs/servers/http/jetty/default.nix
@@ -57,7 +57,7 @@ in
   };
 
   jetty_12 = common {
-    version = "12.0.22";
-    hash = "sha256-Ey3z+C+cBh8clWqcGULEsQQcbSbuaGwGr+arJE+GChs=";
+    version = "12.0.23";
+    hash = "sha256-oY6IU59ir52eM4qO2arOLErN4CEUCT0iRM4I9ip+m3I=";
   };
 }

--- a/pkgs/servers/http/jetty/default.nix
+++ b/pkgs/servers/http/jetty/default.nix
@@ -57,7 +57,7 @@ in
   };
 
   jetty_12 = common {
-    version = "12.0.25";
-    hash = "sha256-rbLCP0EPPipaNMPtyelLIoK7RMHAZ9I6neV6BpGacWc=";
+    version = "12.1.0";
+    hash = "sha256-wVStusEURjaBYoh/37vO7PvdNFXrn7rLccchWGYzz+8=";
   };
 }

--- a/pkgs/servers/http/jetty/default.nix
+++ b/pkgs/servers/http/jetty/default.nix
@@ -57,7 +57,7 @@ in
   };
 
   jetty_12 = common {
-    version = "12.0.21";
-    hash = "sha256-U/W6h0S7b0zLoYahDGo/pkKa+NIMKR0tiX3pyRl40zg=";
+    version = "12.0.22";
+    hash = "sha256-Ey3z+C+cBh8clWqcGULEsQQcbSbuaGwGr+arJE+GChs=";
   };
 }

--- a/pkgs/servers/http/jetty/default.nix
+++ b/pkgs/servers/http/jetty/default.nix
@@ -57,7 +57,7 @@ in
   };
 
   jetty_12 = common {
-    version = "12.0.23";
-    hash = "sha256-oY6IU59ir52eM4qO2arOLErN4CEUCT0iRM4I9ip+m3I=";
+    version = "12.0.25";
+    hash = "sha256-rbLCP0EPPipaNMPtyelLIoK7RMHAZ9I6neV6BpGacWc=";
   };
 }


### PR DESCRIPTION
Manual backport of #414498, #422621, #435536, #437398 to `release-25.05`.

- [x] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
  