### PR TITLE
haskellPackages.opencv: fix eval with allowBroken

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -777,6 +777,15 @@ builtins.intersectAttrs super {
   colour = dontCheck super.colour;
   spatial-rotations = dontCheck super.spatial-rotations;
 
+  # This package is marked broken, but it causes some evail failures for nixpkgs-review.
+  # cabal2nix still adds opencv3, which has been removed. It makes no sense to add opencv4,
+  # because the haskell package is only targeting opencv 3.x specifically.
+  # TODO: Remove this package entirely from hackage-packages.nix. It's broken and has been last
+  # updated in 2018.
+  opencv = overrideCabal (drv: {
+    libraryPkgconfigDepends = [ ];
+  }) super.opencv;
+
   LDAP = dontCheck (
     overrideCabal (drv: {
       librarySystemDepends = drv.librarySystemDepends or [ ] ++ [ pkgs.cyrus_sasl.dev ];


### PR DESCRIPTION
This is a bit of an odd case, but it seems to break local evaluation for nixpkgs-review, so fix it temporarily.

Resolves #439496.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
