### PR TITLE
libax25: new src target and enforce strictDeps

### DIFF
--- a/pkgs/by-name/li/libax25/package.nix
+++ b/pkgs/by-name/li/libax25/package.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "libax25";
   version = "0.0.12-rc5";
 
+  strictDeps = true;
+
   nativeBuildInputs = [
     autoreconfHook
     glibc

--- a/pkgs/by-name/li/libax25/package.nix
+++ b/pkgs/by-name/li/libax25/package.nix
@@ -1,7 +1,8 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  autoreconfHook,
   glibc,
 }:
 
@@ -9,13 +10,19 @@ stdenv.mkDerivation rec {
   pname = "libax25";
   version = "0.0.12-rc5";
 
-  buildInputs = [ glibc ] ++ lib.optionals stdenv.hostPlatform.isStatic [ glibc.static ];
+  nativeBuildInputs = [
+    autoreconfHook
+    glibc
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isStatic [ glibc.static ];
 
-  # Due to recent unsolvable administrative domain problems with linux-ax25.org,
-  # the new domain is linux-ax25.in-berlin.de
-  src = fetchurl {
-    url = "https://linux-ax25.in-berlin.de/pub/ax25-lib/libax25-${version}.tar.gz";
-    hash = "sha256-vxV5GVDOHr38N/512ArZpnZ+a7FTbXBNpoSJkc9DI98=";
+  # src from linux-ax25.in-berlin.de remote has been
+  # unreliable, pointing to github mirror from the radiocatalog
+  src = fetchFromGitHub {
+    owner = "radiocatalog";
+    repo = "libax25";
+    tag = "libax25-${finalAttrs.version}";
+    hash = "sha256-MQDrroRZhtWJiu3N7FQVp5/sqe1MDjdwKu4ufnfHTUM=";
   };
 
   configureFlags = [ "--sysconfdir=/etc" ];

--- a/pkgs/by-name/li/libax25/package.nix
+++ b/pkgs/by-name/li/libax25/package.nix
@@ -6,7 +6,7 @@
   glibc,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libax25";
   version = "0.0.12-rc5";
 
@@ -39,4 +39,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ sarcasticadmin ];
     platforms = platforms.linux;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Moving to a mirror of the src at radiocatalog on GitHub since https://linux-ax25.in-berlin.de is unreliable.

failures:
      - https://nixpkgs-update-logs.nix-community.org/libax25/2025-08-22.log
      - https://nixpkgs-update-logs.nix-community.org/libax25/2025-09-01.log
      - https://nixpkgs-update-logs.nix-community.org/libax25/2025-09-13.log

`autoreconfHook` is now needed in nativeBuildInputs after moving from `fetchurl`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
