### PR TITLE
some: put NIX_CFLAGS_COMPILE under env to fix withCFlags

### DIFF
--- a/pkgs/by-name/sc/screen/package.nix
+++ b/pkgs/by-name/sc/screen/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   ];
 
   # We need _GNU_SOURCE so that mallocmock_reset() is defined: https://savannah.gnu.org/bugs/?66416
-  NIX_CFLAGS_COMPILE = "-D_GNU_SOURCE=1 -Wno-int-conversion -Wno-incompatible-pointer-types";
+  env.NIX_CFLAGS_COMPILE = "-D_GNU_SOURCE=1 -Wno-int-conversion -Wno-incompatible-pointer-types";
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/development/interpreters/python/pypy/default.nix
+++ b/pkgs/development/interpreters/python/pypy/default.nix
@@ -120,14 +120,16 @@ stdenv.mkDerivation rec {
   dontPatchShebangs = true;
   disallowedReferences = [ python ];
 
-  # fix compiler error in curses cffi module, where char* != const char*
-  NIX_CFLAGS_COMPILE =
-    if stdenv.cc.isClang then "-Wno-error=incompatible-function-pointer-types" else null;
-  C_INCLUDE_PATH = lib.makeSearchPathOutput "dev" "include" buildInputs;
-  LIBRARY_PATH = lib.makeLibraryPath buildInputs;
-  LD_LIBRARY_PATH = lib.makeLibraryPath (
-    builtins.filter (x: x.outPath != stdenv.cc.libc.outPath or "") buildInputs
-  );
+  env = {
+    # fix compiler error in curses cffi module, where char* != const char*
+    NIX_CFLAGS_COMPILE =
+      if stdenv.cc.isClang then "-Wno-error=incompatible-function-pointer-types" else null;
+    C_INCLUDE_PATH = lib.makeSearchPathOutput "dev" "include" buildInputs;
+    LIBRARY_PATH = lib.makeLibraryPath buildInputs;
+    LD_LIBRARY_PATH = lib.makeLibraryPath (
+      builtins.filter (x: x.outPath != stdenv.cc.libc.outPath or "") buildInputs
+    );
+  };
 
   patches = [
     ./dont_fetch_vendored_deps.patch


### PR DESCRIPTION
see https://github.com/NixOS/nixpkgs/pull/438709

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
