### PR TITLE
calceph: init at 4.0.5

### DIFF
--- a/pkgs/by-name/ca/calceph/package.nix
+++ b/pkgs/by-name/ca/calceph/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  cmake,
+  gfortran,
+}:
+stdenv.mkDerivation rec {
+  pname = "calceph";
+  version = "4.0.5";
+  src = fetchFromGitLab {
+    domain = "gitlab.obspm.fr";
+    owner = "imcce_calceph";
+    repo = "calceph";
+    tag = "calceph_${builtins.replaceStrings [ "." ] [ "_" ] version}";
+    hash = "sha256-V4Hh3FItBv3zYerNqNPeRJ5Afj3QTfdG3Ps5xeiDASg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gfortran
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+  ];
+
+  meta = {
+    homepage = "https://www.imcce.fr/inpop/calceph/";
+    changelog = "https://gitlab.obspm.fr/imcce_calceph/calceph/-/blob/${src.rev}/NEWS";
+    description = "C library for interacting with binary planetary ephemeris files, such INPOPxx, JPL DExxx and SPICE";
+    license = with lib.licenses; [
+      cecill21
+      cecill-b
+      cecill-c
+    ];
+    maintainers = with lib.maintainers; [ kiranshila ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
Adds the [CALCEPH](https://www.imcce.fr/inpop/calceph/) C library for working with binary ephemeris files.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
