### PR TITLE
[Backport release-25.05] warp-plus: 1.2.5 -> 1.2.6-unstable-2025-08-13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18961,12 +18961,6 @@
     name = "Michael Bergmeister";
     githubId = 53442728;
   };
-  paveloom = {
-    email = "contact@paveloom.dev";
-    github = "paveloom";
-    githubId = 49961859;
-    name = "Pavel Sobolev";
-  };
   pawelchcki = {
     email = "pawel.chcki@gmail.com";
     github = "pawelchcki";

--- a/nixos/tests/flaresolverr.nix
+++ b/nixos/tests/flaresolverr.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix (
   { lib, ... }:
   {
     name = "flaresolverr";
-    meta.maintainers = with lib.maintainers; [ paveloom ];
+    meta.maintainers = with lib.maintainers; [ ];
 
     nodes.machine =
       { pkgs, ... }:

--- a/nixos/tests/whisparr.nix
+++ b/nixos/tests/whisparr.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix (
   { lib, ... }:
   {
     name = "whisparr";
-    meta.maintainers = [ lib.maintainers.paveloom ];
+    meta.maintainers = [ ];
 
     nodes.machine =
       { pkgs, ... }:

--- a/pkgs/by-name/cp/cppcheck/package.nix
+++ b/pkgs/by-name/cp/cppcheck/package.nix
@@ -116,10 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "http://cppcheck.sourceforge.net";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [
-      joachifm
-      paveloom
-    ];
+    maintainers = with lib.maintainers; [ joachifm ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ea/earthlyls/package.nix
+++ b/pkgs/by-name/ea/earthlyls/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/glehmann/earthlyls/releases/tag/${version}";
     license = lib.licenses.mit;
     mainProgram = "earthlyls";
-    maintainers = with lib.maintainers; [ paveloom ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 }

--- a/pkgs/by-name/ed/eddie/package.nix
+++ b/pkgs/by-name/ed/eddie/package.nix
@@ -138,7 +138,7 @@ buildDotnetModule rec {
     homepage = "https://eddie.website";
     license = lib.licenses.gpl3Plus;
     mainProgram = "eddie-ui";
-    maintainers = with lib.maintainers; [ paveloom ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/fl/flaresolverr/package.nix
+++ b/pkgs/by-name/fl/flaresolverr/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/FlareSolverr/FlareSolverr/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = licenses.mit;
     mainProgram = "flaresolverr";
-    maintainers = with maintainers; [ paveloom ];
+    maintainers = with maintainers; [ ];
     inherit (undetected-chromedriver.meta) platforms;
   };
 })

--- a/pkgs/by-name/fo/fopnu/package.nix
+++ b/pkgs/by-name/fo/fopnu/package.nix
@@ -48,7 +48,7 @@ stdenvNoCC.mkDerivation rec {
     license = licenses.unfree;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     mainProgram = "fopnu";
-    maintainers = with maintainers; [ paveloom ];
+    maintainers = with maintainers; [ ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/by-name/gr/gr-framework/package.nix
+++ b/pkgs/by-name/gr/gr-framework/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     description = "GR framework is a graphics library for visualisation applications";
     homepage = "https://gr-framework.org";
     license = licenses.mit;
-    maintainers = with maintainers; [ paveloom ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/io/ios-safari-remote-debug/package.nix
+++ b/pkgs/by-name/io/ios-safari-remote-debug/package.nix
@@ -35,6 +35,6 @@ buildGoModule rec {
     homepage = "https://git.gay/besties/ios-safari-remote-debug";
     license = lib.licenses.agpl3Plus;
     mainProgram = "ios-safari-remote-debug";
-    maintainers = with lib.maintainers; [ paveloom ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/io/ios-webkit-debug-proxy/package.nix
+++ b/pkgs/by-name/io/ios-webkit-debug-proxy/package.nix
@@ -74,9 +74,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/google/ios-webkit-debug-proxy/releases/tag/${finalAttrs.src.rev}";
     license = licenses.bsd3;
     mainProgram = "ios_webkit_debug_proxy";
-    maintainers = with maintainers; [
-      abustany
-      paveloom
-    ];
+    maintainers = with maintainers; [ abustany ];
   };
 })

--- a/pkgs/by-name/la/lazygit/package.nix
+++ b/pkgs/by-name/la/lazygit/package.nix
@@ -45,7 +45,6 @@ buildGoModule rec {
       Br1ght0ne
       equirosa
       khaneliman
-      paveloom
       starsep
       sigmasquadron
     ];

--- a/pkgs/by-name/me/mesonlsp/package.nix
+++ b/pkgs/by-name/me/mesonlsp/package.nix
@@ -164,7 +164,7 @@ stdenv'.mkDerivation (finalAttrs: {
     changelog = "https://github.com/JCWasmx86/mesonlsp/releases/tag/v${finalAttrs.version}";
     license = licenses.gpl3Plus;
     mainProgram = "mesonlsp";
-    maintainers = with maintainers; [ paveloom ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
     # ../src/liblog/log.cpp:41:7: error: call to 'format' is ambiguous
     broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64;

--- a/pkgs/by-name/mo/mold/package.nix
+++ b/pkgs/by-name/mo/mold/package.nix
@@ -129,9 +129,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
     mainProgram = "mold";
-    maintainers = with lib.maintainers; [
-      azahi
-      paveloom
-    ];
+    maintainers = with lib.maintainers; [ azahi ];
   };
 })

--- a/pkgs/by-name/pv/pvs-studio/package.nix
+++ b/pkgs/by-name/pv/pvs-studio/package.nix
@@ -77,6 +77,6 @@ stdenv.mkDerivation rec {
       "x86_64-linux"
     ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    maintainers = with lib.maintainers; [ paveloom ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/st/streamrip/package.nix
+++ b/pkgs/by-name/st/streamrip/package.nix
@@ -66,7 +66,7 @@ python3Packages.buildPythonApplication rec {
     description = "Scriptable music downloader for Qobuz, Tidal, SoundCloud, and Deezer";
     homepage = "https://github.com/nathom/streamrip";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ paveloom ];
+    maintainers = with maintainers; [ ];
     mainProgram = "rip";
   };
 }

--- a/pkgs/by-name/su/substudy/package.nix
+++ b/pkgs/by-name/su/substudy/package.nix
@@ -42,6 +42,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "http://www.randomhacks.net/substudy";
     license = licenses.asl20;
     mainProgram = "substudy";
-    maintainers = with maintainers; [ paveloom ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/su/subtitleedit/package.nix
+++ b/pkgs/by-name/su/subtitleedit/package.nix
@@ -95,6 +95,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     platforms = platforms.all;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    maintainers = with maintainers; [ paveloom ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/tr/tracy/package.nix
+++ b/pkgs/by-name/tr/tracy/package.nix
@@ -124,7 +124,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [
       mpickering
       nagisa
-      paveloom
     ];
     platforms = platforms.linux ++ lib.optionals (!withWayland) platforms.darwin;
   };

--- a/pkgs/by-name/un/undetected-chromedriver/package.nix
+++ b/pkgs/by-name/un/undetected-chromedriver/package.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation (finalAttrs: {
   meta = chromedriver.meta // {
     description = "Custom Selenium ChromeDriver that passes all bot mitigation systems";
     mainProgram = "undetected-chromedriver";
-    maintainers = with lib.maintainers; [ paveloom ];
+    maintainers = with lib.maintainers; [ ];
   };
 })

--- a/pkgs/by-name/vt/vtfedit/package.nix
+++ b/pkgs/by-name/vt/vtfedit/package.nix
@@ -75,6 +75,6 @@ stdenv.mkDerivation rec {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.lgpl21Plus;
     inherit (wine.meta) platforms;
-    maintainers = with lib.maintainers; [ paveloom ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/wa/warp-plus/fix-endpoints.patch
+++ b/pkgs/by-name/wa/warp-plus/fix-endpoints.patch
@@ -1,0 +1,95 @@
+From b1bc81051810899189b071349443d82fdc1caebe Mon Sep 17 00:00:00 2001
+From: NImaism <nima.gholamyy@gmail.com>
+Date: Sat, 16 Aug 2025 22:20:15 +0330
+Subject: [PATCH] fix: warp endpoints issues
+
+---
+ app/app.go               | 18 ++++++++++++++----
+ cmd/warp-plus/rootcmd.go | 10 ----------
+ 2 files changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/app/app.go b/app/app.go
+index 770c58b536e11be3ebdb098c54cf74228139cb51..0197655d681539ed1dd1915ed65107cb7c007b17 100644
+--- a/app/app.go
++++ b/app/app.go
+@@ -56,6 +56,16 @@ func RunWarp(ctx context.Context, l *slog.Logger, opts WarpOptions) error {
+ 		return errors.New("must provide country for psiphon")
+ 	}
+ 
++	if opts.Endpoint == "" {
++		ident, err := warp.LoadOrCreateIdentity(l, path.Join(opts.CacheDir, "primary"), opts.License)
++		if err != nil {
++			l.Error("failed to load or create primary warp identity")
++			return err
++		}
++
++		opts.Endpoint = ident.Config.Peers[0].Endpoint.V4[:len(ident.Config.Peers[0].Endpoint.V4)-2] + ":500"
++	}
++
+ 	// Decide Working Scenario
+ 	endpoints := []string{opts.Endpoint, opts.Endpoint}
+ 
+@@ -96,7 +106,7 @@ func RunWarp(ctx context.Context, l *slog.Logger, opts WarpOptions) error {
+ 	case opts.Gool:
+ 		l.Info("running in warp-in-warp (gool) mode")
+ 		// run warp in warp
+-		warpErr = runWarpInWarp(ctx, l, opts, endpoints)
++		warpErr = runWarpInWarp(ctx, l, opts, endpoints[0])
+ 	default:
+ 		l.Info("running in normal warp mode")
+ 		// just run primary warp on bindAddress
+@@ -237,7 +247,7 @@ func runWarp(ctx context.Context, l *slog.Logger, opts WarpOptions, endpoint str
+ 	return nil
+ }
+ 
+-func runWarpInWarp(ctx context.Context, l *slog.Logger, opts WarpOptions, endpoints []string) error {
++func runWarpInWarp(ctx context.Context, l *slog.Logger, opts WarpOptions, endpoint string) error {
+ 	// make primary identity
+ 	ident1, err := warp.LoadOrCreateIdentity(l, path.Join(opts.CacheDir, "primary"), opts.License)
+ 	if err != nil {
+@@ -254,7 +264,7 @@ func runWarpInWarp(ctx context.Context, l *slog.Logger, opts WarpOptions, endpoi
+ 
+ 	// Enable trick and keepalive on all peers in config
+ 	for i, peer := range conf.Peers {
+-		peer.Endpoint = endpoints[0]
++		peer.Endpoint = endpoint
+ 		peer.Trick = true
+ 		peer.KeepAlive = 5
+ 
+@@ -297,7 +307,7 @@ func runWarpInWarp(ctx context.Context, l *slog.Logger, opts WarpOptions, endpoi
+ 	}
+ 
+ 	// Create a UDP port forward between localhost and the remote endpoint
+-	addr, err := wiresocks.NewVtunUDPForwarder(ctx, netip.MustParseAddrPort("127.0.0.1:0"), endpoints[0], tnet1, singleMTU)
++	addr, err := wiresocks.NewVtunUDPForwarder(ctx, netip.MustParseAddrPort("127.0.0.1:0"), endpoint, tnet1, singleMTU)
+ 	if err != nil {
+ 		return err
+ 	}
+diff --git a/cmd/warp-plus/rootcmd.go b/cmd/warp-plus/rootcmd.go
+index 87642c3708d5084d89771808c0ff7e96f6da1014..87eec817a35390cae4b66ad51fd152fce55670f6 100644
+--- a/cmd/warp-plus/rootcmd.go
++++ b/cmd/warp-plus/rootcmd.go
+@@ -13,7 +13,6 @@ import (
+ 	"github.com/adrg/xdg"
+ 	"github.com/bepass-org/warp-plus/app"
+ 	p "github.com/bepass-org/warp-plus/psiphon"
+-	"github.com/bepass-org/warp-plus/warp"
+ 	"github.com/bepass-org/warp-plus/wiresocks"
+ 	"github.com/peterbourgon/ff/v4"
+ 	"github.com/peterbourgon/ff/v4/ffval"
+@@ -205,15 +204,6 @@ func (c *rootConfig) exec(ctx context.Context, args []string) error {
+ 		opts.Scan = &wiresocks.ScanOptions{V4: c.v4, V6: c.v6, MaxRTT: c.rtt}
+ 	}
+ 
+-	// If the endpoint is not set, choose a random warp endpoint
+-	if opts.Endpoint == "" {
+-		addrPort, err := warp.RandomWarpEndpoint(c.v4, c.v6)
+-		if err != nil {
+-			fatal(l, err)
+-		}
+-		opts.Endpoint = addrPort.String()
+-	}
+-
+ 	go func() {
+ 		if err := app.RunWarp(ctx, l, opts); err != nil {
+ 			fatal(l, err)

--- a/pkgs/by-name/wa/warp-plus/package.nix
+++ b/pkgs/by-name/wa/warp-plus/package.nix
@@ -10,16 +10,16 @@
 
 buildGoModule rec {
   pname = "warp-plus";
-  version = "1.2.5";
+  version = "1.2.6";
 
   src = fetchFromGitHub {
     owner = "bepass-org";
     repo = "warp-plus";
     rev = "v${version}";
-    hash = "sha256-gDn4zicSD+Hz3GsL6pzGpUaiHcw+8KHDaOJGCML6LOA=";
+    hash = "sha256-Zi428QI0DBIPEywXPi0TwDQWJuQyQcB6N5nqtYkkpHk=";
   };
 
-  vendorHash = "sha256-MWzF9+yK+aUr8D4d64+qCD6XIqtmWH5hCLmQoksgFf8=";
+  vendorHash = "sha256-cCMbda2dVZypGqy9zoh0D3lVHWw/HNbCaSe0Nj5wL6s=";
 
   ldflags = [
     "-s"
@@ -32,6 +32,7 @@ buildGoModule rec {
       # Skip tests that require network access
       skippedTests = [
         "TestConcurrencySafety"
+        "TestNoiseHandshake"
         "TestTwoDevicePing"
       ];
     in

--- a/pkgs/by-name/wa/warp-plus/package.nix
+++ b/pkgs/by-name/wa/warp-plus/package.nix
@@ -47,7 +47,7 @@ buildGoModule rec {
     description = "Warp + Psiphon, an anti censorship utility for Iran";
     homepage = "https://github.com/bepass-org/warp-plus";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ paveloom ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "warp-plus";
     # Doesn't work with Go toolchain >1.22, runtime error:
     # 'panic: tls.ConnectionState doesn't match'

--- a/pkgs/by-name/wa/warp-plus/package.nix
+++ b/pkgs/by-name/wa/warp-plus/package.nix
@@ -10,16 +10,16 @@
 
 buildGoModule rec {
   pname = "warp-plus";
-  version = "1.2.6";
+  version = "1.2.6-unstable-2025-08-13";
 
   src = fetchFromGitHub {
     owner = "bepass-org";
     repo = "warp-plus";
-    rev = "v${version}";
-    hash = "sha256-Zi428QI0DBIPEywXPi0TwDQWJuQyQcB6N5nqtYkkpHk=";
+    rev = "08d43e9e4c079534e47ba19fb2965c968c9621b2";
+    hash = "sha256-MHz8b1whSzUJO0YogxMPuXMaQRfR+xxSYhFxq412EmE=";
   };
 
-  vendorHash = "sha256-cCMbda2dVZypGqy9zoh0D3lVHWw/HNbCaSe0Nj5wL6s=";
+  vendorHash = "sha256-GmxiQk50iQoH2J/qUVvl9RBz6aIQp8RURqTzrl6NdCY=";
 
   ldflags = [
     "-s"
@@ -27,10 +27,16 @@ buildGoModule rec {
     "-X main.version=${version}"
   ];
 
+  patches = [
+    # https://github.com/bepass-org/warp-plus/pull/291
+    ./fix-endpoints.patch
+  ];
+
   checkFlags =
     let
       # Skip tests that require network access
       skippedTests = [
+        "TestStdNetBindReceiveFuncAfterClose"
         "TestConcurrencySafety"
         "TestNoiseHandshake"
         "TestTwoDevicePing"
@@ -39,8 +45,11 @@ buildGoModule rec {
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   passthru = {
-    updateScript = nix-update-script { };
-    tests.version = testers.testVersion { package = warp-plus; };
+    updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+    tests.version = testers.testVersion {
+      package = warp-plus;
+      command = "warp-plus version";
+    };
   };
 
   meta = {

--- a/pkgs/by-name/wa/warp-plus/package.nix
+++ b/pkgs/by-name/wa/warp-plus/package.nix
@@ -56,10 +56,7 @@ buildGoModule rec {
     description = "Warp + Psiphon, an anti censorship utility for Iran";
     homepage = "https://github.com/bepass-org/warp-plus";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ phanirithvij ];
     mainProgram = "warp-plus";
-    # Doesn't work with Go toolchain >1.22, runtime error:
-    # 'panic: tls.ConnectionState doesn't match'
-    broken = true;
   };
 }

--- a/pkgs/by-name/wh/whisparr/package.nix
+++ b/pkgs/by-name/wh/whisparr/package.nix
@@ -91,6 +91,6 @@ stdenv.mkDerivation rec {
     ];
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     mainProgram = "Whisparr";
-    maintainers = [ lib.maintainers.paveloom ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyqtdarktheme/default.nix
+++ b/pkgs/development/python-modules/pyqtdarktheme/default.nix
@@ -58,6 +58,6 @@ buildPythonPackage rec {
     description = "Flat dark theme for PySide and PyQt";
     homepage = "https://pyqtdarktheme.readthedocs.io/en/stable";
     license = licenses.mit;
-    maintainers = with maintainers; [ paveloom ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/undetected-chromedriver/default.nix
+++ b/pkgs/development/python-modules/undetected-chromedriver/default.nix
@@ -49,6 +49,6 @@ buildPythonPackage {
     description = "Python library for the custom Selenium ChromeDriver that passes all bot mitigation systems";
     homepage = "https://github.com/ultrafunkamsterdam/undetected-chromedriver";
     license = licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ paveloom ];
+    maintainers = with lib.maintainers; [ ];
   };
 }


### PR DESCRIPTION
manual backport to `release-25.05`, for #437862.

* [ ]  Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md?rgh-link-date=2025-08-10T17%3A52%3A14Z#changes-acceptable-for-releases).
  * Even as a non-committer, if you find that it is not acceptable, leave a comment.