### PR TITLE
replace-workspace-values.py: fix missing key exception

### DIFF
--- a/pkgs/build-support/rust/replace-workspace-values.py
+++ b/pkgs/build-support/rust/replace-workspace-values.py
@@ -44,17 +44,17 @@ def replace_key(
 
             final: dict[str, Any] = workspace_dep.copy()
 
-            merged_features = local_dep.pop("features", []) + workspace_dep.get("features", [])
+            merged_features = local_dep.pop("features", []) + workspace_dep.get(
+                "features", []
+            )
             if merged_features:
                 final["features"] = merged_features
 
             local_default_features = local_dep.pop(
-                "default-features",
-                local_dep.pop("default_features", None)
+                "default-features", local_dep.pop("default_features", None)
             )
             workspace_default_features = workspace_dep.get(
-                "default-features",
-                workspace_dep.get("default_features")
+                "default-features", workspace_dep.get("default_features")
             )
 
             if not workspace_default_features and local_default_features:
@@ -68,7 +68,9 @@ def replace_key(
                 final["package"] = local_dep.pop("package")
 
             if local_dep:
-                raise Exception(f"Unhandled keys in inherited dependency {key}: {local_dep}")
+                raise Exception(
+                    f"Unhandled keys in inherited dependency {key}: {local_dep}"
+                )
 
             table[key] = final
         elif section == "package":

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/crate_missing_field.toml
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/crate_missing_field.toml
@@ -1,0 +1,13 @@
+[package]
+name = "im_using_workspaces"
+version = { workspace = true }
+publish = false
+readme.workspace = true
+keywords = [
+    "workspace",
+    "other_thing",
+    "third_thing",
+]
+
+[dependencies]
+bar = "1.0.0"

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/default.nix
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/default.nix
@@ -8,4 +8,8 @@ runCommand "git-dependency-workspace-inheritance-test" { } ''
   cp --no-preserve=mode ${./crate_lints.toml} "$out"
   ${replaceWorkspaceValues} "$out" ${./workspace.toml}
   diff -u "$out" ${./want_lints.toml}
+
+  cp --no-preserve=mode ${./crate_missing_field.toml} "$out"
+  ${replaceWorkspaceValues} "$out" ${./workspace.toml}
+  diff -u "$out" ${./want_missing_field.toml}
 ''

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/want_missing_field.toml
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/want_missing_field.toml
@@ -1,0 +1,12 @@
+[package]
+name = "im_using_workspaces"
+version = "1.0.0"
+publish = false
+keywords = [
+    "workspace",
+    "other_thing",
+    "third_thing",
+]
+
+[dependencies]
+bar = "1.0.0"


### PR DESCRIPTION
If a cargo workspace member defines a key with `.workpace = true` but this key does not exist in the workspace manifest, the script was raising an exception. The case is now handled properly.

Closes #439477
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
