### PR TITLE
why3find: init at 1.2.0

### DIFF
--- a/pkgs/by-name/wh/why3find/package.nix
+++ b/pkgs/by-name/wh/why3find/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchurl,
+  ocamlPackages,
+  why3,
+}:
+
+with ocamlPackages;
+buildDunePackage {
+  pname = "why3find";
+  version = "1.2.0";
+
+  src = fetchurl {
+    url = "https://git.frama-c.com/-/project/1056/uploads/043312a7a70961338479016ac535c706/why3find-1.2.0.tbz";
+    hash = "sha256-eslkMBo0i0+Oy8jW9eRNuyGXuwkV6eeYcxZm5MfgA6w=";
+  };
+
+  propagatedBuildInputs = [
+    dune-site
+    terminal_size
+    why3
+    yojson
+    zmq
+  ];
+
+  meta = {
+    description = "Why3 Package Manager";
+    homepage = "https://git.frama-c.com/pub/why3find";
+    license = lib.licenses.lgpl21Only;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/zmq/default.nix
+++ b/pkgs/development/ocaml-modules/zmq/default.nix
@@ -15,10 +15,9 @@ buildDunePackage rec {
     hash = "sha256-tetCmVg27/WHZ+HMwKZVHCrHTzWAlKwkAjNDibB1+6g=";
   };
 
-  buildInputs = [
-    czmq
-    dune-configurator
-  ];
+  buildInputs = [ dune-configurator ];
+
+  propagatedBuildInputs = [ czmq ];
 
   meta = {
     description = "ZeroMQ bindings for OCaml";


### PR DESCRIPTION
cc @jthulhu

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
