### PR TITLE
ocamlPackages.num: 1.1 → 1.6

### DIFF
--- a/pkgs/development/ocaml-modules/num/default.nix
+++ b/pkgs/development/ocaml-modules/num/default.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  fetchpatch,
   ocaml,
   findlib,
   withStatic ? false,
@@ -10,22 +9,21 @@
 
 stdenv.mkDerivation (
   rec {
-    version = "1.1";
+    version = "1.6";
     pname = "ocaml${ocaml.version}-num";
     src = fetchFromGitHub {
       owner = "ocaml";
       repo = "num";
-      rev = "v${version}";
-      sha256 = "0a4mhxgs5hi81d227aygjx35696314swas0vzy3ig809jb7zq4h0";
+      tag = "v${version}";
+      hash = "sha256-JWn0WBsbKpiUlxRDaXmwXVbL2WhqQIDrXiZk1aXeEtQ=";
     };
 
-    patches = [
-      (fetchpatch {
-        url = "https://github.com/ocaml/num/commit/6d4c6d476c061298e6385e8a0864f083194b9307.patch";
-        sha256 = "18zlvb5n327q8y3c52js5dvyy29ssld1l53jqng8m9w1k24ypi0b";
-      })
-    ]
-    ++ lib.optional withStatic ./enable-static.patch;
+    patches = lib.optional withStatic ./enable-static.patch;
+
+    postPatch = ''
+      substituteInPlace num.opam --replace-fail '1.7~dev' "${version}"
+      substituteInPlace src/Makefile --replace-fail "cp META.num META" "mv META.num META"
+    '';
 
     nativeBuildInputs = [
       ocaml
@@ -35,6 +33,8 @@ stdenv.mkDerivation (
     strictDeps = true;
 
     createFindlibDestdir = true;
+
+    installTargets = "findlib-install";
 
     meta = {
       description = "Legacy Num library for arbitrary-precision integer and rational arithmetic";


### PR DESCRIPTION
Compatible with OCaml 5.4.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
