### PR TITLE
liboprf: 0.8.0 -> 0.9.2; python313Packages.ble-serial: init at 3.0.0

### DIFF
--- a/pkgs/by-name/bl/ble-serial/package.nix
+++ b/pkgs/by-name/bl/ble-serial/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication ble-serial

--- a/pkgs/by-name/li/libopaque/package.nix
+++ b/pkgs/by-name/li/libopaque/package.nix
@@ -28,6 +28,13 @@ stdenv.mkDerivation (finalAttrs: {
     liboprf
   ];
 
+  # expand_message_xmd has been renamed to oprf_expand_message_xmd in liboprf
+  # TODO: remove in the next release
+  postPatch = ''
+    substituteInPlace opaque.c \
+      --replace-fail 'expand_message_xmd' 'oprf_expand_message_xmd'
+  '';
+
   postInstall = ''
     mkdir -p ${placeholder "out"}/lib/pkgconfig
     cp ../libopaque.pc ${placeholder "out"}/lib/pkgconfig/

--- a/pkgs/by-name/li/liboprf/package.nix
+++ b/pkgs/by-name/li/liboprf/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "liboprf";
-  version = "0.8.0";
+  version = "0.9.2";
 
   src = fetchFromGitHub {
     owner = "stef";
     repo = "liboprf";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xDE9UkHDAaA7zC6IxxEIUG7ziS1yYNLJbmVJZLJyL7U=";
+    hash = "sha256-Toja0rR0321i7L1dsB9YxrwNJwKUzuSfK5LLR3tex7U=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src";

--- a/pkgs/development/python-modules/ble-serial/default.nix
+++ b/pkgs/development/python-modules/ble-serial/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  bleak,
+  coloredlogs,
+  pyserial,
+  bless,
+}:
+
+buildPythonPackage rec {
+  pname = "ble-serial";
+  version = "3.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Jakeler";
+    repo = "ble-serial";
+    tag = "v${version}";
+    hash = "sha256-lbqu6VeE8XEIUvUILqKsTA+0/lxTr8GTbUBkSae/ruE=";
+    fetchSubmodules = true;
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    bleak
+    coloredlogs
+    pyserial
+  ];
+
+  optional-dependencies = {
+    server = [
+      bless
+    ];
+  };
+
+  # Requires real hardware to test
+  # https://github.com/Jakeler/ble-serial/blob/3f1a619208a0eb372a0993aadc086c4842946f21/tests/test.py
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "ble_serial.bluetooth.ble_client"
+    "ble_serial.scan"
+  ];
+
+  meta = {
+    description = "\"RFCOMM for BLE\" a Serial UART over Bluetooth low energy (4+) bridge";
+    homepage = "https://github.com/Jakeler/ble-serial";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ eljamm ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/pyoprf/default.nix
+++ b/pkgs/development/python-modules/pyoprf/default.nix
@@ -4,7 +4,11 @@
   buildPythonPackage,
   liboprf,
   setuptools,
+  ble-serial,
+  pyserial,
+  pyserial-asyncio,
   pysodium,
+  pyudev,
   securestring,
   pytestCheckHook,
 }:
@@ -32,7 +36,11 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   dependencies = [
+    ble-serial
+    pyserial
+    pyserial-asyncio
     pysodium
+    pyudev
     securestring
   ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1949,6 +1949,8 @@ self: super: with self; {
 
   blake3 = callPackage ../development/python-modules/blake3 { };
 
+  ble-serial = callPackage ../development/python-modules/ble-serial { };
+
   bleach = callPackage ../development/python-modules/bleach { };
 
   bleach-allowlist = callPackage ../development/python-modules/bleach-allowlist { };


### PR DESCRIPTION
Supersedes https://github.com/NixOS/nixpkgs/pull/439593

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
