### PR TITLE
josm: 19423 -> 19439, fix update script

### DIFF
--- a/pkgs/by-name/jo/josm/package.nix
+++ b/pkgs/by-name/jo/josm/package.nix
@@ -11,20 +11,20 @@
 }:
 let
   pname = "josm";
-  version = "19423";
+  version = "19439";
   srcs = {
     jar = fetchurl {
       url = "https://josm.openstreetmap.de/download/josm-snapshot-${version}.jar";
-      hash = "sha256-s8aMV31NsDFE5XLP523PH3RNvq78eTAa+UvmjyY5a+E=";
+      hash = "sha256-EuboKKNpApYlh9b78oB5AbtOM38oMe3NEa4fovA78Uk=";
     };
     macosx = fetchurl {
       url = "https://josm.openstreetmap.de/download/macosx/josm-macos-${version}-java21.zip";
-      hash = "sha256-8eps1eTUn9FHHYwECH/742PV7wnnRO08dlZmaxd1aZU=";
+      hash = "sha256-b38Xd0qx0ceNtJ5UIWDJkGOvaHSB/46onPbd6LJ6siY=";
     };
     pkg = fetchsvn {
       url = "https://josm.openstreetmap.de/svn/trunk/native/linux/tested";
       rev = version;
-      hash = "sha256-4mK+IdVRDhINJqzOovw7YPNiJmFxTCIfYVNMXKSdBv0=";
+      hash = "sha256-9YTSX4chUxijtJ7a1pLE2kYo9hdOB/8vnnfFqMeXKbE=";
     };
   };
 

--- a/pkgs/by-name/jo/josm/update.sh
+++ b/pkgs/by-name/jo/josm/update.sh
@@ -11,7 +11,7 @@ version="$(curl https://josm.openstreetmap.de/apt/pool/universe/j/josm/ |
   sort -n |
   tail -n1)"
 
-pkgHash="$(nurl -H https://github.com/JOSM/josm "$version-tested")"
+pkgHash="$(nurl -f fetchsvn -H https://josm.openstreetmap.de/svn/trunk/native/linux/tested "$version")"
 
 update-source-version josm "$version" --source-key=srcs.jar
 update-source-version josm "$version" --ignore-same-version --source-key=srcs.macosx


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
