### PR TITLE
ci/eval/compare: add 10.rebuild-nixos-tests label

### DIFF
--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -103,9 +103,15 @@ let
           // lib.mapAttrs' (
             kernel: rebuilds: lib.nameValuePair "10.rebuild-${kernel}-stdenv" (lib.elem "stdenv" rebuilds)
           ) rebuildsByKernel
-          # Set the "11.by: package-maintainer" label to whether all packages directly
-          # changed are maintained by the PR's author.
           // {
+            "10.rebuild-nixos-tests" =
+              lib.elem "nixosTests.simple" (extractPackageNames diffAttrs.rebuilds)
+              &&
+                # Only set this label when no other label with indication for staging has been set.
+                # This avoids confusion whether to target staging or batch this with kernel updates.
+                lib.last (lib.sort lib.lessThan (lib.attrValues rebuildCountByKernel)) <= 500;
+            # Set the "11.by: package-maintainer" label to whether all packages directly
+            # changed are maintained by the PR's author.
             "11.by: package-maintainer" =
               maintainers ? ${githubAuthorId}
               && lib.all (lib.flip lib.elem maintainers.${githubAuthorId}) (

--- a/nixos/tests/simple.nix
+++ b/nixos/tests/simple.nix
@@ -1,15 +1,7 @@
-{ pkgs, ... }:
 {
   name = "simple";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ ];
-  };
 
-  nodes.machine =
-    { ... }:
-    {
-      imports = [ ../modules/profiles/minimal.nix ];
-    };
+  nodes.machine = { };
 
   testScript = ''
     start_all()


### PR DESCRIPTION
This indicates that the NixOS test-driver changed and all NixOS tests have to be rebuilt. It can be used to either re-target to staging or to batch this with other similar changes, at least.

I created the new label with the following description for now:

> This PR causes rebuilds for all NixOS tests and should normally target the staging branches.

*(before anyone wants to suggest changes, this has a 100 character limit, keep that in mind!)*

This can later be adjusted, when the `kernel-updates-rebuilding-all-nixos-tests` branch exists.

Resolves #437208

## Things done

- [x] Tested in my fork.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
