### PR TITLE
nodejs: patch away absolute paths from GYP script

### DIFF
--- a/pkgs/development/web/nodejs/gyp-patches-set-fallback-value-for-CLT-darwin.patch
+++ b/pkgs/development/web/nodejs/gyp-patches-set-fallback-value-for-CLT-darwin.patch
@@ -1,0 +1,63 @@
+Sandboxed builds need a fallback value for the version of the Command Line Tools
+being used.
+
+diff --git a/tools/gyp/pylib/gyp/xcode_emulation.py b/tools/gyp/pylib/gyp/xcode_emulation.py
+index 508f6ccac3e..44bcd988c4c 100644
+--- a/tools/gyp/pylib/gyp/xcode_emulation.py
++++ b/tools/gyp/pylib/gyp/xcode_emulation.py
+@@ -1495,24 +1495,8 @@ def XcodeVersion():
+     global XCODE_VERSION_CACHE
+     if XCODE_VERSION_CACHE:
+         return XCODE_VERSION_CACHE
+-    version = ""
++    version = "11.0.0.0.1.1567737322"
+     build = ""
+-    try:
+-        version_list = GetStdoutQuiet(["xcodebuild", "-version"]).splitlines()
+-        # In some circumstances xcodebuild exits 0 but doesn't return
+-        # the right results; for example, a user on 10.7 or 10.8 with
+-        # a bogus path set via xcode-select
+-        # In that case this may be a CLT-only install so fall back to
+-        # checking that version.
+-        if len(version_list) < 2:
+-            raise GypError("xcodebuild returned unexpected results")
+-        version = version_list[0].split()[-1]  # Last word on first line
+-        build = version_list[-1].split()[-1]  # Last word on last line
+-    except (GypError, OSError):
+-        # Xcode not installed so look for XCode Command Line Tools
+-        version = CLTVersion()  # macOS Catalina returns 11.0.0.0.1.1567737322
+-        if not version:
+-            raise GypError("No Xcode or CLT version detected!")
+     # Be careful to convert "4.2.3" to "0423" and "11.0.0" to "1100":
+     version = version.split(".")[:3]  # Just major, minor, micro
+     version[0] = version[0].zfill(2)  # Add a leading zero if major is one digit
+ 
+ 
+--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/xcode_emulation.py
++++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/xcode_emulation.py
+@@ -1495,24 +1495,8 @@ def XcodeVersion():
+     global XCODE_VERSION_CACHE
+     if XCODE_VERSION_CACHE:
+         return XCODE_VERSION_CACHE
+-    version = ""
++    version = "11.0.0.0.1.1567737322"
+     build = ""
+-    try:
+-        version_list = GetStdoutQuiet(["xcodebuild", "-version"]).splitlines()
+-        # In some circumstances xcodebuild exits 0 but doesn't return
+-        # the right results; for example, a user on 10.7 or 10.8 with
+-        # a bogus path set via xcode-select
+-        # In that case this may be a CLT-only install so fall back to
+-        # checking that version.
+-        if len(version_list) < 2:
+-            raise GypError("xcodebuild returned unexpected results")
+-        version = version_list[0].split()[-1]  # Last word on first line
+-        build = version_list[-1].split()[-1]  # Last word on last line
+-    except (GypError, OSError):
+-        # Xcode not installed so look for XCode Command Line Tools
+-        version = CLTVersion()  # macOS Catalina returns 11.0.0.0.1.1567737322
+-        if not version:
+-            raise GypError("No Xcode or CLT version detected!")
+     # Be careful to convert "4.2.3" to "0423" and "11.0.0" to "1100":
+     version = version.split(".")[:3]  # Just major, minor, micro
+     version[0] = version[0].zfill(2)  # Add a leading zero if major is one digit

--- a/pkgs/development/web/nodejs/gyp-patches.nix
+++ b/pkgs/development/web/nodejs/gyp-patches.nix
@@ -47,3 +47,7 @@ lib.optionals patch_tools_catch_oserror ([
     extraPrefix = "deps/npm/node_modules/node-gyp/gyp/";
   })
 ])
+# TODO: remove the Darwin conditionals from this file
+++ lib.optionals stdenv.buildPlatform.isDarwin ([
+  ./gyp-patches-set-fallback-value-for-CLT-darwin.patch
+])


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Staging-next builds are broken on Darwin because the `CLTVersion` function in `xcode_emulation.py` relies on absolute paths. By patching the use of this function and hard-coding an arbitrary version number, hydra should no longer reach the exception it's currently getting.

Refs: https://github.com/NixOS/nixpkgs/pull/439129#pullrequestreview-3174131534

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
