### PR TITLE
[staging-25.05] treewide: pytestFlagsArray -> enabledTestPaths (trivial)

### DIFF
--- a/pkgs/applications/audio/mopidy/tidal.nix
+++ b/pkgs/applications/audio/mopidy/tidal.nix
@@ -24,7 +24,7 @@ python3Packages.buildPythonApplication rec {
     pytest-mock
   ];
 
-  pytestFlagsArray = [ "tests/" ];
+  enabledTestPaths = [ "tests/" ];
 
   meta = with lib; {
     description = "Mopidy extension for playing music from Tidal";

--- a/pkgs/applications/graphics/inkscape/extensions/silhouette/default.nix
+++ b/pkgs/applications/graphics/inkscape/extensions/silhouette/default.nix
@@ -57,7 +57,7 @@ python3.pkgs.buildPythonApplication rec {
     umockdev
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "test"
   ];
 

--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -132,7 +132,7 @@ python3.pkgs.buildPythonApplication rec {
     pycryptodomex
   ];
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   postCheck = ''
     $out/bin/electrum help >/dev/null

--- a/pkgs/applications/misc/electrum/ltc.nix
+++ b/pkgs/applications/misc/electrum/ltc.nix
@@ -157,7 +157,7 @@ python3.pkgs.buildPythonApplication {
   ];
   buildInputs = lib.optional stdenv.hostPlatform.isLinux qtwayland;
 
-  pytestFlagsArray = [ "electrum_ltc/tests" ];
+  enabledTestPaths = [ "electrum_ltc/tests" ];
 
   disabledTests = [
     "test_loop" # test tries to bind 127.0.0.1 causing permission error

--- a/pkgs/applications/misc/mbutil/default.nix
+++ b/pkgs/applications/misc/mbutil/default.nix
@@ -23,7 +23,7 @@ buildPythonApplication rec {
   build-system = [ setuptools ];
 
   nativeCheckInputs = [ pytestCheckHook ];
-  pytestFlagsArray = [ "test/test.py" ];
+  enabledTestPaths = [ "test/test.py" ];
 
   meta = {
     description = "Importer and exporter for MBTiles";

--- a/pkgs/applications/science/misc/sasview/default.nix
+++ b/pkgs/applications/science/misc/sasview/default.nix
@@ -59,7 +59,7 @@ python3.pkgs.buildPythonApplication rec {
     unittest-xml-reporting
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "test"
   ];
 

--- a/pkgs/by-name/ad/adios2/package.nix
+++ b/pkgs/by-name/ad/adios2/package.nix
@@ -121,7 +121,7 @@ stdenv.mkDerivation (finalAttrs: {
     rm ../testing/adios2/python/TestBPWriteTypesHighLevelAPI.py
   '';
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "../testing/adios2/python/Test*.py"
   ];
 

--- a/pkgs/by-name/ap/apache-airflow/python-package.nix
+++ b/pkgs/by-name/ap/apache-airflow/python-package.nix
@@ -288,7 +288,7 @@ buildPythonPackage rec {
     airflow db reset -y
   '';
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "tests/core/test_core.py"
   ];
 

--- a/pkgs/by-name/ar/arouteserver/package.nix
+++ b/pkgs/by-name/ar/arouteserver/package.nix
@@ -46,7 +46,7 @@ python3Packages.buildPythonPackage rec {
     "pierky.arouteserver"
   ];
 
-  pytestFlagsArray = [ "tests/static" ];
+  enabledTestPaths = [ "tests/static" ];
 
   disabledTests = [
     # disable copyright year check of files

--- a/pkgs/by-name/aw/awsebcli/package.nix
+++ b/pkgs/by-name/aw/awsebcli/package.nix
@@ -70,7 +70,7 @@ python.pkgs.buildPythonApplication rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "tests/unit"
   ];
 

--- a/pkgs/by-name/bc/bcal/package.nix
+++ b/pkgs/by-name/bc/bcal/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     python3Packages.pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "test.py" ];
+  enabledTestPaths = [ "test.py" ];
 
   meta = with lib; {
     description = "Storage conversion and expression calculator";

--- a/pkgs/by-name/ca/castero/package.nix
+++ b/pkgs/by-name/ca/castero/package.nix
@@ -39,7 +39,7 @@ python3.pkgs.buildPythonApplication rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "tests"
   ];
 

--- a/pkgs/by-name/ch/charmcraft/package.nix
+++ b/pkgs/by-name/ch/charmcraft/package.nix
@@ -76,7 +76,7 @@ python3Packages.buildPythonApplication rec {
     export HOME="$(pwd)/check-phase"
   '';
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   disabledTests = [
     # Relies upon the `charm` tool being installed

--- a/pkgs/by-name/cr/credslayer/package.nix
+++ b/pkgs/by-name/cr/credslayer/package.nix
@@ -27,7 +27,7 @@ python3.pkgs.buildPythonApplication rec {
     wireshark-cli
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "tests/tests.py"
   ];
 

--- a/pkgs/by-name/fi/fittrackee/package.nix
+++ b/pkgs/by-name/fi/fittrackee/package.nix
@@ -72,7 +72,7 @@ python3Packages.buildPythonApplication rec {
     time-machine
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "fittrackee"
   ];
 

--- a/pkgs/by-name/ge/gemmi/package.nix
+++ b/pkgs/by-name/ge/gemmi/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     "test_reading"
   ];
 
-  pytestFlagsArray = [ "../tests" ];
+  enabledTestPaths = [ "../tests" ];
 
   meta = {
     description = "Macromolecular crystallography library and utilities";

--- a/pkgs/by-name/he/herbstluftwm/package.nix
+++ b/pkgs/by-name/he/herbstluftwm/package.nix
@@ -116,7 +116,7 @@ stdenv.mkDerivation rec {
     export PYTHONPATH="$PYTHONPATH:../python"
   '';
 
-  pytestFlagsArray = [ "../tests" ];
+  enabledTestPaths = [ "../tests" ];
   disabledTests = [
     "test_autostart" # $PATH problems
     "test_wmexec_to_other" # timeouts in sandbox

--- a/pkgs/by-name/kn/knowsmore/package.nix
+++ b/pkgs/by-name/kn/knowsmore/package.nix
@@ -45,7 +45,7 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonImportsCheck = [ "knowsmore" ];
 
-  pytestFlagsArray = [ "tests/tests*" ];
+  enabledTestPaths = [ "tests/tests*" ];
 
   meta = with lib; {
     description = "Tool for pentesting Microsoft Active Directory";

--- a/pkgs/by-name/ma/mackup/package.nix
+++ b/pkgs/by-name/ma/mackup/package.nix
@@ -29,7 +29,7 @@ python3Packages.buildPythonApplication rec {
 
   nativeCheckInputs = with python3Packages; [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/*.py" ];
+  enabledTestPaths = [ "tests/*.py" ];
 
   # Disabling tests failing on darwin due to a missing pgrep binary on procps
   disabledTests = [ "test_is_process_running" ];

--- a/pkgs/by-name/me/memray/package.nix
+++ b/pkgs/by-name/me/memray/package.nix
@@ -53,7 +53,7 @@ python3Packages.buildPythonApplication rec {
 
   pythonImportsCheck = [ "memray" ];
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   disabledTests = [
     # Import issue

--- a/pkgs/by-name/op/open-web-calendar/package.nix
+++ b/pkgs/by-name/op/open-web-calendar/package.nix
@@ -63,7 +63,7 @@ python.pkgs.buildPythonApplication rec {
 
   nativeCheckInputs = with python.pkgs; [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "open_web_calendar/test" ];
+  enabledTestPaths = [ "open_web_calendar/test" ];
 
   pythonImportsCheck = [ "open_web_calendar.app" ];
 

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -284,7 +284,7 @@ python.pkgs.buildPythonApplication rec {
   # manually managed in postPatch
   dontUsePytestXdist = false;
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "src"
   ];
 

--- a/pkgs/by-name/ph/phase-cli/package.nix
+++ b/pkgs/by-name/ph/phase-cli/package.nix
@@ -38,7 +38,7 @@ python3Packages.buildPythonApplication rec {
     python3Packages.pytestCheckHook
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "tests/*.py"
   ];
 

--- a/pkgs/by-name/ro/routersploit/package.nix
+++ b/pkgs/by-name/ro/routersploit/package.nix
@@ -43,7 +43,7 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonImportsCheck = [ "routersploit" ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     # Run the same tests as upstream does in the first round
     "tests/core/"
     "tests/test_exploit_scenarios.py"

--- a/pkgs/by-name/s3/s3ql/package.nix
+++ b/pkgs/by-name/s3/s3ql/package.nix
@@ -50,7 +50,7 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonImportsCheck = [ "s3ql" ];
 
-  pytestFlagsArray = [ "tests/" ];
+  enabledTestPaths = [ "tests/" ];
 
   passthru.updateScript = nix-update-script {
     extraArgs = [

--- a/pkgs/by-name/sn/snakemake/package.nix
+++ b/pkgs/by-name/sn/snakemake/package.nix
@@ -88,7 +88,7 @@ python3Packages.buildPythonApplication rec {
 
   versionCheckProgramArg = "--version";
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "tests/tests.py"
     "tests/test_expand.py"
     "tests/test_io.py"

--- a/pkgs/by-name/sn/snapcraft/package.nix
+++ b/pkgs/by-name/sn/snapcraft/package.nix
@@ -141,7 +141,7 @@ python3Packages.buildPythonApplication rec {
       squashfsTools
     ];
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   disabledTests = [
     "test_bin_echo"

--- a/pkgs/by-name/wo/world-wall-clock/package.nix
+++ b/pkgs/by-name/wo/world-wall-clock/package.nix
@@ -26,7 +26,7 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeCheckInputs = with python3.pkgs; [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/*" ];
+  enabledTestPaths = [ "tests/*" ];
 
   meta = {
     description = "TUI application that provides a multi-timezone graphical clock in a terminal environment.";

--- a/pkgs/development/python-modules/accelerate/default.nix
+++ b/pkgs/development/python-modules/accelerate/default.nix
@@ -78,7 +78,7 @@ buildPythonPackage rec {
   preCheck = lib.optionalString config.cudaSupport ''
     export TRITON_PTXAS_PATH="${lib.getExe' cudatoolkit "ptxas"}"
   '';
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
   disabledTests = [
     # try to download data:
     "FeatureExamplesTests"

--- a/pkgs/development/python-modules/actdiag/default.nix
+++ b/pkgs/development/python-modules/actdiag/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "src/actdiag/tests/" ];
+  enabledTestPaths = [ "src/actdiag/tests/" ];
 
   disabledTests = [
     # AttributeError: 'TestRstDirectives' object has no attribute 'assertRegexpMatches'

--- a/pkgs/development/python-modules/aeidon/default.nix
+++ b/pkgs/development/python-modules/aeidon/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "aeidon/test" ];
+  enabledTestPaths = [ "aeidon/test" ];
 
   disabledTests = [
     # requires gspell to work with gobject introspection

--- a/pkgs/development/python-modules/afsapi/default.nix
+++ b/pkgs/development/python-modules/afsapi/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "async_tests.py" ];
+  enabledTestPaths = [ "async_tests.py" ];
 
   pythonImportsCheck = [ "afsapi" ];
 

--- a/pkgs/development/python-modules/ahocorapy/default.nix
+++ b/pkgs/development/python-modules/ahocorapy/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "tests/ahocorapy_test.py"
   ];
 

--- a/pkgs/development/python-modules/aiokef/default.nix
+++ b/pkgs/development/python-modules/aiokef/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     pytest-cov-stub
   ];
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
   pythonImportsCheck = [ "aiokef" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/aiomultiprocess/default.nix
+++ b/pkgs/development/python-modules/aiomultiprocess/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "aiomultiprocess/tests/*.py" ];
+  enabledTestPaths = [ "aiomultiprocess/tests/*.py" ];
 
   disabledTests = [
     # tests are flaky and make the whole test suite time out

--- a/pkgs/development/python-modules/aiosqlite/default.nix
+++ b/pkgs/development/python-modules/aiosqlite/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   # Tests are not pick-up automatically by the hook
-  pytestFlagsArray = [ "aiosqlite/tests/*.py" ];
+  enabledTestPaths = [ "aiosqlite/tests/*.py" ];
 
   pythonImportsCheck = [ "aiosqlite" ];
 

--- a/pkgs/development/python-modules/ancp-bids/default.nix
+++ b/pkgs/development/python-modules/ancp-bids/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "ancpbids" ];
 
-  pytestFlagsArray = [ "tests/auto" ];
+  enabledTestPaths = [ "tests/auto" ];
 
   disabledTests = [ "test_fetch_dataset" ];
 

--- a/pkgs/development/python-modules/anonip/default.nix
+++ b/pkgs/development/python-modules/anonip/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     pytest-cov-stub
   ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   pythonImportsCheck = [ "anonip" ];
 

--- a/pkgs/development/python-modules/ansi2image/default.nix
+++ b/pkgs/development/python-modules/ansi2image/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "ansi2image" ];
 
-  pytestFlagsArray = [ "tests/tests.py" ];
+  enabledTestPaths = [ "tests/tests.py" ];
 
   meta = with lib; {
     description = "Module to convert ANSI text to an image";

--- a/pkgs/development/python-modules/aocd/default.nix
+++ b/pkgs/development/python-modules/aocd/default.nix
@@ -62,7 +62,7 @@ buildPythonPackage rec {
     requests-mock
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "tests/"
   ];
 

--- a/pkgs/development/python-modules/apipkg/default.nix
+++ b/pkgs/development/python-modules/apipkg/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "test_apipkg.py" ];
+  enabledTestPaths = [ "test_apipkg.py" ];
 
   pythonImportsCheck = [ "apipkg" ];
 

--- a/pkgs/development/python-modules/asn1/default.nix
+++ b/pkgs/development/python-modules/asn1/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/test_asn1.py" ];
+  enabledTestPaths = [ "tests/test_asn1.py" ];
 
   pythonImportsCheck = [ "asn1" ];
 

--- a/pkgs/development/python-modules/aspell-python/default.nix
+++ b/pkgs/development/python-modules/aspell-python/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     export HOME=$(mktemp -d)
   '';
 
-  pytestFlagsArray = [ "test/unittests.py" ];
+  enabledTestPaths = [ "test/unittests.py" ];
 
   disabledTests = lib.optionals (pythonAtLeast "3.10") [
     # https://github.com/WojciechMula/aspell-python/issues/22

--- a/pkgs/development/python-modules/astropy-extension-helpers/default.nix
+++ b/pkgs/development/python-modules/astropy-extension-helpers/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
   ];
 
   # avoid import mismatch errors, as conftest.py is copied to build dir
-  pytestFlagsArray = [ "extension_helpers" ];
+  enabledTestPaths = [ "extension_helpers" ];
 
   disabledTests = [
     # https://github.com/astropy/extension-helpers/issues/43

--- a/pkgs/development/python-modules/asyncinotify/default.nix
+++ b/pkgs/development/python-modules/asyncinotify/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "asyncinotify" ];
 
-  pytestFlagsArray = [ "test.py" ];
+  enabledTestPaths = [ "test.py" ];
 
   meta = with lib; {
     badPlatforms = [

--- a/pkgs/development/python-modules/attacut/default.nix
+++ b/pkgs/development/python-modules/attacut/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/*" ];
+  enabledTestPaths = [ "tests/*" ];
 
   pythonImportsCheck = [ "attacut" ];
 

--- a/pkgs/development/python-modules/autopxd2/default.nix
+++ b/pkgs/development/python-modules/autopxd2/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "test/"
   ];
 

--- a/pkgs/development/python-modules/aw-client/default.nix
+++ b/pkgs/development/python-modules/aw-client/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
 
   # Only run this test, the others are integration tests that require
   # an instance of aw-server running in order to function.
-  pytestFlagsArray = [ "tests/test_requestqueue.py" ];
+  enabledTestPaths = [ "tests/test_requestqueue.py" ];
 
   preCheck = ''
     # Fake home folder for tests that write to $HOME

--- a/pkgs/development/python-modules/awswrangler/default.nix
+++ b/pkgs/development/python-modules/awswrangler/default.nix
@@ -74,7 +74,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "awswrangler" ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     # Subset of tests that run in upstream CI (many others require credentials)
     # https://github.com/aws/aws-sdk-pandas/blob/20fec775515e9e256e8cee5aee12966516608840/.github/workflows/minimal-tests.yml#L36-L43
     "tests/unit/test_metadata.py"

--- a/pkgs/development/python-modules/ayla-iot-unofficial/default.nix
+++ b/pkgs/development/python-modules/ayla-iot-unofficial/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests/ayla_iot_unofficial.py" ];
+  enabledTestPaths = [ "tests/ayla_iot_unofficial.py" ];
 
   # tests interact with the actual API
   doCheck = false;

--- a/pkgs/development/python-modules/azure-core/default.nix
+++ b/pkgs/development/python-modules/azure-core/default.nix
@@ -63,7 +63,7 @@ buildPythonPackage rec {
     export PYTHONPATH=tests/testserver_tests/coretestserver:$PYTHONPATH
   '';
 
-  pytestFlagsArray = [ "tests/" ];
+  enabledTestPaths = [ "tests/" ];
 
   # disable tests which touch network
   disabledTests = [

--- a/pkgs/development/python-modules/bagit/default.nix
+++ b/pkgs/development/python-modules/bagit/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     mock
     pytestCheckHook
   ];
-  pytestFlagsArray = [ "test.py" ];
+  enabledTestPaths = [ "test.py" ];
   pythonImportsCheck = [ "bagit" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/base36/default.nix
+++ b/pkgs/development/python-modules/base36/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "test_base36.py" ];
+  enabledTestPaths = [ "test_base36.py" ];
   pythonImportsCheck = [ "base36" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/beautifultable/default.nix
+++ b/pkgs/development/python-modules/beautifultable/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "test.py" ];
+  enabledTestPaths = [ "test.py" ];
 
   pythonImportsCheck = [ "beautifultable" ];
 

--- a/pkgs/development/python-modules/binary2strings/default.nix
+++ b/pkgs/development/python-modules/binary2strings/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "binary2strings" ];
 
-  pytestFlagsArray = [ "tests/test.py" ];
+  enabledTestPaths = [ "tests/test.py" ];
 
   meta = with lib; {
     description = "Module to extract Ascii, Utf8, and Unicode strings from binary data";

--- a/pkgs/development/python-modules/biom-format/default.nix
+++ b/pkgs/development/python-modules/biom-format/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "biom_tests/tests" ];
+  enabledTestPaths = [ "biom_tests/tests" ];
 
   pythonImportsCheck = [ "biom" ];
 

--- a/pkgs/development/python-modules/biothings-client/default.nix
+++ b/pkgs/development/python-modules/biothings-client/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     pytest-asyncio
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     # All other tests make network requests to exercise the API
     "tests/test_async.py::test_generate_async_settings"
     "tests/test_async.py::test_url_protocol"

--- a/pkgs/development/python-modules/blockdiag/default.nix
+++ b/pkgs/development/python-modules/blockdiag/default.nix
@@ -67,7 +67,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "src/blockdiag/tests/" ];
+  enabledTestPaths = [ "src/blockdiag/tests/" ];
 
   disabledTests = [
     # Test require network access

--- a/pkgs/development/python-modules/braintree/default.nix
+++ b/pkgs/development/python-modules/braintree/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "braintree" ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "tests/"
     "tests/fixtures"
     "tests/unit"

--- a/pkgs/development/python-modules/brotli/default.nix
+++ b/pkgs/development/python-modules/brotli/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "python/tests" ];
+  enabledTestPaths = [ "python/tests" ];
 
   meta = with lib; {
     homepage = "https://github.com/google/brotli";

--- a/pkgs/development/python-modules/brotlicffi/default.nix
+++ b/pkgs/development/python-modules/brotlicffi/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
   # Test data is only available from libbrotli git checkout, not brotli.src
   doCheck = false;
 
-  pytestFlagsArray = [ "test/" ];
+  enabledTestPaths = [ "test/" ];
 
   pythonImportsCheck = [ "brotlicffi" ];
 

--- a/pkgs/development/python-modules/bundlewrap/default.nix
+++ b/pkgs/development/python-modules/bundlewrap/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     # only unit tests as integration tests need a OpenSSH client/server setup
     "tests/unit"
   ];

--- a/pkgs/development/python-modules/cart/default.nix
+++ b/pkgs/development/python-modules/cart/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "unittests" ];
+  enabledTestPaths = [ "unittests" ];
 
   pythonImportsCheck = [ "cart" ];
 

--- a/pkgs/development/python-modules/cassandra-driver/default.nix
+++ b/pkgs/development/python-modules/cassandra-driver/default.nix
@@ -88,7 +88,7 @@ buildPythonPackage rec {
     unset NIX_REDIRECTS LD_PRELOAD
   '';
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   disabledTestPaths = [
     # requires puresasl

--- a/pkgs/development/python-modules/celery-singleton/default.nix
+++ b/pkgs/development/python-modules/celery-singleton/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     pytest-cov-stub
   ];
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   # Tests require a running Redis backend
   disabledTests = [

--- a/pkgs/development/python-modules/changefinder/default.nix
+++ b/pkgs/development/python-modules/changefinder/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage {
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
-  pytestFlagsArray = [ "test/test.py" ];
+  enabledTestPaths = [ "test/test.py" ];
 
   pythonImportsCheck = [ "changefinder" ];
 

--- a/pkgs/development/python-modules/chart-studio/default.nix
+++ b/pkgs/development/python-modules/chart-studio/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
   '';
 
   # most tests talk to a network service, so only run ones that don't do that.
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "chart_studio/tests/test_core"
     "chart_studio/tests/test_plot_ly/test_api"
   ];

--- a/pkgs/development/python-modules/checkdmarc/default.nix
+++ b/pkgs/development/python-modules/checkdmarc/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "checkdmarc" ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   disabledTests = [
     # Tests require network access

--- a/pkgs/development/python-modules/chess/default.nix
+++ b/pkgs/development/python-modules/chess/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "test.py" ];
+  enabledTestPaths = [ "test.py" ];
 
   meta = with lib; {
     description = "Chess library with move generation, move validation, and support for common formats";

--- a/pkgs/development/python-modules/ciso8601/default.nix
+++ b/pkgs/development/python-modules/ciso8601/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     pytz
   ];
 
-  pytestFlagsArray = [ "tests/tests.py" ];
+  enabledTestPaths = [ "tests/tests.py" ];
 
   pythonImportsCheck = [ "ciso8601" ];
 

--- a/pkgs/development/python-modules/clevercsv/default.nix
+++ b/pkgs/development/python-modules/clevercsv/default.nix
@@ -65,7 +65,7 @@ buildPythonPackage rec {
   '';
 
   # their ci only runs unit tests, there are also integration and fuzzing tests
-  pytestFlagsArray = [ "./tests/test_unit" ];
+  enabledTestPaths = [ "./tests/test_unit" ];
 
   disabledTestPaths = [
     # ModuleNotFoundError: No module named 'wilderness'

--- a/pkgs/development/python-modules/click-command-tree/default.nix
+++ b/pkgs/development/python-modules/click-command-tree/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   pythonImportsCheck = [ "click_command_tree" ];
 

--- a/pkgs/development/python-modules/cmigemo/default.nix
+++ b/pkgs/development/python-modules/cmigemo/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "test/" ];
+  enabledTestPaths = [ "test/" ];
 
   pythonImportsCheck = [ "cmigemo" ];
 

--- a/pkgs/development/python-modules/cobble/default.nix
+++ b/pkgs/development/python-modules/cobble/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   disabledTests = [
     # Broken tests

--- a/pkgs/development/python-modules/coconut/default.nix
+++ b/pkgs/development/python-modules/coconut/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
   ];
 
   # Currently most tests have performance issues
-  pytestFlagsArray = [ "coconut/tests/constants_test.py" ];
+  enabledTestPaths = [ "coconut/tests/constants_test.py" ];
 
   pythonImportsCheck = [ "coconut" ];
 

--- a/pkgs/development/python-modules/compressed-rtf/default.nix
+++ b/pkgs/development/python-modules/compressed-rtf/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "compressed_rtf" ];
 
-  pytestFlagsArray = [ "tests/tests.py" ];
+  enabledTestPaths = [ "tests/tests.py" ];
 
   meta = with lib; {
     description = "Compressed Rich Text Format (RTF) compression and decompression";

--- a/pkgs/development/python-modules/consonance/default.nix
+++ b/pkgs/development/python-modules/consonance/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/test_handshakes_offline.py" ];
+  enabledTestPaths = [ "tests/test_handshakes_offline.py" ];
 
   pythonImportsCheck = [ "consonance" ];
 

--- a/pkgs/development/python-modules/coredis/default.nix
+++ b/pkgs/development/python-modules/coredis/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "coredis" ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     # All other tests require Docker
     "tests/test_lru_cache.py"
     "tests/test_parsers.py"

--- a/pkgs/development/python-modules/craft-application/default.nix
+++ b/pkgs/development/python-modules/craft-application/default.nix
@@ -94,7 +94,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "craft_application" ];
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   disabledTests = [
     "test_to_yaml_file"

--- a/pkgs/development/python-modules/craft-archives/default.nix
+++ b/pkgs/development/python-modules/craft-archives/default.nix
@@ -61,7 +61,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/development/python-modules/craft-cli/default.nix
+++ b/pkgs/development/python-modules/craft-cli/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     writableTmpDirAsHomeHook
   ];
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/development/python-modules/craft-grammar/default.nix
+++ b/pkgs/development/python-modules/craft-grammar/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     pyyaml
   ];
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   # Temp fix for test incompatibility with Python 3.13
   disabledTests = [

--- a/pkgs/development/python-modules/craft-parts/default.nix
+++ b/pkgs/development/python-modules/craft-parts/default.nix
@@ -78,7 +78,7 @@ buildPythonPackage rec {
     squashfsTools
   ];
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   preCheck = ''
     export HOME=$(mktemp -d)

--- a/pkgs/development/python-modules/craft-platforms/default.nix
+++ b/pkgs/development/python-modules/craft-platforms/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "craft_platforms" ];
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   disabledTests = [
     # Attempts to get distro information, and expects "ubuntu-ish"

--- a/pkgs/development/python-modules/craft-providers/default.nix
+++ b/pkgs/development/python-modules/craft-providers/default.nix
@@ -82,7 +82,7 @@ buildPythonPackage rec {
     export HOME="$(pwd)/check-phase"
   '';
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   disabledTestPaths = [
     # Relies upon "logassert" python package which isn't in nixpkgs

--- a/pkgs/development/python-modules/craft-store/default.nix
+++ b/pkgs/development/python-modules/craft-store/default.nix
@@ -72,7 +72,7 @@ buildPythonPackage rec {
     pyyaml
   ];
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/development/python-modules/curated-tokenizers/default.nix
+++ b/pkgs/development/python-modules/curated-tokenizers/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
 
   # Explicitly set the path to avoid running vendored
   # sentencepiece tests.
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   preCheck = ''
     # avoid local paths, relative imports wont resolve correctly

--- a/pkgs/development/python-modules/cvxpy/default.nix
+++ b/pkgs/development/python-modules/cvxpy/default.nix
@@ -67,7 +67,7 @@ buildPythonPackage rec {
     export LDFLAGS="-lgomp"
   '';
 
-  pytestFlagsArray = [ "cvxpy" ];
+  enabledTestPaths = [ "cvxpy" ];
 
   disabledTests = [
     # Disable the slowest benchmarking tests, cuts test time in half

--- a/pkgs/development/python-modules/cyclonedx-python-lib/default.nix
+++ b/pkgs/development/python-modules/cyclonedx-python-lib/default.nix
@@ -78,7 +78,7 @@ buildPythonPackage rec {
     export PYTHONPATH=tests''${PYTHONPATH+:$PYTHONPATH}
   '';
 
-  pytestFlagsArray = [ "tests/" ];
+  enabledTestPaths = [ "tests/" ];
 
   disabledTests = [
     # These tests require network access

--- a/pkgs/development/python-modules/daltonlens/default.nix
+++ b/pkgs/development/python-modules/daltonlens/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "tests/"
   ];
 

--- a/pkgs/development/python-modules/databricks-sql-connector/default.nix
+++ b/pkgs/development/python-modules/databricks-sql-connector/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   pythonImportsCheck = [ "databricks" ];
 

--- a/pkgs/development/python-modules/datapoint/default.nix
+++ b/pkgs/development/python-modules/datapoint/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     requests-mock
   ];
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   pythonImportsCheck = [ "datapoint" ];
 

--- a/pkgs/development/python-modules/datatable/default.nix
+++ b/pkgs/development/python-modules/datatable/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-isystem ${lib.getInclude stdenv.cc.libcxx}/include/c++/v1";
 
   # test suite is very cpu intensive, only run small subset to ensure package is working as expected
-  pytestFlagsArray = [ "tests/test-sets.py" ];
+  enabledTestPaths = [ "tests/test-sets.py" ];
 
   disabledTests = [
     # skip tests which are irrelevant to our installation or use way too much memory

--- a/pkgs/development/python-modules/dateparser/default.nix
+++ b/pkgs/development/python-modules/dateparser/default.nix
@@ -68,7 +68,7 @@ buildPythonPackage rec {
   '';
 
   # Upstream only runs the tests in tests/ in CI, others use git clone
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   disabledTests = [
     # access network

--- a/pkgs/development/python-modules/dbt-bigquery/default.nix
+++ b/pkgs/development/python-modules/dbt-bigquery/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   pythonImportsCheck = [ "dbt.adapters.bigquery" ];
 

--- a/pkgs/development/python-modules/dbt-redshift/default.nix
+++ b/pkgs/development/python-modules/dbt-redshift/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   pythonImportsCheck = [ "dbt.adapters.redshift" ];
 

--- a/pkgs/development/python-modules/dbt-snowflake/default.nix
+++ b/pkgs/development/python-modules/dbt-snowflake/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   pythonImportsCheck = [ "dbt.adapters.snowflake" ];
 

--- a/pkgs/development/python-modules/decorator/default.nix
+++ b/pkgs/development/python-modules/decorator/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/test.py " ];
+  enabledTestPaths = [ "tests/test.py " ];
 
   meta = with lib; {
     changelog = "https://github.com/micheles/decorator/blob/${src.tag}/CHANGES.md";

--- a/pkgs/development/python-modules/detectron2/default.nix
+++ b/pkgs/development/python-modules/detectron2/default.nix
@@ -129,7 +129,7 @@ buildPythonPackage {
       rm -r detectron2
     '';
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     # prevent include $sourceRoot/projects/*/tests
     "tests"
   ];

--- a/pkgs/development/python-modules/diffusers/default.nix
+++ b/pkgs/development/python-modules/diffusers/default.nix
@@ -134,7 +134,7 @@ buildPythonPackage rec {
       cat ${conftestSkipNetworkErrors} >> tests/conftest.py
     '';
 
-  pytestFlagsArray = [ "tests/" ];
+  enabledTestPaths = [ "tests/" ];
 
   disabledTests = [
     # depends on current working directory

--- a/pkgs/development/python-modules/django-hierarkey/default.nix
+++ b/pkgs/development/python-modules/django-hierarkey/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
 
   DJANGO_SETTINGS_MODULE = "tests.settings";
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   meta = with lib; {
     description = "Flexible and powerful hierarchical key-value store for your Django models";

--- a/pkgs/development/python-modules/django-otp/default.nix
+++ b/pkgs/development/python-modules/django-otp/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     runHook postCheck
   '';
 
-  pytestFlagsArray = [ "src/django_otp/test.py" ];
+  enabledTestPaths = [ "src/django_otp/test.py" ];
 
   pythonImportsCheck = [ "django_otp" ];
 

--- a/pkgs/development/python-modules/dns-lexicon/default.nix
+++ b/pkgs/development/python-modules/dns-lexicon/default.nix
@@ -70,7 +70,7 @@ buildPythonPackage rec {
   ]
   ++ optional-dependencies.full;
 
-  pytestFlagsArray = [ "tests/" ];
+  enabledTestPaths = [ "tests/" ];
 
   disabledTestPaths = [
     # Needs network access

--- a/pkgs/development/python-modules/docker/default.nix
+++ b/pkgs/development/python-modules/docker/default.nix
@@ -60,7 +60,7 @@ buildPythonPackage rec {
   ]
   ++ lib.flatten (lib.attrValues optional-dependencies);
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   # Deselect socket tests on Darwin because it hits the path length limit for a Unix domain socket
   disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/development/python-modules/dodgy/default.nix
+++ b/pkgs/development/python-modules/dodgy/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests/test_checks.py" ];
+  enabledTestPaths = [ "tests/test_checks.py" ];
 
   meta = {
     description = "Looks at Python code to search for things which look \"dodgy\" such as passwords or diffs";

--- a/pkgs/development/python-modules/dohq-artifactory/default.nix
+++ b/pkgs/development/python-modules/dohq-artifactory/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     responses
   ];
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/development/python-modules/dotmap/default.nix
+++ b/pkgs/development/python-modules/dotmap/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "dotmap/test.py" ];
+  enabledTestPaths = [ "dotmap/test.py" ];
 
   pythonImportsCheck = [ "dotmap" ];
 

--- a/pkgs/development/python-modules/dsinternals/default.nix
+++ b/pkgs/development/python-modules/dsinternals/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "dsinternals" ];
 
-  pytestFlagsArray = [ "tests/*.py" ];
+  enabledTestPaths = [ "tests/*.py" ];
 
   meta = with lib; {
     description = "Module to interact with Windows Active Directory";

--- a/pkgs/development/python-modules/ducc0/default.nix
+++ b/pkgs/development/python-modules/ducc0/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     scipy
     pytest-xdist
   ];
-  pytestFlagsArray = [ "python/test" ];
+  enabledTestPaths = [ "python/test" ];
   pythonImportsCheck = [ "ducc0" ];
 
   postInstall = ''

--- a/pkgs/development/python-modules/dulwich/default.nix
+++ b/pkgs/development/python-modules/dulwich/default.nix
@@ -60,7 +60,7 @@ buildPythonPackage rec {
   ]
   ++ lib.flatten (lib.attrValues optional-dependencies);
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   disabledTests = [
     # AssertionError: 'C:\\\\foo.bar\\\\baz' != 'C:\\foo.bar\\baz'

--- a/pkgs/development/python-modules/durationpy/default.nix
+++ b/pkgs/development/python-modules/durationpy/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "test.py" ];
+  enabledTestPaths = [ "test.py" ];
 
   pythonImportsCheck = [ "durationpy" ];
 

--- a/pkgs/development/python-modules/envs/default.nix
+++ b/pkgs/development/python-modules/envs/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "envs/tests.py" ];
+  enabledTestPaths = [ "envs/tests.py" ];
 
   disabledTests = [ "test_list_envs" ];
 

--- a/pkgs/development/python-modules/eradicate/default.nix
+++ b/pkgs/development/python-modules/eradicate/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "eradicate" ];
 
-  pytestFlagsArray = [ "test_eradicate.py" ];
+  enabledTestPaths = [ "test_eradicate.py" ];
 
   meta = with lib; {
     description = "Library to remove commented-out code from Python files";

--- a/pkgs/development/python-modules/esprima/default.nix
+++ b/pkgs/development/python-modules/esprima/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "test/__main__.py::TestEsprima" ];
+  enabledTestPaths = [ "test/__main__.py::TestEsprima" ];
 
   pythonImportsCheck = [ "esprima" ];
 

--- a/pkgs/development/python-modules/events/default.nix
+++ b/pkgs/development/python-modules/events/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "events" ];
 
-  pytestFlagsArray = [ "events/tests/tests.py" ];
+  enabledTestPaths = [ "events/tests/tests.py" ];
 
   meta = with lib; {
     description = "Bringing the elegance of C# EventHanlder to Python";

--- a/pkgs/development/python-modules/extension-helpers/default.nix
+++ b/pkgs/development/python-modules/extension-helpers/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "extension_helpers" ];
 
-  pytestFlagsArray = [ "extension_helpers/tests" ];
+  enabledTestPaths = [ "extension_helpers/tests" ];
 
   disabledTests = [
     # Test require network access

--- a/pkgs/development/python-modules/extract-msg/default.nix
+++ b/pkgs/development/python-modules/extract-msg/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "extract_msg" ];
 
-  pytestFlagsArray = [ "extract_msg_tests/*.py" ];
+  enabledTestPaths = [ "extract_msg_tests/*.py" ];
 
   meta = with lib; {
     description = "Extracts emails and attachments saved in Microsoft Outlook's .msg files";

--- a/pkgs/development/python-modules/fabric/default.nix
+++ b/pkgs/development/python-modules/fabric/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests/*.py" ];
+  enabledTestPaths = [ "tests/*.py" ];
 
   pythonImportsCheck = [ "fabric" ];
 

--- a/pkgs/development/python-modules/falcon/default.nix
+++ b/pkgs/development/python-modules/falcon/default.nix
@@ -77,7 +77,7 @@ buildPythonPackage rec {
   ]
   ++ lib.optionals (pythonOlder "3.10") [ testtools ];
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   disabledTestPaths = [
     # needs a running server

--- a/pkgs/development/python-modules/fast-histogram/default.nix
+++ b/pkgs/development/python-modules/fast-histogram/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "${builtins.placeholder "out"}/${python.sitePackages}" ];
+  enabledTestPaths = [ "${builtins.placeholder "out"}/${python.sitePackages}" ];
 
   pythonImportsCheck = [ "fast_histogram" ];
 

--- a/pkgs/development/python-modules/fasteners/default.nix
+++ b/pkgs/development/python-modules/fasteners/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "fasteners" ];
 
-  pytestFlagsArray = [ "tests/" ];
+  enabledTestPaths = [ "tests/" ];
 
   meta = with lib; {
     description = "Module that provides useful locks";

--- a/pkgs/development/python-modules/fedora-messaging/default.nix
+++ b/pkgs/development/python-modules/fedora-messaging/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   meta = {
     description = "Library for sending AMQP messages with JSON schema in Fedora infrastructure";

--- a/pkgs/development/python-modules/ffmpeg-progress-yield/default.nix
+++ b/pkgs/development/python-modules/ffmpeg-progress-yield/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     "test_quit_gracefully"
   ];
 
-  pytestFlagsArray = [ "test/test.py" ];
+  enabledTestPaths = [ "test/test.py" ];
 
   pythonImportsCheck = [ "ffmpeg_progress_yield" ];
 

--- a/pkgs/development/python-modules/filedate/default.nix
+++ b/pkgs/development/python-modules/filedate/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/unit.py" ];
+  enabledTestPaths = [ "tests/unit.py" ];
 
   disabledTests = [ "test_created" ];
 

--- a/pkgs/development/python-modules/finetuning-scheduler/default.nix
+++ b/pkgs/development/python-modules/finetuning-scheduler/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
   env.PACKAGE_NAME = "pytorch";
 
   nativeCheckInputs = [ pytestCheckHook ];
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
   disabledTests =
     lib.optionals (pythonOlder "3.12") [
       # torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:

--- a/pkgs/development/python-modules/flake8-deprecated/default.nix
+++ b/pkgs/development/python-modules/flake8-deprecated/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "run_tests.py" ];
+  enabledTestPaths = [ "run_tests.py" ];
 
   pythonImportsCheck = [ "flake8_deprecated" ];
 

--- a/pkgs/development/python-modules/flake8-length/default.nix
+++ b/pkgs/development/python-modules/flake8-length/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "flake8_length" ];
 
-  pytestFlagsArray = [ "tests/" ];
+  enabledTestPaths = [ "tests/" ];
 
   meta = with lib; {
     description = "Flake8 plugin for a smart line length validation";

--- a/pkgs/development/python-modules/flask-paginate/default.nix
+++ b/pkgs/development/python-modules/flask-paginate/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "flask_paginate" ];
 
-  pytestFlagsArray = [ "tests/tests.py" ];
+  enabledTestPaths = [ "tests/tests.py" ];
 
   meta = with lib; {
     description = "Pagination support for Flask";

--- a/pkgs/development/python-modules/flask-principal/default.nix
+++ b/pkgs/development/python-modules/flask-principal/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "test_principal.py" ];
+  enabledTestPaths = [ "test_principal.py" ];
 
   meta = with lib; {
     homepage = "http://packages.python.org/Flask-Principal/";

--- a/pkgs/development/python-modules/flask-sock/default.nix
+++ b/pkgs/development/python-modules/flask-sock/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     simple-websocket
   ];
 
-  pytestFlagsArray = [ "tests/test_flask_sock.py" ];
+  enabledTestPaths = [ "tests/test_flask_sock.py" ];
 
   pythonImportsCheck = [ "flask_sock" ];
 

--- a/pkgs/development/python-modules/flask-socketio/default.nix
+++ b/pkgs/development/python-modules/flask-socketio/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     redis
   ];
 
-  pytestFlagsArray = [ "test_socketio.py" ];
+  enabledTestPaths = [ "test_socketio.py" ];
 
   pythonImportsCheck = [ "flask_socketio" ];
 

--- a/pkgs/development/python-modules/fpyutils/default.nix
+++ b/pkgs/development/python-modules/fpyutils/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "fpyutils/tests/*.py" ];
+  enabledTestPaths = [ "fpyutils/tests/*.py" ];
 
   disabledTests = [
     # Don't run test which requires bash

--- a/pkgs/development/python-modules/freesasa/default.nix
+++ b/pkgs/development/python-modules/freesasa/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "test.py" ];
+  enabledTestPaths = [ "test.py" ];
 
   meta = {
     description = "FreeSASA Python Module";

--- a/pkgs/development/python-modules/gensim/default.nix
+++ b/pkgs/development/python-modules/gensim/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
   # Test setup takes several minutes
   doCheck = false;
 
-  pytestFlagsArray = [ "gensim/test" ];
+  enabledTestPaths = [ "gensim/test" ];
 
   meta = with lib; {
     description = "Topic-modelling library";

--- a/pkgs/development/python-modules/geopandas/default.nix
+++ b/pkgs/development/python-modules/geopandas/default.nix
@@ -87,7 +87,7 @@ buildPythonPackage rec {
     "test_read_file_url"
   ];
 
-  pytestFlagsArray = [ "geopandas" ];
+  enabledTestPaths = [ "geopandas" ];
 
   pythonImportsCheck = [ "geopandas" ];
 

--- a/pkgs/development/python-modules/glean-sdk/default.nix
+++ b/pkgs/development/python-modules/glean-sdk/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "glean-core/python/tests" ];
+  enabledTestPaths = [ "glean-core/python/tests" ];
 
   disabledTests = [
     # RuntimeError: No ping received.

--- a/pkgs/development/python-modules/granian/default.nix
+++ b/pkgs/development/python-modules/granian/default.nix
@@ -69,7 +69,7 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  pytestFlagsArray = [ "tests/" ];
+  enabledTestPaths = [ "tests/" ];
 
   pythonImportCheck = [ "granian" ];
 

--- a/pkgs/development/python-modules/graphrag/default.nix
+++ b/pkgs/development/python-modules/graphrag/default.nix
@@ -99,7 +99,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   disabledTests = [
     # touch the network

--- a/pkgs/development/python-modules/guidance/default.nix
+++ b/pkgs/development/python-modules/guidance/default.nix
@@ -88,7 +88,7 @@ buildPythonPackage rec {
   ]
   ++ optional-dependencies.schemas;
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   disabledTests = [
     # require network access

--- a/pkgs/development/python-modules/habanero/default.nix
+++ b/pkgs/development/python-modules/habanero/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "habanero" ];
 
   # almost the entirety of the test suite makes network calls
-  pytestFlagsArray = [ "test/test-filters.py" ];
+  enabledTestPaths = [ "test/test-filters.py" ];
 
   meta = {
     description = "Python interface to Library Genesis";

--- a/pkgs/development/python-modules/hdate/default.nix
+++ b/pkgs/development/python-modules/hdate/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     syrupy
   ];
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   pythonImportsCheck = [ "hdate" ];
 

--- a/pkgs/development/python-modules/html-sanitizer/default.nix
+++ b/pkgs/development/python-modules/html-sanitizer/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "html_sanitizer/tests.py" ];
+  enabledTestPaths = [ "html_sanitizer/tests.py" ];
 
   disabledTests = [
     # Tests are sensitive to output

--- a/pkgs/development/python-modules/html5-parser/default.nix
+++ b/pkgs/development/python-modules/html5-parser/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "html5_parser" ];
 
-  pytestFlagsArray = [ "test/*.py" ];
+  enabledTestPaths = [ "test/*.py" ];
 
   meta = with lib; {
     description = "Fast C based HTML 5 parsing for python";

--- a/pkgs/development/python-modules/httmock/default.nix
+++ b/pkgs/development/python-modules/httmock/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   pythonImportsCheck = [ "httmock" ];
 

--- a/pkgs/development/python-modules/http-message-signatures/default.nix
+++ b/pkgs/development/python-modules/http-message-signatures/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     requests
   ];
 
-  pytestFlagsArray = [ "test/test.py" ];
+  enabledTestPaths = [ "test/test.py" ];
 
   pythonImportsCheck = [ "http_message_signatures" ];
 

--- a/pkgs/development/python-modules/httpie/default.nix
+++ b/pkgs/development/python-modules/httpie/default.nix
@@ -81,7 +81,7 @@ buildPythonPackage rec {
     installManPage docs/http.1
   '';
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "httpie"
     "tests"
   ];

--- a/pkgs/development/python-modules/hyperscan/default.nix
+++ b/pkgs/development/python-modules/hyperscan/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "hyperscan" ];
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -78,7 +78,7 @@ buildPythonPackage rec {
     export HYPOTHESIS_PROFILE=ci
   '';
 
-  pytestFlagsArray = [ "tests/cover" ];
+  enabledTestPaths = [ "tests/cover" ];
 
   # Hypothesis by default activates several "Health Checks", including one that fires if the builder is "too slow".
   # This check is disabled [1] if Hypothesis detects a CI environment, i.e. either `CI` or `TF_BUILD` is defined [2].

--- a/pkgs/development/python-modules/hyppo/default.nix
+++ b/pkgs/development/python-modules/hyppo/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     matplotlib
     seaborn
   ];
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "hyppo"
   ];
 

--- a/pkgs/development/python-modules/i-pi/default.nix
+++ b/pkgs/development/python-modules/i-pi/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
   ]
   ++ lib.optional (pythonAtLeast "3.12") distutils;
 
-  pytestFlagsArray = [ "ipi_tests/unit_tests" ];
+  enabledTestPaths = [ "ipi_tests/unit_tests" ];
   disabledTests = [
     "test_driver_base"
     "test_driver_forcebuild"

--- a/pkgs/development/python-modules/icalendar/default.nix
+++ b/pkgs/development/python-modules/icalendar/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     "test_docstring_of_python_file"
   ];
 
-  pytestFlagsArray = [ "src/icalendar" ];
+  enabledTestPaths = [ "src/icalendar" ];
 
   meta = with lib; {
     changelog = "https://github.com/collective/icalendar/blob/${src.tag}/CHANGES.rst";

--- a/pkgs/development/python-modules/import-expression/default.nix
+++ b/pkgs/development/python-modules/import-expression/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   pythonImportsCheck = [ "import_expression" ];
 

--- a/pkgs/development/python-modules/intelhex/default.nix
+++ b/pkgs/development/python-modules/intelhex/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "intelhex/test.py" ];
+  enabledTestPaths = [ "intelhex/test.py" ];
 
   pythonImportsCheck = [ "intelhex" ];
 

--- a/pkgs/development/python-modules/intensity-normalization/default.nix
+++ b/pkgs/development/python-modules/intensity-normalization/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   pythonImportsCheck = [
     "intensity_normalization"

--- a/pkgs/development/python-modules/iocextract/default.nix
+++ b/pkgs/development/python-modules/iocextract/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "iocextract" ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   disabledTests = [
     # AssertionError: 'http://exampledotcom/test' != 'http://example.com/test'

--- a/pkgs/development/python-modules/iometer/default.nix
+++ b/pkgs/development/python-modules/iometer/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "tests/test.py"
   ];
 

--- a/pkgs/development/python-modules/iptools/default.nix
+++ b/pkgs/development/python-modules/iptools/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/iptools/iptools_test.py" ];
+  enabledTestPaths = [ "tests/iptools/iptools_test.py" ];
 
   meta = with lib; {
     description = "Utilities for manipulating IP addresses including a class that can be used to include CIDR network blocks in Django's INTERNAL_IPS setting";

--- a/pkgs/development/python-modules/isal/default.nix
+++ b/pkgs/development/python-modules/isal/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   disabledTests = [
     # calls `python -m isal` and fails on import

--- a/pkgs/development/python-modules/isbnlib/default.nix
+++ b/pkgs/development/python-modules/isbnlib/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     pytest-cov-stub
   ];
 
-  pytestFlagsArray = [ "isbnlib/test/" ];
+  enabledTestPaths = [ "isbnlib/test/" ];
 
   # All disabled tests require a network connection
   disabledTests = [

--- a/pkgs/development/python-modules/iso4217/default.nix
+++ b/pkgs/development/python-modules/iso4217/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     cp -r ${table} $out/${python.sitePackages}/iso4217/table.xml
   '';
 
-  pytestFlagsArray = [ "iso4217/test.py" ];
+  enabledTestPaths = [ "iso4217/test.py" ];
 
   pythonImportsCheck = [ "iso4217" ];
 

--- a/pkgs/development/python-modules/iso8601/default.nix
+++ b/pkgs/development/python-modules/iso8601/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     pytz
   ];
 
-  pytestFlagsArray = [ "iso8601" ];
+  enabledTestPaths = [ "iso8601" ];
 
   pythonImportsCheck = [ "iso8601" ];
 

--- a/pkgs/development/python-modules/itanium-demangler/default.nix
+++ b/pkgs/development/python-modules/itanium-demangler/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/test.py" ];
+  enabledTestPaths = [ "tests/test.py" ];
 
   pythonImportsCheck = [ "itanium_demangler" ];
 

--- a/pkgs/development/python-modules/joblib/default.nix
+++ b/pkgs/development/python-modules/joblib/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     threadpoolctl
   ];
 
-  pytestFlagsArray = [ "joblib/test" ];
+  enabledTestPaths = [ "joblib/test" ];
 
   disabledTests = [
     "test_disk_used" # test_disk_used is broken: https://github.com/joblib/joblib/issues/57

--- a/pkgs/development/python-modules/jsbeautifier/default.nix
+++ b/pkgs/development/python-modules/jsbeautifier/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "jsbeautifier" ];
 
-  pytestFlagsArray = [ "jsbeautifier/tests/testindentation.py" ];
+  enabledTestPaths = [ "jsbeautifier/tests/testindentation.py" ];
 
   meta = with lib; {
     description = "JavaScript unobfuscator and beautifier";

--- a/pkgs/development/python-modules/jsmin/default.nix
+++ b/pkgs/development/python-modules/jsmin/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "jsmin/test.py" ];
+  enabledTestPaths = [ "jsmin/test.py" ];
 
   pythonImportsCheck = [ "jsmin" ];
 

--- a/pkgs/development/python-modules/jsonpatch/default.nix
+++ b/pkgs/development/python-modules/jsonpatch/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "jsonpatch" ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   meta = with lib; {
     description = "Library to apply JSON Patches according to RFC 6902";

--- a/pkgs/development/python-modules/jsonpath-python/default.nix
+++ b/pkgs/development/python-modules/jsonpath-python/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
   nativeCheckInputs = [ pytestCheckHook ];
   pythonImportsCheck = [ "jsonpath" ];
-  pytestFlagsArray = [ "test/test*.py" ];
+  enabledTestPaths = [ "test/test*.py" ];
 
   meta = with lib; {
     homepage = "https://github.com/sean2077/jsonpath-python";

--- a/pkgs/development/python-modules/jsonpath/default.nix
+++ b/pkgs/development/python-modules/jsonpath/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "jsonpath" ];
 
-  pytestFlagsArray = [ "test/test*.py" ];
+  enabledTestPaths = [ "test/test*.py" ];
 
   meta = with lib; {
     description = "XPath for JSON";

--- a/pkgs/development/python-modules/jsonref/default.nix
+++ b/pkgs/development/python-modules/jsonref/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   pythonImportsCheck = [ "jsonref" ];
 

--- a/pkgs/development/python-modules/jsonrpc-async/default.nix
+++ b/pkgs/development/python-modules/jsonrpc-async/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   pythonImportsCheck = [ "jsonrpc_async" ];
 

--- a/pkgs/development/python-modules/jsonrpc-base/default.nix
+++ b/pkgs/development/python-modules/jsonrpc-base/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   pythonImportsCheck = [ "jsonrpc_base" ];
 

--- a/pkgs/development/python-modules/junos-eznc/default.nix
+++ b/pkgs/development/python-modules/junos-eznc/default.nix
@@ -62,7 +62,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   disabledTests = [
     # jnpr.junos.exception.FactLoopError: A loop was detected while gathering the...

--- a/pkgs/development/python-modules/langchain-aws/default.nix
+++ b/pkgs/development/python-modules/langchain-aws/default.nix
@@ -64,7 +64,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests/unit_tests" ];
+  enabledTestPaths = [ "tests/unit_tests" ];
 
   pythonImportsCheck = [ "langchain_aws" ];
 

--- a/pkgs/development/python-modules/langchain-azure-dynamic-sessions/default.nix
+++ b/pkgs/development/python-modules/langchain-azure-dynamic-sessions/default.nix
@@ -68,7 +68,7 @@ buildPythonPackage rec {
     toml
   ];
 
-  pytestFlagsArray = [ "tests/unit_tests" ];
+  enabledTestPaths = [ "tests/unit_tests" ];
 
   pythonImportsCheck = [ "langchain_azure_dynamic_sessions" ];
 

--- a/pkgs/development/python-modules/langchain-community/default.nix
+++ b/pkgs/development/python-modules/langchain-community/default.nix
@@ -93,7 +93,7 @@ buildPythonPackage rec {
     toml
   ];
 
-  pytestFlagsArray = [ "tests/unit_tests" ];
+  enabledTestPaths = [ "tests/unit_tests" ];
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -81,7 +81,7 @@ buildPythonPackage rec {
     syrupy
   ];
 
-  pytestFlagsArray = [ "tests/unit_tests" ];
+  enabledTestPaths = [ "tests/unit_tests" ];
 
   passthru = {
     tests.pytest = langchain-core.overridePythonAttrs (_: {

--- a/pkgs/development/python-modules/langchain-groq/default.nix
+++ b/pkgs/development/python-modules/langchain-groq/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests/unit_tests" ];
+  enabledTestPaths = [ "tests/unit_tests" ];
 
   pythonImportsCheck = [ "langchain_groq" ];
 

--- a/pkgs/development/python-modules/langchain-huggingface/default.nix
+++ b/pkgs/development/python-modules/langchain-huggingface/default.nix
@@ -76,7 +76,7 @@ buildPythonPackage rec {
     toml
   ];
 
-  pytestFlagsArray = [ "tests/unit_tests" ];
+  enabledTestPaths = [ "tests/unit_tests" ];
 
   pythonImportsCheck = [ "langchain_huggingface" ];
 

--- a/pkgs/development/python-modules/langchain-mongodb/default.nix
+++ b/pkgs/development/python-modules/langchain-mongodb/default.nix
@@ -60,7 +60,7 @@ buildPythonPackage rec {
     syrupy
   ];
 
-  pytestFlagsArray = [ "tests/unit_tests" ];
+  enabledTestPaths = [ "tests/unit_tests" ];
 
   pythonImportsCheck = [ "langchain_mongodb" ];
 

--- a/pkgs/development/python-modules/langchain-ollama/default.nix
+++ b/pkgs/development/python-modules/langchain-ollama/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
     syrupy
   ];
 
-  pytestFlagsArray = [ "tests/unit_tests" ];
+  enabledTestPaths = [ "tests/unit_tests" ];
 
   pythonImportsCheck = [ "langchain_ollama" ];
 

--- a/pkgs/development/python-modules/langchain-openai/default.nix
+++ b/pkgs/development/python-modules/langchain-openai/default.nix
@@ -77,7 +77,7 @@ buildPythonPackage rec {
     toml
   ];
 
-  pytestFlagsArray = [ "tests/unit_tests" ];
+  enabledTestPaths = [ "tests/unit_tests" ];
 
   disabledTests = [
     # These tests require network access

--- a/pkgs/development/python-modules/langchain-text-splitters/default.nix
+++ b/pkgs/development/python-modules/langchain-text-splitters/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests/unit_tests" ];
+  enabledTestPaths = [ "tests/unit_tests" ];
 
   passthru.updateScript = nix-update-script {
     extraArgs = [

--- a/pkgs/development/python-modules/langgraph-cli/default.nix
+++ b/pkgs/development/python-modules/langgraph-cli/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     docker-compose
   ];
 
-  pytestFlagsArray = [ "tests/unit_tests" ];
+  enabledTestPaths = [ "tests/unit_tests" ];
 
   pythonImportsCheck = [ "langgraph_cli" ];
 

--- a/pkgs/development/python-modules/libsass/default.nix
+++ b/pkgs/development/python-modules/libsass/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     werkzeug
   ];
 
-  pytestFlagsArray = [ "sasstests.py" ];
+  enabledTestPaths = [ "sasstests.py" ];
 
   pythonImportsCheck = [ "sass" ];
 

--- a/pkgs/development/python-modules/libtmux/default.nix
+++ b/pkgs/development/python-modules/libtmux/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   disabledTests = [
     # Fail with: 'no server running on /tmp/tmux-1000/libtmux_test8sorutj1'.

--- a/pkgs/development/python-modules/libusb1/default.nix
+++ b/pkgs/development/python-modules/libusb1/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "usb1/testUSB1.py" ];
+  enabledTestPaths = [ "usb1/testUSB1.py" ];
 
   meta = with lib; {
     homepage = "https://github.com/vpelletier/python-libusb1";

--- a/pkgs/development/python-modules/litestar/default.nix
+++ b/pkgs/development/python-modules/litestar/default.nix
@@ -96,7 +96,7 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     # Follow github CI
     "docs/examples/"
   ];

--- a/pkgs/development/python-modules/livekit-api/default.nix
+++ b/pkgs/development/python-modules/livekit-api/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "livekit-api/tests" ];
+  enabledTestPaths = [ "livekit-api/tests" ];
 
   pythonImportsCheck = [ "livekit" ];
 

--- a/pkgs/development/python-modules/looseversion/default.nix
+++ b/pkgs/development/python-modules/looseversion/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   pythonImportsCheck = [ "looseversion" ];
 

--- a/pkgs/development/python-modules/losant-rest/default.nix
+++ b/pkgs/development/python-modules/losant-rest/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     requests-mock
   ];
 
-  pytestFlagsArray = [ "tests/platformrest_tests.py" ];
+  enabledTestPaths = [ "tests/platformrest_tests.py" ];
 
   pythonImportsCheck = [ "platformrest" ];
 

--- a/pkgs/development/python-modules/luhn/default.nix
+++ b/pkgs/development/python-modules/luhn/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "test.py" ];
+  enabledTestPaths = [ "test.py" ];
 
   pythonImportsCheck = [ "luhn" ];
 

--- a/pkgs/development/python-modules/luna-usb/default.nix
+++ b/pkgs/development/python-modules/luna-usb/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
     apollo-fpga
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "tests/"
   ];
 

--- a/pkgs/development/python-modules/macaddress/default.nix
+++ b/pkgs/development/python-modules/macaddress/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     reprshed
   ];
 
-  pytestFlagsArray = [ "test.py" ];
+  enabledTestPaths = [ "test.py" ];
 
   meta = with lib; {
     homepage = "https://github.com/mentalisttraceur/python-macaddress";

--- a/pkgs/development/python-modules/md-toc/default.nix
+++ b/pkgs/development/python-modules/md-toc/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "md_toc/tests/*.py" ];
+  enabledTestPaths = [ "md_toc/tests/*.py" ];
 
   pythonImportsCheck = [ "md_toc" ];
 

--- a/pkgs/development/python-modules/mdx-truly-sane-lists/default.nix
+++ b/pkgs/development/python-modules/mdx-truly-sane-lists/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "mdx_truly_sane_lists/tests.py" ];
+  enabledTestPaths = [ "mdx_truly_sane_lists/tests.py" ];
 
   meta = {
     description = "Extension for Python-Markdown that makes lists truly sane";

--- a/pkgs/development/python-modules/mixbox/default.nix
+++ b/pkgs/development/python-modules/mixbox/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "mixbox" ];
 
-  pytestFlagsArray = [ "test/*.py" ];
+  enabledTestPaths = [ "test/*.py" ];
 
   disabledTests = [
     # Tests are out-dated

--- a/pkgs/development/python-modules/mohawk/default.nix
+++ b/pkgs/development/python-modules/mohawk/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "mohawk/tests.py" ];
+  enabledTestPaths = [ "mohawk/tests.py" ];
 
   meta = {
     description = "Python library for Hawk HTTP authorization";

--- a/pkgs/development/python-modules/monotonic-alignment-search/default.nix
+++ b/pkgs/development/python-modules/monotonic-alignment-search/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     torch
   ];
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   pythonImportsCheck = [ "monotonic_alignment_search" ];
 

--- a/pkgs/development/python-modules/moreorless/default.nix
+++ b/pkgs/development/python-modules/moreorless/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "moreorless" ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "moreorless/tests/click.py"
     "moreorless/tests/combined.py"
     "moreorless/tests/general.py"

--- a/pkgs/development/python-modules/mpire/default.nix
+++ b/pkgs/development/python-modules/mpire/default.nix
@@ -73,7 +73,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.testing;
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   meta = {
     description = "A Python package for easy multiprocessing, but faster than multiprocessing";

--- a/pkgs/development/python-modules/mqtt2influxdb/default.nix
+++ b/pkgs/development/python-modules/mqtt2influxdb/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "mqtt2influxdb" ];
 
-  pytestFlagsArray = [ "tests/test.py" ];
+  enabledTestPaths = [ "tests/test.py" ];
 
   meta = with lib; {
     description = "Flexible MQTT to InfluxDB Bridge";

--- a/pkgs/development/python-modules/mrsqm/default.nix
+++ b/pkgs/development/python-modules/mrsqm/default.nix
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "tests/mrsqm"
   ];
 

--- a/pkgs/development/python-modules/music-tag/default.nix
+++ b/pkgs/development/python-modules/music-tag/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   checkInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "test" ];
+  enabledTestPaths = [ "test" ];
 
   # Tests fail: ModuleNotFoundError: No module named '_test_common'
   doCheck = false;

--- a/pkgs/development/python-modules/mypy/extensions.nix
+++ b/pkgs/development/python-modules/mypy/extensions.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   # make the testsuite run with pytest, so we can disable individual tests
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/testextensions.py" ];
+  enabledTestPaths = [ "tests/testextensions.py" ];
 
   disabledTests = lib.optionals (pythonAtLeast "3.14") [
     # https://github.com/python/mypy_extensions/issues/65

--- a/pkgs/development/python-modules/natasha/default.nix
+++ b/pkgs/development/python-modules/natasha/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
-  pytestFlagsArray = [ "tests/" ];
+  enabledTestPaths = [ "tests/" ];
   pythonImportsCheck = [ "natasha" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/nilearn/default.nix
+++ b/pkgs/development/python-modules/nilearn/default.nix
@@ -66,7 +66,7 @@ buildPythonPackage rec {
   ];
 
   # do subset of tests which don't fetch resources
-  pytestFlagsArray = [ "nilearn/connectome/tests" ];
+  enabledTestPaths = [ "nilearn/connectome/tests" ];
 
   meta = {
     description = "Module for statistical learning on neuroimaging data";

--- a/pkgs/development/python-modules/niworkflows/default.nix
+++ b/pkgs/development/python-modules/niworkflows/default.nix
@@ -91,7 +91,7 @@ buildPythonPackage rec {
     writableTmpDirAsHomeHook
   ];
 
-  pytestFlagsArray = [ "niworkflows" ];
+  enabledTestPaths = [ "niworkflows" ];
 
   disabledTests = [
     # try to download data:

--- a/pkgs/development/python-modules/nmapthon2/default.nix
+++ b/pkgs/development/python-modules/nmapthon2/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/scanner_tests.py" ];
+  enabledTestPaths = [ "tests/scanner_tests.py" ];
 
   pythonImportsCheck = [ "nmapthon2" ];
 

--- a/pkgs/development/python-modules/numericalunits/default.nix
+++ b/pkgs/development/python-modules/numericalunits/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "tests/tests.py"
   ];
 

--- a/pkgs/development/python-modules/nwdiag/default.nix
+++ b/pkgs/development/python-modules/nwdiag/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "src/nwdiag/tests/" ];
+  enabledTestPaths = [ "src/nwdiag/tests/" ];
 
   disabledTests = [
     # AttributeError: 'TestRstDirectives' object has no attribute 'assertRegexpMatches'

--- a/pkgs/development/python-modules/objax/default.nix
+++ b/pkgs/development/python-modules/objax/default.nix
@@ -62,7 +62,7 @@ buildPythonPackage rec {
     tensorflow
   ];
 
-  pytestFlagsArray = [ "tests/*.py" ];
+  enabledTestPaths = [ "tests/*.py" ];
 
   disabledTests = [
     # Test requires internet access for prefetching some weights

--- a/pkgs/development/python-modules/objsize/default.nix
+++ b/pkgs/development/python-modules/objsize/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "objsize" ];
 
-  pytestFlagsArray = [ "test_objsize.py" ];
+  enabledTestPaths = [ "test_objsize.py" ];
 
   meta = with lib; {
     description = "Traversal over objects subtree and calculate the total size";

--- a/pkgs/development/python-modules/okta/default.nix
+++ b/pkgs/development/python-modules/okta/default.nix
@@ -60,7 +60,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests/" ];
+  enabledTestPaths = [ "tests/" ];
 
   disabledTests = [
     "test_client_raise_exception"

--- a/pkgs/development/python-modules/onnx/default.nix
+++ b/pkgs/development/python-modules/onnx/default.nix
@@ -99,7 +99,7 @@ buildPythonPackage rec {
     mv onnx/__init__.py onnx/__init__.py.hidden
   '';
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "onnx/test"
     "examples"
   ];

--- a/pkgs/development/python-modules/openhomedevice/default.nix
+++ b/pkgs/development/python-modules/openhomedevice/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "openhomedevice" ];
 
-  pytestFlagsArray = [ "tests/*.py" ];
+  enabledTestPaths = [ "tests/*.py" ];
 
   meta = with lib; {
     description = "Python module to access Linn Ds and Openhome devices";

--- a/pkgs/development/python-modules/opensimplex/default.nix
+++ b/pkgs/development/python-modules/opensimplex/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ numpy ];
 
   nativeCheckInputs = [ pytestCheckHook ];
-  pytestFlagsArray = [ "tests/test_opensimplex.py" ];
+  enabledTestPaths = [ "tests/test_opensimplex.py" ];
   pythonImportsCheck = [ "opensimplex" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-grpc/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-grpc/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   pythonImportsCheck = [ "opentelemetry.exporter.otlp.proto.grpc" ];
 

--- a/pkgs/development/python-modules/osc-sdk-python/default.nix
+++ b/pkgs/development/python-modules/osc-sdk-python/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   '';
 
   # Only keep test not requiring access and secret keys
-  pytestFlagsArray = [ "tests/test_net.py" ];
+  enabledTestPaths = [ "tests/test_net.py" ];
 
   pythonImportsCheck = [ "osc_sdk_python" ];
 

--- a/pkgs/development/python-modules/papis/default.nix
+++ b/pkgs/development/python-modules/papis/default.nix
@@ -89,7 +89,7 @@ buildPythonPackage rec {
     export HOME=$(mktemp -d);
   '';
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "papis"
     "tests"
   ];

--- a/pkgs/development/python-modules/parameterized/default.nix
+++ b/pkgs/development/python-modules/parameterized/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "parameterized/test.py" ];
+  enabledTestPaths = [ "parameterized/test.py" ];
 
   pythonImportsCheck = [ "parameterized" ];
 

--- a/pkgs/development/python-modules/paramz/default.nix
+++ b/pkgs/development/python-modules/paramz/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
       --replace-fail "assertRaisesRegexp" "assertRaisesRegex"
   '';
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "paramz/tests/array_core_tests.py"
     "paramz/tests/cacher_tests.py"
     "paramz/tests/examples_tests.py"

--- a/pkgs/development/python-modules/parsedatetime/default.nix
+++ b/pkgs/development/python-modules/parsedatetime/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/Test*.py" ];
+  enabledTestPaths = [ "tests/Test*.py" ];
 
   disabledTests = [
     # https://github.com/bear/parsedatetime/issues/263

--- a/pkgs/development/python-modules/pcapy-ng/default.nix
+++ b/pkgs/development/python-modules/pcapy-ng/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
 
   doCheck = pythonOlder "3.10";
 
-  pytestFlagsArray = [ "pcapytests.py" ];
+  enabledTestPaths = [ "pcapytests.py" ];
 
   meta = with lib; {
     description = "Module to interface with the libpcap packet capture library";

--- a/pkgs/development/python-modules/peft/default.nix
+++ b/pkgs/development/python-modules/peft/default.nix
@@ -68,7 +68,7 @@ buildPythonPackage rec {
     scipy
   ];
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   # These tests fail when MPS devices are detected
   disabledTests = lib.optional stdenv.isDarwin [

--- a/pkgs/development/python-modules/periodiq/default.nix
+++ b/pkgs/development/python-modules/periodiq/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
   ];
   versionCheckProgramArg = "--version";
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   pythonImportsCheck = [ "periodiq" ];
 

--- a/pkgs/development/python-modules/phonenumbers/default.nix
+++ b/pkgs/development/python-modules/phonenumbers/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/*.py" ];
+  enabledTestPaths = [ "tests/*.py" ];
 
   pythonImportsCheck = [ "phonenumbers" ];
 

--- a/pkgs/development/python-modules/pins/default.nix
+++ b/pkgs/development/python-modules/pins/default.nix
@@ -76,7 +76,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pins" ];
 
-  pytestFlagsArray = [ "pins/tests/" ];
+  enabledTestPaths = [ "pins/tests/" ];
 
   disabledTestPaths = [
     # Tests require network access

--- a/pkgs/development/python-modules/plum-py/default.nix
+++ b/pkgs/development/python-modules/plum-py/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "plum" ];
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   disabledTestPaths = [
     # tests enum.IntFlag behaviour which has been disallowed in python 3.11.6

--- a/pkgs/development/python-modules/plyer/default.nix
+++ b/pkgs/development/python-modules/plyer/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "plyer/tests" ];
+  enabledTestPaths = [ "plyer/tests" ];
   disabledTests = [
     # assumes dbus is not installed, it fails and is not very robust.
     "test_notification_notifysend"

--- a/pkgs/development/python-modules/prometheus-flask-exporter/default.nix
+++ b/pkgs/development/python-modules/prometheus-flask-exporter/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
-  pytestFlagsArray = [ "tests/" ];
+  enabledTestPaths = [ "tests/" ];
 
   meta = with lib; {
     description = "Prometheus exporter for Flask applications";

--- a/pkgs/development/python-modules/psutil/default.nix
+++ b/pkgs/development/python-modules/psutil/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
   # our sandboxing which we can work around by disabling some tests:
   # - cpu_times was flaky on darwin
   # - the other disabled tests are likely due to sandboxing (missing specific errors)
-  pytestFlagsArray = [
+  enabledTestPaths = [
     # Note: $out must be referenced as test import paths are relative
     "${placeholder "out"}/${python.sitePackages}/psutil/tests/test_system.py"
   ];

--- a/pkgs/development/python-modules/publicsuffixlist/default.nix
+++ b/pkgs/development/python-modules/publicsuffixlist/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "publicsuffixlist" ];
 
-  pytestFlagsArray = [ "publicsuffixlist/test.py" ];
+  enabledTestPaths = [ "publicsuffixlist/test.py" ];
 
   meta = with lib; {
     changelog = "https://github.com/ko-zu/psl/blob/v${version}-gha/CHANGES.md";

--- a/pkgs/development/python-modules/py-bip39-bindings/default.nix
+++ b/pkgs/development/python-modules/py-bip39-bindings/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   pythonImportsCheck = [ "bip39" ];
 

--- a/pkgs/development/python-modules/py-sr25519-bindings/default.nix
+++ b/pkgs/development/python-modules/py-sr25519-bindings/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     py-bip39-bindings
   ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   pythonImportsCheck = [ "sr25519" ];
 

--- a/pkgs/development/python-modules/py-ubjson/default.nix
+++ b/pkgs/development/python-modules/py-ubjson/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     "test_recursion"
   ];
 
-  pytestFlagsArray = [ "test/test.py" ];
+  enabledTestPaths = [ "test/test.py" ];
 
   pythonImportsCheck = [ "ubjson" ];
 

--- a/pkgs/development/python-modules/py2bit/default.nix
+++ b/pkgs/development/python-modules/py2bit/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "py2bitTest/test.py" ];
+  enabledTestPaths = [ "py2bitTest/test.py" ];
 
   meta = {
     homepage = "https://github.com/deeptools/py2bit";

--- a/pkgs/development/python-modules/pybigwig/default.nix
+++ b/pkgs/development/python-modules/pybigwig/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pyBigWig" ];
 
-  pytestFlagsArray = [ "pyBigWigTest/test*.py" ];
+  enabledTestPaths = [ "pyBigWigTest/test*.py" ];
 
   disabledTests = [
     # Test file is downloaded from GitHub

--- a/pkgs/development/python-modules/pycdio/default.nix
+++ b/pkgs/development/python-modules/pycdio/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "test/test-*.py" ];
+  enabledTestPaths = [ "test/test-*.py" ];
 
   meta = {
     homepage = "https://www.gnu.org/software/libcdio/";

--- a/pkgs/development/python-modules/pycognito/default.nix
+++ b/pkgs/development/python-modules/pycognito/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
   ]
   ++ moto.optional-dependencies.cognitoidp;
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   disabledTests = [
     # Test requires network access

--- a/pkgs/development/python-modules/pycurl/default.nix
+++ b/pkgs/development/python-modules/pycurl/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     # don't pick up the tests directory below examples/
     "tests"
   ];

--- a/pkgs/development/python-modules/pydemumble/default.nix
+++ b/pkgs/development/python-modules/pydemumble/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/" ];
+  enabledTestPaths = [ "tests/" ];
 
   pythonImportsCheck = [ "pydemumble" ];
 

--- a/pkgs/development/python-modules/pydot/default.nix
+++ b/pkgs/development/python-modules/pydot/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     })
   ];
 
-  pytestFlagsArray = [ "test/test_pydot.py" ];
+  enabledTestPaths = [ "test/test_pydot.py" ];
 
   pythonImportsCheck = [ "pydot" ];
 

--- a/pkgs/development/python-modules/pydsdl/default.nix
+++ b/pkgs/development/python-modules/pydsdl/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "pydsdl/_test.py" ];
+  enabledTestPaths = [ "pydsdl/_test.py" ];
 
   meta = with lib; {
     description = "Library to process Cyphal DSDL";

--- a/pkgs/development/python-modules/pydub/default.nix
+++ b/pkgs/development/python-modules/pydub/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
     "pydub.playback"
   ];
 
-  pytestFlagsArray = [ "test/test.py" ];
+  enabledTestPaths = [ "test/test.py" ];
 
   meta = with lib; {
     description = "Manipulate audio with a simple and easy high level interface";

--- a/pkgs/development/python-modules/pyeapi/default.nix
+++ b/pkgs/development/python-modules/pyeapi/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "test/unit" ];
+  enabledTestPaths = [ "test/unit" ];
 
   pythonImportsCheck = [ "pyeapi" ];
 

--- a/pkgs/development/python-modules/pyfakefs/default.nix
+++ b/pkgs/development/python-modules/pyfakefs/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "pyfakefs/tests"
   ];
 

--- a/pkgs/development/python-modules/pygtfs/default.nix
+++ b/pkgs/development/python-modules/pygtfs/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
-  pytestFlagsArray = [ "pygtfs/test/test.py" ];
+  enabledTestPaths = [ "pygtfs/test/test.py" ];
 
   pythonImportsCheck = [ "pygtfs" ];
 

--- a/pkgs/development/python-modules/pylibjpeg-openjpeg/default.nix
+++ b/pkgs/development/python-modules/pylibjpeg-openjpeg/default.nix
@@ -62,7 +62,7 @@ buildPythonPackage rec {
     "lib/openjpeg"
   ];
 
-  pytestFlagsArray = [ "openjpeg/tests" ];
+  enabledTestPaths = [ "openjpeg/tests" ];
 
   pythonImportsCheck = [ "openjpeg" ];
 

--- a/pkgs/development/python-modules/pymarshal/default.nix
+++ b/pkgs/development/python-modules/pymarshal/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     pyyaml
   ];
 
-  pytestFlagsArray = [ "test" ];
+  enabledTestPaths = [ "test" ];
 
   meta = {
     description = "Python data serialization library";

--- a/pkgs/development/python-modules/pymdstat/default.nix
+++ b/pkgs/development/python-modules/pymdstat/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "unitest.py" ];
+  enabledTestPaths = [ "unitest.py" ];
 
   meta = with lib; {
     description = "Pythonic library to parse Linux /proc/mdstat file";

--- a/pkgs/development/python-modules/pymunk/default.nix
+++ b/pkgs/development/python-modules/pymunk/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "pymunk/tests" ];
+  enabledTestPaths = [ "pymunk/tests" ];
 
   pythonImportsCheck = [ "pymunk" ];
 

--- a/pkgs/development/python-modules/pyowm/default.nix
+++ b/pkgs/development/python-modules/pyowm/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   # Run only tests which don't require network access
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   pythonImportsCheck = [ "pyowm" ];
 

--- a/pkgs/development/python-modules/pyqldb/default.nix
+++ b/pkgs/development/python-modules/pyqldb/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     export AWS_DEFAULT_REGION=us-east-1
   '';
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   pythonImportsCheck = [ "pyqldb" ];
 

--- a/pkgs/development/python-modules/pyqtgraph/default.nix
+++ b/pkgs/development/python-modules/pyqtgraph/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     export FONTCONFIG_FILE=${fontsConf}
   '';
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     # we only want to run unittests
     "tests"
   ];

--- a/pkgs/development/python-modules/pyquaternion/default.nix
+++ b/pkgs/development/python-modules/pyquaternion/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "pyquaternion/test/" ];
+  enabledTestPaths = [ "pyquaternion/test/" ];
 
   pythonImportsCheck = [ "pyquaternion" ];
 

--- a/pkgs/development/python-modules/pytest-ansible/default.nix
+++ b/pkgs/development/python-modules/pytest-ansible/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     export HOME=$TMPDIR
   '';
 
-  pytestFlagsArray = [ "tests/" ];
+  enabledTestPaths = [ "tests/" ];
 
   disabledTests = [
     # Host unreachable in the inventory

--- a/pkgs/development/python-modules/pytest-base-url/default.nix
+++ b/pkgs/development/python-modules/pytest-base-url/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     pytest-metadata
   ];
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   disabledTests = [
     # should be xfail? or mocking doesn't work

--- a/pkgs/development/python-modules/pytest-recording/default.nix
+++ b/pkgs/development/python-modules/pytest-recording/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     "test_other_socket"
   ];
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   pythonImportsCheck = [ "pytest_recording" ];
 

--- a/pkgs/development/python-modules/pytest-relaxed/default.nix
+++ b/pkgs/development/python-modules/pytest-relaxed/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   pythonImportsCheck = [ "pytest_relaxed" ];
 

--- a/pkgs/development/python-modules/pytest-voluptuous/default.nix
+++ b/pkgs/development/python-modules/pytest-voluptuous/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pytest_voluptuous" ];
 
-  pytestFlagsArray = [ "tests/test_plugin.py" ];
+  enabledTestPaths = [ "tests/test_plugin.py" ];
 
   meta = with lib; {
     description = "Pytest plugin for asserting data against voluptuous schema";

--- a/pkgs/development/python-modules/python-datemath/default.nix
+++ b/pkgs/development/python-modules/python-datemath/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     pytz
   ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   pythonImportsCheck = [ "datemath" ];
 

--- a/pkgs/development/python-modules/python-i18n/default.nix
+++ b/pkgs/development/python-modules/python-i18n/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pyyaml
   ];
-  pytestFlagsArray = [ "i18n/tests/run_tests.py" ];
+  enabledTestPaths = [ "i18n/tests/run_tests.py" ];
   pythonImportsCheck = [ "i18n" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/python-nvd3/default.nix
+++ b/pkgs/development/python-modules/python-nvd3/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   meta = {
     homepage = "https://github.com/areski/python-nvd3";

--- a/pkgs/development/python-modules/python-slugify/default.nix
+++ b/pkgs/development/python-modules/python-slugify/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "test.py" ];
+  enabledTestPaths = [ "test.py" ];
 
   pythonImportsCheck = [ "slugify" ];
 

--- a/pkgs/development/python-modules/python-utils/default.nix
+++ b/pkgs/development/python-modules/python-utils/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "python_utils" ];
 
-  pytestFlagsArray = [ "_python_utils_tests" ];
+  enabledTestPaths = [ "_python_utils_tests" ];
 
   disabledTests = [
     # Flaky tests

--- a/pkgs/development/python-modules/pytimeparse/default.nix
+++ b/pkgs/development/python-modules/pytimeparse/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   nativeCheckInputs = [ pytestCheckHook ];
-  pytestFlagsArray = [ "pytimeparse/tests/testtimeparse.py" ];
+  enabledTestPaths = [ "pytimeparse/tests/testtimeparse.py" ];
 
   pythonImportsCheck = [ "pytimeparse" ];
 

--- a/pkgs/development/python-modules/pyuseragents/default.nix
+++ b/pkgs/development/python-modules/pyuseragents/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   };
 
   nativeCheckInputs = [ pytestCheckHook ];
-  pytestFlagsArray = [ "test.py" ];
+  enabledTestPaths = [ "test.py" ];
   pythonImportsCheck = [ "pyuseragents" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pyversasense/default.nix
+++ b/pkgs/development/python-modules/pyversasense/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests/test.py" ];
+  enabledTestPaths = [ "tests/test.py" ];
 
   disabledTests = [
     # Tests are not properly mocking network requests

--- a/pkgs/development/python-modules/pywinrm/default.nix
+++ b/pkgs/development/python-modules/pywinrm/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "winrm" ];
 
-  pytestFlagsArray = [ "winrm/tests/" ];
+  enabledTestPaths = [ "winrm/tests/" ];
 
   meta = with lib; {
     description = "Python library for Windows Remote Management";

--- a/pkgs/development/python-modules/pyxnat/default.nix
+++ b/pkgs/development/python-modules/pyxnat/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
   preCheck = ''
     export PYXNAT_SKIP_NETWORK_TESTS=1
   '';
-  pytestFlagsArray = [ "pyxnat" ];
+  enabledTestPaths = [ "pyxnat" ];
   disabledTestPaths = [
     # require a running local XNAT instance e.g. in a docker container:
     "pyxnat/tests/attributes_test.py"

--- a/pkgs/development/python-modules/razdel/default.nix
+++ b/pkgs/development/python-modules/razdel/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   };
 
   nativeCheckInputs = [ pytest7CheckHook ];
-  pytestFlagsArray = [ "razdel" ];
+  enabledTestPaths = [ "razdel" ];
   pythonImportsCheck = [ "razdel" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/reconplogger/default.nix
+++ b/pkgs/development/python-modules/reconplogger/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "reconplogger" ];
 
-  pytestFlagsArray = [ "reconplogger_tests.py" ];
+  enabledTestPaths = [ "reconplogger_tests.py" ];
 
   meta = with lib; {
     description = "Module to ease the standardization of logging within omni:us";

--- a/pkgs/development/python-modules/redshift-connector/default.nix
+++ b/pkgs/development/python-modules/redshift-connector/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
   ];
 
   # integration tests require a Redshift cluster
-  pytestFlagsArray = [ "test/unit" ];
+  enabledTestPaths = [ "test/unit" ];
 
   __darwinAllowLocalNetworking = true; # required for tests
 

--- a/pkgs/development/python-modules/reolink/default.nix
+++ b/pkgs/development/python-modules/reolink/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
   # https://github.com/fwestenberg/reolink/issues/83
   doCheck = false;
 
-  pytestFlagsArray = [ "test.py" ];
+  enabledTestPaths = [ "test.py" ];
 
   disabledTests = [
     # Tests require network access

--- a/pkgs/development/python-modules/repoze-lru/default.nix
+++ b/pkgs/development/python-modules/repoze-lru/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "repoze/lru/tests.py" ];
+  enabledTestPaths = [ "repoze/lru/tests.py" ];
 
   disabledTests = [
     # time sensitive tests

--- a/pkgs/development/python-modules/requests-cache/default.nix
+++ b/pkgs/development/python-modules/requests-cache/default.nix
@@ -87,7 +87,7 @@ buildPythonPackage rec {
     export HOME=$(mktemp -d);
   '';
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     # Integration tests require local DBs
     "tests/unit"
   ];

--- a/pkgs/development/python-modules/requests-http-signature/default.nix
+++ b/pkgs/development/python-modules/requests-http-signature/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "test/test.py" ];
+  enabledTestPaths = [ "test/test.py" ];
 
   disabledTests = [
     # Test require network access

--- a/pkgs/development/python-modules/restructuredtext-lint/default.nix
+++ b/pkgs/development/python-modules/restructuredtext-lint/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "restructuredtext_lint/test/test.py" ];
+  enabledTestPaths = [ "restructuredtext_lint/test/test.py" ];
 
   pythonImportsCheck = [ "restructuredtext_lint" ];
 

--- a/pkgs/development/python-modules/ripe-atlas-sagan/default.nix
+++ b/pkgs/development/python-modules/ripe-atlas-sagan/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/*.py" ];
+  enabledTestPaths = [ "tests/*.py" ];
 
   disabledTests = [
     # This test fail for unknown reason, I suspect it to be flaky.

--- a/pkgs/development/python-modules/robotframework-requests/default.nix
+++ b/pkgs/development/python-modules/robotframework-requests/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "RequestsLibrary" ];
 
-  pytestFlagsArray = [ "utests" ];
+  enabledTestPaths = [ "utests" ];
 
   meta = with lib; {
     description = "Robot Framework keyword library wrapper around the HTTP client library requests";

--- a/pkgs/development/python-modules/robotframework-tools/default.nix
+++ b/pkgs/development/python-modules/robotframework-tools/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
   '';
 
   nativeCheckInputs = [ pytestCheckHook ];
-  pytestFlagsArray = [ "test" ];
+  enabledTestPaths = [ "test" ];
   pythonImportsCheck = [ "robottools" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/rpcq/default.nix
+++ b/pkgs/development/python-modules/rpcq/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     # Don't run tests that spin-up a zmq server
     "rpcq/test/test_base.py"
     "rpcq/test/test_spec.py"

--- a/pkgs/development/python-modules/safetensors/default.nix
+++ b/pkgs/development/python-modules/safetensors/default.nix
@@ -87,7 +87,7 @@ buildPythonPackage rec {
     pytestCheckHook
     torch
   ];
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
   # don't require PaddlePaddle (not in Nixpkgs), Flax, or Tensorflow (onerous) to run tests:
   disabledTestPaths = [
     "tests/test_flax_comparison.py"

--- a/pkgs/development/python-modules/scikit-bio/default.nix
+++ b/pkgs/development/python-modules/scikit-bio/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   # only the $out dir contains the built cython extensions, so we run the tests inside there
-  pytestFlagsArray = [ "${placeholder "out"}/${python.sitePackages}/skbio" ];
+  enabledTestPaths = [ "${placeholder "out"}/${python.sitePackages}/skbio" ];
 
   disabledTestPaths = [
     # don't know why, but this segfaults

--- a/pkgs/development/python-modules/seqdiag/default.nix
+++ b/pkgs/development/python-modules/seqdiag/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   patches = [ ./fix_test_generate.patch ];
 
   nativeCheckInputs = [ pytestCheckHook ];
-  pytestFlagsArray = [ "src/seqdiag/tests/" ];
+  enabledTestPaths = [ "src/seqdiag/tests/" ];
 
   pythonImportsCheck = [ "seqdiag" ];
 

--- a/pkgs/development/python-modules/serverlessrepo/default.nix
+++ b/pkgs/development/python-modules/serverlessrepo/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
       --replace "boto3~=1.9, >=1.9.56" "boto3"
   '';
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   pythonImportsCheck = [ "serverlessrepo" ];
 

--- a/pkgs/development/python-modules/setuptools-scm-git-archive/default.nix
+++ b/pkgs/development/python-modules/setuptools-scm-git-archive/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   pythonImportsCheck = [ "setuptools_scm_git_archive" ];
 

--- a/pkgs/development/python-modules/sh/default.nix
+++ b/pkgs/development/python-modules/sh/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   # A test needs the HOME directory to be different from $TMPDIR.
   preCheck = ''

--- a/pkgs/development/python-modules/signxml/default.nix
+++ b/pkgs/development/python-modules/signxml/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "signxml" ];
 
-  pytestFlagsArray = [ "test/test.py" ];
+  enabledTestPaths = [ "test/test.py" ];
 
   meta = with lib; {
     description = "Python XML Signature and XAdES library";

--- a/pkgs/development/python-modules/simpleeval/default.nix
+++ b/pkgs/development/python-modules/simpleeval/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "test_simpleeval.py" ];
+  enabledTestPaths = [ "test_simpleeval.py" ];
 
   pythonImportsCheck = [ "simpleeval" ];
 

--- a/pkgs/development/python-modules/simplesat/default.nix
+++ b/pkgs/development/python-modules/simplesat/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
       --replace-fail "assertRaisesRegexp" "assertRaisesRegex"
   '';
 
-  pytestFlagsArray = [ "simplesat/tests" ];
+  enabledTestPaths = [ "simplesat/tests" ];
 
   meta = with lib; {
     description = "Prototype for SAT-based dependency handling";

--- a/pkgs/development/python-modules/simsimd/default.nix
+++ b/pkgs/development/python-modules/simsimd/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     tabulate
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "scripts/test.py"
   ];
 

--- a/pkgs/development/python-modules/siphash24/default.nix
+++ b/pkgs/development/python-modules/siphash24/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     "siphash24"
   ];
 
-  pytestFlagsArray = [ "test.py" ];
+  enabledTestPaths = [ "test.py" ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/sismic/default.nix
+++ b/pkgs/development/python-modules/sismic/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "sismic" ];
 
-  pytestFlagsArray = [ "tests/" ];
+  enabledTestPaths = [ "tests/" ];
 
   disabledTests = [
     # Time related tests, might lead to flaky tests on slow/busy machines

--- a/pkgs/development/python-modules/skops/default.nix
+++ b/pkgs/development/python-modules/skops/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     pytest-cov-stub
     streamlit
   ];
-  pytestFlagsArray = [ "skops" ];
+  enabledTestPaths = [ "skops" ];
   disabledTests = [
     # flaky
     "test_base_case_works_as_expected"

--- a/pkgs/development/python-modules/slovnet/default.nix
+++ b/pkgs/development/python-modules/slovnet/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     razdel
   ];
   nativeCheckInputs = [ pytestCheckHook ];
-  pytestFlagsArray = [ "tests/" ];
+  enabledTestPaths = [ "tests/" ];
   disabledTestPaths = [
     # Tries to download model binary artifacts:
     "tests/test_api.py"

--- a/pkgs/development/python-modules/smart-open/default.nix
+++ b/pkgs/development/python-modules/smart-open/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
   ]
   ++ lib.flatten (lib.attrValues optional-dependencies);
 
-  pytestFlagsArray = [ "smart_open" ];
+  enabledTestPaths = [ "smart_open" ];
 
   disabledTests = [
     # https://github.com/RaRe-Technologies/smart_open/issues/784

--- a/pkgs/development/python-modules/snakemake-interface-common/default.nix
+++ b/pkgs/development/python-modules/snakemake-interface-common/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "snakemake_interface_common" ];
 
-  pytestFlagsArray = [ "tests/tests.py" ];
+  enabledTestPaths = [ "tests/tests.py" ];
 
   meta = with lib; {
     description = "Common functions and classes for Snakemake and its plugins";

--- a/pkgs/development/python-modules/sphinx-rtd-dark-mode/default.nix
+++ b/pkgs/development/python-modules/sphinx-rtd-dark-mode/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     sphinx
   ];
 
-  pytestFlagsArray = [ "tests/build.py" ];
+  enabledTestPaths = [ "tests/build.py" ];
 
   pythonImportsCheck = [ "sphinx_rtd_dark_mode" ];
 

--- a/pkgs/development/python-modules/sseclient-py/default.nix
+++ b/pkgs/development/python-modules/sseclient-py/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "sseclient" ];
 
-  pytestFlagsArray = [ "tests/unittests.py" ];
+  enabledTestPaths = [ "tests/unittests.py" ];
 
   meta = with lib; {
     description = "Pure-Python Server Side Events (SSE) client";

--- a/pkgs/development/python-modules/statsd/default.nix
+++ b/pkgs/development/python-modules/statsd/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "statsd/tests.py" ];
+  enabledTestPaths = [ "statsd/tests.py" ];
 
   meta = with lib; {
     maintainers = with maintainers; [ domenkozar ];

--- a/pkgs/development/python-modules/stim/default.nix
+++ b/pkgs/development/python-modules/stim/default.nix
@@ -70,7 +70,7 @@ buildPythonPackage rec {
 
   enableParallelBuilding = true;
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     # From .github/workflows
     "src/"
     "glue/cirq"

--- a/pkgs/development/python-modules/stm32loader/default.nix
+++ b/pkgs/development/python-modules/stm32loader/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
   ]
   ++ lib.flatten (lib.attrValues optional-dependencies);
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   meta = with lib; {
     description = "Flash firmware to STM32 microcontrollers in Python";

--- a/pkgs/development/python-modules/streaming-form-data/default.nix
+++ b/pkgs/development/python-modules/streaming-form-data/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     requests-toolbelt
   ];
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   pythonImportsCheck = [ "streaming_form_data" ];
 

--- a/pkgs/development/python-modules/stringzilla/default.nix
+++ b/pkgs/development/python-modules/stringzilla/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "scripts/test.py" ];
+  enabledTestPaths = [ "scripts/test.py" ];
 
   meta = {
     changelog = "https://github.com/ashvardanian/StringZilla/releases/tag/${src.tag}";

--- a/pkgs/development/python-modules/stumpy/default.nix
+++ b/pkgs/development/python-modules/stumpy/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "stumpy" ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     # whole testsuite is very CPU intensive, only run core tests
     # TODO: move entire test suite to passthru.tests
     "tests/test_core.py"

--- a/pkgs/development/python-modules/subunit/default.nix
+++ b/pkgs/development/python-modules/subunit/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "python/subunit" ];
+  enabledTestPaths = [ "python/subunit" ];
 
   disabledTestPaths = [
     # these tests require testtools and don't work with pytest

--- a/pkgs/development/python-modules/swh-objstorage/default.nix
+++ b/pkgs/development/python-modules/swh-objstorage/default.nix
@@ -81,7 +81,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "swh.objstorage" ];
 
-  pytestFlagsArray = [ "swh/objstorage/tests" ];
+  enabledTestPaths = [ "swh/objstorage/tests" ];
 
   nativeCheckInputs = [
     aiohttp

--- a/pkgs/development/python-modules/symbolic/default.nix
+++ b/pkgs/development/python-modules/symbolic/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "py" ];
+  enabledTestPaths = [ "py" ];
 
   pythonImportsCheck = [ "symbolic" ];
 

--- a/pkgs/development/python-modules/teamcity-messages/default.nix
+++ b/pkgs/development/python-modules/teamcity-messages/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/unit-tests/" ];
+  enabledTestPaths = [ "tests/unit-tests/" ];
 
   pythonImportsCheck = [ "teamcity" ];
 

--- a/pkgs/development/python-modules/telegraph/default.nix
+++ b/pkgs/development/python-modules/telegraph/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/" ];
+  enabledTestPaths = [ "tests/" ];
 
   disabledTests = [ "test_get_page" ];
 

--- a/pkgs/development/python-modules/tencentcloud-sdk-python/default.nix
+++ b/pkgs/development/python-modules/tencentcloud-sdk-python/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "tencentcloud" ];
 
-  pytestFlagsArray = [ "tests/unit/" ];
+  enabledTestPaths = [ "tests/unit/" ];
 
   meta = with lib; {
     description = "Tencent Cloud API 3.0 SDK for Python";

--- a/pkgs/development/python-modules/tensorly/default.nix
+++ b/pkgs/development/python-modules/tensorly/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     "tensorly.contrib"
   ];
 
-  pytestFlagsArray = [ "tensorly" ];
+  enabledTestPaths = [ "tensorly" ];
 
   disabledTests = [
     # this can fail on hydra and other peoples machines, check with others before re-enabling

--- a/pkgs/development/python-modules/tesla-powerwall/default.nix
+++ b/pkgs/development/python-modules/tesla-powerwall/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     "test_parse_endpoint"
   ];
 
-  pytestFlagsArray = [ "tests/unit" ];
+  enabledTestPaths = [ "tests/unit" ];
 
   pythonImportsCheck = [ "tesla_powerwall" ];
 

--- a/pkgs/development/python-modules/tess/default.nix
+++ b/pkgs/development/python-modules/tess/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tess/tests.py" ];
+  enabledTestPaths = [ "tess/tests.py" ];
 
   preCheck = ''
     cd $out/${python.sitePackages}

--- a/pkgs/development/python-modules/testfixtures/default.nix
+++ b/pkgs/development/python-modules/testfixtures/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     "testfixtures/tests/test_django"
   ];
 
-  pytestFlagsArray = [ "testfixtures/tests" ];
+  enabledTestPaths = [ "testfixtures/tests" ];
 
   pythonImportsCheck = [ "testfixtures" ];
 

--- a/pkgs/development/python-modules/textacy/default.nix
+++ b/pkgs/development/python-modules/textacy/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     # Almost all tests have to deal with downloading a dataset, only test pure tests
     "tests/test_constants.py"
     "tests/preprocessing/test_normalize.py"

--- a/pkgs/development/python-modules/textstat/default.nix
+++ b/pkgs/development/python-modules/textstat/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     "textstat"
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "test.py"
   ];
 

--- a/pkgs/development/python-modules/texttable/default.nix
+++ b/pkgs/development/python-modules/texttable/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "texttable" ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   meta = with lib; {
     description = "Module to generate a formatted text table, using ASCII characters";

--- a/pkgs/development/python-modules/textx/tests.nix
+++ b/pkgs/development/python-modules/textx/tests.nix
@@ -45,7 +45,7 @@ buildPythonPackage {
     textx-types-dsl
   ];
 
-  pytestFlagsArray = [ "tests/functional" ];
+  enabledTestPaths = [ "tests/functional" ];
   disabledTests = [
     "test_examples" # assertion error: 0 == 12
   ];

--- a/pkgs/development/python-modules/throttler/default.nix
+++ b/pkgs/development/python-modules/throttler/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests/" ];
+  enabledTestPaths = [ "tests/" ];
 
   disabledTestPaths = [
     # time sensitive tests

--- a/pkgs/development/python-modules/timeago/default.nix
+++ b/pkgs/development/python-modules/timeago/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "test/testcase.py" ];
+  enabledTestPaths = [ "test/testcase.py" ];
 
   pythonImportsCheck = [ "timeago" ];
 

--- a/pkgs/development/python-modules/timm/default.nix
+++ b/pkgs/development/python-modules/timm/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     pytest-timeout
   ];
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   disabledTests =
     lib.optionals

--- a/pkgs/development/python-modules/tinyrecord/default.nix
+++ b/pkgs/development/python-modules/tinyrecord/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     tinydb
   ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   pythonImportsCheck = [ "tinyrecord" ];
 

--- a/pkgs/development/python-modules/titlecase/default.nix
+++ b/pkgs/development/python-modules/titlecase/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "titlecase/tests.py" ];
+  enabledTestPaths = [ "titlecase/tests.py" ];
 
   pythonImportsCheck = [ "titlecase" ];
 

--- a/pkgs/development/python-modules/trimesh/default.nix
+++ b/pkgs/development/python-modules/trimesh/default.nix
@@ -63,7 +63,7 @@ buildPythonPackage rec {
     "test_load"
   ];
 
-  pytestFlagsArray = [ "tests/test_minimal.py" ];
+  enabledTestPaths = [ "tests/test_minimal.py" ];
 
   pythonImportsCheck = [
     "trimesh"

--- a/pkgs/development/python-modules/trx-python/default.nix
+++ b/pkgs/development/python-modules/trx-python/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     export HOME=$TMPDIR
   '';
 
-  pytestFlagsArray = [ "trx/tests" ];
+  enabledTestPaths = [ "trx/tests" ];
 
   disabledTestPaths = [
     # access to network

--- a/pkgs/development/python-modules/ttp/default.nix
+++ b/pkgs/development/python-modules/ttp/default.nix
@@ -97,7 +97,7 @@ buildPythonPackage rec {
     "test_ttp_templates_dir_env_variable"
   ];
 
-  pytestFlagsArray = [ "test/pytest" ];
+  enabledTestPaths = [ "test/pytest" ];
 
   meta = with lib; {
     changelog = "https://github.com/dmulyalin/ttp/releases/tag/${version}";

--- a/pkgs/development/python-modules/tweedledum/default.nix
+++ b/pkgs/development/python-modules/tweedledum/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "tweedledum" ];
 
   nativeCheckInputs = [ pytestCheckHook ];
-  pytestFlagsArray = [ "python/test" ];
+  enabledTestPaths = [ "python/test" ];
 
   meta = with lib; {
     description = "Library for synthesizing and manipulating quantum circuits";

--- a/pkgs/development/python-modules/typed-settings/default.nix
+++ b/pkgs/development/python-modules/typed-settings/default.nix
@@ -68,7 +68,7 @@ buildPythonPackage rec {
   ++ (lib.optional (pythonOlder "3.11") typing-extensions)
   ++ (lib.flatten (lib.attrValues optional-dependencies));
 
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   disabledTests = [
     # 1Password CLI is not available

--- a/pkgs/development/python-modules/typeshed-client/default.nix
+++ b/pkgs/development/python-modules/typeshed-client/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "typeshed_client" ];
 
-  pytestFlagsArray = [ "tests/test.py" ];
+  enabledTestPaths = [ "tests/test.py" ];
 
   meta = with lib; {
     description = "Retrieve information from typeshed and other typing stubs";

--- a/pkgs/development/python-modules/ultralytics/default.nix
+++ b/pkgs/development/python-modules/ultralytics/default.nix
@@ -75,7 +75,7 @@ buildPythonPackage rec {
     onnxruntime
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     # rest of the tests require internet access
     "tests/test_python.py"
   ];

--- a/pkgs/development/python-modules/unicode-slugify/default.nix
+++ b/pkgs/development/python-modules/unicode-slugify/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "slugify/tests.py" ];
+  enabledTestPaths = [ "slugify/tests.py" ];
 
   meta = with lib; {
     description = "Generates unicode slugs";

--- a/pkgs/development/python-modules/virt-firmware/default.nix
+++ b/pkgs/development/python-modules/virt-firmware/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     pkgs.systemd
   ];
 
-  pytestFlagsArray = [ "tests/tests.py" ];
+  enabledTestPaths = [ "tests/tests.py" ];
 
   pythonImportsCheck = [ "virt.firmware.efi" ];
 

--- a/pkgs/development/python-modules/vobject/default.nix
+++ b/pkgs/development/python-modules/vobject/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   meta = with lib; {
     description = "Module for reading vCard and vCalendar files";

--- a/pkgs/development/python-modules/voluptuous/default.nix
+++ b/pkgs/development/python-modules/voluptuous/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "voluptuous" ];
 
-  pytestFlagsArray = [ "voluptuous/tests/" ];
+  enabledTestPaths = [ "voluptuous/tests/" ];
 
   meta = with lib; {
     description = "Python data validation library";

--- a/pkgs/development/python-modules/wakeonlan/default.nix
+++ b/pkgs/development/python-modules/wakeonlan/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "test_wakeonlan.py" ];
+  enabledTestPaths = [ "test_wakeonlan.py" ];
 
   pythonImportsCheck = [ "wakeonlan" ];
 

--- a/pkgs/development/python-modules/wasserstein/default.nix
+++ b/pkgs/development/python-modules/wasserstein/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
-  pytestFlagsArray = [ "wasserstein/tests" ];
+  enabledTestPaths = [ "wasserstein/tests" ];
   disabledTestPaths = [
     "wasserstein/tests/test_emd.py" # requires "ot"
     # cyclic dependency on energyflow

--- a/pkgs/development/python-modules/wcag-contrast-ratio/default.nix
+++ b/pkgs/development/python-modules/wcag-contrast-ratio/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "test.py" ];
+  enabledTestPaths = [ "test.py" ];
 
   pythonImportsCheck = [ "wcag_contrast_ratio" ];
 

--- a/pkgs/development/python-modules/weaviate-client/default.nix
+++ b/pkgs/development/python-modules/weaviate-client/default.nix
@@ -87,7 +87,7 @@ buildPythonPackage rec {
     "test_client_with_extra_options"
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "test"
     "mock_tests"
   ];

--- a/pkgs/development/python-modules/wsme/default.nix
+++ b/pkgs/development/python-modules/wsme/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     webtest
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "wsme/tests"
     "tests/pecantest"
     "tests/test_sphinxext.py"

--- a/pkgs/development/python-modules/wurlitzer/default.nix
+++ b/pkgs/development/python-modules/wurlitzer/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "wurlitzer" ];
 
-  pytestFlagsArray = [ "test.py" ];
+  enabledTestPaths = [ "test.py" ];
 
   meta = with lib; {
     description = "Capture C-level output in context managers";

--- a/pkgs/development/python-modules/yara-python/default.nix
+++ b/pkgs/development/python-modules/yara-python/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
 
   setupPyBuildFlags = [ "--dynamic-linking" ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   pythonImportsCheck = [ "yara" ];
 

--- a/pkgs/development/python-modules/yaramod/default.nix
+++ b/pkgs/development/python-modules/yaramod/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests/" ];
+  enabledTestPaths = [ "tests/" ];
 
   pythonImportsCheck = [ "yaramod" ];
 

--- a/pkgs/development/python-modules/yargy/default.nix
+++ b/pkgs/development/python-modules/yargy/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ pymorphy2 ];
   pythonImportsCheck = [ "yargy" ];
   nativeCheckInputs = [ pytestCheckHook ];
-  pytestFlagsArray = [ "tests" ];
+  enabledTestPaths = [ "tests" ];
 
   meta = with lib; {
     description = "Rule-based facts extraction for Russian language";

--- a/pkgs/development/python-modules/yeelight/default.nix
+++ b/pkgs/development/python-modules/yeelight/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "yeelight/tests.py" ];
+  enabledTestPaths = [ "yeelight/tests.py" ];
 
   pythonImportsCheck = [ "yeelight" ];
 

--- a/pkgs/development/python-modules/yq/default.nix
+++ b/pkgs/development/python-modules/yq/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "test/test.py" ];
+  enabledTestPaths = [ "test/test.py" ];
 
   pythonImportsCheck = [ "yq" ];
 

--- a/pkgs/development/python-modules/yte/default.nix
+++ b/pkgs/development/python-modules/yte/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "yte" ];
 
-  pytestFlagsArray = [ "tests.py" ];
+  enabledTestPaths = [ "tests.py" ];
 
   preCheck = ''
     # The CLI test need yte on the PATH

--- a/pkgs/development/python-modules/zc-lockfile/default.nix
+++ b/pkgs/development/python-modules/zc-lockfile/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     zope-testing
   ];
 
-  pytestFlagsArray = [ "src/zc/lockfile/tests.py" ];
+  enabledTestPaths = [ "src/zc/lockfile/tests.py" ];
 
   pythonNamespaces = [ "zc" ];
 

--- a/pkgs/development/python-modules/zope-cachedescriptors/default.nix
+++ b/pkgs/development/python-modules/zope-cachedescriptors/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "src/zope/cachedescriptors/tests.py" ];
+  enabledTestPaths = [ "src/zope/cachedescriptors/tests.py" ];
 
   pythonImportsCheck = [ "zope.cachedescriptors" ];
 

--- a/pkgs/development/python-modules/zope-deprecation/default.nix
+++ b/pkgs/development/python-modules/zope-deprecation/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "src/zope/deprecation/tests.py" ];
+  enabledTestPaths = [ "src/zope/deprecation/tests.py" ];
 
   pythonImportsCheck = [ "zope.deprecation" ];
 

--- a/pkgs/development/python-modules/zope-dottedname/default.nix
+++ b/pkgs/development/python-modules/zope-dottedname/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "src/zope/dottedname/tests.py" ];
+  enabledTestPaths = [ "src/zope/dottedname/tests.py" ];
 
   pythonImportsCheck = [ "zope.dottedname" ];
 

--- a/pkgs/development/python-modules/zope-event/default.nix
+++ b/pkgs/development/python-modules/zope-event/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "src/zope/event/tests.py" ];
+  enabledTestPaths = [ "src/zope/event/tests.py" ];
 
   pythonNamespaces = [ "zope" ];
 

--- a/pkgs/development/python-modules/zope-testing/default.nix
+++ b/pkgs/development/python-modules/zope-testing/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "src/zope/testing/tests.py" ];
+  enabledTestPaths = [ "src/zope/testing/tests.py" ];
 
   pythonImportsCheck = [ "zope.testing" ];
 

--- a/pkgs/development/python-modules/zxing-cpp/default.nix
+++ b/pkgs/development/python-modules/zxing-cpp/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "test.py" ];
+  enabledTestPaths = [ "test.py" ];
 
   pythonImportsCheck = [ "zxingcpp" ];
 }

--- a/pkgs/servers/home-assistant/intents.nix
+++ b/pkgs/servers/home-assistant/intents.nix
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "intents/tests"
   ];
 


### PR DESCRIPTION
Manual backport of #403112 to `staging-25.05`.


I did have to resolve a few merge conflicts, specifically:
```
        both modified:   pkgs/development/python-modules/accelerate/default.nix
        both modified:   pkgs/development/python-modules/cairosvg/default.nix
        both modified:   pkgs/development/python-modules/craft-providers/default.nix
        both modified:   pkgs/development/python-modules/langchain-community/default.nix
        deleted by us:   pkgs/development/python-modules/pypcap/default.nix
```
Otherwise this was a clean cherry-pick.