### PR TITLE
vimPlugins: strictly enforce only overrides in `overrides.nix`

### DIFF
--- a/pkgs/applications/editors/vim/plugins/aliases.nix
+++ b/pkgs/applications/editors/vim/plugins/aliases.nix
@@ -125,6 +125,7 @@ mapAliases (
     surround = vim-surround;
     sleuth = vim-sleuth;
     solidity = vim-solidity;
+    ssr = ssr-nvim; # Added 2025-08-31
     stylish-haskell = vim-stylish-haskell;
     stylishHaskell = vim-stylish-haskell; # backwards compat, added 2014-10-18
     suda-vim = vim-suda; # backwards compat, added 2024-05-16

--- a/pkgs/applications/editors/vim/plugins/corePlugins.nix
+++ b/pkgs/applications/editors/vim/plugins/corePlugins.nix
@@ -1,0 +1,31 @@
+{
+  symlinkJoin,
+}:
+final: prev: {
+
+  corePlugins = symlinkJoin {
+    name = "core-vim-plugins";
+    paths = with final; [
+      # plugin managers
+      lazy-nvim
+      mini-deps
+      packer-nvim
+      vim-plug
+
+      # core dependencies
+      plenary-nvim
+
+      # popular plugins
+      mini-nvim
+      nvim-cmp
+      nvim-lspconfig
+      nvim-treesitter
+      vim-airline
+      vim-fugitive
+      vim-surround
+    ];
+
+    meta.description = "Collection of popular vim plugins (for internal testing purposes)";
+  };
+
+}

--- a/pkgs/applications/editors/vim/plugins/default.nix
+++ b/pkgs/applications/editors/vim/plugins/default.nix
@@ -48,6 +48,8 @@ let
     inherit (neovimUtils) buildNeovimPlugin;
   };
 
+  corePlugins = callPackage ./corePlugins.nix { };
+
   # TL;DR
   # * Add your plugin to ./vim-plugin-names
   # * run ./update.py
