### PR TITLE
klystrack: Fix FTBFS, maintain abit

### DIFF
--- a/pkgs/by-name/kl/klystrack/package.nix
+++ b/pkgs/by-name/kl/klystrack/package.nix
@@ -8,38 +8,47 @@
   pkg-config,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "klystrack";
   version = "1.7.6";
 
   src = fetchFromGitHub {
     owner = "kometbomb";
     repo = "klystrack";
-    tag = version;
+    tag = finalAttrs.version;
     fetchSubmodules = true;
-    sha256 = "1h99sm2ddaq483hhk2s3z4bjbgn0d2h7qna7l7qq98wvhqix8iyz";
+    hash = "sha256-30fUI4abo4TxoUdZfKBowL4lF/lDiwnhQASr1kTVKcE=";
   };
 
   # https://github.com/kometbomb/klystrack/commit/6dac9eb5e75801ce4dec1d8b339f78e3df2f54bc fixes build but doesn't apply as-is, just patch in the flag
   # Make embedded date reproducible
+  # Use pkg-config instead of sdl2-config
   postPatch = ''
     substituteInPlace Makefile \
       --replace-fail '-DUSESDL_IMAGE' '-DUSESDL_IMAGE -DUSESDL_RWOPS'
 
     substituteInPlace Makefile klystron/Makefile \
       --replace-fail 'date' 'date --date @$(SOURCE_DATE_EPOCH)'
+
+    substituteInPlace klystron/common.mk klystron/tools/makebundle/Makefile \
+      --replace-fail 'sdl2-config' 'pkg-config sdl2 SDL2_image'
   '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
 
   buildInputs = [
     SDL2
     SDL2_image
   ];
-  nativeBuildInputs = [ pkg-config ];
 
   patches = [
     (fetchpatch {
       url = "https://github.com/kometbomb/klystrack/commit/bb537595d02140176831c4a1b8e9121978b32d22.patch";
-      sha256 = "06gl9q0jwg039kpxb13lg9x0k59s11968qn4lybgkadvzmhxkgmi";
+      hash = "sha256-sb7ZYf27qfmWp8RiZFIIOpUJenp0hNXvTAM8LgFO9Bk=";
     })
   ];
 
@@ -55,6 +64,8 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
+    runHook preInstall
+
     install -Dm755 bin.release/klystrack $out/bin/klystrack
 
     mkdir -p $out/lib/klystrack
@@ -65,14 +76,16 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/applications
     substitute linux/klystrack.desktop $out/share/applications/klystrack.desktop \
       --replace "klystrack %f" "$out/bin/klystrack %f"
+
+    runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Chiptune tracker";
     homepage = "https://kometbomb.github.io/klystrack";
-    license = licenses.mit;
-    maintainers = with maintainers; [ suhr ];
-    platforms = platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ suhr ];
+    platforms = lib.platforms.linux;
     mainProgram = "klystrack";
   };
-}
+})

--- a/pkgs/by-name/kl/klystrack/package.nix
+++ b/pkgs/by-name/kl/klystrack/package.nix
@@ -21,9 +21,13 @@ stdenv.mkDerivation rec {
   };
 
   # https://github.com/kometbomb/klystrack/commit/6dac9eb5e75801ce4dec1d8b339f78e3df2f54bc fixes build but doesn't apply as-is, just patch in the flag
+  # Make embedded date reproducible
   postPatch = ''
     substituteInPlace Makefile \
       --replace-fail '-DUSESDL_IMAGE' '-DUSESDL_IMAGE -DUSESDL_RWOPS'
+
+    substituteInPlace Makefile klystron/Makefile \
+      --replace-fail 'date' 'date --date @$(SOURCE_DATE_EPOCH)'
   '';
 
   buildInputs = [

--- a/pkgs/by-name/kl/klystrack/package.nix
+++ b/pkgs/by-name/kl/klystrack/package.nix
@@ -20,6 +20,12 @@ stdenv.mkDerivation rec {
     sha256 = "1h99sm2ddaq483hhk2s3z4bjbgn0d2h7qna7l7qq98wvhqix8iyz";
   };
 
+  # https://github.com/kometbomb/klystrack/commit/6dac9eb5e75801ce4dec1d8b339f78e3df2f54bc fixes build but doesn't apply as-is, just patch in the flag
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail '-DUSESDL_IMAGE' '-DUSESDL_IMAGE -DUSESDL_RWOPS'
+  '';
+
   buildInputs = [
     SDL2
     SDL2_image


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
