### PR TITLE
pbc: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26186,6 +26186,11 @@
     githubId = 47905926;
     name = "toyboot4e";
   };
+  tphanir = {
+    github = "tphanir";
+    name = "phani";
+    githubId = 125972587;
+  };
   tpw_rules = {
     name = "Thomas Watson";
     email = "twatson52@icloud.com";

--- a/pkgs/by-name/pb/pbc/package.nix
+++ b/pkgs/by-name/pb/pbc/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  gmp,
+  flex,
+  bison,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pbc";
+  version = "1.0.0";
+
+  src = fetchurl {
+    url = "https://crypto.stanford.edu/pbc/files/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    hash = "sha256-GCdaNnKDB3uv419EMgBJnjsZxKN1SVPaKhsvDWtZItw=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  buildInputs = [
+    gmp
+  ];
+  nativeBuildInputs = [
+    bison
+    flex
+  ];
+
+  strictDeps = true;
+
+  env = {
+    LEX = "flex";
+    LEXLIB = "-lfl";
+    ac_cv_lib_fl_yywrap = "yes";
+  };
+
+  meta = {
+    description = "Pairing-based cryptography library by Stanford";
+    homepage = "https://crypto.stanford.edu/pbc/";
+    license = with lib.licenses; [
+      lgpl3Only
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ tphanir ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds the Pairing-Based Cryptography (PBC) library by Stanford. It's a C library for pairing-based cryptosystems widely used in cryptography research and applications.

Also adds myself to the maintainers list.

Things done

Built on platform:
[x] x86_64-linux
[ ] aarch64-linux
[ ] x86_64-darwin
[ ] aarch64-darwin

Tested, as applicable:
[x] Built with nix-build
[x] Linked successfully with a sample C program including the library
[ ] Ran nixpkgs-review