@@ -66,6 +68,7 @@ lib.pipe initialPackages [
   (extends luaPackagePlugins)
   (extends nodePackagePlugins)
   (extends nonGeneratedPlugins)
+  (extends corePlugins)
   (extends overrides)
   (extends aliases)
   lib.makeExtensible

--- a/pkgs/applications/editors/vim/plugins/luaPackagePlugins.nix
+++ b/pkgs/applications/editors/vim/plugins/luaPackagePlugins.nix
@@ -12,6 +12,7 @@ let
     "fzf-lua"
     "gitsigns-nvim"
     "grug-far-nvim"
+    "haskell-tools-nvim"
     "image-nvim"
     "lsp-progress-nvim"
     "lualine-nvim"

--- a/pkgs/applications/editors/vim/plugins/luaPackagePlugins.nix
+++ b/pkgs/applications/editors/vim/plugins/luaPackagePlugins.nix
@@ -36,6 +36,7 @@ let
     "plenary-nvim"
     "rest-nvim"
     "rocks-config-nvim"
+    "rocks-nvim"
     "rtp-nvim"
     "telescope-manix"
     "telescope-nvim"

--- a/pkgs/applications/editors/vim/plugins/luaPackagePlugins.nix
+++ b/pkgs/applications/editors/vim/plugins/luaPackagePlugins.nix
@@ -37,6 +37,7 @@ let
     "rest-nvim"
     "rocks-config-nvim"
     "rocks-nvim"
+    "rustaceanvim"
     "rtp-nvim"
     "telescope-manix"
     "telescope-nvim"

--- a/pkgs/applications/editors/vim/plugins/luaPackagePlugins.nix
+++ b/pkgs/applications/editors/vim/plugins/luaPackagePlugins.nix
@@ -9,6 +9,7 @@ let
 
   luarocksPackageNames = [
     "fidget-nvim"
+    "fzf-lua"
     "gitsigns-nvim"
     "grug-far-nvim"
     "image-nvim"

--- a/pkgs/applications/editors/vim/plugins/non-generated/notmuch-vim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/notmuch-vim/default.nix
@@ -1,0 +1,1 @@
+{ notmuch }: notmuch.vim

--- a/pkgs/applications/editors/vim/plugins/non-generated/nvim-treesitter-parsers/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/nvim-treesitter-parsers/default.nix
@@ -1,0 +1,5 @@
+{
+  lib,
+  vimPlugins,
+}:
+lib.recurseIntoAttrs vimPlugins.nvim-treesitter.grammarPlugins

--- a/pkgs/applications/editors/vim/plugins/non-generated/parinfer-rust/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/parinfer-rust/default.nix
@@ -1,0 +1,1 @@
+{ parinfer-rust }: parinfer-rust

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -36,7 +36,6 @@
   nodejs,
   openscad,
   openssh,
-  parinfer-rust,
   ranger,
   ripgrep,
   sqlite,
@@ -2866,8 +2865,6 @@ in
   package-info-nvim = super.package-info-nvim.overrideAttrs {
     dependencies = [ self.nui-nvim ];
   };
-
-  inherit parinfer-rust;
 
   parpar-nvim = super.parpar-nvim.overrideAttrs {
     dependencies = with self; [

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -3206,7 +3206,7 @@ in
     }
   );
 
-  ssr = super.ssr-nvim.overrideAttrs {
+  ssr-nvim = super.ssr-nvim.overrideAttrs {
     dependencies = [ self.nvim-treesitter ];
   };
 

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1275,8 +1275,7 @@ in
     dependencies = [ self.plenary-nvim ];
   };
 
-  fzf-lua = neovimUtils.buildNeovimPlugin {
-    luaAttr = luaPackages.fzf-lua;
+  fzf-lua = super.fzf-lua.overrideAttrs {
     runtimeDeps = [ fzf ];
     nvimSkipModules = [
       "fzf-lua.shell_helper"

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -7,7 +7,6 @@
   fetchFromGitHub,
   fetchpatch,
   fetchurl,
-  neovimUtils,
   replaceVars,
   # Language dependencies
   fetchYarnDeps,
@@ -61,7 +60,6 @@
   codeium,
   # command-t dependencies
   getconf,
-  ruby,
   # cornelis dependencies
   cornelis,
   # cpsm dependencies
@@ -105,7 +103,6 @@
   # hurl dependencies
   hurl,
   # must be lua51Packages
-  luajitPackages,
   aider-chat,
   # typst-preview dependencies
   tinymist,

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -3058,20 +3058,16 @@ in
     dependencies = [ self.plenary-nvim ];
   };
 
-  rocks-nvim =
-    (neovimUtils.buildNeovimPlugin {
-      luaAttr = luaPackages.rocks-nvim;
-    }).overrideAttrs
-      (oa: {
-        passthru = oa.passthru // {
-          initLua = ''
-            vim.g.rocks_nvim = {
-              luarocks_binary = "${neovim-unwrapped.lua.pkgs.luarocks_bootstrap}/bin/luarocks"
-              }
-          '';
-        };
+  rocks-nvim = super.rocks-nvim.overrideAttrs (oa: {
+    passthru = oa.passthru // {
+      initLua = ''
+        vim.g.rocks_nvim = {
+          luarocks_binary = "${neovim-unwrapped.lua.pkgs.luarocks_bootstrap}/bin/luarocks"
+          }
+      '';
+    };
 
-      });
+  });
 
   rustaceanvim = neovimUtils.buildNeovimPlugin {
     checkInputs = [

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -9,7 +9,6 @@
   fetchurl,
   neovimUtils,
   replaceVars,
-  symlinkJoin,
   # Language dependencies
   fetchYarnDeps,
   mkYarnModules,
@@ -137,36 +136,6 @@ let
   buildNeoVimPlugin = throw "New plugin definitions should be done outside `overrides.nix`";
 in
 {
-  corePlugins = symlinkJoin {
-    name = "core-vim-plugins";
-    paths = with self; [
-      # plugin managers
-      lazy-nvim
-      mini-deps
-      packer-nvim
-      vim-plug
-
-      # core dependencies
-      plenary-nvim
-
-      # popular plugins
-      mini-nvim
-      nvim-cmp
-      nvim-lspconfig
-      nvim-treesitter
-      vim-airline
-      vim-fugitive
-      vim-surround
-    ];
-
-    meta = {
-      description = "Collection of popular vim plugins (for internal testing purposes)";
-    };
-  };
-
-  #######################
-  # Regular overrides
-
   advanced-git-search-nvim = super.advanced-git-search-nvim.overrideAttrs {
     checkInputs = with self; [
       snacks-nvim

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -3069,12 +3069,11 @@ in
 
   });
 
-  rustaceanvim = neovimUtils.buildNeovimPlugin {
+  rustaceanvim = super.rustaceanvim.overrideAttrs {
     checkInputs = [
       # Optional integration
       self.neotest
     ];
-    luaAttr = luaPackages.rustaceanvim;
   };
 
   rust-tools-nvim = super.rust-tools-nvim.overrideAttrs {

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -128,12 +128,22 @@ self: super:
 let
   luaPackages = neovim-unwrapped.lua.pkgs;
 
-  # Ensure the vim plugin builders are not used in this file.
-  # If they are used, these stubs will throw.
-  buildVimPlugin = throw "New plugin definitions should be done outside `overrides.nix`";
-  buildNeoVimPlugin = throw "New plugin definitions should be done outside `overrides.nix`";
+  # Ensures new attributes are not added in this file.
+  assertNoAdditions =
+    overrides:
+    let
+      prevNames = lib.attrNames super;
+      definedNames = lib.attrNames overrides;
+      addedNames = lib.subtractLists prevNames definedNames;
+    in
+    lib.throwIfNot (addedNames == [ ])
+      "vimPlugins: the following attributes should not be defined in overrides.nix:${
+        lib.concatMapStrings (name: "\n- ${name}") addedNames
+      }"
+      overrides;
 in
-{
+
+assertNoAdditions {
   advanced-git-search-nvim = super.advanced-git-search-nvim.overrideAttrs {
     checkInputs = with self; [
       snacks-nvim

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -34,7 +34,6 @@
   neovim-unwrapped,
   nim1,
   nodejs,
-  notmuch,
   openscad,
   openssh,
   parinfer-rust,
@@ -2305,8 +2304,6 @@ in
 
   NotebookNavigator-nvim = super.NotebookNavigator-nvim.overrideAttrs {
   };
-
-  notmuch-vim = notmuch.vim;
 
   nterm-nvim = super.nterm-nvim.overrideAttrs {
     dependencies = [ self.aniseed ];

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2663,8 +2663,6 @@ in
     dependencies = [ self.nvim-treesitter ];
   };
 
-  nvim-treesitter-parsers = lib.recurseIntoAttrs self.nvim-treesitter.grammarPlugins;
-
   nvim-treesitter-pyfold = super.nvim-treesitter-pyfold.overrideAttrs {
     dependencies = [ self.nvim-treesitter ];
   };

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1401,10 +1401,9 @@ in
     dependencies = [ self.luasnip ];
   };
 
-  haskell-tools-nvim = neovimUtils.buildNeovimPlugin {
+  haskell-tools-nvim = super.haskell-tools-nvim.overrideAttrs {
     # Optional integrations
     checkInputs = [ self.telescope-nvim ];
-    luaAttr = luaPackages.haskell-tools-nvim;
   };
 
   helm-ls-nvim = super.helm-ls-nvim.overrideAttrs {


### PR DESCRIPTION
Follow up to https://github.com/NixOS/nixpkgs/pull/438708#discussion_r2312087936, previously @khaneliman explicitly shadowed `buildVimPlugin` and `buildNeoVimPlugin` to ensure they are not used to build new plugins.

This PR takes things a step further, by asserting that _no_ attributes are defined in the `overrides.nix` overlay that aren't already present in the overlay's `super` (aka `prev`).


When initially added, the new assertion picked up the following package definitions:

```
nix-repl> pkgs.vimPlugins

      (stack trace omitted for brevity, see PR edit history)

       error: vimPlugins: the following attributes should not be defined in overrides.nix:
       - corePlugins
       - fzf-lua
       - haskell-tools-nvim
       - notmuch-vim
       - nvim-treesitter-parsers
       - parinfer-rust
       - rocks-nvim
       - rustaceanvim
       - ssr
```

...which I've resolved as part of this PR.

As the eval CI ignores `vimPlugins`, I _manually_ verified that all attributes touched in this PR still evaluate to the exact same derivation as on master. Including every `vimPlugins.nvim-treesitter-parsers` derivation.

I did this by running `nix-instantiate -A vimPlugins` on master and this branch, then comparing the out-paths:

```sh
$ nix-instantiate --expr '(import ./. { config = { allowAliases = false; allowBroken = true; allowUnfree = true; }; }).vimPlugins' > ../vimPlugins-pr.txt

$ git reset --hard upstream/HEAD

$ nix-instantiate --expr '(import ./. { config = { allowAliases = false; allowBroken = true; allowUnfree = true; }; }).vimPlugins' > ../vimPlugins-master.txt

$ diff ../vimPlugins-master.txt ../vimPlugins-pr.txt

```

I've attached the files for transparency:
- [vimPlugins-master.txt](https://github.com/user-attachments/files/22066710/vimPlugins-master.txt)
- [vimPlugins-pr.txt](https://github.com/user-attachments/files/22066711/vimPlugins-pr.txt)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
