### PR TITLE
tabby-terminal: init at 1.0.230

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9604,6 +9604,13 @@
     githubId = 6905586;
     keys = [ { fingerprint = "386E D1BF 848A BB4A 6B4A  3C45 FC83 907C 125B C2BC"; } ];
   };
+  geodic = {
+    name = "geodic";
+    email = "th3geodic@proton.me";
+    matrix = "@geodic:matrix.org";
+    github = "geodic";
+    githubId = 64704703;
+  };
   geoffreyfrogeye = {
     name = "Geoffrey Frogeye";
     email = "geoffrey@frogeye.fr";

--- a/pkgs/by-name/ta/tabby-terminal/package.nix
+++ b/pkgs/by-name/ta/tabby-terminal/package.nix
@@ -1,0 +1,231 @@
+{
+  lib,
+  stdenv,
+
+  fetchFromGitHub,
+  fetchYarnDeps,
+  fetchpatch2,
+
+  copyDesktopItems,
+  fixup-yarn-lock,
+  makeBinaryWrapper,
+  makeDesktopItem,
+  replaceVars,
+  writableTmpDirAsHomeHook,
+
+  fontconfig,
+  libsecret,
+  pkg-config,
+
+  electron,
+  http-server,
+  jq,
+  moreutils,
+  nodejs,
+  patch-package,
+  python3,
+  yarn,
+}:
+
+stdenv.mkDerivation (
+  finalAttrs:
+  let
+    electron41Patch = fetchpatch2 {
+      url = "https://github.com/eugeny/tabby/commit/00890fe67969021ca10037ec5b85ec7f9f7edc63.patch";
+      hash = "sha256-uGqsnOWWQts10WaPmWvxHNk5jcohhAAUk+3iFs5CK5Y=";
+    };
+
+    packages = lib.attrNames finalAttrs.passthru.pkgHashes;
+    builtinPlugins = lib.filter (lib.hasPrefix "tabby-") packages;
+  in
+  {
+    pname = "tabby-terminal";
+    version = "1.0.230";
+
+    __structuredAttrs = true;
+    strictDeps = true;
+
+    src = fetchFromGitHub {
+      owner = "Eugeny";
+      repo = "tabby";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-b9FehwLl5h5HB+Id5cSW9FGp7bDpwUwxfSxB912PkFU=";
+      # apply this patch in `src.postCheckout` because it would break the yarn
+      # caches + update script when applied through `patches`.
+      #
+      # bumps node-abi and electron so it can build against a modern version of
+      # electron
+      postCheckout = "git -C $out apply ${electron41Patch}";
+    };
+
+    patches = [
+      ./splice-argv.patch
+      (replaceVars ./use-nix-version.patch { inherit (finalAttrs) version; })
+    ];
+
+    postPatch = ''
+      jq '.version = "${finalAttrs.version}"' app/package.json | sponge app/package.json
+      substituteInPlace tabby-core/src/configDefaults.yaml \
+        --replace-warn 'enableAutomaticUpdates: true' 'enableAutomaticUpdates: false'
+    '';
+
+    buildInputs = [
+      fontconfig
+      libsecret
+    ];
+
+    nativeBuildInputs = [
+      copyDesktopItems
+      makeBinaryWrapper
+      writableTmpDirAsHomeHook
+
+      electron
+      fixup-yarn-lock
+      http-server
+      jq
+      moreutils
+      nodejs
+      patch-package
+      pkg-config
+      (python3.withPackages (
+        p: with p; [
+          distutils
+          gyp
+        ]
+      ))
+      yarn
+    ];
+
+    configurePhase = ''
+      runHook preConfigure
+
+    ''
+    # Loop through all the yarn caches and install the deps for the respective package
+    + lib.concatMapStringsSep "\n" (cache: ''
+      pushd ${cache.name}
+        fixup-yarn-lock yarn.lock
+        yarn config --offline set yarn-offline-mirror ${cache.value}
+        yarn install \
+          --offline \
+          --prefer-offline \
+          --frozen-lockfile \
+          --ignore-scripts \
+          --no-progress \
+          --non-interactive
+        patch-package
+        patchShebangs node_modules
+      popd
+    '') (lib.attrsToList finalAttrs.passthru.yarnCaches)
+    + ''
+      pushd node_modules
+    ''
+    # Loop through the "built in" plugins and link them to the node_modules
+    + lib.concatMapStringsSep "\n" (plugin: ''
+      ln -fs ../${plugin} ${plugin}
+    '') builtinPlugins
+    + ''
+      popd
+
+      # missing type declaration for some reason
+      sed -i -e '9a \type VideoFrame = any;' node_modules/electron/electron.d.ts
+
+      runHook postConfigure
+    '';
+
+    buildPhase =
+      # Start a fake (and completely unnecessary) http-server to let electron-rebuild "download" the headers and hashes
+      ''
+        runHook preBuild
+
+        mkdir -p http-cache/v${electron.version}
+        pushd http-cache/v${electron.version}
+          tar \
+            --transform 's|^\./|node_headers/|' \
+            -czvf node-v${electron.version}-headers.tar.gz \
+            -C ${electron.headers} .
+          sha256sum node-v${electron.version}-headers.tar.gz > SHASUMS256.txt
+        popd
+        http-server http-cache &
+      ''
+      # Rebuild all the needed packages using electron-rebuild
+      + lib.concatMapStringsSep "\n" (pkg: ''
+        yarn --offline electron-rebuild -v ${electron.version} -m ${pkg} -f -d "http://localhost:8080"
+      '') finalAttrs.passthru.rebuildPkgs
+      + ''
+        kill $!
+
+        yarn build
+
+        runHook postBuild
+      '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share/tabby
+      cp -r . $out/share/tabby
+
+      # Tabby needs TABBY_DEV to run manually with electron
+      makeWrapper "${lib.getExe electron}" $out/bin/tabby \
+        --add-flags $out/share/tabby/app \
+        --set TABBY_DEV 1
+
+      for iconsize in 16 32 64 128
+      do
+        size="$iconsize"x"$iconsize"
+        mkdir -p $out/share/icons/hicolor/$size/apps
+        ln -s $out/share/tabby/build/icons/"$size".png $out/share/icons/hicolor/$size/apps/tabby.png
+      done
+
+      runHook postInstall
+    '';
+
+    desktopItems = lib.singleton (makeDesktopItem {
+      name = "tabby";
+      desktopName = "Tabby";
+      exec = "tabby %u";
+      comment = "A terminal for a more modern age";
+      icon = "tabby";
+      categories = [
+        "Utility"
+        "TerminalEmulator"
+        "System"
+      ];
+    });
+
+    passthru = {
+      pkgHashes = lib.importJSON ./pkg-hashes.json;
+
+      yarnCaches = lib.mapAttrs (
+        cacheName: hash:
+        fetchYarnDeps {
+          name = "offline-${cacheName}";
+          src = lib.removeSuffix "/." (finalAttrs.src + "/" + cacheName);
+          inherit hash;
+        }
+      ) finalAttrs.passthru.pkgHashes;
+
+      rebuildPkgs = [
+        "app"
+        "tabby-core"
+        "tabby-local"
+        "tabby-ssh"
+        "tabby-terminal"
+      ];
+
+      updateScript = ./update.sh;
+    };
+
+    meta = {
+      description = "Terminal for a more modern age";
+      homepage = "https://tabby.sh";
+      license = lib.licenses.mit;
+      mainProgram = "tabby";
+      maintainers = with lib.maintainers; [
+        dtomvan
+        geodic
+      ];
+      platforms = lib.platforms.linux;
+    };
+  }
+)

--- a/pkgs/by-name/ta/tabby-terminal/pkg-hashes.json
+++ b/pkgs/by-name/ta/tabby-terminal/pkg-hashes.json
@@ -1,0 +1,19 @@
+{
+  ".": "sha256-0mRcLU7qQbljlwKVJoG60a2OF2jJoW431aCs2Xn5R+8=",
+  "app": "sha256-0oSygY5cOU1yA5YiZeRaRmcCjCJvIg/FTSDvvR/eJ6U=",
+  "web": "sha256-kdER/yB8O7gfWnLZ/rNl4ha1eNnypcVmS1L7RrFCn0Q=",
+  "tabby-auto-sudo-password": "sha256-lR8C8EIA0hKas0H1go1GipqKYDxsFX3roZ7gDu4YLLY=",
+  "tabby-community-color-schemes": "sha256-oZgyP0hTU9bxszOVg3Bmiu6yos2d2Inc1Do8To4z8GQ=",
+  "tabby-core": "sha256-Z42TZeE0z96ZRtIFIgGbQyv8gtGY/Llya/Dhs8JtuWo=",
+  "tabby-electron": "sha256-h5HIu1FCbPsQIijhto3LdpLD2FnRmalqPq4/sjU9EOM=",
+  "tabby-linkifier": "sha256-78wgw6BbN/GtRMYeJF9svn9hn82bTZj4+8TXf/rAC64=",
+  "tabby-local": "sha256-GmVoeKxF8Sj55fDPN4GhwGVXoktdiwF3EFYTJHGO/NQ=",
+  "tabby-plugin-manager": "sha256-CrgsIGg834A+WQh7o07Quv+SSFqYxPMugZsSOHCrdPU=",
+  "tabby-serial": "sha256-sg/CJnlkUcohFgmY6xGE79WG5mmx9jh196mb8iVCk6g=",
+  "tabby-settings": "sha256-7t9mXsMqU892fLHyHmivgDxECSVn8KgRNAz9E2nKC/I=",
+  "tabby-ssh": "sha256-GJP0KyDCLQ9MszCJcm4851g07fnZCN0svpPgnVjXjgY=",
+  "tabby-telnet": "sha256-J8nBBUxwTdigcdohEF6dw8+EHRBUm8O1SLM9oDB3VaA=",
+  "tabby-terminal": "sha256-LS30V7iqLI0sEm3xlnMFtMnIxhALOMjQ148+zR0NyqU=",
+  "tabby-web-demo": "sha256-i8UoUMb5m+rf/73eKPm2S0v6cs8qSqy6lRjnZ6GoO/k=",
+  "tabby-web": "sha256-ErhWM0jiVK4PBosBz4IHi1xiemAzRuk/EE8ntyhO2PE="
+}

--- a/pkgs/by-name/ta/tabby-terminal/splice-argv.patch
+++ b/pkgs/by-name/ta/tabby-terminal/splice-argv.patch
@@ -1,0 +1,17 @@
+diff --git a/app/lib/cli.ts b/app/lib/cli.ts
+index 03213dd8..2ff31389 100644
+--- a/app/lib/cli.ts
++++ b/app/lib/cli.ts
+@@ -1,9 +1,9 @@
+ import { app } from 'electron'
+ 
+ export function parseArgs (argv: string[], cwd: string): any {
+-    if (argv[0].includes('node')) {
+-        argv = argv.slice(1)
+-    }
++
++    // This is because we are running with electron
++    argv = argv.slice(1)
+ 
+     return require('yargs/yargs')(argv.slice(1))
+         .usage('tabby [command] [arguments]')

--- a/pkgs/by-name/ta/tabby-terminal/update.sh
+++ b/pkgs/by-name/ta/tabby-terminal/update.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I ../../.. -i bash -p common-updater-scripts curl gnused jq moreutils prefetch-yarn-deps
+
+set -xeuo pipefail
+
+version="$(curl https://api.github.com/repos/Eugeny/tabby/releases/latest | jq -r .tag_name | sed 's/^v//')"
+update-source-version tabby-terminal "$version"
+
+package_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+src_dir="$(nix-build -A tabby-terminal.src --no-out-link)"
+hashes_file="$package_dir/pkg-hashes.json"
+
+for subproject in $(jq -r 'keys[]' "$hashes_file"); do
+  hash="$(prefetch-yarn-deps "$src_dir/$subproject/yarn.lock")"
+  hash="$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 "$hash")"
+  jq ".[\"$subproject\"] |= \"$hash\"" "$hashes_file" | sponge "$hashes_file"
+done

--- a/pkgs/by-name/ta/tabby-terminal/use-nix-version.patch
+++ b/pkgs/by-name/ta/tabby-terminal/use-nix-version.patch
@@ -1,0 +1,19 @@
+diff --git a/scripts/vars.mjs b/scripts/vars.mjs
+index 1366049981..d750898821 100755
+--- a/scripts/vars.mjs
++++ b/scripts/vars.mjs
+@@ -10,13 +10,7 @@
+ 
+ const electronInfo = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../node_modules/electron/package.json')))
+ 
+-export let version = childProcess.execSync('git describe --tags', { encoding:'utf-8' })
+-version = version.substring(1).trim()
+-version = version.replace('-', '-c')
+-
+-if (version.includes('-c')) {
+-    version = semver.inc(version, 'prepatch').replace('-0', `-nightly.${process.env.REV ?? 0}`)
+-}
++export let version = "@version@"
+ 
+ export const builtinPlugins = [
+     'tabby-core',


### PR DESCRIPTION
An attempt at reviving the effort to package https://tabby.sh/ for NixOS.

- Cleaned up the code
- Updated to latest version
- Used electron headers from `electron.headers` instead of a manual FOD
- Wrote an update script
- Disabled automatic updates because that doesn't work on NixOS and isn't expected anyways

cc @geodic

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
