### PR TITLE
python313Packages.pgspecial: skip tests on darwin as postgresqlTestHook is not available there, adopt, pgcli: update maintainers

### DIFF
--- a/pkgs/development/python-modules/pgcli/default.nix
+++ b/pkgs/development/python-modules/pgcli/default.nix
@@ -73,7 +73,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/dbcli/pgcli/raw/v${version}/changelog.rst";
     license = licenses.bsd3;
     maintainers = with maintainers; [
-      dywedir
       SuperSandro2000
     ];
   };

--- a/pkgs/development/python-modules/pgspecial/default.nix
+++ b/pkgs/development/python-modules/pgspecial/default.nix
@@ -11,6 +11,7 @@
   setuptools,
   setuptools-scm,
   sqlparse,
+  stdenv,
 }:
 
 buildPythonPackage rec {
@@ -33,6 +34,9 @@ buildPythonPackage rec {
     sqlparse
     psycopg
   ];
+
+  # postgresqlTestHook is not available on Darwin
+  doCheck = stdenv.hostPlatform.isLinux;
 
   nativeCheckInputs = [
     configobj

--- a/pkgs/development/python-modules/pgspecial/default.nix
+++ b/pkgs/development/python-modules/pgspecial/default.nix
@@ -63,6 +63,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/dbcli/pgspecial";
     changelog = "https://github.com/dbcli/pgspecial/releases/tag/v${version}";
     license = licenses.bsd3;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.SuperSandro2000 ];
   };
 }


### PR DESCRIPTION
Closes #439812

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
