### PR TITLE
python3Packages.gpaw: fix darwin build

### DIFF
--- a/pkgs/development/python-modules/gpaw/default.nix
+++ b/pkgs/development/python-modules/gpaw/default.nix
@@ -36,7 +36,7 @@ let
 
       # BLAS
       libraries += ['blas']
-      library_dirs += ['${blas}/lib']
+      library_dirs += ['${lib.getLib blas}/lib']
 
       # FFTW
       fftw = True
@@ -51,9 +51,8 @@ let
       libxc = True
       if libxc:
         xc = '${libxc}/'
-        include_dirs += [xc + 'include']
-        library_dirs += [xc + 'lib/']
-        extra_link_args += ['-Wl,-rpath={xc}/lib'.format(xc=xc)]
+        include_dirs += ['${lib.getDev libxc}/include']
+        library_dirs += ['${lib.getLib libxc}/lib']
         if 'xc' not in libraries:
           libraries.append('xc')
 
@@ -61,9 +60,8 @@ let
       libvdwxc = True
       if libvdwxc:
         vdwxc = '${libvdwxc}/'
-        extra_link_args += ['-Wl,-rpath=%s/lib' % vdwxc]
-        library_dirs += ['%s/lib' % vdwxc]
-        include_dirs += ['%s/include' % vdwxc]
+        library_dirs += ['${lib.getLib libvdwxc}/lib']
+        include_dirs += ['${lib.getDev libvdwxc}/include']
         libraries += ['vdwxc']
     '';
   };


### PR DESCRIPTION
Trying to fix the darwin build of GPAW as suggested in https://github.com/NixOS/nixpkgs/pull/438998

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
