### PR TITLE
chiaki-ng: 1.9.8 -> 1.9.9

### DIFF
--- a/pkgs/games/chiaki-ng/default.nix
+++ b/pkgs/games/chiaki-ng/default.nix
@@ -35,7 +35,7 @@
   xxHash,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "chiaki-ng";
   version = "1.9.8";
 
@@ -126,4 +126,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     mainProgram = "chiaki";
   };
-}
+})

--- a/pkgs/games/chiaki-ng/default.nix
+++ b/pkgs/games/chiaki-ng/default.nix
@@ -37,13 +37,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "chiaki-ng";
-  version = "1.9.8";
+  version = "1.9.9";
 
   src = fetchFromGitHub {
     owner = "streetpea";
     repo = "chiaki-ng";
-    rev = "v${version}";
-    hash = "sha256-HQmXbi2diewA/+AMjlkyffvD73TkX6D+lMh+FL2Rcz4=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-7pDQnlElnBkW+Nr6R+NaylZbsGH8dB31nd7jxYD66yQ=";
     fetchSubmodules = true;
   };
 
@@ -86,12 +86,6 @@ stdenv.mkDerivation (finalAttrs: {
     libdovi
     xxHash
   ];
-
-  # handle library name discrepancy when curl not built with cmake
-  postPatch = ''
-    substituteInPlace lib/CMakeLists.txt \
-      --replace-fail 'libcurl_shared' 'libcurl'
-  '';
 
   cmakeFlags = [
     "-Wno-dev"


### PR DESCRIPTION
https://github.com/streetpea/chiaki-ng/compare/v1.9.8...v1.9.9
- switch to `finalAttrs` pattern

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
