### PR TITLE
jellyfin-mpv-shim: fix build on darwin

### DIFF
--- a/pkgs/development/python-modules/pyobjc-framework-Quartz/default.nix
+++ b/pkgs/development/python-modules/pyobjc-framework-Quartz/default.nix
@@ -1,0 +1,65 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  darwin,
+  pyobjc-core,
+  pyobjc-framework-Cocoa,
+  lib,
+}:
+
+buildPythonPackage rec {
+  pname = "pyobjc-framework-Quartz";
+  version = "11.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ronaldoussoren";
+    repo = "pyobjc";
+    tag = "v${version}";
+    hash = "sha256-2qPGJ/1hXf3k8AqVLr02fVIM9ziVG9NMrm3hN1de1Us=";
+  };
+
+  sourceRoot = "${src.name}/pyobjc-framework-Quartz";
+
+  build-system = [ setuptools ];
+
+  buildInputs = [ darwin.libffi ];
+
+  nativeBuildInputs = [
+    darwin.DarwinTools # sw_vers
+  ];
+
+  # See https://github.com/ronaldoussoren/pyobjc/pull/641. Unfortunately, we
+  # cannot just pull that diff with fetchpatch due to https://discourse.nixos.org/t/how-to-apply-patches-with-sourceroot/59727.
+  postPatch = ''
+    substituteInPlace pyobjc_setup.py \
+      --replace-fail "-buildversion" "-buildVersion" \
+      --replace-fail "-productversion" "-productVersion" \
+      --replace-fail "/usr/bin/sw_vers" "sw_vers" \
+      --replace-fail "/usr/bin/xcrun" "xcrun"
+  '';
+
+  dependencies = [
+    pyobjc-core
+    pyobjc-framework-Cocoa
+  ];
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-I${darwin.libffi.dev}/include"
+    "-Wno-error=unused-command-line-argument"
+  ];
+
+  pythonImportsCheck = [
+    "Quartz"
+    "PyObjCTools"
+  ];
+
+  meta = {
+    description = "PyObjC wrappers for the Quartz frameworks on macOS";
+    homepage = "https://github.com/ronaldoussoren/pyobjc";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ xyenon ];
+  };
+}

--- a/pkgs/development/python-modules/pyobjc-framework-Security/default.nix
+++ b/pkgs/development/python-modules/pyobjc-framework-Security/default.nix
@@ -1,0 +1,65 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  darwin,
+  pyobjc-core,
+  pyobjc-framework-Cocoa,
+  lib,
+}:
+
+buildPythonPackage rec {
+  pname = "pyobjc-framework-Security";
+  version = "11.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ronaldoussoren";
+    repo = "pyobjc";
+    tag = "v${version}";
+    hash = "sha256-2qPGJ/1hXf3k8AqVLr02fVIM9ziVG9NMrm3hN1de1Us=";
+  };
+
+  sourceRoot = "${src.name}/pyobjc-framework-Security";
+
+  build-system = [ setuptools ];
+
+  buildInputs = [ darwin.libffi ];
+
+  nativeBuildInputs = [
+    darwin.DarwinTools # sw_vers
+  ];
+
+  # See https://github.com/ronaldoussoren/pyobjc/pull/641. Unfortunately, we
+  # cannot just pull that diff with fetchpatch due to https://discourse.nixos.org/t/how-to-apply-patches-with-sourceroot/59727.
+  postPatch = ''
+    substituteInPlace pyobjc_setup.py \
+      --replace-fail "-buildversion" "-buildVersion" \
+      --replace-fail "-productversion" "-productVersion" \
+      --replace-fail "/usr/bin/sw_vers" "sw_vers" \
+      --replace-fail "/usr/bin/xcrun" "xcrun"
+  '';
+
+  dependencies = [
+    pyobjc-core
+    pyobjc-framework-Cocoa
+  ];
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-I${darwin.libffi.dev}/include"
+    "-Wno-error=unused-command-line-argument"
+  ];
+
+  pythonImportsCheck = [
+    "Security"
+    "PyObjCTools"
+  ];
+
+  meta = {
+    description = "PyObjC wrappers for the Security frameworks on macOS";
+    homepage = "https://github.com/ronaldoussoren/pyobjc";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ xyenon ];
+  };
+}

