### PR TITLE
maintainers: drop ehmry

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7306,12 +7306,6 @@
     githubId = 20847625;
     name = "Elizabeth Paź";
   };
-  ehmry = {
-    email = "ehmry@posteo.net";
-    github = "ehmry";
-    githubId = 537775;
-    name = "Emery Hemingway";
-  };
   eigengrau = {
     email = "seb@schattenkopie.de";
     name = "Sebastian Reuße";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -346,7 +346,6 @@ with lib.maintainers;
   dhall = {
     members = [
       Gabriella439
-      ehmry
     ];
     scope = "Maintain Dhall and related packages.";
     shortName = "Dhall";

--- a/nixos/modules/programs/nncp.nix
+++ b/nixos/modules/programs/nncp.nix
@@ -89,6 +89,4 @@ in
       '';
     };
   };
-
-  meta.maintainers = with lib.maintainers; [ ehmry ];
 }

--- a/nixos/modules/services/network-filesystems/eris-server.nix
+++ b/nixos/modules/services/network-filesystems/eris-server.nix
@@ -123,6 +123,4 @@ in
             };
       };
   };
-
-  meta.maintainers = with lib.maintainers; [ ehmry ];
 }

--- a/nixos/modules/services/network-filesystems/rsyncd.nix
+++ b/nixos/modules/services/network-filesystems/rsyncd.nix
@@ -141,8 +141,6 @@ in
 
   };
 
-  meta.maintainers = with lib.maintainers; [ ehmry ];
-
   # TODO: socket activated rsyncd
 
 }

--- a/nixos/modules/services/networking/yggdrasil.nix
+++ b/nixos/modules/services/networking/yggdrasil.nix
@@ -264,7 +264,6 @@ in
     doc = ./yggdrasil.md;
     maintainers = with lib.maintainers; [
       gazally
-      ehmry
       nagy
     ];
   };

--- a/nixos/tests/ccache.nix
+++ b/nixos/tests/ccache.nix
@@ -2,9 +2,6 @@ import ./make-test-python.nix (
   { pkgs, ... }:
   {
     name = "ccache";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [ ehmry ];
-    };
 
     nodes.machine =
       { ... }:

--- a/nixos/tests/cjdns.nix
+++ b/nixos/tests/cjdns.nix
@@ -21,9 +21,6 @@ in
 { pkgs, ... }:
 {
   name = "cjdns";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ ehmry ];
-  };
 
   nodes = {
     # Alice finds peers over over ETHInterface.

--- a/nixos/tests/eris-server.nix
+++ b/nixos/tests/eris-server.nix
@@ -1,7 +1,6 @@
 { pkgs, lib, ... }:
 {
   name = "eris-server";
-  meta.maintainers = with lib.maintainers; [ ehmry ];
 
   nodes.server = {
     environment.systemPackages = [

--- a/nixos/tests/molly-brown.nix
+++ b/nixos/tests/molly-brown.nix
@@ -6,9 +6,6 @@ in
 {
 
   name = "molly-brown";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ ehmry ];
-  };
 
   nodes = {
 

--- a/nixos/tests/rsyncd.nix
+++ b/nixos/tests/rsyncd.nix
@@ -1,7 +1,6 @@
 { pkgs, ... }:
 {
   name = "rsyncd";
-  meta.maintainers = with pkgs.lib.maintainers; [ ehmry ];
 
   nodes =
     let

--- a/pkgs/applications/misc/confclerk/default.nix
+++ b/pkgs/applications/misc/confclerk/default.nix
@@ -28,7 +28,6 @@ mkDerivation rec {
     mainProgram = "confclerk";
     homepage = "http://www.toastfreeware.priv.at/confclerk";
     license = lib.licenses.gpl2;
-    maintainers = with lib.maintainers; [ ehmry ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/misc/elf-dissector/default.nix
+++ b/pkgs/applications/misc/elf-dissector/default.nix
@@ -47,7 +47,6 @@ stdenv.mkDerivation {
     description = "Tools for inspecting, analyzing and optimizing ELF files";
     license = licenses.gpl2;
     maintainers = with maintainers; [
-      ehmry
       philiptaron
     ];
   };

--- a/pkgs/applications/networking/browsers/av-98/default.nix
+++ b/pkgs/applications/networking/browsers/av-98/default.nix
@@ -28,7 +28,6 @@ python3Packages.buildPythonApplication {
     description = "Experimental console client for the Gemini protocol";
     mainProgram = "av98";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ ehmry ];
 
     broken = true;
   };

--- a/pkgs/applications/networking/browsers/kristall/default.nix
+++ b/pkgs/applications/networking/browsers/kristall/default.nix
@@ -51,7 +51,6 @@ stdenv.mkDerivation rec {
     description = "Graphical small-internet client, supports gemini, http, https, gopher, finger";
     mainProgram = "kristall";
     homepage = "https://random-projects.net/projects/kristall.gemini";
-    maintainers = with maintainers; [ ehmry ];
     license = licenses.gpl3Only;
     inherit (qtmultimedia.meta) platforms;
   };

--- a/pkgs/applications/search/recoll/default.nix
+++ b/pkgs/applications/search/recoll/default.nix
@@ -209,7 +209,6 @@ mkDerivation rec {
     platforms = platforms.unix;
     maintainers = with maintainers; [
       jcumming
-      ehmry
     ];
 
     # `Makefile.am` assumes the ability to run the hostPlatform's python binary at build time

--- a/pkgs/by-name/al/alephone/package.nix
+++ b/pkgs/by-name/al/alephone/package.nix
@@ -99,7 +99,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "alephone";
     homepage = "https://alephone.lhowon.org/";
     license = [ lib.licenses.gpl3 ];
-    maintainers = with lib.maintainers; [ ehmry ];
     platforms = lib.platforms.linux;
   };
 

--- a/pkgs/by-name/ba/balls/package.nix
+++ b/pkgs/by-name/ba/balls/package.nix
@@ -51,6 +51,5 @@ buildNimPackage (finalAttrs: {
     mainProgram = "balls";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ ehmry ];
   };
 })

--- a/pkgs/by-name/ba/baresip/package.nix
+++ b/pkgs/by-name/ba/baresip/package.nix
@@ -185,7 +185,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/baresip/baresip";
     maintainers = with lib.maintainers; [
       raskin
-      ehmry
       rnhmjoj
     ];
     mainProgram = "baresip";

--- a/pkgs/by-name/ba/base45/package.nix
+++ b/pkgs/by-name/ba/base45/package.nix
@@ -17,6 +17,5 @@ buildNimPackage (finalAttrs: {
     description = "Base45 library for Nim";
     license = lib.licenses.unlicense;
     mainProgram = "base45";
-    maintainers = with lib.maintainers; [ ehmry ];
   };
 })

--- a/pkgs/by-name/bo/bombadillo/package.nix
+++ b/pkgs/by-name/bo/bombadillo/package.nix
@@ -33,6 +33,5 @@ buildGoModule rec {
     mainProgram = "bombadillo";
     homepage = "https://bombadillo.colorfield.space/";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ ehmry ];
   };
 }

--- a/pkgs/by-name/bu/butt/package.nix
+++ b/pkgs/by-name/bu/butt/package.nix
@@ -71,7 +71,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Easy to use, multi OS streaming tool";
     homepage = "https://danielnoethen.de/butt/";
     license = lib.licenses.gpl2;
-    maintainers = with lib.maintainers; [ ehmry ];
     mainProgram = "butt";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/c2/c2nim/package.nix
+++ b/pkgs/by-name/c2/c2nim/package.nix
@@ -17,6 +17,5 @@ buildNimPackage (finalAttrs: {
     description = "Tool to translate Ansi C code to Nim";
     mainProgram = "c2nim";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.ehmry ];
   };
 })

