### PR TITLE
[Backport release-25.05] nano: 8.4 -> 8.6; unbreak on darwin

### DIFF
--- a/pkgs/by-name/na/nano/package.nix
+++ b/pkgs/by-name/na/nano/package.nix
@@ -31,11 +31,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "nano";
-  version = "8.4";
+  version = "8.5";
 
   src = fetchurl {
     url = "mirror://gnu/nano/${pname}-${version}.tar.xz";
-    hash = "sha256-WtKSIrvVViTYfqZ3kosxBqdDEU1sb5tB82yXviqOYo0=";
+    hash = "sha256-AAsBHTOcFBr5ZG1DKI9UMl/1xujTnW5IK3h7vGZUwmo=";
   };
 
   nativeBuildInputs = [ texinfo ] ++ lib.optional enableNls gettext;

--- a/pkgs/by-name/na/nano/package.nix
+++ b/pkgs/by-name/na/nano/package.nix
@@ -31,11 +31,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "nano";
-  version = "8.5";
+  version = "8.6";
 
   src = fetchurl {
     url = "mirror://gnu/nano/${pname}-${version}.tar.xz";
-    hash = "sha256-AAsBHTOcFBr5ZG1DKI9UMl/1xujTnW5IK3h7vGZUwmo=";
+    hash = "sha256-96v78O7V9XOrUb13pFjzLYL5hZxV6WifgZ2W/hQ3phk=";
   };
 
   nativeBuildInputs = [ texinfo ] ++ lib.optional enableNls gettext;

--- a/pkgs/by-name/na/nano/package.nix
+++ b/pkgs/by-name/na/nano/package.nix
@@ -63,6 +63,10 @@ stdenv.mkDerivation rec {
         cp ${nixSyntaxHighlight}/nix.nanorc $out/share/nano/
       '';
 
+  # https://hydra.nixos.org/build/300187289/nixlog/1
+  # openat-die.c:57:10: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
+  hardeningDisable = [ "format" ];
+
   enableParallelBuilding = true;
   strictDeps = true;
 


### PR DESCRIPTION
Manual backport of #416220, #417500, #435653 to `release-25.05`.

- [x] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.