### PR TITLE
python3Packages.marimo: 0.14.16 -> 0.15.2

### DIFF
--- a/pkgs/development/python-modules/marimo/default.nix
+++ b/pkgs/development/python-modules/marimo/default.nix
@@ -5,18 +5,18 @@
   pythonOlder,
 
   # build-system
-  hatchling,
+  uv-build,
 
   # dependencies
   click,
   docutils,
   itsdangerous,
   jedi,
+  loro,
   markdown,
   narwhals,
   packaging,
   psutil,
-  pycrdt,
   pygments,
   pymdown-extensions,
   pyyaml,
@@ -33,32 +33,27 @@
 
 buildPythonPackage rec {
   pname = "marimo";
-  version = "0.14.16";
+  version = "0.15.2";
   pyproject = true;
 
   # The github archive does not include the static assets
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-8PKRrH+m+HyAcvQBnG6fY1rX77N+AhTyJUPI3ZgwQtE=";
+    hash = "sha256-cmkz/ZyVYfpz4yOxghsXPF4PhRluwqSXo1CcwvwkXFg=";
   };
 
-  build-system = [ hatchling ];
-
-  pythonRelaxDeps = [
-    "pycrdt"
-    "websockets"
-  ];
+  build-system = [ uv-build ];
 
   dependencies = [
     click
     docutils
     itsdangerous
     jedi
+    loro
     markdown
     narwhals
     packaging
     psutil
-    pycrdt
     pygments
     pymdown-extensions
     pyyaml


### PR DESCRIPTION
bump marimo 0.14.16 (broken) to 0.15.2

 - change build system (hatchling -> uv-build)
 - update dependencies (add loro, remove pycdrt)

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
