### PR TITLE
util-linux: use `systemdLibs`, minor cleanup

### DIFF
--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -21,6 +21,7 @@
   pam,
   systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
   systemd,
+  systemdLibs,
   sqlite,
   nlsSupport ? true,
   translateManpages ? true,
@@ -164,7 +165,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals pamSupport [ pam ]
   ++ lib.optionals capabilitiesSupport [ libcap_ng ]
   ++ lib.optionals ncursesSupport [ ncurses ]
-  ++ lib.optionals systemdSupport [ systemd ];
+  ++ lib.optionals systemdSupport [ systemdLibs ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -37,12 +37,12 @@
 let
   isMinimal = cryptsetupSupport == false && !nlsSupport && !ncursesSupport && !systemdSupport;
 in
-stdenv.mkDerivation (finalPackage: rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "util-linux" + lib.optionalString isMinimal "-minimal";
   version = "2.41.1";
 
   src = fetchurl {
-    url = "mirror://kernel/linux/utils/util-linux/v${lib.versions.majorMinor version}/util-linux-${version}.tar.xz";
+    url = "mirror://kernel/linux/utils/util-linux/v${lib.versions.majorMinor finalAttrs.version}/util-linux-${finalAttrs.version}.tar.xz";
     hash = "sha256-vprZonb0MFq33S9SJci+H/VDUvVl/03t6WKMGqp97Fc=";
   };
 
@@ -231,7 +231,7 @@ stdenv.mkDerivation (finalPackage: rec {
   meta = {
     homepage = "https://www.kernel.org/pub/linux/utils/util-linux/";
     description = "Set of system utilities for Linux";
-    changelog = "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v${lib.versions.majorMinor version}/v${version}-ReleaseNotes";
+    changelog = "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v${lib.versions.majorMinor finalAttrs.version}/v${finalAttrs.version}-ReleaseNotes";
     # https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/tree/README.licensing
     license = with lib.licenses; [
       gpl2Only


### PR DESCRIPTION
I was investigating why `systemd` was required in a Home Manager profile when I found out that `util-linux` was requiring it.

This PR is a proposal, similar to https://github.com/NixOS/nixpkgs/pull/433641

Feel free to let me know what you think.

Here's the closure size after/before:

```
❯ nix path-info -Sh ./result-bin
/nix/store/qx5wjl2d6bpy82vwkvv9hfm3nfbsm44r-util-linux-2.41.1-bin         88.1 MiB
❯ jj new master
❯ nix-build -A util-linux
/nix/store/ad5skbqn01fbmgwd0b879zy5x5skgxj1-util-linux-2.41.1-bin
❯ nix path-info -Sh ./result-bin
/nix/store/ad5skbqn01fbmgwd0b879zy5x5skgxj1-util-linux-2.41.1-bin        206.7 MiB
```

On top of that, this PR make a very minor cleanup in the `postInstall` attribute, regrouping lines that are meant to be together, making it easier to read.

Lastly, it also fixes the use of the `finalAttrs` pattern, there's no need to use `rec` when using it. 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
