### PR TITLE
webtunnel: 0-unstable-2024-07-06 -> 0.0.3, build on all golang platforms

### DIFF
--- a/pkgs/by-name/we/webtunnel/package.nix
+++ b/pkgs/by-name/we/webtunnel/package.nix
@@ -3,16 +3,18 @@
   buildGoModule,
   fetchFromGitLab,
 }:
-buildGoModule {
+
+buildGoModule rec {
   pname = "webtunnel";
-  version = "0-unstable-2024-07-06"; # package is not versioned upstream
+  version = "0.0.3";
+
   src = fetchFromGitLab {
     domain = "gitlab.torproject.org";
     group = "tpo";
     owner = "anti-censorship/pluggable-transports";
     repo = "webtunnel";
-    rev = "e64b1b3562f3ab50d06141ecd513a21ec74fe8c6";
-    hash = "sha256-25ZtoCe1bcN6VrSzMfwzT8xSO3xw2qzE4Me3Gi4GbVs=";
+    rev = "v${version}";
+    hash = "sha256-HB95GCIJeO5fKUW23VHrtNZdc9x9fk2vnmI9JogDWSQ=";
   };
 
   vendorHash = "sha256-3AAPySLAoMimXUOiy8Ctl+ghG5q+3dWRNGXHpl9nfG0=";
@@ -22,7 +24,5 @@ buildGoModule {
     homepage = "https://community.torproject.org/relay/setup/webtunnel/";
     maintainers = [ lib.maintainers.gbtb ];
     license = lib.licenses.mit;
-    platforms = lib.platforms.linux;
   };
-
 }


### PR DESCRIPTION
v0.0.3 release: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/webtunnel/-/releases/v0.0.3

Tested to work on aarch64-darwin, by connecting to Tor over a WebTunnel bridge.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
