### PR TITLE
[25.05] linux_6_15: remove, zfs: 2.3.3 -> 2.3.4, linux_6_12_hardened: v6.12.34-hardened1 -> v6.12.43-hardened1

### DIFF
--- a/nixos/doc/manual/configuration/linux-kernel.chapter.md
+++ b/nixos/doc/manual/configuration/linux-kernel.chapter.md
@@ -24,6 +24,12 @@ abandoned by the kernel developers, even on stable NixOS versions. If you
 pin your kernel onto a non-longterm version, expect your evaluation to fail as
 soon as the version is out of maintenance.
 
+A kernel will be removed from nixpkgs when the first batch of stable kernels
+_after_ the final release is published. E.g. when 6.15.11 is the final release
+of the 6.15 series and is released together with 6.16.3 and 6.12.43, it will be
+removed on the release of 6.16.4 and 6.12.44. Custom kernel variants such
+as linux-hardened are also affected by this.
+
 Longterm versions of kernels will be removed before the next stable NixOS that will
 exceed the maintenance period of the kernel version.
 

--- a/nixos/tests/kernel-generic.nix
+++ b/nixos/tests/kernel-generic.nix
@@ -41,8 +41,6 @@ let
       linux_6_1_hardened
       linux_6_6_hardened
       linux_6_12_hardened
-      linux_6_13_hardened
-      linux_6_14_hardened
       linux_rt_5_4
       linux_rt_5_10
       linux_rt_5_15

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -42,12 +42,12 @@
     "6.12": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-v6.12.41-hardened1.patch",
-            "sha256": "1a0gc03nr0aiy2zadg6hfy718nlb2k8p5h5ymvwsdl6kblxi9f47",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.12.41-hardened1/linux-hardened-v6.12.41-hardened1.patch"
+            "name": "linux-hardened-v6.12.43-hardened1.patch",
+            "sha256": "10hp4718agz7bj4wnis7g1c8ahnwn5917a5v88y9iwawrjm9148v",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.12.43-hardened1/linux-hardened-v6.12.43-hardened1.patch"
         },
-        "sha256": "09qfpxyxi3z8cd64r2r5mxvh54a5sx8p5mk4d50y4ga2k6pa66bb",
-        "version": "6.12.41"
+        "sha256": "1vmxywg11z946i806sg7rk7jr9px87spmwwbzjxpps2nsjybpjqg",
+        "version": "6.12.43"
     },
     "6.6": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -49,26 +49,6 @@
         "sha256": "0kf2f3r96npzs01kdq3q2ag7zg8l3avfyqwv5qbs9v373wwgxwx7",
         "version": "6.12.34"
     },
-    "6.13": {
-        "patch": {
-            "extra": "-hardened1",
-            "name": "linux-hardened-v6.13.12-hardened1.patch",
-            "sha256": "0i9raq3qcc6pxvs9l6yn5b6k8kiywwlis33kkpd8byqhs57aqsic",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.13.12-hardened1/linux-hardened-v6.13.12-hardened1.patch"
-        },
-        "sha256": "0hhj49k3ksjcp0dg5yiahqzryjfdpr9c1a9ph6j9slzmkikbn7v1",
-        "version": "6.13.12"
-    },
-    "6.14": {
-        "patch": {
-            "extra": "-hardened1",
-            "name": "linux-hardened-v6.14.11-hardened1.patch",
-            "sha256": "07f0d76rag6jcclxdl24w70545fb8jrqy98xcdmgxwjabclaa1lp",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.14.11-hardened1/linux-hardened-v6.14.11-hardened1.patch"
-        },
-        "sha256": "06rvydmc2yfspidnsay5hin3i8p4fxy3bvzwnry7gjf9dl5cs71z",
-        "version": "6.14.11"
-    },
     "6.6": {
         "patch": {
             "extra": "-hardened1",

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -42,12 +42,12 @@
     "6.12": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-v6.12.34-hardened1.patch",
-            "sha256": "1aw8r52gbxp53sgl4pwv51axw0kmgh3ib6gfvw81dlyaajmlbm6b",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.12.34-hardened1/linux-hardened-v6.12.34-hardened1.patch"
+            "name": "linux-hardened-v6.12.41-hardened1.patch",
+            "sha256": "1a0gc03nr0aiy2zadg6hfy718nlb2k8p5h5ymvwsdl6kblxi9f47",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.12.41-hardened1/linux-hardened-v6.12.41-hardened1.patch"
         },
-        "sha256": "0kf2f3r96npzs01kdq3q2ag7zg8l3avfyqwv5qbs9v373wwgxwx7",
-        "version": "6.12.34"
+        "sha256": "09qfpxyxi3z8cd64r2r5mxvh54a5sx8p5mk4d50y4ga2k6pa66bb",
+        "version": "6.12.41"
     },
     "6.6": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -34,11 +34,6 @@
         "hash": "sha256:1bmx2vpxy6nkxnmm2a3zmv9smaajfhvslj6id54j4yq2sc722l5n",
         "lts": true
     },
