### PR TITLE
{crystal_1_14,crystal_1_15,crystal_1_16,crystal_1_17}: bump LLVM; crystal_1_11: drop

### DIFF
--- a/pkgs/by-name/ah/ahk_x11/package.nix
+++ b/pkgs/by-name/ah/ahk_x11/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  crystal_1_11,
+  crystal,
   copyDesktopItems,
   gtk3,
   libxkbcommon,
@@ -11,6 +11,8 @@
   openbox,
   xvfb-run,
   xdotool,
+  nix-update-script,
+  versionCheckHook,
 
   buildDevTarget ? false, # the dev version prints debug info
 }:
@@ -18,7 +20,7 @@
 # NOTICE: AHK_X11 from this package does not support compiling scripts into portable executables.
 let
   pname = "ahk_x11";
-  version = "1.0.4-unstable-2025-01-30"; # 1.0.4 cannot build on Crystal 1.12 or below.
+  version = "1.0.5-unstable-2025-09-04";
 
   inherit (xorg)
     libXinerama
@@ -27,9 +29,6 @@ let
     libXi
     ;
 
-  # See upstream README. Crystal 1.11 or below is needed to work around phil294/AHK_X11#89.
-  crystal = crystal_1_11;
-
 in
 crystal.buildCrystalPackage {
   inherit pname version;
@@ -37,8 +36,8 @@ crystal.buildCrystalPackage {
   src = fetchFromGitHub {
     owner = "phil294";
     repo = "AHK_X11";
-    rev = "66eb5208d95f4239822053c7d35f32bc62d57573"; # tag = version;
-    hash = "sha256-KzD5ExYPRYgsYO+/hlnoQpBJwokjaK5lYL2kobI2XQ0=";
+    rev = "f5375887dec3953c4cb3d78271821645bc3840f2";
+    hash = "sha256-GTcbwCVWnC+KP2qLArEUIUMs5S0vpkA4gJHQpWP1TNg=";
     fetchSubmodules = true;
   };
 
@@ -99,6 +98,11 @@ crystal.buildCrystalPackage {
   # https://github.com/phil294/AHK_X11?tab=readme-ov-file#accessibility
   # I don't know how to fix it for xvfb and openbox.
   doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "AutoHotkey for X11";

--- a/pkgs/by-name/ah/ahk_x11/shards.nix
+++ b/pkgs/by-name/ah/ahk_x11/shards.nix
@@ -6,17 +6,17 @@
   };
   cron_parser = {
     url = "https://github.com/kostya/cron_parser.git";
-    tag = "v0.4.0";
+    rev = "v0.4.0";
     sha256 = "17fgg2nvyx99v05l10h6cnxfr7swz8yaxhmnk4l47kg2spi8w90a";
   };
   future = {
     url = "https://github.com/crystal-community/future.cr.git";
-    tag = "v1.0.0";
+    rev = "v1.0.0";
     sha256 = "1mji2djkrf4vxgs432kgkzxx54ybzk636789k2vsws3sf14l74i8";
   };
   gi-crystal = {
     url = "https://github.com/hugopl/gi-crystal.git";
-    tag = "v0.22.1";
+    rev = "v0.22.1";
     sha256 = "1bwsr5i6cmvnc72qdnmq4v6grif1hahrc7s6js2ivdrfix72flyg";
   };
   gtk3 = {
@@ -26,7 +26,7 @@
   };
   harfbuzz = {
     url = "https://github.com/hugopl/harfbuzz.cr.git";
-    tag = "v0.2.0";
+    rev = "v0.2.0";
     sha256 = "06wgqxwyib5416yp53j2iwcbr3bl4jjxb1flm7z103l365par694";
   };
   notify = {
@@ -36,12 +36,12 @@
   };
   pango = {
     url = "https://github.com/hugopl/pango.cr.git";
-    tag = "v0.3.1";
+    rev = "v0.3.1";
     sha256 = "0xlf127flimnll875mcq92q7xsi975rrgdpcpmnrwllhdhfx9qmv";
   };
   tasker = {
     url = "https://github.com/spider-gazelle/tasker.git";
-    tag = "v2.1.4";
+    rev = "v2.1.4";
     sha256 = "0254sl279nrw5nz43dz5gm89ah1zrw5bvxfma81navpx5gfg9pyb";
   };
   x11 = {

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -17,7 +17,9 @@
   libyaml,
   libffi,
   llvmPackages_15,
-  llvmPackages_18,
+  llvmPackages_19,
+  llvmPackages_20,
+  llvmPackages_21,
   makeWrapper,
   openssl,
   pcre2,
@@ -308,7 +310,7 @@ rec {
     version = "1.14.1";
     sha256 = "sha256-cQWK92BfksOW8GmoXn4BmPGJ7CLyLAeKccOffQMh5UU=";
     binary = binaryCrystal_1_10;
-    llvmPackages = llvmPackages_18;
+    llvmPackages = llvmPackages_19;
     doCheck = false; # Some compiler spec problems on x86-64_linux with the .0 release
   };
 
@@ -316,7 +318,7 @@ rec {
     version = "1.15.1";
     sha256 = "sha256-L/Q8yZdDq/wn4kJ+zpLfi4pxznAtgjxTCbLnEiCC2K0=";
     binary = binaryCrystal_1_10;
-    llvmPackages = llvmPackages_18;
+    llvmPackages = llvmPackages_19;
     doCheck = false;
   };
 
@@ -324,7 +326,7 @@ rec {
     version = "1.16.3";
     sha256 = "sha256-U9H1tHUMyDNicZnXzEccDki5bGXdV0B2Wu2PyCksPVI=";
     binary = binaryCrystal_1_10;
-    llvmPackages = llvmPackages_18;
+    llvmPackages = llvmPackages_20;
     doCheck = false;
   };
 
@@ -332,7 +334,7 @@ rec {
     version = "1.17.1";
     sha256 = "sha256-+wHhozPhpIsfQy1Lw+V48zvuWCfXzT4IC9KA1AU/DLw=";
     binary = binaryCrystal_1_10;
-    llvmPackages = llvmPackages_18;
+    llvmPackages = llvmPackages_21;
     doCheck = false;
   };
 

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -16,7 +16,6 @@
   libxml2,
   libyaml,
   libffi,
-  llvmPackages_15,
   llvmPackages_19,
   llvmPackages_20,
   llvmPackages_21,
@@ -170,11 +169,7 @@ let
         export threads=$NIX_BUILD_CORES
         export CRYSTAL_CACHE_DIR=$TMP
         export MACOSX_DEPLOYMENT_TARGET=10.11
-
-        # Available since 1.13.0 https://github.com/crystal-lang/crystal/pull/14574
-        if [[ -f src/SOURCE_DATE_EPOCH ]]; then
-          export SOURCE_DATE_EPOCH="$(<src/SOURCE_DATE_EPOCH)"
-        fi
+        export SOURCE_DATE_EPOCH="$(<src/SOURCE_DATE_EPOCH)"
       '';
 
       strictDeps = true;
@@ -296,14 +291,6 @@ rec {
       x86_64-darwin = "sha256-5kkObQl0VIO6zqQ8TYl0JzYyUmwfmPE9targpfwseSQ=";
       aarch64-linux = "sha256-AzFz+nrU/HJmCL1hbCKXf5ej/uypqV1GJPVLQ4J3778=";
     };
-  };
-
-  # When removing this version, also remove checks for src/SOURCE_DATE_EPOCH existence
-  crystal_1_11 = generic {
-    version = "1.11.2";
-    sha256 = "sha256-BBEDWqFtmFUNj0kuGBzv71YHO3KjxV4d2ySTCD4HhLc=";
-    binary = binaryCrystal_1_10;
-    llvmPackages = llvmPackages_15;
   };
 
   crystal_1_14 = generic {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -652,6 +652,7 @@ mapAliases {
   crystal_1_7 = throw "'crystal_1_7' has been removed as it is obsolete and no longer used in the tree. Consider using 'crystal' instead"; # Added 2025-02-13
   crystal_1_8 = throw "'crystal_1_8' has been removed as it is obsolete and no longer used in the tree. Consider using 'crystal' instead"; # Added 2025-02-13
   crystal_1_9 = throw "'crystal_1_9' has been removed as it is obsolete and no longer used in the tree. Consider using 'crystal' instead"; # Added 2025-02-13
+  crystal_1_11 = throw "'crystal_1_11' has been removed as it is obsolete and no longer used in the tree. Consider using 'crystal' instead"; # Added 2025-09-04
   crystal_1_12 = throw "'crystal_1_12' has been removed as it is obsolete and no longer used in the tree. Consider using 'crystal' instead"; # Added 2025-02-19
   clash-geoip = throw "'clash-geoip' has been removed. Consider using 'dbip-country-lite' instead."; # added 2024-10-19
   clash-verge = throw "'clash-verge' has been removed, as it was broken and unmaintained. Consider using 'clash-verge-rev' or 'clash-nyanpasu' instead"; # Added 2024-09-17

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4720,7 +4720,6 @@ with pkgs;
   corretto21 = javaPackages.compiler.corretto21;
 
   inherit (callPackage ../development/compilers/crystal { })
-    crystal_1_11
     crystal_1_14
     crystal_1_15
     crystal_1_16


### PR DESCRIPTION
Following up on https://github.com/NixOS/nixpkgs/pull/437526#discussion_r2304022147 for the bumps.

LLVM 15 is being removed for the 25.11 release. ~~`ahk_x11` is the only casualty here; hopefully the issues with supported Crystal versions can be worked out, or in the worst case the changes for newer LLVM support from later versions of Crystal could be backported to the 1.11 codebase?~~

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `c0a8ca9803645de3fd491c8f3ea00513870e87b7`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 1 package marked as broken and skipped:</summary>
  <ul>
    <li>ahk_x11</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 30 packages built:</summary>
  <ul>
    <li>ameba</li>
    <li>ameba-ls</li>
    <li>amqpcat</li>
    <li>blahaj</li>
    <li>collision</li>
    <li>crystal</li>
    <li>crystal.bin</li>
    <li>crystal.lib</li>
    <li>crystal2nix</li>
    <li>crystal_1_14</li>
    <li>crystal_1_14.bin</li>
    <li>crystal_1_14.lib</li>
    <li>crystal_1_15</li>
    <li>crystal_1_15.bin</li>
    <li>crystal_1_15.lib</li>
    <li>crystal_1_17</li>
    <li>crystal_1_17.bin</li>
    <li>crystal_1_17.lib</li>
    <li>crystalline</li>
    <li>gi-crystal</li>
    <li>icr</li>
    <li>invidious</li>
    <li>kakoune-cr</li>
    <li>lucky-cli</li>
    <li>mint</li>
    <li>oq</li>
    <li>rtfm</li>
    <li>shards</li>
    <li>thicket</li>
    <li>tmuxPlugins.fingers</li>
  </ul>
</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
