### PR TITLE
nitrokey-app2: 2.3.5 -> 2.4.1, fix SVG display

### DIFF
--- a/pkgs/tools/security/nitrokey-app2/default.nix
+++ b/pkgs/tools/security/nitrokey-app2/default.nix
@@ -1,30 +1,38 @@
 {
   lib,
   stdenv,
-  python3,
+  buildPythonApplication,
   fetchFromGitHub,
-  wrapQtAppsHook,
-  qtbase,
-  qtwayland,
-  qtsvg,
+  poetry-core,
+  fido2,
+  nitrokey,
+  pyside6,
+  usb-monitor,
+  qt6,
 }:
 
-python3.pkgs.buildPythonApplication rec {
-  pname = "nitrokey-app2";
-  version = "2.3.5";
-  pyproject = true;
+let
+  inherit (qt6)
+    wrapQtAppsHook
+    qtbase
+    qtwayland
+    qtsvg
+    ;
+in
 
-  disabled = python3.pythonOlder "3.9";
+buildPythonApplication rec {
+  pname = "nitrokey-app2";
+  version = "2.4.1";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Nitrokey";
     repo = "nitrokey-app2";
     tag = "v${version}";
-    hash = "sha256-zhTDr4GyE4jridK3ee8ae3v5behMbuo86q9WdrBVqQg=";
+    hash = "sha256-nzhhtnKKOHA+Cw1y+BpYsyQklzkDnmFRKGIfaJ/dmaQ=";
   };
 
-  nativeBuildInputs = with python3.pkgs; [
-    poetry-core
+  nativeBuildInputs = [
     wrapQtAppsHook
   ];
 
@@ -36,7 +44,12 @@ python3.pkgs.buildPythonApplication rec {
     qtsvg
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    fido2
     nitrokey
     pyside6
     usb-monitor
@@ -51,6 +64,12 @@ python3.pkgs.buildPythonApplication rec {
   postInstall = ''
     install -Dm755 meta/com.nitrokey.nitrokey-app2.desktop $out/share/applications/com.nitrokey.nitrokey-app2.desktop
     install -Dm755 meta/nk-app2.png $out/share/icons/hicolor/128x128/apps/com.nitrokey.nitrokey-app2.png
+  '';
+
+  # wrapQtApps only wrapps binary files and normally skips python programs.
+  # Manually pass the qtWrapperArgs from wrapQtAppsHook to wrap python programs.
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15560,7 +15560,7 @@ with pkgs;
 
   nitrokey-app = libsForQt5.callPackage ../tools/security/nitrokey-app { };
 
-  nitrokey-app2 = qt6Packages.callPackage ../tools/security/nitrokey-app2 { };
+  nitrokey-app2 = python3Packages.callPackage ../tools/security/nitrokey-app2 { };
 
   hy = with python3Packages; toPythonApplication hy;
 


### PR DESCRIPTION
https://github.com/Nitrokey/nitrokey-app2/releases/tag/v2.4.1
https://github.com/Nitrokey/nitrokey-app2/releases/tag/v2.4.0

~Cleanup unused/useless Qt apps wrapping, since the program is pure python. Fix the Qt plugin path to restore display of SVG images (finally!) and fix a warning about missing wayland plugin.~

~wrapQtApps only works for C++ applications but not for Python. nitrokey-app2 is purely implemented in Python and uses pyside6 for Qt. As such, only the Python wrapping is needed but no Qt wrapping.~

Fix the wrapping with Qt plugin paths to restore display of SVG icons and to fix a warning about missing wayland plugin.

Closes #438004


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `87eeb038a08eae265118685aeb1b87e65f19b005`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>nitrokey-app2</li>
    <li>nitrokey-app2.dist</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
