### PR TITLE
nixos/dolphin: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -197,6 +197,7 @@
   ./programs/digitalbitbox/default.nix
   ./programs/direnv.nix
   ./programs/dmrconfig.nix
+  ./programs/dolphin.nix
   ./programs/droidcam.nix
   ./programs/dublin-traceroute.nix
   ./programs/ecryptfs.nix

--- a/nixos/modules/programs/dolphin.nix
+++ b/nixos/modules/programs/dolphin.nix
@@ -1,0 +1,41 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.dolphin;
+in
+{
+  meta = {
+    maintainers = lib.teams.kde.members;
+  };
+
+  options = {
+    programs.dolphin = {
+      enable = lib.mkEnableOption "Dolphin, the Plasma file manager";
+
+      package = lib.mkPackageOption pkgs "kdePackages.dolphin" {
+        default = [
+          "kdePackages"
+          "dolphin"
+        ];
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment = {
+      etc."xdg/menus/applications.menu".source =
+        "${pkgs.kdePackages.plasma-workspace}/etc/xdg/menus/plasma-applications.menu";
+
+      systemPackages = with pkgs; [
+        cfg.package
+        baloo-widgets # baloo information in Dolphin
+        dolphin-plugins
+      ];
+    };
+  };
+}

--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -160,9 +160,6 @@ in
           kate
           ktexteditor # provides elevated actions for kate
           khelpcenter
-          dolphin
-          baloo-widgets # baloo information in Dolphin
-          dolphin-plugins
           spectacle
           ffmpegthumbs
           krdp
@@ -253,6 +250,7 @@ in
       serif = [ "Noto Serif" ];
     };
 
+    programs.dolphin.enable = mkDefault true;
     programs.gnupg.agent.pinentryPackage = mkDefault pkgs.pinentry-qt;
     programs.kde-pim.enable = mkDefault true;
     programs.ssh.askPassword = mkDefault "${kdePackages.ksshaskpass.out}/bin/ksshaskpass";


### PR DESCRIPTION
Closes #409986

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
