### PR TITLE
nixos/pmount: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -124,6 +124,8 @@
 
 - [Prometheus Storagebox Exporter](https://github.com/fleaz/prometheus-storagebox-exporter), a Prometheus exporter for Hetzner storage boxes.
 
+- [pmount](https://salsa.debian.org/debian/pmount), a tool that allows normal users to mount removable devices without requiring root privileges Available at [programs.pmount](#opt-programs.pmount.enable).
+
 - [lemurs](https://github.com/coastalwhite/lemurs), a customizable TUI display/login manager. Available at [services.displayManager.lemurs](#opt-services.displayManager.lemurs.enable).
 
 - [paisa](https://github.com/ananthakumaran/paisa), a personal finance tracker and dashboard. Available as [services.paisa](#opt-services.paisa.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -288,6 +288,7 @@
   ./programs/partition-manager.nix
   ./programs/pay-respects.nix
   ./programs/plotinus.nix
+  ./programs/pmount.nix
   ./programs/pqos-wrapper.nix
   ./programs/projecteur.nix
   ./programs/proxychains.nix

--- a/nixos/modules/programs/pmount.nix
+++ b/nixos/modules/programs/pmount.nix
@@ -1,0 +1,44 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib.options) mkEnableOption mkPackageOption;
+  inherit (lib.modules) mkIf;
+  inherit (lib.meta) getExe';
+
+  cfg = config.programs.pmount;
+
+  mkSetuidWrapper = package: command: {
+    setuid = true;
+    owner = "root";
+    group = "root";
+    source = getExe' package command;
+  };
+in
+{
+  options.programs.pmount = {
+    enable = mkEnableOption ''
+      pmount, a tool that allows normal users to mount removable devices
+      without requiring root privileges
+    '';
+
+    package = mkPackageOption pkgs "pmount" { };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    security.wrappers = {
+      pmount = mkSetuidWrapper cfg.package "pmount";
+      pumount = mkSetuidWrapper cfg.package "pumount";
+    };
+
+    systemd.tmpfiles.rules = [
+      "d /media - root root - -"
+    ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add `programs.pmount` to actually make pmount work correctly.
- The package is added to `environment.systemPackages` for other outputs (man).
- pmount needs setuid wrappers to set the right permissions for the user.
- pmount uses /media by default.

Related PR https://github.com/NixOS/nixpkgs/pull/433847.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
