### PR TITLE
finit: init at 4.14

### DIFF
--- a/pkgs/by-name/fi/finit/package.nix
+++ b/pkgs/by-name/fi/finit/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  libite,
+  libuev,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "finit";
+  version = "4.14";
+
+  src = fetchFromGitHub {
+    owner = "troglobit";
+    repo = "finit";
+    tag = finalAttrs.version;
+    hash = "sha256-v4QHc6pX50z4j4UBpw7J2k78Pqt7n503qiDRDWyrhOc=";
+  };
+
+  postPatch = ''
+    substituteInPlace plugins/modprobe.c --replace-fail \
+      '"/lib/modules"' '"/run/booted-system/kernel-modules/lib/modules"'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    libite
+    libuev
+  ];
+
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
+
+  configureFlags = [
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+
+    # tweak default plugin list
+    "--enable-modprobe-plugin=yes"
+    "--enable-modules-load-plugin=yes"
+    "--enable-hotplug-plugin=no"
+
+    # minimal replacement for systemd notification library
+    "--with-libsystemd"
+  ];
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-D_PATH_LOGIN=\"/run/current-system/sw/bin/login\""
+    "-DSYSCTL_PATH=\"/run/current-system/sw/bin/sysctl\""
+  ];
+
+  meta = {
+    description = "Fast init for Linux";
+    mainProgram = "initctl";
+    homepage = "https://troglobit.com/projects/finit/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ aanderse ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
