### PR TITLE
[25.05] top-level: various improvements to release.nix & co

### DIFF
--- a/pkgs/os-specific/darwin/xcode/default.nix
+++ b/pkgs/os-specific/darwin/xcode/default.nix
@@ -46,6 +46,7 @@ let
         description = "Apple's XCode SDK";
         license = licenses.unfree;
         platforms = platforms.darwin ++ platforms.linux;
+        hydraPlatforms = [ ];
         sourceProvenance = [ sourceTypes.binaryNativeCode ];
       };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -119,7 +119,7 @@ with pkgs;
     You should not evaluate entire Nixpkgs without measures to handle failing packages.
   '';
 
-  tests = callPackages ../test { };
+  tests = lib.recurseIntoAttrs (callPackages ../test { });
 
   defaultPkgConfigPackages =
     # We don't want nix-env -q to enter this, because all of these are aliases.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5555,10 +5555,10 @@ with pkgs;
 
   # Haskell and GHC
 
-  haskell = callPackage ./haskell-packages.nix { };
+  haskell = recurseIntoAttrs (callPackage ./haskell-packages.nix { });
 
   haskellPackages =
-    dontRecurseIntoAttrs
+    recurseIntoAttrs
       # Prefer native-bignum to avoid linking issues with gmp
       # GHC 9.6 rts can't be built statically with hadrian, so we need to use 9.4
       # until 9.8 is ready

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2403,7 +2403,7 @@ with pkgs;
 
   roundcube = callPackage ../servers/roundcube { };
 
