### PR TITLE
python3Packages.fastexcel: 0.14.0 -> 0.15.0

### DIFF
--- a/pkgs/development/python-modules/fastexcel/default.nix
+++ b/pkgs/development/python-modules/fastexcel/default.nix
@@ -8,12 +8,10 @@
   cargo,
   rustc,
 
-  # dependencies
-  pyarrow,
-
   # optional-dependencies
   pandas,
   polars,
+  pyarrow,
 
   # tests
   pytest-mock,
@@ -22,19 +20,19 @@
 
 buildPythonPackage rec {
   pname = "fastexcel";
-  version = "0.14.0";
+  version = "0.15.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ToucanToco";
     repo = "fastexcel";
     tag = "v${version}";
-    hash = "sha256-sBpefpJm8b+6WQeO7zqihFDYPRnMZUQFSapcDkqekI0=";
+    hash = "sha256-kGGtTgy8k6TeP4iwonIwiQKiYMFAXw9v5Q5dpdcYP7A=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-gwLVxW9ETzvnI0tE8EWr8pUtvsBAQ/tC4tgEso15N3M=";
+    hash = "sha256-SdraNHOicCjIKFaTSRn4dEzfW8w243y/w9ym9JduMQo=";
   };
 
   nativeBuildInputs = [
@@ -44,13 +42,17 @@ buildPythonPackage rec {
     rustc
   ];
 
-  dependencies = [
-    pyarrow
+  maturinBuildFlags = [
+    "--features __maturin"
   ];
 
   optional-dependencies = {
+    pyarrow = [
+      pyarrow
+    ];
     pandas = [
       pandas
+      pyarrow
     ];
     polars = [
       polars
@@ -59,11 +61,17 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [
     "fastexcel"
+    "fastexcel._fastexcel"
   ];
+
+  preCheck = ''
+    rm -rf python/fastexcel
+  '';
 
   nativeCheckInputs = [
     pandas
     polars
+    pyarrow
     pytest-mock
     pytestCheckHook
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/ToucanToco/fastexcel/compare/v0.14.0...v0.15.0
Changelog: https://github.com/ToucanToco/fastexcel/releases/tag/v0.15.0


- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc