### PR TITLE
fancontrol: harden systemd service

### DIFF
--- a/nixos/modules/services/hardware/fancontrol.nix
+++ b/nixos/modules/services/hardware/fancontrol.nix
@@ -32,7 +32,6 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-
     systemd.services.fancontrol = {
       documentation = [ "man:fancontrol(8)" ];
       description = "software fan control";
@@ -42,6 +41,57 @@ in
       serviceConfig = {
         Restart = "on-failure";
         ExecStart = "${lib.getExe' pkgs.lm_sensors "fancontrol"} ${configFile}";
+
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+
+        PrivateDevices = true;
+        PrivateNetwork = true;
+        PrivateTmp = true;
+
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectProc = "noaccess";
+        ProtectSystem = "strict";
+
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+
+        DeviceAllow = "";
+        DevicePolicy = "closed";
+        ReadWritePaths = [
+          "/sys/class/hwmon"
+        ];
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RemoveIPC = true;
+        SystemCallArchitectures = "native";
+        IPAddressDeny = "any";
+        UMask = "0077";
+        RestrictAddressFamilies = "none";
+        SystemCallFilter = [
+          "@system-service"
+          (lib.concatStringsSep " " [
+            "~"
+            "@clock"
+            "@cpu-emulation"
+            "@debug"
+            "@keyring"
+            "@module"
+            "@mount"
+            "@obsolete"
+            "@privileged"
+            "@raw-io"
+            "@reboot"
+            "@resources"
+            "@swap"
+          ])
+        ];
       };
     };
 


### PR DESCRIPTION
Because it interacts with the hwmon subsystem in sysfs, fancontrol seemingly must be executed as root. However, right now it has all the other permissions of root, which means that any upstream security issues, bugs, etc have a very large blast radius; this doesn't follow the principle of least privilege.
    
This PR adds systemd hardening; reducing most kernel access, removing all capabilities, removing privileged fs access, stripping out most write access, removing network access, etc.
    
Basically, taking this service from roughly being able to do anything, to being able to do only what it requires.

I'm presently running this on my system.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
