### PR TITLE
nix-prefetch-darcs: init

### DIFF
--- a/pkgs/build-support/fetchdarcs/builder.sh
+++ b/pkgs/build-support/fetchdarcs/builder.sh
@@ -12,8 +12,8 @@ elif test -n "$context"; then
     tagflags="--context=$context"
 fi
 
-echo "getting $url $partial ${tagtext} into $out"
+echo "Cloning $url $partial ${tagtext} into $out"
 
-darcs get --lazy $tagflags "$url" "$out"
+darcs clone --lazy $tagflags "$url" "$out"
 # remove metadata, because it can change
 rm -rf "$out/_darcs"

--- a/pkgs/build-support/fetchdarcs/nix-prefetch-darcs
+++ b/pkgs/build-support/fetchdarcs/nix-prefetch-darcs
@@ -1,0 +1,184 @@
+#!/bin/sh
+set -eu
+
+quiet=
+name="fetchdarcs"
+repository=
+tag=
+context=
+darcs_hash=
+exp_hash=
+
+usage() {
+	echo "Usage: nix-prefetch-darcs [options] [REPOSITORY] [FILENAME [EXPECTED-HASH]]"
+	echo
+	echo "Options:"
+	echo "	--quiet               Suppress most error messages."
+	echo "	--name <NAME>         Symbolic store path name to use for the result."
+	echo "	--repo <REPOSITORY>   URL for the Darcs repository."
+	echo "	--tag <REGEXP>        Clone specified by tag matching a regular expression."
+	echo "	--context <FILENAME>  Clone specified by context file."
+	echo "	--darcs-hash <HASH>   Clone specified by hash. WARN: hash order is fickle by design."
+	echo "	--hash <HASH>         Expected hash."
+	echo "	--help                Show this help message."
+}
+
+# Argument parsing
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--quiet)
+		  quiet=1; shift 1 ;;
+		--name)
+			name="$2"; shift 2 ;;
+		--repository)
+			repository="$2"; shift 2 ;;
+		--tag)
+			tag="$2"; shift 2 ;;
+		--context)
+			context="$2"; shift 2 ;;
+		--darcs-hash)
+			darcs_hash="$2"; shift 2 ;;
+		--hash)
+			exp_hash="$2"; shift 2 ;;
+		--help)
+			usage; exit 0 ;;
+		*)
+			# Positional arguments
+			if [ -z "$repository" ]; then
+				repository="$1"
+				shift
+			elif [ -z "$context" ]; then
+				context="$1"
+				shift
+			elif [ -z "$exp_hash" ]; then
+				exp_hash="$1"
+				shift
+			else
+				echo "Error: Too many arguments" >&2
+				usage
+				exit 1
+			fi
+			;;
+	esac
+done
+
+if [ -z "$repository" ]; then
+	echo "Error: URL for repository is required." >&2
+	echo >&2
+	usage
+	exit 1
+fi
+
+state_flag_count=0
+[ -n "$tag" ] && state_flag_count=$(( state_flag_count + 1 ))
+[ -n "$context" ] && state_flag_count=$(( state_flag_count + 1 ))
+[ -n "$darcs_hash" ] && state_flag_count=$(( state_flag_count + 1 ))
+
+if [ "$state_flag_count" -gt 1 ]; then
+	echo "Error: no more than 1 of --tag, --context, --darcs-hash flags can be set. $state_flag_count were set." >&2
+	echo >&2
+	usage
+	exit 1
+elif [ -n "$context" ]; then
+	if [ ! -s "$context" ]; then
+		echo "Error: context file must be readable & non-empty @ “$context”" >&2
+		echo >&2
+		usage
+		exit 1
+	else
+		context="$(realpath "$context")"
+	fi
+fi
+
+weak_hash=
+hash=
+hash_algo="${NIX_HASH_ALGO:-"sha256"}"
+hash_format="${hashFormat:-"--base32"}"
+final_path=
+final_context=
+
+# If the hash was given, a file with that hash may already be in the
+# store.
+if [ -n "$exp_hash" ]; then
+	final_path=$(nix-store --print-fixed-path --recursive "$hash_algo" "$exp_hash" "$name")
+	if ! nix-store --check-validity "$final_path" 2> /dev/null; then
+		final_path=""
+	fi
+	hash="$exp_hash"
+fi
+
+# If we don’t know the hash or a path with that hash doesn’t exist,
+# download the file and add it to the store.
+if [ -z "$final_path" ]; then
+	tmp_clone="$(realpath ${quiet:+--quiet} "$(mktemp ${quiet:+--quiet} -d --tmpdir darcs-clone-tmp-XXXXXXXX)")"
+	trap "rm -rf \"$tmp_clone\"" EXIT
+
+	clone_args="--lazy"
+	if [ -n "$quiet" ]; then
+		clone_args="$clone_args --quiet"
+	fi
+	if [ -n "$tag" ]; then
+		clone_args="$clone_args --tag=$tag"
+	elif [ -n "$context" ]; then
+		clone_args="$clone_args --context=$context"
+	elif [ -n "$darcs_hash" ]; then
+		clone_args="$clone_args --to-hash=$darcs_hash"
+	fi
+
+	cd "$tmp_clone"
+	# Do not print Darcs progress to stdout (else stdout isn’t parsable JSON)
+	if [ -t 1 ]; then
+		darcs clone $clone_args "$repository" "$name" >/dev/tty
+	else
+		darcs clone $clone_args "$repository" "$name" >/dev/null
+	fi
+	cd "$tmp_clone/$name"
+	# Will put the current Darcs context into the store.
+	new_context="$tmp_clone/${name}-context.txt"
+	darcs log --context > "$new_context"
+	final_context="$(nix-store --add-fixed "$hash_algo" "$new_context")"
+	# Darcs has a weak hash using the XOR of the patch hashes which is useful
+	# for other scripts
+	# https://darcs.net/Internals/Hashes
+	weak_hash="$(darcs show repo | grep '^ *Weak Hash:' | cut -d: -f2- | tr -d "[:space:]")"
+	cd - >/dev/null
+	rm -rf "$tmp_clone/$name/_darcs"
+
+	hash="$(nix-hash --type "$hash_algo" "$hash_format" "$tmp_clone/$name")"
+	final_path=$(nix-store --add-fixed --recursive "$hash_algo" "$tmp_clone/$name")
+
+	if [ -n "$exp_hash" ] && [ "$exp_hash" != "$hash" ]; then
+		echo "Hash mismatch for “$repository”" >&2
+		echo "Expected: $exp_hash" >&2
+		echo "Got:      $hash" >&2
+		exit 1
+	fi
+fi
+
+json_escape() {
+	printf '%s' "$1" | jq -Rs .
+}
+
+cat <<EOF
+{
+	"repository": $(json_escape "$repository"),
+EOF
+if [ -n "$tag" ]; then cat <<EOF
+	"tag": "$(json_escape "$tag")",
+EOF
+elif [ -n "$darcs_hash" ]; then cat <<EOF
+	"darcs-hash": $(json_escape "$darcs_hash"),
+EOF
+fi; if [ -n "$weak_hash" ]; then cat <<EOF
+	"weak-hash": $(json_escape "$weak_hash"),
+EOF
+fi; if [ -s "$final_context" ]; then cat <<EOF
+	"context": $(json_escape "$final_context"),
+EOF
+fi; cat <<EOF
+	"path": "$final_path",
+	$(json_escape "$hash_algo"): $(json_escape "$hash"),
+	"hash": "$(nix-hash --to-sri --type "$hash_algo" "$hash")"
+}
+EOF
+# vim: noet ci pi sts=0

