### PR TITLE
nixos/parallels-guest: remove unnecessary systemd user services

### DIFF
--- a/nixos/modules/virtualisation/parallels-guest.nix
+++ b/nixos/modules/virtualisation/parallels-guest.nix
@@ -81,44 +81,16 @@ in
       };
     };
 
-    systemd.user.services = {
-      prlcc = {
-        description = "Parallels Control Center";
-        wantedBy = [ "graphical-session.target" ];
-        path = [ prl-tools ];
-        serviceConfig = {
-          ExecStart = "${prl-tools}/bin/prlcc";
-          WorkingDirectory = "${prl-tools}/bin";
-        };
-      };
-      prldnd = {
-        description = "Parallels Drag And Drop Tool";
-        wantedBy = [ "graphical-session.target" ];
-        path = [ prl-tools ];
-        serviceConfig = {
-          ExecStart = "${prl-tools}/bin/prldnd";
-          WorkingDirectory = "${prl-tools}/bin";
-        };
-      };
-      prlcp = {
-        description = "Parallels Copy Paste Tool";
-        wantedBy = [ "graphical-session.target" ];
-        path = [ prl-tools ];
-        serviceConfig = {
-          ExecStart = "${prl-tools}/bin/prlcp";
-          Restart = "always";
-          WorkingDirectory = "${prl-tools}/bin";
-        };
-      };
-      prlshprof = {
-        description = "Parallels Shared Profile Tool";
-        wantedBy = [ "graphical-session.target" ];
-        path = [ prl-tools ];
-        serviceConfig = {
-          ExecStart = "${prl-tools}/bin/prlshprof";
-          WorkingDirectory = "${prl-tools}/bin";
-        };
+    systemd.user.services.prlcc = {
+      description = "Parallels Control Center";
+      wantedBy = [ "graphical-session.target" ];
+      path = [ prl-tools ];
+      serviceConfig = {
+        ExecStart = "${prl-tools}/bin/prlcc";
+        WorkingDirectory = "${prl-tools}/bin";
       };
     };
   };
+
+  meta.maintainers = with maintainers; [ codgician ];
 }


### PR DESCRIPTION
* Remove unnecessary systemd user services to avoid clipboard sharing freezing entire window.
* Added myself as maintainer of `parallels-guest` module.

`prldnd`, `prlcp` and `prlshprof` are actually invoked and managed by `prlcc`. There is no need to create a systemd user service for them. In fact, removing them would resolve clipboard sharing having potential freezing the entire VM window.

<img width="2800" height="1878" alt="image" src="https://github.com/user-attachments/assets/2fe6a737-8b14-4f7c-9266-6ca3ae0f341a" />


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
