### PR TITLE
grafanaPlugins.grafana-sentry-datasource: fix zipHash

### DIFF
--- a/pkgs/servers/monitoring/grafana/plugins/grafana-sentry-datasource/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-sentry-datasource/default.nix
@@ -3,12 +3,7 @@
 grafanaPlugin {
   pname = "grafana-sentry-datasource";
   version = "2.2.1";
-  zipHash = {
-    x86_64-linux = "sha256-6pjBUqUHXLLgFzfal/OKsMBVlVXxuRglOj3XRnnduRY=";
-    aarch64-linux = "sha256-0kjxBnv34lRB5qeVOyik7qvlEsz7CYur9EyIDTe+AKM=";
-    x86_64-darwin = "sha256-yHgF+XmJXnJjfPwabs1dsrnWvssTmYpeZUXUl+gQxfM=";
-    aarch64-darwin = "sha256-ysLXSKG7q/u70NynYqKKRlYIl5rkYy0AMoza3sQSPNM=";
-  };
+  zipHash = "sha256-VJ1RpVWT3d+BrZ9zUoAaNshrE3zBgEkimqUl+innBhg=";
   meta = {
     description = "Integrate Sentry data into Grafana";
     license = lib.licenses.asl20;


### PR DESCRIPTION
Turns out they have a zip with all the architectures inside... 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
