### PR TITLE
nixos/aria2: Allow openPorts to be used even when service disabled

### DIFF
--- a/nixos/modules/services/networking/aria2.nix
+++ b/nixos/modules/services/networking/aria2.nix
@@ -239,7 +239,7 @@ in
         UMask = cfg.serviceUMask;
       };
     };
-  })];
+  }); ];
 
   meta.maintainers = [ lib.maintainers.timhae ];
 }

--- a/nixos/modules/services/networking/aria2.nix
+++ b/nixos/modules/services/networking/aria2.nix
@@ -190,57 +190,58 @@ in
       };
     })
     (lib.mkIf cfg.enable {
-    assertions = [
-      {
-        assertion = cfg.settings.enable-rpc;
-        message = "RPC has to be enabled, the default module option takes care of that.";
-      }
-      {
-        assertion = !(cfg.settings ? rpc-secret);
-        message = "Set the RPC secret through services.aria2.rpcSecretFile so it will not end up in the world-readable nix store.";
-      }
-    ];
-
-    users.users.aria2 = {
-      group = "aria2";
-      uid = config.ids.uids.aria2;
-      description = "aria2 user";
-      home = homeDir;
-      createHome = false;
-    };
-
-    users.groups.aria2.gid = config.ids.gids.aria2;
-
-    systemd.tmpfiles.rules = [
-      "d '${homeDir}' 0770 aria2 aria2 - -"
-      "d '${config.services.aria2.settings.dir}' ${config.services.aria2.downloadDirPermission} aria2 aria2 - -"
-    ];
-
-    systemd.services.aria2 = {
-      description = "aria2 Service";
-      after = [ "network.target" ];
-      wantedBy = [ "multi-user.target" ];
-      preStart = ''
-        if [[ ! -e "${cfg.settings.save-session}" ]]
-        then
-          touch "${cfg.settings.save-session}"
-        fi
-        cp -f "${pkgs.writeText "aria2.conf" (customToKeyValue cfg.settings)}" "${cfg.settings.conf-path}"
-        chmod +w "${cfg.settings.conf-path}"
-        echo "rpc-secret=$(cat "$CREDENTIALS_DIRECTORY/rpcSecretFile")" >> "${cfg.settings.conf-path}"
-      '';
-
-      serviceConfig = {
-        Restart = "on-abort";
-        ExecStart = "${pkgs.aria2}/bin/aria2c --conf-path=${cfg.settings.conf-path}";
-        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
-        User = "aria2";
-        Group = "aria2";
-        LoadCredential = "rpcSecretFile:${cfg.rpcSecretFile}";
-        UMask = cfg.serviceUMask;
+      assertions = [
+        {
+          assertion = cfg.settings.enable-rpc;
+          message = "RPC has to be enabled, the default module option takes care of that.";
+        }
+        {
+          assertion = !(cfg.settings ? rpc-secret);
+          message = "Set the RPC secret through services.aria2.rpcSecretFile so it will not end up in the world-readable nix store.";
+        }
+      ];
+  
+      users.users.aria2 = {
+        group = "aria2";
+        uid = config.ids.uids.aria2;
+        description = "aria2 user";
+        home = homeDir;
+        createHome = false;
       };
-    };
-  })];
+  
+      users.groups.aria2.gid = config.ids.gids.aria2;
+  
+      systemd.tmpfiles.rules = [
+        "d '${homeDir}' 0770 aria2 aria2 - -"
+        "d '${config.services.aria2.settings.dir}' ${config.services.aria2.downloadDirPermission} aria2 aria2 - -"
+      ];
+  
+      systemd.services.aria2 = {
+        description = "aria2 Service";
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        preStart = ''
+          if [[ ! -e "${cfg.settings.save-session}" ]]
+          then
+            touch "${cfg.settings.save-session}"
+          fi
+          cp -f "${pkgs.writeText "aria2.conf" (customToKeyValue cfg.settings)}" "${cfg.settings.conf-path}"
+          chmod +w "${cfg.settings.conf-path}"
+          echo "rpc-secret=$(cat "$CREDENTIALS_DIRECTORY/rpcSecretFile")" >> "${cfg.settings.conf-path}"
+        '';
+  
+        serviceConfig = {
+          Restart = "on-abort";
+          ExecStart = "${pkgs.aria2}/bin/aria2c --conf-path=${cfg.settings.conf-path}";
+          ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+          User = "aria2";
+          Group = "aria2";
+          LoadCredential = "rpcSecretFile:${cfg.rpcSecretFile}";
+          UMask = cfg.serviceUMask;
+        };
+      };
+    })
+  ];
 
   meta.maintainers = [ lib.maintainers.timhae ];
 }

