### PR TITLE
biglybt: Add 'swt' to biglybt package dependencies

### DIFF
--- a/pkgs/by-name/bi/biglybt/package.nix
+++ b/pkgs/by-name/bi/biglybt/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  swt,
   fetchurl,
   jre,
   wrapGAppsHook3,
@@ -16,7 +17,18 @@ stdenv.mkDerivation rec {
     hash = "sha256-NBXEY5f2kVPoZit7Gy4rM61bwQSdXovg0gURukhxJJ4=";
   };
 
-  nativeBuildInputs = [ wrapGAppsHook3 ];
+  nativeBuildInputs = [
+    swt
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    swt
+  ];
+
+  runtimeDeps = [
+    swt
+  ];
 
   configurePhase = ''
     runHook preConfigure
@@ -33,6 +45,11 @@ stdenv.mkDerivation rec {
     install -d $out/{share/{biglybt,applications,icons/hicolor/scalable/apps},bin}
 
     cp -r ./* $out/share/biglybt/
+
+    ln -s ${swt}/lib/* $out/share/biglybt/
+    rm -rf $out/share/biglybt/swt/*.jar $out/share/biglybt/swt/J17/*.jar
+    ln -s ${swt}/jars/swt.jar $out/share/biglybt/swt/swt-$(uname -m).jar
+    ln -s ${swt}/jars/swt.jar $out/share/biglybt/swt/J17/swt-$(uname -m).jar
 
     ln -s $out/share/biglybt/biglybt.desktop $out/share/applications/
 

--- a/pkgs/by-name/sw/swt/package.nix
+++ b/pkgs/by-name/sw/swt/package.nix
@@ -17,10 +17,21 @@ stdenv.mkDerivation (finalAttrs: {
   hardeningDisable = [ "format" ];
 
   passthru.srcMetadataByPlatform = {
+    # Note: This may look like an error but the content of the src.zip is in fact
+    # equal on all linux systems as well as all darwin systems. Even though each
+    # of these zip archives themselves contains a different hash.
     x86_64-linux.platform = "gtk-linux-x86_64";
     x86_64-linux.hash = "sha256-lKAB2aCI3dZdt3pE7uSvSfxc8vc3oMSTCx5R+71Aqdk=";
+    aarch64-linux.platform = "gtk-linux-aarch64";
+    aarch64-linux.hash = "sha256-lKAB2aCI3dZdt3pE7uSvSfxc8vc3oMSTCx5R+71Aqdk=";
+    ppc64le-linux.platform = "gtk-linux-ppc64le";
+    ppc64le-linux.hash = "sha256-lKAB2aCI3dZdt3pE7uSvSfxc8vc3oMSTCx5R+71Aqdk=";
+    riscv64-linux.platform = "gtk-linux-riscv64";
+    riscv64-linux.hash = "sha256-lKAB2aCI3dZdt3pE7uSvSfxc8vc3oMSTCx5R+71Aqdk=";
     x86_64-darwin.platform = "cocoa-macosx-x86_64";
     x86_64-darwin.hash = "sha256-Uns3fMoetbZAIrL/N0eVd42/3uygXakDdxpaxf5SWDI=";
+    aarch64-darwin.platform = "cocoa-macosx-aarch64";
+    aarch64-darwin.hash = "sha256-Uns3fMoetbZAIrL/N0eVd42/3uygXakDdxpaxf5SWDI";
   };
   passthru.srcMetadata =
     finalAttrs.passthru.srcMetadataByPlatform.${stdenv.hostPlatform.system} or null;


### PR DESCRIPTION
When I tried to start biglybt on a fresh install it complained about a missing swt dependency. Apparently it looks not only for it within its install folder but also within ~/.swt, this is probably why this was overlooked until now.

<img width="801" height="293" alt="image" src="https://github.com/user-attachments/assets/713d8556-661c-4ad9-8c65-e2402084bf35" />

Fixes #416199

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
