### PR TITLE
[25.05] postgrest: 13.0.0 -> 13.0.6

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2799,12 +2799,12 @@ self: super:
         doJailbreak
         # 2022-12-02: Hackage release lags behind actual releases: https://github.com/PostgREST/postgrest/issues/2275
         (overrideSrc rec {
-          version = "13.0.4";
+          version = "13.0.5";
           src = pkgs.fetchFromGitHub {
             owner = "PostgREST";
             repo = "postgrest";
             rev = "v${version}";
-            hash = "sha256-Y9Nxfs2w3Iinx61Om7dd+R8TTsK12oWD+3vki3WUz9Y=";
+            hash = "sha256-5gBXQPU1pMwbpL+6DnWzAnilohH0JETNkES6sBP8tdM=";
           };
         })
       ];

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2799,12 +2799,12 @@ self: super:
         doJailbreak
         # 2022-12-02: Hackage release lags behind actual releases: https://github.com/PostgREST/postgrest/issues/2275
         (overrideSrc rec {
-          version = "13.0.5";
+          version = "13.0.6";
           src = pkgs.fetchFromGitHub {
             owner = "PostgREST";
             repo = "postgrest";
             rev = "v${version}";
-            hash = "sha256-5gBXQPU1pMwbpL+6DnWzAnilohH0JETNkES6sBP8tdM=";
+            hash = "sha256-BM7fLW7LYrl+++NVztr407QyAhj2k5zO70iDqSe22dc=";
           };
         })
       ];

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2799,12 +2799,12 @@ self: super:
         doJailbreak
         # 2022-12-02: Hackage release lags behind actual releases: https://github.com/PostgREST/postgrest/issues/2275
         (overrideSrc rec {
-          version = "13.0.0";
+          version = "13.0.4";
           src = pkgs.fetchFromGitHub {
             owner = "PostgREST";
             repo = "postgrest";
             rev = "v${version}";
-            hash = "sha256-j+WlY7D3hkPHIjiyCFenC5trF31L05gEPptCwOVil6U=";
+            hash = "sha256-Y9Nxfs2w3Iinx61Om7dd+R8TTsK12oWD+3vki3WUz9Y=";
           };
         })
       ];


### PR DESCRIPTION
Backport for #418832, parts of #437501, and #439273.

No breaking changes, just bugfixes.

Release Notes:
https://github.com/PostgREST/postgrest/blob/v13.0.6/CHANGELOG.md