### PR TITLE
vtk: switch to libpq

### DIFF
--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -54,7 +54,7 @@
   openvdb,
   c-blosc,
   unixODBC,
-  postgresql,
+  libpq,
   libmysqlclient,
   ffmpeg,
   libjpeg,
@@ -174,7 +174,7 @@ stdenv.mkDerivation (finalAttrs: {
     imath
     c-blosc
     unixODBC
-    postgresql
+    libpq
     libmysqlclient
     ffmpeg
     opencascade-occt


### PR DESCRIPTION
Consumers who only need libpq, should use `libpq` to reduce the number of rebuilds for `postgresql`. Otherwise we might have too many rebuilds to get minor updates for PostgreSQL straight into master.

Fixes https://github.com/NixOS/nixpkgs/pull/417613/files#r2317138041

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
