### PR TITLE
docker-tools: added meta.mainProgram to dockerTools.streamLayeredImage

### DIFF
--- a/nixos/tests/docker-tools-nix-shell.nix
+++ b/nixos/tests/docker-tools-nix-shell.nix
@@ -1,5 +1,9 @@
 # nix-build -A nixosTests.docker-tools-nix-shell
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  ...
+}:
 let
   inherit (config.node.pkgs.dockerTools) examples;
 in
@@ -17,7 +21,7 @@ in
       { ... }:
       {
         virtualisation = {
-          diskSize = 3072;
+          diskSize = 4096;
           docker.enable = true;
         };
       };
@@ -34,61 +38,61 @@ in
 
     with subtest("buildNixShellImage: Can build a basic derivation"):
         docker.succeed(
-            "${examples.nix-shell-basic} | docker load",
+            "${examples.nix-shell-basic}/bin/stream-nix-shell-basic | docker load",
             "docker run --rm nix-shell-basic bash -c 'buildDerivation && $out/bin/hello' | grep '^Hello, world!$'"
         )
 
     with subtest("buildNixShellImage: Runs the shell hook"):
         docker.succeed(
-            "${examples.nix-shell-hook} | docker load",
+            "${examples.nix-shell-hook}/bin/stream-nix-shell-hook | docker load",
             "docker run --rm -it nix-shell-hook | grep 'This is the shell hook!'"
         )
 
     with subtest("buildNixShellImage: Sources stdenv, making build inputs available"):
         docker.succeed(
-            "${examples.nix-shell-inputs} | docker load",
+            "${examples.nix-shell-inputs}/bin/stream-nix-shell-inputs | docker load",
             "docker run --rm -it nix-shell-inputs | grep 'Hello, world!'"
         )
 
     with subtest("buildNixShellImage: passAsFile works"):
         docker.succeed(
-            "${examples.nix-shell-pass-as-file} | docker load",
+            "${examples.nix-shell-pass-as-file}/bin/stream-nix-shell-pass-as-file | docker load",
             "docker run --rm -it nix-shell-pass-as-file | grep 'this is a string'"
         )
 
     with subtest("buildNixShellImage: run argument works"):
         docker.succeed(
-            "${examples.nix-shell-run} | docker load",
+            "${examples.nix-shell-run}/bin/stream-nix-shell-run | docker load",
             "docker run --rm -it nix-shell-run | grep 'This shell is not interactive'"
         )
 
     with subtest("buildNixShellImage: command argument works"):
         docker.succeed(
-            "${examples.nix-shell-command} | docker load",
+            "${examples.nix-shell-command}/bin/stream-nix-shell-command | docker load",
             "docker run --rm -it nix-shell-command | grep 'This shell is interactive'"
         )
 
     with subtest("buildNixShellImage: home directory is writable by default"):
         docker.succeed(
-            "${examples.nix-shell-writable-home} | docker load",
+            "${examples.nix-shell-writable-home}/bin/stream-nix-shell-writable-home | docker load",
             "docker run --rm -it nix-shell-writable-home"
         )
 
     with subtest("buildNixShellImage: home directory can be made non-existent"):
         docker.succeed(
-            "${examples.nix-shell-nonexistent-home} | docker load",
+            "${examples.nix-shell-nonexistent-home}/bin/stream-nix-shell-nonexistent-home | docker load",
             "docker run --rm -it nix-shell-nonexistent-home"
         )
 
     with subtest("buildNixShellImage: can build derivations"):
         docker.succeed(
-            "${examples.nix-shell-build-derivation} | docker load",
+            "${examples.nix-shell-build-derivation}/bin/stream-nix-shell-build-derivation | docker load",
             "docker run --rm -it nix-shell-build-derivation"
         )
 
     with subtest("streamLayeredImage: with nix db"):
         docker.succeed(
-            "${examples.nix-layered} | docker load",
+            "${examples.nix-layered}/bin/stream-nix-layered | docker load",
             "docker run --rm ${examples.nix-layered.imageName} nix-store -q --references /bin/bash"
         )
   '';

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -1224,10 +1224,14 @@ rec {
               # take images can know in advance how the image is supposed to be used.
               isExe = true;
             };
+            meta = {
+              mainProgram = "stream-${baseName}";
+            };
             nativeBuildInputs = [ makeWrapper ];
           }
           ''
-            makeWrapper $streamScript $out --add-flags $conf
+            mkdir -p $out/bin
+            makeWrapper $streamScript $out/bin/stream-${baseName} --add-flags $conf
           '';
     in
     result


### PR DESCRIPTION
This allows `lib.getExe` to be used on packages built with this utility.

- Added `meta.mainPackage` to packages which are built using the utility.
- Moved output executable script out to `$out/bin/stream-${baseName}` to give `lib.getExe` something to look for at the normal location.

Resolves #385808

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
