### PR TITLE
{kicad, timeshift}: use `util-linuxMinimal`, refactor, cleanup

### DIFF
--- a/pkgs/applications/backup/timeshift/unwrapped.nix
+++ b/pkgs/applications/backup/timeshift/unwrapped.nix
@@ -16,14 +16,14 @@
   xapp,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "timeshift";
   version = "25.07.7";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "timeshift";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-X3TwUkOeGzcgFM/4Fyfs8eQuGK2wHe3t13WSpIizX8s=";
   };
 
@@ -76,4 +76,4 @@ stdenv.mkDerivation rec {
       bobby285271
     ];
   };
-}
+})

--- a/pkgs/applications/backup/timeshift/unwrapped.nix
+++ b/pkgs/applications/backup/timeshift/unwrapped.nix
@@ -11,7 +11,7 @@
   gtk3,
   json-glib,
   libgee,
-  util-linux,
+  util-linuxMinimal,
   vte,
   xapp,
 }:
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     for FILE in src/Core/Main.vala src/Utility/Device.vala; do
       substituteInPlace "$FILE" \
-        --replace-fail "/sbin/blkid" "${lib.getExe' util-linux "blkid"}"
+        --replace-fail "/sbin/blkid" "${lib.getExe' util-linuxMinimal "blkid"}"
     done
 
     substituteInPlace ./src/Utility/IconManager.vala \

--- a/pkgs/applications/backup/timeshift/unwrapped.nix
+++ b/pkgs/applications/backup/timeshift/unwrapped.nix
@@ -62,16 +62,16 @@ stdenv.mkDerivation (finalAttrs: {
     NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
   };
 
-  meta = with lib; {
+  meta = {
     description = "System restore tool for Linux";
     longDescription = ''
       TimeShift creates filesystem snapshots using rsync+hardlinks or BTRFS snapshots.
       Snapshots can be restored using TimeShift installed on the system or from Live CD or USB.
     '';
     homepage = "https://github.com/linuxmint/timeshift";
-    license = licenses.gpl2Plus;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
       ShamrockLee
       bobby285271
     ];

--- a/pkgs/applications/backup/timeshift/unwrapped.nix
+++ b/pkgs/applications/backup/timeshift/unwrapped.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "timeshift";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-X3TwUkOeGzcgFM/4Fyfs8eQuGK2wHe3t13WSpIizX8s=";
   };
 

--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -26,6 +26,7 @@
   libgcrypt,
   libgpg-error,
   ninja,
+  writableTmpDirAsHomeHook,
 
   util-linux,
   libselinux,
@@ -182,12 +183,6 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals withNgspice [ libngspice ]
   ++ optionals debug [ valgrind ];
 
-  # some ngspice tests attempt to write to $HOME/.cache/
-  # this could be and was resolved with XDG_CACHE_HOME = "$TMP";
-  # but failing tests still attempt to create $HOME
-  # and the newer CLI tests seem to also use $HOME...
-  HOME = "$TMP";
-
   # debug builds fail all but the python test
   doInstallCheck = !debug;
   installCheckTarget = "test";
@@ -201,6 +196,7 @@ stdenv.mkDerivation (finalAttrs: {
         pytest-image-diff
       ]
     ))
+    writableTmpDirAsHomeHook
   ];
 
   dontStrip = debug;

--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -51,7 +51,6 @@
 
   stable,
   testing,
-  baseName,
   kicadSrc,
   kicadVersion,
   withNgspice,
@@ -69,7 +68,7 @@ assert testing -> !stable -> throw "testing implies stable and cannot be used wi
 
 let
   opencascade-occt = opencascade-occt_7_6;
-  inherit (lib) optional optionals optionalString;
+  inherit (lib) optional optionals;
 in
 stdenv.mkDerivation rec {
   pname = "kicad-base";

--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -28,7 +28,7 @@
   ninja,
   writableTmpDirAsHomeHook,
 
-  util-linux,
+  util-linuxMinimal,
   libselinux,
   libsepol,
   libthai,
@@ -140,7 +140,7 @@ stdenv.mkDerivation (finalAttrs: {
   # wanted by configuration on linux, doesn't seem to affect performance
   # no effect on closure size
   ++ optionals (stdenv.hostPlatform.isLinux) [
-    util-linux
+    util-linuxMinimal
     libselinux
     libsepol
     libthai

--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -88,10 +88,10 @@ stdenv.mkDerivation rec {
   # nix removes .git, so its approximated here
   postPatch = lib.optionalString (!stable || testing) ''
     substituteInPlace cmake/KiCadVersion.cmake \
-      --replace "unknown" "${builtins.substring 0 10 src.rev}"
+      --replace-fail "unknown" "${builtins.substring 0 10 src.rev}"
 
     substituteInPlace cmake/CreateGitVersionHeader.cmake \
-      --replace "0000000000000000000000000000000000000000" "${src.rev}"
+      --replace-fail "0000000000000000000000000000000000000000" "${src.rev}"
   '';
 
   preConfigure = optionalString debug ''

--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -75,9 +75,9 @@ let
     optionalString
     ;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "kicad-base";
-  version = if stable then kicadVersion else builtins.substring 0 10 src.rev;
+  version = if stable then kicadVersion else builtins.substring 0 10 finalAttrs.src.rev;
 
   src = kicadSrc;
 
@@ -93,10 +93,10 @@ stdenv.mkDerivation rec {
   # nix removes .git, so its approximated here
   postPatch = lib.optionalString (!stable || testing) ''
     substituteInPlace cmake/KiCadVersion.cmake \
-      --replace-fail "unknown" "${builtins.substring 0 10 src.rev}"
+      --replace-fail "unknown" "${builtins.substring 0 10 finalAttrs.src.rev}"
 
     substituteInPlace cmake/CreateGitVersionHeader.cmake \
-      --replace-fail "0000000000000000000000000000000000000000" "${src.rev}"
+      --replace-fail "0000000000000000000000000000000000000000" "${finalAttrs.src.rev}"
   '';
 
   preConfigure = optionalString debug ''
@@ -112,7 +112,7 @@ stdenv.mkDerivation rec {
     (cmakeBool "KICAD_USE_CMAKE_FINDPROTOBUF" false)
     (cmakeBool "KICAD_SCRIPTING_WXPYTHON" withScripting)
     (cmakeBool "KICAD_BUILD_I18N" withI18n)
-    (cmakeBool "KICAD_BUILD_QA_TESTS" (!doInstallCheck))
+    (cmakeBool "KICAD_BUILD_QA_TESTS" (!finalAttrs.doInstallCheck))
     (cmakeBool "KICAD_STDLIB_DEBUG" debug)
     (cmakeBool "KICAD_USE_VALGRIND" debug)
     (cmakeBool "KICAD_SANITIZE_ADDRESS" sanitizeAddress)
@@ -215,4 +215,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.all;
     broken = stdenv.hostPlatform.isDarwin;
   };
-}
+})

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -178,7 +178,7 @@ stdenv.mkDerivation rec {
   passthru.libraries = callPackages ./libraries.nix { inherit libSrc; };
   passthru.callPackage = newScope { inherit addonPath python3; };
   base = callPackage ./base.nix {
-    inherit stable testing baseName;
+    inherit stable testing;
     inherit kicadSrc kicadVersion;
     inherit wxGTK python wxPython;
     inherit withNgspice withScripting withI18n;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