--- a/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
@@ -8,6 +8,7 @@
   cacert,
   coreutils,
   cvs,
+  darcs,
   findutils,
   gawk,
   git,
@@ -64,6 +65,11 @@ rec {
     breezy
   ];
   nix-prefetch-cvs = mkPrefetchScript "cvs" ../../../build-support/fetchcvs/nix-prefetch-cvs [ cvs ];
+  nix-prefetch-darcs = mkPrefetchScript "darcs" ../../../build-support/fetchdarcs/nix-prefetch-darcs [
+    darcs
+    cacert
+    jq
+  ];
   nix-prefetch-git = mkPrefetchScript "git" ../../../build-support/fetchgit/nix-prefetch-git [
     findutils
     gawk
@@ -88,6 +94,7 @@ rec {
     paths = [
       nix-prefetch-bzr
       nix-prefetch-cvs
+      nix-prefetch-darcs
       nix-prefetch-git
       nix-prefetch-hg
       nix-prefetch-svn


### PR DESCRIPTION
<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Based on my prior work on #405600 in recent times, one can now prefetch Darcs repositories (& can be piped to `jq` too).

Successes:

```sh-session
$ result/bin/nix-prefetch-darcs https://smeder.ee/~toastal/test-delete.darcs
Finished cloning.        
{
	"repository": "https://smeder.ee/~toastal/test-delete.darcs",
	"weak-hash": "9168dfb6fd8cd980513d983b1ba0841ab67ff31a",
	"context": "/nix/store/mafyzlsdzqhxbma6b0cfnr1jwkpry9s9-fetchdarcs-context.txt",
	"path": "/nix/store/4r5saywxlhd1x2fn03cqqvakck1x8523-fetchdarcs",
	"sha256": "0hrsa78q2nzfd2awgfn34c0qsbcfybpnwx039asa4pc51s8yb52y",
	"hash": "sha256-XpTlkQ6FXaK0SgN0bu/yji2NASPDuseVaO5bgdFROkM="
}
$ result/bin/nix-prefetch-darcs https://smeder.ee/~toastal/test-delete.darcs | jq --tab
{
	"repository": "https://smeder.ee/~toastal/test-delete.darcs",
	"weak-hash": "9168dfb6fd8cd980513d983b1ba0841ab67ff31a",
	"context": "/nix/store/mafyzlsdzqhxbma6b0cfnr1jwkpry9s9-fetchdarcs-context.txt",
	"path": "/nix/store/4r5saywxlhd1x2fn03cqqvakck1x8523-fetchdarcs",
	"sha256": "0hrsa78q2nzfd2awgfn34c0qsbcfybpnwx039asa4pc51s8yb52y",
	"hash": "sha256-XpTlkQ6FXaK0SgN0bu/yji2NASPDuseVaO5bgdFROkM="
}
$ result/bin/nix-prefetch-darcs --darcs-hash 19ba8b57bc1baa413feaca216d5068f09077c24a https://smeder.ee/~toastal/test-delete.darcs
Going to specified version...
Unapplying 1 patch
Finished cloning.         
{
	"repository": "https://smeder.ee/~toastal/test-delete.darcs",
	"darcs-hash": "19ba8b57bc1baa413feaca216d5068f09077c24a",
	"weak-hash": "72c932b0d89cfa7cc05bb4e4327c0da67e4d84ba",
	"context": "/nix/store/1w7apl8lzr23r21z2zpz0504b6wvq3g3-fetchdarcs-context.txt",
	"path": "/nix/store/dq8v078m29r0zsr5065hbyd27hajc407-fetchdarcs",
	"sha256": "05ry7lwrk63rw0iqhv33awvd7l357l3s2bpgwas1n8arwz9n49m0",
	"hash": "sha256-oCZi0+dZIRu04u8uoQc9ZdDTNldjbIgj4HmYmTk9Phc="
}
$ result/bin/nix-prefetch-darcs --hash sha256-oCZi0+dZIRu04u8uoQc9ZdDTNldjbIgj4HmYmTk9Phc= --darcs-hash 19ba8b57bc1baa413feaca216d5068f090
77c24a https://smeder.ee/~toastal/test-delete.darcs
{
	"repository": "https://smeder.ee/~toastal/test-delete.darcs",
	"darcs-hash": "19ba8b57bc1baa413feaca216d5068f09077c24a",
	"path": "/nix/store/dq8v078m29r0zsr5065hbyd27hajc407-fetchdarcs",
	"sha256": "sha256-oCZi0+dZIRu04u8uoQc9ZdDTNldjbIgj4HmYmTk9Phc=",
	"hash": "sha256-oCZi0+dZIRu04u8uoQc9ZdDTNldjbIgj4HmYmTk9Phc="
}
$ result/bin/nix-prefetch-darcs --tag 0.3 https://smeder.ee/~toastal/test-delete.darcs
Going to specified version...
Unapplying 2 patches
Finished cloning.         
{
	"repository": "https://smeder.ee/~toastal/test-delete.darcs",
	"tag": ""0.3"",
	"weak-hash": "6b73b9e76487503dffb17ec55f2c6556ee3a46f0",
	"context": "/nix/store/2q546c5rrs8l3mfllsbxdhxjcd009dvv-fetchdarcs-context.txt",
	"path": "/nix/store/nf45b01qxk4spk3mljz4z1dcqr2qlfqh-fetchdarcs",
	"sha256": "0v7i9b9avg2fg9dww8f71znf5icdk5pa123kl6f8blnp89rl9v4k",
	"hash": "sha256-k+xEc0LX0oWcoXOIoG6ZjcXi7A/HIc5bek68rdJK8Ww="
}
$ cat context.txt 

Context:


[5&6
$USER <$EMAIL>**20250903123840
 Ignore-this: 32c2e78529411652e8a14a38b7c4a63498922fdac42b8b217ee2718615dec3017f3e6b5d5eb16aa1
] 

[4
$USER <$EMAIL>**20250903123824
 Ignore-this: ead3860ff8ba0483625902accaf9e2b74be1be7cf0b4af639c2c555cc92de091b7eb9b5820c1d11c
] 

[TAG 0.3
$USER <$EMAIL>**20250903123804
 Ignore-this: 571534fdee98ee32fba8b9e5547c1d458ae6ce6185415e6b9e763d552b9f8f754eb171752a25c1e6
] 
$ result/bin/nix-prefetch-darcs --context ./context.txt https://smeder.ee/~toastal/test-delete.darcs
Going to specified version...
Unapplying 0 patches
Finished cloning.         
{
	"repository": "https://smeder.ee/~toastal/test-delete.darcs",
	"weak-hash": "9168dfb6fd8cd980513d983b1ba0841ab67ff31a",
	"context": "/nix/store/mafyzlsdzqhxbma6b0cfnr1jwkpry9s9-fetchdarcs-context.txt",
	"path": "/nix/store/4r5saywxlhd1x2fn03cqqvakck1x8523-fetchdarcs",
	"sha256": "0hrsa78q2nzfd2awgfn34c0qsbcfybpnwx039asa4pc51s8yb52y",
	"hash": "sha256-XpTlkQ6FXaK0SgN0bu/yji2NASPDuseVaO5bgdFROkM="
}
```

Failures:

```sh-session
$ result/bin/nix-prefetch-darcs
Error: URL for repository is required.

Usage: nix-prefetch-darcs [options] [REPOSITORY] [FILENAME [EXPECTED-HASH]]

Options:
	--quiet               Suppress most error messages.
	--name <NAME>         Symbolic store path name to use for the result.
	--repo <REPOSITORY>   URL for the Darcs repository.
	--tag <REGEXP>        Clone specified by tag matching a regular expression.
	--context <FILENAME>  Clone specified by context file.
	--darcs-hash <HASH>   Clone specified by hash. WARN: hash order is fickle by design.
	--hash <HASH>         Expected hash.
	--help                Show this help message.
$ result/bin/nix-prefetch-darcs --context ./context.txt --tag 0.3 https://smeder.ee/~toastal/test-delete.darcs
Error: no more than 1 of --tag, --context, --darcs-hash flags can be set. 2 were set.

Usage: nix-prefetch-darcs [options] [REPOSITORY] [FILENAME [EXPECTED-HASH]]

Options:
	--quiet               Suppress most error messages.
	--name <NAME>         Symbolic store path name to use for the result.
	--repo <REPOSITORY>   URL for the Darcs repository.
	--tag <REGEXP>        Clone specified by tag matching a regular expression.
	--context <FILENAME>  Clone specified by context file.
	--darcs-hash <HASH>   Clone specified by hash. WARN: hash order is fickle by design.
	--hash <HASH>         Expected hash.
	--help                Show this help message.
$ result/bin/nix-prefetch-darcs --context ./does-not-exist.txt https://smeder.ee/~toastal/test-delete.darcs
Error: context file must be readable & non-empty @ “./does-not-exist.txt”

Usage: nix-prefetch-darcs [options] [REPOSITORY] [FILENAME [EXPECTED-HASH]]

Options:
	--quiet               Suppress most error messages.
	--name <NAME>         Symbolic store path name to use for the result.
	--repo <REPOSITORY>   URL for the Darcs repository.
	--tag <REGEXP>        Clone specified by tag matching a regular expression.
	--context <FILENAME>  Clone specified by context file.
	--darcs-hash <HASH>   Clone specified by hash. WARN: hash order is fickle by design.
	--hash <HASH>         Expected hash.
	--help                Show this help message.
```

Additionally I moved from “get” to “clone” as a result of

```sh-session
$ darcs --version
2.18.5 (release)
$ darcs get --help | head -n2
Usage: darcs get [OPTION]... <REPOSITORY> [<DIRECTORY>]
Alias for `darcs clone'.
```

After doing this patch tho, I think it is a bad design to have `rev` doing double duty held up by an implicit regex. I think there should be an explicit `tag` + `rev` (since `hash` is taken) + `assert` on the pattern to make it explicit to the user. This would be a breaking change, but I feel it is better for users.

 I am also not sold on the the flag name `--darcs-hash`… maybe `--patch-hash` or just `--patch`?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
