### PR TITLE
nixos/home-assistant: set permission for input devices

### DIFF
--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -868,6 +868,10 @@ in
             "amshan"
             "benqprojector"
           ];
+          componentsUsingInputDevices = [
+            # Components that require access to input devices (/dev/input/*)
+            "keyboard_remote"
+          ];
         in
         {
           ExecStart = escapeSystemdExecArgs (
@@ -898,13 +902,15 @@ in
           # Hardening
           AmbientCapabilities = capabilities;
           CapabilityBoundingSet = capabilities;
-          DeviceAllow = (
+          DeviceAllow =
             optionals (any useComponent componentsUsingSerialDevices) [
               "char-ttyACM rw"
               "char-ttyAMA rw"
               "char-ttyUSB rw"
             ]
-          );
+            ++ optionals (any useComponent componentsUsingInputDevices) [
+              "char-input rw"
+            ];
           DevicePolicy = "closed";
           LockPersonality = true;
           MemoryDenyWriteExecute = true;
@@ -946,9 +952,13 @@ in
           RestrictNamespaces = true;
           RestrictRealtime = true;
           RestrictSUIDSGID = true;
-          SupplementaryGroups = optionals (any useComponent componentsUsingSerialDevices) [
-            "dialout"
-          ];
+          SupplementaryGroups =
+            optionals (any useComponent componentsUsingSerialDevices) [
+              "dialout"
+            ]
+            ++ optionals (any useComponent componentsUsingInputDevices) [
+              "input"
+            ];
           SystemCallArchitectures = "native";
           SystemCallFilter = [
             "@system-service"


### PR DESCRIPTION
Currently only keyboard_remote uses evdev.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
