### PR TITLE
gitlab-ci-local: 4.60.1 -> 4.61.1

### DIFF
--- a/pkgs/by-name/gi/gitlab-ci-local/package.nix
+++ b/pkgs/by-name/gi/gitlab-ci-local/package.nix
@@ -12,16 +12,16 @@
 
 buildNpmPackage rec {
   pname = "gitlab-ci-local";
-  version = "4.60.1";
+  version = "4.61.1";
 
   src = fetchFromGitHub {
     owner = "firecow";
     repo = "gitlab-ci-local";
     rev = version;
-    hash = "sha256-6v5iyQCP+3bJdG9uvPAsMaJ7mW2xj1kMhn8h2eLsl28=";
+    hash = "sha256-zHYUe5fAjK34zCjTYkg4pvvjRsaeuCyu7Gelcqki8P0=";
   };
 
-  npmDepsHash = "sha256-P09uxOtlY9AAJyKLTdnFOfw0H6V4trr2hznEonOO58E=";
+  npmDepsHash = "sha256-eLT2ejLOtEI7eqWikBc/wFrStCuvYHvlZk9JiMPfuUI=";
 
   nativeBuildInputs = [
     makeBinaryWrapper
@@ -34,29 +34,6 @@ buildNpmPackage rec {
   '';
 
   postInstall = ''
-    NODE_MODULES=$out/lib/node_modules/gitlab-ci-local/node_modules
-
-    # Remove intermediate build files for re2 to reduce dependencies.
-    #
-    # This does not affect the behavior. On npm `re2` does not ship
-    # the build directory and downloads a prebuilt version of the
-    # `re2.node` binary. This method produces the same result.
-    find $NODE_MODULES/re2/build -type f ! -path "*/Release/re2.node" -delete
-    strip -x $NODE_MODULES/re2/build/Release/re2.node
-
-    # Remove files that depend on python3
-    #
-    # The node-gyp package is only used for building re2, so it is
-    # not needed at runtime. I did not remove the whole directory
-    # because of some dangling links to the node-gyp directory which
-    # is not required. It is possible to remove the directory and all
-    # the files that link to it, but I figured it was not worth
-    # tracking down the files.
-    #
-    # The re2/vendor directory is used for building the re2.node
-    # binary, so it is not needed at runtime.
-    rm -rf $NODE_MODULES/{node-gyp/gyp,re2/vendor}
-
     wrapProgram $out/bin/gitlab-ci-local \
       --prefix PATH : "${
         lib.makeBinPath [


### PR DESCRIPTION
Updates gitlab-ci-local.
Removed the patch because upstream replaced re2 with re2js.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
