### PR TITLE
coq-kernel: fix breakage from Python 3 update and handle Rocq update

### DIFF
--- a/pkgs/applications/editors/jupyter-kernels/coq/default.nix
+++ b/pkgs/applications/editors/jupyter-kernels/coq/default.nix
@@ -1,40 +1,53 @@
 {
   lib,
-  stdenv,
   callPackage,
   runCommand,
   makeWrapper,
   coq,
   imagemagick,
-  python3,
+  python312,
 }:
 
 # Jupyter console:
 # nix run --impure --expr 'with import <nixpkgs> {}; jupyter-console.withSingleKernel coq-kernel.definition'
 
-# Jupyter console with packages:
-# nix run --impure --expr 'with import <nixpkgs> {}; jupyter-console.withSingleKernel (coq-kernel.definitionWithPackages [coqPackages.bignums])'
+# Jupyter console with packages: (using Coq 8.20, before the Rocq transition at version 9.0)
+# nix run --impure --expr 'with import <nixpkgs> {}; jupyter-console.withSingleKernel ((coq-kernel.override { coq = coq_8_20; }).definitionWithPackages (with coqPackages_8_20; [bignums stdlib]))'
 
 # Jupyter notebook:
 # nix run --impure --expr 'with import <nixpkgs> {}; jupyter.override { definitions.coq = coq-kernel.definition; }'
 
 let
-  python = python3.withPackages (ps: [
+  # Nixpkgs master is currently on python3 >= python313. This doesn't work with
+  # this package, because it depends on the "future" package, which is no longer
+  # compatible with Python 3.13.
+
+  coq-jupyter = callPackage ./kernel.nix {
+    inherit coq;
+    python3 = python312;
+  };
+
+  python = python312.withPackages (ps: [
     ps.traitlets
     ps.jupyter-core
     ps.ipykernel
-    (callPackage ./kernel.nix { })
+    coq-jupyter
   ]);
 
-  logos = runCommand "coq-logos" { buildInputs = [ imagemagick ]; } ''
-    mkdir -p $out
-    convert ${coq.src}/ide/coqide/coq.png -resize 32x32 $out/logo-32x32.png
-    convert ${coq.src}/ide/coqide/coq.png -resize 64x64 $out/logo-64x64.png
-  '';
+  # At version 9.0, Coq underwent a name change to Rocq.
+  # A couple paths and environment variables need to change at this point.
+  isRocq = lib.versionAtLeast coq.coq-version "9.0";
 
-in
+  logos =
+    let
+      dir = if isRocq then "rocqide" else "coqide";
+    in
+    runCommand "coq-logos" { buildInputs = [ imagemagick ]; } ''
+      mkdir -p $out
+      convert ${coq.src}/ide/${dir}/coq.png -resize 32x32 $out/logo-32x32.png
+      convert ${coq.src}/ide/${dir}/coq.png -resize 64x64 $out/logo-64x64.png
+    '';
 
-rec {
   launcher =
     runCommand "coq-kernel-launcher"
       {
@@ -48,10 +61,8 @@ rec {
           --suffix PATH : ${coq}/bin
       '';
 
-  definition = definitionWithPackages [ ];
-
   definitionWithPackages = packages: {
-    displayName = "Coq " + coq.version;
+    displayName = (if isRocq then "Rocq " else "Coq ") + coq.version;
     argv = [
       "${launcher}/bin/coq-kernel"
       "-f"
@@ -60,10 +71,27 @@ rec {
     language = "coq";
     logo32 = "${logos}/logo-32x32.png";
     logo64 = "${logos}/logo-64x64.png";
-    env = {
-      COQPATH = lib.concatStringsSep ":" (
-        map (x: "${x}/lib/coq/${coq.coq-version}/user-contrib/") packages
-      );
-    };
+    env = lib.listToAttrs [
+      {
+        name = if isRocq then "ROCQPATH" else "COQPATH";
+        value = lib.concatStringsSep ":" (
+          map (x: "${x}/lib/coq/${coq.coq-version}/user-contrib/") packages
+        );
+      }
+      {
+        name = "OCAMLPATH";
+        value = lib.concatStringsSep ":" (
+          map (x: "${x}/lib/ocaml/${coq.ocaml.version}/site-lib/") ([ coq.ocamlPackages.findlib ] ++ packages)
+        );
+      }
+    ];
   };
-}
+
+in
+
+launcher.overrideAttrs (_oldAttrs: {
+  passthru = {
+    inherit coq-jupyter definitionWithPackages logos;
+    definition = definitionWithPackages [ ];
+  };
+})


### PR DESCRIPTION
This deals with two issues affecting `coq-kernel`:

1. `python3` changed from `python312` to `python313`, which isn't compatible with one of the dependencies. This PR specifically imports `python312`, and also makes the launcher the default output of this package, so automated checks should catch breakage like this in the future.
2. Coq 9.0 came out, along with a change to a new name, Rocq. Nixpkgs currently contains a number of Coq package sets, both from before version 9.0 and after. This PR adds support for either.

To test it with packages, I'd recommend using `coq_8_20`, like this (in the Nixpkgs checkout root):

```
nix run --impure --expr 'with import ./. {}; jupyter-console.withSingleKernel ((coq-kernel.override { coq = coq_8_20; }).definitionWithPackages (with coqPackages_8_20; [bignums stdlib]))'
```

Then you can run a simple proof to make sure the `bignums` package is working:

```
Require Import Bignums.BigN.BigN.
Check (BigN.add_comm 1 2).
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
