### PR TITLE
vscode-extensions.elijah-potter.harper: init at 0.61.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1612,6 +1612,8 @@ let
         };
       };
 
+      elijah-potter.harper = callPackage ./elijah-potter.harper { };
+
       elixir-lsp.vscode-elixir-ls = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "elixir-ls";

--- a/pkgs/applications/editors/vscode/extensions/elijah-potter.harper/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/elijah-potter.harper/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  vscode-utils,
+  vscode-extension-update-script,
+  jq,
+  harper,
+  moreutils,
+  ...
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "harper";
+    publisher = "elijah-potter";
+    version = harper.version;
+    hash = "sha256-m9PN1BZf6rLrNnX8meX2TjGx8zGLl0GgnHEgQirh9Oc=";
+  };
+
+  nativeBuildInputs = [
+    jq
+    moreutils
+  ];
+
+  postInstall = ''
+    cd "$out/$installPrefix"
+    jq '.contributes.configuration.properties."harper.path".default = "${harper}/bin/harper-ls"' package.json | sponge package.json
+  '';
+  passthru.updateScript = vscode-extension-update-script { };
+
+  meta = {
+    changelog = "https://github.com/Automattic/harper/releases/tag/v${harper.version}";
+    description = "The grammar checker for developers as a Visual Studio Code extension";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=elijah-potter.harper";
+    homepage = "https://github.com/automattic/harper";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ MasterEvarior ];
+  };
+}


### PR DESCRIPTION
I've added a new Visual Studio Code extension for [Harper](https://github.com/Automattic/harper), which is a local grammar checker. Harper is already packaged and pretty up-to-date.

Everything is pretty standard, only thing I needed to change is set the path to the executable to the one in the nix-store. I've done this through setting a setting in the extension

I did not execute any tests because I did not find any that I thought were applicable.

https://github.com/Automattic/harper/releases/tag/v0.61.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
