### PR TITLE
jportaudio: init at 0-unstable-2025-10-24

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18086,6 +18086,12 @@
     githubId = 24192522;
     name = "MithicSpirit";
   };
+  MiyakoMeow = {
+    email = "miyakomeowaqwq@gmail.com";
+    github = "MiyakoMeow";
+    githubId = 110924386;
+    name = "MiyakoMeow";
+  };
   miyu = {
     email = "miyu@allthingslinux.org";
     github = "fndov";

--- a/pkgs/by-name/jp/jportaudio/package.nix
+++ b/pkgs/by-name/jp/jportaudio/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  stdenv,
+  pkgs,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "jportaudio";
+  version = "0-unstable-2026-02-13";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "philburk";
+    repo = "portaudio-java";
+    rev = "d185a5322ecbe8bd209e14e7341fb73d0c7d2cc3";
+    hash = "sha256-XG1bJm0hDSF4cE2OvQ5bvN8pmaKwIl9zDlsRCnTXnLc=";
+  };
+
+  nativeBuildInputs = with pkgs; [
+    cmake
+    # Prefer Ninja-backed CMake builds if available
+    # (falls back to Makefiles when ninja is absent)
+    # Add ninja to leverage standard CMake hooks without manual make calls
+    ninja
+    gradle
+    jdk
+  ];
+  buildInputs = with pkgs; [ portaudio ];
+
+  env = {
+    JAVA_HOME = pkgs.jdk.home;
+    GRADLE_HOME = pkgs.gradle;
+  };
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+  ];
+
+  # Use standard CMake phases; run Gradle after native build via postBuild hook
+  postBuild = ''
+    : "${"cmakeBuildDir:=build"}"
+    nativeLibDir="$PWD/native-libs"
+    mkdir -p "$nativeLibDir"
+    # Collect built native libraries from CMake build directory only
+    if [ -d "$cmakeBuildDir" ]; then
+      find "$cmakeBuildDir" -type f -name '*.so' -exec cp -v -n {} "$nativeLibDir/" \;
+    fi
+
+    export GRADLE_USER_HOME="$(mktemp -d)"
+    # Run Gradle from source root
+    sourceRoot="$NIX_BUILD_TOP/source"
+    ( cd "$sourceRoot" && gradle --no-daemon -Djava.library.path="$nativeLibDir" assemble )
+  '';
+
+  # After CMake install, place built JARs into $out
+  postInstall = ''
+    : "${"cmakeBuildDir:=build"}"
+    sourceRoot="$NIX_BUILD_TOP/source"
+    mkdir -p "$out/share/java"
+    if ls "$sourceRoot"/build/libs/*.jar >/dev/null 2>&1; then
+      cp "$sourceRoot"/build/libs/*.jar "$out/share/java/"
+    fi
+
+    # Ensure unversioned symlink exists if only versioned lib was installed by CMake
+    if [ ! -e "$out/lib/libjportaudio.so" ]; then
+      candidate=$(ls "$out"/lib/libjportaudio*.so* 2>/dev/null | sort -V | tail -n1 || true)
+      ln -s "$(basename "$candidate")" "$out/lib/libjportaudio.so"
+    fi
+  '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version=branch"
+      ];
+    };
+  };
+
+  meta = {
+    description = "Java wrapper for PortAudio audio library";
+    homepage = "https://github.com/philburk/portaudio-java";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      MiyakoMeow
+      ungeskriptet
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Add package: `portaudio-java`

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
