### PR TITLE
python313Packages.scikit-fuzzy: 0.4.2-unstable-2023-09-14 -> 0.5.0

### DIFF
--- a/pkgs/development/python-modules/scikit-fuzzy/default.nix
+++ b/pkgs/development/python-modules/scikit-fuzzy/default.nix
@@ -8,12 +8,12 @@
   networkx,
   numpy,
   scipy,
-  pytest7CheckHook,
+  pytestCheckHook,
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "scikit-fuzzy";
-  version = "0.4.2-unstable-2023-09-14";
+  version = "0.5.0";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -21,13 +21,13 @@ buildPythonPackage {
   src = fetchFromGitHub {
     owner = "scikit-fuzzy";
     repo = "scikit-fuzzy";
-    rev = "d7551b649f34c2f5e98836e9b502279226d3b225";
-    hash = "sha256-91Udm2dIaIwTVG6V1EqYA/4qryuS4APgaa7tIa3sSQE=";
+    tag = "v${version}";
+    hash = "sha256-02aIYBdbQXQD9S1R/gZZeKTn5LxloE0GGGRttxJnR/o=";
   };
 
   build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     networkx
     numpy
     scipy
@@ -35,7 +35,7 @@ buildPythonPackage {
 
   nativeCheckInputs = [
     matplotlib
-    pytest7CheckHook
+    pytestCheckHook
   ];
 
   preCheck = "rm -rf build";
@@ -45,6 +45,7 @@ buildPythonPackage {
   meta = with lib; {
     homepage = "https://github.com/scikit-fuzzy/scikit-fuzzy";
     description = "Fuzzy logic toolkit for scientific Python";
+    changelog = "https://github.com/scikit-fuzzy/scikit-fuzzy/releases/tag/${src.tag}";
     license = licenses.bsd3;
     maintainers = [ maintainers.bcdarwin ];
   };


### PR DESCRIPTION
Routine update ([changelog](https://github.com/scikit-fuzzy/scikit-fuzzy/releases/tag/v0.5.0)).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
