### PR TITLE
gcc: build with --enable-default-pie configure option

### DIFF
--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -20,6 +20,7 @@
   enablePlugin,
   disableGdbPlugin ? !enablePlugin,
   enableShared,
+  enableDefaultPie,
   targetPrefix,
 
   langC,
@@ -278,6 +279,9 @@ let
       "--disable-symvers"
       "libat_cv_have_ifunc=no"
       "--disable-gnu-indirect-function"
+    ]
+    ++ lib.optionals enableDefaultPie [
+      "--enable-default-pie"
     ]
     ++ lib.optionals langJit [
       "--enable-host-shared"

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -19,6 +19,7 @@
   cargo,
   staticCompiler ? false,
   enableShared ? stdenv.targetPlatform.hasSharedLibraries,
+  enableDefaultPie ? true,
   enableLTO ? stdenv.hostPlatform.hasSharedLibraries,
   texinfo ? null,
   perl ? null, # optional, for texi2pod (then pod2man)
@@ -137,6 +138,7 @@ let
       darwin
       disableBootstrap
       disableGdbPlugin
+      enableDefaultPie
       enableLTO
       enableMultilib
       enablePlugin

--- a/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
@@ -193,6 +193,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--disable-multilib"
     "--disable-nls"
     "--disable-shared"
+    "--enable-default-pie"
     "--enable-languages=${
       lib.concatStrings (
         lib.intersperse "," (

--- a/pkgs/development/libraries/gcc/libgcc/default.nix
+++ b/pkgs/development/libraries/gcc/libgcc/default.nix
@@ -54,9 +54,10 @@ stdenv.mkDerivation (finalAttrs: {
     # Drop in libiberty, as external builds are not expected
     cd "$buildRoot"
     (
-      mkdir -p build-${stdenv.buildPlatform.config}/libiberty/
-      cd build-${stdenv.buildPlatform.config}/libiberty/
-      ln -s ${buildPackages.libiberty}/lib/libiberty.a ./
+      mkdir -p "build-${stdenv.buildPlatform.config}/libiberty/pic"
+      cd "build-${stdenv.buildPlatform.config}/libiberty/"
+      ln -s "${buildPackages.libiberty}/lib/libiberty.a" ./
+      ln -s "${buildPackages.libiberty}/lib/libiberty_pic.a" pic/libiberty.a
     )
     mkdir -p "$buildRoot/gcc"
     cd "$buildRoot/gcc"

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -425,6 +425,11 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
               #   ...-binutils-patchelfed-ld-2.40/bin/ld: ...-xgcc-13.0.0/libexec/gcc/x86_64-unknown-linux-gnu/13.0.1/liblto_plugin.so:
               #     error loading plugin: ...-bootstrap-tools/lib/libpthread.so.0: undefined symbol: __libc_vfork, version GLIBC_PRIVATE
               enableLTO = false;
+
+              # relocatable libs may not be available in the bootstrap
+              # which will cause compilation to fail with
+              # configure: error: C compiler cannot create executables
+              enableDefaultPie = false;
             }
           )).overrideAttrs
             (a: {


### PR DESCRIPTION
Let's configure GCC with `--enable-default-pie`.  
We already build clang with the equivalent `CLANG_DEFAULT_PIE_ON_LINUX` set to `ON` (upstream default).

| Distribution | gcc --enable-default-pie enabled | Reference |
|--------------|--------------|---------|
| **Alpine Linux** | 2016 | [Commit 5b7befa1b](https://git.alpinelinux.org/aports/commit/?id=5b7befa1b989315a57f4fb49b8381ce06ded96c9) |
| **Debian** | 2016 | [Bug #835148](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=835148) |
| **Ubuntu** | 2016 | [SecurityTeam/PIE](https://wiki.ubuntu.com/SecurityTeam/PIE) |
| **Arch Linux** | 2017 | [FS#49791](https://bugs.archlinux.org/task/49791) |
| **Void Linux** | 2017 | [Commit 1c2290eec1](https://github.com/void-linux/void-packages/commit/1c2290eec19af90eb1e5afc27e48c08329fb6b0e) |
| **Gentoo** | 2017 | [News - 17.0 Profiles](https://www.gentoo.org/support/news-items/2017-11-30-new-17-profiles.html) |

Configuring GCC directly with `--enable-default-pie` is simple and matches what most mainstream distributions have been doing for years. It results in a compiler that opportunistically enables pie whenever it does not conflict with other flags.

Currently our clang stdenvs (pkgsLLVM, darwin default stdenvs) opportunistically apply pie, and our gcc stdenvs (linux default stdenv) do not. This is a bit weird since in some stdenvs adding the "pie" hardening flag is required to get ASLR supporting executables, and in others it's a mix of a no-op and a footgun that can cause builds to fail.

It's easier for `gcc` and `clang` to do the right thing by default based on whatever combination of flags have been passed than for our wrapper, so this PR should avoid issues with differing static/shared flags. gcc is extremely sensitive to the ordering of pie flags and static build flags. Prior attempts like #252310 got stuck, mostly due to this complexity.

The `enable-default-pie` approach doesn't break some unusual stdenvs that we had trouble with in previous attempts. `pkgsExtraHardening.pkgsStatic.hello` can be built on both `aarch64-linux` and `x86_64-linux`.

Comparison of checksec PIE Disabled processes running on my desktop before and after rebuilding on this PR branch:

```
$ sudo nix run nixpkgs#checksec -- procAll | grep "PIE Disabled" | wc -l
103
$ sudo nix run nixpkgs#checksec -- procAll | grep "PIE Disabled" | wc -l
4
```

---

This impacts the behavior of the existing "pie" hardening flag, so we need to decide what to do about that. The current state on this branch enables pie by default at the compiler level while leaving the hardening flag as a no-op, which is fine for some testing but not ready to merge.

If workable it might be nice to drop the hardening flag entirely, and handle treewide removal in a followup.
Packages that cannot build with pie can explicitly pass `-no-pie` when needed. Most packages already do due to the prevalence of compilers built with `--enable-default-pie` across other distros, however packages that have not been maintained in the past decade may need it passed via `NIX_CFLAGS_COMPILE`.  
I have ran into zero packages that needed this treatment in a full rebuild of my desktop on this PR, but I'd be surprised if there are none.

An alternative to dropping the "pie" flag is to teach the wrappers to pass `-no-pie` when the flag is disabled for stdenvs using compilers that have pie by default, along with adding "pie" to the default hardening flag list for those stdenvs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Annoyances encountered: tailscale build failing due to kernel version #438765, dbus-broker failure due to kernel version #439331

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
