### PR TITLE
television: add wrapper helper

### DIFF
--- a/pkgs/by-name/te/television/package.nix
+++ b/pkgs/by-name/te/television/package.nix
@@ -1,60 +1,99 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
-  makeWrapper,
-  testers,
-  television,
+  callPackage,
+  installShellFiles,
   nix-update-script,
-  extraPackages ? [ ],
+  testers,
+  targetPackages,
+  extraPackages ? null,
 }:
-rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "television";
-  version = "0.13.5";
 
-  src = fetchFromGitHub {
-    owner = "alexpasmantier";
-    repo = "television";
-    tag = finalAttrs.version;
-    hash = "sha256-IlFOYnZ9xPQaRheielKqAckyVlSVQMhnO4wCtVixlNQ=";
-  };
+assert
+  (extraPackages == null)
+  || lib.warn "Overriding television with the 'extraPackages' attribute is deprecated. Please use `television.withPackages (p: [ p.fd ...])` instead.";
 
-  cargoHash = "sha256-QKUspbC1bmSeZP0n/O5roEqQkrja+fVKLhAvgzqNS9E=";
+let
+  television = rustPlatform.buildRustPackage (finalAttrs: {
+    pname = "television";
 
-  nativeBuildInputs = [ makeWrapper ];
+    version = "0.13.5";
 
-  postInstall = lib.optionalString (extraPackages != [ ]) ''
-    wrapProgram $out/bin/tv \
-      --prefix PATH : ${lib.makeBinPath extraPackages}
-  '';
-
-  # TODO(@getchoo): Investigate selectively disabling some tests, or fixing them
-  # https://github.com/NixOS/nixpkgs/pull/423662#issuecomment-3156362941
-  doCheck = false;
-
-  passthru = {
-    tests.version = testers.testVersion {
-      package = television;
-      command = "XDG_DATA_HOME=$TMPDIR tv --version";
+    src = fetchFromGitHub {
+      owner = "alexpasmantier";
+      repo = "television";
+      tag = finalAttrs.version;
+      hash = "sha256-IlFOYnZ9xPQaRheielKqAckyVlSVQMhnO4wCtVixlNQ=";
     };
-    updateScript = nix-update-script { };
-  };
 
-  meta = {
-    description = "Blazingly fast general purpose fuzzy finder TUI";
-    longDescription = ''
-      Television is a fast and versatile fuzzy finder TUI.
-      It lets you quickly search through any kind of data source (files, git
-      repositories, environment variables, docker images, you name it) using a
-      fuzzy matching algorithm and is designed to be easily extensible.
-    '';
-    homepage = "https://github.com/alexpasmantier/television";
-    changelog = "https://github.com/alexpasmantier/television/releases/tag/${finalAttrs.version}";
-    license = lib.licenses.mit;
-    mainProgram = "tv";
-    maintainers = with lib.maintainers; [
-      louis-thevenet
-      getchoo
+    cargoHash = "sha256-QKUspbC1bmSeZP0n/O5roEqQkrja+fVKLhAvgzqNS9E=";
+
+    strictDeps = true;
+    nativeBuildInputs = [
+      installShellFiles
     ];
-  };
-})
+
+    # TODO(@getchoo): Investigate selectively disabling some tests, or fixing them
+    # https://github.com/NixOS/nixpkgs/pull/423662#issuecomment-3156362941
+    doCheck = false;
+
+    postInstall = ''
+      installManPage target/${stdenv.hostPlatform.rust.cargoShortTarget}/assets/tv.1
+
+      installShellCompletion --cmd tv \
+        television/utils/shell/completion.bash \
+        television/utils/shell/completion.fish \
+        television/utils/shell/completion.nu \
+        television/utils/shell/completion.zsh
+    '';
+
+    passthru = {
+      updateScript = nix-update-script { };
+
+      withPackages =
+        f:
+        callPackage ./wrapper.nix {
+          television = finalAttrs.finalPackage;
+          extraPackages = f targetPackages;
+        };
+
+      tests = {
+        version = testers.testVersion {
+          package = finalAttrs.finalPackage;
+          command = "XDG_DATA_HOME=$TMPDIR tv --version";
+        };
+        wrapper = testers.testVersion {
+          package = finalAttrs.finalPackage.withPackages (pkgs: [
+            pkgs.fd
+            pkgs.git
+          ]);
+
+          command = "XDG_DATA_HOME=$TMPDIR tv --version";
+        };
+      };
+    };
+
+    meta = {
+      description = "Blazingly fast general purpose fuzzy finder TUI";
+      longDescription = ''
+        Television is a fast and versatile fuzzy finder TUI.
+        It lets you quickly search through any kind of data source (files, git
+        repositories, environment variables, docker images, you name it) using a
+        fuzzy matching algorithm and is designed to be easily extensible.
+      '';
+      homepage = "https://github.com/alexpasmantier/television";
+      changelog = "https://github.com/alexpasmantier/television/releases/tag/${finalAttrs.version}";
+      license = lib.licenses.mit;
+      mainProgram = "tv";
+      maintainers = with lib.maintainers; [
+        louis-thevenet
+        getchoo
+        RossSmyth
+      ];
+    };
+  });
+in
+
+if extraPackages == null then television else television.withPackages (lib.const extraPackages)

--- a/pkgs/by-name/te/television/wrapper.nix
+++ b/pkgs/by-name/te/television/wrapper.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  symlinkJoin,
+  television,
+  makeBinaryWrapper,
+  extraPackages,
+}:
+
+symlinkJoin {
+  inherit (television) version;
+  pname = "${television.pname}-with-pkgs";
+
+  paths = [ television ];
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  postBuild = ''
+    wrapProgram $out/bin/tv \
+      --prefix PATH : "${lib.makeBinPath extraPackages}"
+  '';
+
+  meta = {
+    inherit (television.meta)
+      description
+      longDescription
+      homepage
+      changelog
+      license
+      mainProgram
+      maintainers
+      ;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. makeWrapper -> makeBinaryWrapper
2. strictDeps = true
3. installManPage
4. installShellCompletion
5. Add "share" output
6. Wrap program to inject the "cable-dir" argument so that the user doesn't have to download the cables
7. Add `withPkgs` wrapper helper to bring television in line with other packages like python, hunspell, typst, and others.
8. Add test for the wrapper
9. Add a backwards compatible warning for the previous override-based package injection

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
