### PR TITLE
cider-2: 3.0.0 -> 3.1.1, fix update script

### DIFF
--- a/pkgs/by-name/ci/cider-2/package.nix
+++ b/pkgs/by-name/ci/cider-2/package.nix
@@ -8,21 +8,25 @@
 
   # Required dependencies for autoPatchelfHook
   alsa-lib,
+  asar,
   gtk3,
   libgbm,
+  libGL,
   nspr,
   nss,
+  widevine-cdm,
 }:
 stdenv.mkDerivation rec {
   pname = "cider-2";
-  version = "3.0.0";
+  version = "3.1.1";
 
   src = fetchurl {
     url = "https://repo.cider.sh/apt/pool/main/cider-v${version}-linux-x64.deb";
-    hash = "sha256-XKyzt8QkPNQlgFxR12KA5t+PCJki7UuFpn4SGmoGkpg=";
+    hash = "sha256-2gd/ThI59GFU/lMKFLtwHeRWSqp14jFd8YMrV8Cu/oQ=";
   };
 
   nativeBuildInputs = [
+    asar
     dpkg
     autoPatchelfHook
     makeWrapper
@@ -32,6 +36,7 @@ stdenv.mkDerivation rec {
     alsa-lib
     gtk3
     libgbm
+    libGL
     nspr
     nss
   ];
@@ -54,10 +59,25 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  postInstall = ''
+    ${lib.getExe asar} extract $out/lib/cider/resources/app.asar ./cider-build
+
+    # Patch login popup webview creation
+    substituteInPlace ./cider-build/.vite/build/events-*.js \
+      --replace-fail 'else if(c.includes(r))return{action:"allow"}' 'else if(c.includes(r))return{action:"allow",overrideBrowserWindowOptions:{webPreferences:{devTools:!0,nodeIntegration:!1,contextIsolation:!0,webSecurity:!1,sandbox:!1,experimentalFeatures:!0}}}'
+
+    ${lib.getExe asar} pack ./cider-build $out/lib/cider/resources/app.asar
+    rm -rf ./cider-build
+
+    # Install Widevine CDM for DRM support
+    ln -sf ${widevine-cdm}/share/google/chrome/WidevineCdm $out/lib/cider/
+  '';
+
   postFixup = ''
     makeWrapper $out/lib/cider/Cider $out/bin/${pname} \
       --add-flags "\$\{NIXOS_OZONE_WL:+\$\{WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true\}\}" \
-      --add-flags "--no-sandbox --disable-gpu-sandbox"
+      --add-flags "--no-sandbox --disable-gpu-sandbox" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libGL ]}"
 
     mv $out/share/applications/cider.desktop $out/share/applications/${pname}.desktop
     substituteInPlace $out/share/applications/${pname}.desktop \

--- a/pkgs/by-name/ci/cider-2/updater.sh
+++ b/pkgs/by-name/ci/cider-2/updater.sh
@@ -29,7 +29,7 @@ fi
 cd ../../../..
 
 if [[ "${1-default}" != "--deps-only" ]]; then
-    SHA="$(nix-prefetch-url --quiet --unpack --type sha256 $DEB_URL)"
+    SHA="$(nix-prefetch-url --quiet --type sha256 $DEB_URL)"
     SRI=$(nix --experimental-features nix-command hash to-sri "sha256:$SHA")
     update-source-version cider-2 "$NEW_VERSION" "$SRI"
 fi


### PR DESCRIPTION
This was a bit tough, had to patch app.asar in order to get login popup working. Let me know if you have any better ideas. I have also added the missing libGL that makes hw acceleration working. Widevine download seems to have been broken for new users, I've manually included the dep now so cider doesn't have to download it on first run.

Also, the update script was broken: https://r.ryantm.com/log/cider-2/2025-08-31.log

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