-    "6.15": {
-        "version": "6.15.11",
-        "hash": "sha256:14sxwrvw9p4ybizb8ky1rgahc62q0aw5qkmzqp3cpnavqfgldaw9",
-        "lts": false
-    },
     "6.16": {
         "version": "6.16.4",
         "hash": "sha256:08mnd8qir2vxjmgblhnqfrfbv2zlig68f4r5askk7d8h3b3y79fn",

--- a/pkgs/os-specific/linux/zfs/2_3.nix
+++ b/pkgs/os-specific/linux/zfs/2_3.nix
@@ -11,10 +11,10 @@ callPackage ./generic.nix args {
   # this attribute is the correct one for this package.
   kernelModuleAttribute = "zfs_2_3";
   # check the release notes for compatible kernels
-  kernelCompatible = kernel: kernel.kernelOlder "6.16";
+  kernelCompatible = kernel: kernel.kernelOlder "6.17";
 
   # this package should point to the latest release.
-  version = "2.3.3";
+  version = "2.3.4";
 
   tests = {
     inherit (nixosTests.zfs) series_2_3;
@@ -28,5 +28,5 @@ callPackage ./generic.nix args {
     amarshall
   ];
 
-  hash = "sha256-NXAbyGBfpzWfm4NaP1/otTx8fOnoRV17343qUMdQp5U=";
+  hash = "sha256-8BSuDRDyqPGAiyGGxFyEZIcXB+cKsKk25jcFPrSK3GI=";
 }

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -211,14 +211,6 @@ in
           ];
         };
 
-        linux_6_15 = callPackage ../os-specific/linux/kernel/mainline.nix {
-          branch = "6.15";
-          kernelPatches = [
-            kernelPatches.bridge_stp_helper
-            kernelPatches.request_key_helper
-          ];
-        };
-
         linux_6_16 = callPackage ../os-specific/linux/kernel/mainline.nix {
           branch = "6.16";
           kernelPatches = [
@@ -319,6 +311,7 @@ in
         linux_6_11 = throw "linux 6.11 was removed because it has reached its end of life upstream";
         linux_6_13 = throw "linux 6.13 was removed because it has reached its end of life upstream";
         linux_6_14 = throw "linux 6.14 was removed because it has reached its end of life upstream";
+        linux_6_15 = throw "linux 6.15 was removed because it has reached its end of life upstream";
 
         linux_4_19_hardened = throw "linux 4.19 was removed because it will reach its end of life within 24.11";
         linux_6_9_hardened = throw "linux 6.9 was removed because it has reached its end of life upstream";
@@ -326,6 +319,7 @@ in
         linux_6_11_hardened = throw "linux 6.11 was removed because it has reached its end of life upstream";
         linux_6_13_hardened = throw "linux 6.13 was removed because it has reached its end of life upstream";
         linux_6_14_hardened = throw "linux 6.14 was removed because it has reached its end of life upstream";
+        linux_6_15_hardened = throw "linux 6.15 was removed because it has reached its end of life upstream";
 
         linux_ham = kernels.linux_latest;
       }
@@ -744,7 +738,6 @@ in
     linux_6_1 = recurseIntoAttrs (packagesFor kernels.linux_6_1);
     linux_6_6 = recurseIntoAttrs (packagesFor kernels.linux_6_6);
     linux_6_12 = recurseIntoAttrs (packagesFor kernels.linux_6_12);
-    linux_6_15 = recurseIntoAttrs (packagesFor kernels.linux_6_15);
     linux_6_16 = recurseIntoAttrs (packagesFor kernels.linux_6_16);
   }
   // lib.optionalAttrs config.allowAliases {
@@ -754,6 +747,7 @@ in
     linux_6_11 = throw "linux 6.11 was removed because it reached its end of life upstream"; # Added 2025-03-23
     linux_6_13 = throw "linux 6.13 was removed because it reached its end of life upstream"; # Added 2025-06-22
     linux_6_14 = throw "linux 6.14 was removed because it reached its end of life upstream"; # Added 2025-06-22
+    linux_6_15 = throw "linux 6.15 was removed because it reached its end of life upstream"; # Added 2025-08-23
   };
 
   rtPackages = {
@@ -809,6 +803,7 @@ in
       linux_ham = recurseIntoAttrs (packagesFor kernels.linux_latest);
       linux_6_13_hardened = throw "linux 6.13 was removed because it has reached its end of life upstream";
       linux_6_14_hardened = throw "linux 6.14 was removed because it has reached its end of life upstream";
+      linux_6_15_hardened = throw "linux 6.15 was removed because it has reached its end of life upstream";
     }
   );
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Primary goal was to backport the 6.15 removal (https://github.com/NixOS/nixpkgs/pull/436253/files)
It was requested to include the ZFS update so that 6.16 is an option for ZFS users now that 6.15 has to go (https://github.com/NixOS/nixpkgs/pull/436930/files)
While at it, I decided to backport the hardened kernel from master (https://github.com/NixOS/nixpkgs/pull/438964). We should probably do an update of the rest as well.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
