### PR TITLE
bmake: interrupt test fails on x86_64-linux some of the time

### DIFF
--- a/pkgs/by-name/bm/bmake/package.nix
+++ b/pkgs/by-name/bm/bmake/package.nix
@@ -53,22 +53,17 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Disabled tests:
+  # * cmd-interrupt: tries to `SIGINT` make itself, flaky as a result
   # * directive-export{,-gmake}: another failure related to TZ variables
   # * opt-keep-going-indirect: not yet known
-  # * varmod-localtime: musl doesn't support TZDIR and this test relies on
-  #   impure, implicit paths
-  # * interrupt-compat (fails on x86_64-linux building for i686-linux)
-  env.BROKEN_TESTS = lib.concatStringsSep " " (
-    [
-      "directive-export"
-      "directive-export-gmake"
-      "opt-keep-going-indirect"
-      "varmod-localtime"
-    ]
-    ++ lib.optionals stdenv.targetPlatform.is32bit [
-      "interrupt-compat"
-    ]
-  );
+  # * varmod-localtime: musl doesn't support TZDIR and this test relies on impure, implicit paths
+  env.BROKEN_TESTS = lib.concatStringsSep " " [
+    "cmd-interrupt"
+    "directive-export"
+    "directive-export-gmake"
+    "opt-keep-going-indirect"
+    "varmod-localtime"
+  ];
 
   strictDeps = true;
 


### PR DESCRIPTION
It's not core to the way that `bmake` is used in Nixpkgs; let's turn it off.

This was previously proposed in https://github.com/NixOS/nixpkgs/commit/269f0be9ee6682bd5665a90faf03a2b6dd179b23, part of the Nix 2.31.0 PR, but @trofi [convinced me](https://github.com/NixOS/nixpkgs/pull/426289#issuecomment-3242381951) that it should be universally turned off.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test