### PR TITLE
uvwasi: 0.0.21 -> 0.0.23

### DIFF
--- a/pkgs/by-name/uv/uvwasi/package.nix
+++ b/pkgs/by-name/uv/uvwasi/package.nix
@@ -11,20 +11,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "uvwasi";
-  version = "0.0.21";
+  version = "0.0.23";
 
   src = fetchFromGitHub {
     owner = "nodejs";
     repo = "uvwasi";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-po2Pwqf97JXGKY8WysvyR1vSkqQ4XIF0VQG+83yV9nM=";
+    hash = "sha256-+vz/qTMRRDHV1VE4nny9vYYtarZHk1xoM4EZiah3jnY=";
   };
-
-  # Patch was sent upstream: https://github.com/nodejs/uvwasi/pull/302.
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'DESTINATION ''${CMAKE_INSTALL_INCLUDEDIR}/uvwasi' 'DESTINATION ''${CMAKE_INSTALL_INCLUDEDIR}'
-  '';
 
   outputs = [
     "out"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/nodejs/uvwasi/releases/tag/v0.0.22
https://github.com/nodejs/uvwasi/releases/tag/v0.0.23

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
