### PR TITLE
keymap-drawer: pin `tree-sitter` to 0.24.0

### DIFF
--- a/pkgs/development/python-modules/keymap-drawer/default.nix
+++ b/pkgs/development/python-modules/keymap-drawer/default.nix
@@ -3,6 +3,7 @@
 
   buildPythonPackage,
   fetchFromGitHub,
+  fetchPypi,
   pythonOlder,
 
   nix-update-script,
@@ -46,7 +47,16 @@ buildPythonPackage {
     pydantic-settings
     pyparsing
     pyyaml
-    tree-sitter
+    # keymap-drawer currently requires tree-sitter 0.24.0
+    # See https://github.com/caksoylar/keymap-drawer/issues/183
+    (tree-sitter.overrideAttrs rec {
+      version = "0.24.0";
+      src = fetchPypi {
+        inherit version;
+        inherit (tree-sitter) pname;
+        hash = "sha256-q9la9lyi9Pfso1Y0M5HtZp52Tzd0i1NSlG8A9/x45zQ=";
+      };
+    })
     tree-sitter-grammars.tree-sitter-devicetree
   ];
 


### PR DESCRIPTION
keymap-drawer currently requires tree-sitter 0.24.0, and does not work correctly when run with 0.25+.

`pkgs.python.pkgs.tree-sitter` was bumped in #431074 (d1f7e12d7e2f58912ccb44bb19c8cb83591ee89a), so explicitly pin the input to 0.24.0 via an override for now.

See https://github.com/caksoylar/keymap-drawer/issues/183 and https://github.com/caksoylar/keymap-drawer/commit/481a40d

Fixes #438386 (cc @Asqiir)

Note: Currently (without this PR), if I use `pythonRelaxDeps = [ "tree-sitter" ]` together with `tree-sitter` 0.25.1, the package will build but fail at runtime. I'd like to add package tests that can detect these kinda runtime failures, but I'm currently lacking inspiration. I guess I could probably do something that checks some [example files](https://github.com/caksoylar/keymap-drawer/tree/main/examples) produce the expected output 🤔  ...regardless, that's out-of-scope for _this_ PR.

I have tested this against [the `draw` script](https://github.com/MattSturgeon/glove80-config/blob/c20e606f5ec758fd2c22ff829d6865ee17ad0160/packages/draw.nix) in my https://github.com/MattSturgeon/Glove80-Config. When run with `nix run .#draw --override-input nixpkgs` pointing to this branch, everything built and ran as expected.

Aside: it'd be nice to get upstream updated to support 0.25.1. That is tracked by https://github.com/caksoylar/keymap-drawer/issues/183.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