-  roundcubePlugins = dontRecurseIntoAttrs (callPackage ../servers/roundcube/plugins { });
+  roundcubePlugins = recurseIntoAttrs (callPackage ../servers/roundcube/plugins { });
 
   rsyslog = callPackage ../tools/system/rsyslog {
     withHadoop = false; # Currently Broken

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5691,7 +5691,7 @@ with pkgs;
 
   gwt240 = callPackage ../development/compilers/gwt/2.4.0.nix { };
 
-  idrisPackages = dontRecurseIntoAttrs (
+  idrisPackages = recurseIntoAttrs (
     callPackage ../development/idris-modules {
       idris-no-deps = haskellPackages.idris;
       pkgs = pkgs.__splicedPackages;
@@ -9963,9 +9963,11 @@ with pkgs;
 
   ### DEVELOPMENT / LIBRARIES / AGDA
 
-  agdaPackages = callPackage ./agda-packages.nix {
-    inherit (haskellPackages) Agda;
-  };
+  agdaPackages = recurseIntoAttrs (
+    callPackage ./agda-packages.nix {
+      inherit (haskellPackages) Agda;
+    }
+  );
   agda = agdaPackages.agda;
 
   ### DEVELOPMENT / LIBRARIES / BASH
@@ -11127,7 +11129,7 @@ with pkgs;
   # Even though this is a set of packages not single package, use `callPackage`
   # not `callPackages` so the per-package callPackages don't have their
   # `.override` clobbered. C.F. `llvmPackages` which does the same.
-  darwin = recurseIntoAttrs (callPackage ./darwin-packages.nix { });
+  darwin = callPackage ./darwin-packages.nix { };
 
   displaylink = callPackage ../os-specific/linux/displaylink {
     inherit (linuxPackages) evdi;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3641,9 +3641,9 @@ with pkgs;
 
   importNpmLock = callPackages ../build-support/node/import-npm-lock { };
 
-  nodePackages_latest = dontRecurseIntoAttrs nodejs_latest.pkgs;
+  nodePackages_latest = recurseIntoAttrs nodejs_latest.pkgs;
 
-  nodePackages = dontRecurseIntoAttrs nodejs.pkgs;
+  nodePackages = recurseIntoAttrs nodejs.pkgs;
 
   node2nix = nodePackages.node2nix;
 

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -45,174 +45,176 @@ makeScopeWithSplicing' {
       impure-cmds = pkgs.callPackage ../os-specific/darwin/impure-cmds { };
     in
 
-    impure-cmds
-    // apple-source-packages
-    // {
+    lib.recurseIntoAttrs (
+      impure-cmds
+      // apple-source-packages
+      // {
 
-      inherit (self.adv_cmds) ps;
+        inherit (self.adv_cmds) ps;
 
-      binutils-unwrapped = callPackage ../os-specific/darwin/binutils {
-        inherit (pkgs) cctools;
-        inherit (pkgs.llvmPackages) clang-unwrapped llvm llvm-manpages;
-      };
+        binutils-unwrapped = callPackage ../os-specific/darwin/binutils {
+          inherit (pkgs) cctools;
+          inherit (pkgs.llvmPackages) clang-unwrapped llvm llvm-manpages;
+        };
 
-      binutils = pkgs.wrapBintoolsWith {
-        libc = if stdenv.targetPlatform != stdenv.hostPlatform then pkgs.libcCross else pkgs.stdenv.cc.libc;
-        bintools = self.binutils-unwrapped;
-      };
+        binutils = pkgs.wrapBintoolsWith {
+          libc = if stdenv.targetPlatform != stdenv.hostPlatform then pkgs.libcCross else pkgs.stdenv.cc.libc;
+          bintools = self.binutils-unwrapped;
+        };
 
-      # x86-64 Darwin gnat-bootstrap emits assembly
-      # with MOVQ as the mnemonic for quadword interunit moves
-      # such as `movq %rbp, %xmm0`.
-      # The clang integrated assembler recognises this as valid,
-      # but unfortunately the cctools.gas GNU assembler does not;
-      # it instead uses MOVD as the mnemonic.
-      # The assembly that a GCC build emits is determined at build time
-      # and cannot be changed afterwards.
-      #
-      # To build GNAT on x86-64 Darwin, therefore,
-      # we need both the clang _and_ the cctools.gas assemblers to be available:
-      # the former to build at least the stage1 compiler,
-      # and the latter at least to be detectable
-      # as the target for the final compiler.
-      binutilsDualAs-unwrapped = pkgs.buildEnv {
-        name = "${lib.getName self.binutils-unwrapped}-dualas-${lib.getVersion self.binutils-unwrapped}";
-        paths = [
-          self.binutils-unwrapped
-          (lib.getOutput "gas" pkgs.cctools)
-        ];
-      };
+        # x86-64 Darwin gnat-bootstrap emits assembly
+        # with MOVQ as the mnemonic for quadword interunit moves
+        # such as `movq %rbp, %xmm0`.
+        # The clang integrated assembler recognises this as valid,
+        # but unfortunately the cctools.gas GNU assembler does not;
+        # it instead uses MOVD as the mnemonic.
+        # The assembly that a GCC build emits is determined at build time
+        # and cannot be changed afterwards.
+        #
+        # To build GNAT on x86-64 Darwin, therefore,
+        # we need both the clang _and_ the cctools.gas assemblers to be available:
+        # the former to build at least the stage1 compiler,
+        # and the latter at least to be detectable
+        # as the target for the final compiler.
+        binutilsDualAs-unwrapped = pkgs.buildEnv {
+          name = "${lib.getName self.binutils-unwrapped}-dualas-${lib.getVersion self.binutils-unwrapped}";
+          paths = [
+            self.binutils-unwrapped
+            (lib.getOutput "gas" pkgs.cctools)
+          ];
+        };
 
-      binutilsDualAs = self.binutils.override {
-        bintools = self.binutilsDualAs-unwrapped;
-      };
+        binutilsDualAs = self.binutils.override {
+          bintools = self.binutilsDualAs-unwrapped;
+        };
 
-      binutilsNoLibc = pkgs.wrapBintoolsWith {
-        libc = preLibcCrossHeaders;
-        bintools = self.binutils-unwrapped;
-      };
+        binutilsNoLibc = pkgs.wrapBintoolsWith {
+          libc = preLibcCrossHeaders;
+          bintools = self.binutils-unwrapped;
+        };
 
-      # Removes propagated packages from the stdenv, so those packages can be built without depending upon themselves.
-      bootstrapStdenv = mkBootstrapStdenv pkgs.stdenv;
+        # Removes propagated packages from the stdenv, so those packages can be built without depending upon themselves.
+        bootstrapStdenv = mkBootstrapStdenv pkgs.stdenv;
 
-      libSystem = callPackage ../os-specific/darwin/libSystem { };
+        libSystem = callPackage ../os-specific/darwin/libSystem { };
 
-      DarwinTools = callPackage ../os-specific/darwin/DarwinTools { };
+        DarwinTools = callPackage ../os-specific/darwin/DarwinTools { };
 
-      libunwind = callPackage ../os-specific/darwin/libunwind { };
+        libunwind = callPackage ../os-specific/darwin/libunwind { };
 
-      sigtool = callPackage ../os-specific/darwin/sigtool { };
+        sigtool = callPackage ../os-specific/darwin/sigtool { };
 
-      signingUtils = callPackage ../os-specific/darwin/signing-utils { };
+        signingUtils = callPackage ../os-specific/darwin/signing-utils { };
 
-      autoSignDarwinBinariesHook = pkgs.makeSetupHook {
-        name = "auto-sign-darwin-binaries-hook";
-        propagatedBuildInputs = [ self.signingUtils ];
-      } ../os-specific/darwin/signing-utils/auto-sign-hook.sh;
+        autoSignDarwinBinariesHook = pkgs.makeSetupHook {
+          name = "auto-sign-darwin-binaries-hook";
+          propagatedBuildInputs = [ self.signingUtils ];
+        } ../os-specific/darwin/signing-utils/auto-sign-hook.sh;
 
-      iosSdkPkgs = callPackage ../os-specific/darwin/xcode/sdk-pkgs.nix {
-        buildIosSdk = buildPackages.darwin.iosSdkPkgs.sdk;
-        targetIosSdkPkgs = targetPackages.darwin.iosSdkPkgs;
-        inherit (pkgs.llvmPackages) clang-unwrapped;
-      };
+        iosSdkPkgs = callPackage ../os-specific/darwin/xcode/sdk-pkgs.nix {
+          buildIosSdk = buildPackages.darwin.iosSdkPkgs.sdk;
+          targetIosSdkPkgs = targetPackages.darwin.iosSdkPkgs;
+          inherit (pkgs.llvmPackages) clang-unwrapped;
+        };
 
-      lsusb = callPackage ../os-specific/darwin/lsusb { };
+        lsusb = callPackage ../os-specific/darwin/lsusb { };
 
-      openwith = callPackage ../os-specific/darwin/openwith { };
+        openwith = callPackage ../os-specific/darwin/openwith { };
 
-      trash = callPackage ../os-specific/darwin/trash { };
+        trash = callPackage ../os-specific/darwin/trash { };
 
-      inherit (self.file_cmds) xattr;
+        inherit (self.file_cmds) xattr;
 
-      inherit (pkgs.callPackages ../os-specific/darwin/xcode { })
-        xcode_8_1
-        xcode_8_2
-        xcode_9_1
-        xcode_9_2
-        xcode_9_3
-        xcode_9_4
-        xcode_9_4_1
-        xcode_10_1
-        xcode_10_2
-        xcode_10_2_1
-        xcode_10_3
-        xcode_11
-        xcode_11_1
-        xcode_11_2
-        xcode_11_3_1
-        xcode_11_4
-        xcode_11_5
-        xcode_11_6
-        xcode_11_7
-        xcode_12
-        xcode_12_0_1
-        xcode_12_1
-        xcode_12_2
-        xcode_12_3
-        xcode_12_4
-        xcode_12_5
-        xcode_12_5_1
-        xcode_13
-        xcode_13_1
-        xcode_13_2
-        xcode_13_3
-        xcode_13_3_1
-        xcode_13_4
-        xcode_13_4_1
-        xcode_14
-        xcode_14_1
-        xcode_15
-        xcode_15_0_1
-        xcode_15_1
-        xcode_15_2
-        xcode_15_3
-        xcode_15_4
-        xcode_16
-        xcode_16_1
-        xcode_16_2
-        xcode_16_3
-        xcode
-        requireXcode
-        ;
+        inherit (pkgs.callPackages ../os-specific/darwin/xcode { })
+          xcode_8_1
+          xcode_8_2
+          xcode_9_1
+          xcode_9_2
+          xcode_9_3
+          xcode_9_4
+          xcode_9_4_1
+          xcode_10_1
+          xcode_10_2
+          xcode_10_2_1
+          xcode_10_3
+          xcode_11
+          xcode_11_1
+          xcode_11_2
+          xcode_11_3_1
+          xcode_11_4
+          xcode_11_5
+          xcode_11_6
+          xcode_11_7
+          xcode_12
+          xcode_12_0_1
+          xcode_12_1
+          xcode_12_2
+          xcode_12_3
+          xcode_12_4
+          xcode_12_5
+          xcode_12_5_1
+          xcode_13
+          xcode_13_1
+          xcode_13_2
+          xcode_13_3
+          xcode_13_3_1
+          xcode_13_4
+          xcode_13_4_1
+          xcode_14
+          xcode_14_1
+          xcode_15
+          xcode_15_0_1
+          xcode_15_1
+          xcode_15_2
+          xcode_15_3
+          xcode_15_4
+          xcode_16
+          xcode_16_1
+          xcode_16_2
+          xcode_16_3
+          xcode
+          requireXcode
+          ;
 
-      xcodeProjectCheckHook = pkgs.makeSetupHook {
-        name = "xcode-project-check-hook";
-        propagatedBuildInputs = [ pkgs.pkgsBuildHost.openssl ];
-      } ../os-specific/darwin/xcode-project-check-hook/setup-hook.sh;
+        xcodeProjectCheckHook = pkgs.makeSetupHook {
+          name = "xcode-project-check-hook";
+          propagatedBuildInputs = [ pkgs.pkgsBuildHost.openssl ];
+        } ../os-specific/darwin/xcode-project-check-hook/setup-hook.sh;
 
-      # See doc/packages/darwin-builder.section.md
-      linux-builder = lib.makeOverridable (
-        { modules }:
-        let
-          toGuest = builtins.replaceStrings [ "darwin" ] [ "linux" ];
+        # See doc/packages/darwin-builder.section.md
+        linux-builder = lib.makeOverridable (
+          { modules }:
+          let
+            toGuest = builtins.replaceStrings [ "darwin" ] [ "linux" ];
 
-          nixos = import ../../nixos {
-            configuration = {
-              imports = [
-                ../../nixos/modules/profiles/nix-builder-vm.nix
-              ]
-              ++ modules;
+            nixos = import ../../nixos {
+              configuration = {
+                imports = [
+                  ../../nixos/modules/profiles/nix-builder-vm.nix
+                ]
+                ++ modules;
 
-              # If you need to override this, consider starting with the right Nixpkgs
-              # in the first place, ie change `pkgs` in `pkgs.darwin.linux-builder`.
-              # or if you're creating new wiring that's not `pkgs`-centric, perhaps use the
-              # macos-builder profile directly.
-              virtualisation.host = { inherit pkgs; };
+                # If you need to override this, consider starting with the right Nixpkgs
+                # in the first place, ie change `pkgs` in `pkgs.darwin.linux-builder`.
+                # or if you're creating new wiring that's not `pkgs`-centric, perhaps use the
+                # macos-builder profile directly.
+                virtualisation.host = { inherit pkgs; };
 
-              nixpkgs.hostPlatform = lib.mkDefault (toGuest stdenv.hostPlatform.system);
+                nixpkgs.hostPlatform = lib.mkDefault (toGuest stdenv.hostPlatform.system);
+              };
+
+              system = null;
             };
 
-            system = null;
-          };
+          in
+          nixos.config.system.build.macos-builder-installer
+        ) { modules = [ ]; };
 
-        in
-        nixos.config.system.build.macos-builder-installer
-      ) { modules = [ ]; };
+        linux-builder-x86_64 = self.linux-builder.override {
+          modules = [ { nixpkgs.hostPlatform = "x86_64-linux"; } ];
+        };
 
-      linux-builder-x86_64 = self.linux-builder.override {
-        modules = [ { nixpkgs.hostPlatform = "x86_64-linux"; } ];
-      };
-
-    }
+      }
+    )
   );
 }

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -78,7 +78,7 @@ in
   # `name: pkgs: pkgs.haskell.packages.${name}.ghc == pkgs.buildPackages.haskell.compiler.${name}.ghc`.
   # This isn't problematic since pkgsBuildBuild.buildPackages is also build->build,
   # just something to keep in mind.
-  compiler =
+  compiler = pkgs.lib.recurseIntoAttrs (
     let
       bb = pkgsBuildBuild.haskell;
     in
@@ -492,7 +492,8 @@ in
             name: compiler.${name}.override { enableNativeBignum = true; }
           )
         );
-    };
+    }
+  );
 
   # Default overrides that are applied to all package sets.
   packageOverrides = self: super: { };

