### PR TITLE
nushell: 0.106.1 -> 0.107.0, nushellPlugins.*: update

### DIFF
--- a/pkgs/shells/nushell/default.nix
+++ b/pkgs/shells/nushell/default.nix
@@ -23,7 +23,7 @@ let
   # NOTE: when updating this to a new non-patch version, please also try to
   # update the plugins. Plugins only work if they are compiled for the same
   # major/minor version.
-  version = "0.106.1";
+  version = "0.107.0";
 in
 rustPlatform.buildRustPackage {
   pname = "nushell";
@@ -33,10 +33,10 @@ rustPlatform.buildRustPackage {
     owner = "nushell";
     repo = "nushell";
     tag = version;
-    hash = "sha256-VrGsdO7RiTlf8JK3MBMcgj0z4cWUklDwikMN5Pu6JQI=";
+    hash = "sha256-ghBuqkiVHvPxD4zBpvL6NG+qL54SD/aLZNZqWUK4a28=";
   };
 
-  cargoHash = "sha256-GSpR54QGiY9Yrs/A8neoKK6hMvSr3ORtNnwoz4GGprY=";
+  cargoHash = "sha256-HQy6maPKxreYPLni0/XETF/EEJqGGcpAurzf+QTVX18=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/shells/nushell/plugins/hcl.nix
+++ b/pkgs/shells/nushell/plugins/hcl.nix
@@ -33,5 +33,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/Yethal/nu_plugin_hcl";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ yethal ];
+    broken = true;
   };
 })

--- a/pkgs/shells/nushell/plugins/hcl.nix
+++ b/pkgs/shells/nushell/plugins/hcl.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nu_plugin_hcl";
-  version = "0.106.1";
+  version = "0.107.0";
 
   src = fetchFromGitHub {
     owner = "Yethal";
     repo = "nu_plugin_hcl";
     tag = finalAttrs.version;
-    hash = "sha256-LM5tDmPWmpHd4HNnWoEdDXdKUkFA8J8VeDFMw32JXLk=";
+    hash = "sha256-KtX1i3iAZcEHnDdceV4JyildA//y/pnIxK/U/NbSw5w=";
   };
 
-  cargoHash = "sha256-QCkNabv3pqtaRA7Ux5eiZPE/vRILlWKdQce7Gb0vzes=";
+  cargoHash = "sha256-CaPyAQgUpGBZx65j7ih4NOBR34rDpE0HQ425freGEOk=";
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
 
@@ -33,6 +33,5 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/Yethal/nu_plugin_hcl";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ yethal ];
-    broken = true;
   };
 })

--- a/pkgs/shells/nushell/plugins/highlight.nix
+++ b/pkgs/shells/nushell/plugins/highlight.nix
@@ -34,5 +34,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/cptpiepmatz/nu-plugin-highlight";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ mgttlinger ];
+    broken = true;
   };
 })

--- a/pkgs/shells/nushell/plugins/semver.nix
+++ b/pkgs/shells/nushell/plugins/semver.nix
@@ -7,16 +7,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nu_plugin_semver";
-  version = "0.11.6";
+  version = "0.11.7";
 
   src = fetchFromGitHub {
     owner = "abusch";
     repo = "nu_plugin_semver";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-JF+aY7TW0NGo/E1eFVpBZQoxLxuGja8DSoJy4xgi1Lk=";
+    hash = "sha256-RrkOVo5MTLtVAp6d+Y1oP3jwImXeofXRdGXRFlwYA9I=";
   };
 
-  cargoHash = "sha256-609w/7vmKcNv1zSfd+k6TTeU2lQuzHX3W5Y8EqKIiAM=";
+  cargoHash = "sha256-vKrwoPn8MLjzTrR7p3SH7I2LKKieJCm4tuarp4hktKA=";
 
   passthru.update-script = nix-update-script { };
 

--- a/pkgs/shells/nushell/plugins/skim.nix
+++ b/pkgs/shells/nushell/plugins/skim.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nu_plugin_skim";
-  version = "0.17.0";
+  version = "0.19.0";
 
   src = fetchFromGitHub {
     owner = "idanarye";
     repo = "nu_plugin_skim";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2ZrN+0qdz7fgBS9KPogUIemkzO+uJdAvSOEBkfl7MI4=";
+    hash = "sha256-7yG1/HdapH/Jf6I/cw/1dCjVSwqMPd7XMAK9tG7IqRg=";
   };
 
-  cargoHash = "sha256-8oAfnZ+uIckoj3QXb8ypJw/kC2VnMWRMl/oOoRkbtok=";
+  cargoHash = "sha256-FqB4EaHQYSOyT1Oda1FHSbmL4Wrza/9m3nkI01GowUE=";
 
   nativeBuildInputs = lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
 

--- a/pkgs/shells/nushell/plugins/units.nix
+++ b/pkgs/shells/nushell/plugins/units.nix
@@ -30,5 +30,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/JosephTLyons/nu_plugin_units";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ mgttlinger ];
+    broken = true;
   };
 })


### PR DESCRIPTION
https://www.nushell.sh/blog/2025-09-02-nushell_0_107_0.html

Update plugins:
- hcl
- semver
- skim

Mark plugin packages as broken:
- highlight
- units

closes https://github.com/NixOS/nixpkgs/issues/439911

Resolved #450157

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
