### PR TITLE
mysterium-node: init at 1.35.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15287,7 +15287,7 @@
     github = "M0NsTeRRR";
     githubId = 37785089;
   };
-  m0ustache3 = {
+  m0ustach3 = {
     name = "M0ustach3";
     github = "M0ustach3";
     githubId = 37956764;

--- a/pkgs/by-name/my/mysterium-node/package.nix
+++ b/pkgs/by-name/my/mysterium-node/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "mysterium-node";
+  version = "1.35.4";
+
+  src = fetchFromGitHub {
+    owner = "mysteriumnetwork";
+    repo = "node";
+    tag = finalAttrs.version;
+    hash = "sha256-VVma0cMaBJYRdMF5I6hZ6g3eO1FHY/s/YR3q7YigHoU=";
+  };
+
+  vendorHash = "sha256-ep8h0XLxNPBNOL+zVg7hAO+Jzr9UYRARF54enavjyvg=";
+
+  subPackages = [
+    "cmd/mysterium_node"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/mysteriumnetwork/node/metadata.Version=${finalAttrs.version}"
+    "-X github.com/mysteriumnetwork/node/metadata.BuildNumber=${finalAttrs.version}"
+    "-X github.com/mysteriumnetwork/node/metadata.BuildBranch=${finalAttrs.version}"
+    "-X github.com/mysteriumnetwork/node/metadata.BuildCommit=${finalAttrs.version}"
+  ];
+
+  tags = [
+    "netgo"
+  ];
+
+  env.CGO_ENABLED = 0;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -Dm755 $GOPATH/bin/mysterium_node $out/bin/mysterium-node
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Official implementation of distributed VPN network (dVPN) protocol";
+    homepage = "https://github.com/mysteriumnetwork/node";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      m0ustach3
+    ];
+    changelog = "https://github.com/mysteriumnetwork/node/releases/tag/${finalAttrs.version}";
+    mainProgram = "mysterium-node";
+  };
+})


### PR DESCRIPTION
Added mysterium-node : A node to run an open-source ecosystem of tools and infrastructure to liberate the web : https://www.mysterium.network/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
