### PR TITLE
cobra-cli: install shell completions for bash, zsh, and fish

### DIFF
--- a/pkgs/by-name/co/cobra-cli/package.nix
+++ b/pkgs/by-name/co/cobra-cli/package.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   makeWrapper,
+  installShellFiles,
   go,
 }:
 
@@ -19,7 +20,10 @@ buildGoModule rec {
 
   vendorHash = "sha256-vrtGPQzY+NImOGaSxV+Dvch+GNPfL9XfY4lfCHTGXwY=";
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+    installShellFiles
+  ];
 
   allowGoReference = true;
 
@@ -33,6 +37,13 @@ buildGoModule rec {
   postFixup = ''
     wrapProgram "$out/bin/cobra-cli" \
       --prefix PATH : ${go}/bin
+  '';
+
+  postInstall = ''
+    installShellCompletion --cmd cobra-cli \
+      --bash <($out/bin/cobra-cli completion bash) \
+      --fish <($out/bin/cobra-cli completion fish) \
+      --zsh <($out/bin/cobra-cli completion zsh) \
   '';
 
   meta = {


### PR DESCRIPTION
add missing postInstall phase with standard `installShellCompletion` call to make the existing completion functionality inside the binary automatically available

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
