### PR TITLE
rtl8852cu: init at `15788c8`

### DIFF
--- a/pkgs/os-specific/linux/rtl8852cu/default.nix
+++ b/pkgs/os-specific/linux/rtl8852cu/default.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  kernel,
+  bc,
+  nukeReferences,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rtl8852cu";
+  version = "${kernel.version}-unstable-20240510";
+
+  src = fetchFromGitHub {
+    owner = "morrownr";
+    repo = "rtl8852cu-20240510";
+    rev = "15788c86a7ae14dd74cac7e475b6f4a9953a2c8c";
+    hash = "sha256-nd6SoIG28Y29OXlwofrIqH8UNBVq9/TVsapX+ADuw10=";
+  };
+
+  nativeBuildInputs = [
+    bc
+    nukeReferences
+  ]
+  ++ kernel.moduleBuildDependencies;
+  hardeningDisable = [
+    "pic"
+    "format"
+  ];
+
+  postPatch = ''
+    substituteInPlace ./Makefile \
+      --replace-fail /sbin/depmod \# \
+      --replace-fail '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/" \
+      --replace-fail 'cp -f $(MODULE_NAME).conf /etc/modprobe.d' "" \
+      --replace-fail "sh edit-options.sh" ""
+    substituteInPlace ./platform/i386_pc.mk \
+      --replace-fail /lib/modules "${kernel.dev}/lib/modules"
+  '';
+
+  makeFlags = [
+    "ARCH=${stdenv.hostPlatform.linuxArch}"
+    ("CONFIG_PLATFORM_I386_PC=" + (if stdenv.hostPlatform.isx86 then "y" else "n"))
+    ("CONFIG_PLATFORM_ARM_RPI=" + (if stdenv.hostPlatform.isAarch then "y" else "n"))
+  ]
+  ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+  ];
+
+  preInstall = ''
+    mkdir -p "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
+    mkdir -p "$out/usr/lib/systemd/system-sleep"
+  '';
+
+  postInstall = ''
+    nuke-refs $out/lib/modules/*/kernel/net/wireless/*.ko
+  '';
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-designated-init"; # Similar to 79c1cf6
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Driver for Realtek rtl8852cu and rtl8832cu chipsets";
+    homepage = "https://github.com/morrownr/rtl8852cu-20240510";
+    license = lib.licenses.gpl2Only;
+    platforms = [ "x86_64-linux" ];
+    broken = kernel.kernelOlder "6" && kernel.isHardened; # Similar to 79c1cf6
+    maintainers = with lib.maintainers; [ u2x1 ];
+  };
+})

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -529,6 +529,8 @@ in
 
         rtl8852bu = callPackage ../os-specific/linux/rtl8852bu { };
 
+        rtl8852cu = callPackage ../os-specific/linux/rtl8852cu { };
+
         rtl88xxau-aircrack = callPackage ../os-specific/linux/rtl88xxau-aircrack { };
 
         rtl8821au = callPackage ../os-specific/linux/rtl8821au { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add the RTL8852CU driver, based on @lonyelon's package for [`rtl8852bu`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/rtl8852bu/default.nix). Tested on my device:
```
Bus 004 Device 003: ID 0bda:c832 Realtek Semiconductor Corp. 802.11ax WLAN Adapter
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
