### PR TITLE
petsc: 3.23.5 -> 3.23.6

### DIFF
--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -10,7 +10,6 @@
   bison,
   mpi, # generic mpi dependency
   mpiCheckPhaseHook,
-  python3,
   python3Packages,
 
   # Build options
@@ -78,7 +77,6 @@ let
   petscPackages = lib.makeScope newScope (self: {
     inherit
       mpi
-      python3
       python3Packages
       # global override options
       mpiSupport
@@ -121,10 +119,10 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   nativeBuildInputs = [
-    python3
     gfortran
     pkg-config
     bison
+    python3Packages.python
   ]
   ++ lib.optional mpiSupport mpi
   ++ lib.optionals pythonSupport [
@@ -154,7 +152,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     (replaceVars ./fix-petsc4py-install-prefix.patch {
-      PYTHON_SITEPACKAGES = python3.sitePackages;
+      PYTHON_SITEPACKAGES = python3Packages.python.sitePackages;
     })
   ];
 

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -181,13 +181,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-cxx=${lib.getDev mpi}/bin/mpicxx"
     "--with-fc=${lib.getDev mpi}/bin/mpif90"
   ]
-  ++ lib.optionals (!debug) [
-    "--with-debugging=0"
-    "COPTFLAGS=-O3"
-    "FOPTFLAGS=-O3"
-    "CXXOPTFLAGS=-O3"
-    "CXXFLAGS=-O3"
-  ]
+  ++ lib.optional (!debug) "--with-debugging=0"
   ++ lib.optional (!fortranSupport) "--with-fortran-bindings=0"
   ++ lib.optional pythonSupport "--with-petsc4py=1"
   ++ lib.optional withMetis "--with-metis=1"

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -111,11 +111,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "petsc";
-  version = "3.23.5";
+  version = "3.23.6";
 
   src = fetchzip {
     url = "https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-${finalAttrs.version}.tar.gz";
-    hash = "sha256-pfGb/9GlKsZJpdEU6lOr61a8AE5NR9MlZ0mHJ/j+eDs=";
+    hash = "sha256-sKXLYtOw6xom7c7ARpOY4dcsV5zR5KgbYrt1bnHF/Io=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/pf/pflotran/package.nix
+++ b/pkgs/by-name/pf/pflotran/package.nix
@@ -11,7 +11,7 @@
   parmetis,
   hdf5-fortran-mpi,
   mpiCheckPhaseHook,
-  python3,
+  python312Packages,
 }:
 
 let
@@ -31,6 +31,7 @@ let
       {
         withMetis = true;
         withParmetis = true;
+        python3Packages = python312Packages;
       };
 in
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/sl/slepc/package.nix
+++ b/pkgs/by-name/sl/slepc/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitLab,
-  python3,
   python3Packages,
   arpack-mpi,
   petsc,
@@ -29,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Fix slepc4py install prefix
     substituteInPlace config/packages/slepc4py.py \
       --replace-fail "slepc.prefixdir,'lib'" \
-      "slepc.prefixdir,'${python3.sitePackages}'"
+      "slepc.prefixdir,'${python3Packages.python.sitePackages}'"
 
     patchShebangs lib/slepc/bin
   '';
@@ -43,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   nativeBuildInputs = [
-    python3
+    python3Packages.python
   ]
   ++ lib.optionals pythonSupport [
     python3Packages.setuptools

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11561,7 +11561,6 @@ self: super: with self; {
 
   petsc4py = toPythonModule (
     pkgs.petsc.override {
-      python3 = python;
       python3Packages = self;
       pythonSupport = true;
     }
@@ -16798,7 +16797,6 @@ self: super: with self; {
   slepc4py = toPythonModule (
     pkgs.slepc.override {
       pythonSupport = true;
-      python3 = self.python;
       python3Packages = self;
       petsc = petsc4py;
     }


### PR DESCRIPTION
Diff: https://gitlab.com/petsc/petsc/-/compare/v3.23.5...v3.23.6

use default debugging/optimization flags i.e. -g/-O
Should fix build on darwin.

fix pflotran build as petsc < 3.22 require configure with python < 3.13

pflotran is working on supporting petsc-3.24, see https://gitlab.com/pflotran/pflotran/-/commits/glenn%2Fpetsc-3.24-cpr-debugging

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