--- a/pkgs/by-name/cj/cjdns/package.nix
+++ b/pkgs/by-name/cj/cjdns/package.nix
@@ -84,7 +84,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/cjdelisle/cjdns";
     description = "Encrypted networking for regular people";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ ehmry ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 }

--- a/pkgs/by-name/co/collapseos-cvm/package.nix
+++ b/pkgs/by-name/co/collapseos-cvm/package.nix
@@ -29,7 +29,6 @@ stdenv.mkDerivation rec {
     downloadPage = "http://collapseos.org/files/";
     homepage = "http://collapseos.org/";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ ehmry ];
     mainProgram = "cos-serial";
   };
 }

--- a/pkgs/by-name/di/didder/package.nix
+++ b/pkgs/by-name/di/didder/package.nix
@@ -32,7 +32,6 @@ buildGoModule rec {
   meta = src.meta // {
     description = "Extensive, fast, and accurate command-line image dithering tool";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ ehmry ];
     mainProgram = "didder";
   };
 }

--- a/pkgs/by-name/dn/dnslink-std-go/package.nix
+++ b/pkgs/by-name/dn/dnslink-std-go/package.nix
@@ -21,6 +21,5 @@ buildGoModule rec {
     homepage = "https://dnslink.org/";
     license = lib.licenses.mit;
     mainProgram = "dnslink";
-    maintainers = with lib.maintainers; [ ehmry ];
   };
 }

--- a/pkgs/by-name/ea/eaglemode/package.nix
+++ b/pkgs/by-name/ea/eaglemode/package.nix
@@ -142,7 +142,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [
       chuangzhu
-      ehmry
     ];
     platforms = platforms.linux;
   };

--- a/pkgs/by-name/er/eris-go/package.nix
+++ b/pkgs/by-name/er/eris-go/package.nix
@@ -41,7 +41,6 @@ buildGoModule rec {
     description = "Implementation of ERIS for Go";
     homepage = "https://codeberg.org/eris/eris-go";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ ehmry ];
     mainProgram = "eris-go";
   };
 }

