### PR TITLE
python3Packages.ase: 3.25.0-unstable-2025-06-24 -> 3.26.0 and python3Packages.dscribe: disable tests that fail under ase 3.26

### DIFF
--- a/pkgs/development/python-modules/ase/default.nix
+++ b/pkgs/development/python-modules/ase/default.nix
@@ -3,8 +3,6 @@
   stdenv,
   fetchFromGitLab,
   buildPythonPackage,
-  isPy27,
-  fetchPypi,
   pythonAtLeast,
 
   # build-system
@@ -29,14 +27,14 @@
 
 buildPythonPackage rec {
   pname = "ase";
-  version = "3.25.0-unstable-2025-06-24";
+  version = "3.26.0";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "ase";
     repo = "ase";
-    rev = "4e22dabfbe7ae2329e50260ca1b6f08a83527ac3";
-    hash = "sha256-ehMyVtPxfTxT8T418VyLGnUEyYip4LPTTaGL0va7qgM=";
+    tag = version;
+    hash = "sha256-1738NQPgOqSr2PZu1T2b9bL0V+ZzGk2jcWBhLF21VQs=";
   };
 
   build-system = [ setuptools ];
@@ -79,7 +77,8 @@ buildPythonPackage rec {
 
   meta = {
     description = "Atomic Simulation Environment";
-    homepage = "https://wiki.fysik.dtu.dk/ase/";
+    homepage = "https://ase-lib.org/";
+    changelog = "https://ase-lib.org/releasenotes.html";
     license = lib.licenses.lgpl21Plus;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/dscribe/default.nix
+++ b/pkgs/development/python-modules/dscribe/default.nix
@@ -79,6 +79,17 @@ buildPythonPackage rec {
     "test_examples"
   ];
 
+  # Broken due to use of missing _get_constraints attr in ase >= 3.26.0
+  # https://github.com/SINGROUP/dscribe/issues/160
+  disabledTestPaths = [
+    "tests/test_examples.py::test_examples"
+    "tests/test_general.py::test_atoms_to_system"
+    "tests/test_lmbtr.py"
+    "tests/test_mbtr.py"
+    "tests/test_sinematrix.py"
+    "tests/test_valle_oganov.py"
+  ];
+
   meta = {
     description = "Machine learning descriptors for atomistic systems";
     homepage = "https://github.com/SINGROUP/dscribe";


### PR DESCRIPTION
### ase

https://gitlab.com/ase/ase/-/tags/3.26.0

Supersedes #437438 by r-ryantm to add:
1. `rev` -> `tag`
2. Fixed homepage
3. Added changelog
4. Removed obsolete inputs

And keeps the version bump, of course.

### dscribe

1. Disabled two tests that depended on old ase internals
2. Filed https://github.com/SINGROUP/dscribe/issues/160

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