--- a/nixos/modules/services/networking/aria2.nix
+++ b/nixos/modules/services/networking/aria2.nix
@@ -55,10 +55,7 @@ in
       [ "services" "aria2" "rpcListenPort" ]
       [ "services" "aria2" "settings" "rpc-listen-port" ]
     )
-    (lib.mkRenamedOptionModule
-      [ "programs" "aria2" "openPorts" ]
-      [ "services" "aria2" "openPorts" ]
-    )
+    (lib.mkRenamedOptionModule [ "programs" "aria2" "openPorts" ] [ "services" "aria2" "openPorts" ])
   ];
 
   options = {
@@ -186,7 +183,9 @@ in
       # to allow bittorrent to work with ad-hoc invocations of aria2c.
       networking.firewall = lib.mkIf cfg.openPorts {
         allowedUDPPortRanges = config.services.aria2.settings.listen-port;
-        allowedTCPPorts = lib.mkIf config.services.aria2.settings.enable-rpc [ config.services.aria2.settings.rpc-listen-port ];
+        allowedTCPPorts = lib.mkIf config.services.aria2.settings.enable-rpc [
+          config.services.aria2.settings.rpc-listen-port
+        ];
       };
     })
     (lib.mkIf cfg.enable {
@@ -200,7 +199,7 @@ in
           message = "Set the RPC secret through services.aria2.rpcSecretFile so it will not end up in the world-readable nix store.";
         }
       ];
-  
+
       users.users.aria2 = {
         group = "aria2";
         uid = config.ids.uids.aria2;
@@ -208,14 +207,14 @@ in
         home = homeDir;
         createHome = false;
       };
-  
+
       users.groups.aria2.gid = config.ids.gids.aria2;
-  
+
       systemd.tmpfiles.rules = [
         "d '${homeDir}' 0770 aria2 aria2 - -"
         "d '${config.services.aria2.settings.dir}' ${config.services.aria2.downloadDirPermission} aria2 aria2 - -"
       ];
-  
+
       systemd.services.aria2 = {
         description = "aria2 Service";
         after = [ "network.target" ];
@@ -229,7 +228,7 @@ in
           chmod +w "${cfg.settings.conf-path}"
           echo "rpc-secret=$(cat "$CREDENTIALS_DIRECTORY/rpcSecretFile")" >> "${cfg.settings.conf-path}"
         '';
-  
+
         serviceConfig = {
           Restart = "on-abort";
           ExecStart = "${pkgs.aria2}/bin/aria2c --conf-path=${cfg.settings.conf-path}";

--- a/nixos/modules/services/networking/aria2.nix
+++ b/nixos/modules/services/networking/aria2.nix
@@ -188,7 +188,7 @@ in
         allowedUDPPortRanges = config.services.aria2.settings.listen-port;
         allowedTCPPorts = lib.mkIf config.services.aria2.settings.enable-rpc [ config.services.aria2.settings.rpc-listen-port ];
     }
-    lib.mkIf cfg.enable {
+    (lib.mkIf cfg.enable {
     assertions = [
       {
         assertion = cfg.settings.enable-rpc;
@@ -239,8 +239,7 @@ in
         UMask = cfg.serviceUMask;
       };
     };
-  }
-  ];
+  })];
 
   meta.maintainers = [ lib.maintainers.timhae ];
 }

--- a/nixos/modules/services/networking/aria2.nix
+++ b/nixos/modules/services/networking/aria2.nix
@@ -179,15 +179,16 @@ in
     };
   };
 
-  # Need to open ports for proper functioning
-  # Note: As we do not have a dedicated programs.aria2.openPorts, people may use services.aria2.openPorts even when !cfg.enable,
-  # to allow bittorrent to work with ad-hoc invocations of aria2c.
-  config.networking.firewall = lib.mkIf cfg.openPorts {
-    allowedUDPPortRanges = config.services.aria2.settings.listen-port;
-    allowedTCPPorts = lib.mkIf config.services.aria2.settings.enable-rpc [ config.services.aria2.settings.rpc-listen-port ];
-  };
-
-  config = lib.mkIf cfg.enable {
+  config = lib.mkMerge [
+    {
+      # Need to open ports for proper functioning
+      # Note: As we do not have a dedicated programs.aria2.openPorts, people may use services.aria2.openPorts even when !cfg.enable,
+      # to allow bittorrent to work with ad-hoc invocations of aria2c.
+      networking.firewall = lib.mkIf cfg.openPorts {
+        allowedUDPPortRanges = config.services.aria2.settings.listen-port;
+        allowedTCPPorts = lib.mkIf config.services.aria2.settings.enable-rpc [ config.services.aria2.settings.rpc-listen-port ];
+    }
+    lib.mkIf cfg.enable {
     assertions = [
       {
         assertion = cfg.settings.enable-rpc;
@@ -238,7 +239,8 @@ in
         UMask = cfg.serviceUMask;
       };
     };
-  };
+  }
+  ];
 
   meta.maintainers = [ lib.maintainers.timhae ];
 }

