### PR TITLE
haskell.compiler.ghc{9102,9122}: drop

### DIFF
--- a/pkgs/development/compilers/ghc/9.10.2.nix
+++ b/pkgs/development/compilers/ghc/9.10.2.nix
@@ -1,4 +1,0 @@
-import ./common-hadrian.nix {
-  version = "9.10.2";
-  sha256 = "55fd40a005575ac6b33ea928beda81e8c56ffea354b6ac474ee9f9911f23a8de";
-}

--- a/pkgs/development/compilers/ghc/9.12.2.nix
+++ b/pkgs/development/compilers/ghc/9.12.2.nix
@@ -1,4 +1,0 @@
-import ./common-hadrian.nix {
-  version = "9.12.2";
-  sha256 = "0e49cd5dde43f348c5716e5de9a5d7a0f8d68d945dc41cf75dfdefe65084f933";
-}

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -254,35 +254,23 @@
               "sha256-vtjT+TL/7sYPu4rcVV3xCqJQ+uqkyBbf9l0KIi97j/0=";
         })
       ]
-      ++
-        lib.optionals
-          (
-            (lib.versions.majorMinor version == "9.12" && lib.versionOlder version "9.12.3")
-            || (lib.versions.majorMinor version != "9.12" && lib.versionOlder version "9.14.1")
-          )
-          [
-            (fetchpatch {
-              name = "ghc-rts-Fix-compile-on-powerpc64-elf-v1.patch";
-              url = "https://gitlab.haskell.org/ghc/ghc/-/commit/05e5785a3157c71e327a8e9bdc80fa7082918739.patch";
-              hash = "sha256-xP5v3cKhXeTRSFvRiKEn9hPxGXgVgykjTILKjh/pdDU=";
-            })
-          ]
+      ++ lib.optionals (lib.versionOlder version "9.12") [
+        (fetchpatch {
+          name = "ghc-rts-Fix-compile-on-powerpc64-elf-v1.patch";
+          url = "https://gitlab.haskell.org/ghc/ghc/-/commit/05e5785a3157c71e327a8e9bdc80fa7082918739.patch";
+          hash = "sha256-xP5v3cKhXeTRSFvRiKEn9hPxGXgVgykjTILKjh/pdDU=";
+        })
+      ]
       # Fix build with gcc15
       # https://gitlab.haskell.org/ghc/ghc/-/issues/25662
       # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13863
