### PR TITLE
multipass: patch working dir base from `/usr/local` to `/var/lib`

### DIFF
--- a/nixos/tests/multipass.nix
+++ b/nixos/tests/multipass.nix
@@ -30,6 +30,7 @@ in
     machine.wait_for_unit("sockets.target")
     machine.wait_for_unit("multipass.service")
     machine.wait_for_file("/var/lib/multipass/data/multipassd/network/multipass_subnet")
+    machine.wait_for_file("/var/lib/multipass/config/multipassd/multipass_root_cert.pem")
 
     # Wait for Multipass to settle
     machine.sleep(1)

--- a/pkgs/by-name/mu/multipass/base_dir_linux.patch
+++ b/pkgs/by-name/mu/multipass/base_dir_linux.patch
@@ -1,0 +1,13 @@
+diff --git i/src/platform/platform_linux.cpp w/src/platform/platform_linux.cpp
+index 987eaeffd..226623f29 100644
+--- i/src/platform/platform_linux.cpp
++++ w/src/platform/platform_linux.cpp
+@@ -468,7 +468,7 @@ std::filesystem::path mp::platform::Platform::get_root_cert_dir() const
+     using Path = std::filesystem::path;
+     const auto base_dir = utils::in_multipass_snap()
+                               ? Path{utils::snap_common_dir().toStdString()} / "data"
+-                              : Path{"/usr/local/etc"};
++                              : Path{"/var/lib/multipass/config"};
+ 
+     return base_dir / daemon_name;
+ }

--- a/pkgs/by-name/mu/multipass/multipassd.nix
+++ b/pkgs/by-name/mu/multipass/multipassd.nix
@@ -52,6 +52,11 @@ stdenv.mkDerivation {
     # unreachable path was not annotated as such - this patch adds the annotation to ensure
     # that the test suite passes in the nix build process.
     ./test_unreachable_call.patch
+    # By default, the base dir for placing generated config and certs is in /usr/local
+    # which can cause some issues if the permissions are set incorrectly - which appears
+    # to be the case when Multipass creates the dir. The Nix module already uses /var/lib/multipass
+    # so this patch switches the base dir there, where permissions should already be set
+    ./base_dir_linux.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
## Things done

Multipass, when not in a Snap package, uses `/usr/local/etc` as a base directory for generated configuration and certs.

In some cases (#439105), Multipass is the only thing on the system using `/usr/local`, so it creates the directory but with the incorrect permissions - resulting in an error reading the certificate, and the CLI to stop functioning (I think, based on the issue report).

This change introduces a patch which points Multipass at the `XDG_CONFIG_HOME` that is set in the Multipass module, and [is configured](https://github.com/NixOS/nixpkgs/blob/9dffc88331b751c85bfd89c89eecf879e284e90d/nixos/modules/virtualisation/multipass.nix#L59-L60) with the correct permissions.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
