### PR TITLE
nixos/iso-image: add support for `boot.loader.efi.installDeviceTree`

### DIFF
--- a/nixos/modules/system/boot/loader/efi.nix
+++ b/nixos/modules/system/boot/loader/efi.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ config, lib, ... }:
 {
   options.boot.loader.efi = {
 
@@ -12,6 +12,15 @@
       default = "/boot";
       type = lib.types.str;
       description = "Where the EFI System Partition is mounted.";
+    };
+
+    installDeviceTree = lib.mkOption {
+      default = with config.hardware.deviceTree; enable && name != null;
+      defaultText = ''with config.hardware.deviceTree; enable && name != null'';
+      description = ''
+        Install the devicetree blob specified by `config.hardware.deviceTree.name`
+        to the ESP and instruct the bootloader to pass this DTB to linux.
+      '';
     };
   };
 }

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -161,6 +161,20 @@ in
       ]
       (config: lib.strings.removeSuffix ".conf" config.boot.loader.systemd-boot.netbootxyz.entryFilename)
     )
+    (mkRenamedOptionModule
+      [
+        "boot"
+        "loader"
+        "systemd-boot"
+        "installDeviceTree"
+      ]
+      [
+        "boot"
+        "loader"
+        "efi"
+        "installDeviceTree"
+      ]
+    )
   ];
 
   options.boot.loader.systemd-boot = {
@@ -241,15 +255,6 @@ in
 
         `null` means no limit i.e. all generations
         that have not been garbage collected yet.
-      '';
-    };
-
-    installDeviceTree = mkOption {
-      default = with config.hardware.deviceTree; enable && name != null;
-      defaultText = ''with config.hardware.deviceTree; enable && name != null'';
-      description = ''
-        Install the devicetree blob specified by `config.hardware.deviceTree.name`
-        to the ESP and instruct systemd-boot to pass this DTB to linux.
       '';
     };
 
@@ -537,7 +542,7 @@ in
       }
       {
         assertion =
-          cfg.installDeviceTree
+          efi.installDeviceTree
           -> config.hardware.deviceTree.enable
           -> config.hardware.deviceTree.name != null;
         message = "Cannot install devicetree without 'config.hardware.deviceTree.enable' enabled and 'config.hardware.deviceTree.name' set";
@@ -626,7 +631,7 @@ in
 
     boot.bootspec.extensions."org.nixos.systemd-boot" = {
       inherit (config.boot.loader.systemd-boot) sortKey;
-      devicetree = lib.mkIf cfg.installDeviceTree "${config.hardware.deviceTree.package}/${config.hardware.deviceTree.name}";
+      devicetree = lib.mkIf efi.installDeviceTree "${config.hardware.deviceTree.package}/${config.hardware.deviceTree.name}";
     };
 
     system = {

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -197,7 +197,7 @@ in
           # (we would then be able to use `dumpdtb`). Thus, the following config
           # will not boot, but it does allow us to assert that the boot entry has
           # the correct contents.
-          boot.loader.systemd-boot.installDeviceTree = pkgs.stdenv.hostPlatform.isAarch64;
+          boot.loader.efi.installDeviceTree = pkgs.stdenv.hostPlatform.isAarch64;
           hardware.deviceTree.name = "dummy.dtb";
           hardware.deviceTree.package = lib.mkForce (
             pkgs.runCommand "dummy-devicetree-package" { } ''


### PR DESCRIPTION
There are 2 commits here: I first rename rename `boot.loader.systemd-boot.installDeviceTree` to `boot.loader.efi.installDeviceTree`, and then I add support for `boot.loader.efi.installDeviceTree` to `iso-image.nix`.

Many thanks to @jmbaur for introducing me to the embedded world!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
