### PR TITLE
android-translation-layer: 0-unstable-2025-07-14 -> 0-unstable-2025-08-06

### DIFF
--- a/pkgs/by-name/an/android-translation-layer/add-gio-unix-dep.patch
+++ b/pkgs/by-name/an/android-translation-layer/add-gio-unix-dep.patch
@@ -1,13 +1,13 @@
 diff --git a/meson.build b/meson.build
-index 8f525118..658cd9e5 100644
+index ba8027c2..fb21e317 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -178,7 +178,7 @@ libtranslationlayer_so = shared_library('translation_layer_main', [
+@@ -171,7 +171,7 @@ libtranslationlayer_so = shared_library('translation_layer_main', [
                                                                          extra_deps,
                                                                    	dependency('gtk4', version: '>=4.14'), dependency('gl'), dependency('egl'), dependency('wayland-client'), dependency('jni'),
                                                                    	dependency('libportal'), dependency('sqlite3'), dependency('libavcodec', version: '>=59'), dependency('libdrm'),
 -                                                                  	dependency('gudev-1.0'), dependency('libswscale'), dependency('webkitgtk-6.0'),
 +                                                                  	dependency('gudev-1.0'), dependency('libswscale'), dependency('webkitgtk-6.0'), dependency('gio-unix-2.0'),
-                                                                   	libandroidfw_dep, wayland_protos_dep
+                                                                         libart_dep, wayland_protos_dep
                                                                    ],
                                                                    link_with: [ libandroid_so ],

--- a/pkgs/by-name/an/android-translation-layer/configure-art-path.patch
+++ b/pkgs/by-name/an/android-translation-layer/configure-art-path.patch
@@ -1,25 +1,26 @@
 diff --git a/meson.build b/meson.build
-index 8f525118..c1761a2d 100644
+index 8f525118..ba8027c2 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -11,8 +11,8 @@ dir_base = meson.current_source_dir()
+@@ -9,22 +9,15 @@ add_project_dependencies(incdir_dep, language: 'c')
+ cc = meson.get_compiler('c')
+ dir_base = meson.current_source_dir()
  builddir_base = meson.current_build_dir()
- # FIXME: make art install a pkgconfig file
- libart_dep = [
+-# FIXME: make art install a pkgconfig file
+-libart_dep = [
 -	cc.find_library('art', dirs : [ '/usr' / get_option('libdir') / 'art', '/usr/local' / get_option('libdir') / 'art', get_option('prefix') / get_option('libdir') / 'art' ]),
 -     	cc.find_library('nativebridge', dirs : [ '/usr' / get_option('libdir') / 'art', '/usr/local' / get_option('libdir') / 'art', get_option('prefix') / get_option('libdir') / 'art' ])
-+	cc.find_library('art', dirs : [ '/usr' / get_option('libdir') / 'art', '/usr/local' / get_option('libdir') / 'art', get_option('prefix') / get_option('libdir') / 'art', '@artStandalonePackageDir@' / get_option('libdir') / 'art' ]),
-+     	cc.find_library('nativebridge', dirs : [ '/usr' / get_option('libdir') / 'art', '/usr/local' / get_option('libdir') / 'art', get_option('prefix') / get_option('libdir') / 'art', '@artStandalonePackageDir@' / get_option('libdir') / 'art' ])
- ]
+-]
++libart_dep = dependency('art-standalone')
  libdl_bio_dep = [
  	cc.find_library('dl_bio')
-@@ -21,10 +21,10 @@ libc_bio_dep = [
+ ]
+ libc_bio_dep = [
  	cc.find_library('c_bio')
  ]
- libandroidfw_dep = [
+-libandroidfw_dep = [
 -	cc.find_library('androidfw', dirs : [ '/usr' / get_option('libdir') / 'art', '/usr/local' / get_option('libdir') / 'art', get_option('prefix') / get_option('libdir') / 'art' ]),
-+	cc.find_library('androidfw', dirs : [ '/usr' / get_option('libdir') / 'art', '/usr/local' / get_option('libdir') / 'art', get_option('prefix') / get_option('libdir') / 'art', '@artStandalonePackageDir@' / 'lib' / 'art' ]),
- ]
+-]
 -if fs.is_file('/usr' / get_option('libdir') / 'java/core-all_classes.jar')
 -  bootclasspath_dir = '/usr' / get_option('libdir') / 'java'
 +if fs.is_file('@artStandalonePackageDir@' / get_option('libdir') / 'java/core-all_classes.jar')
@@ -27,3 +28,12 @@ index 8f525118..c1761a2d 100644
  elif fs.is_file('/usr/local' / get_option('libdir') / 'java/core-all_classes.jar')
    bootclasspath_dir = '/usr/local' / get_option('libdir') / 'java'
  elif fs.is_file(get_option('prefix') / get_option('libdir') / 'java/core-all_classes.jar')
+@@ -179,7 +172,7 @@ libtranslationlayer_so = shared_library('translation_layer_main', [
+                                                                   	dependency('gtk4', version: '>=4.14'), dependency('gl'), dependency('egl'), dependency('wayland-client'), dependency('jni'),
+                                                                   	dependency('libportal'), dependency('sqlite3'), dependency('libavcodec', version: '>=59'), dependency('libdrm'),
+                                                                   	dependency('gudev-1.0'), dependency('libswscale'), dependency('webkitgtk-6.0'),
+-                                                                  	libandroidfw_dep, wayland_protos_dep
++                                                                        libart_dep, wayland_protos_dep
+                                                                   ],
+                                                                   link_with: [ libandroid_so ],
+                                                                   link_args: [

--- a/pkgs/by-name/an/android-translation-layer/package.nix
+++ b/pkgs/by-name/an/android-translation-layer/package.nix
@@ -29,13 +29,13 @@
 
 stdenv.mkDerivation {
   pname = "android-translation-layer";
-  version = "0-unstable-2025-07-14";
+  version = "0-unstable-2025-08-06";
 
   src = fetchFromGitLab {
     owner = "android_translation_layer";
     repo = "android_translation_layer";
-    rev = "828f779c4f7170f608047c500d6d3b64b480df7f";
-    hash = "sha256-1KYZWlzES3tbskqvA8qSQCegE0uLTLCq4q2CX6uix4o=";
+    rev = "d52985a6df81d73a8f6dfbdee337f7ff90b724cb";
+    hash = "sha256-fJ8S04YucoCzHiIQdiQd+Il0YGNFsOkSiGWjZKNMTIM=";
   };
 
   patches = [

--- a/pkgs/by-name/an/android-translation-layer/package.nix
+++ b/pkgs/by-name/an/android-translation-layer/package.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation {
   };
 
   patches = [
+    # meson: use pkg-config from art-standalone instead of manual library search
+    # See: https://gitlab.com/android_translation_layer/android_translation_layer/-/merge_requests/164
     (replaceVars ./configure-art-path.patch {
       artStandalonePackageDir = "${art-standalone}";
     })

--- a/pkgs/by-name/an/android-translation-layer/package.nix
+++ b/pkgs/by-name/an/android-translation-layer/package.nix
@@ -25,6 +25,7 @@
   makeWrapper,
   replaceVars,
   nixosTests,
+  bintools,
 }:
 
 stdenv.mkDerivation {
@@ -86,7 +87,8 @@ stdenv.mkDerivation {
 
   postFixup = ''
     wrapProgram $out/bin/android-translation-layer \
-      --prefix LD_LIBRARY_PATH : ${art-standalone}/lib/art
+      --prefix LD_LIBRARY_PATH : ${art-standalone}/lib/art \
+      --prefix PATH : ${lib.makeBinPath [ bintools ]}
   '';
 
   passthru.tests = {

--- a/pkgs/by-name/ar/art-standalone/package.nix
+++ b/pkgs/by-name/ar/art-standalone/package.nix
@@ -35,6 +35,10 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # Do not hardocde addr2line binary path
     ./no-hardcode-path-addr2line.patch
+
+    # Add support for pkg-config
+    # See: https://gitlab.com/android_translation_layer/art_standalone/-/merge_requests/37
+    ./pkg-config-support.patch
   ];
 
   postPatch = ''

--- a/pkgs/by-name/ar/art-standalone/package.nix
+++ b/pkgs/by-name/ar/art-standalone/package.nix
@@ -72,6 +72,14 @@ stdenv.mkDerivation (finalAttrs: {
       configureFlags = oldAttrs.configureFlags ++ [
         "--enable-jni"
       ];
+      # Disable failing tests when jni enabled
+      postPatch = oldAttrs.postPatch or "" + ''
+        sed -i '/TEST_DECL(test_wolfSSL_Tls13_ECH)/d;
+                /TEST_DECL(test_wolfSSL_Tls13_ECH_HRR)/d;
+                /TEST_DECL(test_TLSX_CA_NAMES_bad_extension)/d' tests/api.c
+        sed -i '/quic/d' tests/include.am
+        sed -i '300,305d' tests/unit.c
+      '';
     }))
     xz
     zlib

--- a/pkgs/by-name/ar/art-standalone/pkg-config-support.patch
+++ b/pkgs/by-name/ar/art-standalone/pkg-config-support.patch
@@ -1,0 +1,45 @@
+diff --git a/Makefile b/Makefile
+index 42df5b18..3321adae 100644
+--- a/Makefile
++++ b/Makefile
+@@ -32,6 +32,8 @@ ____dalvikvm_bin_64 := $(____TOPDIR)/out/host/linux-x86/bin/dalvikvm64
+ __RPATH_BIN := \$${ORIGIN}/../$(____LIBDIR)/art/:\$${ORIGIN}/../$(____LIBDIR)/java/dex/art/natives
+ __RPATH_LIB := \$${ORIGIN}
+ 
++__VERSION ?= 0.0.0
++
+ # Jack compiler was google's first attempt at a solution for desugaring Java 8 and newer bytecode into bytecode compatible with older dex file formats.
+ # Thankfully, google realized that this was a bad idea, and in a typical google fashion, axed the project.
+ # They experimented with other approaches, but currently (2022) the way to do this is to use d8/r8 instead of dx;
+@@ -112,6 +114,15 @@ install:
+ # our stable C API for libandroidfw, used by ATL
+ 	install -Dt $(____INSTALL_INCLUDEDIR)/androidfw $(____TOPDIR)/libandroidfw/include/androidfw/androidfw_c_api.h
+ 
++	# install pkg-config file
++	mkdir -p $(____INSTALL_LIBDIR)/pkgconfig
++	sed -e 's|@prefix@|$(____PREFIX)|g' \
++	    -e 's|@libdir@|$(____LIBDIR)|g' \
++	    -e 's|@includedir@|$(____INCLUDEDIR)|g' \
++	    -e 's|@version@|$(__VERSION)|g' \
++	    art-standalone.pc.in > $(____INSTALL_LIBDIR)/pkgconfig/art-standalone.pc
++
++
+ # TODO: figure out sharing dependencies and have this in a separate repo
+ install_adbd:
+ 	install -Dt $(____INSTALL_BINDIR) $(____TOPDIR)/out/host/linux-x86/bin/adbd
+diff --git a/art-standalone.pc.in b/art-standalone.pc.in
+new file mode 100644
+index 00000000..210cd031
+--- /dev/null
++++ b/art-standalone.pc.in
+@@ -0,0 +1,10 @@
++prefix=@prefix@
++exec_prefix=${prefix}
++libdir=${prefix}/@libdir@
++includedir=${prefix}/@includedir@
++
++Name: art-standalone
++Description: Android ART runtime (standalone build, minimal ATL deps)
++Version: @version@
++Libs: -L${libdir}/art -lart -lnativebridge -landroidfw
++Cflags: -I${includedir} -I${includedir}/androidfw


### PR DESCRIPTION
Changes: https://gitlab.com/android_translation_layer/android_translation_layer/-/compare/828f779c4f7170f608047c500d6d3b64b480df7f...d52985a6df81d73a8f6dfbdee337f7ff90b724cb?from_project_id=23475119

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