--- a/pkgs/by-name/er/eriscmd/package.nix
+++ b/pkgs/by-name/er/eriscmd/package.nix
@@ -35,7 +35,6 @@ buildNimPackage (
     meta = final.src.meta // {
       homepage = "https://codeberg.org/eris/nim-eris";
       license = lib.licenses.unlicense;
-      maintainers = with lib.maintainers; [ ehmry ];
       mainProgram = "eriscmd";
       badPlatforms = lib.platforms.darwin;
     };

--- a/pkgs/by-name/er/erofs-utils/package.nix
+++ b/pkgs/by-name/er/erofs-utils/package.nix
@@ -63,7 +63,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git/tree/ChangeLog?h=v${finalAttrs.version}";
     license = with lib.licenses; [ gpl2Plus ];
     maintainers = with lib.maintainers; [
-      ehmry
       nikstur
       jmbaur
     ];

--- a/pkgs/by-name/eu/eurofurence/package.nix
+++ b/pkgs/by-name/eu/eurofurence/package.nix
@@ -55,7 +55,6 @@ stdenvNoCC.mkDerivation {
   meta = {
     homepage = "https://web.archive.org/web/20200131023120/http://eurofurence.net/eurofurence.html";
     description = "Family of geometric rounded sans serif fonts";
-    maintainers = with lib.maintainers; [ ehmry ];
     license = lib.licenses.free;
   };
 }

--- a/pkgs/by-name/f2/f2fs-tools/package.nix
+++ b/pkgs/by-name/f2/f2fs-tools/package.nix
@@ -56,7 +56,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
-      ehmry
       jagajaga
     ];
   };

--- a/pkgs/by-name/fi/figlet/package.nix
+++ b/pkgs/by-name/fi/figlet/package.nix
@@ -47,7 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Program for making large letters out of ordinary text";
     homepage = "http://www.figlet.org/";
     license = lib.licenses.afl21;
-    maintainers = with lib.maintainers; [ ehmry ];
     platforms = lib.platforms.unix;
     mainProgram = "figlet";
   };

--- a/pkgs/by-name/fj/fjo/package.nix
+++ b/pkgs/by-name/fj/fjo/package.nix
@@ -29,7 +29,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://codeberg.org/VoiDD/fjo";
     license = lib.licenses.agpl3Only;
     mainProgram = "berg";
-    maintainers = with lib.maintainers; [ ehmry ];
     broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/ge/getdns/package.nix
+++ b/pkgs/by-name/ge/getdns/package.nix
@@ -66,7 +66,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://getdnsapi.net";
     maintainers = with lib.maintainers; [
       leenaars
-      ehmry
     ];
     license = lib.licenses.bsd3;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/gn/gnaural/package.nix
+++ b/pkgs/by-name/gn/gnaural/package.nix
@@ -44,7 +44,6 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Programmable auditory binaural-beat synthesizer";
     homepage = "https://gnaural.sourceforge.net/";
-    maintainers = with maintainers; [ ehmry ];
     license = with licenses; [ gpl2Only ];
     mainProgram = "gnaural";
   };

--- a/pkgs/by-name/gn/gnubg/package.nix
+++ b/pkgs/by-name/gn/gnubg/package.nix
@@ -59,7 +59,6 @@ stdenv.mkDerivation rec {
     description = "World class backgammon application";
     homepage = "https://www.gnu.org/software/gnubg/";
     license = licenses.gpl3;
-    maintainers = [ maintainers.ehmry ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/gp/gptfdisk/package.nix
+++ b/pkgs/by-name/gp/gptfdisk/package.nix
@@ -65,6 +65,5 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     homepage = "https://www.rodsbooks.com/gdisk/";
     platforms = platforms.all;
-    maintainers = [ maintainers.ehmry ];
   };
 }

--- a/pkgs/by-name/gu/gubbi-font/package.nix
+++ b/pkgs/by-name/gu/gubbi-font/package.nix
@@ -29,6 +29,5 @@ stdenv.mkDerivation rec {
     description = "Kannada font";
     license = licenses.gpl3Plus;
     platforms = platforms.all;
-    maintainers = with maintainers; [ ehmry ];
   };
 }

--- a/pkgs/by-name/hd/hdapsd/package.nix
+++ b/pkgs/by-name/hd/hdapsd/package.nix
@@ -28,6 +28,5 @@ stdenv.mkDerivation rec {
     homepage = "http://hdaps.sf.net/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.ehmry ];
   };
 }

--- a/pkgs/by-name/hj/hjson-go/package.nix
+++ b/pkgs/by-name/hj/hjson-go/package.nix
@@ -26,7 +26,6 @@ buildGoModule rec {
     description = "Utility to convert JSON to and from HJSON";
     homepage = "https://hjson.github.io/";
     changelog = "https://github.com/hjson/hjson-go/releases/tag/v${version}";
-    maintainers = with lib.maintainers; [ ehmry ];
     license = lib.licenses.mit;
     mainProgram = "hjson-cli";
   };

