### PR TITLE
freerdp: add sdl3 client

### DIFF
--- a/pkgs/by-name/fr/freerdp/package.nix
+++ b/pkgs/by-name/fr/freerdp/package.nix
@@ -46,6 +46,9 @@
   SDL2,
   SDL2_ttf,
   SDL2_image,
+  sdl3,
+  sdl3-ttf,
+  sdl3-image,
   systemd,
   libjpeg_turbo,
   libkrb5,
@@ -137,6 +140,9 @@ stdenv.mkDerivation (finalAttrs: {
     SDL2
     SDL2_ttf
     SDL2_image
+    sdl3
+    sdl3-ttf
+    sdl3-image
     uriparser
     zlib
   ]


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

SDL2 client is deprecated and SDL3 client is no longer experimental
https://github.com/FreeRDP/FreeRDP/pull/11223
https://github.com/FreeRDP/FreeRDP/pull/11546

Binary name changes if we keep both. Potential breaking change?
Before: `sdl-freerdp` (SDL2)
After: `sdl2-freerdp` and `sdl3-freerdp`

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 439680`
Commit: `50a34c62c41ab8fc752b3a8b3323ac141c101b00`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 29 packages built:</summary>
  <ul>
    <li>brutespray</li>
    <li>budgie-control-center</li>
    <li>budgie-control-center.debug</li>
    <li>crowbar</li>
    <li>crowbar.dist</li>
    <li>freerdp</li>
    <li>gnome-connections</li>
    <li>gnome-control-center</li>
    <li>gnome-control-center.debug</li>
    <li>gnome-remote-desktop</li>
    <li>gtk-frdp</li>
    <li>guacamole-server</li>
    <li>kdePackages.krdc</li>
    <li>kdePackages.krdc.debug</li>
    <li>kdePackages.krdc.dev</li>
    <li>kdePackages.krdc.devtools</li>
    <li>kdePackages.krdp</li>
    <li>kdePackages.krdp.debug</li>
    <li>kdePackages.krdp.dev</li>
    <li>kdePackages.krdp.devtools</li>
    <li>medusa</li>
    <li>medusa.man</li>
    <li>phosh</li>
    <li>phosh-mobile-settings</li>
    <li>remmina</li>
    <li>weston</li>
    <li>x11docker</li>
    <li>xwayland-run</li>
    <li>xwayland-run.man</li>
  </ul>
</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
