### PR TITLE
Revert "maintainers: require GitHub handle (documentation) (#437469)"

### DIFF
--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -119,8 +119,9 @@ When adding users to [`maintainer-list.nix`](./maintainer-list.nix), the followi
 
   Note: GitHub's "Verified" label does not display the user's full key fingerprint, and should not be used for validating the key matches.
 
-- Ensure that the user has specified a `github` account name and a `githubId` and verify the two match.
+- If the user has specified a `github` account name, ensure they have also specified a `githubId` and verify the two match.
 
+  Maintainer entries that include a `github` field must also include their `githubId`.
   People can and do change their GitHub name frequently, and the ID is used as the official and stable identity of the maintainer.
 
   Given a maintainer entry like this:
@@ -138,7 +139,7 @@ When adding users to [`maintainer-list.nix`](./maintainer-list.nix), the followi
 
   First, make sure that the listed GitHub handle matches the author of the commit.
 
-  Then, visit the URL `https://api.github.com/user/10137` and validate that the `login` field matches the provided `github` handle.
+  Then, visit the URL `https://api.github.com/users/ghost` and validate that the `id` field matches the provided `githubId`.
 
 ### Maintainer teams
 

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4,12 +4,13 @@
    handle = {
      # Required
      name = "Your name";
+
+     # Optional, but at least one of email, matrix or githubId must be given
+     email = "address@example.org";
+     matrix = "@user:example.org";
      github = "GithubUsername";
      githubId = your-github-id;
 
-     # Optional
-     email = "address@example.org";
-     matrix = "@user:example.org";
      keys = [{
        fingerprint = "AAAA BBBB CCCC DDDD EEEE  FFFF 0000 1111 2222 3333";
      }];
@@ -20,16 +21,16 @@
 
    - `handle` is the handle you are going to use in nixpkgs expressions,
    - `name` is a name that people would know and recognize you by,
-   - `github` is your GitHub handle (as it appears in the URL of your profile page, `https://github.com/<userhandle>`),
-   - `githubId` is your GitHub user ID, which can be found at `https://api.github.com/users/<userhandle>`,
    - `email` is your maintainer email address,
    - `matrix` is your Matrix user ID,
+   - `github` is your GitHub handle (as it appears in the URL of your profile page, `https://github.com/<userhandle>`),
+   - `githubId` is your GitHub user ID, which can be found at `https://api.github.com/users/<userhandle>`,
    - `keys` is a list of your PGP/GPG key fingerprints.
 
-   Specifying a GitHub account is required, because:
-   - you will get invited to the @NixOS/nixpkgs-maintainers team;
-   - once you are part of the @NixOS org, you can be requested for review;
-   - once you can be requested for review, CI will request you review pull requests that modify a package for which you are a maintainer.
+   Specifying a GitHub account ensures that you automatically:
+   - get invited to the @NixOS/nixpkgs-maintainers team ;
+   - once you are part of the @NixOS org, OfBorg will request you review
+     pull requests that modify a package for which you are a maintainer.
 
    `handle == github` is strongly preferred whenever `github` is an acceptable attribute name and is short and convenient.
 


### PR DESCRIPTION
This PR reverts "maintainers: require GitHub handle (documentation) (https://github.com/NixOS/nixpkgs/pull/437469)" (commit d3b00da0e997a091f1dca1b8f70def6ec934f17e.

The PR has been merged within maybe a day. Due to its severe impact, this wasn't supposed to happen without more in-depth evaluation and preparation:

What the author tries to do here has to a great extent already been subject to an RFC (https://github.com/NixOS/rfcs/pull/167), but it ended up not being merged. Obviously, it could not reach a community consensus back then. If the author thinks this will work out differently as of today, he should go through the RFC process to make sure the intended change is in the best interest of the community. Considering that we're talking about a community reshape here (it would currently modify who can do meaningful contributions and who can't), a quickly merged PR does hardly correspond to its impact. Furthermore, it is designed to specifically affect community members which are not reachable through GitHub, so it might need even more time for proper community feedback.

Furthermore, the PR would make changes to the handling of personal data within `nixpkgs`. Specifically, personal data which could previously be provided based on deliberate consent would become mandatory. Due to regulations of personal data usage in different jurisdictions, we should make sure to avoid legal implications before attempting something like this. The PR does not state how it's supposed to achieve this, so it would be preferable to contact the maintainers who provided data based on the old data handling, and ask them whether they consent to the intended change.

The PR should be reverted for now, with the option to re-apply it after going through the RFC process, and acquiring the consent of the affected maintainers.

@NixOS/steering

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
