### PR TITLE
timr-tui: initialize at 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8546,6 +8546,12 @@
     githubId = 12560461;
     name = "Arne Keller";
   };
+  flokkq = {
+    email = "weberclemens07@gmail.com";
+    github = "flokkq";
+    githubId = 98653095;
+    name = "Clemens Weber";
+  };
   flokli = {
     email = "flokli@flokli.de";
     github = "flokli";

--- a/pkgs/by-name/op/opentelemetry-cpp/package.nix
+++ b/pkgs/by-name/op/opentelemetry-cpp/package.nix
@@ -65,21 +65,20 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  cmakeFlags =
-    [
-      (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
-      (lib.cmakeBool "WITH_BENCHMARK" false)
-      (lib.cmakeBool "WITH_OTLP_HTTP" enableHttp)
-      (lib.cmakeBool "WITH_OTLP_GRPC" enableGrpc)
-      (lib.cmakeBool "WITH_PROMETHEUS" enablePrometheus)
-      (lib.cmakeBool "WITH_ELASTICSEARCH" enableElasticSearch)
-      (lib.cmakeBool "WITH_ZIPKIN" enableZipkin)
-      (lib.cmakeFeature "OTELCPP_PROTO_PATH" "${opentelemetry-proto}")
-    ]
-    ++ lib.optionals (cxxStandard != null) [
-      (lib.cmakeFeature "CMAKE_CXX_STANDARD" cxxStandard)
-      (lib.cmakeFeature "WITH_STL" "CXX${cxxStandard}")
-    ];
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "WITH_BENCHMARK" false)
+    (lib.cmakeBool "WITH_OTLP_HTTP" enableHttp)
+    (lib.cmakeBool "WITH_OTLP_GRPC" enableGrpc)
+    (lib.cmakeBool "WITH_PROMETHEUS" enablePrometheus)
+    (lib.cmakeBool "WITH_ELASTICSEARCH" enableElasticSearch)
+    (lib.cmakeBool "WITH_ZIPKIN" enableZipkin)
+    (lib.cmakeFeature "OTELCPP_PROTO_PATH" "${opentelemetry-proto}")
+  ]
+  ++ lib.optionals (cxxStandard != null) [
+    (lib.cmakeFeature "CMAKE_CXX_STANDARD" cxxStandard)
+    (lib.cmakeFeature "WITH_STL" "CXX${cxxStandard}")
+  ];
 
   outputs = [
     "out"

--- a/pkgs/by-name/ti/timr-tui/package.nix
+++ b/pkgs/by-name/ti/timr-tui/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  alsa-lib-with-plugins,
+  alsa-plugins,
+  pipewire,
+  enableSound ? false,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "timr-tui";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "sectore";
+    repo = "timr-tui";
+    rev = "v${version}";
+    hash = "sha256-fzYrC7btI7o0NpX39FuYEBiZzP2ndgYZ9oys9T5PiTg=";
+  };
+
+  cargoHash = "sha256-3g86/+b1hpxphbxLYnx7Q/3P4QsRverTsOKPWWeAaXI=";
+
+  # Enable upstream "sound" feature when requested
+  buildFeatures = lib.optionals enableSound [ "sound" ];
+
+  nativeBuildInputs = lib.optionals (enableSound && stdenv.isLinux) [ pkg-config ];
+
+  # Runtime/FFI deps for the sound feature (Linux)
+  buildInputs = lib.optionals (enableSound && stdenv.isLinux) [
+    (alsa-lib-with-plugins.override {
+      plugins = [
+        alsa-plugins
+        pipewire
+      ];
+    })
+  ];
+
+  meta = with lib; {
+    description = "TUI to organize your time: Pomodoro, Countdown, Timer.";
+    homepage = "https://github.com/sectore/timr-tui";
+    changelog = "https://github.com/sectore/timr-tui/releases/tag/v${version}";
+    license = licenses.mit;
+    mainProgram = "timr-tui";
+    maintainers = with maintainers; [ flokkq ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
<!--
TUI to organize your time: Pomodoro, Countdown, Timer.
https://github.com/sectore/timr-tui
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - ~~[ ] [NixOS tests] in [nixos/tests].~~
  - ~~[ ] [Package tests] at `passthru.tests`.~~
  - ~~[ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~~
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - ~~[ ] Package update: when the change is major or breaking.~~
- NixOS Release Notes
  - ~~[ ] Module addition: when adding a new NixOS module.~~
  - ~~[ ] Module update: when the change is significant.~~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
