### PR TITLE
nodejs: fix hydra darwin builds

### DIFF
--- a/pkgs/development/web/nodejs/gyp-patches.nix
+++ b/pkgs/development/web/nodejs/gyp-patches.nix
@@ -1,13 +1,19 @@
 {
   lib,
+  stdenv,
   fetchpatch2,
   patch_npm ? true,
   patch_tools ? true,
+  patch_npm_catch_oserror ? patch_npm,
+  patch_tools_catch_oserror ? patch_tools,
+  patch_npm_regex_handling ? patch_npm && stdenv.buildPlatform.isDarwin,
+  patch_tools_regex_handling ? patch_tools && stdenv.buildPlatform.isDarwin,
 }:
 let
   url = "https://github.com/nodejs/gyp-next/commit/8224deef984add7e7afe846cfb82c9d3fa6da1fb.patch?full_index=1";
+  url_regex_handling = "https://github.com/nodejs/gyp-next/commit/b21ee3150eea9fc1a8811e910e5ba64f42e1fb77.patch?full_index=1";
 in
-lib.optionals patch_tools ([
+lib.optionals patch_tools_catch_oserror ([
   # Fixes builds with Nix sandbox on Darwin for gyp.
   (fetchpatch2 {
     inherit url;
@@ -16,10 +22,27 @@ lib.optionals patch_tools ([
     extraPrefix = "tools/gyp/";
   })
 ])
-++ lib.optionals patch_npm ([
+++ lib.optionals patch_npm_catch_oserror ([
   (fetchpatch2 {
     inherit url;
     hash = "sha256-cXTwmCRHrNhuY1+3cD/EvU0CJ+1Nk4TRh6c3twvfaW8=";
+    stripLen = 1;
+    extraPrefix = "deps/npm/node_modules/node-gyp/gyp/";
+  })
+])
+++ lib.optionals patch_tools_regex_handling ([
+  # Fixes builds with Nix sandbox on Darwin for gyp.
+  (fetchpatch2 {
+    url = url_regex_handling;
+    hash = "sha256-xDZO8GgZLPvCeTrCu6RVVFV5bmbuz9UPgHiaAJE6im0=";
+    stripLen = 1;
+    extraPrefix = "tools/gyp/";
+  })
+])
+++ lib.optionals patch_npm_regex_handling ([
+  (fetchpatch2 {
+    url = url_regex_handling;
+    hash = "sha256-fW5kQh+weCK0g3wzTJLZgAuXxetb14UAf6yxW6bIgbU=";
     stripLen = 1;
     extraPrefix = "deps/npm/node_modules/node-gyp/gyp/";
   })

--- a/pkgs/development/web/nodejs/v24.nix
+++ b/pkgs/development/web/nodejs/v24.nix
@@ -17,7 +17,7 @@ let
 
   gypPatches =
     if stdenv.buildPlatform.isDarwin then
-      callPackage ./gyp-patches.nix { patch_tools = false; }
+      callPackage ./gyp-patches.nix { patch_tools_catch_oserror = false; }
       ++ [
         ./gyp-patches-set-fallback-value-for-CLT.patch
       ]


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Should fix https://hydra.nixos.org/build/306435782.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