-      ++
-        lib.optionals
-          (
-            lib.versionOlder version "9.12.3"
-            && !(lib.versionAtLeast version "9.10.2" && lib.versionOlder version "9.12")
-          )
-          [
-            (fetchpatch {
-              name = "ghc-hp2ps-c-gnu17.patch";
-              url = "https://src.fedoraproject.org/rpms/ghc/raw/9c26d7c3c3de73509a25806e5663b37bcf2e0b4e/f/hp2ps-C-gnu17.patch";
-              hash = "sha256-Vr5wkiSE1S5e+cJ8pWUvG9KFpxtmvQ8wAy08ElGNp5E=";
-            })
-          ]
+      ++ lib.optionals (lib.versionOlder version "9.10") [
+        (fetchpatch {
+          name = "ghc-hp2ps-c-gnu17.patch";
+          url = "https://src.fedoraproject.org/rpms/ghc/raw/9c26d7c3c3de73509a25806e5663b37bcf2e0b4e/f/hp2ps-C-gnu17.patch";
+          hash = "sha256-Vr5wkiSE1S5e+cJ8pWUvG9KFpxtmvQ8wAy08ElGNp5E=";
+        })
+      ]
       # Fix subword division regression in 9.12.3 https://gitlab.haskell.org/ghc/ghc/-/merge_requests/15264
       ++ lib.optionals (version == "9.12.3") [
         (fetchpatch {

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -304,7 +304,7 @@
       ]
 
       # Unreleased or still in-progress upstream cross fixes
-      ++ lib.optionals (lib.versionAtLeast version "9.10.2" && lib.versionOlder version "9.15") [
+      ++ lib.optionals (lib.versionAtLeast version "9.10" && lib.versionOlder version "9.15") [
         # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13919
         (fetchpatch {
           name = "include-modern-utimbuf.patch";

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -238,17 +238,17 @@
           hash = "sha256-L3FQvcm9QB59BOiR2g5/HACAufIG08HiT53EIOjj64g=";
         })
       ]
-      ++ lib.optionals (lib.versionOlder version "9.12.1") [
+      ++ lib.optionals (lib.versionOlder version "9.12") [
         (fetchpatch {
           name = "ghc-ppc-support-elf-v2-on-powerpc64-big-endian.patch";
           url = "https://gitlab.haskell.org/ghc/ghc/-/commit/ead75532c9dc915bfa9ebaef0ef5d148e793cc0a.patch";
           # ghc-platform was split out of ghc-boot in ddcdd88c2c95445a87ee028f215d1e876939a4d9
-          postFetch = lib.optionalString (lib.versionOlder version "9.10.1") ''
+          postFetch = lib.optionalString (lib.versionOlder version "9.10") ''
             substituteInPlace $out \
               --replace-fail 'libraries/ghc-platform/src/GHC' 'libraries/ghc-boot/GHC'
           '';
           hash =
-            if lib.versionOlder version "9.10.1" then
+            if lib.versionOlder version "9.10" then
               "sha256-5SVSW1aYoItqHli5QjnudH4zGporYNLDeEo4gZksBZw="
             else
               "sha256-vtjT+TL/7sYPu4rcVV3xCqJQ+uqkyBbf9l0KIi97j/0=";

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -144,23 +144,6 @@ in
         inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
         inherit buildTargetLlvmPackages llvmPackages;
       };
-      ghc9102 = callPackage ../development/compilers/ghc/9.10.2.nix {
-        bootPkgs =
-          if
-            stdenv.buildPlatform.isPower64
-            && stdenv.buildPlatform.isBigEndian
-            && pkgs.stdenv.hostPlatform.isAbiElfv1
-          then
-            # No bindist, "borrowing" the GHC from Debian
-            bb.packages.ghc966DebianBinary
-          else if stdenv.buildPlatform.isi686 then
-            bb.packages.ghc967
-          else
-            bb.packages.ghc984Binary;
-        inherit (buildPackages.python3Packages) sphinx;
-        inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
-        inherit buildTargetLlvmPackages llvmPackages;
-      };
       ghc9103 = callPackage ../development/compilers/ghc/9.10.3.nix {
         bootPkgs =
           if
@@ -294,11 +277,6 @@ in
         buildHaskellPackages = bh.packages.ghc984;
         ghc = bh.compiler.ghc984;
         compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.8.x.nix { };
-      };
-      ghc9102 = callPackage ../development/haskell-modules {
-        buildHaskellPackages = bh.packages.ghc9102;
-        ghc = bh.compiler.ghc9102;
-        compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.10.x.nix { };
       };
       ghc9103 = callPackage ../development/haskell-modules {
         buildHaskellPackages = bh.packages.ghc9103;

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -161,14 +161,6 @@ in
         inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
         inherit buildTargetLlvmPackages llvmPackages;
       };
-      ghc9122 = callPackage ../development/compilers/ghc/9.12.2.nix {
-        bootPkgs =
-          # No suitable bindist packaged yet
-          bb.packages.ghc9103;
-        inherit (buildPackages.python3Packages) sphinx;
-        inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
-        inherit buildTargetLlvmPackages llvmPackages;
-      };
       ghc9123 = callPackage ../development/compilers/ghc/9.12.3.nix {
         bootPkgs =
           # No suitable bindist packaged yet
@@ -282,11 +274,6 @@ in
         buildHaskellPackages = bh.packages.ghc9103;
         ghc = bh.compiler.ghc9103;
         compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.10.x.nix { };
-      };
-      ghc9122 = callPackage ../development/haskell-modules {
-        buildHaskellPackages = bh.packages.ghc9122;
-        ghc = bh.compiler.ghc9122;
-        compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.12.x.nix { };
       };
       ghc9123 = callPackage ../development/haskell-modules {
         buildHaskellPackages = bh.packages.ghc9123;


### PR DESCRIPTION
Drops all GHC minor versions that are currently:
- Not the latest minor version of the respective major version, and
- Not the latest version in a stackage major, and
- Not used for bootstrapping others (GHC 9.6.3 is used to bootstrap GHC 9.6.7, so can't drop that)

This applies our [Deprecation Policy](https://nixos.org/manual/nixpkgs/unstable/#ghc-deprecation-policy). Removal of GHC minor version has so far not appeared in Release Notes, so not adding these here either.

9.4, 9.6 and 9.8 drops already merged.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
