### PR TITLE
nixDependencies: use `override` only

### DIFF
--- a/pkgs/by-name/aw/aws-sdk-cpp/package.nix
+++ b/pkgs/by-name/aw/aws-sdk-cpp/package.nix
@@ -14,6 +14,8 @@
   apis ? [ "*" ],
   # Whether to enable AWS' custom memory management.
   customMemoryManagement ? true,
+  # Builds in 2+h with 2 cores, and ~10m with a big-parallel builder.
+  requiredSystemFeatures ? [ "big-parallel" ],
 }:
 
 let
@@ -116,8 +118,7 @@ stdenv.mkDerivation rec {
 
   __darwinAllowLocalNetworking = true;
 
-  # Builds in 2+h with 2 cores, and ~10m with a big-parallel builder.
-  requiredSystemFeatures = [ "big-parallel" ];
+  inherit requiredSystemFeatures;
 
   passthru = {
     tests = {

--- a/pkgs/by-name/bo/boehmgc/package.nix
+++ b/pkgs/by-name/bo/boehmgc/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
-  # doc: https://github.com/ivmai/bdwgc/blob/v8.2.8/doc/README.macros (LARGE_CONFIG)
+  # doc: https://github.com/bdwgc/bdwgc/blob/v8.2.8/doc/README.macros (LARGE_CONFIG)
   enableLargeConfig ? false,
   enableMmap ? true,
   enableStatic ? false,
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "8.2.8";
 
   src = fetchFromGitHub {
-    owner = "ivmai";
+    owner = "bdwgc";
     repo = "bdwgc";
     rev = "v${finalAttrs.version}";
     hash = "sha256-UQSLK/05uPal6/m+HMz0QwXVII1leonlmtSZsXjJ+/c=";
@@ -45,15 +45,15 @@ stdenv.mkDerivation (finalAttrs: {
       defineFlag = flag: "-D${flag}";
 
       # This stanza can be dropped when a release fixes this issue:
-      #   https://github.com/ivmai/bdwgc/issues/376
+      #   https://github.com/bdwgc/bdwgc/issues/376
       # The version is checked with == instead of versionAtLeast so we
       # don't forget to disable the fix (and if the next release does
       # not fix the problem the test failure will be a reminder to
       # extend the set of versions requiring the workaround).
       noSoftVDB = lib.optional (stdenv.hostPlatform.isPower64 && finalAttrs.version == "8.2.8") (
         # do not use /proc primitives to track dirty bits; see:
-        # https://github.com/ivmai/bdwgc/issues/479#issuecomment-1279687537
-        # https://github.com/ivmai/bdwgc/blob/54522af853de28f45195044dadfd795c4e5942aa/include/private/gcconfig.h#L741
+        # https://github.com/bdwgc/bdwgc/issues/479#issuecomment-1279687537
+        # https://github.com/bdwgc/bdwgc/blob/54522af853de28f45195044dadfd795c4e5942aa/include/private/gcconfig.h#L741
         "NO_SOFT_VDB"
       );
 
@@ -101,7 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
       Alternatively, the garbage collector may be used as a leak detector for
       C or C++ programs, though that is not its primary goal.
     '';
-    changelog = "https://github.com/ivmai/bdwgc/blob/v${finalAttrs.version}/ChangeLog";
+    changelog = "https://github.com/bdwgc/bdwgc/blob/v${finalAttrs.version}/ChangeLog";
     license = "https://hboehm.info/gc/license.txt"; # non-copyleft, X11-style license
     maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;

--- a/pkgs/tools/package-management/nix/dependencies.nix
+++ b/pkgs/tools/package-management/nix/dependencies.nix
@@ -20,18 +20,19 @@ regular@{
       initialMarkStackSize = 1048576;
     };
 
-    aws-sdk-cpp =
-      (regular.aws-sdk-cpp.override {
-        apis = [
-          "identity-management"
-          "s3"
-          "transfer"
-        ];
-        customMemoryManagement = false;
-      }).overrideAttrs
-        {
-          # only a stripped down version is build which takes a lot less resources to build
-          requiredSystemFeatures = [ ];
-        };
+    aws-sdk-cpp = regular.aws-sdk-cpp.override {
+      # Nix only needs these AWS APIs.
+      apis = [
+        "identity-management"
+        "s3"
+        "transfer"
+      ];
+
+      # Don't use AWS' custom memory management.
+      customMemoryManagement = false;
+
+      # only a stripped down version is built which takes a lot less resources to build
+      requiredSystemFeatures = [ ];
+    };
   };
 }

--- a/pkgs/tools/package-management/nix/dependencies.nix
+++ b/pkgs/tools/package-management/nix/dependencies.nix
@@ -8,19 +8,17 @@ regular@{
 
 {
   scopeFunction = scope: {
-    boehmgc =
-      (regular.boehmgc.override {
-        enableLargeConfig = true;
-      }).overrideAttrs
-        (attrs: {
-          # Increase the initial mark stack size to avoid stack
-          # overflows, since these inhibit parallel marking (see
-          # GC_mark_some()). To check whether the mark stack is too
-          # small, run Nix with GC_PRINT_STATS=1 and look for messages
-          # such as `Mark stack overflow`, `No room to copy back mark
-          # stack`, and `Grew mark stack to ... frames`.
-          NIX_CFLAGS_COMPILE = "-DINITIAL_MARK_STACK_SIZE=1048576";
-        });
+    boehmgc = regular.boehmgc.override {
+      enableLargeConfig = true;
+
+      # Increase the initial mark stack size to avoid stack overflows, since these inhibit parallel
+      # marking (see `GC_mark_some()` in `mark.c`).
+      #
+      # Run Nix with `GC_PRINT_STATS=1` set to see if the mark stack is too small.
+      # Look for messages such as `Mark stack overflow`, `No room to copy back mark stack`, and
+      # `Grew mark stack to ... frames`.
+      initialMarkStackSize = 1048576;
+    };
 
     aws-sdk-cpp =
       (regular.aws-sdk-cpp.override {


### PR DESCRIPTION
As reported in https://github.com/NixOS/nixpkgs/pull/437584#discussion_r2319480377, setting `NIX_CFLAGS_COMPILE` in an `overrideAttrs` has consequences which can cause the derivation to fail to evaluate on some systems.

See https://github.com/NixOS/nixpkgs/pull/421201 for more commentary on avoiding `overrideAttrs` in Nixpkgs.

What this PR does is introduce override flags to `boehmgc` and `aws-sdk-cpp` for the desired customizations. In `boehmgc`, rather than using the `NIX_CFLAGS_COMPILE` brutal instrument, we use the existing `CFLAGS_EXTRA` Makefile option.

I also noticed that the `boehmgc` master repository has been moved (no hash changes) so that's updated as well.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
