### PR TITLE
scdl: Add ffmpeg as a dependency of scdl

### DIFF
--- a/pkgs/by-name/sc/scdl/package.nix
+++ b/pkgs/by-name/sc/scdl/package.nix
@@ -2,6 +2,7 @@
   lib,
   python3Packages,
   fetchPypi,
+  ffmpeg-headless,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -26,6 +27,15 @@ python3Packages.buildPythonApplication rec {
     soundcloud-v2
     filelock
   ];
+
+  # Ensure ffmpeg is available in $PATH:
+  makeWrapperArgs =
+    let
+      packagesToBinPath = [ ffmpeg-headless ];
+    in
+    [
+      ''--prefix PATH : "${lib.makeBinPath packagesToBinPath}"''
+    ];
 
   # No tests in repository
   doCheck = false;


### PR DESCRIPTION
Simply added ffmpeg as a dependency of the package `scdl` because it requires ffmpeg for it's core functionality.
Previously ffmpeg would have to be available in the environment when running scdl.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
