### PR TITLE
python3Packages.pymatgen: add moyopy dependency

### DIFF
--- a/pkgs/development/python-modules/moyopy/default.nix
+++ b/pkgs/development/python-modules/moyopy/default.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  rustPlatform,
+
+  # dependencies
+  typing-extensions,
+
+  # tests
+  numpy,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "moyopy";
+  version = "0.4.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "spglib";
+    repo = "moyo";
+    tag = "v${version}";
+    hash = "sha256-TWZAqvtPeJqKXUFiNxD8H/aqjiDSWaTkMEQW0cuhEMY=";
+  };
+
+  sourceRoot = "${src.name}/moyopy";
+  cargoRoot = "..";
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
+
+  env = {
+    CARGO_TARGET_DIR = "./target";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit
+      pname
+      version
+      src
+      sourceRoot
+      cargoRoot
+      ;
+    hash = "sha256-L4SAX4HWx+TSPQm7K6C5IEpFkx/AlscmKRs2wPEQun4=";
+  };
+
+  build-system = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  dependencies = [
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "moyopy" ];
+
+  nativeCheckInputs = [
+    numpy
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # Circular dependency with pymatgen
+    "python/tests/test_interface.py"
+  ];
+
+  meta = {
+    description = "Python interface of moyo, a fast and robust crystal symmetry finder";
+    homepage = "https://spglib.github.io/moyo/python/";
+    changelog = "https://github.com/spglib/moyo/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/development/python-modules/pymatgen/default.nix
+++ b/pkgs/development/python-modules/pymatgen/default.nix
@@ -46,6 +46,7 @@
 
   # tests
   addBinToPathHook,
+  moyopy,
   pytest-xdist,
   pytestCheckHook,
 }:
@@ -122,6 +123,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     addBinToPathHook
+    moyopy
     pytestCheckHook
     pytest-xdist
   ]
@@ -169,11 +171,7 @@ buildPythonPackage rec {
     "test_timer"
   ];
 
-  disabledTestPaths = [
-    # We have not packaged moyopy yet.
-    "tests/analysis/test_prototypes.py::test_get_protostructure_label_from_moyopy"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
     # Crash when running the pmg command
     # Critical error: required built-in appearance SystemAppearance not found
     "tests/cli/test_pmg_plot.py"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9593,6 +9593,8 @@ self: super: with self; {
 
   moviepy = callPackage ../development/python-modules/moviepy { };
 
+  moyopy = callPackage ../development/python-modules/moyopy { };
+
   mozart-api = callPackage ../development/python-modules/mozart-api { };
 
   mozilla-django-oidc = callPackage ../development/python-modules/mozilla-django-oidc { };


### PR DESCRIPTION
## Things done

- **python3Packages.moyopy: init at 0.4.4**
- **python3Packages.pymatgen: add moyopy dependency**

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
