### PR TITLE
python3Packages: init mkdocs-table-reader-plugin at 3.1.0

### DIFF
--- a/pkgs/development/python-modules/mkdocs-table-reader-plugin/default.nix
+++ b/pkgs/development/python-modules/mkdocs-table-reader-plugin/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  mkdocs,
+  pandas,
+  tabulate,
+  pyyaml,
+  pytestCheckHook,
+  openpyxl,
+  mkdocs-macros,
+}:
+
+buildPythonPackage rec {
+  pname = "mkdocs-table-reader-plugin";
+  version = "3.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "timvink";
+    repo = "mkdocs-table-reader-plugin";
+    tag = "v${version}";
+    hash = "sha256-XyMz0CeLQderzzz/Z3H6rja619wPzx42X3jz30wt6a8=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    mkdocs
+    pandas
+    tabulate
+    pyyaml
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    openpyxl
+    mkdocs-macros
+  ];
+
+  pythonImportsCheck = [
+    "mkdocs_table_reader_plugin"
+  ];
+
+  disabledTests = [
+    # fails with non zero exit code without printing stdout/stderr of `mkdocs build` -> cause unknown
+    "test_compatibility_markdownextradata"
+    "test_macros_jinja2_syntax"
+  ];
+
+  meta = {
+    description = "MkDocs plugin that enables a markdown tag like {{ read_csv('table.csv') }} to directly insert various table formats into a page";
+    homepage = "https://github.com/timvink/mkdocs-table-reader-plugin";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ marcel ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9406,6 +9406,10 @@ self: super: with self; {
 
   mkdocs-swagger-ui-tag = callPackage ../development/python-modules/mkdocs-swagger-ui-tag { };
 
+  mkdocs-table-reader-plugin =
+    callPackage ../development/python-modules/mkdocs-table-reader-plugin
+      { };
+
   mkdocstrings = callPackage ../development/python-modules/mkdocstrings { };
 
   mkdocstrings-python = callPackage ../development/python-modules/mkdocstrings-python { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
