### PR TITLE
[Backport release-25.05] nightfox-gtk-theme: 0-unstable-2025-07-21 -> 0-unstable-2025-08-21 

### DIFF
--- a/pkgs/by-name/ni/nightfox-gtk-theme/package.nix
+++ b/pkgs/by-name/ni/nightfox-gtk-theme/package.nix
@@ -70,13 +70,13 @@ lib.checkListOfEnum "${pname}: colorVariants" colorVariantList colorVariants lib
   stdenvNoCC.mkDerivation
   {
     inherit pname;
-    version = "0-unstable-2025-07-28";
+    version = "0-unstable-2025-08-21";
 
     src = fetchFromGitHub {
       owner = "Fausto-Korpsvart";
       repo = "Nightfox-GTK-Theme";
-      rev = "ea0172aa853e8f6c2b00568c4cd6dcbea7991b7c";
-      hash = "sha256-9+RBAG/JKGXjW6zRut8eXM4EYkbNRZ+yw5tLDrSMBXg=";
+      rev = "4d73329de5ac65dc3e957e1635d471c7d3122a6b";
+      hash = "sha256-QTsouPINcn8coLk5z2EFMG1egP97rFVPgiYqGhwu62c=";
     };
 
     propagatedUserEnvPkgs = [ gtk-engine-murrine ];

--- a/pkgs/by-name/ni/nightfox-gtk-theme/package.nix
+++ b/pkgs/by-name/ni/nightfox-gtk-theme/package.nix
@@ -70,13 +70,13 @@ lib.checkListOfEnum "${pname}: colorVariants" colorVariantList colorVariants lib
   stdenvNoCC.mkDerivation
   {
     inherit pname;
-    version = "0-unstable-2025-07-21";
+    version = "0-unstable-2025-07-28";
 
     src = fetchFromGitHub {
       owner = "Fausto-Korpsvart";
       repo = "Nightfox-GTK-Theme";
-      rev = "d6327b176d19f6f00a9fbe0175fb95953c12b7de";
-      hash = "sha256-46ur/Mvc8r1yr/ViZ+pEbK2OdVSqJCSBh7e9AfrRIRY=";
+      rev = "ea0172aa853e8f6c2b00568c4cd6dcbea7991b7c";
+      hash = "sha256-9+RBAG/JKGXjW6zRut8eXM4EYkbNRZ+yw5tLDrSMBXg=";
     };
 
     propagatedUserEnvPkgs = [ gtk-engine-murrine ];


### PR DESCRIPTION
Manual backport of #429675 #437007 to `release-25.05`.

- [x] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.