### PR TITLE
coqPackages.dpdgraph: 1.0+8.20 -> 1.0+9.0

### DIFF
--- a/pkgs/development/coq-modules/dpdgraph/default.nix
+++ b/pkgs/development/coq-modules/dpdgraph/default.nix
@@ -10,9 +10,8 @@ let
   hasWarning = lib.versionAtLeast coq.ocamlPackages.ocaml.version "4.08";
 in
 
-mkCoqDerivation {
+(mkCoqDerivation {
   pname = "dpdgraph";
-  owner = "Karmaki";
   repo = "coq-dpdgraph";
   inherit version;
   defaultVersion =
@@ -20,6 +19,7 @@ mkCoqDerivation {
       case = case: out: { inherit case out; };
     in
     lib.switch coq.coq-version [
+      (case "9.0" "1.0+9.0")
       (case "8.20" "1.0+8.20")
       (case "8.19" "1.0+8.19")
       (case "8.18" "1.0+8.18")
@@ -36,6 +36,7 @@ mkCoqDerivation {
       (case "8.7" "0.6.2")
     ] null;
 
+  release."1.0+9.0".sha256 = "sha256-gXy70fj2bAkE0did4gI0wTyWp9AIvOo4xTTihaFIpZ0=";
   release."1.0+8.20".sha256 = "sha256-szfH/OksCH3SCbcFjwEvLwHE5avmHp1vYiJM6KAXFqs=";
   release."1.0+8.19".sha256 = "sha256-L1vjEydYiwDFTXES3sgfdaO/D50AbTJKBXUKUCgbpto=";
   release."1.0+8.18".sha256 = "sha256-z14MI1VSYzPqmF1PqDXzymXWRMYoTlQAfR/P3Pdf7fI=";
@@ -58,15 +59,12 @@ mkCoqDerivation {
   release."0.6".sha256 = "0qvar8gfbrcs9fmvkph5asqz4l5fi63caykx3bsn8zf0xllkwv0n";
   releaseRev = v: "v${v}";
 
-  nativeBuildInputs = [ autoreconfHook ];
   mlPlugin = true;
-  buildInputs = [ coq.ocamlPackages.ocamlgraph ];
-
-  # dpd_compute.ml uses deprecated Pervasives.compare
-  # Versions prior to 0.6.5 do not have the WARN_ERR build flag
-  preConfigure = lib.optionalString hasWarning ''
-    substituteInPlace Makefile.in --replace "-warn-error +a " ""
-  '';
+  buildInputs = with coq.ocamlPackages; [
+    ocaml
+    findlib
+    ocamlgraph
+  ];
 
   buildFlags = lib.optional hasWarning "WARN_ERR=";
 
@@ -81,4 +79,16 @@ mkCoqDerivation {
     license = licenses.lgpl21;
     maintainers = with maintainers; [ vbgl ];
   };
-}
+}).overrideAttrs
+  (
+    o:
+    lib.optionalAttrs (o.version != "dev" && lib.versions.isLe "1.0+9.0" o.version) {
+      nativeBuildInputs = [ autoreconfHook ];
+
+      # dpd_compute.ml uses deprecated Pervasives.compare
+      # Versions prior to 0.6.5 do not have the WARN_ERR build flag
+      preConfigure = lib.optionalString hasWarning ''
+        substituteInPlace Makefile.in --replace "-warn-error +a " ""
+      '';
+    }
+  )


### PR DESCRIPTION
master also dropped autotools

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
