### PR TITLE
replaceVars: work around content-addressed output path shenanigans

### DIFF
--- a/pkgs/build-support/replace-vars/replace-vars-with.nix
+++ b/pkgs/build-support/replace-vars/replace-vars-with.nix
@@ -82,6 +82,25 @@ let
     preferLocalBuild = true;
     allowSubstitutes = false;
 
+    # Due to NixOS/nix#12361 the placeholder paths of content-addressed derivations
+    # do not follow the expected format, it lacks the `storeDir` and (more importantly)
+    # the `name`.
+    # This breaks assumptions of some downstream users of replaceVars, notably being able
+    # to filter out patches using their name:
+    #   $ nix build -f. rocmPackages.clang --arg config '{ contentAddressedByDefault = true; }'
+    #   [...]
+    #   > applying patch /nix/store/8va99vng26z2pqlhvsva787rkqnqw8j4-clang-at-least-16-LLVMgold-path.patch
+    #   > patching file lib/Driver/ToolChains/CommonArgs.cpp
+    #   > Hunk #1 succeeded at 775 (offset 186 lines).
+    #   [...]
+    #   > applying patch /nix/store/8va99vng26z2pqlhvsva787rkqnqw8j4-clang-at-least-16-LLVMgold-path.patch
+    #   > patching file lib/Driver/ToolChains/CommonArgs.cpp
+    #   > Reversed (or previously applied) patch detected!  Assume -R? [n]
+    #   > Apply anyway? [n]
+    #   > Skipping patch.
+    #   > 1 out of 1 hunk ignored -- saving rejects to file lib/Driver/ToolChains/CommonArgs.cpp.rej
+    __contentAddressed = false;
+
     buildPhase = ''
       runHook preBuild
 


### PR DESCRIPTION
The placeholder output paths in content-addressed derivations lack the derivation name (NixOS/nix#12361), which breaks the general assumption that we could filter them using said name (e.g. when adjusting patch sets).

This is not really the fault of `replaceVar`, but the combination of it together with a patch seems common enough that we can just work around this here without many unneeded ill effects.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
