### PR TITLE
lazyssh: init at 0.2.0

### DIFF
--- a/pkgs/by-name/la/lazyssh/package.nix
+++ b/pkgs/by-name/la/lazyssh/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "lazyssh";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "Adembc";
+    repo = "lazyssh";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0R/H+HaJ13dQhLbFgLAvv4MhXADT3UqWeyTgegKjFxM=";
+  };
+
+  vendorHash = "sha256-/RgjcAy2H9sWMWDA3QxMkT4LkzxvZqOZzKeR9u9bsH0=";
+
+  ldflags = [
+    "-X=main.version=${finalAttrs.version}"
+    "-X=main.gitCommit=v${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv $out/bin/cmd $out/bin/lazyssh
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal-based SSH manager";
+    homepage = "https://github.com/Adembc/lazyssh";
+    changelog = "https://github.com/Adembc/lazyssh/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kpbaks ];
+    mainProgram = "lazyssh";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Init package [lazyssh](https://github.com/Adembc/lazyssh) at `0.2.0`. A terminal-based SSH manager inspired by lazydocker and k9s - Written in go.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
