### PR TITLE
stash-clipboard: init at 0.4.0; init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -86,6 +86,8 @@
 
 - [rqbit](https://github.com/ikatson/rqbit), a bittorrent client written in Rust. It has HTTP API and Web UI, and can be used as a library. Available as [services.rqbit](#opt-services.rqbit.enable).
 
+- [stash-clipboard](https://github.com/NotAShelf/stash), a Wayland clipboard "manager" with fast persistent history and multi-media support. Available as [services.stash-clipboard](#opt-services.stash-clipboard.enable).
+
 - [Tailscale Serve](https://tailscale.com/kb/1552/tailscale-services), configure Tailscale Serve for exposing local services to your tailnet. Available as [services.tailscale.serve](#opt-services.tailscale.serve.enable).
 
 - [qui](https://github.com/autobrr/qui), a modern alternative webUI for qBittorrent, with multi-instance support. Written in Go/React. Available as [services.qui](#opt-services.qui.enable).

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -36,6 +36,8 @@
 
 - [Matrix Authentication Service](https://github.com/element-hq/matrix-authentication-service) is an OAuth2.0 and OpenID Connect provider for Matrix homeservers (such as Synapse). It replaces standard password authentication with modern OpenID Connect flows, and can delegate authentication to upstream OIDC providers. Available as [services.matrix-authentication-service](#opt-services.matrix-authentication-service.enable).
 
+- [stash-clipboard](https://github.com/NotAShelf/stash), a Wayland clipboard "manager" with fast persistent history and multi-media support. Available as [services.stash-clipboard](#opt-services.stash-clipboard.enable).
+
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -973,6 +973,7 @@
   ./services/misc/spice-webdavd.nix
   ./services/misc/spoolman.nix
   ./services/misc/sssd.nix
+  ./services/misc/stash-clipboard.nix
   ./services/misc/subsonic.nix
   ./services/misc/sundtek.nix
   ./services/misc/svnserve.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -981,6 +981,7 @@
   ./services/misc/spice-webdavd.nix
   ./services/misc/spoolman.nix
   ./services/misc/sssd.nix
+  ./services/misc/stash-clipboard.nix
   ./services/misc/subsonic.nix
   ./services/misc/sundtek.nix
   ./services/misc/svnserve.nix

--- a/nixos/modules/services/misc/stash-clipboard.nix
+++ b/nixos/modules/services/misc/stash-clipboard.nix
@@ -1,0 +1,73 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.stash-clipboard;
+  inherit (lib)
+    mkPackageOption
+    mkEnableOption
+    mkOption
+    types
+    mkIf
+    getExe
+    concatStringsSep
+    ;
+in
+{
+  options.services.stash-clipboard = {
+    enable = mkEnableOption "stash, a Wayland clipboard manager";
+
+    package = mkPackageOption pkgs [ "stash-clipboard" ] { };
+
+    flags = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "--max-items 10" ];
+      description = "Flags to pass to stash watch.";
+    };
+
+    filterFile = mkOption {
+      type = types.str;
+      default = "";
+      example = "/etc/stash/clipboard_filter";
+      description = ''
+        Stash can be configured to avoid storing clipboard entries that match a sensitive pattern, using a regular expression.
+        The file set here should contain your regex pattern (no quotes).
+
+        Example regex to block common password patterns:
+        - (password|secret|api[_-]?key|token)[=: ]+[^\s]+
+      '';
+    };
+
+    excludedApps = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "Bitwarden" ];
+      description = ''
+        List of application classes to exclude from the database.
+        Entries from these apps are still copied to the clipboard, but it will never be put inside the database.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    systemd = {
+      user.services.stash-clipboard = {
+        description = "Stash clipboard manager daemon";
+        wantedBy = [ "graphical-session.target" ];
+        after = [ "graphical-session.target" ];
+        serviceConfig = {
+          ExecStart = "${getExe cfg.package} ${concatStringsSep " " cfg.flags} watch";
+          LoadCredential = mkIf (cfg.filterFile != "") "clipboard_filter:${cfg.filterFile}";
+        };
+        environment = mkIf (cfg.excludedApps != [ ]) {
+          STASH_EXCLUDED_APPS = concatStringsSep "," cfg.excludedApps;
+        };
+      };
+    };
+  };
+}

--- a/nixos/modules/services/misc/stash-clipboard.nix
+++ b/nixos/modules/services/misc/stash-clipboard.nix
@@ -1,0 +1,73 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.stash-clipboard;
+  inherit (lib)
+    mkPackageOption
+    mkEnableOption
+    mkOption
+    types
+    mkIf
+    getExe
+    concatStringsSep
+    ;
+in
+{
+  options.services.stash-clipboard = {
+    enable = mkEnableOption "stash, a Wayland clipboard manager";
+
+    package = mkPackageOption pkgs [ "stash-clipboard" ] { };
+
+    arguments = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "--max-items 10" ];
+      description = "A list of arguments to pass to stash watch.";
+    };
+
+    filterFile = mkOption {
+      type = types.str;
+      default = "";
+      example = "/etc/stash/clipboard_filter";
+      description = ''
+        Stash can be configured to avoid storing clipboard entries that match a sensitive pattern, using a regular expression.
+        The file set here should contain your regex pattern (no quotes).
+
+        Example regex to block common password patterns:
+        - (password|secret|api[_-]?key|token)[=: ]+[^\s]+
+      '';
+    };
+
+    excludedApps = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "Bitwarden" ];
+      description = ''
+        List of application classes to exclude from the database.
+        Entries from these apps are still copied to the clipboard, but it will never be put inside the database.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    systemd = {
+      user.services.stash-clipboard = {
+        description = "Stash clipboard manager daemon";
+        wantedBy = [ "graphical-session.target" ];
+        after = [ "graphical-session.target" ];
+        serviceConfig = {
+          ExecStart = "${getExe cfg.package} ${concatStringsSep " " cfg.arguments} watch";
+          LoadCredential = mkIf (cfg.filterFile != "") "clipboard_filter:${cfg.filterFile}";
+        };
+        environment = mkIf (cfg.excludedApps != [ ]) {
+          STASH_EXCLUDED_APPS = concatStringsSep "," cfg.excludedApps;
+        };
+      };
+    };
+  };
+}

