### PR TITLE
docker: replace `util-linux` with `util-linuxMinimal`, refactor

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -43,7 +43,7 @@ rec {
       iptables,
       e2fsprogs,
       xz,
-      util-linux,
+      util-linuxMinimal,
       xfsprogs,
       gitMinimal,
       procps,
@@ -175,7 +175,7 @@ rec {
               xz
               xfsprogs
               procps
-              util-linux
+              util-linuxMinimal
               gitMinimal
             ]
           );

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -82,7 +82,7 @@ rec {
         src = fetchFromGitHub {
           owner = "opencontainers";
           repo = "runc";
-          rev = runcRev;
+          tag = runcRev;
           hash = runcHash;
         };
 
@@ -104,7 +104,7 @@ rec {
         src = fetchFromGitHub {
           owner = "containerd";
           repo = "containerd";
-          rev = containerdRev;
+          tag = containerdRev;
           hash = containerdHash;
         };
 
@@ -121,7 +121,7 @@ rec {
         src = fetchFromGitHub {
           owner = "krallin";
           repo = "tini";
-          rev = tiniRev;
+          tag = tiniRev;
           hash = tiniHash;
         };
 
@@ -139,7 +139,7 @@ rec {
       moby-src = fetchFromGitHub {
         owner = "moby";
         repo = "moby";
-        rev = mobyRev;
+        tag = mobyRev;
         hash = mobyHash;
       };
 
@@ -266,6 +266,8 @@ rec {
         src = fetchFromGitHub {
           owner = "docker";
           repo = "cli";
+          # Cannot use `tag` since upstream forgot to tag release, see
+          # https://github.com/docker/cli/issues/5789
           rev = cliRev;
           hash = cliHash;
         };

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -21,7 +21,6 @@ let
       # package dependencies
       stdenv,
       fetchFromGitHub,
-      fetchpatch,
       buildGoModule,
       makeBinaryWrapper,
       installShellFiles,
@@ -33,7 +32,6 @@ let
       runc,
       tini,
       libtool,
-      bash,
       sqlite,
       iproute2,
       docker-buildx,

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -194,15 +194,21 @@ rec {
           '';
 
           buildPhase = ''
+            runHook preBuild
+
             export GOCACHE="$TMPDIR/go-cache"
             # build engine
             export AUTO_GOPATH=1
             export DOCKER_GITCOMMIT="${cliRev}"
             export VERSION="${version}"
             ./hack/make.sh dynbinary
+
+            runHook postBuild
           '';
 
           installPhase = ''
+            runHook preInstall
+
             install -Dm755 ./bundles/dynbinary-daemon/dockerd $out/libexec/docker/dockerd
             install -Dm755 ./bundles/dynbinary-daemon/docker-proxy $out/libexec/docker/docker-proxy
 
@@ -223,6 +229,8 @@ rec {
             install -Dm755 ./contrib/dockerd-rootless.sh $out/libexec/docker/dockerd-rootless.sh
             makeWrapper $out/libexec/docker/dockerd-rootless.sh $out/bin/dockerd-rootless \
               --prefix PATH : "$out/libexec/docker:$extraPath:$extraUserPath"
+
+            runHook postInstall
           '';
 
           DOCKER_BUILDTAGS =
@@ -301,6 +309,8 @@ rec {
 
         # Keep eyes on BUILDTIME format - https://github.com/docker/cli/blob/${version}/scripts/build/.variables
         buildPhase = ''
+          runHook preBuild
+
           export GOCACHE="$TMPDIR/go-cache"
 
           # Mimic AUTO_GOPATH
@@ -312,6 +322,7 @@ rec {
           export BUILDTIME="1970-01-01T00:00:00Z"
           make dynbinary
 
+          runHook postBuild
         '';
 
         outputs = [ "out" ];

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -23,7 +23,7 @@ rec {
       fetchFromGitHub,
       fetchpatch,
       buildGoModule,
-      makeWrapper,
+      makeBinaryWrapper,
       installShellFiles,
       pkg-config,
       glibc,
@@ -153,7 +153,7 @@ rec {
           vendorHash = null;
 
           nativeBuildInputs = [
-            makeWrapper
+            makeBinaryWrapper
             pkg-config
             go-md2man
             go
@@ -273,7 +273,7 @@ rec {
         vendorHash = null;
 
         nativeBuildInputs = [
-          makeWrapper
+          makeBinaryWrapper
           pkg-config
           go-md2man
           go

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -1,6 +1,6 @@
 { lib, callPackage }:
 
-rec {
+let
   dockerGen =
     {
       version,
@@ -144,7 +144,7 @@ rec {
       };
 
       moby = buildGoModule (
-        lib.optionalAttrs stdenv.hostPlatform.isLinux rec {
+        lib.optionalAttrs stdenv.hostPlatform.isLinux {
           pname = "moby";
           inherit version;
 
@@ -257,17 +257,7 @@ rec {
       };
     in
     buildGoModule (
-      lib.optionalAttrs (!clientOnly) {
-        # allow overrides of docker components
-        # TODO: move packages out of the let...in into top-level to allow proper overrides
-        inherit
-          docker-runc
-          docker-containerd
-          docker-tini
-          moby
-          ;
-      }
-      // rec {
+      {
         pname = "docker";
         inherit version;
 
@@ -379,38 +369,57 @@ rec {
           inherit knownVulnerabilities;
         };
       }
+      // lib.optionalAttrs (!clientOnly) {
+        # allow overrides of docker components
+        # TODO: move packages out of the let...in into top-level to allow proper overrides
+        inherit
+          docker-runc
+          docker-containerd
+          docker-tini
+          moby
+          ;
+      }
     );
-
+in
+{
   # Get revisions from
   # https://github.com/moby/moby/tree/${version}/hack/dockerfile/install/*
-  docker_25 = callPackage dockerGen rec {
-    version = "25.0.12";
-    # Upstream forgot to tag release
-    # https://github.com/docker/cli/issues/5789
-    cliRev = "43987fca488a535d810c429f75743d8c7b63bf4f";
-    cliHash = "sha256-OwufdfuUPbPtgqfPeiKrQVkOOacU2g4ommHb770gV40=";
-    mobyRev = "v${version}";
-    mobyHash = "sha256-EBOdbFP6UBK1uhXi1IzcPxYihHikuzzwMvv2NHsksYk=";
-    runcRev = "v1.2.5";
-    runcHash = "sha256-J/QmOZxYnMPpzm87HhPTkYdt+fN+yeSUu2sv6aUeTY4=";
-    containerdRev = "v1.7.27";
-    containerdHash = "sha256-H94EHnfW2Z59KcHcbfJn+BipyZiNUvHe50G5EXbrIps=";
-    tiniRev = "v0.19.0";
-    tiniHash = "sha256-ZDKu/8yE5G0RYFJdhgmCdN3obJNyRWv6K/Gd17zc1sI=";
-  };
+  docker_25 =
+    let
+      version = "25.0.12";
+    in
+    callPackage dockerGen {
+      inherit version;
+      # Upstream forgot to tag release
+      # https://github.com/docker/cli/issues/5789
+      cliRev = "43987fca488a535d810c429f75743d8c7b63bf4f";
+      cliHash = "sha256-OwufdfuUPbPtgqfPeiKrQVkOOacU2g4ommHb770gV40=";
+      mobyRev = "v${version}";
+      mobyHash = "sha256-EBOdbFP6UBK1uhXi1IzcPxYihHikuzzwMvv2NHsksYk=";
+      runcRev = "v1.2.5";
+      runcHash = "sha256-J/QmOZxYnMPpzm87HhPTkYdt+fN+yeSUu2sv6aUeTY4=";
+      containerdRev = "v1.7.27";
+      containerdHash = "sha256-H94EHnfW2Z59KcHcbfJn+BipyZiNUvHe50G5EXbrIps=";
+      tiniRev = "v0.19.0";
+      tiniHash = "sha256-ZDKu/8yE5G0RYFJdhgmCdN3obJNyRWv6K/Gd17zc1sI=";
+    };
 
-  docker_28 = callPackage dockerGen rec {
-    version = "28.3.3";
-    cliRev = "v${version}";
-    cliHash = "sha256-+nYpd9VGzzMPcBUfGM7V9MkrslYHDSUlE0vhTqDGc1s=";
-    mobyRev = "v${version}";
-    mobyHash = "sha256-3SWjoF4sXVuYxnENq5n6ZzPJx6BQXnyP8VXTQaaUSFA=";
-    runcRev = "v1.2.6";
-    runcHash = "sha256-XMN+YKdQOQeOLLwvdrC6Si2iAIyyHD5RgZbrOHrQE/g=";
-    containerdRev = "v1.7.27";
-    containerdHash = "sha256-H94EHnfW2Z59KcHcbfJn+BipyZiNUvHe50G5EXbrIps=";
-    tiniRev = "v0.19.0";
-    tiniHash = "sha256-ZDKu/8yE5G0RYFJdhgmCdN3obJNyRWv6K/Gd17zc1sI=";
-  };
+  docker_28 =
+    let
+      version = "28.3.3";
+    in
+    callPackage dockerGen {
+      version = "28.3.3";
+      cliRev = "v${version}";
+      cliHash = "sha256-+nYpd9VGzzMPcBUfGM7V9MkrslYHDSUlE0vhTqDGc1s=";
+      mobyRev = "v${version}";
+      mobyHash = "sha256-3SWjoF4sXVuYxnENq5n6ZzPJx6BQXnyP8VXTQaaUSFA=";
+      runcRev = "v1.2.6";
+      runcHash = "sha256-XMN+YKdQOQeOLLwvdrC6Si2iAIyyHD5RgZbrOHrQE/g=";
+      containerdRev = "v1.7.27";
+      containerdHash = "sha256-H94EHnfW2Z59KcHcbfJn+BipyZiNUvHe50G5EXbrIps=";
+      tiniRev = "v0.19.0";
+      tiniHash = "sha256-ZDKu/8yE5G0RYFJdhgmCdN3obJNyRWv6K/Gd17zc1sI=";
+    };
 
 }

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -232,11 +232,12 @@ let
             runHook postInstall
           '';
 
-          DOCKER_BUILDTAGS =
+          env.DOCKER_BUILDTAGS = toString (
             lib.optionals withSystemd [ "journald" ]
             ++ lib.optionals (!withBtrfs) [ "exclude_graphdriver_btrfs" ]
             ++ lib.optionals (!withLvm) [ "exclude_graphdriver_devicemapper" ]
-            ++ lib.optionals withSeccomp [ "seccomp" ];
+            ++ lib.optionals withSeccomp [ "seccomp" ]
+          );
 
           meta = docker-meta // {
             homepage = "https://mobyproject.org/";

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -160,13 +160,14 @@ let
             libtool
             installShellFiles
           ];
+
           buildInputs = [
             sqlite
           ]
-          ++ lib.optional withLvm lvm2
-          ++ lib.optional withBtrfs btrfs-progs
-          ++ lib.optional withSystemd systemd
-          ++ lib.optional withSeccomp libseccomp;
+          ++ lib.optionals withLvm [ lvm2 ]
+          ++ lib.optionals withBtrfs [ btrfs-progs ]
+          ++ lib.optionals withSystemd [ systemd ]
+          ++ lib.optionals withSeccomp [ libseccomp ];
 
           extraPath = lib.optionals stdenv.hostPlatform.isLinux (
             lib.makeBinPath [
@@ -234,10 +235,10 @@ let
           '';
 
           DOCKER_BUILDTAGS =
-            lib.optional withSystemd "journald"
-            ++ lib.optional (!withBtrfs) "exclude_graphdriver_btrfs"
-            ++ lib.optional (!withLvm) "exclude_graphdriver_devicemapper"
-            ++ lib.optional withSeccomp "seccomp";
+            lib.optionals withSystemd [ "journald" ]
+            ++ lib.optionals (!withBtrfs) [ "exclude_graphdriver_btrfs" ]
+            ++ lib.optionals (!withLvm) [ "exclude_graphdriver_devicemapper" ]
+            ++ lib.optionals withSeccomp [ "seccomp" ];
 
           meta = docker-meta // {
             homepage = "https://mobyproject.org/";
@@ -247,10 +248,11 @@ let
       );
 
       plugins =
-        lib.optional buildxSupport docker-buildx
-        ++ lib.optional composeSupport docker-compose
-        ++ lib.optional sbomSupport docker-sbom
-        ++ lib.optional initSupport docker-init;
+        lib.optionals buildxSupport [ docker-buildx ]
+        ++ lib.optionals composeSupport [ docker-compose ]
+        ++ lib.optionals sbomSupport [ docker-sbom ]
+        ++ lib.optionals initSupport [ docker-init ];
+
       pluginsRef = symlinkJoin {
         name = "docker-plugins";
         paths = plugins;

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -62,6 +62,7 @@ rec {
       withSeccomp ? stdenv.hostPlatform.isLinux,
       libseccomp,
       knownVulnerabilities ? [ ],
+      versionCheckHook,
     }:
     let
       docker-meta = {
@@ -342,6 +343,10 @@ rec {
         + ''
           runHook postInstall
         '';
+
+        doInstallCheck = true;
+        nativeInstallCheckInputs = [ versionCheckHook ];
+        versionCheckProgramArg = "--version";
 
         passthru = {
           # Exposed for tarsum build on non-linux systems (build-support/docker/default.nix)


### PR DESCRIPTION
This PR:

- replace `util-linux` with `util-linuxMinimal`
- refactor and cleanup

Each change lives in its own commit, let me know if you prefer only one commit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
