### PR TITLE
bashdb: 5.0-1.1.2 -> 5.2-1.1.2-unstable-2025-06-07

### DIFF
--- a/pkgs/by-name/ba/bashdb/bash-5-or-greater.patch
+++ b/pkgs/by-name/ba/bashdb/bash-5-or-greater.patch
@@ -1,0 +1,21 @@
+diff --git a/configure.ac b/configure.ac
+index cf96d6f..3a621bc 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -102,13 +102,13 @@ bash_version=`$SH_PROG --version`
+ [bash_major=`$SH_PROG -c 'echo ${BASH_VERSINFO[0]}'`]
+ [bash_minor=`$SH_PROG -c 'echo ${BASH_VERSINFO[1]}'`]
+ bash_5_or_greater=no
+-case "${bash_major}.${bash_minor}" in
+-  'OK_BASH_VERS' | '5.0' | '5.1')
++case "${bash_major}" in
++  '5')
+     bash_5_or_greater=yes
+     ;;
+   *)
+     AC_MSG_WARN([You have Bash $bash_version installed.])
+-    AC_MSG_ERROR([This package is only known to work with Bash 5.0 or 5.1])
++    AC_MSG_ERROR([This package is only known to work with Bash 5])
+     ;;
+ esac
+ 

--- a/pkgs/by-name/ba/bashdb/package.nix
+++ b/pkgs/by-name/ba/bashdb/package.nix
@@ -52,6 +52,9 @@ stdenv.mkDerivation {
     '';
     license = lib.licenses.gpl2Plus;
     mainProgram = "bashdb";
+    maintainers = with lib.maintainers; [
+      jk
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/ba/bashdb/package.nix
+++ b/pkgs/by-name/ba/bashdb/package.nix
@@ -44,10 +44,14 @@ stdenv.mkDerivation {
   ];
 
   meta = {
-    description = "Bash script debugger";
-    mainProgram = "bashdb";
     homepage = "https://bashdb.sourceforge.net/";
+    description = "A gdb-like debugger for bash";
+    longDescription = ''
+      The Bash Debugger Project is a source-code debugger for bash that follows
+      the gdb command syntax.
+    '';
     license = lib.licenses.gpl2Plus;
+    mainProgram = "bashdb";
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/ba/bashdb/package.nix
+++ b/pkgs/by-name/ba/bashdb/package.nix
@@ -1,38 +1,47 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  fetchpatch,
-  makeWrapper,
-  python3Packages,
+
+  fetchFromGitHub,
+
+  autoreconfHook,
+  texinfo,
+  perl,
+
+  python3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "bashdb";
-  version = "5.0-1.1.2";
+  version = "5.2-1.1.2-unstable-2025-06-07";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/bashdb/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-MBdtKtKMWwCy4tIcXqGu+PuvQKj52fcjxnxgUx87czA=";
+  src = fetchFromGitHub {
+    owner = "Trepan-Debuggers";
+    repo = "bashdb";
+    rev = "7d0f9751e04fa54f48f0ab4be32ecb8030a4315d";
+    sha256 = "sha256-fwxmlFC66Lv+zD632s9a44I9IEQ/82caKnQ44pdVes4=";
   };
 
   patches = [
-    # Enable building with bash 5.1/5.2
-    # Remove with any upstream 5.1-x.y.z release
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/freebsd/freebsd-ports/569fbb806d9ee813afa8b27d2098a44f93433922/devel/bashdb/files/patch-configure";
-      sha256 = "19zfzcnxavndyn6kfxp775kjcd0gigsm4y3bnh6fz5ilhnnbbbgr";
-    })
+    ./bash-5-or-greater.patch
   ];
-  patchFlags = [ "-p0" ];
 
   nativeBuildInputs = [
-    makeWrapper
+    autoreconfHook
+    texinfo # maninfo
+    perl # pod2man
   ];
 
-  postInstall = ''
-    wrapProgram $out/bin/bashdb --prefix PYTHONPATH ":" "$(toPythonPath ${python3Packages.pygments})"
-  '';
+  buildInputs = [
+    # used at runtime by term-highlight.py
+    (python3.withPackages (ps: [ ps.pygments ]))
+  ];
+
+  configureFlags = [
+    # wants to point where bash expects dbg-main
+    # for now point to self
+    "--with-dbg-main=${placeholder "out"}/share/bashdb/bashdb-main.inc"
+  ];
 
   meta = {
     description = "Bash script debugger";

--- a/pkgs/by-name/ba/bashdb/package.nix
+++ b/pkgs/by-name/ba/bashdb/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
     description = "Bash script debugger";
     mainProgram = "bashdb";
     homepage = "https://bashdb.sourceforge.net/";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Update bashdb and fix the build

related to #436622 

Does still have some issues

```
$ ./result/bin/bashdb ./maintainers/scripts/eval-release.sh
bash debugger, bashdb, release 5.2-1.1.2

Copyright 2002-2004, 2006-2012, 2014, 2016-2019, 2021, 2023-2024 Rocky Bernstein
This is free software, covered by the GNU General Public License, and you are
welcome to change it and/or distribute copies of it under certain conditions.

/nix/store/1l796xv4qwg18109h7j22k3pgaj3g886-bashdb-5.2-1.1.2-unstable-2025-06-07/share/bashdb/lib/processor.sh: line 45: set: emacs: invalid option name
/nix/store/1l796xv4qwg18109h7j22k3pgaj3g886-bashdb-5.2-1.1.2-unstable-2025-06-07/share/bashdb/lib/help.sh: line 40: complete: command not found
/nix/store/1l796xv4qwg18109h7j22k3pgaj3g886-bashdb-5.2-1.1.2-unstable-2025-06-07/share/bashdb/lib/help.sh: line 40: complete: command not found
/nix/store/1l796xv4qwg18109h7j22k3pgaj3g886-bashdb-5.2-1.1.2-unstable-2025-06-07/share/bashdb/lib/help.sh: line 40: complete: command not found
/nix/store/1l796xv4qwg18109h7j22k3pgaj3g886-bashdb-5.2-1.1.2-unstable-2025-06-07/share/bashdb/lib/help.sh: line 40: complete: command not found
/nix/store/1l796xv4qwg18109h7j22k3pgaj3g886-bashdb-5.2-1.1.2-unstable-2025-06-07/share/bashdb/lib/help.sh: line 40: complete: command not found
/nix/store/1l796xv4qwg18109h7j22k3pgaj3g886-bashdb-5.2-1.1.2-unstable-2025-06-07/share/bashdb/command/eval.sh: line 69: complete: command not found
/nix/store/1l796xv4qwg18109h7j22k3pgaj3g886-bashdb-5.2-1.1.2-unstable-2025-06-07/share/bashdb/lib/help.sh: line 40: complete: command not found
/nix/store/1l796xv4qwg18109h7j22k3pgaj3g886-bashdb-5.2-1.1.2-unstable-2025-06-07/share/bashdb/lib/help.sh: line 40: complete: command not found
/nix/store/1l796xv4qwg18109h7j22k3pgaj3g886-bashdb-5.2-1.1.2-unstable-2025-06-07/share/bashdb/lib/help.sh: line 40: complete: command not found
/nix/store/1l796xv4qwg18109h7j22k3pgaj3g886-bashdb-5.2-1.1.2-unstable-2025-06-07/share/bashdb/lib/help.sh: line 40: complete: command not found
/nix/store/1l796xv4qwg18109h7j22k3pgaj3g886-bashdb-5.2-1.1.2-unstable-2025-06-07/share/bashdb/lib/help.sh: line 40: complete: command not found
/nix/store/1l796xv4qwg18109h7j22k3pgaj3g886-bashdb-5.2-1.1.2-unstable-2025-06-07/share/bashdb/lib/help.sh: line 40: complete: command not found
(/home/user/projects/personal/nixpkgs/maintainers/scripts/eval-release.sh:3):
3:	if [[ -z "$VERBOSE" ]]; then
bashdb<0>
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
