### PR TITLE
postgresqlPackages.pg_bigm: 1.2-20240606 -> 1.2-20250903

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_bigm.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_bigm.nix
@@ -7,23 +7,18 @@
 
 postgresqlBuildExtension (finalAttrs: {
   pname = "pg_bigm";
-  version = "1.2-20240606";
+  version = "1.2-20250903";
 
   src = fetchFromGitHub {
     owner = "pgbigm";
     repo = "pg_bigm";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-5Uy1DmGZR4WdtRUvNdZ5b9zBHJUb9idcEzW20rkreBs=";
+    hash = "sha256-8V+sGebagYxXW1o2k2cNlGG4cFOObdRAvqCXKyR95hI=";
   };
 
   makeFlags = [ "USE_PGXS=1" ];
 
   meta = {
-    # PostgreSQL 18 support issue upstream: https://github.com/pgbigm/pg_bigm/issues/28
-    # Check after next package update.
-    broken = lib.warnIf (
-      finalAttrs.version != "1.2-20240606"
-    ) "Is postgresql18Packages.pg_bigm still broken?" (lib.versionAtLeast postgresql.version "18");
     description = "Text similarity measurement and index searching based on bigrams";
     homepage = "https://pgbigm.osdn.jp/";
     maintainers = [ ];


### PR DESCRIPTION
Release Notes:
https://github.com/pgbigm/pg_bigm/releases/tag/v1.2-20250903

Now supports PG 18.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
