### PR TITLE
gg-jj: patch lockfile to fix mismatched NPM/Cargo versions of Tauri

### DIFF
--- a/pkgs/by-name/gg/gg-jj/package.nix
+++ b/pkgs/by-name/gg/gg-jj/package.nix
@@ -33,9 +33,19 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-AdatJNDqIoRHfaf81iFhOs2JGLIxy7agFJj96bFPj00=";
 
   npmDeps = fetchNpmDeps {
-    inherit (finalAttrs) pname version src;
-    hash = "sha256-izCl3pE15ocEGYOYCUR1iTR+82nDB06Ed4YOGRGByfI=";
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      patches
+      ;
+    hash = "sha256-ehXGLpCCN+BNqtwjEatcfR0kQHj5WOofTDR5mLSVW0U=";
   };
+
+  patches = [
+    # Remove after https://github.com/gulbanana/gg/pull/68 is released
+    ./update-tauri-npm-to-match-cargo.patch
+  ];
 
   nativeBuildInputs = [
     cargo-tauri.hook

--- a/pkgs/by-name/gg/gg-jj/update-tauri-npm-to-match-cargo.patch
+++ b/pkgs/by-name/gg/gg-jj/update-tauri-npm-to-match-cargo.patch
@@ -1,0 +1,81 @@
+From 627de4bd148229a1feb327262b9f0b2a75077ed3 Mon Sep 17 00:00:00 2001
+From: Mitchell Skaggs <skaggsm333@gmail.com>
+Date: Mon, 1 Sep 2025 19:02:19 -0500
+Subject: [PATCH] update `@tauri-apps/api` and `@tauri-apps/plugin-shell` to
+ match Cargo versions
+
+In Tauri *CLI* versions >=2.8.0, the build fails if NPM and Cargo versions
+are not aligned. This is not a new requirement, this merely verifies an
+existing requirement. The CLI version in Nixpkgs was updated and now
+detects this already-existing error.
+
+This pulls the NPM versions up to match the existing Cargo versions
+without touching any other dependencies.
+---
+ package-lock.json | 18 +++++++++---------
+ package.json      |  4 ++--
+ 2 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/package-lock.json b/package-lock.json
+index 3affe19..ebe27e7 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -9,8 +9,8 @@
+       "version": "0.29.0",
+       "dependencies": {
+         "@catppuccin/palette": "^1.0.3",
+-        "@tauri-apps/api": "^2.0.0-beta.0",
+-        "@tauri-apps/plugin-shell": "^2.0.0-beta.0",
++        "@tauri-apps/api": "^2.4.1",
++        "@tauri-apps/plugin-shell": "2.2.1",
+         "feather-icons": "^4.29.1",
+         "modern-normalize": "^2.0.0"
+       },
+@@ -793,9 +793,9 @@
+       }
+     },
+     "node_modules/@tauri-apps/api": {
+-      "version": "2.1.1",
+-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.1.1.tgz",
+-      "integrity": "sha512-fzUfFFKo4lknXGJq8qrCidkUcKcH2UHhfaaCNt4GzgzGaW2iS26uFOg4tS3H4P8D6ZEeUxtiD5z0nwFF0UN30A==",
++      "version": "2.4.1",
++      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.4.1.tgz",
++      "integrity": "sha512-5sYwZCSJb6PBGbBL4kt7CnE5HHbBqwH+ovmOW6ZVju3nX4E3JX6tt2kRklFEH7xMOIwR0btRkZktuLhKvyEQYg==",
+       "license": "Apache-2.0 OR MIT",
+       "funding": {
+         "type": "opencollective",
+@@ -1002,9 +1002,9 @@
+       }
+     },
+     "node_modules/@tauri-apps/plugin-shell": {
+-      "version": "2.0.1",
+-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.0.1.tgz",
+-      "integrity": "sha512-akU1b77sw3qHiynrK0s930y8zKmcdrSD60htjH+mFZqv5WaakZA/XxHR3/sF1nNv9Mgmt/Shls37HwnOr00aSw==",
++      "version": "2.2.1",
++      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.2.1.tgz",
++      "integrity": "sha512-G1GFYyWe/KlCsymuLiNImUgC8zGY0tI0Y3p8JgBCWduR5IEXlIJS+JuG1qtveitwYXlfJrsExt3enhv5l2/yhA==",
+       "license": "MIT OR Apache-2.0",
+       "dependencies": {
+         "@tauri-apps/api": "^2.0.0"
+@@ -2054,4 +2054,4 @@
+       "license": "ISC"
+     }
+   }
+-}
+\ No newline at end of file
++}
+diff --git a/package.json b/package.json
+index 6000620..9d61871 100644
+--- a/package.json
++++ b/package.json
+@@ -14,8 +14,8 @@
+   },
+   "dependencies": {
+     "@catppuccin/palette": "^1.0.3",
+-    "@tauri-apps/api": "^2.0.0-beta.0",
+-    "@tauri-apps/plugin-shell": "^2.0.0-beta.0",
++    "@tauri-apps/api": "^2.4.1",
++    "@tauri-apps/plugin-shell": "2.2.1",
+     "feather-icons": "^4.29.1",
+     "modern-normalize": "^2.0.0"
+   },


### PR DESCRIPTION
After https://github.com/NixOS/nixpkgs/pull/438726 updated `tauri` to >=2.8.0, it now checks for mismatched versions (https://github.com/tauri-apps/tauri/pull/13993) and now fails to build `gg-jj`. This was always a problem, it just wasn't checked until now. This patch bumps the NPM versions to match the newer Cargo versions (since I assume that's preferable to a downgrade).

I struggled a bit to figure out how to properly apply the patch until I read the source of `fetchNpmDeps` since it only documents the `src` and `hash` parameters. Passing `@args` through to the actual derivation is obvious in hindsight :laughing:

This will probably be resolved whenever `gg-jj` gets some new activity since the new CLI will fail their build too. They don't have Issues enabled, but I'll send this patch upstream by itself as a surgical fix.

Maintainer: @pluiedev
Last major change: @alyssais

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
