### PR TITLE
nrsc5: 1.0 -> 3.0.1

### DIFF
--- a/pkgs/by-name/nr/nrsc5/package.nix
+++ b/pkgs/by-name/nr/nrsc5/package.nix
@@ -12,24 +12,22 @@
 }:
 let
   src_faad2 = fetchFromGitHub {
-    owner = "dsvensson";
+    owner = "knik0";
     repo = "faad2";
-    rev = "b7aa099fd3220b71180ed2b0bc19dc6209a1b418";
-    sha256 = "0pcw2x9rjgkf5g6irql1j4m5xjb4lxj6468z8v603921bnir71mf";
+    tag = "2.11.2";
+    hash = "sha256-JvmblrmE3doUMUwObBN2b+Ej+CDBWNemBsyYSCXGwo8=";
   };
 
-  version = "1.0";
-
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "nrsc5";
-  inherit version;
+  version = "3.0.1";
 
   src = fetchFromGitHub {
     owner = "theori-io";
     repo = "nrsc5";
-    rev = "v${version}";
-    sha256 = "09zzh3h1zzf2lwrbz3i7rif2hw36d9ska8irvxaa9lz6xc1y68pg";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-chLoCXbEQaIrSHLQAm0++NGNYuQNCseSCR37qjXwW04=";
   };
 
   postUnpack = ''
@@ -44,10 +42,6 @@ stdenv.mkDerivation {
     sed -i '/GIT_REPOSITORY/d' CMakeLists.txt
     sed -i '/GIT_TAG/d' CMakeLists.txt
     sed -i "s:set (FAAD2_PREFIX .*):set (FAAD2_PREFIX \"$srcRoot/faad2-prefix\"):" CMakeLists.txt
-    # see https://github.com/dsvensson/faad2/pull/2
-    substituteInPlace $faadSrc/libfaad/pns.c \
-      --replace-fail 'r1_dep = __r1;' 'r1_dep = *__r1;' \
-      --replace-fail 'r2_dep = __r2;' 'r2_dep = *__r2;'
   '';
 
   nativeBuildInputs = [
@@ -75,4 +69,4 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ markuskowa ];
     mainProgram = "nrsc5";
   };
-}
+})


### PR DESCRIPTION
Changelog: https://github.com/theori-io/nrsc5/releases

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
