### PR TITLE
python313Packages.torchio: 0.20.21 -> 0.20.22

### DIFF
--- a/pkgs/development/python-modules/torchio/default.nix
+++ b/pkgs/development/python-modules/torchio/default.nix
@@ -10,7 +10,7 @@
   # dependencies
   deprecated,
   einops,
-  matplotlib,
+  humanize,
   nibabel,
   numpy,
   packaging,
@@ -21,22 +21,28 @@
   tqdm,
   typer,
 
+  # optional dependencies
+  colorcet,
+  matplotlib,
+  pandas,
+  ffmpeg-python,
+  scikit-learn,
+
   # tests
-  humanize,
   parameterized,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "torchio";
-  version = "0.20.21";
+  version = "0.20.22";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "TorchIO-project";
     repo = "torchio";
     tag = "v${version}";
-    hash = "sha256-l2KQLZDxsP8Bjk/vPG2YbU+8Z6/lOvNvy9NYKTdW+cY=";
+    hash = "sha256-LP0hlle8BCoZrJWs5aX/xvI+EPHdOGBARoKwQRqswQc=";
   };
 
   build-system = [
@@ -57,6 +63,16 @@ buildPythonPackage rec {
     tqdm
     typer
   ];
+
+  optional-dependencies = {
+    csv = [ pandas ];
+    plot = [
+      colorcet
+      matplotlib
+    ];
+    video = [ ffmpeg-python ];
+    sklearn = [ scikit-learn ];
+  };
 
   nativeCheckInputs = [
     matplotlib


### PR DESCRIPTION
Routine update and added optional dependencies. [changelog](https://github.com/TorchIO-project/torchio/releases/tag/v0.20.22)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
