### PR TITLE
[Backport release-25.05] python3Packages.qt-material: 2.14 -> 2.17, modernize, fix

### DIFF
--- a/pkgs/development/python-modules/qt-material/default.nix
+++ b/pkgs/development/python-modules/qt-material/default.nix
@@ -1,28 +1,34 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   jinja2,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "qt-material";
   version = "2.17";
-  format = "setuptools";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-tQCgwfXvj0aozwN9GqW9+epOthgYC2MyU5373QZHrQ0=";
+  src = fetchFromGitHub {
+    owner = "dunderlab";
+    repo = "qt-material";
+    tag = "v${version}";
+    hash = "sha256-ilrPA8SoVCo6FgwxWQ4sOjqURCFDQJLlTTkCZzTZQKI=";
   };
 
-  propagatedBuildInputs = [ jinja2 ];
+  build-system = [ setuptools ];
+
+  dependencies = [ jinja2 ];
 
   pythonImportsCheck = [ "qt_material" ];
 
-  meta = with lib; {
+  meta = {
+    changelog = "https://github.com/dunderlab/qt-material/releases/tag/${src.tag}";
     description = "Material inspired stylesheet for PySide2, PySide6, PyQt5 and PyQt6";
-    homepage = "https://github.com/UN-GCPDS/qt-material";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ _999eagle ];
+    homepage = "https://github.com/dunderlab/qt-material";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ _999eagle ];
   };
 }

--- a/pkgs/development/python-modules/qt-material/default.nix
+++ b/pkgs/development/python-modules/qt-material/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "qt-material";
-  version = "2.14";
+  version = "2.17";
   format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-tdu1relyF8964za7fAR8kL6zncfyBIpJjJFq1fL3riM=";
+    hash = "sha256-tQCgwfXvj0aozwN9GqW9+epOthgYC2MyU5373QZHrQ0=";
   };
 
   propagatedBuildInputs = [ jinja2 ];


### PR DESCRIPTION
Manual backport of 7b21af5aba61994e437adf3470e2579654d3f91b and #434692 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.