### PR TITLE
optnix: 0.2.0 -> 0.3.0

### DIFF
--- a/pkgs/by-name/op/optnix/package.nix
+++ b/pkgs/by-name/op/optnix/package.nix
@@ -5,20 +5,24 @@
   buildGoModule,
   installShellFiles,
   nix-update-script,
+  scdoc,
 }:
 buildGoModule (finalAttrs: {
   pname = "optnix";
-  version = "0.2.0";
+  version = "0.3.0";
   src = fetchFromGitHub {
     owner = "water-sucks";
     repo = "optnix";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CI0D70oP4usQXh39wm2z+s9QKQaaHFB6og3B/VHaAiY=";
+    hash = "sha256-kPCRCnjuKZd6RE5pkQJMYWpexnMyhUy9jrBFSztkiLM=";
   };
 
-  vendorHash = "sha256-/rV21mX6VrJj39M6dBw4ubp6+O47hxeLn0ZcsG6Ujno=";
+  vendorHash = "sha256-g/H91PiHWSRRQOkaobw2wAYX/07DFxWTCTlKzf7BT1Y=";
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+    scdoc
+  ];
 
   env = {
     CGO_ENABLED = 0;
@@ -27,7 +31,7 @@ buildGoModule (finalAttrs: {
 
   buildPhase = ''
     runHook preBuild
-    make all
+    make all man
     runHook postBuild
   '';
 
@@ -35,6 +39,9 @@ buildGoModule (finalAttrs: {
     runHook preInstall
 
     install -Dm755 ./optnix -t $out/bin
+
+    install -Dm755 ./optnix.1 -t $out/share/man/man1
+    install -Dm755 ./optnix.toml.5 -t $out/share/man/man5
 
     runHook postInstall
   '';


### PR DESCRIPTION
Updates `optnix` package to v0.3.0.

Changelog: https://github.com/water-sucks/optnix/compare/v0.2.0...v0.3.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