--- a/pkgs/by-name/ho/hottext/package.nix
+++ b/pkgs/by-name/ho/hottext/package.nix
@@ -37,7 +37,6 @@ buildNimPackage (finalAttrs: {
     description = "Simple RSVP speed-reading utility";
     license = lib.licenses.unlicense;
     homepage = "https://git.sr.ht/~ehmry/hottext";
-    maintainers = with lib.maintainers; [ ehmry ];
     mainProgram = "hottext";
   };
 })

--- a/pkgs/by-name/li/libdiscid/package.nix
+++ b/pkgs/by-name/li/libdiscid/package.nix
@@ -30,7 +30,6 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     description = "C library for creating MusicBrainz DiscIDs from audio CDs";
     homepage = "https://musicbrainz.org/doc/libdiscid";
-    maintainers = with maintainers; [ ehmry ];
     license = licenses.lgpl21;
     platforms = platforms.all;
   };

--- a/pkgs/by-name/li/libogg/package.nix
+++ b/pkgs/by-name/li/libogg/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://xiph.org/ogg/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ ehmry ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/li/libtoxcore/package.nix
+++ b/pkgs/by-name/li/libtoxcore/package.nix
@@ -64,7 +64,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       peterhoeg
-      ehmry
     ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/li/libvorbis/package.nix
+++ b/pkgs/by-name/li/libvorbis/package.nix
@@ -36,7 +36,6 @@ stdenv.mkDerivation rec {
     description = "Vorbis audio compression reference implementation";
     homepage = "https://xiph.org/vorbis/";
     license = licenses.bsd3;
-    maintainers = [ maintainers.ehmry ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/lo/loudgain/package.nix
+++ b/pkgs/by-name/lo/loudgain/package.nix
@@ -54,6 +54,5 @@ stdenv.mkDerivation rec {
 
   meta = src.meta // {
     license = lib.licenses.free;
-    maintainers = with lib.maintainers; [ ehmry ];
   };
 }

--- a/pkgs/by-name/lz/lziprecover/package.nix
+++ b/pkgs/by-name/lz/lziprecover/package.nix
@@ -33,7 +33,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
       vlaci
-      ehmry
     ];
     platforms = lib.platforms.all;
     mainProgram = "lziprecover";

--- a/pkgs/by-name/lz/lzlib/package.nix
+++ b/pkgs/by-name/lz/lzlib/package.nix
@@ -42,6 +42,5 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Data compression library providing in-memory LZMA compression and decompression functions, including integrity checking of the decompressed data";
     license = lib.licenses.bsd2;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ ehmry ];
   };
 })

--- a/pkgs/by-name/ma/ma/package.nix
+++ b/pkgs/by-name/ma/ma/package.nix
@@ -43,7 +43,6 @@ stdenv.mkDerivation {
     description = "Minimalistic variant of the Acme editor";
     homepage = "http://call-with-current-continuation.org/ma/ma.html";
     mainProgram = "ma";
-    maintainers = with lib.maintainers; [ ehmry ];
     # Per the README:
     # > All of MA's source code is hereby placed in the public domain
     license = lib.licenses.publicDomain;

--- a/pkgs/by-name/ma/maiko/package.nix
+++ b/pkgs/by-name/ma/maiko/package.nix
@@ -32,7 +32,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://interlisp.org/";
     changelog = "https://github.com/Interlisp/maiko/releases";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ehmry ];
     inherit (xorg.libX11.meta) platforms;
   };
 })

--- a/pkgs/by-name/ma/makebootfat/package.nix
+++ b/pkgs/by-name/ma/makebootfat/package.nix
@@ -17,7 +17,6 @@ stdenv.mkDerivation rec {
     description = "Create bootable USB disks using the FAT filesystem and syslinux";
     homepage = "http://advancemame.sourceforge.net/boot-readme.html";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.ehmry ];
     platforms = platforms.linux;
     mainProgram = "makebootfat";
   };

--- a/pkgs/by-name/ma/mawk/package.nix
+++ b/pkgs/by-name/ma/mawk/package.nix
@@ -38,7 +38,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Interpreter for the AWK Programming Language";
     license = lib.licenses.gpl2Only;
     mainProgram = "mawk";
-    maintainers = with lib.maintainers; [ ehmry ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/mb/mbuffer/package.nix
+++ b/pkgs/by-name/mb/mbuffer/package.nix
@@ -36,7 +36,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Tool for buffering data streams with a large set of unique features";
     homepage = "https://www.maier-komor.de/mbuffer.html";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ ehmry ];
     platforms = lib.platforms.linux; # Maybe other non-darwin Unix
     mainProgram = "mbuffer";
   };

--- a/pkgs/by-name/mi/min/package.nix
+++ b/pkgs/by-name/mi/min/package.nix
@@ -39,7 +39,6 @@ buildNimPackage (finalAttrs: {
     changelog = "https://github.com/h3rald/min/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.mit;
     mainProgram = "min";
-    maintainers = with lib.maintainers; [ ehmry ];
   };
 
 })

