### PR TITLE
stdenv: fix withCFlags when NIX_CFLAGS_COMPILE exists outside of env

### DIFF
--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -417,11 +417,19 @@ rec {
   withCFlags =
     compilerFlags: stdenv:
     stdenv.override (old: {
-      mkDerivationFromStdenv = extendMkDerivationArgs old (args: {
-        env = (args.env or { }) // {
-          NIX_CFLAGS_COMPILE = toString (args.env.NIX_CFLAGS_COMPILE or "") + " ${toString compilerFlags}";
-        };
-      });
+      mkDerivationFromStdenv = extendMkDerivationArgs old (
+        args:
+        if lib.hasAttr "env" args then
+          {
+            env = (args.env or { }) // {
+              NIX_CFLAGS_COMPILE = toString (args.env.NIX_CFLAGS_COMPILE or "") + " ${toString compilerFlags}";
+            };
+          }
+        else
+          {
+            NIX_CFLAGS_COMPILE = toString (args.NIX_CFLAGS_COMPILE or "") + " ${toString compilerFlags}";
+          }
+      );
     });
 
   withDefaultHardeningFlags =


### PR DESCRIPTION
But now it fails in php

<details><summary>Nix Stack Trace</summary>
<p>

```
       … from call site
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/lib/customisation.nix:163:18:
          162|       let
          163|         result = f origArgs;
             |                  ^
          164|

       … while calling anonymous lambda
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/pkgs/development/interpreters/php/8.4.nix:1:1:
            1| { callPackage, ... }@_args:
             | ^
            2|

       … from call site
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/pkgs/development/interpreters/php/8.4.nix:4:10:
            3| let
            4|   base = callPackage ./generic.nix (
             |          ^
            5|     _args

       (7 duplicate frames omitted)

       … while calling 'generic'
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/pkgs/development/interpreters/php/generic.nix:6:5:
            5|   generic =
            6|     {
             |     ^
            7|       callPackage,

       … from call site
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/pkgs/development/interpreters/php/generic.nix:224:5:
          223|     in
          224|     stdenv.mkDerivation (
             |     ^
          225|       finalAttrs:

       … while calling anonymous lambda
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/pkgs/stdenv/adapters.nix:36:29:
           35|     withOldMkDerivation old (
           36|       _: mkDerivationSuper: args:
             |                             ^
           37|       (mkDerivationSuper args).overrideAttrs f

       … from call site
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/pkgs/stdenv/adapters.nix:37:8:
           36|       _: mkDerivationSuper: args:
           37|       (mkDerivationSuper args).overrideAttrs f
             |        ^
           38|     );

       … while calling anonymous lambda
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/pkgs/stdenv/adapters.nix:36:29:
           35|     withOldMkDerivation old (
           36|       _: mkDerivationSuper: args:
             |                             ^
           37|       (mkDerivationSuper args).overrideAttrs f

       … from call site
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/pkgs/stdenv/adapters.nix:37:7:
           36|       _: mkDerivationSuper: args:
           37|       (mkDerivationSuper args).overrideAttrs f
             |       ^
           38|     );

       … while calling 'overrideAttrs'
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/pkgs/development/interpreters/php/generic.nix:384:15:
          383|             overrideAttrs =
          384|               f:
             |               ^
          385|               let

       … from call site
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/pkgs/development/interpreters/php/generic.nix:389:23:
          388|                 );
          389|                 php = generic (args // { phpAttrsOverrides = newPhpAttrsOverrides; });
             |                       ^
          390|               in

       (13130 duplicate frames omitted)

       … from call site
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/pkgs/stdenv/generic/make-derivation.nix:84:14:
           83|       # An infinite recursion here can be caused by having the attribute names of expression `e` in `.overrideAttrs(finalAttrs: previousAttrs: e)` depend on `finalAttrs`. Only the attribute values of `e` can depend on `finalAttrs`.
           84|       args = rattrs (args // { inherit finalPackage overrideAttrs; });
             |              ^
           85|       #              ^^^^

       … while calling anonymous lambda
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/pkgs/development/interpreters/php/generic.nix:225:7:
          224|     stdenv.mkDerivation (
          225|       finalAttrs:
             |       ^
          226|       let

       … in the right operand of the update (//) operator
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/pkgs/development/interpreters/php/generic.nix:417:23:
          416|         };
          417|         final = attrs // (lib.toExtension phpAttrsOverrides) final attrs;
             |                       ^
          418|       in

       … from call site
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/pkgs/development/interpreters/php/generic.nix:417:27:
          416|         };
          417|         final = attrs // (lib.toExtension phpAttrsOverrides) final attrs;
             |                           ^
          418|       in

       … while calling anonymous lambda
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/lib/fixed-points.nix:512:14:
          511|     if lib.isFunction f then
          512|       final: prev:
             |              ^
          513|       let

       … from call site
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/lib/fixed-points.nix:518:9:
          517|         # f is (final: prev: { ... })
          518|         f final prev
             |         ^
          519|       else

       … while calling 'composeExtensions'
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/lib/fixed-points.nix:335:18:
          334|   composeExtensions =
          335|     f: g: final: prev:
             |                  ^
          336|     let

       … in the left operand of the update (//) operator
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/lib/fixed-points.nix:340:14:
          339|     in
          340|     fApplied // g final prev';
             |              ^
          341|

       … from call site
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/lib/fixed-points.nix:337:18:
          336|     let
          337|       fApplied = f final prev;
             |                  ^
          338|       prev' = prev // fApplied;

       (8196 duplicate frames omitted)

       … while evaluating a branch condition
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/lib/fixed-points.nix:516:7:
          515|       in
          516|       if lib.isFunction fPrev then
             |       ^
          517|         # f is (final: prev: { ... })

       … from call site
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/lib/fixed-points.nix:516:10:
          515|       in
          516|       if lib.isFunction fPrev then
             |          ^
          517|         # f is (final: prev: { ... })

       … while calling 'isFunction'
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/lib/trivial.nix:1023:16:
         1022|   */
         1023|   isFunction = f: builtins.isFunction f || (f ? __functor && isFunction (f.__functor f));
             |                ^
         1024|

       … in the left operand of the OR (||) operator
         at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/lib/trivial.nix:1023:41:
         1022|   */
         1023|   isFunction = f: builtins.isFunction f || (f ? __functor && isFunction (f.__functor f));
             |                                         ^
         1024|

       error: stack overflow; max-call-depth exceeded
       at /nix/store/pp0ch7rrc6ciswnhncnwvd5pmmbn3p3d-source/lib/trivial.nix:1023:19:
         1022|   */
         1023|   isFunction = f: builtins.isFunction f || (f ? __functor && isFunction (f.__functor f));
             |                   ^
         1024|
error: some errors were encountered during the evaluation
```

</p>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
