### PR TITLE
treewide: remove stringy licenses

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -167,6 +167,11 @@ lib.mapAttrs mkLicense (
       fullName = "Apache License 2.0";
     };
 
+    baekmuk = {
+      spdxId = "Baekmuk";
+      fullName = "Baekmuk License";
+    };
+
     bitstreamVera = {
       spdxId = "Bitstream-Vera";
       fullName = "Bitstream Vera Font License";
@@ -180,6 +185,11 @@ lib.mapAttrs mkLicense (
     bitTorrent11 = {
       spdxId = "BitTorrent-1.1";
       fullName = " BitTorrent Open Source License v1.1";
+    };
+
+    boehmGC = {
+      spdxId = "Boehm-GC";
+      fullName = "Boehm-Demers-Weiser GC License";
     };
 
     bola11 = {
@@ -586,6 +596,11 @@ lib.mapAttrs mkLicense (
       free = false;
     };
 
+    fontException = {
+      spdxId = "Font-exception-2.0";
+      fullName = "Font exception 2.0";
+    };
+
     fraunhofer-fdk = {
       fullName = "Fraunhofer FDK AAC Codec Library";
       spdxId = "FDK-AAC";
@@ -593,6 +608,11 @@ lib.mapAttrs mkLicense (
 
     free = {
       fullName = "Unspecified free software license";
+    };
+
+    freeimage = {
+      spdxId = "FreeImage";
+      fullName = "FreeImage Public License v1.0";
     };
 
     fsl11Mit = {
@@ -764,6 +784,11 @@ lib.mapAttrs mkLicense (
       fullName = "INRIA Non-Commercial License Agreement for the Zélus compiler";
       url = "https://github.com/INRIA/zelus/raw/829f2b97cba93b0543a9ca0272269e6b8fdad356/LICENSE";
       free = false;
+    };
+
+    interbase = {
+      spdxId = "Interbase-1.0";
+      fullName = "Interbase Public License v1.0";
     };
 
     ipa = {
@@ -1042,6 +1067,11 @@ lib.mapAttrs mkLicense (
       redistributable = true; # Only if used in Netdata products.
     };
 
+    ngpl = {
+      spdxId = "NGPL";
+      fullName = "Nethack General Public License";
+    };
+
     nistSoftware = {
       spdxId = "NIST-Software";
       fullName = "NIST Software License";
@@ -1132,6 +1162,11 @@ lib.mapAttrs mkLicense (
     osl3 = {
       spdxId = "OSL-3.0";
       fullName = "Open Software License 3.0";
+    };
+
+    paratype = {
+      fullName = "ParaType Free Font Licensing Agreement";
+      url = "https://web.archive.org/web/20161209023955/http://www.paratype.ru/public/pt_openlicense_eng.asp";
     };
 
     parity70 = {
@@ -1262,6 +1297,11 @@ lib.mapAttrs mkLicense (
       redistributable = false; # only free to redistribute "for non-commercial purposes"
     };
 
+    tcpWrappers = {
+      spdxId = "TCP-wrappers";
+      fullName = "TCP Wrappers License";
+    };
+
     teamspeak = {
       fullName = "Teamspeak client license";
       url = "https://www.teamspeak.com/en/privacy-and-terms/";
@@ -1307,6 +1347,11 @@ lib.mapAttrs mkLicense (
       # TODO: add spdxId when it gets accepted to spdx
       # https://tools.spdx.org/app/license_requests/458
       # https://github.com/spdx/license-list-XML/issues/2757
+    };
+
+    torque11 = {
+      spdxId = "TORQUE-1.1";
+      fullName = "TORQUE v2.5+ Software License v1.1";
     };
 
     tsl = {
@@ -1447,6 +1492,11 @@ lib.mapAttrs mkLicense (
     x11 = {
       spdxId = "X11";
       fullName = "X11 License";
+    };
+
+    xerox = {
+      spdxId = "Xerox";
+      fullName = "Xerox License";
     };
 
     xfig = {

--- a/pkgs/applications/science/misc/megam/default.nix
+++ b/pkgs/applications/science/misc/megam/default.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation {
       almost every other maxent package out there.
     '';
     homepage = "http://www.umiacs.umd.edu/~hal/megam";
-    license = "non-commercial";
+    license = lib.licenses.unfree;
     maintainers = with maintainers; [ leixb ];
     platforms = platforms.unix;
   };

--- a/pkgs/applications/terminal-emulators/rxvt-unicode-plugins/urxvt-theme-switch/default.nix
+++ b/pkgs/applications/terminal-emulators/rxvt-unicode-plugins/urxvt-theme-switch/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "urxvt plugin that allows to switch color themes during runtime";
     homepage = "https://github.com/felixr/urxvt-theme-switch";
-    license = "CCBYNC";
+    license = lib.licenses.cc-by-nc-30;
     maintainers = [ ];
     platforms = platforms.unix;
   };

--- a/pkgs/by-name/ba/baekmuk-ttf/package.nix
+++ b/pkgs/by-name/ba/baekmuk-ttf/package.nix
@@ -1,4 +1,8 @@
-{ stdenvNoCC, fetchurl }:
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+}:
 
 stdenvNoCC.mkDerivation rec {
   pname = "baekmuk-ttf";
@@ -21,6 +25,6 @@ stdenvNoCC.mkDerivation rec {
   meta = {
     description = "Korean font";
     homepage = "http://kldp.net/projects/baekmuk/";
-    license = "BSD-like";
+    license = lib.licenses.baekmuk;
   };
 }

--- a/pkgs/by-name/bo/boehmgc/package.nix
+++ b/pkgs/by-name/bo/boehmgc/package.nix
@@ -115,7 +115,7 @@ stdenv.mkDerivation (finalAttrs: {
       C or C++ programs, though that is not its primary goal.
     '';
     changelog = "https://github.com/bdwgc/bdwgc/blob/v${finalAttrs.version}/ChangeLog";
-    license = "https://hboehm.info/gc/license.txt"; # non-copyleft, X11-style license
+    license = lib.licenses.boehmGC;
     maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/bo/boolstuff/package.nix
+++ b/pkgs/by-name/bo/boolstuff/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Library for operations on boolean expression binary trees";
     homepage = "http://perso.b2b2c.ca/~sarrazip/dev/boolstuff.html";
-    license = "GPL";
+    license = lib.licenses.gpl2Only;
     maintainers = [ lib.maintainers.marcweber ];
     mainProgram = "booldnf";
     platforms = lib.platforms.all;

--- a/pkgs/by-name/bu/buddy/package.nix
+++ b/pkgs/by-name/bu/buddy/package.nix
@@ -27,7 +27,10 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://sourceforge.net/projects/buddy/";
     description = "Binary decision diagram package";
-    license = "as-is";
+    license = {
+      url = "https://sourceforge.net/p/buddy/gitcode/ci/master/tree/README";
+      fullName = "Buddy License";
+    };
 
     platforms = lib.platforms.unix; # Once had cygwin problems
   };

--- a/pkgs/by-name/cs/cscope/package.nix
+++ b/pkgs/by-name/cs/cscope/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
       used to manage projects involving 20 million lines of code!
     '';
 
-    license = "BSD-style";
+    license = lib.licenses.bsd3;
 
     homepage = "https://cscope.sourceforge.net/";
 

--- a/pkgs/by-name/fc/fcgi/package.nix
+++ b/pkgs/by-name/fc/fcgi/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Language independent, scalable, open extension to CGI";
     homepage = "https://fastcgi-archives.github.io/"; # Formerly http://www.fastcgi.com/
-    license = "FastCGI, see LICENSE.TERMS";
+    license = lib.licenses.oml;
     mainProgram = "cgi-fcgi";
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ jtbx ];

--- a/pkgs/by-name/fr/freeimage/package.nix
+++ b/pkgs/by-name/fr/freeimage/package.nix
@@ -113,7 +113,11 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Open Source library for accessing popular graphics image file formats";
     homepage = "http://freeimage.sourceforge.net/";
-    license = "GPL";
+    license = with lib.licenses; [
+      freeimage
+      gpl2Only
+      gpl3Only
+    ];
     knownVulnerabilities = [
       "CVE-2024-31570"
       "CVE-2024-28584"

--- a/pkgs/by-name/ja/ja2-stracciatella/package.nix
+++ b/pkgs/by-name/ja/ja2-stracciatella/package.nix
@@ -104,7 +104,11 @@ stdenv.mkDerivation rec {
     # Fails to build on x86_64-linux as of 2025-03-16 and potentially earlier
     broken = true;
     description = "Jagged Alliance 2, with community fixes";
-    license = "SFI Source Code license agreement";
+    license = {
+      fullName = "Strategy First Inc. Source Code License Agreement";
+      url = "https://github.com/ja2-stracciatella/ja2-stracciatella/blob/master/SFI%20Source%20Code%20license%20agreement.txt";
+      free = false;
+    };
     homepage = "https://ja2-stracciatella.github.io/";
     maintainers = [ ];
   };

--- a/pkgs/by-name/ja/jade/package.nix
+++ b/pkgs/by-name/ja/jade/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "James Clark's DSSSL Engine";
-    license = "custom";
+    license = lib.licenses.x11;
     homepage = "http://www.jclark.com/jade/";
     platforms = with lib.platforms; linux;
     maintainers = [ ];

--- a/pkgs/by-name/li/lib3ds/package.nix
+++ b/pkgs/by-name/li/lib3ds/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Library for managing 3D-Studio Release 3 and 4 \".3DS\" files";
     homepage = "https://lib3ds.sourceforge.net/";
-    license = "LGPL";
+    license = lib.licenses.lgpl2Only;
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/li/libmhash/package.nix
+++ b/pkgs/by-name/li/libmhash/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       which are based on hash algorithms.
     '';
     homepage = "https://mhash.sourceforge.net";
-    license = "LGPL";
+    license = lib.licenses.lgpl2Only;
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/li/libofx/package.nix
+++ b/pkgs/by-name/li/libofx/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Opensource implementation of the Open Financial eXchange specification";
     homepage = "https://libofx.sourceforge.net/";
-    license = "LGPL";
+    license = lib.licenses.gpl2Only;
     platforms = lib.platforms.unix;
     maintainers = [ ];
   };

--- a/pkgs/by-name/mp/mpage/package.nix
+++ b/pkgs/by-name/mp/mpage/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
       ISO 8859.1 to print 8-bit characters.
     '';
 
-    license = "liberal"; # a non-copyleft license, see `Copyright' file
+    license = lib.licenses.gpl2Plus;
     homepage = "http://www.mesa.nl/pub/mpage/";
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/na/nafees/package.nix
+++ b/pkgs/by-name/na/nafees/package.nix
@@ -61,7 +61,10 @@ stdenv.mkDerivation {
     # Used to be GPLv2.  The license distributed with the fonts looks
     # more like a modified BSD, but still contains the GPLv2 embedded
     # font exception, and some not-for-resale language.
-    license = "unknown";
+    license = {
+      fullName = "Nafees License Agreement";
+      url = "https://www.cle.org.pk/software/license/Nafees_Pakistani_Naskh_License.html";
+    };
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ bergey ];
   };

--- a/pkgs/by-name/ne/neko/package.nix
+++ b/pkgs/by-name/ne/neko/package.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
       lib.licenses.zlib # zlib.ndll
       lib.licenses.asl20 # mod_neko, mod_tora, mbedTLS
       lib.licenses.mit # overall, other libs
-      "https://github.com/HaxeFoundation/neko/blob/v2-3-0/LICENSE#L24-L40" # boehm gc
+      lib.licenses.boehmGC # boehm gc
     ];
     maintainers = with lib.maintainers; [
       marcweber

--- a/pkgs/by-name/ne/neverball/package.nix
+++ b/pkgs/by-name/ne/neverball/package.nix
@@ -67,7 +67,12 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://neverball.org/";
     description = "Tilt the floor to roll a ball";
-    license = "GPL";
+    license = with lib.licenses; [
+      gpl2Plus
+      ijg
+      mit
+      gpl3Only
+    ];
     maintainers = [ ];
     platforms = with lib.platforms; linux;
   };

--- a/pkgs/by-name/oc/ocaml_make/package.nix
+++ b/pkgs/by-name/oc/ocaml_make/package.nix
@@ -29,7 +29,11 @@ stdenv.mkDerivation {
   meta = {
     homepage = "http://www.ocaml.info/home/ocaml_sources.html";
     description = "Generic OCaml Makefile for GNU Make";
-    license = "LGPL";
+    license = with lib.licenses; [
+      lgpl21Only
+      ocamlLgplLinkingException
+      gpl3Only
+    ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/op/openscenegraph/package.nix
+++ b/pkgs/by-name/op/openscenegraph/package.nix
@@ -147,6 +147,9 @@ stdenv.mkDerivation rec {
       raskin
     ];
     platforms = with platforms; linux ++ darwin;
-    license = "OpenSceneGraph Public License - free LGPL-based license";
+    license = with lib.licenses; [
+      lgpl21Only
+      wxWindowsException31
+    ];
   };
 }

--- a/pkgs/by-name/os/osgqt/package.nix
+++ b/pkgs/by-name/os/osgqt/package.nix
@@ -42,7 +42,10 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Qt bindings for OpenSceneGraph";
     homepage = "https://github.com/openscenegraph/osgQt";
-    license = "OpenSceneGraph Public License - free LGPL-based license";
+    license = with lib.licenses; [
+      lgpl21Only
+      wxWindowsException31
+    ];
     maintainers = [ lib.maintainers.nim65s ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/pa/paratype-pt-mono/package.nix
+++ b/pkgs/by-name/pa/paratype-pt-mono/package.nix
@@ -30,7 +30,7 @@ stdenvNoCC.mkDerivation {
     homepage = "http://www.paratype.ru/public/";
     description = "Open Paratype font";
 
-    license = "Open Paratype license";
+    license = lib.licenses.paratype;
     # no commercial distribution of the font on its own
     # must rename on modification
     # http://www.paratype.ru/public/pt_openlicense.asp

--- a/pkgs/by-name/pa/paratype-pt-sans/package.nix
+++ b/pkgs/by-name/pa/paratype-pt-sans/package.nix
@@ -30,7 +30,7 @@ stdenvNoCC.mkDerivation {
     homepage = "http://www.paratype.ru/public/";
     description = "Open Paratype font";
 
-    license = "Open Paratype license";
+    license = lib.licenses.paratype;
     # no commercial distribution of the font on its own
     # must rename on modification
     # http://www.paratype.ru/public/pt_openlicense.asp

--- a/pkgs/by-name/pa/paratype-pt-serif/package.nix
+++ b/pkgs/by-name/pa/paratype-pt-serif/package.nix
@@ -30,7 +30,7 @@ stdenvNoCC.mkDerivation {
     homepage = "http://www.paratype.ru/public/";
     description = "Open Paratype font";
 
-    license = "Open Paratype license";
+    license = lib.licenses.paratype;
     # no commercial distribution of the font on its own
     # must rename on modification
     # http://www.paratype.ru/public/pt_openlicense.asp

--- a/pkgs/by-name/rm/rman/package.nix
+++ b/pkgs/by-name/rm/rman/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Parse formatted man pages and man page source from most flavors of UNIX and converts them to HTML, ASCII, TkMan, DocBook, and other formats";
-    license = "artistic";
+    license = lib.licenses.artistic1;
     platforms = lib.platforms.all;
     mainProgram = "rman";
   };

--- a/pkgs/by-name/so/soapui/package.nix
+++ b/pkgs/by-name/so/soapui/package.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     description = "Most Advanced REST & SOAP Testing Tool in the World";
     homepage = "https://www.soapui.org/";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
-    license = "SoapUI End User License Agreement";
+    license = lib.licenses.eupl11;
     maintainers = with maintainers; [ gerschtli ];
     platforms = platforms.linux; # we don't fetch the dmg yet
     mainProgram = "soapui";

--- a/pkgs/by-name/sq/squashfuse/package.nix
+++ b/pkgs/by-name/sq/squashfuse/package.nix
@@ -44,6 +44,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/vasi/squashfuse";
     maintainers = [ ];
     platforms = lib.platforms.unix;
-    license = "BSD-2-Clause";
+    license = lib.licenses.bsd2;
   };
 }

--- a/pkgs/by-name/ss/ssldump/package.nix
+++ b/pkgs/by-name/ss/ssldump/package.nix
@@ -34,7 +34,10 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "SSLv3/TLS network protocol analyzer";
     homepage = "https://ssldump.sourceforge.net";
-    license = "BSD-style";
+    license = with lib.licenses; [
+      bsdOriginal
+      bsdOriginalShortened
+    ];
     maintainers = with maintainers; [ aycanirican ];
     platforms = platforms.unix;
     mainProgram = "ssldump";

--- a/pkgs/by-name/ta/tahoe-lafs/package.nix
+++ b/pkgs/by-name/ta/tahoe-lafs/package.nix
@@ -163,7 +163,10 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://tahoe-lafs.org/";
     license = [
       lib.licenses.gpl2Plus # or
-      "TGPPLv1+"
+      {
+        fullName = "Transitive Grace Period Public Licence version 1.0";
+        url = "https://github.com/tahoe-lafs/tahoe-lafs/blob/master/COPYING.TGPPL.rst";
+      }
     ];
     maintainers = with lib.maintainers; [ MostAwesomeDude ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/tc/tcp_wrappers/package.nix
+++ b/pkgs/by-name/tc/tcp_wrappers/package.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
     '';
 
     homepage = "ftp://ftp.porcupine.org/pub/security/index.html";
-    license = "BSD-style";
+    license = lib.licenses.tcpWrappers;
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/tl/tla/package.nix
+++ b/pkgs/by-name/tl/tla/package.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   stdenv,
   fetchurl,
   which,
@@ -41,6 +42,6 @@ stdenv.mkDerivation rec {
     description = "GNU Arch (aka. `tla'), a distributed revision control system";
     mainProgram = "tla";
     homepage = "https://www.gnu.org/software/gnu-arch/";
-    license = "GPL";
+    license = lib.licenses.gpl2Plus;
   };
 }

--- a/pkgs/by-name/to/torque/package.nix
+++ b/pkgs/by-name/to/torque/package.nix
@@ -94,6 +94,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/adaptivecomputing/torque";
     description = "Resource management system for submitting and controlling jobs on supercomputers, clusters, and grids";
     platforms = platforms.linux;
-    license = "TORQUEv1.1";
+    license = lib.licenses.torque11;
   };
 }

--- a/pkgs/by-name/tt/ttf2pt1/package.nix
+++ b/pkgs/by-name/tt/ttf2pt1/package.nix
@@ -47,7 +47,13 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "True Type to Postscript Type 3 converter, fpdf";
     homepage = "https://ttf2pt1.sourceforge.net/index.html";
-    license = "ttf2pt1";
+    license = with lib.licenses; [
+      gpl2Plus
+      {
+        fullName = "ttf2pt1 License";
+        url = "https://git.altlinux.org/gears/t/ttf2pt1.git?p=ttf2pt1.git;a=blob;f=ttf2pt1/COPYRIGHT;h=75e8f38e5a7638ee7d23892c86442ddcc35f4761;hb=f3cdb9f16159edf8115dc81520be9af791e846b2";
+      }
+    ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/tw/twurl/package.nix
+++ b/pkgs/by-name/tw/twurl/package.nix
@@ -14,7 +14,7 @@ bundlerApp {
   meta = with lib; {
     description = "OAuth-enabled curl for the Twitter API";
     homepage = "https://github.com/twitter/twurl";
-    license = "MIT";
+    license = lib.licenses.mit;
     maintainers = with maintainers; [ brecht ];
     platforms = platforms.unix;
     mainProgram = "twurl";

--- a/pkgs/by-name/un/unifont/package.nix
+++ b/pkgs/by-name/un/unifont/package.nix
@@ -66,7 +66,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://unifoundry.com/unifont/";
 
     # Basically GPL2+ with font exception.
-    license = "https://unifoundry.com/LICENSE.txt";
+    license = with lib.licenses; [
+      gpl2Plus
+      fontException
+    ];
     maintainers = [ maintainers.rycee ];
     platforms = platforms.all;
   };

--- a/pkgs/by-name/un/unifont_upper/package.nix
+++ b/pkgs/by-name/un/unifont_upper/package.nix
@@ -28,7 +28,10 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://unifoundry.com/unifont/";
 
     # Basically GPL2+ with font exception.
-    license = "https://unifoundry.com/LICENSE.txt";
+    license = with lib.licenses; [
+      gpl2Plus
+      fontException
+    ];
     maintainers = [ maintainers.mathnerd314 ];
     platforms = platforms.all;
   };

--- a/pkgs/by-name/un/unnethack/package.nix
+++ b/pkgs/by-name/un/unnethack/package.nix
@@ -77,7 +77,11 @@ stdenv.mkDerivation {
     description = "Fork of NetHack";
     mainProgram = "unnethack";
     homepage = "https://unnethack.wordpress.com/";
-    license = "nethack";
+    license = with lib.licenses; [
+      gpl3Only
+      cc-by-sa-30
+      publicDomain
+    ];
     platforms = lib.platforms.all;
     maintainers = [ ];
   };

--- a/pkgs/by-name/un/unscii/package.nix
+++ b/pkgs/by-name/un/unscii/package.nix
@@ -80,7 +80,11 @@ stdenv.mkDerivation rec {
     description = "Bitmapped character-art-friendly Unicode fonts";
     # Basically GPL2+ with font exception — because of the Unifont-augmented
     # version. The reduced version is public domain.
-    license = "http://unifoundry.com/LICENSE.txt";
+    license = with lib.licenses; [
+      gpl2Plus
+      fontException
+      ofl
+    ];
     maintainers = [ lib.maintainers.raskin ];
     homepage = "http://viznut.fi/unscii/";
   };

--- a/pkgs/by-name/wo/wooting-udev-rules/package.nix
+++ b/pkgs/by-name/wo/wooting-udev-rules/package.nix
@@ -27,7 +27,8 @@ stdenv.mkDerivation {
     homepage = "https://help.wooting.io/article/147-configuring-device-access-for-wootility-under-linux-udev-rules";
     description = "udev rules that give NixOS permission to communicate with Wooting keyboards";
     platforms = platforms.linux;
-    license = "unknown";
+    # We think they are so simple that they are uncopyrightable
+    license = lib.licenses.publicDomain;
     maintainers = with maintainers; [
       returntoreality
     ];

--- a/pkgs/by-name/xt/xtitle/package.nix
+++ b/pkgs/by-name/xt/xtitle/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     description = "Outputs X window titles";
     homepage = "https://github.com/baskerville/xtitle";
     maintainers = with maintainers; [ meisternu ];
-    license = "Custom";
+    license = lib.licenses.unlicense;
     platforms = platforms.linux;
     mainProgram = "xtitle";
   };

--- a/pkgs/by-name/zs/zsh/package.nix
+++ b/pkgs/by-name/zs/zsh/package.nix
@@ -182,7 +182,7 @@ stdenv.mkDerivation {
       completion, shell functions (with autoloading), a history mechanism, and
       a host of other features.
     '';
-    license = "MIT-like";
+    license = lib.licenses.mit-modern;
     homepage = "https://www.zsh.org/";
     maintainers = with lib.maintainers; [
       pSub

--- a/pkgs/development/compilers/chicken/5/default.nix
+++ b/pkgs/development/compilers/chicken/5/default.nix
@@ -58,6 +58,7 @@ lib.makeScope newScope (self: {
                 "bsd" = lib.licenses.bsd3;
                 "bsd-1-clause" = lib.licenses.bsd1;
                 "bsd-2-clause" = lib.licenses.bsd2;
+                "bsd-3" = lib.licenses.bsd3;
                 "bsd-3-clause" = lib.licenses.bsd3;
                 "gpl" = lib.licenses.gpl3Only;
                 "gpl-2" = lib.licenses.gpl2Only;
@@ -75,6 +76,7 @@ lib.makeScope newScope (self: {
                 "public-domain" = lib.licenses.publicDomain;
                 "srfi" = lib.licenses.bsd3;
                 "unicode" = lib.licenses.ucd;
+                "unknown" = lib.licenses.free;
                 "zlib-acknowledgement" = lib.licenses.zlib;
               }
             ).${license} or license;

--- a/pkgs/development/compilers/mlton/20130715.nix
+++ b/pkgs/development/compilers/mlton/20130715.nix
@@ -131,5 +131,5 @@ stdenv.mkDerivation rec {
     cp -r $(pwd)/install/${usr_prefix}/man $out
   '';
 
-  meta = import ./meta.nix;
+  meta = import ./meta.nix { inherit lib; };
 }

--- a/pkgs/development/compilers/mlton/20180207-binary.nix
+++ b/pkgs/development/compilers/mlton/20180207-binary.nix
@@ -64,5 +64,5 @@ stdenv.mkDerivation rec {
       done
     '';
 
-  meta = import ./meta.nix;
+  meta = import ./meta.nix { inherit lib; };
 }

--- a/pkgs/development/compilers/mlton/20210117-binary.nix
+++ b/pkgs/development/compilers/mlton/20210117-binary.nix
@@ -84,5 +84,5 @@ stdenv.mkDerivation rec {
       done
     '';
 
-  meta = import ./meta.nix;
+  meta = import ./meta.nix { inherit lib; };
 }

--- a/pkgs/development/compilers/mlton/from-git-source.nix
+++ b/pkgs/development/compilers/mlton/from-git-source.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   fetchgit,
   gmp,
   mltonBootstrap,
@@ -45,5 +46,5 @@ stdenv.mkDerivation {
 
   doCheck = true;
 
-  meta = import ./meta.nix;
+  meta = import ./meta.nix { inherit lib; };
 }

--- a/pkgs/development/compilers/mlton/meta.nix
+++ b/pkgs/development/compilers/mlton/meta.nix
@@ -1,4 +1,7 @@
 {
+  lib,
+}:
+{
   description = "Open-source, whole-program, optimizing Standard ML compiler";
   longDescription = ''
     MLton is an open source, whole-program optimizing compiler for the Standard ML programming language.
@@ -10,7 +13,7 @@
   '';
 
   homepage = "http://mlton.org/";
-  license = "bsd";
+  license = lib.licenses.smlnj;
   platforms = [
     "i686-linux"
     "x86_64-linux"

--- a/pkgs/development/ocaml-modules/camlzip/default.nix
+++ b/pkgs/development/ocaml-modules/camlzip/default.nix
@@ -90,7 +90,10 @@ stdenv.mkDerivation {
       ZIP and GZIP format, as well as to Java JAR files.  It provides functions
       for reading from and writing to compressed files in these formats.
     '';
-    license = "LGPL+linking exceptions";
+    license = with lib.licenses; [
+      lgpl21Plus
+      ocamlLgplLinkingException
+    ];
     inherit (ocaml.meta) platforms;
     maintainers = with maintainers; [ maggesi ];
   };

--- a/pkgs/development/ocaml-modules/ssl/default.nix
+++ b/pkgs/development/ocaml-modules/ssl/default.nix
@@ -37,7 +37,10 @@ buildDunePackage rec {
   meta = {
     homepage = "http://savonet.rastageeks.org/";
     description = "OCaml bindings for libssl";
-    license = "LGPL+link exception";
+    license = with lib.licenses; [
+      lgpl21Plus
+      ocamlLgplLinkingException
+    ];
     maintainers = with lib.maintainers; [
       anmonteiro
       dandellion

--- a/pkgs/development/ocaml-modules/taglib/default.nix
+++ b/pkgs/development/ocaml-modules/taglib/default.nix
@@ -33,7 +33,7 @@ buildDunePackage rec {
     description = "Bindings for the taglib library which provides functions for reading tags in headers of audio files";
     license = with licenses; [
       lgpl21Plus
-      "link-exception"
+      ocamlLgplLinkingException
     ]; # GNU Library Public License 2 Linking Exception
     maintainers = with maintainers; [ dandellion ];
   };

--- a/pkgs/development/tools/misc/distcc/default.nix
+++ b/pkgs/development/tools/misc/distcc/default.nix
@@ -100,7 +100,7 @@ let
     meta = {
       description = "Fast, free distributed C/C++ compiler";
       homepage = "http://distcc.org";
-      license = "GPL";
+      license = lib.licenses.gpl2Only;
 
       platforms = lib.platforms.linux;
       maintainers = with lib.maintainers; [ anderspapitto ];

--- a/pkgs/games/nethack/default.nix
+++ b/pkgs/games/nethack/default.nix
@@ -231,7 +231,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Rogue-like game";
     homepage = "http://nethack.org/";
-    license = "nethack";
+    license = lib.licenses.ngpl;
     platforms = if x11Mode then platforms.linux else platforms.unix;
     maintainers = [ ];
     mainProgram = "nethack";

--- a/pkgs/os-specific/linux/ndiswrapper/default.nix
+++ b/pkgs/os-specific/linux/ndiswrapper/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Ndis driver wrapper for the Linux kernel";
     homepage = "https://sourceforge.net/projects/ndiswrapper";
-    license = "GPL";
+    license = lib.licenses.gpl2Plus;
     platforms = [
       "i686-linux"
       "x86_64-linux"

--- a/pkgs/servers/firebird/default.nix
+++ b/pkgs/servers/firebird/default.nix
@@ -22,9 +22,9 @@ let
       downloadPage = "https://github.com/FirebirdSQL/firebird/";
       homepage = "https://firebirdsql.org/";
       changelog = "https://github.com/FirebirdSQL/firebird/blob/master/CHANGELOG.md";
-      license = [
-        "IDPL"
-        "Interbase-1.0"
+      license = with lib.licenses; [
+        mpl11
+        interbase
       ];
       platforms = platforms.linux;
       maintainers = with maintainers; [

--- a/pkgs/test/haskell/setBuildTarget/default.nix
+++ b/pkgs/test/haskell/setBuildTarget/default.nix
@@ -15,7 +15,7 @@ let
       isLibrary = false;
       isExecutable = true;
       executableHaskellDepends = [ base ];
-      license = "unknown";
+      license = pkgs.lib.licenses.mit;
     };
 
   drv = haskellPackages.callPackage pkgDef { };

--- a/pkgs/tools/package-management/akku/default.nix
+++ b/pkgs/tools/package-management/akku/default.nix
@@ -44,29 +44,37 @@ lib.makeScope newScope (self: rec {
                 (
                   lib.licenses
                   // (with lib.licenses; {
+                    "0bsd" = bsd0;
                     "agpl" = agpl3Only;
+                    "apache-2.0" = asl20;
                     "artistic" = artistic2;
                     "bsd" = bsd3;
                     "bsd-1-clause" = bsd1;
                     "bsd-2-clause" = bsd2;
                     "bsd-3-clause" = bsd3;
+                    "cc0-1.0" = cc0;
                     "gpl" = gpl3Only;
                     "gpl-2" = gpl2Only;
+                    "gpl-2.0-or-later" = gpl2Plus;
                     "gplv2" = gpl2Only;
                     "gpl-3" = gpl3Only;
                     "gpl-3.0" = gpl3Only;
+                    "gpl-3.0-or-later" = gpl3Plus;
                     "gplv3" = gpl3Only;
                     "lgpl" = lgpl3Only;
                     "lgpl-2" = lgpl2Only;
                     "lgpl-2.0+" = lgpl2Plus;
                     "lgpl-2.1" = lgpl21Only;
                     "lgpl-2.1-or-later" = lgpl21Plus;
+                    "lgpl-3.0-or-later" = lgpl3Plus;
                     "lgpl-3" = lgpl3Only;
                     "lgplv3" = lgpl3Only;
                     "public-domain" = publicDomain;
                     "srfi" = bsd3;
                     "unicode" = ucd;
+                    "xerox" = xerox;
                     "zlib-acknowledgement" = zlib;
+                    "noassertion" = free;
                   })
                 ).${s} or s;
             in


### PR DESCRIPTION
This removes most of the stringy licenses with the exceptions of the ones in haskellPackages, nodePackages, and the ones making use of node2nix.

Maybe a bit too large; would be up to splitting it into multiple PRs if wanted.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
