### PR TITLE
verve: init at 0.3.2

### DIFF
--- a/pkgs/by-name/ve/verve/package.nix
+++ b/pkgs/by-name/ve/verve/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  rustPlatform,
+  fetchYarnDeps,
+  yarnConfigHook,
+  yarnBuildHook,
+  cargo-tauri_1,
+  fetchFromGitHub,
+  nix-update-script,
+  nodejs,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "verve";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "parthjadhav";
+    repo = "verve";
+    tag = finalAttrs.version;
+    hash = "sha256-u5rGIBpq+DWE+XcPmvfZUfJ/V0sSUm8bHjMLfVhRRiA=";
+  };
+
+  cargoHash = "sha256-Yxt6oSG91y8GOInsP98FXGssop63vo0SIxisdq76Uzo=";
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = finalAttrs.src + "/yarn.lock";
+    hash = "sha256-bFTIsQGlYN53/Wnqh5yuFIqAe1XXvNp+Q4BxgoZUvpg=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    cargo-tauri_1.hook
+    yarnConfigHook
+    yarnBuildHook
+  ];
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Modern Open-Source Launcher alternative to Raycast";
+    homepage = "https://github.com/ParthJadhav/Verve";
+    changelog = "https://github.com/ParthJadhav/Verve/releases/tag/${finalAttrs.version}";
+
+    license = lib.licenses.agpl3Only;
+    mainProgram = "verve";
+    platforms = lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ eveeifyeve ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes: https://github.com/NixOS/nixpkgs/issues/377566#issuecomment-3245812870 

For those who say I can't use Tauri v2, I have made a upstream issue here since it's not supported upstream: https://github.com/ParthJadhav/Verve/issues/50 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
