### PR TITLE
{signal-desktop-bin, vscode, github-desktop}: use `systemdLibs`

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -15,7 +15,7 @@
   nss,
   nspr,
   xorg,
-  systemd,
+  systemdLibs,
   fontconfig,
   libdbusmenu,
   glib,
@@ -230,12 +230,12 @@ stdenv.mkDerivation (
       libgbm
       nss
       nspr
-      systemd
+      systemdLibs
       xorg.libxkbfile
     ];
 
     runtimeDependencies = lib.optionals stdenv.hostPlatform.isLinux [
-      (lib.getLib systemd)
+      systemdLibs
       fontconfig.lib
       libdbusmenu
       wayland

--- a/pkgs/by-name/gi/github-desktop/package.nix
+++ b/pkgs/by-name/gi/github-desktop/package.nix
@@ -15,7 +15,7 @@
   alsa-lib,
   cups,
   libgbm,
-  systemd,
+  systemdLibs,
   openssl,
   libglvnd,
 }:
@@ -92,7 +92,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   runtimeDependencies = [
-    (lib.getLib systemd)
+    systemdLibs
   ];
 
   meta = {

--- a/pkgs/by-name/si/signal-desktop-bin/generic.nix
+++ b/pkgs/by-name/si/signal-desktop-bin/generic.nix
@@ -45,7 +45,7 @@
   libgbm,
   libwebp,
   # Runtime dependencies:
-  systemd,
+  systemdLibs,
   libnotify,
   libdbusmenu,
   libpulseaudio,
@@ -186,13 +186,13 @@ stdenv.mkDerivation rec {
     nspr
     nss
     pango
-    systemd
+    systemdLibs
     xorg.libxcb
     xorg.libxshmfence
   ];
 
   runtimeDependencies = [
-    (lib.getLib systemd)
+    systemdLibs
     libappindicator-gtk3
     libnotify
     libdbusmenu


### PR DESCRIPTION
This PR:

- Replace `systemd` and `(lib.getLib systemd)` with `systemdLibs`

I was able to test the 3 programs: `signal-desktop-bin`, `github-desktop` and `vscode`, they run fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
