### PR TITLE
[Backport release-25.05] keycloak: switch to finalAttrs pattern

### DIFF
--- a/pkgs/by-name/ke/keycloak/package.nix
+++ b/pkgs/by-name/ke/keycloak/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchzip,
-  makeWrapper,
+  makeBinaryWrapper,
   jre_headless,
   nixosTests,
   callPackage,
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    makeWrapper
+    makeBinaryWrapper
     jre_headless
   ];
 

--- a/pkgs/by-name/ke/keycloak/package.nix
+++ b/pkgs/by-name/ke/keycloak/package.nix
@@ -1,6 +1,6 @@
 {
-  stdenv,
   lib,
+  stdenv,
   fetchzip,
   makeWrapper,
   jre_headless,
@@ -22,12 +22,12 @@ let
     ) "--features-disabled=${lib.concatStringsSep "," disabledFeatures}"}
   '';
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "keycloak";
   version = "26.2.5";
 
   src = fetchzip {
-    url = "https://github.com/keycloak/keycloak/releases/download/${version}/keycloak-${version}.zip";
+    url = "https://github.com/keycloak/keycloak/releases/download/${finalAttrs.version}/keycloak-${finalAttrs.version}.zip";
     hash = "sha256-yXbHdznZlrz4T2+154cM+eAmPO/TR5kRCVVi26H66ok=";
   };
 
@@ -103,5 +103,4 @@ stdenv.mkDerivation rec {
       leona
     ];
   };
-
-}
+})


### PR DESCRIPTION
Manual backport of #427220 to `release-25.05`.

- [x] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.