### PR TITLE
shira: init at 1.7.1-unstable-2025-08-31

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25506,6 +25506,11 @@
     github = "thefossguy";
     githubId = 44400303;
   };
+  thegu5 = {
+    name = "Gus";
+    github = "thegu5";
+    githubId = 58223632;
+  };
   thehans255 = {
     name = "Hans Jorgensen";
     email = "foss-contact@thehans255.com";

--- a/pkgs/by-name/sh/shira/package.nix
+++ b/pkgs/by-name/sh/shira/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  ffmpeg,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "shira";
+  version = "1.7.1-unstable-2025-08-31";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "KraXen72";
+    repo = "shira";
+    rev = "a7478efa434597324458441f328c1b2f84c04dbc";
+    hash = "sha256-k15GaOmS0rlQBQldnLo1SzIyCkNQux6P5b7ZG2BIa90=";
+  };
+
+  build-system = [
+    python3Packages.flit-core
+  ];
+
+  dependencies = with python3Packages; [
+    click
+    mediafile
+    pillow
+    python-dateutil
+    requests-cache
+    yt-dlp
+    ytmusicapi
+  ];
+
+  makeWrapperArgs = [
+    "--prefix PATH : ${
+      lib.makeBinPath [
+        ffmpeg
+      ]
+    }"
+  ];
+
+  meta = {
+    description = "Download music from YouTube, YouTube Music and Soundcloud";
+    homepage = "https://github.com/KraXen72/shira/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ thegu5 ];
+    mainProgram = "shiradl";
+  };
+}


### PR DESCRIPTION
This adds [shira](https://github.com/KraXen72/shira) (binary name `shiradl`), a program that simplifies downloading music with the correct metadata. I added myself as a maintainer.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
