### PR TITLE
[25.05] maintainers: drop various / fix github handles

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9937,12 +9937,6 @@
     github = "higebu";
     githubId = 733288;
   };
-  hikari = {
-    email = "HikariNee@protonmail.com";
-    github = "HikariNee";
-    githubId = 72349937;
-    name = "Hikari";
-  };
   hirenashah = {
     email = "hiren@hiren.io";
     github = "hirenashah";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4537,11 +4537,6 @@
     githubId = 2245737;
     name = "Christopher Mark Poole";
   };
-  chrpinedo = {
-    github = "chrpinedo";
-    githubId = 2324630;
-    name = "Christian Pinedo";
-  };
   chuahou = {
     email = "human+github@chuahou.dev";
     github = "chuahou";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7258,12 +7258,6 @@
     githubId = 1365692;
     name = "Will Fancher";
   };
-  elysasrc = {
-    name = "Elysa";
-    github = "ElysaSrc";
-    githubId = 101974839;
-    email = "elysasrc@proton.me";
-  };
   emantor = {
     email = "rouven+nixos@czerwinskis.de";
     github = "Emantor";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8732,14 +8732,6 @@
     githubId = 45048741;
     name = "Alwanga Oyango";
   };
-  galaxy = {
-    email = "galaxy@dmc.chat";
-    matrix = "@galaxy:mozilla.org";
-    name = "The Galaxy";
-    github = "ga1aksy";
-    githubId = 148551648;
-    keys = [ { fingerprint = "48CA 3873 9E9F CA8E 76A0  835A E3DE CF85 4212 E1EA"; } ];
-  };
   gale-username = {
     name = "gale";
     email = "git@galewebsite.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5485,7 +5485,7 @@
   dandellion = {
     email = "daniel@dodsorf.as";
     matrix = "@dandellion:dodsorf.as";
-    github = "dali99";
+    github = "D4ndellion";
     githubId = 990767;
     name = "Daniel Olsen";
   };
@@ -5882,7 +5882,7 @@
   declan = {
     name = "Declan Rixon";
     email = "declan.fraser.rixon@gmail.com";
-    github = "DeclanBaggins";
+    github = "MadelineBaggins";
     githubId = 57464835;
   };
   deeengan = {
@@ -7212,7 +7212,7 @@
   ElliottSullingeFarrall = {
     name = "Elliott Sullinge-Farrall";
     email = "elliott.chalford@gmail.com";
-    github = "ElliottSullingeFarrall";
+    github = "elliott-farrall";
     githubId = 108588212;
   };
   elliottvillars = {
@@ -8652,7 +8652,7 @@
   fxttr = {
     name = "Florian Büstgens";
     email = "fb@fx-ttr.de";
-    github = "fxttr";
+    github = "fmarl";
     githubId = 16306293;
   };
   fzakaria = {
@@ -8751,7 +8751,7 @@
   };
   gangaram = {
     email = "Ganga.Ram@tii.ae";
-    github = "gangaram-tii";
+    github = "gngram";
     githubId = 131853076;
     name = "Ganga Ram";
   };
@@ -8770,7 +8770,7 @@
   gardspirito = {
     name = "gardspirito";
     email = "nyxoroso@gmail.com";
-    github = "gardspirito";
+    github = "luna-spirito";
     githubId = 29687558;
   };
   garrison = {
@@ -9044,7 +9044,7 @@
   };
   gilice = {
     email = "gilice@proton.me";
-    github = "gilice";
+    github = "algorithmiker";
     githubId = 104317939;
     name = "gilice";
   };
@@ -12998,7 +12998,7 @@
   };
   kinzoku = {
     email = "kinzoku@the-nebula.xyz";
-    github = "kinzoku-dev";
+    github = "kinzokudev";
     githubId = 140647311;
     name = "Ayman Hamza";
   };
@@ -13797,7 +13797,7 @@
     name = "Jacob LeCoq";
     email = "lecoqjacob@gmail.com";
     githubId = 9278174;
-    github = "bayou-brogrammer";
+    github = "HexSleeves";
     keys = [ { fingerprint = "C505 1E8B 06AC 1776 6875  1B60 93AF DAD0 10B3 CB8D"; } ];
   };
   ledif = {
@@ -14773,7 +14773,7 @@
   };
   ma9e = {
     email = "sean@lfo.team";
-    github = "furrycatherder";
+    github = "sphaugh";
     githubId = 36235154;
     name = "Sean Haugh";
   };
@@ -16232,7 +16232,7 @@
   };
   minizilla = {
     email = "m.billyzaelani@gmail.com";
-    github = "minizilla";
+    github = "smoothprogrammer";
     githubId = 20436235;
     name = "Billy Zaelani Malik";
   };
