### PR TITLE
python3Packages.uv-dynamic-versioning: add setup hook

### DIFF
--- a/pkgs/development/python-modules/dicomweb-client/default.nix
+++ b/pkgs/development/python-modules/dicomweb-client/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   pythonOlder,
   hatchling,
+  uv-dynamic-versioning,
   pytestCheckHook,
   pytest-localserver,
   numpy,
@@ -25,14 +26,9 @@ buildPythonPackage rec {
     hash = "sha256-ZxeZiCw8I5+Bf266PQ6WQA8mBRC7K3/kZrmuW4l6kQU=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail ', "uv-dynamic-versioning"' "" \
-      --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
-  '';
-
   build-system = [
     hatchling
+    uv-dynamic-versioning
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/fastmcp/default.nix
+++ b/pkgs/development/python-modules/fastmcp/default.nix
@@ -7,6 +7,7 @@
 
   # build-system
   hatchling,
+  uv-dynamic-versioning,
 
   # dependencies
   authlib,
@@ -42,14 +43,9 @@ buildPythonPackage rec {
     hash = "sha256-jIXrMyNnyPE2DUgg+sxT6LD4dTmKQglh4cFuaw179Z0=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail ', "uv-dynamic-versioning>=0.7.0"' "" \
-      --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
-  '';
-
   build-system = [
     hatchling
+    uv-dynamic-versioning
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/mcp/default.nix
+++ b/pkgs/development/python-modules/mcp/default.nix
@@ -6,6 +6,7 @@
 
   # build-system
   hatchling,
+  uv-dynamic-versioning,
 
   # dependencies
   anyio,
@@ -50,12 +51,7 @@ buildPythonPackage rec {
     hash = "sha256-CxrUGgQfU1R87D3ZzZCHbQBMIOJRneH6CLbHS62sCaY=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail ', "uv-dynamic-versioning"' "" \
-      --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
-  ''
-  + lib.optionalString stdenv.buildPlatform.isDarwin ''
+  postPatch = lib.optionalString stdenv.buildPlatform.isDarwin ''
     # time.sleep(0.1) feels a bit optimistic and it has been flaky whilst
     # testing this on macOS under load.
     substituteInPlace \
@@ -67,7 +63,10 @@ buildPythonPackage rec {
       --replace-fail "time.sleep(0.1)" "time.sleep(1)"
   '';
 
-  build-system = [ hatchling ];
+  build-system = [
+    hatchling
+    uv-dynamic-versioning
+  ];
 
   pythonRelaxDeps = [
     "pydantic-settings"

--- a/pkgs/development/python-modules/uv-dynamic-versioning/default.nix
+++ b/pkgs/development/python-modules/uv-dynamic-versioning/default.nix
@@ -57,6 +57,8 @@ buildPythonPackage rec {
     writableTmpDirAsHomeHook
   ];
 
+  setupHook = ./setup-hook.sh;
+
   meta = {
     description = "Dynamic versioning based on VCS tags for uv/hatch project";
     homepage = "https://github.com/ninoseki/uv-dynamic-versioning";

--- a/pkgs/development/python-modules/uv-dynamic-versioning/setup-hook.sh
+++ b/pkgs/development/python-modules/uv-dynamic-versioning/setup-hook.sh
@@ -1,0 +1,8 @@
+uv-version-pretend-hook() {
+  echo "Setting UV_DYNAMIC_VERSIONING_BYPASS to $version"
+  export UV_DYNAMIC_VERSIONING_BYPASS=$version
+}
+
+if [ -z "${dontBypassUvDynamicVersioning-}" ]; then
+  preBuildHooks+=(uv-version-pretend-hook)
+fi


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is the same thing that poetry-dynamic-versioning does

https://github.com/NixOS/nixpkgs/blob/6cfbaf0be9248c3695d09f6bb949426ce8a1f1c8/pkgs/development/python-modules/poetry-dynamic-versioning/setup-hook.sh#L1-L8

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