--- a/pkgs/top-level/packages-config.nix
+++ b/pkgs/top-level/packages-config.nix
@@ -14,8 +14,6 @@
         fusePackages
         gns3Packages
         haskellPackages
-        nodePackages
-        nodePackages_latest
         platformioPackages
         rPackages
         roundcubePlugins

--- a/pkgs/top-level/packages-config.nix
+++ b/pkgs/top-level/packages-config.nix
@@ -13,18 +13,10 @@
       inherit (super)
         fusePackages
         gns3Packages
-        haskellPackages
         platformioPackages
         rPackages
         sourceHanPackages
         ;
-
-      # Make sure haskell.compiler is included, so alternative GHC versions show up,
-      # but don't add haskell.packages.* since they contain the same packages (at
-      # least by name) as haskellPackages.
-      haskell = super.haskell // {
-        compiler = recurseIntoAttrs super.haskell.compiler;
-      };
 
       # emacsPackages is an alias for emacs.pkgs
       # Re-introduce emacsPackages here so that emacs.pkgs can be searched.

--- a/pkgs/top-level/packages-config.nix
+++ b/pkgs/top-level/packages-config.nix
@@ -16,7 +16,6 @@
         haskellPackages
         platformioPackages
         rPackages
-        roundcubePlugins
         sourceHanPackages
         ;
 

