### PR TITLE
nixos/ifstate: remove manual /var/run creation

### DIFF
--- a/nixos/modules/services/networking/ifstate.nix
+++ b/nixos/modules/services/networking/ifstate.nix
@@ -291,9 +291,6 @@ in
               # Otherwise systemd starts ifstate again, after the encryption password was entered by the user
               # and we are able to implement the cleanup using ExecStop rather than a separate unit.
               RemainAfterExit = true;
-              # When using network namespaces pyroute2 expects this directory to exists.
-              # @liske is currently investigating whether this should be considered a bug in pyroute2.
-              ExecStartPre = "${lib.getExe' pkgs.coreutils "mkdir"} /var/run";
               ExecStart = "${lib.getExe initrdCfg.package} --config ${
                 config.environment.etc."ifstate/ifstate.initrd.yaml".source
               } apply";


### PR DESCRIPTION
The directory seems to be created by other processes using recent changes in master now. Therefore the manual mkdir is not needed anymore.

As per the removed code comment, this will probably also be fixed later in pyroute2 directly.


The nixos tests were failing because the mkdir failed, because the directory already exists. The tests succeed not without the mkdir, which was not the case before the mkdir was initially added.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