--- a/pkgs/by-name/mo/molly-brown/package.nix
+++ b/pkgs/by-name/mo/molly-brown/package.nix
@@ -28,7 +28,6 @@ buildGoModule {
     description = "Full-featured Gemini server";
     mainProgram = "molly-brown";
     homepage = "https://tildegit.org/solderpunk/molly-brown";
-    maintainers = with maintainers; [ ehmry ];
     license = licenses.bsd2;
   };
 }

--- a/pkgs/by-name/mo/mosdepth/package.nix
+++ b/pkgs/by-name/mo/mosdepth/package.nix
@@ -33,7 +33,6 @@ buildNimPackage (finalAttrs: {
     homepage = "https://github.com/brentp/mosdepth";
     maintainers = with maintainers; [
       jbedo
-      ehmry
     ];
     platforms = platforms.linux;
   };

--- a/pkgs/by-name/na/navilu-font/package.nix
+++ b/pkgs/by-name/na/navilu-font/package.nix
@@ -31,6 +31,5 @@ stdenvNoCC.mkDerivation rec {
       description = "Kannada handwriting font";
       license = licenses.gpl3Plus;
       platforms = platforms.all;
-      maintainers = with maintainers; [ ehmry ];
     };
 }

--- a/pkgs/by-name/nc/ncdc/package.nix
+++ b/pkgs/by-name/nc/ncdc/package.nix
@@ -48,7 +48,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Modern and lightweight direct connect client with a friendly ncurses interface";
     homepage = "https://dev.yorhel.nl/ncdc";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ehmry ];
     mainProgram = "ncdc";
   };
 })

--- a/pkgs/by-name/ni/nim-unwrapped-2_2/package.nix
+++ b/pkgs/by-name/ni/nim-unwrapped-2_2/package.nix
@@ -177,7 +177,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.mit;
     mainProgram = "nim";
     maintainers = with maintainers; [
-      ehmry
       eveeifyeve
     ];
   };

--- a/pkgs/by-name/ni/nim_builder/package.nix
+++ b/pkgs/by-name/ni/nim_builder/package.nix
@@ -19,6 +19,5 @@ stdenv.mkDerivation {
   meta = {
     description = "Internal Nixpkgs utility for buildNimPackage";
     mainProgram = "nim_builder";
-    maintainers = [ lib.maintainers.ehmry ];
   };
 }

--- a/pkgs/by-name/ni/nim_lk/package.nix
+++ b/pkgs/by-name/ni/nim_lk/package.nix
@@ -40,6 +40,5 @@ buildNimSbom (finalAttrs: {
     mainProgram = "nim_lk";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ ehmry ];
   };
 }) ./sbom.json

--- a/pkgs/by-name/nn/nncp/package.nix
+++ b/pkgs/by-name/nn/nncp/package.nix
@@ -77,7 +77,6 @@ stdenv.mkDerivation (finalAttrs: {
       transmission exists.
     '';
     maintainers = with lib.maintainers; [
-      ehmry
       woffs
     ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/pa/papeer/package.nix
+++ b/pkgs/by-name/pa/papeer/package.nix
@@ -24,6 +24,5 @@ buildGoModule rec {
     mainProgram = "papeer";
     homepage = "https://papeer.tech/";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ ehmry ];
   };
 }

--- a/pkgs/by-name/pc/pcapfix/package.nix
+++ b/pkgs/by-name/pc/pcapfix/package.nix
@@ -19,7 +19,6 @@ stdenv.mkDerivation rec {
     homepage = "https://f00l.de/pcapfix/";
     description = "Repair your broken pcap and pcapng files";
     license = licenses.gpl3;
-    maintainers = [ maintainers.ehmry ];
     platforms = platforms.all;
     mainProgram = "pcapfix";
   };

--- a/pkgs/by-name/ph/pharo/package.nix
+++ b/pkgs/by-name/ph/pharo/package.nix
@@ -104,7 +104,6 @@ stdenv.mkDerivation (finalAttrs: {
       system, excellent dev tools, and maintained releases, Pharo is an
       attractive platform to build and deploy mission critical applications.
     '';
-    maintainers = with lib.maintainers; [ ehmry ];
     mainProgram = "pharo";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/pl/plzip/package.nix
+++ b/pkgs/by-name/pl/plzip/package.nix
@@ -39,7 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [
       _360ied
-      ehmry
     ];
     mainProgram = "plzip";
   };

--- a/pkgs/by-name/pr/preserves-nim/package.nix
+++ b/pkgs/by-name/pr/preserves-nim/package.nix
@@ -30,6 +30,5 @@ buildNimSbom (finalAttrs: {
     description = "Utilities for working with Preserves documents and schemas";
     license = lib.licenses.unlicense;
     homepage = "https://git.syndicate-lang.org/ehmry/preserves-nim";
-    maintainers = with lib.maintainers; [ ehmry ];
   };
 }) ./sbom.json

--- a/pkgs/by-name/pr/preserves-tools/package.nix
+++ b/pkgs/by-name/pr/preserves-tools/package.nix
@@ -29,7 +29,6 @@ rustPlatform.buildRustPackage rec {
     description = "Command-line utilities for working with Preserves documents";
     homepage = "https://preserves.dev/doc/preserves-tool.html";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ ehmry ];
     mainProgram = "preserves-tool";
   };
 }

