### PR TITLE
python313Packages.ledgerblue: fix by dropping unused `future` dep

### DIFF
--- a/pkgs/development/python-modules/ledgerblue/default.nix
+++ b/pkgs/development/python-modules/ledgerblue/default.nix
@@ -4,8 +4,8 @@
   bleak,
   buildPythonPackage,
   ecpy,
+  fetchpatch,
   fetchPypi,
-  future,
   hidapi,
   nfcpy,
   pillow,
@@ -33,6 +33,14 @@ buildPythonPackage rec {
     hash = "sha256-6s2V8cXik6jEg8z3UK49qVwodPbwXMIkWk7iJ7OY0rM=";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "ledgerblue-no-future.patch";
+      url = "https://github.com/LedgerHQ/blue-loader-python/commit/40a9904933bbf9d9bb50f20b942215725e2f8e2c.patch";
+      hash = "sha256-6FIHeB6ReqvMKX20K33DuKk39E/FPsq59ah2Zf3Nt8I=";
+    })
+  ];
+
   build-system = [
     setuptools
     setuptools-scm
@@ -42,7 +50,6 @@ buildPythonPackage rec {
 
   dependencies = [
     ecpy
-    future
     hidapi
     nfcpy
     pillow


### PR DESCRIPTION
Fixes #438625 by applying https://github.com/LedgerHQ/blue-loader-python/pull/153
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
