### PR TITLE
python3Packages.opensearch-py: replace orphaned commit by a commit merged in upstream

### DIFF
--- a/pkgs/development/python-modules/opensearch-py/default.nix
+++ b/pkgs/development/python-modules/opensearch-py/default.nix
@@ -43,11 +43,8 @@ buildPythonPackage rec {
 
   patches = [
     # Remove delete event_loop fixture to fix test with pytest-asyncio 1.x
-    (fetchpatch {
-      name = "remove-delete-event-loop-fixture.patch";
-      url = "https://github.com/opensearch-project/opensearch-py/commit/2f9eeaad3f7bd38518b23a59659ccf02fff19577.patch";
-      hash = "sha256-ljg9GiXPOokrIRS+gF+W9DnZ71AzH8WmLeb3G7rLeK8=";
-    })
+    # reference: https://github.com/opensearch-project/opensearch-py/pull/936
+    ./remove-delete-event-loop-fixture.patch
   ];
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/opensearch-py/remove-delete-event-loop-fixture.patch
+++ b/pkgs/development/python-modules/opensearch-py/remove-delete-event-loop-fixture.patch
@@ -1,0 +1,62 @@
+From 2f9eeaad3f7bd38518b23a59659ccf02fff19577 Mon Sep 17 00:00:00 2001
+From: florian <florian@harfanglab.fr>
+Date: Thu, 28 Aug 2025 09:57:14 +0200
+Subject: [PATCH] fix: remove delete event_loop fixture
+
+Signed-off-by: florian <florian@harfanglab.fr>
+---
+ .../test_async/test_transport.py              | 20 +++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/test_opensearchpy/test_async/test_transport.py b/test_opensearchpy/test_async/test_transport.py
+index 51388dddb..34ae41b4e 100644
+--- a/test_opensearchpy/test_async/test_transport.py
++++ b/test_opensearchpy/test_async/test_transport.py
+@@ -439,7 +439,9 @@ async def test_sniff_on_fail_failing_does_not_prevent_retires(
+         assert 1 == len(conn_err.calls)
+         assert 1 == len(conn_data.calls)
+ 
+-    async def test_sniff_after_n_seconds(self, event_loop: Any) -> None:
++    async def test_sniff_after_n_seconds(self) -> None:
++        event_loop = asyncio.get_event_loop()
++
+         t: Any = AsyncTransport(
+             [{"data": CLUSTER_NODES}],
+             connection_class=DummyConnection,
+@@ -493,9 +495,7 @@ async def test_transport_close_closes_all_pool_connections(self) -> None:
+         await t2.close()
+         assert all([conn.closed for conn in t2.connection_pool.connections])
+ 
+-    async def test_sniff_on_start_error_if_no_sniffed_hosts(
+-        self, event_loop: Any
+-    ) -> None:
++    async def test_sniff_on_start_error_if_no_sniffed_hosts(self) -> None:
+         t: Any = AsyncTransport(
+             [
+                 {"data": ""},
+@@ -512,9 +512,9 @@ async def test_sniff_on_start_error_if_no_sniffed_hosts(
+             await t._async_call()
+         assert str(e.value) == "TransportError(N/A, 'Unable to sniff hosts.')"
+ 
+-    async def test_sniff_on_start_waits_for_sniff_to_complete(
+-        self, event_loop: Any
+-    ) -> None:
++    async def test_sniff_on_start_waits_for_sniff_to_complete(self) -> None:
++        event_loop = asyncio.get_event_loop()
++
+         t: Any = AsyncTransport(
+             [
+                 {"delay": 1, "data": ""},
+@@ -550,9 +550,9 @@ async def test_sniff_on_start_waits_for_sniff_to_complete(
+         # and then resolved immediately after.
+         assert 1 <= duration < 2
+ 
+-    async def test_sniff_on_start_close_unlocks_async_calls(
+-        self, event_loop: Any
+-    ) -> None:
++    async def test_sniff_on_start_close_unlocks_async_calls(self) -> None:
++        event_loop = asyncio.get_event_loop()
++
+         t: Any = AsyncTransport(
+             [
+                 {"delay": 10, "data": CLUSTER_NODES},


### PR DESCRIPTION
https://github.com/opensearch-project/opensearch-py/pull/936 was squash merged meaning https://github.com/opensearch-project/opensearch-py/commit/2f9eeaad3f7bd38518b23a59659ccf02fff19577 might be garbage collected soon.

This PR relace the orphaned commit by the actual merged commit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
