### PR TITLE
mpdris2: modernize

### DIFF
--- a/pkgs/by-name/mp/mpdris2/package.nix
+++ b/pkgs/by-name/mp/mpdris2/package.nix
@@ -7,11 +7,11 @@
   gobject-introspection,
   intltool,
   libnotify,
-  python3,
+  python3Packages,
   wrapGAppsHook3,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "mpDris2";
   version = "0.9.1";
   format = "other";
@@ -40,7 +40,7 @@ python3.pkgs.buildPythonApplication rec {
     libnotify
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with python3Packages; [
     dbus-python
     mpd2
     mutagen

--- a/pkgs/by-name/mp/mpdris2/package.nix
+++ b/pkgs/by-name/mp/mpdris2/package.nix
@@ -47,6 +47,13 @@ python3.pkgs.buildPythonApplication rec {
     pygobject3
   ];
 
+  # Python builder already uses makeWrapper, so we disable the hook
+  # and add its args to the existing ones for Python:
+  # https://nixos.org/manual/nixpkgs/stable/#ssec-gnome-common-issues-double-wrapped
+  dontWrapGApps = true;
+
+  makeWrapperArgs = [ "\${gappsWrapperArgs[@]}" ];
+
   patches = [ ./fix-gettext-0.25.patch ];
 
   meta = with lib; {

--- a/pkgs/by-name/mp/mpdris2/package.nix
+++ b/pkgs/by-name/mp/mpdris2/package.nix
@@ -40,7 +40,7 @@ python3Packages.buildPythonApplication rec {
     libnotify
   ];
 
-  propagatedBuildInputs = with python3Packages; [
+  dependencies = with python3Packages; [
     dbus-python
     mpd2
     mutagen

--- a/pkgs/by-name/mp/mpdris2/package.nix
+++ b/pkgs/by-name/mp/mpdris2/package.nix
@@ -56,12 +56,12 @@ python3.pkgs.buildPythonApplication rec {
 
   patches = [ ./fix-gettext-0.25.patch ];
 
-  meta = with lib; {
+  meta = {
     description = "MPRIS 2 support for mpd";
     homepage = "https://github.com/eonpatapon/mpDris2/";
-    license = licenses.gpl3;
+    license = lib.licenses.gpl3Plus;
     maintainers = [ ];
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
     mainProgram = "mpDris2";
   };
 }

--- a/pkgs/by-name/mp/mpdris2/package.nix
+++ b/pkgs/by-name/mp/mpdris2/package.nix
@@ -19,8 +19,8 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "eonpatapon";
     repo = "mpDris2";
-    rev = version;
-    sha256 = "sha256-1Y6K3z8afUXeKhZzeiaEF3yqU0Ef7qdAj9vAkRlD2p8=";
+    tag = version;
+    hash = "sha256-1Y6K3z8afUXeKhZzeiaEF3yqU0Ef7qdAj9vAkRlD2p8=";
   };
 
   preConfigure = ''


### PR DESCRIPTION
originally the executable was wrapped twice


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
