### PR TITLE
neovim: add default-enabled waylandSupport to the wrapper

### DIFF
--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -3,6 +3,7 @@
   lib,
   makeWrapper,
   bundlerEnv,
+  wl-clipboard,
   ruby,
   nodejs,
   writeText,
@@ -39,6 +40,7 @@ let
       # the function you would have passed to python3.withPackages
       extraPython3Packages ? (_: [ ]),
 
+      waylandSupport ? stdenv.hostPlatform.isLinux,
       withNodeJs ? false,
       withPerl ? false,
       withRuby ? true,
@@ -214,6 +216,7 @@ let
         inherit
           viAlias
           vimAlias
+          waylandSupport
           withNodeJs
           withPython3
           withPerl
@@ -234,7 +237,8 @@ let
             op = acc: normalizedPlugin: acc ++ normalizedPlugin.plugin.runtimeDeps or [ ];
             runtimeDeps = lib.foldl' op [ ] pluginsNormalized;
           in
-          lib.optional finalAttrs.withRuby rubyEnv
+          lib.optionals finalAttrs.waylandSupport [ wl-clipboard ]
+          ++ lib.optional finalAttrs.withRuby rubyEnv
           ++ lib.optional finalAttrs.withNodeJs nodejs
           ++ lib.optionals finalAttrs.autowrapRuntimeDeps runtimeDeps;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Copying to the system clipboard on wayland requires the `wl-clipboard`.
This PR adds a `waylandSupport` argument to the wrapper which appends this package to the list of runtime dependencies.
As wayland is fairly popular nowadays, I propose to enable it by default.

cc @NixOS/neovim

Closes #439041

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