--- a/pkgs/by-name/pr/prevo-data/package.nix
+++ b/pkgs/by-name/pr/prevo-data/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [
       das-g
-      ehmry
     ];
   };
 }

--- a/pkgs/by-name/pr/prevo-tools/package.nix
+++ b/pkgs/by-name/pr/prevo-tools/package.nix
@@ -59,7 +59,6 @@ stdenv.mkDerivation rec {
     mainProgram = "prevo";
     maintainers = with lib.maintainers; [
       das-g
-      ehmry
     ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/pr/prevo/package.nix
+++ b/pkgs/by-name/pr/prevo/package.nix
@@ -33,7 +33,6 @@ symlinkJoin rec {
     mainProgram = "prevo";
     maintainers = with lib.maintainers; [
       das-g
-      ehmry
     ];
   };
 }

--- a/pkgs/by-name/ra/ratox/package.nix
+++ b/pkgs/by-name/ra/ratox/package.nix
@@ -36,7 +36,6 @@ stdenv.mkDerivation {
     mainProgram = "ratox";
     homepage = "http://ratox.2f30.org/";
     license = licenses.isc;
-    maintainers = with maintainers; [ ehmry ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/ra/raylib-games/package.nix
+++ b/pkgs/by-name/ra/raylib-games/package.nix
@@ -56,7 +56,6 @@ stdenv.mkDerivation {
     description = "Collection of games made with raylib";
     homepage = "https://www.raylib.com/games.html";
     license = licenses.zlib;
-    maintainers = with maintainers; [ ehmry ];
     inherit (raylib.meta) platforms;
   };
 }

--- a/pkgs/by-name/sh/shapelib/package.nix
+++ b/pkgs/by-name/sh/shapelib/package.nix
@@ -22,7 +22,6 @@ stdenv.mkDerivation rec {
     description = "C Library for reading, writing and updating ESRI Shapefiles";
     homepage = "http://shapelib.maptools.org/";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ ehmry ];
     teams = [ teams.geospatial ];
     changelog = "http://shapelib.maptools.org/release.html";
   };

--- a/pkgs/by-name/so/sockdump/package.nix
+++ b/pkgs/by-name/so/sockdump/package.nix
@@ -27,7 +27,6 @@ python3.pkgs.buildPythonApplication rec {
     mainProgram = "sockdump";
     license = lib.licenses.unlicense;
     maintainers = with lib.maintainers; [
-      ehmry
       picnoir
     ];
   };

--- a/pkgs/by-name/so/solo5/package.nix
+++ b/pkgs/by-name/so/solo5/package.nix
@@ -95,7 +95,6 @@ stdenv.mkDerivation {
     description = "Sandboxed execution environment";
     homepage = "https://github.com/solo5/solo5";
     license = licenses.isc;
-    maintainers = [ maintainers.ehmry ];
     platforms = mapCartesianProduct ({ arch, os }: "${arch}-${os}") {
       arch = [
         "aarch64"

--- a/pkgs/by-name/sp/splat/package.nix
+++ b/pkgs/by-name/sp/splat/package.nix
@@ -62,7 +62,6 @@ stdenv.mkDerivation rec {
     description = "RF Signal Propagation, Loss, And Terrain analysis tool for the electromagnetic spectrum between 20 MHz and 20 GHz";
     license = licenses.gpl2Only;
     homepage = "https://www.qsl.net/kd2bd/splat.html";
-    maintainers = with maintainers; [ ehmry ];
     platforms = platforms.x86_64;
   };
 

--- a/pkgs/by-name/sy/syndicate-server/package.nix
+++ b/pkgs/by-name/sy/syndicate-server/package.nix
@@ -35,7 +35,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://synit.org/";
     license = lib.licenses.asl20;
     mainProgram = "syndicate-server";
-    maintainers = with lib.maintainers; [ ehmry ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/sy/syndicate_utils/package.nix
+++ b/pkgs/by-name/sy/syndicate_utils/package.nix
@@ -31,7 +31,6 @@ buildNimSbom (finalAttrs: {
   meta = finalAttrs.src.meta // {
     description = "Utilities for the Syndicated Actor Model";
     homepage = "https://git.syndicate-lang.org/ehmry/syndicate_utils";
-    maintainers = [ lib.maintainers.ehmry ];
     license = lib.licenses.unlicense;
   };
 }) ./sbom.json

--- a/pkgs/by-name/ta/tarlz/package.nix
+++ b/pkgs/by-name/ta/tarlz/package.nix
@@ -40,7 +40,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Massively parallel combined implementation of the tar archiver and the lzip compressor";
     license = licenses.gpl2Plus;
     platforms = platforms.all;
-    maintainers = with maintainers; [ ehmry ];
     mainProgram = "tarlz";
   };
 })

--- a/pkgs/by-name/tk/tkrzw/package.nix
+++ b/pkgs/by-name/tk/tkrzw/package.nix
@@ -26,7 +26,6 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Set of implementations of DBM";
     homepage = "https://dbmx.net/tkrzw/";
-    maintainers = with maintainers; [ ehmry ];
     license = licenses.asl20;
     platforms = platforms.all;
   };