--- a/pkgs/development/python-modules/pyobjc-framework-WebKit/default.nix
+++ b/pkgs/development/python-modules/pyobjc-framework-WebKit/default.nix
@@ -1,0 +1,66 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  darwin,
+  pyobjc-core,
+  pyobjc-framework-Cocoa,
+  lib,
+}:
+
+buildPythonPackage rec {
+  pname = "pyobjc-framework-WebKit";
+  version = "11.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ronaldoussoren";
+    repo = "pyobjc";
+    tag = "v${version}";
+    hash = "sha256-2qPGJ/1hXf3k8AqVLr02fVIM9ziVG9NMrm3hN1de1Us=";
+  };
+
+  sourceRoot = "${src.name}/pyobjc-framework-WebKit";
+
+  build-system = [ setuptools ];
+
+  buildInputs = [ darwin.libffi ];
+
+  nativeBuildInputs = [
+    darwin.DarwinTools # sw_vers
+  ];
+
+  # See https://github.com/ronaldoussoren/pyobjc/pull/641. Unfortunately, we
+  # cannot just pull that diff with fetchpatch due to https://discourse.nixos.org/t/how-to-apply-patches-with-sourceroot/59727.
+  postPatch = ''
+    substituteInPlace pyobjc_setup.py \
+      --replace-fail "-buildversion" "-buildVersion" \
+      --replace-fail "-productversion" "-productVersion" \
+      --replace-fail "/usr/bin/sw_vers" "sw_vers" \
+      --replace-fail "/usr/bin/xcrun" "xcrun"
+  '';
+
+  dependencies = [
+    pyobjc-core
+    pyobjc-framework-Cocoa
+  ];
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-I${darwin.libffi.dev}/include"
+    "-Wno-error=unused-command-line-argument"
+  ];
+
+  pythonImportsCheck = [
+    "WebKit"
+    "JavaScriptCore"
+    "PyObjCTools"
+  ];
+
+  meta = {
+    description = "PyObjC wrappers for the WebKit frameworks on macOS";
+    homepage = "https://github.com/ronaldoussoren/pyobjc";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ xyenon ];
+  };
+}

--- a/pkgs/development/python-modules/pystray/default.nix
+++ b/pkgs/development/python-modules/pystray/default.nix
@@ -3,15 +3,17 @@
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
-  pillow,
-  xlib,
-  six,
-  xvfb-run,
-  setuptools,
   gobject-introspection,
+  setuptools,
+  pillow,
+  six,
   pygobject3,
   gtk3,
+  stdenv,
+  xlib,
   libayatana-appindicator,
+  pyobjc-framework-Quartz,
+  xvfb-run,
   pytest,
 }:
 
@@ -48,22 +50,22 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     pillow
-    xlib
     six
     pygobject3
     gtk3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    xlib
     libayatana-appindicator
-  ];
+  ]
+  ++ lib.optionals stdenv.isDarwin [ pyobjc-framework-Quartz ];
 
-  nativeCheckInputs = [
-    pytest
-    xvfb-run
-  ];
+  nativeCheckInputs = [ pytest ] ++ lib.optionals stdenv.hostPlatform.isLinux [ xvfb-run ];
 
   checkPhase = ''
     runHook preCheck
 
-    xvfb-run -s '-screen 0 800x600x24' pytest tests/menu_descriptor_tests.py
+    ${lib.optionalString stdenv.hostPlatform.isLinux "xvfb-run -s '-screen 0 800x600x24' "}pytest tests/menu_descriptor_tests.py
 
     runHook postCheck
   '';
@@ -75,7 +77,7 @@ buildPythonPackage rec {
       gpl3Plus
       lgpl3Plus
     ];
-    platforms = platforms.linux;
+    platforms = platforms.all;
     maintainers = with maintainers; [ jojosch ];
   };
 }

--- a/pkgs/development/python-modules/pywebview/default.nix
+++ b/pkgs/development/python-modules/pywebview/default.nix
@@ -9,6 +9,12 @@
   qtpy,
   six,
   typing-extensions,
+  stdenv,
+  pyobjc-core,
+  pyobjc-framework-Cocoa,
+  pyobjc-framework-Quartz,
+  pyobjc-framework-Security,
+  pyobjc-framework-WebKit,
 }:
 
 buildPythonPackage rec {
@@ -32,6 +38,13 @@ buildPythonPackage rec {
     qtpy
     six
     typing-extensions
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    pyobjc-core
+    pyobjc-framework-Cocoa
+    pyobjc-framework-Quartz
+    pyobjc-framework-Security
+    pyobjc-framework-WebKit
   ];
 
   pythonImportsCheck = [ "webview" ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13549,6 +13549,12 @@ self: super: with self; {
 
   pyobjc-framework-Cocoa = callPackage ../development/python-modules/pyobjc-framework-Cocoa { };
 
+  pyobjc-framework-Quartz = callPackage ../development/python-modules/pyobjc-framework-Quartz { };
+
+  pyobjc-framework-Security = callPackage ../development/python-modules/pyobjc-framework-Security { };
+
+  pyobjc-framework-WebKit = callPackage ../development/python-modules/pyobjc-framework-WebKit { };
+
   pyocd = callPackage ../development/python-modules/pyocd { };
 
   pyocd-pemicro = callPackage ../development/python-modules/pyocd-pemicro { };


### PR DESCRIPTION
- Add `pyobjc-framework-{Quartz,Security,WebKit}`
- Fix `pywebview` and `pystray` on darwin

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
