### PR TITLE
font-{{screen,winitzki}-cyrillic,{schumacher,sony,sun}-misc,xfree86-type1}: refactor, move to pkgs/by-name and rename from xorg namespace

### DIFF
--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -177,7 +177,7 @@ let
     {
       postInstall = ''
         alias='cursor -xfree86-cursor-medium-r-normal--0-${sizeString}-0-0-p-0-adobe-fontspecific'
-        echo "$alias" > $out/lib/X11/fonts/Type1/fonts.alias
+        echo "$alias" > $out/share/fonts/X11/Type1/fonts.alias
       '';
     }
   );

--- a/pkgs/by-name/fo/font-schumacher-misc/package.nix
+++ b/pkgs/by-name/fo/font-schumacher-misc/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ font-util ];
 
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+  configureFlags = [ "--with-fontrootdir=$(out)/share/fonts/X11" ];
 
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''

--- a/pkgs/by-name/fo/font-schumacher-misc/package.nix
+++ b/pkgs/by-name/fo/font-schumacher-misc/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  font-util,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-schumacher-misc";
+  version = "1.1.3";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-schumacher-misc-${finalAttrs.version}.tar.xz";
+    hash = "sha256-i4SfDNseVaNMw92LD7N0Q/q7wiTVukQIVWlYEkSmgHA=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    bdftopcf
+    font-util
+    mkfontscale
+  ];
+
+  buildInputs = [ font-util ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Schumacher pcf fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/schumacher-misc";
+    license = lib.licenses.hpnd;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-screen-cyrillic/package.nix
+++ b/pkgs/by-name/fo/font-screen-cyrillic/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-screen-cyrillic";
+  version = "1.0.5";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-screen-cyrillic-${finalAttrs.version}.tar.xz";
+    hash = "sha256-j3WLuM1YDH5lVIfR0Ntp0xmsrlTZMrKV2W2dm4P95cA=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    bdftopcf
+    mkfontscale
+  ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Screen Cyrillic pcf font";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/screen-cyrillic";
+    license = lib.licenses.cronyx;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-screen-cyrillic/package.nix
+++ b/pkgs/by-name/fo/font-screen-cyrillic/package.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation (finalAttrs: {
     mkfontscale
   ];
 
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''
       #!/usr/bin/env nix-shell

--- a/pkgs/by-name/fo/font-sony-misc/package.nix
+++ b/pkgs/by-name/fo/font-sony-misc/package.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation (finalAttrs: {
     mkfontscale
   ];
 
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''
       #!/usr/bin/env nix-shell

--- a/pkgs/by-name/fo/font-sony-misc/package.nix
+++ b/pkgs/by-name/fo/font-sony-misc/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-sony-misc";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-sony-misc-${finalAttrs.version}.tar.xz";
+    hash = "sha256-5rCfgj/MsG4L0LIGIoO2UUFTMjvYp0hunC4/VauElGs=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    bdftopcf
+    mkfontscale
+  ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Sony pcf fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/sony-misc";
+    license = lib.licenses.hpnd;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-sun-misc/package.nix
+++ b/pkgs/by-name/fo/font-sun-misc/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-sun-misc";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-sun-misc-${finalAttrs.version}.tar.xz";
+    hash = "sha256-3YTdEW2Sev+k+g+ilyez7PwPBkI4gXwKHlUqCsOE258=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    bdftopcf
+    mkfontscale
+  ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Open Look Glyph and Cursor pcf fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/sun-misc/";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-sun-misc/package.nix
+++ b/pkgs/by-name/fo/font-sun-misc/package.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation (finalAttrs: {
     mkfontscale
   ];
 
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''
       #!/usr/bin/env nix-shell

--- a/pkgs/by-name/fo/font-winitzki-cyrillic/package.nix
+++ b/pkgs/by-name/fo/font-winitzki-cyrillic/package.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation (finalAttrs: {
     mkfontscale
   ];
 
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''
       #!/usr/bin/env nix-shell

--- a/pkgs/by-name/fo/font-winitzki-cyrillic/package.nix
+++ b/pkgs/by-name/fo/font-winitzki-cyrillic/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-winitzki-cyrillic";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-winitzki-cyrillic-${finalAttrs.version}.tar.xz";
+    hash = "sha256-O22CEi3BR3bjr82HeDOng04fkAxT/Bx7stZ8eBz6l6g=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    bdftopcf
+    mkfontscale
+  ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Winitzki Proof Cyrillic pcf font";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/winitzki-cyrillic";
+    license = lib.licenses.publicDomain;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-xfree86-type1/package.nix
+++ b/pkgs/by-name/fo/font-xfree86-type1/package.nix
@@ -18,8 +18,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ mkfontscale ];
 
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''
       #!/usr/bin/env nix-shell

--- a/pkgs/by-name/fo/font-xfree86-type1/package.nix
+++ b/pkgs/by-name/fo/font-xfree86-type1/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-xfree86-type1";
+  version = "1.0.5";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-xfree86-type1-${finalAttrs.version}.tar.xz";
+    hash = "sha256-qTwseIpeocACr3yGYs+dmCH7HfUbjSssXgAm39/qSDc=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ mkfontscale ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "XFree86 Cusrsor Postscript Type 1 Font";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/xfree86-type1";
+    license = lib.licenses.x11;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -17,6 +17,7 @@
   font-sony-misc,
   font-sun-misc,
   font-util,
+  font-winitzki-cyrillic,
   gccmakedep,
   ico,
   imake,
@@ -150,6 +151,7 @@ self: with self; {
   fontsonymisc = font-sony-misc;
   fontsunmisc = font-sun-misc;
   fontutil = font-util;
+  fontwinitzkicyrillic = font-winitzki-cyrillic;
   libAppleWM = libapplewm;
   libFS = libfs;
   libICE = libice;
@@ -1185,46 +1187,6 @@ self: with self; {
         freetype
         xorgproto
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontwinitzkicyrillic = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-winitzki-cyrillic";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-winitzki-cyrillic-1.0.4.tar.xz";
-        sha256 = "1a4pz8f7hz6nn9xirz2k1j81ykl3lwrpi1ydmzipciy15l984v9v";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -15,6 +15,7 @@
   font-schumacher-misc,
   font-screen-cyrillic,
   font-sony-misc,
+  font-sun-misc,
   font-util,
   gccmakedep,
   ico,
@@ -147,6 +148,7 @@ self: with self; {
   fontschumachermisc = font-schumacher-misc;
   fontscreencyrillic = font-screen-cyrillic;
   fontsonymisc = font-sony-misc;
+  fontsunmisc = font-sun-misc;
   fontutil = font-util;
   libAppleWM = libapplewm;
   libFS = libfs;
@@ -1140,46 +1142,6 @@ self: with self; {
         pkg-config
         bdftopcf
         fontutil
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontsunmisc = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-sun-misc";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-sun-misc-1.0.4.tar.xz";
-        sha256 = "17yvhk1hlajm3q57r09q8830zz7cnckrg8hgzajgyyljdl8xv16x";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
         mkfontscale
       ];
       buildInputs = [ fontutil ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -13,6 +13,7 @@
   font-encodings,
   font-mutt-misc,
   font-schumacher-misc,
+  font-screen-cyrillic,
   font-util,
   gccmakedep,
   ico,
@@ -143,6 +144,7 @@ self: with self; {
   fontbhtype1 = font-bh-type1;
   fontmuttmisc = font-mutt-misc;
   fontschumachermisc = font-schumacher-misc;
+  fontscreencyrillic = font-screen-cyrillic;
   fontutil = font-util;
   libAppleWM = libapplewm;
   libFS = libfs;
@@ -1136,46 +1138,6 @@ self: with self; {
         pkg-config
         bdftopcf
         fontutil
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontscreencyrillic = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-screen-cyrillic";
-      version = "1.0.5";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-screen-cyrillic-1.0.5.tar.xz";
-        sha256 = "1h75zn1rp7bdv6av4cnrajpaq6fkd7dx1lc7aijpw32qrnw8nxcg";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
         mkfontscale
       ];
       buildInputs = [ fontutil ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -18,6 +18,7 @@
   font-sun-misc,
   font-util,
   font-winitzki-cyrillic,
+  font-xfree86-type1,
   gccmakedep,
   ico,
   imake,
@@ -152,6 +153,7 @@ self: with self; {
   fontsunmisc = font-sun-misc;
   fontutil = font-util;
   fontwinitzkicyrillic = font-winitzki-cyrillic;
+  fontxfree86type1 = font-xfree86-type1;
   libAppleWM = libapplewm;
   libFS = libfs;
   libICE = libice;
@@ -1187,44 +1189,6 @@ self: with self; {
         freetype
         xorgproto
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontxfree86type1 = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-xfree86-type1";
-      version = "1.0.5";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-xfree86-type1-1.0.5.tar.xz";
-        sha256 = "0ds8xbgxy9h0bqn2p38vylfzn8cqkp7n51kwmw1c18ayi9w2qg59";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -12,6 +12,7 @@
   font-bh-type1,
   font-encodings,
   font-mutt-misc,
+  font-schumacher-misc,
   font-util,
   gccmakedep,
   ico,
@@ -141,6 +142,7 @@ self: with self; {
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
   fontmuttmisc = font-mutt-misc;
+  fontschumachermisc = font-schumacher-misc;
   fontutil = font-util;
   libAppleWM = libapplewm;
   libFS = libfs;
@@ -1124,47 +1126,6 @@ self: with self; {
       src = fetchurl {
         url = "mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz";
         sha256 = "1vcgc6lbc53fqaz8alhxcb6f231hhvj9hn2nkzg1mclbymhy7avr";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
-        fontutil
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontschumachermisc = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-schumacher-misc";
-      version = "1.1.3";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-schumacher-misc-1.1.3.tar.xz";
-        sha256 = "0w40lr214n39al449fnm4k1bpyj3fjrhz2yxqd6a6m8yvc69z14b";
       };
       hardeningDisable = [
         "bindnow"

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -14,6 +14,7 @@
   font-mutt-misc,
   font-schumacher-misc,
   font-screen-cyrillic,
+  font-sony-misc,
   font-util,
   gccmakedep,
   ico,
@@ -145,6 +146,7 @@ self: with self; {
   fontmuttmisc = font-mutt-misc;
   fontschumachermisc = font-schumacher-misc;
   fontscreencyrillic = font-screen-cyrillic;
+  fontsonymisc = font-sony-misc;
   fontutil = font-util;
   libAppleWM = libapplewm;
   libFS = libfs;
@@ -1138,46 +1140,6 @@ self: with self; {
         pkg-config
         bdftopcf
         fontutil
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontsonymisc = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-sony-misc";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-sony-misc-1.0.4.tar.xz";
-        sha256 = "0swlhjmmagrfkip4i9yq7cr56hains1j41mjs05nxc6c7y19zc76";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
         mkfontscale
       ];
       buildInputs = [ fontutil ];

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -333,6 +333,7 @@ print OUT <<EOF;
   font-sony-misc,
   font-sun-misc,
   font-util,
+  font-winitzki-cyrillic,
   gccmakedep,
   ico,
   imake,
@@ -466,6 +467,7 @@ self: with self; {
   fontsonymisc = font-sony-misc;
   fontsunmisc = font-sun-misc;
   fontutil = font-util;
+  fontwinitzkicyrillic = font-winitzki-cyrillic;
   libAppleWM = libapplewm;
   libFS = libfs;
   libICE = libice;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -331,6 +331,7 @@ print OUT <<EOF;
   font-schumacher-misc,
   font-screen-cyrillic,
   font-sony-misc,
+  font-sun-misc,
   font-util,
   gccmakedep,
   ico,
@@ -463,6 +464,7 @@ self: with self; {
   fontschumachermisc = font-schumacher-misc;
   fontscreencyrillic = font-screen-cyrillic;
   fontsonymisc = font-sony-misc;
+  fontsunmisc = font-sun-misc;
   fontutil = font-util;
   libAppleWM = libapplewm;
   libFS = libfs;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -330,6 +330,7 @@ print OUT <<EOF;
   font-mutt-misc,
   font-schumacher-misc,
   font-screen-cyrillic,
+  font-sony-misc,
   font-util,
   gccmakedep,
   ico,
@@ -461,6 +462,7 @@ self: with self; {
   fontmuttmisc = font-mutt-misc;
   fontschumachermisc = font-schumacher-misc;
   fontscreencyrillic = font-screen-cyrillic;
+  fontsonymisc = font-sony-misc;
   fontutil = font-util;
   libAppleWM = libapplewm;
   libFS = libfs;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -334,6 +334,7 @@ print OUT <<EOF;
   font-sun-misc,
   font-util,
   font-winitzki-cyrillic,
+  font-xfree86-type1,
   gccmakedep,
   ico,
   imake,
@@ -468,6 +469,7 @@ self: with self; {
   fontsunmisc = font-sun-misc;
   fontutil = font-util;
   fontwinitzkicyrillic = font-winitzki-cyrillic;
+  fontxfree86type1 = font-xfree86-type1;
   libAppleWM = libapplewm;
   libFS = libfs;
   libICE = libice;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -328,6 +328,7 @@ print OUT <<EOF;
   font-bh-type1,
   font-encodings,
   font-mutt-misc,
+  font-schumacher-misc,
   font-util,
   gccmakedep,
   ico,
@@ -457,6 +458,7 @@ self: with self; {
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
   fontmuttmisc = font-mutt-misc;
+  fontschumachermisc = font-schumacher-misc;
   fontutil = font-util;
   libAppleWM = libapplewm;
   libFS = libfs;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -329,6 +329,7 @@ print OUT <<EOF;
   font-encodings,
   font-mutt-misc,
   font-schumacher-misc,
+  font-screen-cyrillic,
   font-util,
   gccmakedep,
   ico,
@@ -459,6 +460,7 @@ self: with self; {
   fontbhtype1 = font-bh-type1;
   fontmuttmisc = font-mutt-misc;
   fontschumachermisc = font-schumacher-misc;
+  fontscreencyrillic = font-screen-cyrillic;
   fontutil = font-util;
   libAppleWM = libapplewm;
   libFS = libfs;

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -109,7 +109,6 @@ mirror://xorg/individual/font/font-misc-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-ethiopic-1.0.5.tar.xz
 mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz
-mirror://xorg/individual/font/font-screen-cyrillic-1.0.5.tar.xz
 mirror://xorg/individual/font/font-sony-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-sun-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-winitzki-cyrillic-1.0.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -109,7 +109,6 @@ mirror://xorg/individual/font/font-misc-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-ethiopic-1.0.5.tar.xz
 mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz
-mirror://xorg/individual/font/font-winitzki-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-xfree86-type1-1.0.5.tar.xz
 mirror://xorg/individual/lib/libWindowsWM-1.0.1.tar.bz2
 mirror://xorg/individual/lib/libXcomposite-0.4.6.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -109,7 +109,6 @@ mirror://xorg/individual/font/font-misc-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-ethiopic-1.0.5.tar.xz
 mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz
-mirror://xorg/individual/font/font-sun-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-winitzki-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-xfree86-type1-1.0.5.tar.xz
 mirror://xorg/individual/lib/libWindowsWM-1.0.1.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -109,7 +109,6 @@ mirror://xorg/individual/font/font-misc-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-ethiopic-1.0.5.tar.xz
 mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz
-mirror://xorg/individual/font/font-schumacher-misc-1.1.3.tar.xz
 mirror://xorg/individual/font/font-screen-cyrillic-1.0.5.tar.xz
 mirror://xorg/individual/font/font-sony-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-sun-misc-1.0.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -109,7 +109,6 @@ mirror://xorg/individual/font/font-misc-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-ethiopic-1.0.5.tar.xz
 mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz
-mirror://xorg/individual/font/font-sony-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-sun-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-winitzki-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-xfree86-type1-1.0.5.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -109,7 +109,6 @@ mirror://xorg/individual/font/font-misc-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-ethiopic-1.0.5.tar.xz
 mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz
-mirror://xorg/individual/font/font-xfree86-type1-1.0.5.tar.xz
 mirror://xorg/individual/lib/libWindowsWM-1.0.1.tar.bz2
 mirror://xorg/individual/lib/libXcomposite-0.4.6.tar.xz
 mirror://xorg/individual/lib/libXdamage-1.1.6.tar.xz


### PR DESCRIPTION
<details>
<summary>this is the script i use to get the packages that don't depend on other xorg packages:</summary>

```nix
let
  inherit (import <nixpkgs> { }) lib;

  done = import ./pkgs/servers/x11/xorg/default.nix |> lib.functionArgs |> lib.attrNames;

  pkgs =
    (import ./default.nix { }).xorg
    |> lib.filterAttrs (
      n: v:
      lib.isAttrs v
      && v ? pname
      && !lib.elem n done
      && !lib.elem n (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem v.pname done
      && !lib.elem v.pname (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem (lib.toLower n) done
      && !lib.elem (lib.toLower n) (map (lib.replaceStrings [ "-" ] [ "" ]) done)
    );

  pnames = lib.mapAttrsToList (_: v: v.pname) pkgs;

  filteredPkgs =
    pkgs
    |> lib.filterAttrs (
      n: v:
      true
      # && !v.meta.unfree
      # && !v.meta.broken
      # && !v.meta.unsupported
      # && !lib.hasPrefix "font" n
      && !lib.hasPrefix "xf86" n
    );
in
filteredPkgs
# get deps
|> lib.mapAttrs (
  _: v:
  v.buildInputs ++ v.nativeBuildInputs ++ v.propagatedBuildInputs ++ v.propagatedNativeBuildInputs
)
# filter deps for xorg packages
|> lib.mapAttrs (_: v: lib.filter (x: x ? pname && lib.elem x.pname pnames) v)
# map deps to list and count
|> lib.mapAttrsToList (
  name: value: {
    inherit name;
    deps = map (x: x.pname or "error") value |> lib.unique;
    count = lib.length value;
  }
)
# sort
|> lib.sort (
  x: y: x.count < y.count || (x.count == y.count && (lib.toLower x.name) > (lib.toLower y.name))
)
|> lib.reverseList
# represent as string
|> map (x: "${toString x.count} - ${toString x.name}: ${lib.concatStringsSep " " x.deps}")
```

you can call it like this to get a nice output:

```sh
nix eval --json --file ./xorg-nodepends.nix | jq .[] --raw-output
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Build for platform:
  - [x] x86_64-linux
  - [x] x86_64-linux static
  - [x] aarch64-multiplatform
  - [x] aarch64-multiplatform-musl
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] ran passthru.updateScript
- [x] ran nix-check-deps
- [x] ran nixpkgs-hammer
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc