### PR TITLE
libfrida-core: init at 17.2.17

### DIFF
--- a/pkgs/by-name/li/libfrida-core/package.nix
+++ b/pkgs/by-name/li/libfrida-core/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+}:
+let
+  inherit (stdenvNoCC.hostPlatform) system;
+  version = "17.2.17";
+  source =
+    {
+      x86_64-linux = {
+        url = "https://github.com/frida/frida/releases/download/${version}/frida-core-devkit-${version}-linux-x86_64.tar.xz";
+        hash = "sha256-9elOokCY1bxzG2iL4iOODC/7qavwn77a0zOEBpAtT8Q=";
+      };
+      aarch64-linux = {
+        url = "https://github.com/frida/frida/releases/download/${version}/frida-core-devkit-${version}-linux-arm64.tar.xz";
+        hash = "sha256-jk8BKmp3VNvCYK6kgGouFOBECoDaGiWQ8EzZvBwL7cc=";
+      };
+    }
+    .${system} or (throw "Unsupported system: ${system}");
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "libfrida-core";
+  inherit version;
+
+  src = fetchurl {
+    inherit (source) url hash;
+  };
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/include $out/lib
+    tar -xf $src -C .
+    install -Dm755 libfrida-core.a -t $out/lib
+    install -Dm644 frida-core.h -t $out/include
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Frida core library intended for static linking into bindings";
+    homepage = "https://frida.re/";
+    changelog = "https://frida.re/news/";
+    license = lib.licenses.wxWindowsException31;
+    maintainers = with lib.maintainers; [ nilathedragon ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
This library is necessary to successfully build Frida language bindings such as the frida-go. Unfortunately, frida's build system is extremely non-standard and I've chatted with multiple people in the matrix chat, that agreed that packaging this from source is incredibly difficult.

This binary package might enable frida-python to be packaged from source instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
