### PR TITLE
postfix-tlspol: 1.8.15 -> 1.8.16

### DIFF
--- a/nixos/modules/services/mail/postfix-tlspol.nix
+++ b/nixos/modules/services/mail/postfix-tlspol.nix
@@ -94,16 +94,13 @@ in
 
           dns = {
             address = mkOption {
-              type = types.str;
-              default = if config.networking.resolvconf.useLocalResolver then "127.0.0.1:53" else null;
-              defaultText = literalExpression ''
-                if config.networking.resolvconf.useLocalResolver then
-                  "127.0.0.1:53"
-                else
-                  null
-              '';
+              type = with types; nullOr str;
+              default = null;
+              example = "127.0.0.1:53";
               description = ''
-                IP and port to your DNS resolver
+                IP and port to your DNS resolver.
+
+                Uses resolvers from /etc/resolv.conf if unset.
 
                 ::: {.note}
                 The configured DNS resolver must validate DNSSEC signatures.

--- a/pkgs/by-name/po/postfix-tlspol/package.nix
+++ b/pkgs/by-name/po/postfix-tlspol/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule rec {
   pname = "postfix-tlspol";
-  version = "1.8.15";
+  version = "1.8.16";
 
   src = fetchFromGitHub {
     owner = "Zuplu";
     repo = "postfix-tlspol";
     tag = "v${version}";
-    hash = "sha256-DqFBXU9b6TOujG464Ww4iAA04NA5j0z9N00F7mbV92Q=";
+    hash = "sha256-Yndu5QpPxAVbkatJDa1yqkEfnJr5M5lLImtMKvt9juQ=";
   };
 
   vendorHash = null;


### PR DESCRIPTION
https://github.com/Zuplu/postfix-tlspol/releases/tag/v1.8.16


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