--- a/pkgs/by-name/st/stash-clipboard/package.nix
+++ b/pkgs/by-name/st/stash-clipboard/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "stash-clipboard";
+  version = "0.3.6";
+
+  src = fetchFromGitHub {
+    owner = "NotAShelf";
+    repo = "stash";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NHsyzEjeIjfj5zZB7xoqilJtCzB7toLsxGbH781JD3g=";
+  };
+
+  cargoHash = "sha256-r1WEVjbu0U1S7b3KXV/yre2IdqGEdJ4JqBlx5OjPv10=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Wayland clipboard manager with fast persistent history and multi-media support";
+    homepage = "https://github.com/NotAShelf/stash";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [
+      NotAShelf
+      fazzi
+    ];
+    mainProgram = "stash";
+  };
+})

--- a/pkgs/by-name/st/stash-clipboard/package.nix
+++ b/pkgs/by-name/st/stash-clipboard/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "stash-clipboard";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "NotAShelf";
+    repo = "stash";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-L5UfPKzdU8qQIyXSCMglLhv22J7xInxg3NNKCLkxszM=";
+  };
+
+  cargoHash = "sha256-iXL3G1H8tNS1oPAoEvvx7qwWUef95NBU3dwlEe+34zw=";
+
+  __structuredAttrs = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Wayland clipboard manager with fast persistent history and multi-media support";
+    homepage = "https://github.com/NotAShelf/stash";
+    changelog = "https://github.com/NotAShelf/stash/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mpl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      NotAShelf
+      fazzi
+    ];
+    mainProgram = "stash";
+  };
+})


### PR DESCRIPTION
Adds the package stash-clipboard by @NotAShelf, as well as a module for configuring its service.

The module allows the user to add any extra flags, and also a regex filter which stash can use to avoid storing secure items within the clipboard.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
