### PR TITLE
python313Packages.httplib2: 0.22.0 -> 0.31.0

### DIFF
--- a/pkgs/development/python-modules/httplib2/default.nix
+++ b/pkgs/development/python-modules/httplib2/default.nix
@@ -6,53 +6,49 @@
   fetchFromGitHub,
   mock,
   pyparsing,
+  pysocks,
   pytest-cov-stub,
   pytest-forked,
   pytest-randomly,
   pytest-timeout,
   pytestCheckHook,
   pythonAtLeast,
-  six,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "httplib2";
-  version = "0.22.0";
-  format = "setuptools";
+  version = "0.31.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "httplib2";
     repo = "httplib2";
-    rev = "v${version}";
-    hash = "sha256-76gdiRbF535CEaNXwNqsVeVc0dKglovMPQpGsOkbd/4=";
+    tag = "v${version}";
+    hash = "sha256-faeanUBpNmhBEffENP9hl9tnZoRmKf3Fq1s4FdPs8LQ=";
   };
 
-  propagatedBuildInputs = [ pyparsing ];
+  build-system = [ setuptools ];
+
+  dependencies = [ pyparsing ];
 
   nativeCheckInputs = [
     cryptography
     mock
+    pysocks
     pytest-cov-stub
     pytest-forked
     pytest-randomly
     pytest-timeout
-    six
     pytestCheckHook
   ];
 
   __darwinAllowLocalNetworking = true;
 
-  # Don't run tests for older Pythons
-  doCheck = pythonAtLeast "3.9";
-
   disabledTests = [
     # ValueError: Unable to load PEM file.
     # https://github.com/httplib2/httplib2/issues/192#issuecomment-993165140
     "test_client_cert_password_verified"
-
-    # improper pytest marking
-    "test_head_301"
-    "test_303"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # fails with "ConnectionResetError: [Errno 54] Connection reset by peer"
@@ -62,13 +58,12 @@ buildPythonPackage rec {
     "test_connection_close"
   ];
 
-  disabledTestPaths = [ "python2" ];
-
   pythonImportsCheck = [ "httplib2" ];
 
   meta = with lib; {
     description = "Comprehensive HTTP client library";
     homepage = "https://github.com/httplib2/httplib2";
+    changelog = "https://github.com/httplib2/httplib2/blob/${src.tag}/CHANGELOG";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
   };


### PR DESCRIPTION
Changelog: https://github.com/httplib2/httplib2/blob/v0.30.0/CHANGELOG


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
