### PR TITLE
python313Packages.fhir-core: init at 1.1.4

### DIFF
--- a/pkgs/development/python-modules/fhir-core/default.nix
+++ b/pkgs/development/python-modules/fhir-core/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pydantic,
+  pyyaml,
+  setuptools,
+  pytestCheckHook,
+  lxml,
+}:
+
+buildPythonPackage rec {
+  pname = "fhir-core";
+  version = "1.1.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "nazrulworld";
+    repo = "fhir-core";
+    tag = version;
+    hash = "sha256-5FA/G68O5d1ebGE3xJ0ThN6CNTwh2AA44NuOkW2Z4lA=";
+  };
+
+  # pytest-runner was removed from Nixpkgs
+  postPatch = ''
+    substituteInPlace setup.py --replace-fail '["pytest-runner"]' '[]'
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    pydantic
+    pyyaml
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    lxml
+  ];
+
+  pythonImportsCheck = [
+    "fhir_core"
+  ];
+
+  meta = {
+    description = "Core library for FHIR using Pydantic";
+    homepage = "https://github.com/nazrulworld/fhir-core";
+    changelog = "https://github.com/nazrulworld/fhir-core/releases/tag/${src.tag}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/fhir-resources/default.nix
+++ b/pkgs/development/python-modules/fhir-resources/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  lxml,
+  pytestCheckHook,
+  fhir-core,
+  pydantic,
+  requests,
+  unixtools,
+}:
+
+buildPythonPackage rec {
+  pname = "fhir-resources";
+  version = "8.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "nazrulworld";
+    repo = "fhir.resources";
+    tag = version;
+    hash = "sha256-KKE08BKf8E95y9Wq+21V64dmFv8oL8PwZYBO5oo0fWk=";
+  };
+
+  # pytest-runner was removed from Nixpkgs:
+  postPatch = ''
+    substituteInPlace setup.py --replace-fail '["pytest-runner"]' '[]'
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    pydantic
+    fhir-core
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    lxml
+    requests
+    unixtools.ping
+  ];
+
+  # test directories have their own conftest.py files,
+  # so cannot be tested from root directory as per .travis.yml;
+  # also, tests in fhir/resources/*/tests/* try to access internet
+  preCheck = ''cd tests'';
+
+  pythonImportsCheck = [ "fhir.resources" ];
+
+  meta = {
+    description = "Tools and classes to create and manipulate FHIR Resources";
+    homepage = "https://github.com/nazrulworld/fhir.resources";
+    changelog = "https://github.com/nazrulworld/fhir.resources/blob/main/HISTORY.rst";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5097,6 +5097,8 @@ self: super: with self; {
 
   fhir-py = callPackage ../development/python-modules/fhir-py { };
 
+  fhir-resources = callPackage ../development/python-modules/fhir-resources { };
+
   fiblary3-fork = callPackage ../development/python-modules/fiblary3-fork { };
 
   fickling = callPackage ../development/python-modules/fickling { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5093,6 +5093,8 @@ self: super: with self; {
 
   ffmpy = callPackage ../development/python-modules/ffmpy { };
 
+  fhir-core = callPackage ../development/python-modules/fhir-core { };
+
   fhir-py = callPackage ../development/python-modules/fhir-py { };
 
   fiblary3-fork = callPackage ../development/python-modules/fiblary3-fork { };


### PR DESCRIPTION
python313Packages.fhir-resources: init at 8.1.0

Init [fhir.core](https://github.com/nazrulworld/fhir-core) and [fhir.resources](https://github.com/nazrulworld/fhir-resources), two packages for working with [FHIR](https://www.hl7.org/fhir/overview.html) (health informatics) data.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
