### PR TITLE
[Backport release-25.05] nixos/lomiri: Exclude Morph Browser by default

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -107,7 +107,10 @@ in
             lomiri-thumbnailer
             lomiri-url-dispatcher
             mediascanner2 # TODO possibly needs to be kicked off by graphical-session.target
-            morph-browser
+            # Qt5 qtwebengine is not secure: https://github.com/NixOS/nixpkgs/pull/435067
+            # morph-browser
+            # Adding another browser that is known-working until Morph Browser can migrate to Qt6
+            pkgs.epiphany
             qtmir # not having its desktop file for Xwayland available causes any X11 application to crash the session
             teleports
           ]);

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -469,15 +469,16 @@ in
               machine.send_key("alt-f4")
 
           # Morph is how we go online
-          with subtest("morph browser works"):
-              open_starter()
-              machine.send_chars("Morph\n")
-              wait_for_text(r"(Bookmarks|address|site|visited any)")
-              machine.screenshot("morph_open")
-
-              # morph-browser has a separate VM test to test its basic functionalities
-
-              machine.send_key("alt-f4")
+          # Qt5 qtwebengine is not secure: https://github.com/NixOS/nixpkgs/pull/435067
+          # with subtest("morph browser works"):
+          #     open_starter()
+          #     machine.send_chars("Morph\n")
+          #     wait_for_text(r"(Bookmarks|address|site|visited any)")
+          #     machine.screenshot("morph_open")
+          #
+          #     # morph-browser has a separate VM test to test its basic functionalities
+          #
+          #     machine.send_key("alt-f4")
 
           # LSS provides DE settings
           with subtest("system settings open"):

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -650,14 +650,14 @@ in
               machine.send_key("ret")
 
               # Peers should be loaded
-              wait_for_text("Morph") # or Gallery, but Morph is already packaged
+              wait_for_text("Gallery")
               machine.screenshot("settings_lomiri-content-hub_peers")
 
-              # Select Morph as content source
-              mouse_click(370, 100)
+              # Select Gallery as content source
+              mouse_click(460, 80)
 
-              # Expect Morph to be brought into the foreground, with its Downloads page open
-              wait_for_text("No downloads")
+              # Expect Gallery to be brought into the foreground, with its sharing page open
+              wait_for_text("Photos")
 
               # If lomiri-content-hub encounters a problem, it may have crashed the original application issuing the request.
               # Check that it's still alive
@@ -666,9 +666,10 @@ in
               machine.screenshot("lomiri-content-hub_exchange")
 
               # Testing any more would require more applications & setup, the fact that it's already being attempted is a good sign
-              machine.send_key("esc")
+              machine.send_key("tab")
+              machine.send_key("ret")
 
-              machine.sleep(2) # sleep a tiny bit so morph can close & the focus can return to LSS
+              machine.sleep(2) # sleep a tiny bit so gallery can close & the focus can return to LSS
               machine.send_key("alt-f4")
         '';
     }

--- a/pkgs/by-name/ay/ayatana-indicator-sound/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-sound/package.nix
@@ -48,6 +48,17 @@ stdenv.mkDerivation (finalAttrs: {
     # Build-time Vala codegen
     substituteInPlace src/CMakeLists.txt \
       --replace-fail '/usr/share/gir-1.0/AccountsService-1.0.gir' '${lib.getDev accountsservice}/share/gir-1.0/AccountsService-1.0.gir'
+
+    # timeouts are too short for aarch64 OfBorg builder under loads, which leads to spurious test failures
+    substituteInPlace \
+      tests/accounts-service-user.cc \
+      tests/media-player-user.cc \
+      tests/name-watch-test.cc \
+      tests/notifications-test.cc \
+      tests/volume-control-test.cc \
+      --replace-quiet 'loop(50)' 'loop(500)' \
+      --replace-quiet 'loop(100)' 'loop(1000)' \
+      --replace-quiet 'loop(500)' 'loop(5000)' \
   '';
 
   strictDeps = true;


### PR DESCRIPTION
Manual backport of #436723 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
