### PR TITLE
hii: init at 1.1.5

### DIFF
--- a/pkgs/by-name/hi/hii/package.nix
+++ b/pkgs/by-name/hi/hii/package.nix
@@ -1,0 +1,43 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  installShellFiles,
+}:
+
+buildGoModule {
+  pname = "hii";
+  version = "1.1.5-unstable-2025-08-03";
+
+  src = fetchFromGitHub {
+    owner = "nmeum";
+    repo = "hii";
+    rev = "6c07f4955a85eb32fcc0589238d5a00c1a8722f2";
+    sha256 = "sha256-CXpN57T+o5MPoUxwL48GfEedz05TK8+jPFgdSIdqk+8=";
+  };
+
+  vendorHash = "sha256-lN/ESmpS8K0eC21F5RUbMN35I9b4uBE86CgAnhF1+VA=";
+
+  outputs = [
+    "out"
+    "man"
+    "doc"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installManPage hii.1 hii.5
+    install -Dm644 README.md $doc/share/doc/hii/README.md
+  '';
+
+  meta = {
+    homepage = "https://github.com/nmeum/hii/";
+    license = lib.licenses.gpl3Only;
+    description = "A file-based IRC client inspired by ii";
+    mainProgram = "hii";
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.sternenseemann ];
+  };
+}


### PR DESCRIPTION
simple irc client, rewrite of ii
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
