### PR TITLE
python313Packages.pywebview: fix, use Qt 6, modernize

### DIFF
--- a/pkgs/development/python-modules/pywebview/default.nix
+++ b/pkgs/development/python-modules/pywebview/default.nix
@@ -4,24 +4,17 @@
   fetchFromGitHub,
   setuptools-scm,
   bottle,
-  importlib-resources,
   proxy-tools,
-  pygobject3,
-  pyqtwebengine,
-  pytest,
-  pythonOlder,
-  qt5,
+  pyside6,
   qtpy,
   six,
-  xvfb-run,
+  typing-extensions,
 }:
 
 buildPythonPackage rec {
   pname = "pywebview";
   version = "6.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "r0x0r";
@@ -30,39 +23,16 @@ buildPythonPackage rec {
     hash = "sha256-EuDm3Ixw1z5xwpl4U15Xwg5mE3dXslTvv0N0XyjxrAg=";
   };
 
-  nativeBuildInputs = [
-    setuptools-scm
-    qt5.wrapQtAppsHook
-  ];
+  build-system = [ setuptools-scm ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     bottle
-    pyqtwebengine
+    pyside6
     proxy-tools
-    six
-  ]
-  ++ lib.optionals (pythonOlder "3.7") [ importlib-resources ];
-
-  nativeCheckInputs = [
-    pygobject3
-    pytest
     qtpy
-    xvfb-run
+    six
+    typing-extensions
   ];
-
-  checkPhase = ''
-    # a Qt wrapper is required to run the Qt backend
-    # since the upstream script does not have a way to disable tests individually pytest is used directly instead
-    makeQtWrapper "$(command -v pytest)" tests/run.sh \
-      --set PYWEBVIEW_LOG debug \
-      --add-flags "--deselect tests/test_js_api.py::test_concurrent"
-
-    # HOME and XDG directories are required for the tests
-    env \
-      HOME=$TMPDIR \
-      XDG_RUNTIME_DIR=$TMPDIR/xdg-runtime-dir \
-      xvfb-run -s '-screen 0 800x600x24' tests/run.sh
-  '';
 
   pythonImportsCheck = [ "webview" ];
 


### PR DESCRIPTION
Tests are unfortunately dead now because they segfault somewhere deep in qtwebengine code, jellyfin-mpv-shim seems to run normally though.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
