### PR TITLE
python3Packages.okonomiyaki: fix build

### DIFF
--- a/pkgs/development/python-modules/okonomiyaki/default.nix
+++ b/pkgs/development/python-modules/okonomiyaki/default.nix
@@ -30,12 +30,6 @@ buildPythonPackage rec {
     hash = "sha256-xAF9Tdr+IM3lU+mcNcAWATJLZOVvbx0llqznqHLVqDc=";
   };
 
-  postPatch = ''
-    # Fixed for >= 2.0.0
-    substituteInPlace setup.cfg \
-      --replace-fail "long_description_content_type = rst" "long_description_content_type = text/x-rst"
-  '';
-
   build-system = [ setuptools ];
 
   optional-dependencies = {
@@ -68,6 +62,8 @@ buildPythonPackage rec {
   preCheck = ''
     substituteInPlace okonomiyaki/runtimes/tests/test_runtime.py \
       --replace-fail 'runtime_info = PythonRuntime.from_running_python()' 'raise unittest.SkipTest() #'
+    substituteInPlace okonomiyaki/platforms/_platform.py \
+      --replace-fail 'name.split()[0]' '(name.split() or [""])[0]'
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace okonomiyaki/platforms/tests/test_pep425.py \


### PR DESCRIPTION
- Remove redundant patch (upstream fixed in https://github.com/enthought/okonomiyaki/commit/5c7bbde99c9f76d6b9e5e030c7737112ca848bbe)
- Fix split logic on an empty list


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
