### PR TITLE
nordvpn: init at 4.2.0 (package only)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6485,6 +6485,11 @@
     github = "dietmarw";
     githubId = 9332;
   };
+  different-error = {
+    name = "Sanfer D'souza";
+    github = "different-error";
+    githubId = 9338001;
+  };
   different-name = {
     name = "different-name";
     email = "hello@different-name.dev";

--- a/pkgs/by-name/no/nordvpn/gokogiri-xpath-expression.patch
+++ b/pkgs/by-name/no/nordvpn/gokogiri-xpath-expression.patch
@@ -1,0 +1,10 @@
+--- vendor/github.com/jbowtie/gokogiri/xpath/expression.go
++++ vendor/github.com/jbowtie/gokogiri/xpath/expression.go
+@@ -3,6 +3,7 @@
+ /*
+ #include <libxml/xpath.h>
+ #include <libxml/xpathInternals.h>
++#include <stdlib.h>
+ #include <string.h>
+ 
+ void check_xpath_syntax_noop(void *ctx, const char *fmt, ...) {

--- a/pkgs/by-name/no/nordvpn/package.nix
+++ b/pkgs/by-name/no/nordvpn/package.nix
@@ -1,0 +1,174 @@
+{
+  appendOverlays,
+  buildGoModule,
+  copyDesktopItems,
+  e2fsprogs,
+  fetchFromGitHub,
+  iproute2,
+  iptables,
+  lib,
+  libxml2_13,
+  makeDesktopItem,
+  makeWrapper,
+  openvpn,
+  pkg-config,
+  procps,
+  systemdMinimal,
+  wireguard-tools,
+}:
+let
+  tunnelblickSrc = fetchFromGitHub {
+    owner = "Tunnelblick";
+    repo = "Tunnelblick";
+    tag = "v8.0";
+    hash = "sha256-Kj/F7hI6E+giT+4iGDUjXCLgy/6jcohtTWtLXOpZfo0=";
+  };
+
+  patchedOpenvpn = openvpn.overrideAttrs (old: {
+    patches =
+      (old.patches or [ ])
+      ++ (lib.map
+        (fname: "${tunnelblickSrc}/third_party/sources/openvpn/openvpn-${old.version}/patches/${fname}")
+        [
+          "02-tunnelblick-openvpn_xorpatch-a.diff"
+          "03-tunnelblick-openvpn_xorpatch-b.diff"
+          "04-tunnelblick-openvpn_xorpatch-c.diff"
+          "05-tunnelblick-openvpn_xorpatch-d.diff"
+          "06-tunnelblick-openvpn_xorpatch-e.diff"
+        ]
+      );
+  });
+
+in
+buildGoModule (finalAttrs: {
+  pname = "nordvpn";
+  version = "4.2.0";
+
+  src = fetchFromGitHub {
+    owner = "NordSecurity";
+    repo = "nordvpn-linux";
+    tag = finalAttrs.version;
+    hash = "sha256-9uh/UkOS84tVeW/d6qQ6bYPXzGXEoD21QHzrcMcdj7M=";
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    # cgo build dependencies go here
+    # https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/go.section.md#envcgo_enabled-var-go-cgo_enabled
+    # libxml2 2.14.[0-4] breaks daemon
+    libxml2_13
+  ];
+
+  vendorHash = "sha256-eUM69CQjbML8fWRG8H3w6x4M+E51YrXX/UCUFHerQmM=";
+
+  modPostBuild = ''
+    patch -p0 < ${./gokogiri-xpath-expression.patch}
+  '';
+
+  preBuild = ''
+    # use path $out/bin instead of /usr/lib
+    substituteInPlace internal/constants.go --replace-fail /usr/lib/nordvpn "$out/bin"
+
+    # use path <<openvpnPatch>>/bin/openvpn instead of /usr/lib/nordvpn/openvpn
+    old_ovpn_path='filepath.Join(internal.AppDataPathStatic, "openvpn")'
+    new_ovpn_path=\"${patchedOpenvpn}/bin/openvpn\"
+    substituteInPlace daemon/vpn/openvpn/config.go --replace-fail "$old_ovpn_path" "$new_ovpn_path"
+  '';
+
+  ldflags = [
+    "-X main.Environment=prod"
+    "-X main.Hash=${finalAttrs.version}"
+    # changing the salt would result in nordvpnd crash for existing users
+    "-X main.Salt=f1nd1ngn3m0"
+    "-X main.Version=${finalAttrs.version}"
+  ];
+
+  subPackages = [
+    "cmd/cli"
+    "cmd/daemon"
+    "cmd/norduser"
+  ];
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+
+    go test ./cli
+    # skip tests that require network access
+    go test ./daemon -skip 'TestTransports|TestH1Transport_RoundTrip'
+    go test ./norduser
+
+    runHook postCheck
+  '';
+
+  postInstall = ''
+    # rename to standard names
+    BIN_DIR=$out/bin
+    install $BIN_DIR/cli $BIN_DIR/nordvpn
+    install $BIN_DIR/daemon $BIN_DIR/nordvpnd
+    install $BIN_DIR/norduser $BIN_DIR/norduserd
+    rm $BIN_DIR/{cli,daemon,norduser}
+
+    # nordvpn needs icons for the system tray and notifications
+    ASSETS_PATH=$out/share/icons/hicolor/scalable/apps
+    install -D assets/icon.svg $ASSETS_PATH/nordvpn.svg
+    for file in assets/*; do
+      install "$file" "$ASSETS_PATH/nordvpn-$(basename $file)"
+    done
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/nordvpnd --set PATH ${
+      lib.makeBinPath [
+        e2fsprogs
+        iproute2
+        iptables
+        patchedOpenvpn
+        procps
+        systemdMinimal
+        wireguard-tools
+      ]
+    }
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      categories = [ "Network" ];
+      comment = finalAttrs.meta.description;
+      desktopName = "nordvpn";
+      exec = "nordvpn click %u";
+      icon = "nordvpn";
+      mimeTypes = [ "x-scheme-handler/nordvpn" ];
+      name = "nordvpn";
+      terminal = true;
+      type = "Application";
+    })
+  ];
+
+  meta = {
+    description = "NordVPN application for Linux";
+    longDescription = ''
+      NordVPN application for Linux.
+      This package currently does not support meshnet.
+      Additionally, if you enable firewall via `networking.firewall.enable = true;`,
+      then you should also set `networking.firewall.checkReversePath = "loose";`.
+      Example usage:
+      ```
+      sudo nordvpnd
+      sudo chown myuser:nordvpn /run/nordvpn/nordvpnd.sock
+      nordvpn c
+      ```
+      Contributions welcome!
+    '';
+    homepage = "https://github.com/nordsecurity/nordvpn-linux";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ different-error ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Sample VM **configuration.nix**

```
{
  pkgs,
  lib,
  ...
}:

{
  imports = [
    ./hardware-configuration.nix
  ];

  boot.loader.systemd-boot.enable = true;
  boot.loader.efi.canTouchEfiVariables = true;
  networking.firewall.enable = true;
  networking.firewall.checkReversePath = "loose";

  services.xserver.enable = true;
  services.displayManager.gdm.enable = true;
  services.desktopManager.plasma6.enable = true;

  virtualisation.vmVariant = {
    virtualisation = {
      memorySize = 8192;
      cores = 3;
    };
  };
  users.groups.alice = { };
  users.groups.nordvpn = { };
  users.users.alice = {
    isSystemUser = true;
    password = "alice";
    group = "alice";
    extraGroups = [
      "wheel"
      "nordvpn"
    ];
    shell = pkgs.bash;
    home = "/home/alice";
    createHome = true;
    packages = with pkgs; [
      tree
      tmux
      dunst
      libnotify
      socat
      vim
      nordvpn
    ];
  };
  system.stateVersion = "24.11"; # Did you read the comment?
}
```

```
sudo nordvpnd
sudo chown alice:nordvpn /run/nordvpn/nordvpnd.sock
nordvpn c
```

This PR adds the package found in #406725 (the first two commits). Verified successful connection using openvpn and nordlynx technologies. Does not support meshnet.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
