### PR TITLE
[25.05] zeal: migrate to pkgs/by-name, use qt6

### DIFF
--- a/pkgs/by-name/ze/zeal/package.nix
+++ b/pkgs/by-name/ze/zeal/package.nix
@@ -6,21 +6,12 @@
   extra-cmake-modules,
   pkg-config,
   httplib,
-  qtbase,
-  qtimageformats,
-  qtwebengine,
-  qtx11extras,
   libarchive,
   libXdmcp,
   libpthreadstubs,
-  wrapQtAppsHook,
   xcbutilkeysyms,
+  qt6,
 }:
-
-let
-  isQt5 = lib.versions.major qtbase.version == "5";
-
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "zeal";
   version = "0.7.2";
@@ -36,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     extra-cmake-modules
     pkg-config
-    wrapQtAppsHook
+    qt6.wrapQtAppsHook
   ];
 
   buildInputs = [
@@ -44,12 +35,11 @@ stdenv.mkDerivation (finalAttrs: {
     libXdmcp
     libarchive
     libpthreadstubs
-    qtbase
-    qtimageformats
-    qtwebengine
+    qt6.qtbase
+    qt6.qtimageformats
+    qt6.qtwebengine
     xcbutilkeysyms
-  ]
-  ++ lib.optionals isQt5 [ qtx11extras ];
+  ];
 
   cmakeFlags = [
     (lib.cmakeBool "ZEAL_RELEASE_BUILD" true)
@@ -68,6 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
       peterhoeg
     ];
     mainProgram = "zeal";
-    inherit (qtbase.meta) platforms;
+    inherit (qt6.qtbase.meta) platforms;
   };
 })

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2117,6 +2117,8 @@ mapAliases {
   z3_4_8 = throw "'z3_4_8' has been removed in favour of the latest version. Use 'z3'."; # Added 2025-05-18
   zabbix50 = throw "'zabbix50' has been removed, it would have reached its End of Life a few days after the release of NixOS 25.05. Consider upgrading to 'zabbix60' or 'zabbix70'.";
   zabbix64 = throw "'zabbix64' has been removed because it reached its End of Life. Consider upgrading to 'zabbix70'.";
+  zeal-qt5 = lib.warnOnInstantiate "'zeal-qt5' has been removed from nixpkgs. Please use 'zeal' instead" zeal; # Added 2025-08-31
+  zeal-qt6 = lib.warnOnInstantiate "'zeal-qt6' has been renamed to 'zeal'" zeal; # Added 2025-08-31
   zeroadPackages = recurseIntoAttrs {
     zeroad = lib.warnOnInstantiate "'zeroadPackages.zeroad' has been renamed to 'zeroad'" zeroad; # Added 2025-03-22
     zeroad-data = lib.warnOnInstantiate "'zeroadPackages.zeroad-data' has been renamed to 'zeroad-data'" zeroad-data; # Added 2025-03-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11922,12 +11922,6 @@ with pkgs;
     inherit (plasma5Packages) breeze-icons;
   };
 
-  zeal-qt5 = libsForQt5.callPackage ../data/documentation/zeal { };
-  zeal = zeal-qt5;
-  zeal-qt6 = qt6Packages.callPackage ../data/documentation/zeal {
-    qtx11extras = null; # Because it does not exist in qt6
-  };
-
   ### APPLICATIONS / GIS
 
   qgis-ltr = callPackage ../applications/gis/qgis/ltr.nix { };


### PR DESCRIPTION
Motivated by qt5.qtwebengine being marked vulnerable (#435067):
- Move package from pkgs/data/documentation to pkgs/by-name/ze/zeal
- Switch from Qt5 to Qt6 as the default
- Remove zeal-qt5 and zeal-qt6 variants in favor of single Qt6 version
- Add aliases for deprecated Qt-specific variants

(cherry picked from commit 0e805d89c1af8e75b872d19916bd9e1586ae56f7)

Manual backport due to conflict: https://github.com/NixOS/nixpkgs/pull/438676#issuecomment-3240978315 (Conflict was on aliases and top-level)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
