### PR TITLE
python3Packages.firedrake-fiat: 2025.4.0 -> 2025.4.1

### DIFF
--- a/pkgs/development/python-modules/firedrake-fiat/default.nix
+++ b/pkgs/development/python-modules/firedrake-fiat/default.nix
@@ -14,7 +14,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "firdrake-fiat";
+  pname = "firedrake-fiat";
   version = "2025.4.0";
   pyproject = true;
 

--- a/pkgs/development/python-modules/firedrake-fiat/default.nix
+++ b/pkgs/development/python-modules/firedrake-fiat/default.nix
@@ -11,6 +11,7 @@
   symengine,
   fenics-ufl,
   pytestCheckHook,
+  nix-update-script,
 }:
 
 buildPythonPackage rec {
@@ -61,6 +62,18 @@ buildPythonPackage rec {
   pytestFlags = [
     "--skip-download"
   ];
+
+  passthru = {
+    # python updater script sets the wrong tag
+    skipBulkUpdate = true;
+
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "([0-9.]+)"
+      ];
+    };
+  };
 
   meta = {
     description = "FInite element Automatic Tabulator";

--- a/pkgs/development/python-modules/firedrake-fiat/default.nix
+++ b/pkgs/development/python-modules/firedrake-fiat/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "firedrake-fiat";
-  version = "2025.4.0";
+  version = "2025.4.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "firedrakeproject";
     repo = "fiat";
     tag = version;
-    hash = "sha256-i+hDpeg4SYRF7OK6uh1p1gVscyuJ4FjmyUUiLR7P7/A=";
+    hash = "sha256-rN2JPXsauyBF6X2378kOmqHNB+1EqxiGnDaVoEXy4vw=";
   };
 
   postPatch =

--- a/pkgs/development/python-modules/firedrake/default.nix
+++ b/pkgs/development/python-modules/firedrake/default.nix
@@ -43,9 +43,10 @@
   mpiCheckPhaseHook,
   writableTmpDirAsHomeHook,
 
-  # passthru.tests
+  # passthru
   firedrake,
   mpich,
+  nix-update-script,
 }:
 let
   firedrakePackages = lib.makeScope newScope (self: {
@@ -172,6 +173,13 @@ buildPythonPackage rec {
   passthru = {
     # python updater script sets the wrong tag
     skipBulkUpdate = true;
+
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "([0-9.]+)"
+      ];
+    };
 
     tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
       mpich = firedrake.override {


### PR DESCRIPTION
Diff: https://github.com/firedrakeproject/fiat/compare/2025.4.0...2025.4.1
Changelog: https://github.com/firedrakeproject/fiat/releases/tag/2025.4.1

other changes: 
1. fix pname
2. add update-script

nixpkgs-review depend on https://github.com/NixOS/nixpkgs/pull/437877
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
