### PR TITLE
Collection of improvements for Grav CMS

### DIFF
--- a/nixos/modules/services/web-apps/grav.nix
+++ b/nixos/modules/services/web-apps/grav.nix
@@ -231,7 +231,6 @@ in
           extraConfig = ''
             index index.php index.html /index.php$request_uri;
             add_header X-Content-Type-Options nosniff;
-            add_header X-XSS-Protection "1; mode=block";
             add_header X-Download-Options noopen;
             add_header X-Permitted-Cross-Domain-Policies none;
             add_header X-Frame-Options sameorigin;

--- a/nixos/modules/services/web-apps/grav.nix
+++ b/nixos/modules/services/web-apps/grav.nix
@@ -69,7 +69,7 @@ in
       '';
     };
 
-    phpPackage = mkPackageOption pkgs "php" { };
+    phpPackage = mkPackageOption pkgs "php83" { };
 
     maxUploadSize = mkOption {
       type = types.str;

--- a/pkgs/by-name/gr/grav/package.nix
+++ b/pkgs/by-name/gr/grav/package.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  version = "1.7.48";
+  version = "1.7.49.2";
 in
 stdenvNoCC.mkDerivation {
   pname = "grav";
@@ -14,7 +14,7 @@ stdenvNoCC.mkDerivation {
 
   src = fetchzip {
     url = "https://github.com/getgrav/grav/releases/download/${version}/grav-admin-v${version}.zip";
-    hash = "sha256-e8WpdO0n3pY4Ajs1fvMkMI+CrR6uMitswvYS5rxal4g=";
+    hash = "sha256-Yu7uFoim12pe4OT/dSsQVcZ6nyYGKWLJbsfLFtI05Z8=";
   };
 
   patches = [


### PR DESCRIPTION
- Removes use of X-XSS-Protection to fix problem referenced in <https://github.com/NixOS/nixpkgs/issues/438800>
- Makes sure the module uses PHP 8.3 by default, later versions don't work with Grav
- Applies update 1.7.48 -> 1.7.49.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
