### PR TITLE
python313Packages.urwidgets: fix build

### DIFF
--- a/pkgs/development/python-modules/urwidgets/default.nix
+++ b/pkgs/development/python-modules/urwidgets/default.nix
@@ -25,6 +25,8 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ urwid ];
 
+  pythonRelaxDeps = [ "urwid" ];
+
   pythonImportsCheck = [ "urwidgets" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/urwidgets/default.nix
+++ b/pkgs/development/python-modules/urwidgets/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
   setuptools,
   urwid,
 }:
@@ -12,8 +11,6 @@ buildPythonPackage rec {
   version = "0.2.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
-
   src = fetchFromGitHub {
     owner = "AnonymouX47";
     repo = "urwidgets";
@@ -21,9 +18,9 @@ buildPythonPackage rec {
     hash = "sha256-RgY7m0smcdUspGkCdzepxruEMDq/mAsVFNjHMLoWAyc=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [ urwid ];
+  dependencies = [ urwid ];
 
   pythonRelaxDeps = [ "urwid" ];
 
@@ -32,7 +29,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Collection of widgets for urwid";
     homepage = "https://github.com/AnonymouX47/urwidgets";
-    changelog = "https://github.com/AnonymouX47/urwidgets/releases/tag/v${version}";
+    changelog = "https://github.com/AnonymouX47/urwidgets/releases/tag/${src.tag}";
     license = licenses.mit;
     maintainers = with maintainers; [ huyngo ];
   };


### PR DESCRIPTION
Looking at the [urwid changelog](https://urwid.org/changelog.html), it doesn't seem like urwidgets is affected by any of the breaking changes introduced in urwid 3, so I think we can safely relax this dependency. An upstream issue seems to support that: https://github.com/AnonymouX47/urwidgets/issues/5.

Hydra: https://hydra.nixos.org/build/305935581

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