@@ -16502,7 +16502,7 @@
     name = "Mon Aaraj";
     email = "owo69uwu69@gmail.com";
     matrix = "@mon:tchncs.de";
-    github = "ribosomerocker";
+    github = "subterfugue";
     githubId = 46468162;
   };
   moni = {
@@ -16587,7 +16587,7 @@
   };
   MostafaKhaled = {
     email = "mostafa.khaled.5422@gmail.com";
-    github = "mostafa-khaled775";
+    github = "m04f";
     githubId = 112074172;
     name = "Mostafa Khaled";
   };
@@ -17876,7 +17876,7 @@
   not-my-segfault = {
     email = "michal@tar.black";
     matrix = "@michal:tar.black";
-    github = "not-my-segfault";
+    github = "ihatethefrench";
     githubId = 30374463;
     name = "Michal S.";
   };
@@ -17890,7 +17890,7 @@
   notbandali = {
     name = "Amin Bandali";
     email = "bandali@gnu.org";
-    github = "bandali0";
+    github = "bandali";
     githubId = 1254858;
     keys = [ { fingerprint = "BE62 7373 8E61 6D6D 1B3A  08E8 A21A 0202 4881 6103"; } ];
   };
@@ -18525,7 +18525,7 @@
   };
   ornxka = {
     email = "ornxka@littledevil.sh";
-    github = "ornxka";
+    github = "warmdarksea";
     githubId = 52086525;
     name = "ornxka";
   };
@@ -18733,7 +18733,7 @@
   };
   pagedMov = {
     email = "kylerclay@proton.me";
-    github = "pagedMov";
+    github = "your-github-username";
     githubId = 19557376;
     name = "Kyler Clay";
     keys = [ { fingerprint = "784B 3623 94E7 8F11 0B9D AE0F 56FD CFA6 2A93 B51E"; } ];
@@ -19750,7 +19750,7 @@
   poopsicles = {
     name = "Fumnanya";
     email = "fmowete@outlook.com";
-    github = "poopsicles";
+    github = "dibenzepin";
     githubId = 87488715;
   };
   PopeRigby = {
@@ -20892,7 +20892,7 @@
   };
   rgri = {
     name = "shortcut";
-    github = "rgri";
+    github = "yliceee";
     githubId = 45253749;
   };
   rgrinberg = {
@@ -21217,7 +21217,7 @@
   };
   robertrichter = {
     email = "robert.richter@rrcomtech.com";
-    github = "rrcomtech";
+    github = "judgeNotFound";
     githubId = 50635122;
     name = "Robert Richter";
   };
@@ -21478,7 +21478,7 @@
   };
   rsrohitsingh682 = {
     email = "rsrohitsingh682@gmail.com";
-    github = "rsrohitsingh682";
+    github = "sinrohit";
     githubId = 45477585;
     name = "Rohit Singh";
   };
@@ -22519,7 +22519,7 @@
   };
   shadows_withal = {
     email = "shadows@with.al";
-    github = "shadows-withal";
+    github = "manyinsects";
     githubId = 6445316;
     name = "liv";
   };
