### PR TITLE
python3Packages.torch: fix patch hash instability by using fetchpatch

### DIFF
--- a/pkgs/development/python-modules/torch/source/default.nix
+++ b/pkgs/development/python-modules/torch/source/default.nix
@@ -4,7 +4,7 @@
   pkgs,
   fetchFromGitHub,
   fetchFromGitLab,
-  fetchpatch2,
+  fetchpatch,
   git-unroll,
   buildPythonPackage,
   python,
@@ -301,10 +301,10 @@ buildPythonPackage rec {
 
     # Do not override PYTHONPATH, otherwise, the build fails with:
     # ModuleNotFoundError: No module named 'typing_extensions'
-    (fetchpatch2 {
+    (fetchpatch {
       name = "cmake-build-preserve-PYTHONPATH";
       url = "https://github.com/pytorch/pytorch/commit/231c72240d80091f099c95e326d3600cba866eee.patch";
-      hash = "sha256-7f9qtr7ljqjKdj3DqpcCTS0/Hr2AwOzOl/HA88yU3zI=";
+      hash = "sha256-BBCjxzz2TUkx4nXRyRILA82kMwyb/4+C3eOtYqf5dhk=";
     })
   ]
   ++ lib.optionals cudaSupport [


### PR DESCRIPTION
Hash of cmake-build-preserve-PYTHONPATH mysteriously changed overnight

```
cmake-build-preserve-PYTHONPATH> trying https://github.com/pytorch/pytorch/commit/231c72240d80091f099c95e326d3600cba866eee.patch
cmake-build-preserve-PYTHONPATH>   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
cmake-build-preserve-PYTHONPATH>                                  Dload  Upload   Total   Spent    Left  Speed
cmake-build-preserve-PYTHONPATH> 100  1119  100  1119    0     0   8710      0 --:--:-- --:--:-- --:--:--  8742
error: hash mismatch in fixed-output derivation '/nix/store/vywcjiyn0ix2yr132lvdb8wnqpcp0wyf-cmake-build-preserve-PYTHONPATH.drv':
         specified: sha256-7f9qtr7ljqjKdj3DqpcCTS0/Hr2AwOzOl/HA88yU3zI=
            got:    sha256-jtBpfGTu/GJjg3GlNz9DX9NXRo7F5I27eOKxjpz10u4=

$ nix build github:nixos/nixpkgs/master#python3Packages.torch --rebuild
error: hash mismatch in fixed-output derivation '/nix/store/vywcjiyn0ix2yr132lvdb8wnqpcp0wyf-cmake-build-preserve-PYTHONPATH.drv':
         specified: sha256-7f9qtr7ljqjKdj3DqpcCTS0/Hr2AwOzOl/HA88yU3zI=
            got:    sha256-jtBpfGTu/GJjg3GlNz9DX9NXRo7F5I27eOKxjpz10u4=
error: Cannot build '/nix/store/pzh4f95xxmafyxfc89fd5g6z4lpw36bb-python3.13-torch-2.8.0.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/1d01hcv15z03cz03pih9vmd3cd45bh48-python3.13-torch-2.8.0-dev
         /nix/store/24xa6lscpq14ms8aqwxrixwyqx8c77vb-python3.13-torch-2.8.0-dist
         /nix/store/8qdd54xgrpnbdcw64xr069w2ic469s52-python3.13-torch-2.8.0
         /nix/store/gf6vaig8w7gv21d33y6y7pdhbbpd928a-python3.13-torch-2.8.0-lib
         /nix/store/vphd6s4pxajfinm160c3hskdbxk22n45-python3.13-torch-2.8.0-cxxdev
```

It must have been building fine yesterday for me and @GaetanLepage since we both review ran it. :confused: 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
