### PR TITLE
ladybird: fix gpu acceleration

### DIFF
--- a/pkgs/by-name/la/ladybird/package.nix
+++ b/pkgs/by-name/la/ladybird/package.nix
@@ -29,6 +29,7 @@
   unstableGitUpdater,
   apple-sdk_14,
   libtommath,
+  libGL,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -142,6 +143,15 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   passthru.updateScript = unstableGitUpdater { };
+
+  postFixup = ''
+    wrapProgram $out/bin/Ladybird \
+      --set LD_LIBRARY_PATH ${
+        lib.makeLibraryPath [
+          libGL
+        ]
+      }
+  '';
 
   meta = {
     description = "Browser using the SerenityOS LibWeb engine with a Qt or Cocoa GUI";


### PR DESCRIPTION
fixes
```
279079.797 WebContent(2313490): Failed to initialize EGL
ERR: Display.cpp:1079 (initialize): ANGLE Display::initialize error 12289: Could not dlopen native EGL: libEGL.so.1: cannot open shared object file: No such file or directory
ERR: Display.cpp:1079 (initialize): ANGLE Display::initialize error 12289: Could not dlopen native EGL: libEGL.so.1: cannot open shared object file: No such file or directory
279079.797 WebContent(2313490): Failed to initialize EGL
279079.797 WebContent(2313490): (js warn) "WARNING: Falling back to CPU-only rendering. WebGL support not detected."
```
by adding libGL to the library path

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
