### PR TITLE
python3Packages.crypt4gh: init at 1.7

### DIFF
--- a/pkgs/by-name/cr/crypt4gh/package.nix
+++ b/pkgs/by-name/cr/crypt4gh/package.nix
@@ -1,0 +1,3 @@
+{ python3Packages }:
+
+python3Packages.toPythonApplication python3Packages.crypt4gh

--- a/pkgs/development/python-modules/crypt4gh/default.nix
+++ b/pkgs/development/python-modules/crypt4gh/default.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildPythonPackage,
+  setuptools,
+  fetchFromGitHub,
+  installShellFiles,
+  bats,
+  openssh,
+
+  # deps
+  cryptography,
+  bcrypt,
+  pyyaml,
+  docopt,
+  pynacl,
+}:
+
+buildPythonPackage rec {
+  pname = "crypt4gh";
+  version = "1.7";
+  pyproject = true;
+  src = fetchFromGitHub {
+    owner = "EGA-archive";
+    repo = "crypt4gh";
+    rev = "v${version}";
+    hash = "sha256-kPXD/SityWscHuRn068E6fFxUjt67cC5VEe5o8wtxwk=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    pyyaml
+    docopt
+    cryptography
+    pynacl
+    bcrypt
+  ];
+
+  pythonImportsCheck = [ "crypt4gh" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion \
+      completions/crypt4gh-debug.bash \
+      completions/crypt4gh-debug.bash \
+      completions/crypt4gh.bash
+  '';
+
+  nativeCheckInputs = [
+    bats
+    openssh
+  ];
+  installCheckPhase = ''
+    PATH=$PATH:$out/bin
+    bats tests
+  '';
+
+  meta = {
+    mainProgram = "crypt4gh";
+    description = "Tool to encrypt, decrypt or re-encrypt files, according to the GA4GH encryption file format";
+    homepage = "https://github.com/EGA-archive/crypt4gh";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.richardjacton ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3104,6 +3104,8 @@ self: super: with self; {
 
   crownstone-uart = callPackage ../development/python-modules/crownstone-uart { };
 
+  crypt4gh = callPackage ../development/python-modules/crypt4gh { };
+
   cryptg = callPackage ../development/python-modules/cryptg { };
 
   cryptodatahub = callPackage ../development/python-modules/cryptodatahub { };


### PR DESCRIPTION
Adds the current version of [crypt4gh](https://github.com/EGA-archive/crypt4gh).

> crypt4gh is a Python tool to encrypt, decrypt or re-encrypt files, according to the GA4GH encryption file format.

This used by researchers to submit data to the The European Genome-phenome Archive (EGA)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - I'm not in the mainteriners file yet so nixpkgs-review complained about this.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
