### PR TITLE
Revert "bmake: interrupt test fails on x86_64-linux some of the time"

### DIFF
--- a/pkgs/by-name/bm/bmake/package.nix
+++ b/pkgs/by-name/bm/bmake/package.nix
@@ -53,17 +53,22 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Disabled tests:
-  # * cmd-interrupt: tries to `SIGINT` make itself, flaky as a result
   # * directive-export{,-gmake}: another failure related to TZ variables
   # * opt-keep-going-indirect: not yet known
-  # * varmod-localtime: musl doesn't support TZDIR and this test relies on impure, implicit paths
-  env.BROKEN_TESTS = lib.concatStringsSep " " [
-    "cmd-interrupt"
-    "directive-export"
-    "directive-export-gmake"
-    "opt-keep-going-indirect"
-    "varmod-localtime"
-  ];
+  # * varmod-localtime: musl doesn't support TZDIR and this test relies on
+  #   impure, implicit paths
+  # * interrupt-compat (fails on x86_64-linux building for i686-linux)
+  env.BROKEN_TESTS = lib.concatStringsSep " " (
+    [
+      "directive-export"
+      "directive-export-gmake"
+      "opt-keep-going-indirect"
+      "varmod-localtime"
+    ]
+    ++ lib.optionals stdenv.targetPlatform.is32bit [
+      "interrupt-compat"
+    ]
+  );
 
   strictDeps = true;
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#439193