### PR TITLE
mado: init at 0.3.0

### DIFF
--- a/pkgs/by-name/ma/mado/package.nix
+++ b/pkgs/by-name/ma/mado/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  installShellFiles,
+  oniguruma,
+  rust-jemalloc-sys,
+  stdenv,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "mado";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "akiomik";
+    repo = "mado";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-wAuV4w0dKfUbJVLTdp59/u4y13SPy3wkRfTlpvyE/zY=";
+  };
+
+  cargoHash = "sha256-fkalUnPkjjzhLaACh+WQP4tG5VzZ7wmrh5T1DVgSDwM=";
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
+
+  buildInputs = [
+    oniguruma
+    rust-jemalloc-sys
+  ];
+
+  env = {
+    RUSTONIG_SYSTEM_LIBONIG = true;
+  };
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd mado \
+      --bash <($out/bin/mado generate-shell-completion bash) \
+      --zsh <($out/bin/mado generate-shell-completion zsh) \
+      --fish <($out/bin/mado generate-shell-completion fish)
+  '';
+
+  checkFlags = [
+    #   # seem to be slightly broken inside of the build sandbox
+    "--skip=check_empty_stdin_with_file"
+    "--skip=check_stdin"
+    "--skip=check_stdin_with_file"
+    "--skip=generate_shell_completion_invalid"
+    "--skip=unknown_command"
+  ];
+
+  meta = {
+    description = "Markdown linter written in Rust";
+    homepage = "https://github.com/akiomik/mado";
+    changelog = "https://github.com/akiomik/mado/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jasonxue1 ];
+    mainProgram = "mado";
+  };
+})


### PR DESCRIPTION
- **maintainers: add jasonxue1**
- **mado: init at 0.3.0**

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
