### PR TITLE
matrix-tuwunel: 1.3.0->1.4.1

### DIFF
--- a/pkgs/by-name/ma/matrix-tuwunel/doctest-fix.patch
+++ b/pkgs/by-name/ma/matrix-tuwunel/doctest-fix.patch
@@ -1,0 +1,13 @@
+diff --git i/src/core/utils/debug.rs w/src/core/utils/debug.rs
+index 31163a54..859dd9a9 100644
+--- i/src/core/utils/debug.rs
++++ w/src/core/utils/debug.rs
+@@ -28,7 +28,7 @@ fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+ /// use tuwunel_core::utils::debug::slice_truncated;
+ ///
+ /// #[tracing::instrument(fields(foos = slice_truncated(foos, 42)))]
+-/// fn bar(foos: &[&str]);
++/// fn bar(foos: &[&str]) { }
+ /// ```
+ pub fn slice_truncated<T: fmt::Debug>(
+ 	slice: &[T],

--- a/pkgs/by-name/ma/matrix-tuwunel/package.nix
+++ b/pkgs/by-name/ma/matrix-tuwunel/package.nix
@@ -85,16 +85,20 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "matrix-tuwunel";
-  version = "1.3.0";
+  version = "1.4.1";
 
   src = fetchFromGitHub {
     owner = "matrix-construct";
     repo = "tuwunel";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RuvGoXe/O48mQ4/rN+fh2N1NZ4uhvdtI1q4tRM/bRSE=";
+    hash = "sha256-41oQfqdsHjm3fBaG+y+Q7eru7LzSIwOc6K5A29Jmt2c=";
   };
 
-  cargoHash = "sha256-LwVJe9EqBT7x7eBTzvo4Lu1geNI7CWpsIDNWL8AAg+U=";
+  cargoHash = "sha256-bTLKsWsma+a4ZD5ujJJ0xYvk769umIsTNE21KUTJj0U=";
+
+  patches = [
+    ./doctest-fix.patch
+  ];
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Bump tuwunel from 1.3.0 to 1.4.1.  This includes the [project hydra/room v12/room state vulnerability](https://matrix.org/blog/2025/07/security-predisclosure/) fix.

Changelogs:
- [1.4.0](https://github.com/matrix-construct/tuwunel/releases/tag/v1.4.0)
- [1.4.1](https://github.com/matrix-construct/tuwunel/releases/tag/v1.4.1)

There's [a broken doctest](https://github.com/matrix-construct/tuwunel/pull/152) in this release, so we fix it with a patch.  The alternative would be to disable checks with `doCheck = false`, but the patch is very simple and is more fine-grained.

I upgraded my own server to this version and it seems to work fine.  I haven't tried any of the room v12 stuff, but that's a separate matter.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
