### PR TITLE
refind: install man pages

### DIFF
--- a/pkgs/by-name/re/refind/package.nix
+++ b/pkgs/by-name/re/refind/package.nix
@@ -9,6 +9,7 @@
   withSbsigntool ? false, # currently, cross compiling sbsigntool is broken, so default to false
   sbsigntool,
   makeWrapper,
+  installShellFiles,
 }:
 
 let
@@ -45,6 +46,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-99k86A2na4bFZygeoiW2qHkHzob/dyM8k1elIsEVyPA=";
   };
 
+  outputs = [
+    "out"
+    "man"
+  ];
+
   patches = [
     # Removes hardcoded toolchain for aarch64, allowing successful aarch64 builds.
     ./0001-toolchain.patch
@@ -53,7 +59,11 @@ stdenv.mkDerivation rec {
     ./0002-preserve-dates.patch
   ];
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+    installShellFiles
+  ];
+
   buildInputs = [ gnu-efi_3 ];
 
   hardeningDisable = [ "stackprotector" ];
@@ -111,6 +121,7 @@ stdenv.mkDerivation rec {
     # docs
     install -D -m0644 docs/refind/* $out/share/refind/docs/html/
     install -D -m0644 docs/Styles/* $out/share/refind/docs/Styles/
+    installManPage docs/man/*.8
     install -D -m0644 README.txt $out/share/refind/docs/README.txt
     install -D -m0644 NEWS.txt $out/share/refind/docs/NEWS.txt
     install -D -m0644 BUILDING.txt $out/share/refind/docs/BUILDING.txt


### PR DESCRIPTION
rEFInd [does have man pages](https://man.archlinux.org/man/refind-install.8), but they were not installed. This PR adds a `man` output to `pkgs.refind`, and installs those man pages to it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