@@ -24910,7 +24910,7 @@
   tirex = {
     email = "szymon@kliniewski.pl";
     name = "Szymon Kliniewski";
-    github = "NoneTirex";
+    github = "RealTirex";
     githubId = 26038207;
   };
   tirimia = {
@@ -26375,7 +26375,7 @@
   wenngle = {
     name = "Zeke Stephens";
     email = "zekestephens@gmail.com";
-    github = "wenngle";
+    github = "zekestephens";
     githubId = 63376671;
   };
   wentam = {
@@ -27302,7 +27302,7 @@
   yusdacra = {
     email = "y.bera003.06@protonmail.com";
     matrix = "@yusdacra:nixos.dev";
-    github = "yusdacra";
+    github = "90-008";
     githubId = 19897088;
     name = "Yusuf Bera Ertan";
     keys = [ { fingerprint = "9270 66BD 8125 A45B 4AC4 0326 6180 7181 F60E FCB2"; } ];
@@ -27537,7 +27537,7 @@
   ziguana = {
     name = "Zig Uana";
     email = "git@ziguana.dev";
-    github = "ziguana";
+    github = "nomadic-stare";
     githubId = 45833444;
   };
   zimbatm = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23405,12 +23405,6 @@
     githubId = 16364318;
     name = "Jeffrey Harmon";
   };
-  srghma = {
-    email = "srghma@gmail.com";
-    github = "srghma";
-    githubId = 7573215;
-    name = "Sergei Khoma";
-  };
   srgom = {
     github = "SRGOM";
     githubId = 8103619;

--- a/pkgs/applications/graphics/image_optim/default.nix
+++ b/pkgs/applications/graphics/image_optim/default.nix
@@ -86,7 +86,6 @@ bundlerApp {
     homepage = "https://github.com/toy/image_optim";
     license = licenses.mit;
     maintainers = with maintainers; [
-      srghma
       nicknovitski
     ];
     platforms = platforms.all;

--- a/pkgs/by-name/ca/catppuccin-sddm/package.nix
+++ b/pkgs/by-name/ca/catppuccin-sddm/package.nix
@@ -74,7 +74,6 @@ stdenvNoCC.mkDerivation rec {
     description = "Soothing pastel theme for SDDM";
     homepage = "https://github.com/catppuccin/sddm";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ elysasrc ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/gu/guile-sjson/package.nix
+++ b/pkgs/by-name/gu/guile-sjson/package.nix
@@ -34,7 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "S-expression based json reader/writer for Guile";
     homepage = "https://gitlab.com/dustyweb/guile-sjson";
     license = licenses.lgpl3Plus;
-    maintainers = with maintainers; [ galaxy ];
     platforms = guile.meta.platforms;
   };
 })

--- a/pkgs/by-name/hu/hubstaff/package.nix
+++ b/pkgs/by-name/hu/hubstaff/package.nix
@@ -131,7 +131,6 @@ stdenv.mkDerivation {
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [
       michalrus
-      srghma
     ];
   };
 }

--- a/pkgs/by-name/i3/i3-volume/package.nix
+++ b/pkgs/by-name/i3/i3-volume/package.nix
@@ -54,7 +54,6 @@ stdenv.mkDerivation rec {
       Works with any window manager, such as [i3wm](https://i3wm.org/), [bspwm](https://github.com/baskerville/bspwm), and [KDE](https://kde.org/), as a standalone script, or with statusbars such as [polybar](https://github.com/polybar/polybar), [i3blocks](https://github.com/vivien/i3blocks), [i3status](https://github.com/i3/i3status), and more.
     '';
     homepage = "https://github.com/hastinbe/i3-volume";
-    maintainers = with lib.maintainers; [ srghma ];
     mainProgram = "i3-volume";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/jp/jpeg-archive/package.nix
+++ b/pkgs/by-name/jp/jpeg-archive/package.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation {
     description = "Utilities for archiving photos for saving to long term storage or serving over the web";
     homepage = "https://github.com/danielgtaylor/jpeg-archive";
     license = licenses.mit;
-    maintainers = [ maintainers.srghma ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/ko/konbucase/package.nix
+++ b/pkgs/by-name/ko/konbucase/package.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ryonakano/konbucase";
     description = "Case converting app suitable for coding or typing";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ galaxy ];
     platforms = lib.platforms.linux;
     mainProgram = "konbucase";
   };

--- a/pkgs/by-name/lu/lux/package.nix
+++ b/pkgs/by-name/lu/lux/package.nix
@@ -39,7 +39,6 @@ buildGoModule rec {
     homepage = "https://github.com/iawia002/lux";
     changelog = "https://github.com/iawia002/lux/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ galaxy ];
     mainProgram = "lux";
   };
 }

--- a/pkgs/by-name/sa/safeeyes/package.nix
+++ b/pkgs/by-name/sa/safeeyes/package.nix
@@ -79,7 +79,6 @@ buildPythonApplication rec {
     homepage = "http://slgobinath.github.io/SafeEyes";
     description = "Protect your eyes from eye strain using this simple and beautiful, yet extensible break reminder. A Free and Open Source Linux alternative to EyeLeo";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ srghma ];
     platforms = platforms.linux;
     mainProgram = "safeeyes";
   };

--- a/pkgs/by-name/so/sozi/package.nix
+++ b/pkgs/by-name/so/sozi/package.nix
@@ -37,7 +37,6 @@ appimageTools.wrapType2 {
     homepage = "https://sozi.baierouge.fr/";
     license = lib.licenses.mpl20;
     mainProgram = "sozi";
-    maintainers = with lib.maintainers; [ srghma ];
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/te/textsnatcher/package.nix
+++ b/pkgs/by-name/te/textsnatcher/package.nix
@@ -61,7 +61,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://textsnatcher.rf.gd/";
     changelog = "https://github.com/RajSolai/TextSnatcher/releases/tag/v${finalAttrs.version}";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ galaxy ];
     mainProgram = "com.github.rajsolai.textsnatcher";
     platforms = platforms.linux;
   };

