### PR TITLE
python3Packages.torch: fix on aarch64-linux

### DIFF
--- a/pkgs/development/python-modules/torch/source/default.nix
+++ b/pkgs/development/python-modules/torch/source/default.nix
@@ -306,6 +306,11 @@ buildPythonPackage rec {
       url = "https://github.com/pytorch/pytorch/commit/231c72240d80091f099c95e326d3600cba866eee.patch";
       hash = "sha256-BBCjxzz2TUkx4nXRyRILA82kMwyb/4+C3eOtYqf5dhk=";
     })
+
+    # Fixes GCC-14 compatibility on ARM
+    # Adapted from https://github.com/pytorch/pytorch/pull/157867
+    # TODO: remove at the next release
+    ./gcc-14-arm-compat.path
   ]
   ++ lib.optionals cudaSupport [
     ./fix-cmake-cuda-toolkit.patch

--- a/pkgs/development/python-modules/torch/source/gcc-14-arm-compat.path
+++ b/pkgs/development/python-modules/torch/source/gcc-14-arm-compat.path
@@ -1,0 +1,49 @@
+diff --git a/aten/src/ATen/cpu/vec/sve/vec_bfloat16.h b/aten/src/ATen/cpu/vec/sve/vec_bfloat16.h
+index 7f05c2ad166..1632b595c4c 100644
+--- a/aten/src/ATen/cpu/vec/sve/vec_bfloat16.h
++++ b/aten/src/ATen/cpu/vec/sve/vec_bfloat16.h
+@@ -220,8 +220,12 @@ class Vectorized<BFloat16> {
+   Vectorized<BFloat16> le(const Vectorized<BFloat16>& other) const;
+ };
+
+-inline std::tuple<Vectorized<float>, Vectorized<float>> convert_bfloat16_float(
+-    const Vectorized<c10::BFloat16>& a) {
++#if defined(__GNUC__) && __GNUC__ == 14
++// Workaround for gcc-14.2.0 ICE during RTL pass: vregs when compiling for SVE
++__attribute__((optimize("no-tree-vectorize")))
++#endif
++inline std::tuple<Vectorized<float>, Vectorized<float>>
++convert_bfloat16_float(const Vectorized<c10::BFloat16>& a) {
+   static_assert(
+       Vectorized<c10::BFloat16>::size() == 2 * Vectorized<float>::size());
+   auto zero = svreinterpret_bf16_f32(svdup_n_f32(0.0f));
+diff --git a/aten/src/ATen/native/cpu/Activation.cpp b/aten/src/ATen/native/cpu/Activation.cpp
+index 52d5383e60f..00c9f4eb253 100644
+--- a/aten/src/ATen/native/cpu/Activation.cpp
++++ b/aten/src/ATen/native/cpu/Activation.cpp
+@@ -26,6 +26,10 @@ namespace at::native {
+
+ namespace {
+
++#if defined(__GNUC__) && __GNUC__ == 14 && defined(__aarch64__) && !defined(__ARM_FEATURE_SVE)
++// Workaround for gcc-14.2.0 ICE during RTL pass: expand when compiling for NEON
++__attribute__((optimize("no-tree-vectorize")))
++#endif
+ static void log_sigmoid_cpu_kernel(TensorBase &output, TensorBase &buffer, const TensorBase &input) {
+   if (at::isReducedFloatingType(input.scalar_type())) {
+     AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "log_sigmoid_cpu", [&]() {
+diff --git a/aten/src/ATen/native/cpu/Unfold2d.cpp b/aten/src/ATen/native/cpu/Unfold2d.cpp
+index 8ef0741e77a..8c94decfff0 100644
+--- a/aten/src/ATen/native/cpu/Unfold2d.cpp
++++ b/aten/src/ATen/native/cpu/Unfold2d.cpp
+@@ -169,6 +169,10 @@ static void unfolded2d_acc_channels_last(
+
+ /* note: due to write issues, this one cannot be parallelized as well as
+  * unfolded2d_copy */
++#if defined(__GNUC__) && __GNUC__ == 14 && defined(__ARM_FEATURE_SVE) && !defined(__ARM_FEATURE_BF16)
++// Workaround for gcc-14.2.0 ICE during RTL pass: vregs when compiling for SVE without BF16
++__attribute__((optimize("no-tree-vectorize")))
++#endif
+ void unfolded2d_acc_kernel(
+     ScalarType dtype,
+     void *finput_data,


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Currently fails with:
```
FAILED: [code=1] caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/UfuncCPUKernel_add.cpp.SVE256.cpp.o
/nix/store/sf05r8srgh21m1804jvagbidggh05n08-gcc-wrapper-14.3.0/bin/g++ -DAT_BUILD_ARM_VEC256_WITH_SLEEF -DAT_PER_OPERATOR_HEADERS -DBUILD_ONEDNN_GRAPH -DCAFFE2_BUILD_MAIN_LIB -DCAFFE2_PERF_WITH_S>
In file included from /build/pytorch/aten/src/ATen/TensorIterator.h:8,
                 from /build/pytorch/build/aten/src/ATen/UfuncCPUKernel_add.cpp:5,
                 from /build/pytorch/build/aten/src/ATen/UfuncCPUKernel_add.cpp.SVE256.cpp:1:
/build/pytorch/c10/util/FunctionRef.h: In static member function ‘static Ret c10::function_ref<Ret(Params ...)>::callback_fn(intptr_t, Params ...) [with Callable = at::native::SVE256::VectorizedL>
/build/pytorch/c10/util/FunctionRef.h:45:3: error: unrecognizable insn:
   45 |   }
      |   ^
(insn 830 829 831 78 (set (reg:VNx8BF 1345 [ _765 ])
        (unspec:VNx8BF [
                (reg:VNx8BF 1351)
                (reg:VNx8BF 1352)
            ] UNSPEC_IORF)) "/build/pytorch/aten/src/ATen/cpu/vec/sve/vec_bfloat16.h":228:31 discrim 1 -1
     (nil))
during RTL pass: vregs
/build/pytorch/c10/util/FunctionRef.h:45:3: internal compiler error: in extract_insn, at recog.cc:2812
0x1ed3ea7 diagnostic_impl(rich_location*, diagnostic_metadata const*, int, char const*, std::__va_list*, diagnostic_t)
        ???:0
0x1ed46ef internal_error(char const*, ...)
        ???:0
0x7886bb fancy_abort(char const*, int, char const*)
        ???:0
0x7863fb _fatal_insn(char const*, rtx_def const*, char const*, int, char const*)
        ???:0
0x78642f _fatal_insn_not_found(rtx_def const*, char const*, int, char const*)
        ???:0
0xf0b523 extract_insn(rtx_insn*)
        ???:0
0xc3588b (anonymous namespace)::pass_instantiate_virtual_regs::execute(function*)
        ???:0
Please submit a full bug report, with preprocessed source (by using -freport-bug).
Please include the complete backtrace with any bug report.
See <https://gcc.gnu.org/bugs/&gt; for instructions.
```

Backported the fix from https://github.com/pytorch/pytorch/pull/157867.

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
