### PR TITLE
openvpn3: fix build on latest Linux

### DIFF
--- a/pkgs/by-name/op/openvpn3/package.nix
+++ b/pkgs/by-name/op/openvpn3/package.nix
@@ -40,6 +40,11 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  patches = [
+    # Should be fixed in v26: https://codeberg.org/OpenVPN/openvpn3-linux/issues/70
+    ./v25-latest-linux-fix.patch
+  ];
+
   postPatch = ''
     echo '#define OPENVPN_VERSION "3.git:unknown:unknown"
     #define PACKAGE_GUIVERSION "v${builtins.replaceStrings [ "_" ] [ ":" ] version}"

--- a/pkgs/by-name/op/openvpn3/v25-latest-linux-fix.patch
+++ b/pkgs/by-name/op/openvpn3/v25-latest-linux-fix.patch
@@ -1,0 +1,27 @@
+diff --git a/openvpn3-core/openvpn/dco/ovpn_dco_linux.h b/openvpn3-core/openvpn/dco/ovpn_dco_linux.h
+index 238f71f7a..5b7fe8d8c 100644
+--- a/openvpn3-core/openvpn/dco/ovpn_dco_linux.h
++++ b/openvpn3-core/openvpn/dco/ovpn_dco_linux.h
+@@ -239,22 +239,6 @@ enum ovpn_netlink_packet_attrs {
+ 	OVPN_PACKET_ATTR_MAX = __OVPN_PACKET_ATTR_AFTER_LAST - 1,
+ };
+ 
+-enum ovpn_ifla_attrs {
+-	IFLA_OVPN_UNSPEC = 0,
+-	IFLA_OVPN_MODE,
+-
+-	__IFLA_OVPN_AFTER_LAST,
+-	IFLA_OVPN_MAX = __IFLA_OVPN_AFTER_LAST - 1,
+-};
+-
+-enum ovpn_mode {
+-	__OVPN_MODE_FIRST = 0,
+-	OVPN_MODE_P2P = __OVPN_MODE_FIRST,
+-	OVPN_MODE_MP,
+-
+-	__OVPN_MODE_AFTER_LAST,
+-};
+-
+ /// \endcond
+ 
+ #endif /* _UAPI_LINUX_OVPN_DCO_H_ */


### PR DESCRIPTION
Fixes build of openvpn3 on latest Linux version. Fixes #436147.

This is a patch-based official with the in-tree fix going to appear in v26 of this package (see [upstream issue](https://codeberg.org/OpenVPN/openvpn3-linux/issues/70) for details; root cause being ovpn support [moved to Kernel](https://blog.openvpn.net/openvpn-dco-added-to-linux-kernel-2025) in 6.16).

Thanks to @andrew-isakov for reporting the issue and finding the relevant issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
