### PR TITLE
[25.05] ocamlPackages: fix some eval issues

### DIFF
--- a/pkgs/development/ocaml-modules/systemd/default.nix
+++ b/pkgs/development/ocaml-modules/systemd/default.nix
@@ -16,7 +16,7 @@ buildDunePackage {
   minimalOCamlVersion = "4.06";
   propagatedBuildInputs = [ systemdLibs ];
   meta = {
-    platform = lib.platforms.linux;
+    platforms = lib.platforms.linux;
     description = "OCaml module for native access to the systemd facilities";
     license = lib.licenses.lgpl3Only;
     maintainers = [ lib.maintainers.atagen ];

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -853,7 +853,7 @@ let
           else
             null;
 
-        janeStreet =
+        janeStreet = lib.recurseIntoAttrs (
           if lib.versionOlder "5.1" ocaml.version then
             import ../development/ocaml-modules/janestreet/0.17.nix {
               inherit self;
@@ -910,7 +910,8 @@ let
             }
           else
             import ../development/ocaml-modules/janestreet {
-            };
+            }
+        );
 
         janeStreet_0_15 =
           (lib.makeScope self.newScope (


### PR DESCRIPTION
Backport of #437201.

ab0b16dd05b55be93a259d16118578257784208a didn't apply, because these throw had only been added on unstable.