### PR TITLE
lixPackageSets.lix_2_90: drop

### DIFF
--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -131,42 +131,6 @@ in
 lib.makeExtensible (self: {
   inherit makeLixScope;
 
-  lix_2_90 = self.makeLixScope {
-    attrName = "lix_2_90";
-
-    lix-args = rec {
-      version = "2.90.0";
-
-      src = fetchFromGitHub {
-        owner = "lix-project";
-        repo = "lix";
-        rev = version;
-        hash = "sha256-f8k+BezKdJfmE+k7zgBJiohtS3VkkriycdXYsKOm3sc=";
-      };
-
-      docCargoDeps = rustPlatform.fetchCargoVendor {
-        name = "lix-doc-${version}";
-        inherit src;
-        sourceRoot = "${src.name or src}/lix-doc";
-        hash = "sha256-VPcrf78gfLlkTRrcbLkPgLOk0o6lsOJBm6HYLvavpNU=";
-      };
-
-      knownVulnerabilities = [
-        "Lix 2.90 is vulnerable to CVE-2025-46415 and CVE-2025-46416 and will not receive updates."
-      ];
-    };
-
-    nix-eval-jobs-args = {
-      version = "2.90.0";
-      src = fetchgit {
-        url = "https://git.lix.systems/lix-project/nix-eval-jobs.git";
-        # https://git.lix.systems/lix-project/nix-eval-jobs/commits/branch/release-2.90
-        rev = "9c23772cf25e0d891bef70b7bcb7df36239672a5";
-        hash = "sha256-oT273pDmYzzI7ACAFUOcsxtT6y34V5KF7VBSqTza7j8=";
-      };
-    };
-  };
-
   lix_2_91 = self.makeLixScope {
     attrName = "lix_2_91";
 
@@ -315,7 +279,6 @@ lib.makeExtensible (self: {
           self.${version}.lix;
     in
     lib.dontRecurseIntoAttrs {
-      lix_2_90 = mkAlias "lix_2_90";
       lix_2_91 = mkAlias "lix_2_91";
       # NOTE: Do not add new versions of Lix here.
       stable = mkAlias "stable";


### PR DESCRIPTION
lix_2_90 has been marked insecure since 2025-06-24 due to two CVEs.

It now fails to build with `error: 'lowdown_opts' has no non-static data member named 'cols'`

I don't see any need to keep a broken insecure version of lix around. If there is a need the build should be fixed, and this can be closed.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
