### PR TITLE
dell-bios-fan-control: init package and module

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -31,6 +31,8 @@
   If your SQLite database is corrupted, the migration might fail and require [manual intervention](https://github.com/louislam/uptime-kuma/issues/5281).
   See the [migration guide](https://github.com/louislam/uptime-kuma/wiki/Migration-From-v1-To-v2) for more information.
 
+- Added `dell-bios-fan-control` package and service.
+
 - We now use the upstream wrapper script for Gradle, supporting both the `JAVA_HOME` and `GRADLE_OPTS` environment variables.
 
 ## Nixpkgs Library {#sec-nixpkgs-release-26.05-lib}

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22183,6 +22183,11 @@
     githubId = 13792812;
     name = "James Leitch";
   };
+  rickyelopez = {
+    github = "rickyelopez";
+    githubId = 31072564;
+    name = "Ricky";
+  };
   rickynils = {
     email = "rickynils@gmail.com";
     github = "rickynils";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -651,6 +651,7 @@
   ./services/hardware/buffyboard.nix
   ./services/hardware/ddccontrol.nix
   ./services/hardware/deepcool-digital-linux.nix
+  ./services/hardware/dell-bios-fan-control.nix
   ./services/hardware/display.nix
   ./services/hardware/fancontrol.nix
   ./services/hardware/freefall.nix

--- a/nixos/modules/services/hardware/dell-bios-fan-control.nix
+++ b/nixos/modules/services/hardware/dell-bios-fan-control.nix
@@ -1,0 +1,49 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.hardware.dell-bios-fan-control;
+in
+{
+  meta.maintainers = with lib.maintainers; [ rickyelopez ];
+
+  options.services.hardware.dell-bios-fan-control = {
+    enable = lib.mkEnableOption "One-shot service to disable dell bios fan control on startup";
+    package = lib.mkPackageOption pkgs "dell-bios-fan-control" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot.kernelModules = [ "i8k" ];
+    environment.systemPackages = [ cfg.package ];
+    # see ref in aur: https://aur.archlinux.org/cgit/aur.git/tree/dell-bios-fan-control.service?h=dell-bios-fan-control-git
+    systemd.services.dell-bios-fan-control = {
+      description = "Disables BIOS control of fans at boot.";
+      wants = [ "dell-bios-fan-control-resume.service" ];
+      wantedBy = [ "multi-user.target" ];
+      before = [ "i8kmon.service" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = "${lib.getExe cfg.package} 0";
+        ExecStop = "${lib.getExe cfg.package} 1";
+      };
+    };
+
+    # see ref in aur: https://aur.archlinux.org/cgit/aur.git/tree/dell-bios-fan-control-resume.service?h=dell-bios-fan-control-git
+    systemd.services.dell-bios-fan-control-resume = {
+      description = "Restart dell-bios-fan-control on resume.";
+      wants = [ "dell-bios-fan-control.service" ];
+      wantedBy = [ "suspend.target" ];
+      after = [ "suspend.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        # re: sleep, see: https://github.com/NixOS/nixpkgs/pull/439978#discussion_r2404279441
+        ExecStartPre = "${pkgs.coreutils}/bin/sleep 30";
+        ExecStart = "${config.systemd.package}/bin/systemctl restart dell-bios-fan-control.service";
+      };
+    };
+  };
+}

--- a/pkgs/by-name/de/dell-bios-fan-control/package.nix
+++ b/pkgs/by-name/de/dell-bios-fan-control/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+stdenv.mkDerivation {
+  pname = "dell-bios-fan-control";
+  version = "0-unstable-2022-01-19";
+
+  src = fetchFromGitHub {
+    owner = "TomFreudenberg";
+    repo = "dell-bios-fan-control";
+    rev = "27006106595bccd6c309da4d1499f93d38903f9a";
+    hash = "sha256-3ihzvwL86c9VJDfGpbWpkOwZ7qU0E5U2UuOeCwPMR1s=";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  hardeningDisable = [
+    "fortify"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    installBin dell-bios-fan-control
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Simple tool to enable or disable the SMBIOS (auto) fan control on various Dell laptops";
+    homepage = "https://github.com/TomFreudenberg/dell-bios-fan-control";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "dell-bios-fan-control";
+    maintainers = with lib.maintainers; [ rickyelopez ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Adds the `dell-bios-fan-control` package and matching one-shot systemd service which runs on multi-user.target.

##### Reviewed points

- [x] package path fits guidelines
- [x] package name fits guidelines
- [x] package version fits guidelines
- [x] package builds on x86_64-linux
- [x] executables tested on x86_64-linux
- [x] `meta.description` is set and fits guidelines
- [x] `meta.license` fits upstream license
- [x] `meta.platforms` is set
- [x] `meta.maintainers` is set
- [x] `meta.mainProgram` is set, if applicable.
- [ ] ~build time only dependencies are declared in `nativeBuildInputs`~
- [x] source is fetched from an official or trusted location
- [x] source is fetched using the appropriate function
- [ ] ~the motives for any special packaging choices are documented~
- [x] the list of `phases` is not overridden
- [x] when a phase (like `installPhase`) is overridden it starts with `runHook preInstall` and ends with `runHook postInstall`.
- [ ] ~patches have a comment describing either the upstream URL or a reason why the patch wasn't upstreamed~
- [ ] ~patches that are remotely available are fetched rather than vendored~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
