### PR TITLE
acct: repair buffer overflow with dump-acct

### DIFF
--- a/pkgs/by-name/ac/acct/package.nix
+++ b/pkgs/by-name/ac/acct/package.nix
@@ -2,6 +2,7 @@
   fetchurl,
   lib,
   stdenv,
+  fetchpatch2,
 }:
 
 stdenv.mkDerivation rec {
@@ -14,6 +15,13 @@ stdenv.mkDerivation rec {
   };
 
   doCheck = true;
+
+  patches = [
+    (fetchpatch2 {
+      url = "https://src.fedoraproject.org/rpms/psacct/raw/rawhide/f/psacct-6.6.4-sprintf-buffer-overflow.patch";
+      hash = "sha256-l74tLIuhpXj+dIA7uAY9L0qMjQ2SbDdc+vjHMyVouFc=";
+    })
+  ];
 
   meta = {
     description = "GNU Accounting Utilities, login and process accounting utilities";


### PR DESCRIPTION
The failure is encountered when doing like
```bash
$ sudo mkdir -p /var/log/account;
$ sudo touch /var/log/account/pacct;
$ nix build 'github:nixos/nixpkgs#acct' -o ./result-acct;
$ sudo ./result-acct/bin/accton on; # writing to /var/log/account/pacct
$ sudo ./result-acct/bin/dump-acct /var/log/account/pacct;
*** buffer overflow detected ***: terminated
[1]    37428 abort      sudo dump-acct /var/log/account/pacct
```
and is apparently rooted in FORTIFY_SOURCE_3. I found out that Gentoo users had already hit and reported this [1] but they found that Fedora users had already hit, reported, and fixed this [2]. So, I'm bringing in Fedora's patch.

[1] - https://bugs.gentoo.org/925419#c14
[2] - https://bugzilla.redhat.com/show_bug.cgi?id=2190057


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Built and ran on `x86_64-linux`:
```bash
$ ./result/bin/dump-acct /var/log/account/pacct | head -n 1
accton          |v3|     0.00|     0.00|     0.00|     0|     0|  2496.00|     0.00|    8260|    8259|S    |       0|pts/2   |Mon Sep  1 09:02:45 2025
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