--- a/pkgs/top-level/packages-config.nix
+++ b/pkgs/top-level/packages-config.nix
@@ -35,5 +35,8 @@
       # show up in search results or repository tracking services that consume our
       # packages.json https://github.com/NixOS/nixpkgs/issues/244966
       minimal-bootstrap = { };
+
+      # This makes it so that tests are not appering on search.nixos.org
+      tests = { };
     };
 }

--- a/pkgs/top-level/packages-config.nix
+++ b/pkgs/top-level/packages-config.nix
@@ -11,19 +11,15 @@
     with super;
     lib.mapAttrs (_: set: recurseIntoAttrs set) {
       inherit (super)
-        agdaPackages
-        apacheHttpdPackages
         fusePackages
         gns3Packages
         haskellPackages
-        idrisPackages
         nodePackages
         nodePackages_latest
         platformioPackages
         rPackages
         roundcubePlugins
         sourceHanPackages
-        zabbix60
         ;
 
       # Make sure haskell.compiler is included, so alternative GHC versions show up,

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -371,27 +371,27 @@ let
         if attrNamesOnly then id else release-lib.getPlatforms
       );
       packageJobs = packagePlatforms pkgs // {
-        haskell.compiler = packagePlatforms pkgs.haskell.compiler;
-        haskellPackages = packagePlatforms pkgs.haskellPackages;
         # Build selected packages (HLS) for multiple Haskell compilers to rebuild
         # the cache after a staging merge
