### PR TITLE
python313Packages.boost-histogram: fix build, more checks

### DIFF
--- a/pkgs/development/python-modules/boost-histogram/default.nix
+++ b/pkgs/development/python-modules/boost-histogram/default.nix
@@ -73,6 +73,8 @@ buildPythonPackage rec {
     "test_numpy_conversion_4"
   ];
 
+  pythonImportsCheck = [ "boost_histogram" ];
+
   meta = {
     description = "Python bindings for the C++14 Boost::Histogram library";
     homepage = "https://github.com/scikit-hep/boost-histogram";

--- a/pkgs/development/python-modules/boost-histogram/default.nix
+++ b/pkgs/development/python-modules/boost-histogram/default.nix
@@ -34,7 +34,8 @@ buildPythonPackage rec {
     owner = "scikit-hep";
     repo = "boost-histogram";
     tag = "v${version}";
-    hash = "sha256-fWbvv9MiBZZiTZLu78tMR5Cx0/7xSuVIya3dkuahPE4=";
+    hash = "sha256-kduE5v1oQT76MRxMuGo+snCBdJ+yOjkOJFO45twcUIs=";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/python-modules/boost-histogram/default.nix
+++ b/pkgs/development/python-modules/boost-histogram/default.nix
@@ -23,6 +23,9 @@
   # tests
   pytestCheckHook,
   pytest-benchmark,
+  pytest-xdist,
+  cloudpickle,
+  hypothesis,
 }:
 
 buildPythonPackage rec {
@@ -57,6 +60,9 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-benchmark
+    pytest-xdist
+    cloudpickle
+    hypothesis
   ];
 
   pytestFlags = [ "--benchmark-disable" ];


### PR DESCRIPTION
Fix the build, enable more tests by updating `nativeCheckInputs` to match upstream, and add `pythonImportsCheck`.

Update to 1.6.1 is currently blocked by `pybind11>=3` not being in nixpkgs yet. See #438171, #419220 for tracking.

Hydra: https://hydra.nixos.org/build/305903614

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
