### PR TITLE
[Backport release-25.05] {libtorrent,rtorrent}: 0.15.1 -> 0.15.5

### DIFF
--- a/pkgs/by-name/li/libtorrent/package.nix
+++ b/pkgs/by-name/li/libtorrent/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rakshasa-libtorrent";
-  version = "0.15.4";
+  version = "0.15.5";
 
   src = fetchFromGitHub {
     owner = "rakshasa";
     repo = "libtorrent";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-EtT1g8fo2XRVO7pGUThoEklxpYKPI7OWwCZ2vVV73k4=";
+    hash = "sha256-iFndmET8bQUg3iZ6c6WDCzSS2tx6sYJt+fEkPAaNm18=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libtorrent/package.nix
+++ b/pkgs/by-name/li/libtorrent/package.nix
@@ -4,7 +4,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  autoconf-archive,
   autoreconfHook,
   cppunit,
   openssl,
@@ -13,19 +12,18 @@
   gitUpdater,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rakshasa-libtorrent";
   version = "0.15.4";
 
   src = fetchFromGitHub {
     owner = "rakshasa";
     repo = "libtorrent";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-EtT1g8fo2XRVO7pGUThoEklxpYKPI7OWwCZ2vVV73k4=";
   };
 
   nativeBuildInputs = [
-    autoconf-archive
     autoreconfHook
     pkg-config
   ];
@@ -53,4 +51,4 @@ stdenv.mkDerivation rec {
     ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/li/libtorrent/package.nix
+++ b/pkgs/by-name/li/libtorrent/package.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rakshasa-libtorrent";
-  version = "0.15.1";
+  version = "0.15.4";
 
   src = fetchFromGitHub {
     owner = "rakshasa";
     repo = "libtorrent";
     rev = "v${version}";
-    hash = "sha256-ejDne7vaV+GYP6M0n3VAEva4UHuxRGwfc2rgxf7U/EM=";
+    hash = "sha256-EtT1g8fo2XRVO7pGUThoEklxpYKPI7OWwCZ2vVV73k4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/rt/rtorrent/package.nix
+++ b/pkgs/by-name/rt/rtorrent/package.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rakshasa-rtorrent";
-  version = "0.15.4";
+  version = "0.15.5";
 
   src = fetchFromGitHub {
     owner = "rakshasa";
     repo = "rtorrent";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-0OnDxmfliVP3GF2xzUZkURippzCGUwLebuyjb7nz/vs=";
+    hash = "sha256-ZUZR/ydGhxLbjMEDAlbU5IbAxU1dCd0vvATdsn0NMQc=";
   };
 
   outputs = [

--- a/pkgs/by-name/rt/rtorrent/package.nix
+++ b/pkgs/by-name/rt/rtorrent/package.nix
@@ -14,6 +14,8 @@
   zlib,
   nixosTests,
   gitUpdater,
+  withLua ? false,
+  lua5_4_compat,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -50,12 +52,14 @@ stdenv.mkDerivation (finalAttrs: {
     ncurses
     openssl
     zlib
-  ];
+  ]
+  ++ lib.optionals withLua [ lua5_4_compat ];
 
   configureFlags = [
     "--with-xmlrpc-tinyxml2"
     "--with-posix-fallocate"
-  ];
+  ]
+  ++ lib.optionals withLua [ "--with-lua" ];
 
   passthru = {
     updateScript = gitUpdater { rev-prefix = "v"; };

--- a/pkgs/by-name/rt/rtorrent/package.nix
+++ b/pkgs/by-name/rt/rtorrent/package.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rakshasa-rtorrent";
-  version = "0.15.1";
+  version = "0.15.4";
 
   src = fetchFromGitHub {
     owner = "rakshasa";
     repo = "rtorrent";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-5ewAeoHvKcZ+5HTMlXLTu63JE3plKATvZToFEDZ9vOs=";
+    hash = "sha256-0OnDxmfliVP3GF2xzUZkURippzCGUwLebuyjb7nz/vs=";
   };
 
   outputs = [


### PR DESCRIPTION
Manual backport of #406051, #421264, #423030, #423209 to `release-25.05`.

Cherry-pick check will fail due to f432d7fea7ecf184c1b0d2152deacf860e1f67c2.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.