### PR TITLE
nixos/lxqt: add options iconThemePackage and extraPackages

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/lxqt.nix
+++ b/nixos/modules/services/x11/desktop-managers/lxqt.nix
@@ -22,6 +22,12 @@ in
 
     services.xserver.desktopManager.lxqt.enable = mkEnableOption "the LXQt desktop manager";
 
+    services.xserver.desktopManager.lxqt.iconThemePackage =
+      lib.mkPackageOption pkgs [ "kdePackages" "breeze-icons" ] { }
+      // {
+        description = "The package that provides a default icon theme.";
+      };
+
     environment.lxqt.excludePackages = mkOption {
       type = with lib.types; listOf package;
       default = [ ];
@@ -57,6 +63,7 @@ in
     environment.systemPackages =
       pkgs.lxqt.preRequisitePackages
       ++ pkgs.lxqt.corePackages
+      ++ [ cfg.iconThemePackage ]
       ++ (utils.removePackagesByName pkgs.lxqt.optionalPackages config.environment.lxqt.excludePackages);
 
     # Link some extra directories in /run/current-system/software/share

--- a/nixos/modules/services/x11/desktop-managers/lxqt.nix
+++ b/nixos/modules/services/x11/desktop-managers/lxqt.nix
@@ -9,8 +9,7 @@
 with lib;
 
 let
-  xcfg = config.services.xserver;
-  cfg = xcfg.desktopManager.lxqt;
+  cfg = config.services.xserver.desktopManager.lxqt;
 
 in
 
@@ -21,16 +20,13 @@ in
 
   options = {
 
-    services.xserver.desktopManager.lxqt.enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable the LXQt desktop manager";
-    };
+    services.xserver.desktopManager.lxqt.enable = mkEnableOption "the LXQt desktop manager";
 
     environment.lxqt.excludePackages = mkOption {
+      type = with lib.types; listOf package;
       default = [ ];
-      example = literalExpression "[ pkgs.lxqt.qterminal ]";
-      type = types.listOf types.package;
+      defaultText = lib.literalExpression "[ ]";
+      example = lib.literalExpression "with pkgs; [ lxqt.qterminal ]";
       description = "Which LXQt packages to exclude from the default environment";
     };
 
@@ -69,7 +65,7 @@ in
     programs.gnupg.agent.pinentryPackage = mkDefault pkgs.pinentry-qt;
 
     # virtual file systems support for PCManFM-QT
-    services.gvfs.enable = true;
+    services.gvfs.enable = mkDefault true;
 
     services.upower.enable = config.powerManagement.enable;
 

--- a/nixos/modules/services/x11/desktop-managers/lxqt.nix
+++ b/nixos/modules/services/x11/desktop-managers/lxqt.nix
@@ -28,6 +28,14 @@ in
         description = "The package that provides a default icon theme.";
       };
 
+    services.xserver.desktopManager.lxqt.extraPackages = lib.mkOption {
+      type = with lib.types; listOf package;
+      default = [ ];
+      defaultText = lib.literalExpression "[ ]";
+      example = lib.literalExpression "with pkgs; [ xscreensaver ]";
+      description = "Extra packages to be installed system wide.";
+    };
+
     environment.lxqt.excludePackages = mkOption {
       type = with lib.types; listOf package;
       default = [ ];
@@ -64,7 +72,8 @@ in
       pkgs.lxqt.preRequisitePackages
       ++ pkgs.lxqt.corePackages
       ++ [ cfg.iconThemePackage ]
-      ++ (utils.removePackagesByName pkgs.lxqt.optionalPackages config.environment.lxqt.excludePackages);
+      ++ (utils.removePackagesByName pkgs.lxqt.optionalPackages config.environment.lxqt.excludePackages)
+      ++ cfg.extraPackages;
 
     # Link some extra directories in /run/current-system/software/share
     environment.pathsToLink = [ "/share" ];


### PR DESCRIPTION
- nixos/lxqt: small edits in the nix expression
- nixos/lxqt: add option: iconThemePackage
- nixos/lxqt: add option: extraPackages

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
