### PR TITLE
le: init at 1.16.8

### DIFF
--- a/pkgs/by-name/le/le/package.nix
+++ b/pkgs/by-name/le/le/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  nix-update-script,
+  fetchFromGitHub,
+  automake,
+  autoconf,
+  gnulib,
+  gettext,
+  ncurses,
+  perl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "le";
+  version = "1.16.8";
+
+  src = fetchFromGitHub {
+    owner = "lavv17";
+    repo = "le";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-1V/IuvrqaqX4weRJnkY0JTMEhnB6hZCWuXtxlMl/6LU=";
+  };
+
+  passthru.updateScript = nix-update-script { };
+
+  nativeBuildInputs = [
+    automake
+    autoconf
+    gnulib
+    gettext
+    perl
+  ];
+  buildInputs = [ ncurses ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    ./autogen.sh \
+        --with-curses-include=${ncurses.dev}/include \
+        --with-curses-lib=${ncurses}/lib \
+        --prefix=$out
+
+    runHook postConfigure
+  '';
+
+  meta = {
+    description = "LE – full screen text editor inspired by Norton Editor";
+    homepage = "https://github.com/lavv17/le";
+    longDescription = ''
+      LE is a text editor which offers wide range of capabilities with a
+      simple interface. It has a pull down menu and a simple help system to
+      get started.
+
+      Among its features there are: various operations with stream and
+      rectangular blocks, search and replace with full regular expressions,
+      text formatting, undelete/uninsert, hex editing, tunable key sequences,
+      tunable colors, tunable syntax highlighting.
+    '';
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.unix;
+    mainProgram = "le";
+  };
+})


### PR DESCRIPTION
This adds the [LE terminal editor](https://en.wikipedia.org/wiki/LE_(text_editor)), which is already available in many other Linux distributions as well as BSD variants.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [N/A] [NixOS tests] in [nixos/tests].
  - [N/A] [Package tests] at `passthru.tests`.
  - [N/A] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [N/A] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [N/A] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [N/A] Module addition: when adding a new NixOS module.
  - [N/A] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
