### PR TITLE
dnsrecon: 1.4.0 -> 1.5.1

### DIFF
--- a/pkgs/by-name/dn/dnsrecon/package.nix
+++ b/pkgs/by-name/dn/dnsrecon/package.nix
@@ -6,21 +6,29 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "dnsrecon";
-  version = "1.4.0";
+  version = "1.5.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "darkoperator";
     repo = "dnsrecon";
     tag = version;
-    hash = "sha256-uBb19JNlbevwqFSNzLzUmmDw063Hl7RPbu453tYZ3Gc=";
+    hash = "sha256-RX7A/vF19wTcvm+kP4ynarzGY+pUIj84zQJIM3tO/2M=";
   };
+
+  pythonRelaxDeps = true;
 
   build-system = with python3.pkgs; [ setuptools ];
 
   dependencies = with python3.pkgs; [
     dnspython
     loguru
+    httpx
+    fastapi
+    uvicorn
+    slowapi
+    stamina
+    ujson
     lxml
     netaddr
     requests

--- a/pkgs/development/python-modules/stamina/default.nix
+++ b/pkgs/development/python-modules/stamina/default.nix
@@ -7,6 +7,7 @@
   hatch-vcs,
   hatchling,
 
+  dirty-equals,
   tenacity,
   typing-extensions,
 
@@ -40,6 +41,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "stamina" ];
 
   nativeCheckInputs = [
+    dirty-equals
     pytestCheckHook
     anyio
   ];

--- a/pkgs/development/python-modules/stamina/default.nix
+++ b/pkgs/development/python-modules/stamina/default.nix
@@ -1,18 +1,15 @@
 {
   lib,
+  anyio,
   buildPythonPackage,
+  dirty-equals,
   fetchFromGitHub,
-
   hatch-fancy-pypi-readme,
   hatch-vcs,
   hatchling,
-
-  dirty-equals,
+  pytestCheckHook,
   tenacity,
   typing-extensions,
-
-  anyio,
-  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -27,24 +24,24 @@ buildPythonPackage rec {
     hash = "sha256-TehGqR3vbjLNByHZE2+Ytq52dpEpiL6+7TRUKwXcC1M=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     hatch-fancy-pypi-readme
     hatch-vcs
     hatchling
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     tenacity
     typing-extensions
   ];
 
-  pythonImportsCheck = [ "stamina" ];
-
   nativeCheckInputs = [
+    anyio
     dirty-equals
     pytestCheckHook
-    anyio
   ];
+
+  pythonImportsCheck = [ "stamina" ];
 
   meta = with lib; {
     description = "Production-grade retries for Python";


### PR DESCRIPTION
Changelog: https://github.com/darkoperator/dnsrecon/releases/tag/1.5.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
