### PR TITLE
tp_smapi: 0.44-unstable-2025-05-26 -> 0.45

### DIFF
--- a/pkgs/os-specific/linux/tp_smapi/default.nix
+++ b/pkgs/os-specific/linux/tp_smapi/default.nix
@@ -5,15 +5,15 @@
   kernel,
 }:
 
-stdenv.mkDerivation rec {
-  name = "tp_smapi-${version}-${kernel.version}";
-  version = "0.44-unstable-2025-05-26";
+stdenv.mkDerivation (finalAttrs: {
+  name = "tp_smapi-${finalAttrs.version}-${kernel.version}";
+  version = "0.45";
 
   src = fetchFromGitHub {
     owner = "linux-thinkpad";
     repo = "tp_smapi";
-    rev = "a6122c0840c36bf232250afd1da30aaedaf24910";
-    hash = "sha256-4bVyhTVj29ni9hduN20+VEl5/N0BAoMNMBw+k4yl8Y0=";
+    tag = "tp-smapi/${finalAttrs.version}";
+    hash = "sha256-rB+DNgWUXd1oQBbDgVEAJVJ16nKCaKDtWGAmpcFsx+A=";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
@@ -27,9 +27,13 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
+    runHook preInstall
+
     install -v -D -m 644 thinkpad_ec.ko "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/firmware/thinkpad_ec.ko"
     install -v -D -m 644 tp_smapi.ko "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/firmware/tp_smapi.ko"
     install -v -D -m 644 hdaps.ko "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/firmware/hdapsd.ko"
+
+    runHook postInstall
   '';
 
   dontStrip = true;
@@ -41,10 +45,10 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/linux-thinkpad/tp_smapi";
     license = lib.licenses.gpl2Plus;
     maintainers = [ ];
-    # driver is only meant for linux thinkpads i think  bellow platforms should cover it.
+    # driver is only meant for linux thinkpads, bellow platforms should cover it.
     platforms = [
       "x86_64-linux"
       "i686-linux"
     ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/linux-thinkpad/tp_smapi/blob/tp-smapi/0.45/CHANGES
https://github.com/linux-thinkpad/tp_smapi/releases/tag/tp-smapi%2F0.45
https://github.com/linux-thinkpad/tp_smapi/compare/a6122c0840c36bf232250afd1da30aaedaf24910...tp-smapi/0.45

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
