### PR TITLE
beammp-launcher: init at 2.7.0

### DIFF
--- a/pkgs/by-name/be/beammp-launcher/package.nix
+++ b/pkgs/by-name/be/beammp-launcher/package.nix
@@ -1,0 +1,69 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  copyDesktopItems,
+  installShellFiles,
+  makeDesktopItem,
+
+  cmake,
+  curl,
+  httplib,
+  nlohmann_json,
+  openssl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "beammp-launcher";
+  version = "2.7.0";
+
+  src = fetchFromGitHub {
+    owner = "BeamMP";
+    repo = "BeamMP-Launcher";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+qdDGOLds2j00BRijFAZ8DMrnjvigs+z+w9+wbitJno=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    installShellFiles
+
+    cmake
+  ];
+
+  buildInputs = [
+    curl
+    httplib
+    nlohmann_json
+    openssl
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      categories = [ "Game" ];
+      comment = "Launcher for the BeamMP mod for BeamNG.drive";
+      desktopName = "BeamMP-Launcher";
+      exec = "BeamMP-Launcher";
+      name = "BeamMP-Launcher";
+      terminal = true;
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    installBin "BeamMP-Launcher"
+    copyDesktopItems
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Launcher for the BeamMP mod for BeamNG.drive";
+    homepage = "https://github.com/BeamMP/BeamMP-Launcher";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "BeamMP-Launcher";
+    maintainers = [ lib.maintainers.Andy3153 ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Created derivation for [**BeamMP Launcher**](https://github.com/BeamMP/BeamMP-Launcher), a launcher for the BeamMP mod for BeamNG.drive.

Based on previous work of:
- @invertedEcho, at PR #413940
- @the-furry-hubofeverything, at https://github.com/the-furry-hubofeverything/hubble-systems/commit/9b3d4585f2b4cc2bb0bef99c50cf65da4d76641a
- @Andy3153 (me), at https://github.com/Andy3153/my-nixpkgs/commit/1243bc018538b67056b951d52adda6993375b7ce

BeamMP currently has some problems with their SSL certificates (https://github.com/BeamMP/BeamMP-Launcher/issues/186), so, until things are fixed on their side, in order to test this program, you have to resort to a hack. The way I test is like this: https://github.com/Andy3153/nixos-rice/commit/78eddffc7ddb76d112ce3a2f23ea7f0436d51566. Hashes might change for that cert.

I already tested/played with this setup for hours, so I can say it works.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
