### PR TITLE
opentelemetry-cpp: run nixfmt

### DIFF
--- a/pkgs/by-name/op/opentelemetry-cpp/package.nix
+++ b/pkgs/by-name/op/opentelemetry-cpp/package.nix
@@ -65,21 +65,20 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  cmakeFlags =
-    [
-      (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
-      (lib.cmakeBool "WITH_BENCHMARK" false)
-      (lib.cmakeBool "WITH_OTLP_HTTP" enableHttp)
-      (lib.cmakeBool "WITH_OTLP_GRPC" enableGrpc)
-      (lib.cmakeBool "WITH_PROMETHEUS" enablePrometheus)
-      (lib.cmakeBool "WITH_ELASTICSEARCH" enableElasticSearch)
-      (lib.cmakeBool "WITH_ZIPKIN" enableZipkin)
-      (lib.cmakeFeature "OTELCPP_PROTO_PATH" "${opentelemetry-proto}")
-    ]
-    ++ lib.optionals (cxxStandard != null) [
-      (lib.cmakeFeature "CMAKE_CXX_STANDARD" cxxStandard)
-      (lib.cmakeFeature "WITH_STL" "CXX${cxxStandard}")
-    ];
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "WITH_BENCHMARK" false)
+    (lib.cmakeBool "WITH_OTLP_HTTP" enableHttp)
+    (lib.cmakeBool "WITH_OTLP_GRPC" enableGrpc)
+    (lib.cmakeBool "WITH_PROMETHEUS" enablePrometheus)
+    (lib.cmakeBool "WITH_ELASTICSEARCH" enableElasticSearch)
+    (lib.cmakeBool "WITH_ZIPKIN" enableZipkin)
+    (lib.cmakeFeature "OTELCPP_PROTO_PATH" "${opentelemetry-proto}")
+  ]
+  ++ lib.optionals (cxxStandard != null) [
+    (lib.cmakeFeature "CMAKE_CXX_STANDARD" cxxStandard)
+    (lib.cmakeFeature "WITH_STL" "CXX${cxxStandard}")
+  ];
 
   outputs = [
     "out"


### PR DESCRIPTION
Broken formatting snuck in from #390485 as it was older than the most recent nixfmt changes.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
