### PR TITLE
pngcheck: 3.0.2 -> 4.0.1

### DIFF
--- a/pkgs/by-name/pn/pngcheck/package.nix
+++ b/pkgs/by-name/pn/pngcheck/package.nix
@@ -1,44 +1,29 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  cmake,
   zlib,
-  installShellFiles,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pngcheck";
-  version = "3.0.2";
+  version = "4.0.1";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/png-mng/pngcheck-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-DX4mLyQRb93yhHqM61yS2fXybvtC6f/2PsK7dnYTHKc=";
+  src = fetchFromGitHub {
+    owner = "pnggroup";
+    repo = "pngcheck";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-1cBcSCkiJmHVgYVCY5Em1UtiyAXgd6djEAChrXptTQM=";
   };
 
-  hardeningDisable = [ "format" ];
-
-  postPatch = ''
-    substituteInPlace $makefile \
-      --replace "gcc" "$CC"
-  '';
-
-  makefile = "Makefile.unx";
-
-  nativeBuildInputs = [ installShellFiles ];
-
+  nativeBuildInputs = [ cmake ];
   buildInputs = [ zlib ];
 
-  installPhase = ''
-    runHook preInstall
-    installBin pngcheck
-    installManPage $pname.1
-    runHook postInstall
-  '';
-
   meta = {
-    homepage = "https://pmt.sourceforge.net/pngcrush";
+    homepage = "https://www.libpng.org/pub/png/apps/pngcheck.html";
     description = "Verifies the integrity of PNG, JNG and MNG files";
-    license = lib.licenses.free;
+    license = lib.licenses.hpnd;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ starcraft66 ];
     mainProgram = "pngcheck";


### PR DESCRIPTION
## Things done

Update pngcheck to 4.0.0 and change to new upstream [per pngcheck's homepage "Change of Address" message](https://www.libpng.org/pub/png/apps/pngcheck.html)

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
