### PR TITLE
maintainers/scripts/haskell/hydra-report: speed up with --no-instantiate

### DIFF
--- a/maintainers/scripts/haskell/hydra-report.hs
+++ b/maintainers/scripts/haskell/hydra-report.hs
@@ -1,4 +1,5 @@
 #! /usr/bin/env nix-shell
+#! nix-shell -I nixpkgs=.
 #! nix-shell -p "haskellPackages.ghcWithPackages (p: [p.aeson p.req])"
 #! nix-shell -p nix-eval-jobs
 #! nix-shell -i runhaskell
@@ -42,7 +43,7 @@ import Data.Aeson (
    encodeFile,
  )
 import Data.Aeson.Decoding (eitherDecodeStrictText)
-import Data.Foldable (Foldable (toList), foldl')
+import Data.Foldable (Foldable (toList))
 import Data.Either (rights)
 import Data.Functor ((<&>))
 import Data.List.NonEmpty (NonEmpty, nonEmpty)
@@ -230,9 +231,9 @@ nixEvalJobsParams =
     -- options necessary to make nix-eval-jobs behave like hydra-eval-jobs used to
     -- https://github.com/NixOS/hydra/commit/d84ff32ce600204c6473889a3ff16cd6053533c9
     "--meta",
-    "--constituents",
     "--force-recurse",
-    "--max-jobs", "1",
+    "--no-instantiate",
+    "--workers", "3",
 
     "-I", ".",
    "pkgs/top-level/release-haskell.nix"


### PR DESCRIPTION
This is a new flag [introduced](https://github.com/nix-community/nix-eval-jobs/pull/379) in `nix-eval-jobs`, which reduces runtime for the `ping-maintainers` subcommand from 12 minutes to 3 minutes for me.

The `--constituents` flag is not supported anymore with `--no-instantiate`, but it doesn't seem to make a difference anyway. Same for `--max-jobs` - I don't get a difference with or without it.

Removing the `foldl'` import because it is warned to be redundant after switching to import the current nixpkgs instance, likely due to a newer GHC version (?).

Put on draft for now, because I don't intend to merge the update to `nix-eval-jobs` in here, that was just for testing.

## Things done

- [x] Tested locally.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
