### PR TITLE
nzbget: 25.2 -> 25.3

### DIFF
--- a/pkgs/by-name/nz/nzbget/package.nix
+++ b/pkgs/by-name/nz/nzbget/package.nix
@@ -22,19 +22,19 @@ let
   par2TurboSrc = fetchFromGitHub {
     owner = "nzbgetcom";
     repo = "par2cmdline-turbo";
-    rev = "v1.3.0"; # from cmake/par2-turbo.cmake
-    hash = "sha256-tNzf//StwE1A5XcmYlKapoaq/dFqMikHsQg3lsyKFj4=";
+    rev = "v1.3.0-20250808"; # from cmake/par2-turbo.cmake
+    hash = "sha256-ZP8AI5htmEcxQQtvgShcQ8qNoRL+jBR1BdKS6yyuB/E=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "nzbget";
-  version = "25.2";
+  version = "25.3";
 
   src = fetchFromGitHub {
     owner = "nzbgetcom";
     repo = "nzbget";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-eFI4zFTMHlAdqsYyg0scrko0mWhlGPDqMPXTH45GHvY=";
+    hash = "sha256-ecTz+axqPOlRe0wi7IRiESn2JjLbalI+sQVKqrvrAoU=";
   };
 
   patches = [

--- a/pkgs/by-name/nz/nzbget/remove-git-usage.patch
+++ b/pkgs/by-name/nz/nzbget/remove-git-usage.patch
@@ -1,4 +1,4 @@
-From de94ddc6fa6ce4f84b658470842ed0450e932eb1 Mon Sep 17 00:00:00 2001
+From 15dc4c64531845b64b574647fc7218170b100533 Mon Sep 17 00:00:00 2001
 From: Morgan Helton <mhelton@gmail.com>
 Date: Tue, 25 Feb 2025 20:36:19 -0600
 Subject: [PATCH] feat: use pre-fetched par2-turbo
@@ -8,7 +8,7 @@ Subject: [PATCH] feat: use pre-fetched par2-turbo
  1 file changed, 7 insertions(+), 12 deletions(-)
 
 diff --git a/cmake/par2-turbo.cmake b/cmake/par2-turbo.cmake
-index bb200067..e2d12f10 100644
+index 0062b4d3..c0dd56ea 100644
 --- a/cmake/par2-turbo.cmake
 +++ b/cmake/par2-turbo.cmake
 @@ -48,18 +48,13 @@ if(CMAKE_SYSROOT)
@@ -19,7 +19,7 @@ index bb200067..e2d12f10 100644
 -	par2-turbo
 -	PREFIX			par2-turbo
 -	GIT_REPOSITORY	https://github.com/nzbgetcom/par2cmdline-turbo.git
--	GIT_TAG			v1.3.0
+-	GIT_TAG			v1.3.0-20250808
 -	TLS_VERIFY		TRUE
 -	GIT_SHALLOW		TRUE
 -	GIT_PROGRESS	TRUE
@@ -28,15 +28,15 @@ index bb200067..e2d12f10 100644
 -	CMAKE_ARGS		 ${CMAKE_ARGS}
 -	INSTALL_COMMAND	""
 +ExternalProject_Add(
-+    par2-turbo
-+    PREFIX par2-turbo 
-+    SOURCE_DIR ${CMAKE_BINARY_DIR}/par2-turbo/src/par2-turbo
-+    BUILD_BYPRODUCTS ${PAR2_LIBS}
-+    CMAKE_ARGS ${CMAKE_ARGS}
-+    INSTALL_COMMAND ""
++    	par2-turbo
++    	PREFIX par2-turbo 
++    	SOURCE_DIR ${CMAKE_BINARY_DIR}/par2-turbo/src/par2-turbo
++    	BUILD_BYPRODUCTS ${PAR2_LIBS}
++    	CMAKE_ARGS ${CMAKE_ARGS}
++    	INSTALL_COMMAND ""
  )
  
  set(LIBS ${LIBS} ${PAR2_LIBS})
 -- 
-2.49.0
+2.50.1
 


### PR DESCRIPTION
https://github.com/nzbgetcom/nzbget/compare/v25.2...v25.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
