### PR TITLE
sddm: install man pages

### DIFF
--- a/pkgs/applications/display-managers/sddm/default.nix
+++ b/pkgs/applications/display-managers/sddm/default.nix
@@ -12,7 +12,7 @@
 }:
 runCommand "sddm-wrapped"
   {
-    inherit (unwrapped) version;
+    inherit (unwrapped) version outputs;
 
     buildInputs =
       unwrapped.buildInputs
@@ -45,4 +45,7 @@ runCommand "sddm-wrapped"
     for i in bin/*; do
       makeQtWrapper ${unwrapped}/$i $out/$i --set SDDM_GREETER_DIR $out/bin
     done
+
+    mkdir -p $man
+    ln -s ${lib.getMan unwrapped}/* $man/
   ''

--- a/pkgs/applications/display-managers/sddm/unwrapped.nix
+++ b/pkgs/applications/display-managers/sddm/unwrapped.nix
@@ -14,6 +14,7 @@
   systemd,
   xkeyboardconfig,
   nixosTests,
+  docutils,
 }:
 let
   isQt6 = lib.versions.major qtbase.version == "6";
@@ -28,6 +29,11 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-r5mnEWham2WnoEqRh5tBj/6rn5mN62ENOCmsLv2Ht+w=";
   };
+
+  outputs = [
+    "out"
+    "man"
+  ];
 
   patches = [
     ./greeter-path.patch
@@ -44,6 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
     qttools
+    docutils
   ];
 
   buildInputs = [
@@ -61,6 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_WITH_QT6" isQt6)
+    (lib.cmakeBool "BUILD_MAN_PAGES" true)
     "-DCONFIG_FILE=/etc/sddm.conf"
     "-DCONFIG_DIR=/etc/sddm.conf.d"
 


### PR DESCRIPTION
sddm [does have man pages](https://man.archlinux.org/man/sddm.conf.5), but they were not installed. This PR adds a man output to `pkgs.kdePackages.sddm`, and installs those man pages to it. This adds a dependency on `docutils`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
