### PR TITLE
i3status-rust: Add manpage to output

### DIFF
--- a/pkgs/by-name/i3/i3status-rust/package.nix
+++ b/pkgs/by-name/i3/i3status-rust/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   pkg-config,
   makeWrapper,
+  installShellFiles,
   dbus,
   libpulseaudio,
   notmuch,
@@ -12,6 +13,7 @@
   lm_sensors,
   iw,
   iproute2,
+  pandoc,
   pipewire,
   withICUCalendar ? false,
   withPipewire ? true,
@@ -34,6 +36,8 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     pkg-config
     makeWrapper
+    installShellFiles
+    pandoc
   ]
   ++ (lib.optionals withPipewire [ rustPlatform.bindgenHook ]);
 
@@ -59,9 +63,14 @@ rustPlatform.buildRustPackage rec {
       --replace "/usr/share/i3status-rust" "$out/share"
   '';
 
+  postBuild = ''
+    cargo xtask generate-manpage
+  '';
+
   postInstall = ''
     mkdir -p $out/share
     cp -R examples files/* $out/share
+    installManPage man/*
   '';
 
   postFixup = ''


### PR DESCRIPTION
The project describes this procedure here: https://github.com/greshake/i3status-rust/blob/master/doc/manual_install.md#packaging

And Arch Linux does the same: https://gitlab.archlinux.org/archlinux/packaging/packages/i3status-rust/-/blob/main/PKGBUILD?ref_type=heads#L46
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