--- a/pkgs/by-name/to/toss/package.nix
+++ b/pkgs/by-name/to/toss/package.nix
@@ -20,7 +20,6 @@ stdenv.mkDerivation rec {
     // {
       description = "Dead simple LAN file transfers from the command line";
       license = with licenses; [ mit ];
-      maintainers = with maintainers; [ ehmry ];
       platforms = platforms.unix;
     };
 }

--- a/pkgs/by-name/to/toxic/package.nix
+++ b/pkgs/by-name/to/toxic/package.nix
@@ -56,7 +56,6 @@ stdenv.mkDerivation rec {
     mainProgram = "toxic";
     homepage = "https://github.com/TokTok/toxic";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ ehmry ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/tr/transmission-remote-gtk/package.nix
+++ b/pkgs/by-name/tr/transmission-remote-gtk/package.nix
@@ -64,7 +64,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/transmission-remote-gtk/transmission-remote-gtk";
     changelog = "https://github.com/transmission-remote-gtk/transmission-remote-gtk/releases/tag/${version}";
     license = lib.licenses.gpl2;
-    maintainers = with lib.maintainers; [ ehmry ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/tu/tup/package.nix
+++ b/pkgs/by-name/tu/tup/package.nix
@@ -97,7 +97,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://gittup.org/tup/";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ ehmry ];
     platforms = platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/ty/typodermic-free-fonts/package.nix
+++ b/pkgs/by-name/ty/typodermic-free-fonts/package.nix
@@ -30,7 +30,6 @@ stdenvNoCC.mkDerivation {
   meta = {
     homepage = "https://typodermicfonts.com/";
     description = "Typodermic fonts";
-    maintainers = with lib.maintainers; [ ehmry ];
     license = lib.licenses.unfree // {
       fullName = "Font Software for Desktop End User License Agreement";
       url = "https://typodermicfonts.com/end-user-license-agreement/";

--- a/pkgs/by-name/ty/typodermic-public-domain/package.nix
+++ b/pkgs/by-name/ty/typodermic-public-domain/package.nix
@@ -30,7 +30,6 @@ stdenvNoCC.mkDerivation {
   meta = {
     homepage = "https://typodermicfonts.com/";
     description = "Vintage Typodermic fonts";
-    maintainers = with lib.maintainers; [ ehmry ];
     license = lib.licenses.cc0;
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/u9/u9fs/package.nix
+++ b/pkgs/by-name/u9/u9fs/package.nix
@@ -24,7 +24,6 @@ stdenv.mkDerivation {
     description = "Serve 9P from Unix";
     homepage = "http://p9f.org/magic/man2html?man=u9fs&sect=4";
     license = licenses.dtoa;
-    maintainers = [ maintainers.ehmry ];
     platforms = platforms.unix;
     mainProgram = "u9fs";
   };

--- a/pkgs/by-name/uh/uhub/package.nix
+++ b/pkgs/by-name/uh/uhub/package.nix
@@ -48,7 +48,6 @@ stdenv.mkDerivation {
     description = "High performance peer-to-peer hub for the ADC network";
     homepage = "https://www.uhub.org/";
     license = licenses.gpl3;
-    maintainers = [ maintainers.ehmry ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/un/unfonts-core/package.nix
+++ b/pkgs/by-name/un/unfonts-core/package.nix
@@ -31,6 +31,5 @@ stdenvNoCC.mkDerivation rec {
     '';
     license = licenses.gpl2;
     platforms = platforms.all;
-    maintainers = [ maintainers.ehmry ];
   };
 }

--- a/pkgs/by-name/vi/vix/package.nix
+++ b/pkgs/by-name/vi/vix/package.nix
@@ -29,7 +29,6 @@ stdenv.mkDerivation {
     description = "Visual Interface heXadecimal dump";
     homepage = "http://actinid.org/vix/";
     license = licenses.gpl3;
-    maintainers = [ maintainers.ehmry ];
     mainProgram = "vix";
     # sys/io.h missing on other platforms
     platforms = [ "x86_64-linux" ];

--- a/pkgs/by-name/wi/windowlab/package.nix
+++ b/pkgs/by-name/wi/windowlab/package.nix
@@ -42,7 +42,6 @@ stdenv.mkDerivation {
     description = "Small and simple stacking window manager";
     homepage = "http://nickgravgaard.com/windowlab/";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ ehmry ];
     platforms = platforms.linux;
     mainProgram = "windowlab";
   };

--- a/pkgs/by-name/xa/xaos/package.nix
+++ b/pkgs/by-name/xa/xaos/package.nix
@@ -68,6 +68,5 @@ stdenv.mkDerivation rec {
     homepage = "https://xaos-project.github.io/";
     license = lib.licenses.gpl2Plus;
     platforms = [ "x86_64-linux" ];
-    maintainers = with lib.maintainers; [ ehmry ];
   };
 }

--- a/pkgs/by-name/xa/xastir/package.nix
+++ b/pkgs/by-name/xa/xastir/package.nix
@@ -88,7 +88,6 @@ stdenv.mkDerivation rec {
     description = "Graphical APRS client";
     homepage = "https://github.com/xastir/xastir";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ lib.maintainers.ehmry ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/xc/xcruiser/package.nix
+++ b/pkgs/by-name/xc/xcruiser/package.nix
@@ -59,7 +59,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://xcruiser.sourceforge.net/";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ ehmry ];
     platforms = with platforms; linux;
     mainProgram = "xcruiser";
   };

--- a/pkgs/by-name/yg/yggdrasil/package.nix
+++ b/pkgs/by-name/yg/yggdrasil/package.nix
@@ -39,7 +39,6 @@ buildGoModule rec {
     homepage = "https://yggdrasil-network.github.io/";
     license = licenses.lgpl3;
     maintainers = with maintainers; [
-      ehmry
       gazally
       lassulus
       peigongdsd

--- a/pkgs/by-name/yg/yggstack/package.nix
+++ b/pkgs/by-name/yg/yggstack/package.nix
@@ -34,7 +34,6 @@ buildGoModule rec {
     homepage = "https://yggdrasil-network.github.io/";
     license = licenses.lgpl3;
     maintainers = with maintainers; [
-      ehmry
       peigongdsd
     ];
   };

--- a/pkgs/by-name/ze/zerotierone/package.nix
+++ b/pkgs/by-name/ze/zerotierone/package.nix
@@ -151,7 +151,6 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [
       sjmackenzie
       zimbatm
-      ehmry
       obadz
       danielfullmer
       mic92 # also can test darwin

--- a/pkgs/development/compilers/squeak/default.nix
+++ b/pkgs/development/compilers/squeak/default.nix
@@ -243,7 +243,6 @@ stdenv.mkDerivation {
       asl20
       mit
     ];
-    maintainers = with lib.maintainers; [ ehmry ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/development/ocaml-modules/diet/default.nix
+++ b/pkgs/development/ocaml-modules/diet/default.nix
@@ -27,6 +27,5 @@ buildDunePackage rec {
     homepage = "https://github.com/mirage/ocaml-diet";
     description = "Simple implementation of Discrete Interval Encoding Trees";
     license = licenses.isc;
-    maintainers = with maintainers; [ ehmry ];
   };
 }

--- a/pkgs/development/ocaml-modules/mirage-block-ramdisk/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-block-ramdisk/default.nix
@@ -34,6 +34,5 @@ buildDunePackage rec {
     description = "In-memory BLOCK device for MirageOS";
     homepage = "https://github.com/mirage/mirage-block-ramdisk";
     license = licenses.isc;
-    maintainers = with maintainers; [ ehmry ];
   };
 }

--- a/pkgs/development/ocaml-modules/mirage-block-unix/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-block-unix/default.nix
@@ -41,6 +41,5 @@ buildDunePackage rec {
     description = "MirageOS disk block driver for Unix";
     homepage = "https://github.com/mirage/mirage-block-unix";
     license = licenses.isc;
-    maintainers = with maintainers; [ ehmry ];
   };
 }

--- a/pkgs/development/python-modules/eris/default.nix
+++ b/pkgs/development/python-modules/eris/default.nix
@@ -24,6 +24,5 @@ buildPythonPackage rec {
     description = "Python implementation of the Encoding for Robust Immutable Storage (ERIS)";
     homepage = "https://eris.codeberg.page/python-eris/";
     license = [ lib.licenses.agpl3Plus ];
-    maintainers = with lib.maintainers; [ ehmry ];
   };
 }

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-oauth2-basic/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-oauth2-basic/default.nix
@@ -15,7 +15,6 @@ mkDiscoursePlugin rec {
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/${name}";
-    maintainers = with maintainers; [ ehmry ];
     license = licenses.mit;
     description = "Basic OAuth2 plugin for use with Discourse";
   };

--- a/pkgs/tools/audio/liquidsoap/full.nix
+++ b/pkgs/tools/audio/liquidsoap/full.nix
@@ -170,7 +170,6 @@ stdenv.mkDerivation {
     changelog = "https://raw.githubusercontent.com/savonet/liquidsoap/main/CHANGES.md";
     maintainers = with lib.maintainers; [
       dandellion
-      ehmry
     ];
     license = lib.licenses.gpl2Plus;
     platforms = ocamlPackages.ocaml.meta.platforms or [ ];

--- a/pkgs/tools/system/plan9port/default.nix
+++ b/pkgs/tools/system/plan9port/default.nix
@@ -135,7 +135,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [
       bbarker
-      ehmry
       ftrvxmtrx
       kovirobi
       matthewdargan


### PR DESCRIPTION
This user is blocked since May 2025, thus can't maintain any packages anymore.

Related:
- https://github.com/NixOS/moderation/commit/06298268253d22c7a4612c6d82c976fff699bddc
- #438880

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