-        haskell.packages =
-          genAttrs
-            [
-              # TODO: share this list between release.nix and release-haskell.nix
-              "ghc90"
-              "ghc92"
-              "ghc94"
-              "ghc96"
-              "ghc98"
-              "ghc910"
-              "ghc912"
-            ]
-            (compilerName: {
-              inherit (packagePlatforms pkgs.haskell.packages.${compilerName})
-                haskell-language-server
-                ;
-            });
+        haskell = packagePlatforms pkgs.haskell // {
+          packages =
+            genAttrs
+              [
+                # TODO: share this list between release.nix and release-haskell.nix
+                "ghc90"
+                "ghc92"
+                "ghc94"
+                "ghc96"
+                "ghc98"
+                "ghc910"
+                "ghc912"
+              ]
+              (compilerName: {
+                inherit (packagePlatforms pkgs.haskell.packages.${compilerName})
+                  haskell-language-server
+                  ;
+              });
+        };
 
         pkgsLLVM.stdenv = [
           "x86_64-linux"

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -392,8 +392,6 @@ let
                 haskell-language-server
                 ;
             });
-        idrisPackages = packagePlatforms pkgs.idrisPackages;
-        agdaPackages = packagePlatforms pkgs.agdaPackages;
 
         pkgsLLVM.stdenv = [
           "x86_64-linux"
@@ -416,16 +414,8 @@ let
           "aarch64-linux"
         ];
 
-        # Language packages disabled in https://github.com/NixOS/nixpkgs/commit/ccd1029f58a3bb9eca32d81bf3f33cb4be25cc66
-
-        #emacsPackages = packagePlatforms pkgs.emacsPackages;
-        #rPackages = packagePlatforms pkgs.rPackages;
+        # Fails CI in its current state
         ocamlPackages = { };
-        perlPackages = { };
-
-        darwin = packagePlatforms pkgs.darwin // {
-          xcode = { };
-        };
       };
       mapTestOn-packages = if attrNamesOnly then packageJobs else mapTestOn packageJobs;
     in

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -416,8 +416,6 @@ let
           "aarch64-linux"
         ];
 
-        tests = packagePlatforms pkgs.tests;
-
         # Language packages disabled in https://github.com/NixOS/nixpkgs/commit/ccd1029f58a3bb9eca32d81bf3f33cb4be25cc66
 
         #emacsPackages = packagePlatforms pkgs.emacsPackages;


### PR DESCRIPTION
This backports:
- #405039
- #430856
- #436841
- #437192
- #437195
- #437196

The changes worked well, this should not cause any problems.

I'm backporting this, because `release-outpaths.nix` / `release-attrpaths.nix` etc. belong to CI (Eval), thus are always backported. They are relatively tightly coupled to `release.nix`, thus the latter needs some backports as well. To make backporting easier to reason about and result in fewer conflicts, I'll just bring these commits along.