### PR TITLE
uhdm: 1.84-unstable-2024-11-12 -> 1.86; surelog: 1.84-unstable-2024-12-06 -> 1.86

### DIFF
--- a/pkgs/by-name/su/surelog/package.nix
+++ b/pkgs/by-name/su/surelog/package.nix
@@ -17,14 +17,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "surelog";
-  version = "1.84-unstable-2024-12-06";
+  version = "1.86";
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
     repo = "surelog";
-    # Once we're back on a stable tag, use "v$(finalAttrs.version}" below.
-    rev = "298a9cddc672cce7f25ec352f9f8f36f5b23aa4e";
-    hash = "sha256-Qv4dosj2dwakNCcvu483ZMuw+LlYs4fhZTULszERLSI=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-EEhaYimyzOgQB7dxbbTfsa7APC6SlFkz9ah9BLcKDq4=";
     fetchSubmodules = false; # we use all dependencies from nix
   };
 

--- a/pkgs/by-name/uh/uhdm/package.nix
+++ b/pkgs/by-name/uh/uhdm/package.nix
@@ -9,16 +9,15 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "UHDM";
-  # When updating this package, also consider updating science/logic/surelog
-  version = "1.84-unstable-2024-11-12";
+  pname = "uhdm";
+  # When updating this package, also consider updating surelog
+  version = "1.86";
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
     repo = "UHDM";
-    # After we're back on a stable tag, use v${finalAttrs.version}
-    rev = "7d90dd0e68759775d0c86885d991925096b5b496";
-    hash = "sha256-msdtBAlOXwYJd0HhWmVo8oMJ6h8OUmy0ILxV1MV52PE=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-f7QJJEP/jL69DdMJOL5WQdDZU+kBnnLi2eX37AoaXls=";
     fetchSubmodules = false; # we use all dependencies from nix
   };
 
@@ -38,7 +37,14 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   doCheck = true;
-  checkPhase = "make test";
+
+  checkPhase = ''
+    runHook preCheck
+
+    make test
+
+    runHook postCheck
+  '';
 
   meta = {
     description = "Universal Hardware Data Model";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/chipsalliance/UHDM/releases/tag/v1.86
https://github.com/chipsalliance/UHDM/compare/7d90dd0e68759775d0c86885d991925096b5b496...v1.86

https://github.com/chipsalliance/Surelog/releases/tag/v1.86
https://github.com/chipsalliance/Surelog/compare/298a9cddc672cce7f25ec352f9f8f36f5b23aa4e...v1.86

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
