### PR TITLE
git-buildpackage: setup passthru.updateScript + 0.9.37 -> 0.9.38 

### DIFF
--- a/pkgs/by-name/gi/git-buildpackage/package.nix
+++ b/pkgs/by-name/gi/git-buildpackage/package.nix
@@ -40,6 +40,8 @@ python3Packages.buildPythonApplication rec {
 
   dependencies = with python3Packages; [
     python-dateutil
+    pyyaml
+    rpm
   ];
 
   pythonImportsCheck = [
@@ -57,8 +59,6 @@ python3Packages.buildPythonApplication rec {
     coverage
     pytest-cov
     pytestCheckHook
-    pyyaml
-    rpm
   ]);
 
   disabledTests = [

--- a/pkgs/by-name/gi/git-buildpackage/package.nix
+++ b/pkgs/by-name/gi/git-buildpackage/package.nix
@@ -1,10 +1,11 @@
 {
   lib,
+  stdenv,
 
   coreutils,
   fetchFromGitHub,
+  nix-update-script,
   python3Packages,
-  stdenv,
 
   # nativeCheckInputs
   debian-devscripts,
@@ -76,6 +77,13 @@ python3Packages.buildPythonApplication rec {
     # [Errno 30] Read-only file system: '/does'
     "tests.doctests.test_GitRepository.test_create_noperm"
   ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "debian/(.*)"
+    ];
+  };
 
   meta = {
     description = "Suite to help with maintaining Debian packages in Git repositories";

--- a/pkgs/by-name/gi/git-buildpackage/package.nix
+++ b/pkgs/by-name/gi/git-buildpackage/package.nix
@@ -17,14 +17,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "git-buildpackage";
-  version = "0.9.37";
+  version = "0.9.38";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "agx";
     repo = "git-buildpackage";
     tag = "debian/${version}";
-    hash = "sha256-0gfryd1GrVfL11u/IrtLSJAABRsTpFfPOGxWfVdYtgE=";
+    hash = "sha256-dZ/uJLcDPkpwIz+Y6WInJ4XlSJ5zzDY65li/xghsJTQ=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
