### PR TITLE
asterisk: 20.15.1 -> 20.15.2

### DIFF
--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -163,12 +163,7 @@ let
       };
     };
 
-  pjproject_2_14_1 = fetchurl {
-    url = "https://raw.githubusercontent.com/asterisk/third-party/master/pjproject/2.14.1/pjproject-2.14.1.tar.bz2";
-    hash = "sha256-MtsK8bOc0fT/H/pUydqK/ahMIVg8yiRDt3TSM1uhUFQ=";
-  };
-
-  pjproject_2_15_1 = fetchurl {
+  pjproject = fetchurl {
     url = "https://raw.githubusercontent.com/asterisk/third-party/master/pjproject/2.15.1/pjproject-2.15.1.tar.bz2";
     hash = "sha256-WLuDzsTUMfSNAG5FXYIWaEUPjPa2yV8JDe9HBi+jpgw=";
   };
@@ -191,13 +186,10 @@ let
   versions = lib.mapAttrs (
     _:
     { version, sha256 }:
-    let
-      pjsip = if lib.versionAtLeast version "20" then pjproject_2_15_1 else pjproject_2_14_1;
-    in
     common {
       inherit version sha256;
       externals = {
-        "externals_cache/${pjsip.name}" = pjsip;
+        "externals_cache/${pjproject.name}" = pjproject;
         "addons/mp3" = mp3-204;
       };
     }

--- a/pkgs/servers/asterisk/versions.json
+++ b/pkgs/servers/asterisk/versions.json
@@ -1,18 +1,18 @@
 {
   "asterisk_18": {
-    "sha256": "0df8be2f57779019895628363a11f74ea356068cca983462ec0feb72528fc8e9",
-    "version": "18.26.3"
+    "sha256": "a17f511bfa092c8fa9eccd3a5ecf5f728ccdcf2b1a04d2c06e7177d96c3c9ee1",
+    "version": "18.26.4"
   },
   "asterisk_20": {
-    "sha256": "fa286ac7a024e685233af6fde54a68a21c8e9934b438da878fb3cff080a6346c",
-    "version": "20.15.1"
+    "sha256": "4bbe0aaecc0e7294780269a5dc7ff78a85c58cf26ffc63dd63be5406eef0b687",
+    "version": "20.15.2"
   },
   "asterisk_21": {
-    "sha256": "811c5b8c501004ee378e77efd009892b366a03a508cfc51eead52396cbf65b2c",
-    "version": "21.10.1"
+    "sha256": "9624e807a1138cabed14431a326c9870e53fc132738dbbd61314abc027785d94",
+    "version": "21.10.2"
   },
   "asterisk_22": {
-    "sha256": "cbe67229f813ccf5e545fbda1fc05eb221897bf03393917390f8f6235cc62179",
-    "version": "22.5.1"
+    "sha256": "5061c852fd850b17e6be9d866c8e73298471883fc5e3ccd5a24b3e1364e24218",
+    "version": "22.5.2"
   }
 }


### PR DESCRIPTION
Replace/take over from https://github.com/NixOS/nixpkgs/pull/439490:

That asterisk 18 update requires pjproject to be updated from 2.14.1 to 2.15.1 which is accomplished by the pull request at hand.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

More:

- [ ] `nixpkgs-review` skipped due to https://github.com/NixOS/nixpkgs/issues/439496
- [x] sent/received some faxes with iaxmodem, using dailplan functions `Busy`, `Wait`, `Answer`, `Playback`, `Goto`, `Dial` (with asterisk 18,20,22)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
