### PR TITLE
moneydance: Allow overriding the JVM

### DIFF
--- a/pkgs/by-name/mo/moneydance/package.nix
+++ b/pkgs/by-name/mo/moneydance/package.nix
@@ -4,6 +4,7 @@
   buildPackages,
   fetchzip,
   makeWrapper,
+  glib,
   openjdk23,
   clientJdk ? openjdk23.override { enableJavaFX = true; },
   wrapGAppsHook3,
@@ -68,7 +69,8 @@ stdenv.mkDerivation (finalAttrs: {
       # This is in postFixup because gappsWrapperArgs is generated in preFixup
       makeWrapper ${clientJdk}/bin/java $out/bin/moneydance \
         "''${gappsWrapperArgs[@]}" \
-        --add-flags ${lib.escapeShellArg (lib.escapeShellArgs finalJvmFlags)}
+        --add-flags ${lib.escapeShellArg (lib.escapeShellArgs finalJvmFlags)} \
+        --suffix PATH : ${lib.makeBinPath [ glib ]}
     '';
 
   passthru = {

--- a/pkgs/by-name/mo/moneydance/package.nix
+++ b/pkgs/by-name/mo/moneydance/package.nix
@@ -5,14 +5,15 @@
   fetchzip,
   makeWrapper,
   openjdk23,
+  clientJdk ? openjdk23.override { enableJavaFX = true; },
   wrapGAppsHook3,
+  baseJvmFlags ? [
+    "-client"
+    "--add-modules"
+    "javafx.swing,javafx.controls,javafx.graphics"
+  ],
   jvmFlags ? [ ],
 }:
-let
-  jdk = openjdk23.override {
-    enableJavaFX = true;
-  };
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "moneydance";
   version = "2024.4_5253";
@@ -32,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
     (buildPackages.wrapGAppsHook3.override { makeWrapper = buildPackages.makeShellWrapper; })
   ];
-  buildInputs = [ jdk ];
+  buildInputs = [ clientJdk ];
   dontWrapGApps = true;
 
   installPhase = ''
@@ -54,25 +55,24 @@ stdenv.mkDerivation (finalAttrs: {
   # 2. https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/setup-hooks/make-wrapper.sh
   postFixup =
     let
-      finalJvmFlags = [
-        "-client"
-        "--add-modules"
-        "javafx.swing,javafx.controls,javafx.graphics"
-        "-classpath"
-        "${placeholder "out"}/libexec/*"
-      ]
-      ++ jvmFlags
-      ++ [ "Moneydance" ];
+      finalJvmFlags =
+        baseJvmFlags
+        ++ [
+          "-classpath"
+          "${placeholder "out"}/libexec/*"
+        ]
+        ++ jvmFlags
+        ++ [ "Moneydance" ];
     in
     ''
       # This is in postFixup because gappsWrapperArgs is generated in preFixup
-      makeWrapper ${jdk}/bin/java $out/bin/moneydance \
+      makeWrapper ${clientJdk}/bin/java $out/bin/moneydance \
         "''${gappsWrapperArgs[@]}" \
         --add-flags ${lib.escapeShellArg (lib.escapeShellArgs finalJvmFlags)}
     '';
 
   passthru = {
-    inherit jdk;
+    jdk = clientJdk;
   };
 
   meta = {


### PR DESCRIPTION
I ended up needing this to run under the [JetBrains JVM](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/compilers/jetbrains-jdk/default.nix) that has the [upstream experimental native Wayland/Vulkan rendering support](https://wiki.openjdk.org/display/wakefield/Pure+Wayland+toolkit+prototype) conveniently patched in (see lucasbergman/home-config@a4fb414); font rendering under Wayland/Hyprland was borderline unreadable otherwise. We should probably have some more unified support for all this business throughout nixpkgs (see e.g. #422043), but for now at least this lets users tinker.

I'm a little shaky on override, overrideAttrs, passthru, etc. so I'm very much open to comment on whether this can be done more cleanly or easily.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test