### PR TITLE
nextpnr: fix build by overriding apycula version

### DIFF
--- a/pkgs/by-name/ne/nextpnr/package.nix
+++ b/pkgs/by-name/ne/nextpnr/package.nix
@@ -6,7 +6,7 @@
   boost,
   python3,
   eigen,
-  python3Packages,
+  fetchPypi,
   icestorm,
   trellis,
   llvmPackages,
@@ -38,6 +38,23 @@ let
     rev = "06d3b424dd0e52d678087c891c022544238fb9e3";
     hash = "sha256-nmyFFUO+/J2lb+lPATEjdYq0d21P1fN3N94JXR8brZ0=";
   };
+
+  python = python3.override {
+    self = python3;
+    packageOverrides = _: super: {
+      # override neccessary until next release comes out which supports 0.21
+      # https://github.com/YosysHQ/nextpnr/issues/1546
+      apycula = super.apycula.overridePythonAttrs rec {
+        version = "0.18";
+
+        src = fetchPypi {
+          inherit version;
+          pname = "Apycula";
+          hash = "sha256-nUaXnx4xFNH5wKZRaFXt0uLAgLm5/dTSKhiZQoSL8pg=";
+        };
+      };
+    };
+  };
 in
 
 stdenv.mkDerivation rec {
@@ -53,13 +70,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    python3
+    python
   ]
   ++ (lib.optional enableGui wrapQtAppsHook);
   buildInputs = [
     boostPython
     eigen
-    python3Packages.apycula
+    python.pkgs.apycula
   ]
   ++ (lib.optional enableGui qtbase)
   ++ (lib.optional stdenv.cc.isClang llvmPackages.openmp);
@@ -78,7 +95,7 @@ stdenv.mkDerivation rec {
       "-DICESTORM_INSTALL_PREFIX=${icestorm}"
       "-DTRELLIS_INSTALL_PREFIX=${trellis}"
       "-DTRELLIS_LIBDIR=${trellis}/lib/trellis"
-      "-DGOWIN_BBA_EXECUTABLE=${python3Packages.apycula}/bin/gowin_bba"
+      "-DGOWIN_BBA_EXECUTABLE=${python.pkgs.apycula}/bin/gowin_bba"
       "-DUSE_OPENMP=ON"
       "-DHIMBAECHEL_UARCH=all"
       "-DHIMBAECHEL_GOWIN_DEVICES=all"


### PR DESCRIPTION
Attempts to temporarily address https://github.com/NixOS/nixpkgs/issues/439087 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc