### PR TITLE
[Backport release-25.05] h2o: 2.3.0.20250430 → 2.3.0-rolling-2025-08-22

### DIFF
--- a/pkgs/by-name/h2/h2o/package.nix
+++ b/pkgs/by-name/h2/h2o/package.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "h2o";
-  version = "2.3.0.20250519";
+  version = "2.3.0.20250716";
 
   src = fetchFromGitHub {
     owner = "h2o";
     repo = "h2o";
-    rev = "87e2aa634f2c0d9f3d9429f7a3cf273f98db0058";
-    sha256 = "sha256-/9YnaOqvYmFme4/mFq8Sx78FMDyGwnErEW45qPVELjU=";
+    rev = "a7ee72ea84815f393353e66c02181832fcd8dbb3";
+    sha256 = "sha256-vym1oF/oFjrcQaKJWqwOYxNRHDsrX0vVh5Li0Zl96KY=";
   };
 
   patches = [

--- a/pkgs/by-name/h2/h2o/package.nix
+++ b/pkgs/by-name/h2/h2o/package.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "h2o";
-  version = "2.3.0.20250430";
+  version = "2.3.0.20250519";
 
   src = fetchFromGitHub {
     owner = "h2o";
     repo = "h2o";
-    rev = "f1918a5b9f75f4da9db801b442886cb13b3c7bcd";
-    sha256 = "sha256-sfOkyEhlLGmXjYqRoI/8pD6/NBY7q6K9y2vS7qwJmrw=";
+    rev = "87e2aa634f2c0d9f3d9429f7a3cf273f98db0058";
+    sha256 = "sha256-/9YnaOqvYmFme4/mFq8Sx78FMDyGwnErEW45qPVELjU=";
   };
 
   patches = [

--- a/pkgs/by-name/h2/h2o/package.nix
+++ b/pkgs/by-name/h2/h2o/package.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "h2o";
-  version = "2.3.0-untagged-2025-08-13";
+  version = "2.3.0-untagged-2025-08-14";
 
   src = fetchFromGitHub {
     owner = "h2o";
     repo = "h2o";
-    rev = "4729b661e3c6654198d2cc62997e1af58bef4b80";
-    sha256 = "sha256-3vVe2nveWohpxtqECq/wcPupAHaRRoG54sG94J+3eyQ=";
+    rev = "ffab9c49c33b1f0e9aec9804028156aae9db8ef0";
+    sha256 = "sha256-kdU2p9oUhxGnw8JU9qGjV4mn2jMeSUL0rLgveMs6NiI=";
   };
 
   patches = [

--- a/pkgs/by-name/h2/h2o/package.nix
+++ b/pkgs/by-name/h2/h2o/package.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "h2o";
-  version = "2.3.0-untagged-2025-08-14";
+  version = "2.3.0-rolling-2025-08-22";
 
   src = fetchFromGitHub {
     owner = "h2o";
     repo = "h2o";
-    rev = "ffab9c49c33b1f0e9aec9804028156aae9db8ef0";
-    hash = "sha256-kdU2p9oUhxGnw8JU9qGjV4mn2jMeSUL0rLgveMs6NiI=";
+    rev = "6476496bd544c3c7f601d7ab2b07e378e8310e11";
+    hash = "sha256-ZSBYg1HCuYifTyDmHyNIjEWab5N1TT+q/4m62mFFDJ0=";
   };
 
   patches = [

--- a/pkgs/by-name/h2/h2o/package.nix
+++ b/pkgs/by-name/h2/h2o/package.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "h2o";
-  version = "2.3.0.20250716";
+  version = "2.3.0.20250717";
 
   src = fetchFromGitHub {
     owner = "h2o";
     repo = "h2o";
-    rev = "a7ee72ea84815f393353e66c02181832fcd8dbb3";
-    sha256 = "sha256-vym1oF/oFjrcQaKJWqwOYxNRHDsrX0vVh5Li0Zl96KY=";
+    rev = "db98b59ba7abfcd1dc9b43ea4b9ad1052aba775e";
+    sha256 = "sha256-vBA5TWyvtaaBZV4RmfAAA7F34fXNkROS0rbZRpEJgrc=";
   };
 
   patches = [

--- a/pkgs/by-name/h2/h2o/package.nix
+++ b/pkgs/by-name/h2/h2o/package.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "h2o";
-  version = "2.3.0.20250717";
+  version = "2.3.0-untagged-2025-08-13";
 
   src = fetchFromGitHub {
     owner = "h2o";
     repo = "h2o";
-    rev = "db98b59ba7abfcd1dc9b43ea4b9ad1052aba775e";
-    sha256 = "sha256-vBA5TWyvtaaBZV4RmfAAA7F34fXNkROS0rbZRpEJgrc=";
+    rev = "4729b661e3c6654198d2cc62997e1af58bef4b80";
+    sha256 = "sha256-3vVe2nveWohpxtqECq/wcPupAHaRRoG54sG94J+3eyQ=";
   };
 
   patches = [

--- a/pkgs/by-name/h2/h2o/package.nix
+++ b/pkgs/by-name/h2/h2o/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   pkg-config,
   cmake,
   makeWrapper,
@@ -32,16 +31,6 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "6476496bd544c3c7f601d7ab2b07e378e8310e11";
     hash = "sha256-ZSBYg1HCuYifTyDmHyNIjEWab5N1TT+q/4m62mFFDJ0=";
   };
-
-  patches = [
-    (fetchpatch {
-      # https://github.com/h2o/h2o/security/advisories/GHSA-mrjm-qq9m-9mjq
-      # https://kb.cert.org/vuls/id/767506
-      name = "CVE-2025-8671.patch";
-      url = "https://github.com/h2o/h2o/commit/579ecfaca155d1f9f12bfd0cff6086dcda4b9692.patch";
-      hash = "sha256-bNnhx5RGBw6SmKmhlACHKPsnVUPzQUqHsunPdiayzv0=";
-    })
-  ];
 
   outputs = [
     "out"

--- a/pkgs/by-name/h2/h2o/package.nix
+++ b/pkgs/by-name/h2/h2o/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "h2o";
     repo = "h2o";
     rev = "ffab9c49c33b1f0e9aec9804028156aae9db8ef0";
-    sha256 = "sha256-kdU2p9oUhxGnw8JU9qGjV4mn2jMeSUL0rLgveMs6NiI=";
+    hash = "sha256-kdU2p9oUhxGnw8JU9qGjV4mn2jMeSUL0rLgveMs6NiI=";
   };
 
   patches = [


### PR DESCRIPTION
Manual backport of #408614 #424618 #433400 #435772 to `release-25.05`.

These should all be stable, non-breaking changes: see https://discourse.nixos.org/t/unstable-stable-versioning-semantics-for-trunk-based-maintainence-mode-packages/68103.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.