### PR TITLE
[Backport release-25.05] mattermostLatest: 10.9.1 -> 10.11.1 

### DIFF
--- a/pkgs/by-name/ma/mattermostLatest/package.nix
+++ b/pkgs/by-name/ma/mattermostLatest/package.nix
@@ -11,10 +11,10 @@ mattermost.override {
     # and make sure the version regex is up to date here.
     # Ensure you also check ../mattermost/package.nix for ESR releases.
     regex = "^v(10\\.[0-9]+\\.[0-9]+)$";
-    version = "10.9.2";
-    srcHash = "sha256-0el9PROsErFFnOIhv+TdFAXaXRECEeBqaiaPGMt5M5E=";
-    vendorHash = "sha256-+wmemZZyuz90VCXjO0ekplxdkv2p0s5h4qUObAA0XwU=";
-    npmDepsHash = "sha256-uAB599r3ZWjnt+jwk7sjSiPsc/tUyiBZzGqLZxuU3xE=";
+    version = "10.10.1";
+    srcHash = "sha256-tPjwtbGzg1G9fWoo8UC82RLm2GOQhvtQiw4vXKxz2ww=";
+    vendorHash = "sha256-hsTmqwISOln2YlMXNBXKu4iPwWsLEyoe5IIth9lYjbM=";
+    npmDepsHash = "sha256-Uv2lqcz2AV/gJJFWSN5cSP7JYgnEJBXzexruKqNU7p4=";
     lockfileOverlay = ''
       unlock(.; "@floating-ui/react"; "channels/node_modules/@floating-ui/react")
     '';

--- a/pkgs/by-name/ma/mattermostLatest/package.nix
+++ b/pkgs/by-name/ma/mattermostLatest/package.nix
@@ -11,8 +11,8 @@ mattermost.override {
     # and make sure the version regex is up to date here.
     # Ensure you also check ../mattermost/package.nix for ESR releases.
     regex = "^v(10\\.[0-9]+\\.[0-9]+)$";
-    version = "10.9.1";
-    srcHash = "sha256-U9PbI2rzoMW48cDFJuhHrL7BWFrqTN7lgTbeL1N0dpQ=";
+    version = "10.9.2";
+    srcHash = "sha256-0el9PROsErFFnOIhv+TdFAXaXRECEeBqaiaPGMt5M5E=";
     vendorHash = "sha256-+wmemZZyuz90VCXjO0ekplxdkv2p0s5h4qUObAA0XwU=";
     npmDepsHash = "sha256-uAB599r3ZWjnt+jwk7sjSiPsc/tUyiBZzGqLZxuU3xE=";
     lockfileOverlay = ''

--- a/pkgs/by-name/ma/mattermostLatest/package.nix
+++ b/pkgs/by-name/ma/mattermostLatest/package.nix
@@ -11,10 +11,10 @@ mattermost.override {
     # and make sure the version regex is up to date here.
     # Ensure you also check ../mattermost/package.nix for ESR releases.
     regex = "^v(10\\.[0-9]+\\.[0-9]+)$";
-    version = "10.10.1";
-    srcHash = "sha256-tPjwtbGzg1G9fWoo8UC82RLm2GOQhvtQiw4vXKxz2ww=";
-    vendorHash = "sha256-hsTmqwISOln2YlMXNBXKu4iPwWsLEyoe5IIth9lYjbM=";
-    npmDepsHash = "sha256-Uv2lqcz2AV/gJJFWSN5cSP7JYgnEJBXzexruKqNU7p4=";
+    version = "10.11.1";
+    srcHash = "sha256-iWznWqnsPDcq9hZqnPHCxqsOJESolVWDC6413hitFpk=";
+    vendorHash = "sha256-Lqa463LLy41aaRbrtJFclfOj55vLjK4pWFAFLzX3TJE=";
+    npmDepsHash = "sha256-p9dq31qw0EZDQIl2ysKE38JgDyLA6XvSv+VtHuRh+8A=";
     lockfileOverlay = ''
       unlock(.; "@floating-ui/react"; "channels/node_modules/@floating-ui/react")
     '';


### PR DESCRIPTION
Manual backport of #420222, #422855, #432564 to `release-25.05`.

- [x] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.