### PR TITLE
asdf-vm: 0.15.0 -> 0.18.0

### DIFF
--- a/pkgs/by-name/as/asdf-vm/package.nix
+++ b/pkgs/by-name/as/asdf-vm/package.nix
@@ -1,96 +1,62 @@
 {
-  stdenv,
   lib,
+  stdenv,
+  buildGoModule,
   fetchFromGitHub,
   makeWrapper,
   installShellFiles,
-  bash,
-  curl,
-  git,
-  writeScript,
 }:
-
-let
-  asdfReshimFile = writeScript "asdf-reshim" ''
-    #!/usr/bin/env bash
-
-    # asdf-vm create "shim" file like this:
-    #
-    #    exec $ASDF_DIR/bin/asdf exec "node" "$@"
-    #
-    # So we should reshim all installed versions every time shell initialized,
-    # because $out always change
-
-    asdfDir="''${ASDF_DIR:-$HOME/.asdf}"
-    asdfDataDir="''${ASDF_DATA_DIR:-$HOME/.asdf}"
-
-    prevAsdfDirFilePath="$asdfDataDir/.nix-prev-asdf-dir-path"
-
-    if [ -r "$prevAsdfDirFilePath" ]; then
-      prevAsdfDir="$(cat "$prevAsdfDirFilePath")"
-    else
-      prevAsdfDir=""
-    fi
-
-    if [ "$prevAsdfDir" != "$asdfDir" ]; then
-      rm -rf "$asdfDataDir"/shims
-      "$asdfDir"/bin/asdf reshim
-      echo "$asdfDir" > "$prevAsdfDirFilePath"
-    fi
-  '';
-
-  asdfPrepareFile = writeScript "asdf-prepare" ''
-    ASDF_DIR="@asdfDir@"
-
-    source "$ASDF_DIR/asdf.sh"
-    ${asdfReshimFile}
-  '';
-in
-stdenv.mkDerivation (finalAttrs: {
+buildGoModule (finalAttrs: {
   pname = "asdf-vm";
-  version = "0.15.0";
+  version = "0.18.0";
 
   src = fetchFromGitHub {
     owner = "asdf-vm";
     repo = "asdf";
+
     tag = "v${finalAttrs.version}";
-    hash = "sha256-quDgoYi+3hZUEAzXWTHuL5UK1T+4o7+G67w0UzZOjJA=";
+    hash = "sha256-BBd+MiRISjMz2m29nNIakG79Oy1k7bZI/Q24QQNp5CY=";
+
   };
+
+  vendorHash = "sha256-gzlHXIzDYo4leP+37HgNrz5faIlrCLYA7AVSvZ6Uicc=";
 
   nativeBuildInputs = [
     makeWrapper
     installShellFiles
   ];
 
-  buildInputs = [
-    bash
-    curl
-    git
-  ];
+  # Tests have additional requirements
+  doCheck = false;
 
-  installPhase = ''
-    mkdir -p $out/share/asdf-vm
-    cp -r . $out/share/asdf-vm
-
+  postInstall = ''
+    # Install profile.d script for environment setup
     mkdir -p $out/etc/profile.d
-    substitute ${asdfPrepareFile} $out/etc/profile.d/asdf-prepare.sh \
-      --replace "@asdfDir@" "$out/share/asdf-vm"
+    cat > $out/etc/profile.d/asdf-prepare.sh <<'EOF'
+    export ASDF_DIR="${placeholder "out"}"
+    export PATH="''${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
+    EOF
 
-    mkdir -p $out/bin
-    makeWrapper $out/share/asdf-vm/bin/asdf $out/bin/asdf \
-      --set ASDF_DIR $out/share/asdf-vm
-
+    # Wrap the asdf binary to set ASDF_DIR
+    wrapProgram $out/bin/asdf \
+      --set ASDF_DIR $out
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    # Generate completions using the built asdf binary
     installShellCompletion --cmd asdf \
-      --zsh completions/_asdf \
-      --fish completions/asdf.fish \
-      --bash completions/asdf.bash
+      --bash <($out/bin/asdf completion bash) \
+      --fish <($out/bin/asdf completion fish) \
+      --zsh <($out/bin/asdf completion zsh)
   '';
 
   meta = {
     description = "Extendable version manager with support for Ruby, Node.js, Erlang & more";
     homepage = "https://asdf-vm.com/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ c4605 ];
+    maintainers = with lib.maintainers; [
+      c4605
+      vringar
+    ];
     mainProgram = "asdf";
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This is a rewrite of the entire package since asdf-vm moved to Go at version 0.16.0.
https://github.com/asdf-vm/asdf/blob/master/CHANGELOG.md

> [!NOTE] 
> This is a rewrite of #425919  as that one appears stalled and also isn't following the recommended commit guidance of  one commit per change

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