--- a/pkgs/by-name/yo/youtubeuploader/package.nix
+++ b/pkgs/by-name/yo/youtubeuploader/package.nix
@@ -35,7 +35,6 @@ buildGoModule rec {
     homepage = "https://github.com/porjo/youtubeuploader";
     changelog = "https://github.com/porjo/youtubeuploader/releases/tag/v${version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ srghma ];
     mainProgram = "youtubeuploader";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/data/themes/lightly-boehs/default.nix
+++ b/pkgs/data/themes/lightly-boehs/default.nix
@@ -38,7 +38,6 @@ mkDerivation {
     mainProgram = "lightly-settings5";
     homepage = "https://github.com/boehs/Lightly";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.hikari ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/python-modules/curlify/default.nix
+++ b/pkgs/development/python-modules/curlify/default.nix
@@ -23,6 +23,5 @@ buildPythonPackage {
     description = "Convert python requests request object to cURL command";
     homepage = "https://github.com/ofw/curlify";
     license = licenses.mit;
-    maintainers = with maintainers; [ chrpinedo ];
   };
 }

--- a/pkgs/tools/misc/pricehist/default.nix
+++ b/pkgs/tools/misc/pricehist/default.nix
@@ -46,6 +46,5 @@ buildPythonApplication rec {
     homepage = "https://gitlab.com/chrisberkhout/pricehist";
     license = licenses.mit;
     mainProgram = "pricehist";
-    maintainers = with maintainers; [ chrpinedo ];
   };
 }


### PR DESCRIPTION
Manual backport of #437078.

Fixed conflicts and Eval (one additional maintainer entry for hikari had to be removed).

Did not run the same script on this branch again, so there could technically still be deleted / renamed accounts here.