--- a/nixos/modules/services/networking/aria2.nix
+++ b/nixos/modules/services/networking/aria2.nix
@@ -182,7 +182,7 @@ in
   # Need to open ports for proper functioning
   # Note: As we do not have a dedicated programs.aria2.openPorts, people may use services.aria2.openPorts even when !cfg.enable,
   # to allow bittorrent to work with ad-hoc invocations of aria2c.
-  networking.firewall = lib.mkIf cfg.openPorts {
+  config.networking.firewall = lib.mkIf cfg.openPorts {
     allowedUDPPortRanges = config.services.aria2.settings.listen-port;
     allowedTCPPorts = lib.mkIf config.services.aria2.settings.enable-rpc [ config.services.aria2.settings.rpc-listen-port ];
   };

--- a/nixos/modules/services/networking/aria2.nix
+++ b/nixos/modules/services/networking/aria2.nix
@@ -179,7 +179,7 @@ in
     };
   };
 
-  config = mkMerge [
+  config = lib.mkMerge [
     ({
       # Need to open ports for proper functioning
       # Note: As we do not have a dedicated programs.aria2.openPorts, people may use services.aria2.openPorts even when !cfg.enable,

--- a/nixos/modules/services/networking/aria2.nix
+++ b/nixos/modules/services/networking/aria2.nix
@@ -179,7 +179,8 @@ in
     };
   };
 
-  config = {
+  config = mkMerge [
+    ({
       # Need to open ports for proper functioning
       # Note: As we do not have a dedicated programs.aria2.openPorts, people may use services.aria2.openPorts even when !cfg.enable,
       # to allow bittorrent to work with ad-hoc invocations of aria2c.
@@ -187,7 +188,8 @@ in
         allowedUDPPortRanges = config.services.aria2.settings.listen-port;
         allowedTCPPorts = lib.mkIf config.services.aria2.settings.enable-rpc [ config.services.aria2.settings.rpc-listen-port ];
       };
-    lib.mkIf cfg.enable {
+    })
+    (lib.mkIf cfg.enable {
     assertions = [
       {
         assertion = cfg.settings.enable-rpc;
@@ -238,7 +240,7 @@ in
         UMask = cfg.serviceUMask;
       };
     };
-  };
+  })];
 
   meta.maintainers = [ lib.maintainers.timhae ];
 }

--- a/nixos/modules/services/networking/aria2.nix
+++ b/nixos/modules/services/networking/aria2.nix
@@ -179,16 +179,15 @@ in
     };
   };
 
-  config = lib.mkMerge [
-    {
+  config = {
       # Need to open ports for proper functioning
       # Note: As we do not have a dedicated programs.aria2.openPorts, people may use services.aria2.openPorts even when !cfg.enable,
       # to allow bittorrent to work with ad-hoc invocations of aria2c.
       networking.firewall = lib.mkIf cfg.openPorts {
         allowedUDPPortRanges = config.services.aria2.settings.listen-port;
         allowedTCPPorts = lib.mkIf config.services.aria2.settings.enable-rpc [ config.services.aria2.settings.rpc-listen-port ];
-    }
-    (lib.mkIf cfg.enable {
+      };
+    lib.mkIf cfg.enable {
     assertions = [
       {
         assertion = cfg.settings.enable-rpc;
@@ -239,7 +238,7 @@ in
         UMask = cfg.serviceUMask;
       };
     };
-  }); ];
+  };
 
   meta.maintainers = [ lib.maintainers.timhae ];
 }


### PR DESCRIPTION
Allow openPorts to be used even when service disabled.

As there is no dedicated "programs.aria2.openPorts" people may want to use "services.aria2.openPorts = true;" to get bittorrent to work for ad-hoc invocations I.E. together with "services.aria2.enable = false;"


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
