### PR TITLE
python3Packages.loro: 1.5.4 -> 1.6.0

### DIFF
--- a/pkgs/development/python-modules/loro/default.nix
+++ b/pkgs/development/python-modules/loro/default.nix
@@ -8,18 +8,17 @@
 
 buildPythonPackage rec {
   pname = "loro";
-  version = "1.5.4";
+  version = "1.6.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-vC1SLkwCkiytZe9d9t1OH+Vd360657XxdU81bM9C9jk=";
+    hash = "sha256-9UO4XHf3Nm3yFi3hwA490sLHUXG36WcM/8C2rFYdcpM=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
-    hash = "sha256-cjIHU2aMxkYMoulePmxFhuZrqMbnOkEL+Ar75+KCVFw=";
+    inherit pname version src;
+    hash = "sha256-sTJ2jA/TLoVp7UTC2YMKzuJi1SxldG8gj3YGPbVco5s=";
   };
 
   build-system = [
@@ -29,12 +28,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ];
-
-  disabledTests = [
-    # Upstream test has hardcoded version and is rarely updated.
-    # See https://github.com/loro-dev/loro-py/issues/19
-    "test_version"
   ];
 
   meta = {


### PR DESCRIPTION
 - bump loro 1.5.4 -> 1.6.0 (replaces #438889)

 - addresses comments in #405160

 - Removes deleted failing upstream test

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
