### PR TITLE
[Backport release-25.05] chromium,chromedriver: 139.0.7258.154 -> 140.0.7339.80

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -533,6 +533,18 @@ let
       # preventing compilations of chromium with versions below their intended version, not about running the very
       # exact version or even running a newer version.
       ./patches/chromium-136-nodejs-assert-minimal-version-instead-of-exact-match.patch
+    ]
+    ++ lib.optionals (chromiumVersionAtLeast "140") [
+      # Fix building with too old Rust (< 1.89)
+      # ld.lld: error: undefined symbol: __rust_no_alloc_shim_is_unstable
+      (fetchpatch {
+        name = "revert-rust-Remove__rust_no_alloc_shim_is_unstable.patch";
+        # https://chromium-review.googlesource.com/c/chromium/src/+/6686150
+        url = "https://chromium.googlesource.com/chromium/src/+/8393b61ba876c8e1614275c97767f9b06b889f48^!?format=TEXT";
+        decode = "base64 -d";
+        revert = true;
+        hash = "sha256-qDrqZKj8b3F0pAiPREDmcXYIEOaFoSIQOkT+lzKJglg=";
+      })
     ];
 
     postPatch =

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -477,9 +477,16 @@ let
       # Rebased variant of patch to build M126+ with LLVM 17.
       # staging-next will bump LLVM to 18, so we will be able to drop this soon.
       ./patches/chromium-126-llvm-17.patch
+    ]
+    ++ lib.optionals (!chromiumVersionAtLeast "140") [
       # Partial revert of https://github.com/chromium/chromium/commit/3687976b0c6d36cf4157419a24a39f6770098d61
       # allowing us to use our rustc and our clang.
       ./patches/chromium-129-rust.patch
+    ]
+    ++ lib.optionals (chromiumVersionAtLeast "140") [
+      # Rebased variant of the patch above due to
+      # https://chromium-review.googlesource.com/c/chromium/src/+/6665907
+      ./patches/chromium-140-rust.patch
     ]
     ++ lib.optionals (!ungoogled && !chromiumVersionAtLeast "136") [
       # Note: We since use LLVM v19.1+ on unstable *and* release-24.11 for all version and as such
@@ -529,21 +536,17 @@ let
     ];
 
     postPatch =
-      lib.optionalString (!isElectron)
-        # TODO: reuse mkGnFlags for this
-        (
-          if (chromiumVersionAtLeast "136") then
-            ''
-              cp ${./files/gclient_args.gni} build/config/gclient_args.gni
-              chmod u+w build/config/gclient_args.gni
-              echo 'checkout_mutter = false' >> build/config/gclient_args.gni
-              echo 'checkout_glic_e2e_tests = false' >> build/config/gclient_args.gni
-            ''
-          else
-            ''
-              ln -s ${./files/gclient_args.gni} build/config/gclient_args.gni
-            ''
-        )
+      # TODO: reuse mkGnFlags for this
+      # TODO: reflow
+      lib.optionalString (!isElectron) ''
+        cp ${./files/gclient_args.gni} build/config/gclient_args.gni
+        chmod u+w build/config/gclient_args.gni
+        echo 'checkout_mutter = false' >> build/config/gclient_args.gni
+        echo 'checkout_glic_e2e_tests = false' >> build/config/gclient_args.gni
+      ''
+      + lib.optionalString (!isElectron && chromiumVersionAtLeast "140") ''
+        echo 'checkout_clusterfuzz_data = false' >> build/config/gclient_args.gni
+      ''
       + lib.optionalString (!isElectron) ''
 
         echo 'LASTCHANGE=${upstream-info.DEPS."src".rev}-refs/tags/${version}@{#0}' > build/util/LASTCHANGE

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -84,6 +84,16 @@ let
         src = fetchgit {
           url = "https://gn.googlesource.com/gn";
           inherit (upstream-info.deps.gn) rev hash;
+          # compat shim release-25.05 to match the new src FOD from unstable
+          leaveDotGit = true;
+          deepClone = true;
+          postFetch = ''
+            cd "$out"
+            mkdir .nix-files
+            git rev-parse --short=12 HEAD > .nix-files/REV_SHORT
+            git describe --match initial-commit | cut -d- -f3 > .nix-files/REV_NUM
+            find "$out" -name .git -print0 | xargs -0 rm -rf
+          '';
         };
 
         # Relax hardening as otherwise gn unstable 2024-06-06 and later fail with:

--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,28 +1,28 @@
 {
   "chromium": {
-    "version": "139.0.7258.154",
+    "version": "140.0.7339.80",
     "chromedriver": {
-      "version": "139.0.7258.155",
-      "hash_darwin": "sha256-9tHj/QSFz9fJTQ+xivOKbssqXsE53BHViy7uCZ4OMhc=",
-      "hash_darwin_aarch64": "sha256-fmflqWTiruKD/VtmNWllCA71tqaB0OIOUiXsmJOTJFI="
+      "version": "140.0.7339.81",
+      "hash_darwin": "sha256-T5VUbwBMWhZLMNp2KYzG6CxApgVXAWphxpG5Uexrz3s=",
+      "hash_darwin_aarch64": "sha256-44c01JbXgl55VpQDy9Ke+p9yj3FJ5MwTdYgDcBI20Ms="
     },
     "deps": {
       "depot_tools": {
-        "rev": "ea7a0baff0d8554cf6d38f525b4e7882c2b4ec18",
-        "hash": "sha256-UouvzNFStYScnyfIJcz1Om7cDhC7EyShZQ/Icu73BPo="
+        "rev": "7d1e2bdb9168718566caba63a170a67cdab2356b",
+        "hash": "sha256-ZOzKQpo7Z/h1eeWQj20ghDq7pFZ9nch8lt60aoK/g2k="
       },
       "gn": {
-        "version": "0-unstable-2025-06-19",
-        "rev": "97b68a0bb62b7528bc3491c7949d6804223c2b82",
-        "hash": "sha256-gwptzuirIdPAV9XCaAT09aM/fY7d6xgBU7oSu9C4tmE="
+        "version": "0-unstable-2025-07-29",
+        "rev": "3a4f5cea73eca32e9586e8145f97b04cbd4a1aee",
+        "hash": "sha256-Z7bTto8BHnJzjvmKmcVAZ0/BrXimcAETV6YGKNTorQw="
       },
       "npmHash": "sha256-R2gOpfPOUAmnsnUTIvzDPHuHNzL/b2fwlyyfTrywEcI="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "9e0d6b2b47ffb17007b713429c9a302f9e43847f",
-        "hash": "sha256-L3cq3kx7hOv8bzwkQ+nyDM9VDzsvHaRzrSwrqwyCdHA=",
+        "rev": "670b6f192f4668d2ac2c06bd77ec3e4eeda7d648",
+        "hash": "sha256-tAiE11g/zymsOOjb64ZIA0GCGDV+6X5qlXUiU9vED/c=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -32,28 +32,28 @@
       },
       "src/third_party/compiler-rt/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt.git",
-        "rev": "2a4f69a118bdc5d03c415de1b9b166b2f1d4084f",
-        "hash": "sha256-RHh2WjV65ROxGPboxztrMUbxzVuPfAkLQkoooEOs7k0="
+        "rev": "dc425afb37a69b60c8c02fef815af29e91b61773",
+        "hash": "sha256-TANkUmIqP+MirWFmegENuJEFK+Ve/o0A0azuxTzeAo8="
       },
       "src/third_party/libc++/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxx.git",
-        "rev": "2c359c239b138a20a03f798e47889448ef131c22",
-        "hash": "sha256-WbEMS4wowBw1j7UT/5G5DSmgy5ldmdjxMszYtobr9UI="
+        "rev": "adbb4a5210ae2a8a4e27fa6199221156c02a9b1a",
+        "hash": "sha256-34+xTZqWpm+1aks2b4nPD3WRJTkTxNj6ZjTuMveiQ+M="
       },
       "src/third_party/libc++abi/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxxabi.git",
-        "rev": "e44c3c4560f1742744ef3f9fb4217a5f26ebca1b",
-        "hash": "sha256-WIJAAHO+n6C5N7nyw8m8xGXr/OXvRGfsScBBdUyjxyg="
+        "rev": "a6c815c69d55ec59d020abde636754d120b402ad",
+        "hash": "sha256-wO64dyP1O3mCBh/iiRkSzaWMkiDkb7B98Avd4SpnY70="
       },
       "src/third_party/libunwind/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libunwind.git",
-        "rev": "5bbf35ae6801f579c523893176789774c0726e22",
-        "hash": "sha256-hpOxKXZkZEWNptp31B1DZ8V9E7LsRbbYdPdUD7EYA+8="
+        "rev": "84c5262b57147e9934c0a8f2302d989b44ec7093",
+        "hash": "sha256-GmLreEtoyHMXr6mZgZ7NS1ZaS9leB9eMbISeN7qmfqw="
       },
       "src/third_party/llvm-libc/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libc.git",
-        "rev": "79a5aa1b7fcbdf3397bc2a08cbd6ef5c302dfb5a",
-        "hash": "sha256-lddA/+ol5crXlEmRa/JqWvnLTGmyKDUMTlTHC1pFLwc="
+        "rev": "6adc0aa946a413c124758a3a0ac12e5a536c7dd3",
+        "hash": "sha256-C5ZmMzhGdRAd9tpad8hnqM6RoXsunKSuYUoUQdsYclI="
       },
       "src/chrome/test/data/perf/canvas_bench": {
         "url": "https://chromium.googlesource.com/chromium/canvas_bench.git",
@@ -72,8 +72,8 @@
       },
       "src/docs/website": {
         "url": "https://chromium.googlesource.com/website.git",
-        "rev": "a812d22617824ad2cd291e110378ccec5ae7735f",
-        "hash": "sha256-LNLHuhVKulsp0w+rXNqwC9Kh2QdouUvMX3ZNFJKv6t0="
+        "rev": "a89f6810f6a5b0e11e4ec00387e9f97e8f6c23ae",
+        "hash": "sha256-LH4TlXPBULUamqTDitDEXiB37705BzEAqX1Lan87eoM="
       },
       "src/media/cdm/api": {
         "url": "https://chromium.googlesource.com/chromium/cdm.git",
@@ -82,23 +82,18 @@
       },
       "src/net/third_party/quiche/src": {
         "url": "https://quiche.googlesource.com/quiche.git",
-        "rev": "823662119bac4eb4a2771a1d45a8c00b5c6737ce",
-        "hash": "sha256-YyNQ7RLkNzV2fbjKuwTT3BSL70Qntb2TY633sbKFD/I="
+        "rev": "42832178b3b6ae20f0d1c9634c040c528614f45f",
+        "hash": "sha256-ImjvS826eyo82TIDw6M/7h3lrwbCwxQ+oKJr8RaqDTc="
       },
       "src/testing/libfuzzer/fuzzers/wasm_corpus": {
         "url": "https://chromium.googlesource.com/v8/fuzzer_wasm_corpus.git",
         "rev": "1df5e50a45db9518a56ebb42cb020a94a090258b",
         "hash": "sha256-gItDOfNqm1tHlmelz3l2GGdiKi9adu1EpPP6U7+8EQY="
       },
-      "src/third_party/accessibility_test_framework/src": {
-        "url": "https://chromium.googlesource.com/external/github.com/google/Accessibility-Test-Framework-for-Android.git",
-        "rev": "4a764c690353ea136c82f1a696a70bf38d1ef5fe",
-        "hash": "sha256-mzVgoxxBWebesG6okyMxxmO6oH+TITA4o9ucHHMMzkQ="
-      },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "d9fc4a372074b1079c193c422fc4a180e79b6636",
-        "hash": "sha256-owMOjZEXhjXkEwzKdNVUk6Uzqdfp8UQq4JLDSvbvyeA="
+        "rev": "cbc4153da8d5796b0fbb3cf288e97bee19436191",
+        "hash": "sha256-lexJRf3EZexLgSuk8ziA+OUW+jTYlkXUPKHU/E6aUcY="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -112,13 +107,13 @@
       },
       "src/third_party/angle/third_party/VK-GL-CTS/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/VK-GL-CTS",
-        "rev": "4c617fa74b67a177c7bde5f48c73f5a5509121ed",
-        "hash": "sha256-fl3yXkdi1KqrrmHB9k+l/eaINuFHgruUL6MB/9QXvhE="
+        "rev": "ad59a18f2ce08e60c9f4ab0aaf9b62679ab8c626",
+        "hash": "sha256-42ShMIXq9CnOlmwXcUvupPpQSNggdlXEkR3mdthsGzg="
       },
       "src/third_party/anonymous_tokens/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/anonymous-tokens.git",
-        "rev": "d708a2602a5947ee068f784daa1594a673d47c4a",
-        "hash": "sha256-GaRtZmYqajLUpt7ToRfMLBlyMiJB5yT9BaaT9pHH7OM="
+        "rev": "50b2ee441f1c3bad73ab7430c41fd1ea5a7a06a6",
+        "hash": "sha256-NiqQy4CEK8qWb2khi4zTSb3fAf3n9LvBsmceSeyQ+Q0="
       },
       "src/third_party/readability/src": {
         "url": "https://chromium.googlesource.com/external/github.com/mozilla/readability.git",
@@ -132,13 +127,13 @@
       },
       "src/third_party/dav1d/libdav1d": {
         "url": "https://chromium.googlesource.com/external/github.com/videolan/dav1d.git",
-        "rev": "63bf075aada99afa112f84c61ddc9cead8ce04d3",
-        "hash": "sha256-TD4RZSNOmlNFJQReViaNxMEgWhdXGccLazBzmd+MNs8="
+        "rev": "716164239ad6e6b11c5dcdaa3fb540309d499833",
+        "hash": "sha256-2J4M6EkfVtPLUpRWwzXdLkvJio4gskC0ihZnM5H3qYc="
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "46b4670bc67cb4f6d34f6ce6a46ba7e1d6059abf",
-        "hash": "sha256-fLyP1ww4gtxOnT7FPWfjYS1+DIex+jfufCz7nZS6L10="
+        "rev": "8550f9c1ff8859d25cc49bdfacef083cff2c5121",
+        "hash": "sha256-gDtFhalOMFWR25XLVbYB/GE1lSQd1ClZ8h175qkC6PU="
       },
       "src/third_party/dawn/third_party/glfw": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
@@ -147,8 +142,8 @@
       },
       "src/third_party/dawn/third_party/dxc": {
         "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectXShaderCompiler",
-        "rev": "d1d0a31a7a6a039a35d3b8bc9586b23c57bea2a5",
-        "hash": "sha256-DCQVRuAEYOne4x2OJMr62HLx7kyan3Uj6UwXnxuDNpg="
+        "rev": "50764bac3d4048144e9ada5f5a742c82cc97cc9a",
+        "hash": "sha256-rs5cw/kpRq0Bcr2ov5kKsupwqkIQDvuvUMbZbAdOmGI="
       },
       "src/third_party/dawn/third_party/dxheaders": {
         "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectX-Headers",
@@ -167,13 +162,13 @@
       },
       "src/third_party/dawn/third_party/webgpu-cts": {
         "url": "https://chromium.googlesource.com/external/github.com/gpuweb/cts",
-        "rev": "2a8d4a83f751286302ce34573409ad75cc318508",
-        "hash": "sha256-VUSsDgNHMiSCLDDicscMwskFu/qOzuz04mqYoFtnJF8="
+        "rev": "5b477670f53e5fefcf4bd829a2952013ef9d1953",
+        "hash": "sha256-os0yeQb6snDvUjYghrIYAy9nUi1j8Y2YoTfsiQ7SlpA="
       },
       "src/third_party/dawn/third_party/webgpu-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/webgpu-native/webgpu-headers",
-        "rev": "4f617851dfa20bd240436d9255bcb7e4dbbb1e3f",
-        "hash": "sha256-ugbed1toiw7aY/v9E6akjFGARBe0/mhRZI9MSHG/JnI="
+        "rev": "c8b371dd2ff8a2b028fdc0206af5958521181ba8",
+        "hash": "sha256-rHDN4ln5kTMzabW427Xktl93E+8EVhWa2i8n4Mh2BgQ="
       },
       "src/third_party/highway/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/highway.git",
@@ -187,13 +182,13 @@
       },
       "src/third_party/boringssl/src": {
         "url": "https://boringssl.googlesource.com/boringssl.git",
-        "rev": "81be8eb2ca225281bb263ac09ece5370d6462a7d",
-        "hash": "sha256-/GYjjNmbj+bAYy5V15rRkZo54nUx0w0iAujBmTrc1/s="
+        "rev": "0a0009998fa180695f3e2071805dc03c9a5f3124",
+        "hash": "sha256-hYUbfUo00gHqYKac0vOpmBHtb5/FBsgXL+UQtrHxGaM="
       },
       "src/third_party/breakpad/breakpad": {
         "url": "https://chromium.googlesource.com/breakpad/breakpad.git",
-        "rev": "9d1f417714a6883f8d4e345c07802eb79edd2e90",
-        "hash": "sha256-yxeNERobO7TxJWUfppbBTysPMTifC2xzjUrN6Yzud+U="
+        "rev": "ff252ff6faf5e3a52dc4955aab0d84831697dc94",
+        "hash": "sha256-8OfbSe+ly/5FFYk8NubAV39ACMr5S4wbLBVdiQHWeok="
       },
       "src/third_party/cast_core/public/src": {
         "url": "https://chromium.googlesource.com/cast_core/public",
@@ -202,8 +197,8 @@
       },
       "src/third_party/catapult": {
         "url": "https://chromium.googlesource.com/catapult.git",
-        "rev": "c4f7831fe85d210ed50572e54d0cb1a26ccc401a",
-        "hash": "sha256-EKObRlHf5Cu7VyntXR2DC62KaBTciAyvSywyAt5gWy8="
+        "rev": "0fd1415f0cf3219ba097d37336141897fab7c5e9",
+        "hash": "sha256-khxdFV6fxbTazz195MlxktLlihXytpNYCykLrI8nftM="
       },
       "src/third_party/ced/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/compact_enc_det.git",
@@ -227,8 +222,8 @@
       },
       "src/third_party/cpuinfo/src": {
         "url": "https://chromium.googlesource.com/external/github.com/pytorch/cpuinfo.git",
-        "rev": "d7427551d6531037da216d20cd36feb19ed4905f",
-        "hash": "sha256-gJgvE3823NyVOIL0Grkldde3U/N9NNqlLAA0btj3TSg="
+        "rev": "33ed0be77d7767d0e2010e2c3cf972ef36c7c307",
+        "hash": "sha256-0rZzbZkOo6DAt1YnH4rtx0FvmCuYH8M6X3DNJ0gURpU="
       },
       "src/third_party/crc32c/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/crc32c.git",
@@ -237,23 +232,28 @@
       },
       "src/third_party/cros_system_api": {
         "url": "https://chromium.googlesource.com/chromiumos/platform2/system_api.git",
-        "rev": "349c5cb547162b967df40a336fc08bb18819a5e1",
-        "hash": "sha256-nSU/Od8TupR6dOVr6XC9btwUkjbQ6m3Oh3tChYo5i4g="
+        "rev": "07b9fafa3fff468afa2960789d2b28444c38db3e",
+        "hash": "sha256-JpimNp8PmsROMiQLy8H39n8l+KDwaivZiIOgSjLF3U4="
       },
       "src/third_party/crossbench": {
         "url": "https://chromium.googlesource.com/crossbench.git",
-        "rev": "77308ff3c8445656fd104cd80e3bd933b23cb05d",
-        "hash": "sha256-ONQSTRjrleGERU2ioaCKBcpYT1vhad4hYj/x0MIOh1Q="
+        "rev": "69b7e2bb8e1d8d92d4efbb92bcddba3af2716577",
+        "hash": "sha256-1cyXu5fSHWLWt3qdafWQu1WyeZ+fT/be7seiv/MDPdQ="
+      },
+      "src/third_party/crossbench-web-tests": {
+        "url": "https://chromium.googlesource.com/chromium/web-tests.git",
+        "rev": "3c76c8201f0732fe9781742229ab8ac43bf90cbf",
+        "hash": "sha256-yJmi1IpUiKhdoHAXyazkpm+Ezuc4Hp8pOIBntG5hN+U="
       },
       "src/third_party/depot_tools": {
         "url": "https://chromium.googlesource.com/chromium/tools/depot_tools.git",
-        "rev": "ea7a0baff0d8554cf6d38f525b4e7882c2b4ec18",
-        "hash": "sha256-UouvzNFStYScnyfIJcz1Om7cDhC7EyShZQ/Icu73BPo="
+        "rev": "7d1e2bdb9168718566caba63a170a67cdab2356b",
+        "hash": "sha256-ZOzKQpo7Z/h1eeWQj20ghDq7pFZ9nch8lt60aoK/g2k="
       },
       "src/third_party/devtools-frontend/src": {
         "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
-        "rev": "bc417052ebef6175721d690a4910e717d92181be",
-        "hash": "sha256-XoI3HbIV52VWbw15Lsk/gwmy09EtenD7iwXVQse5uVs="
+        "rev": "ab96665ae2cfcc054e0243461cfcb56bb016f71a",
+        "hash": "sha256-8G9OCH5xapLf83bXrKwygCrzwF8C9H2NfnIrDbL+uCc="
       },
       "src/third_party/dom_distiller_js/dist": {
         "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",
@@ -267,8 +267,8 @@
       },
       "src/third_party/eigen3/src": {
         "url": "https://chromium.googlesource.com/external/gitlab.com/libeigen/eigen.git",
-        "rev": "d0b490ee091629068e0c11953419eb089f9e6bb2",
-        "hash": "sha256-EmpuOQxshAFa0d6Ddzz6dy21nxHhSn+6Aiz18/o8VUU="
+        "rev": "81044ec13df7608d0d9d86aff2ef9805fc69bed1",
+        "hash": "sha256-W0uonGzjDaN2RbY2U+Kl1a5/nrEZ9T9W426f+a7NUzY="
       },
       "src/third_party/farmhash/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/farmhash.git",
@@ -282,8 +282,8 @@
       },
       "src/third_party/ffmpeg": {
         "url": "https://chromium.googlesource.com/chromium/third_party/ffmpeg.git",
-        "rev": "dcdd0fa51b65a0b1688ff6b8f0cc81908f09ded2",
-        "hash": "sha256-noc3iZ1yCEgkwWyznx48rXC8JuKxla9QgC/CIjRL/y8="
+        "rev": "d2d06b12c22d27af58114e779270521074ff1f85",
+        "hash": "sha256-c5w8CuyE1J0g79lrNq1stdqc1JaAkMbtscdcywmAEMY="
       },
       "src/third_party/flac": {
         "url": "https://chromium.googlesource.com/chromium/deps/flac.git",
@@ -297,8 +297,8 @@
       },
       "src/third_party/fontconfig/src": {
         "url": "https://chromium.googlesource.com/external/fontconfig.git",
-        "rev": "c527fe1452d469e5fa1a211180dd40bcdb79fb2a",
-        "hash": "sha256-dmzY7TcNpZA9SxHn5nN0IaTzBbwCqd1PV5Sg4RuY7aI="
+        "rev": "86b48ec01ece451d5270d0c5181a43151e45a042",
+        "hash": "sha256-6HLV0U/MA1XprKJ70TKvwUBdkGQPwgqP4Oj5dINsKp0="
       },
       "src/third_party/fp16/src": {
         "url": "https://chromium.googlesource.com/external/github.com/Maratyszcza/FP16.git",
@@ -312,8 +312,8 @@
       },
       "src/third_party/freetype/src": {
         "url": "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git",
-        "rev": "43940e4cb8fa6fec96cd52669544629c5eef58fa",
-        "hash": "sha256-1fnH0Qm9qtzjwBNlyHVQrVvvFelKIdhFMhA0zDxQVUY="
+        "rev": "27c1cb10a52420515ce66729dfca897be21691b8",
+        "hash": "sha256-2ialoA/hqlTwnbBkBlgz5CT2nzpUVXVMtEOxSxifiXQ="
       },
       "src/third_party/fxdiv/src": {
         "url": "https://chromium.googlesource.com/external/github.com/Maratyszcza/FXdiv.git",
@@ -357,8 +357,8 @@
       },
       "src/third_party/googletest/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/googletest.git",
-        "rev": "35b75a2cba6ef72b7ce2b6b94b05c54ca07df866",
-        "hash": "sha256-wB33XoxaMQuBls7tNIJ1u61ocKaMw4PyHXBXf/bMNTM="
+        "rev": "373af2e3df71599b87a40ce0e37164523849166b",
+        "hash": "sha256-07pEo2gj3n/IOipqz7UpZkBOywZt7FkfZFCnVyp3xYw="
       },
       "src/third_party/hunspell_dictionaries": {
         "url": "https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries.git",
@@ -367,8 +367,8 @@
       },
       "src/third_party/icu": {
         "url": "https://chromium.googlesource.com/chromium/deps/icu.git",
-        "rev": "b929596baebf0ab4ac7ec07f38365db4c50a559d",
-        "hash": "sha256-/T7uyzwTCDaamLwSvutvbn6BJuoG1RqeR+xhXI5jmJw="
+        "rev": "1b2e3e8a421efae36141a7b932b41e315b089af8",
+        "hash": "sha256-k3z31DhDPoqjcZdUL4vjyUMVpUiNk44+7rCMTDVPH8Q="
       },
       "src/third_party/jsoncpp/source": {
         "url": "https://chromium.googlesource.com/external/github.com/open-source-parsers/jsoncpp.git",
@@ -382,13 +382,13 @@
       },
       "src/third_party/libFuzzer/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt/lib/fuzzer.git",
-        "rev": "e31b99917861f891308269c36a32363b120126bb",
-        "hash": "sha256-Lb+HczYax0T7qvC0/Nwhc5l2szQTUYDouWRMD/Qz7sA="
+        "rev": "bea408a6e01f0f7e6c82a43121fe3af4506c932e",
+        "hash": "sha256-TDi1OvYClJKmEDikanKVTmy8uxUXJ95nuVKo5u+uFPM="
       },
       "src/third_party/fuzztest/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/fuzztest.git",
-        "rev": "45a1c3ad5ac3de58c8e9a3f89036e3f954820d4c",
-        "hash": "sha256-qNGviVNU5VKCVQ1KkGmjGAaXF+ijL3s/u2yN+Ee5rmo="
+        "rev": "7bab06ff5fbbf8b8cce05a8661369dc2e11cde66",
+        "hash": "sha256-uWPhInzuidI4smFRjRF95aaVNTsehKd/1y4uRzr12mk="
       },
       "src/third_party/domato/src": {
         "url": "https://chromium.googlesource.com/external/github.com/googleprojectzero/domato.git",
@@ -402,18 +402,18 @@
       },
       "src/third_party/libaom/source/libaom": {
         "url": "https://aomedia.googlesource.com/aom.git",
-        "rev": "90c632fc6c01cd8637186c783ca8012bab3c3260",
-        "hash": "sha256-e+rUkNOakv6WQrgx1ozoJTynk/GZy1zdsnYX4oz+6ks="
+        "rev": "e91b7aa26d6d0979bba2bee5e1c27a7a695e0226",
+        "hash": "sha256-cER77Q9cM5rh+oeh1LDyKDZyQK5VbtE/ANNTN2cYzMo="
       },
       "src/third_party/crabbyavif/src": {
         "url": "https://chromium.googlesource.com/external/github.com/webmproject/CrabbyAvif.git",
-        "rev": "eb883022a5886739f07f0241f918e2be97d65ff0",
-        "hash": "sha256-IxtMAqN3O/s1GrVKzcge9cQ+DVtJtFvHYvsfjmflwVQ="
+        "rev": "644c9d84c123ac811a611760a9adc807e3eb5be5",
+        "hash": "sha256-snogXm3EMmDJoL2ikoaxeODYfmTaVEsAb5cMcRU7uC4="
       },
       "src/third_party/nearby/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/nearby-connections.git",
-        "rev": "fff5c22e3178a633f57e4ad1fb5ad96a6116240a",
-        "hash": "sha256-2mXmDWn292dNA85EUN5sxarOle5HEW5t526SM1UPeKg="
+        "rev": "a8889d12a27ef7006d1a47dfefc272e0815f5c41",
+        "hash": "sha256-pFcusmbij3OsSAmaKhuI8/bo3AlfP7DuTo/W/6mAZs8="
       },
       "src/third_party/securemessage/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/securemessage.git",
@@ -422,8 +422,8 @@
       },
       "src/third_party/jetstream/main": {
         "url": "https://chromium.googlesource.com/external/github.com/WebKit/JetStream.git",
-        "rev": "6947a460f6b55ef5613c36263049ecf74c5ec1cd",
-        "hash": "sha256-lbsSiSRY3IikAKg30/gK3ncPxzOMhOUSQxvUIUCtJB0="
+        "rev": "fe1f348226d4b7c3447e606577960a606cc058e4",
+        "hash": "sha256-kznek87yenGR9Ft3D06LGDOy7+VPRhSUFru340mvES4="
       },
       "src/third_party/jetstream/v2.2": {
         "url": "https://chromium.googlesource.com/external/github.com/WebKit/JetStream.git",
@@ -432,8 +432,8 @@
       },
       "src/third_party/speedometer/main": {
         "url": "https://chromium.googlesource.com/external/github.com/WebKit/Speedometer.git",
-        "rev": "ba41f91e480cfd79c97a9d1d70a4c3d42d16c72b",
-        "hash": "sha256-DIXGY1wVj2W5A91X3A2eL6Tr+CVdKhHaGHtSqBRjtPQ="
+        "rev": "87f9ed88c8f8abe3a3bb19b9ec5ea49623d803ad",
+        "hash": "sha256-eIrkM7UxuaZox3A8pqEgvgpQCkcBO3zJWFwK45fgWm0="
       },
       "src/third_party/speedometer/v3.1": {
         "url": "https://chromium.googlesource.com/external/github.com/WebKit/Speedometer.git",
@@ -462,8 +462,8 @@
       },
       "src/third_party/cros-components/src": {
         "url": "https://chromium.googlesource.com/external/google3/cros_components.git",
-        "rev": "97dc8c7a1df880206cc54d9913a7e9d73677072a",
-        "hash": "sha256-CT9c4LqTwhldsxoEny8MesULwQC4k95F4tfCtRZErGM="
+        "rev": "7ccdbf60606671c2c057628125908fbfef9bd0c8",
+        "hash": "sha256-g7LzBd2V21AaLdSdCw65WGYvKfrbtpRXsYc+3ILdiKs="
       },
       "src/third_party/libdrm/src": {
         "url": "https://chromium.googlesource.com/chromiumos/third_party/libdrm.git",
@@ -517,23 +517,23 @@
       },
       "src/third_party/libvpx/source/libvpx": {
         "url": "https://chromium.googlesource.com/webm/libvpx.git",
-        "rev": "686bf6f1cde888898498f89ba9aefa66b683566a",
-        "hash": "sha256-rdeALLoqK1bth/EQY86fZC++QgMFCYyn7qMxsh9CMj0="
+        "rev": "a985e5e847a2fe69bef3e547cf25088132194e39",
+        "hash": "sha256-BbXiBbnGwdsbZCZIpurfTzYvDUCysdt+ocRh6xvuUI8="
       },
       "src/third_party/libwebm/source": {
         "url": "https://chromium.googlesource.com/webm/libwebm.git",
-        "rev": "c4522d6cd68582d66f1adfd24debfa9bee202afa",
-        "hash": "sha256-tfji0yPV7v/DETViEp2T7AO6P5xCjPYScTlV3eWFV0w="
+        "rev": "f2a982d748b80586ae53b89a2e6ebbc305848b8c",
+        "hash": "sha256-SxDGt7nPVkSxwRF/lMmcch1h+C2Dyh6GZUXoZjnXWb4="
       },
       "src/third_party/libwebp/src": {
         "url": "https://chromium.googlesource.com/webm/libwebp.git",
-        "rev": "2af6c034ac871c967e04c8c9f8bf2dbc2e271b18",
-        "hash": "sha256-0sKGhXr6Rrpq0eoitAdLQ4l4fgNOzMWIEICrPyzwNz4="
+        "rev": "4fa21912338357f89e4fd51cf2368325b59e9bd9",
+        "hash": "sha256-eaGWMpF6ENrKxGxqXccQ0P1G0X+nQI0EoL0Y0R2VVZ0="
       },
       "src/third_party/libyuv": {
         "url": "https://chromium.googlesource.com/libyuv/libyuv.git",
-        "rev": "88798bcd636a93e92d69242da914deb4cec1dfb6",
-        "hash": "sha256-HPhxj3iK1YjWcfKT4o5CXhmvMBoGaA4JKco2HDf0Nec="
+        "rev": "cdd3bae84818e78466fec1ce954eead8f403d10c",
+        "hash": "sha256-ievGlutmOuuEEhWS82vMqxwqXCq8PF3508N0MCMPQus="
       },
       "src/third_party/lss": {
         "url": "https://chromium.googlesource.com/linux-syscall-support.git",
@@ -567,8 +567,8 @@
       },
       "src/third_party/openscreen/src": {
         "url": "https://chromium.googlesource.com/openscreen",
-        "rev": "dd421dc540e75bd4e52388dcb0656d4d96137a73",
-        "hash": "sha256-Bk9pD6fKdHBgnJOgqv8frA7+4WFBh837h9fXFgEebK8="
+        "rev": "f51be2dd676c855bc588a439f002bc941b87db6b",
+        "hash": "sha256-7AmfZjugPKty0lpinOR/Q22M7F34p57tl+gs6s2BJhY="
       },
       "src/third_party/openscreen/src/buildtools": {
         "url": "https://chromium.googlesource.com/chromium/src/buildtools",
@@ -582,13 +582,13 @@
       },
       "src/third_party/pdfium": {
         "url": "https://pdfium.googlesource.com/pdfium.git",
-        "rev": "bbdc38bc2d1693f56154f78eb5d4ff296d8ca3da",
-        "hash": "sha256-LYo73KuSVBEcRN1PqG0EBFeKaLy66UPtZ3DMHP5YVXM="
+        "rev": "1afaa1a380fcd06cec420f3e5b6ec1d2ccb920dc",
+        "hash": "sha256-kx2jF4kHeGECdf6WzcRKTmwhvmoKl+rIVQ2Ep8Y9rs8="
       },
       "src/third_party/perfetto": {
         "url": "https://chromium.googlesource.com/external/github.com/google/perfetto.git",
-        "rev": "18d4fdc15d027a989db705592585b924f93f1d42",
-        "hash": "sha256-ZmP/EFuFo9/xax8f+NEdGthfdAR/8+cTWoM9XPrkpcQ="
+        "rev": "4ab725613a8ee64e9acd7930eceb8995e24df562",
+        "hash": "sha256-V16Fm389yRNn0b13n70828c8xTdwxoQ6GW8iKLyy0qE="
       },
       "src/third_party/protobuf-javascript/src": {
         "url": "https://chromium.googlesource.com/external/github.com/protocolbuffers/protobuf-javascript",
@@ -597,8 +597,8 @@
       },
       "src/third_party/pthreadpool/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/pthreadpool.git",
-        "rev": "dcc9f28589066af0dbd4555579281230abbf74dd",
-        "hash": "sha256-qogacGPNy6SKQaK8CZvGC8YZbVjhDTXuhDqGopB0Eps="
+        "rev": "149f0a86f5ad215e9f0441684385ce09f345dbe4",
+        "hash": "sha256-3/FnJ2FL6fQSlymqJS/UoXTB4ZiW9d7xpvK3Ur8Ynp4="
       },
       "src/third_party/pyelftools": {
         "url": "https://chromium.googlesource.com/chromiumos/third_party/pyelftools.git",
@@ -617,23 +617,23 @@
       },
       "src/third_party/re2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/re2.git",
-        "rev": "c84a140c93352cdabbfb547c531be34515b12228",
-        "hash": "sha256-f/k2rloV2Nwb0KuJGUX4SijFxAx69EXcsXOG4vo+Kis="
+        "rev": "8451125897dd7816a5c118925e8e42309d598ecc",
+        "hash": "sha256-vjh4HI4JKCMAf5SZeqstb0M01w8ssaTwwrLAUsrFkkQ="
       },
       "src/third_party/ruy/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/ruy.git",
-        "rev": "83fd40d730feb0804fafbc2d8814bcc19a17b2e5",
-        "hash": "sha256-O3JEtXchCdIHdGvjD6kGMJzj7TWVczQCW2YUHK3cABA="
+        "rev": "9940fbf1e0c0863907e77e0600b99bb3e2bc2b9f",
+        "hash": "sha256-fV0El2ZgjxLqstKVN35SL72+diHNK0FkBmG5UwVZFrk="
       },
       "src/third_party/search_engines_data/resources": {
         "url": "https://chromium.googlesource.com/external/search_engines_data.git",
-        "rev": "273082bef7b1bc05eddb5079b83702938e40c677",
-        "hash": "sha256-FrEUhG9G7EMiOvih0/FSlpWIuA3/wyBaQZLapYcutz4="
+        "rev": "5c5db51f8c13cb42379d8b333890971f1a1a1797",
+        "hash": "sha256-Z4ykCZkUVatvkH3ytIdGOp0zEYLKIqr8fta0MnovZKw="
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "4abe0638e35d34b6fdb70f1f5ce0f0e1879a021e",
-        "hash": "sha256-hy06/Sy+rEzNyFv9R2Kg9kX7XIpCbQwCr5VjEH9CtKM="
+        "rev": "1fdbea293a53b270e3f5e74c92cc6670d68412ff",
+        "hash": "sha256-YiGzqaht1r8/dDz0C4fpKsPEIplm33dPce2UpLkYTZ0="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",
@@ -652,8 +652,8 @@
       },
       "src/third_party/swiftshader": {
         "url": "https://swiftshader.googlesource.com/SwiftShader.git",
-        "rev": "ed01d9931de34d3a6fb4d615050db5080d9cea16",
-        "hash": "sha256-is6sl3vRLyBjiHg97rI7WvxIiKg6eelqNfrZGTWPBtM="
+        "rev": "fdb6700ecb04103b658d2e4623d6bc663ba80ea8",
+        "hash": "sha256-jJT0hF1k5a6na+9aH1yHuUo6go/PzgKibP/k60m6+xM="
       },
       "src/third_party/text-fragments-polyfill/src": {
         "url": "https://chromium.googlesource.com/external/github.com/GoogleChromeLabs/text-fragments-polyfill.git",
@@ -662,18 +662,18 @@
       },
       "src/third_party/tflite/src": {
         "url": "https://chromium.googlesource.com/external/github.com/tensorflow/tensorflow.git",
-        "rev": "e6c5574b82d7950f978447704a70971c478f0f50",
-        "hash": "sha256-zdd0y0OILYoRhZ3O64g9MFdWLnAVJiM+CJUIN2RfmKo="
+        "rev": "fe38b1b8c23d86ed93c13ef367b19496e398462d",
+        "hash": "sha256-51tpID94hoxm0I2Mf3WFQBf5MsuzIzlkS9lOto/8tC4="
       },
       "src/third_party/vulkan-deps": {
         "url": "https://chromium.googlesource.com/vulkan-deps",
-        "rev": "f227ce323fb5a2fee1a98b6feea54b0e42b2f30d",
-        "hash": "sha256-8GHLg9S6f/k2XPgqeeZ6UCBQBoHuABdPYhpGecyqo+E="
+        "rev": "c466059b72815c7fbce8bb3ab4832407aabc5dc5",
+        "hash": "sha256-MEMOJBBMBeA0kBlU5ZhkPbfRpn1PSL1950IsU1rWaJ8="
       },
       "src/third_party/glslang/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/glslang",
-        "rev": "d176fb41992d5c091fb1c401e4e70306382e67fc",
-        "hash": "sha256-27C9ZokeehkoFdIpiYkQ6PBgcNUq0kVLl4tvcgFrYLg="
+        "rev": "38f6708b6b6f213010c51ffa8f577a7751e12ce7",
+        "hash": "sha256-HeH7j7IsjeP2vFPhX9cKzZ2O54eIGSCoSnPT4pumA00="
       },
       "src/third_party/spirv-cross/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross",
@@ -682,48 +682,43 @@
       },
       "src/third_party/spirv-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers",
-        "rev": "2a611a970fdbc41ac2e3e328802aed9985352dca",
-        "hash": "sha256-LRjMy9xtOErbJbMh+g2IKXfmo/hWpegZM72F8E122oY="
+        "rev": "97e96f9e9defeb4bba3cfbd034dec516671dd7a3",
+        "hash": "sha256-/OT6//yu8VmQMXs3DSgwEx2lMDTPlUuXJDjboNdLjrI="
       },
       "src/third_party/spirv-tools/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools",
-        "rev": "33e02568181e3312f49a3cf33df470bf96ef293a",
-        "hash": "sha256-yAdd/mXY8EJnE0vCu0n/aVxMH9059T/7cAdB9nP1vQQ="
+        "rev": "3aeaaa088d37b86cff036eee1a9bf452abad7d9d",
+        "hash": "sha256-bkoD3/4o/CjNBAp49vnRq4ZtY7TNgYkVPI5gESM8CUI="
       },
       "src/third_party/vulkan-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers",
-        "rev": "10739e8e00a7b6f74d22dd0a547f1406ff1f5eb9",
-        "hash": "sha256-OorBl9vIN4DqVgT8ae+05yCLon7m0ixQczEzDlpwFRI="
+        "rev": "a01329f307fa6067da824de9f587f292d761680b",
+        "hash": "sha256-LCRK6UzqvcRoa3sr6nsfkDf3aILXj8zjb48lirsLTIw="
       },
       "src/third_party/vulkan-loader/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Loader",
-        "rev": "342da33fdec78d269657194c9082835d647d2e68",
-        "hash": "sha256-G+sTBXuBodkXi7njI0foXTqaxchsWD9XtF9UBsknE30="
+        "rev": "f2389e27734347c1d9f40e03be53f69f969976b1",
+        "hash": "sha256-NIBn5HkAKzNaSruw742QBWPgCkrxQdmITvTASagYlKM="
       },
       "src/third_party/vulkan-tools/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools",
-        "rev": "e3fc64396755191b3c51e5c57d0454872e7fa487",
-        "hash": "sha256-EqLG8kMQx6nHX9iZMrsu0fn1z4nY6TEQ/feTINNbUzQ="
+        "rev": "f766b30b2de3ffe2cf6b656d943720882617ec58",
+        "hash": "sha256-9sF9syF7d28J5yzGsIHUcJ1QB2JmJZpAVqDt92ZZOY4="
       },
       "src/third_party/vulkan-utility-libraries/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Utility-Libraries",
-        "rev": "72665ee1e50db3d949080df8d727dffa8067f5f8",
-        "hash": "sha256-FSk/LeYCt/XeF8XJZtr+DoNbvMmfFIKUaYvmeq5xK+w="
+        "rev": "b0a40d2e50310e9f84327061290a390a061125a3",
+        "hash": "sha256-bj9YCZfIFeaQ9TVpyyztRs3LOIaJkKpkGKbU5g9hEzg="
       },
       "src/third_party/vulkan-validation-layers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-ValidationLayers",
-        "rev": "e086a717059f54c94d090998628250ae8f238fd6",
-        "hash": "sha256-KF06qgduM4rAVs4MHvdS+QZs+3srB+p1NadQYTzc0OM="
+        "rev": "6b1b8e3d259241a68c0944ca0a7bb5320d086191",
+        "hash": "sha256-Do+6/v8Ysp1Wnnmdi5I+UKHpBcEG4xMeRROCWgLmJbY="
       },
       "src/third_party/vulkan_memory_allocator": {
         "url": "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git",
-        "rev": "56300b29fbfcc693ee6609ddad3fdd5b7a449a21",
-        "hash": "sha256-YzxHZagz/M8Y54UnI4h1wu5jSTuaOgv0ifC9d3fJZlQ="
-      },
-      "src/third_party/wasm_tts_engine/src": {
-        "url": "https://chromium.googlesource.com/chromium/wasm-tts-engine",
-        "rev": "352880bb49e2410707543c252ef6b94a21b0f47f",
-        "hash": "sha256-TFkniS4XvP0RlPnI1lv4RxxSY44RUuwCMKmmybENEBw="
+        "rev": "cb0597213b0fcb999caa9ed08c2f88dc45eb7d50",
+        "hash": "sha256-yBCs3zfqs/60htsZAOscjcyKhVbAWE6znweuXcs1oKo="
       },
       "src/third_party/wayland/src": {
         "url": "https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/wayland.git",
@@ -732,8 +727,8 @@
       },
       "src/third_party/wayland-protocols/src": {
         "url": "https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/wayland-protocols.git",
-        "rev": "7d5a3a8b494ae44cd9651f9505e88a250082765e",
-        "hash": "sha256-o/adWEXYSqWib6KoK7XMCWbojapcS4O/CEPxv7iFCw8="
+        "rev": "efbc060534be948b63e1f395d69b583eebba3235",
+        "hash": "sha256-tdpEK7soY0aKSk6VD4nulH7ORubX8RfjXYmNAd/cWKY="
       },
       "src/third_party/wayland-protocols/kde": {
         "url": "https://chromium.googlesource.com/external/github.com/KDE/plasma-wayland-protocols.git",
@@ -757,18 +752,18 @@
       },
       "src/third_party/webgpu-cts/src": {
         "url": "https://chromium.googlesource.com/external/github.com/gpuweb/cts.git",
-        "rev": "2a8d4a83f751286302ce34573409ad75cc318508",
-        "hash": "sha256-VUSsDgNHMiSCLDDicscMwskFu/qOzuz04mqYoFtnJF8="
+        "rev": "07f4412e935c988d60fad2e373287d6450bcd231",
+        "hash": "sha256-yb7NqciuvXi7crCqpN+7hgJ+JXfDF9x48gkYI2uSTtA="
       },
       "src/third_party/webpagereplay": {
         "url": "https://chromium.googlesource.com/webpagereplay.git",
-        "rev": "f3397454e39a7c0b35af192e6d8a1896af7bd9ec",
-        "hash": "sha256-saa07zzzbehOm4gIMoGVB0AZ2nLqmjnT5IfYBSsnZIw="
+        "rev": "eebd5c62cb5c6a5afbb36eccdcc3b3e01f28adc9",
+        "hash": "sha256-WXiWUVTX4JBuavc3qxPpWeM2qZsyMr64iqF/fu9fzRI="
       },
       "src/third_party/webrtc": {
         "url": "https://webrtc.googlesource.com/src.git",
-        "rev": "23d8e44f84822170bee4425760b44237959423e5",
-        "hash": "sha256-8IETxHh2Lcgc2N0pV0kTEsbOAchsgwj6VZVDAcVssxw="
+        "rev": "847fe7905954f3ae883de2936415ff567aa9039b",
+        "hash": "sha256-kcK1kJdPCkXbEFuS+b6wKUBaKLXmkAEwVKp4/YWDv8s="
       },
       "src/third_party/wuffs/src": {
         "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git",
@@ -787,8 +782,8 @@
       },
       "src/third_party/xnnpack/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/XNNPACK.git",
-        "rev": "3c99186b3276aa891f94ebba35f6b16e627d57de",
-        "hash": "sha256-CXX0F2H0WjgOxV2iD8bizj1JZOknry7qTmtsv9yAJFU="
+        "rev": "ae40b1a2d93d5c516bc7657c6c3eea1470f917ae",
+        "hash": "sha256-w+8aCRTlBWQcDh4EvAF87eiLmQWsIsxD9adPTnuA12E="
       },
       "src/third_party/zstd/src": {
         "url": "https://chromium.googlesource.com/external/github.com/facebook/zstd.git",
@@ -797,8 +792,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "a0a7886d6b3707be8d4b403e463fa82fdb3f216c",
-        "hash": "sha256-KjIBJw40hiBkcHNn96dD5iZs2n2HMWIkAJ6ND2+5JJQ="
+        "rev": "fdb12b460f148895f6af2ff0e0d870ff8889f154",
+        "hash": "sha256-x8a8VYFrAZ0huj3WRlczrhg0quXx4cztz8nDs9ToWYg="
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -12,8 +12,9 @@
         "hash": "sha256-UouvzNFStYScnyfIJcz1Om7cDhC7EyShZQ/Icu73BPo="
       },
       "gn": {
+        "version": "0-unstable-2025-06-19",
         "rev": "97b68a0bb62b7528bc3491c7949d6804223c2b82",
-        "hash": "sha256-m+z10s40Q/iYcoMw3o/+tmhIdqHMsYJjdGabHrK/aqo="
+        "hash": "sha256-gwptzuirIdPAV9XCaAT09aM/fY7d6xgBU7oSu9C4tmE="
       },
       "npmHash": "sha256-R2gOpfPOUAmnsnUTIvzDPHuHNzL/b2fwlyyfTrywEcI="
     },
@@ -809,8 +810,9 @@
         "hash": "sha256-UouvzNFStYScnyfIJcz1Om7cDhC7EyShZQ/Icu73BPo="
       },
       "gn": {
+        "version": "0-unstable-2025-06-19",
         "rev": "97b68a0bb62b7528bc3491c7949d6804223c2b82",
-        "hash": "sha256-m+z10s40Q/iYcoMw3o/+tmhIdqHMsYJjdGabHrK/aqo="
+        "hash": "sha256-gwptzuirIdPAV9XCaAT09aM/fY7d6xgBU7oSu9C4tmE="
       },
       "ungoogled-patches": {
         "rev": "139.0.7258.154-1",

--- a/pkgs/applications/networking/browsers/chromium/patches/chromium-140-rust.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/chromium-140-rust.patch
@@ -1,0 +1,21 @@
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+index 77b02f76d2845fdf1a9429f704e59b8f7ab42993..e6ce3abe9872f415a9ef1cfc76f7267e7e44e1c9 100644
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -1917,16 +1917,6 @@ config("runtime_library") {
+     configs += [ "//build/config/c++:runtime_library" ]
+   }
+ 
+-  # Rust and C++ both provide intrinsics for LLVM to call for math operations. We
+-  # want to use the C++ intrinsics, not the ones in the Rust compiler_builtins
+-  # library. The Rust symbols are marked as weak, so that they can be replaced by
+-  # the C++ symbols. This config ensures the C++ symbols exist and are strong in
+-  # order to cause that replacement to occur by explicitly linking in clang's
+-  # compiler-rt library.
+-  if (is_clang && !is_cronet_build) {
+-    configs += [ "//build/config/clang:compiler_builtins" ]
+-  }
+-
+   # TODO(crbug.com/40570904): Come up with a better name for is POSIX + Fuchsia
+   # configuration.
+   if (is_posix || is_fuchsia) {

--- a/pkgs/applications/networking/browsers/chromium/update.mjs
+++ b/pkgs/applications/networking/browsers/chromium/update.mjs
@@ -153,7 +153,7 @@ async function get_gitiles_commit_date(base_url, rev) {
   const response = await (await fetch(url)).text()
   const json = JSON.parse(response.replace(`)]}'\n`, ''))
 
-  const date = new Date(json.commiter.time)
+  const date = new Date(json.committer.time)
   return date.toISOString().split("T")[0]
 }
 

--- a/pkgs/applications/networking/browsers/chromium/update.mjs
+++ b/pkgs/applications/networking/browsers/chromium/update.mjs
@@ -62,7 +62,7 @@ for (const attr_path of Object.keys(lockfile)) {
       chromedriver: !ungoogled ? await fetch_chromedriver_binaries(await get_latest_chromium_release('mac')) : undefined,
       deps: {
         depot_tools: {},
-        gn: {},
+        gn: await fetch_gn(chromium_rev, lockfile_initial[attr_path].deps.gn),
         'ungoogled-patches': !ungoogled ? undefined : {
           rev: ungoogled_patches.rev,
           hash: ungoogled_patches.hash,
@@ -76,12 +76,6 @@ for (const attr_path of Object.keys(lockfile)) {
     lockfile[attr_path].deps.depot_tools = {
       rev: depot_tools.rev,
       hash: depot_tools.hash,
-    }
-
-    const gn = await fetch_gn(chromium_rev, lockfile_initial[attr_path].deps.gn)
-    lockfile[attr_path].deps.gn = {
-      rev: gn.rev,
-      hash: gn.hash,
     }
 
     // DEPS update loop
@@ -133,10 +127,34 @@ for (const attr_path of Object.keys(lockfile)) {
 
 async function fetch_gn(chromium_rev, gn_previous) {
   const DEPS_file = await get_gitiles_file('https://chromium.googlesource.com/chromium/src', chromium_rev, 'DEPS')
-  const gn_rev = /^\s+'gn_version': 'git_revision:(?<rev>.+)',$/m.exec(DEPS_file).groups.rev
-  const hash = gn_rev === gn_previous.rev ? gn_previous.hash : ''
+  const { rev } = /^\s+'gn_version': 'git_revision:(?<rev>.+)',$/m.exec(DEPS_file).groups
 
-  return await prefetch_gitiles('https://gn.googlesource.com/gn', gn_rev, hash)
+  const cache_hit = rev === gn_previous.rev;
+  if (cache_hit) {
+    return gn_previous
+  }
+
+  const commit_date = await get_gitiles_commit_date('https://gn.googlesource.com/gn', rev)
+  const version = `0-unstable-${commit_date}`
+
+  const expr = [`(import ./. {}).gn.override { version = "${version}"; rev = "${rev}"; hash = ""; }`]
+  const derivation = await $nixpkgs`nix-instantiate --expr ${expr}`
+
+  return {
+    version,
+    rev,
+    hash: await prefetch_FOD(derivation),
+  }
+}
+
+
+async function get_gitiles_commit_date(base_url, rev) {
+  const url = `${base_url}/+/${rev}?format=json`
+  const response = await (await fetch(url)).text()
+  const json = JSON.parse(response.replace(`)]}'\n`, ''))
+
+  const date = new Date(json.commiter.time)
+  return date.toISOString().split("T")[0]
 }
 
 
@@ -259,4 +277,3 @@ async function prefetch_FOD(...args) {
 
   return hash
 }
-

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -4,10 +4,9 @@
         "chromium": {
             "deps": {
                 "gn": {
-                    "hash": "sha256-EqbwCLkseND1v3UqM+49N7GuoXJ3PlJjWOes4OijQ3U=",
+                    "hash": "sha256-U0f/Q134UJrSke+/o9Hs4+mQa/vSM2hdkRXhLfhnqME=",
                     "rev": "ed1abc107815210dc66ec439542bee2f6cbabc00",
-                    "url": "https://gn.googlesource.com/gn",
-                    "version": "2025-01-13"
+                    "version": "0-unstable-2025-01-13"
                 }
             },
             "version": "134.0.6998.205"
@@ -1313,10 +1312,9 @@
         "chromium": {
             "deps": {
                 "gn": {
-                    "hash": "sha256-vDKMt23RMDI+KX6CmjfeOhRv2haf/mDOuHpWKnlODcg=",
+                    "hash": "sha256-MnGl+D9ahQibUHCtyOUf1snvmeupUn4D2yrDj55JTe4=",
                     "rev": "6e8e0d6d4a151ab2ed9b4a35366e630c55888444",
-                    "url": "https://gn.googlesource.com/gn",
-                    "version": "2025-03-24"
+                    "version": "0-unstable-2025-03-24"
                 }
             },
             "version": "136.0.7103.177"
@@ -2638,10 +2636,9 @@
         "chromium": {
             "deps": {
                 "gn": {
-                    "hash": "sha256-UB9a7Fr1W0yYld6WbXyRR8dFqWsj/zx4KumDZ5JQKSM=",
+                    "hash": "sha256-BplU8qNKObVrKMLKTyqivPF1L6bbJulFC+Zop9UpmZY=",
                     "rev": "ebc8f16ca7b0d36a3e532ee90896f9eb48e5423b",
-                    "url": "https://gn.googlesource.com/gn",
-                    "version": "2025-05-21"
+                    "version": "0-unstable-2025-05-21"
                 }
             },
             "version": "138.0.7204.243"

--- a/pkgs/development/tools/electron/update.py
+++ b/pkgs/development/tools/electron/update.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i python -p python3.pkgs.joblib python3.pkgs.click python3.pkgs.click-log nix nix-prefetch-git prefetch-yarn-deps prefetch-npm-deps gclient2nix
+#! nix-shell -i python -p python3.pkgs.joblib python3.pkgs.click python3.pkgs.click-log nix nurl prefetch-yarn-deps prefetch-npm-deps gclient2nix
 """
 electron updater
 
@@ -32,7 +32,7 @@ import urllib.request
 import click
 import click_log
 
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Iterable, Tuple
 from urllib.request import urlopen
 from joblib import Parallel, delayed, Memory
@@ -43,6 +43,9 @@ from update_util import *
 SOURCE_INFO_JSON = "info.json"
 
 os.chdir(os.path.dirname(__file__))
+
+# Absolute path of nixpkgs top-level directory
+NIXPKGS_PATH = subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode("utf-8").strip()
 
 memory: Memory = Memory("cache", verbose=0)
 
@@ -79,25 +82,33 @@ def get_electron_file(electron_tag: str, filepath: str) -> str:
 
 
 @memory.cache
+def get_gn_hash(gn_version, gn_commit):
+    print("gn.override", file=sys.stderr)
+    expr = f'(import {NIXPKGS_PATH} {{}}).gn.override {{ version = "{gn_version}"; rev = "{gn_commit}"; hash = ""; }}'
+    out = subprocess.check_output(["nurl", "--hash", "--expr", expr])
+    return out.decode("utf-8").strip()
+
+@memory.cache
 def get_chromium_gn_source(chromium_tag: str) -> dict:
     gn_pattern = r"'gn_version': 'git_revision:([0-9a-f]{40})'"
     gn_commit = re.search(gn_pattern, get_chromium_file(chromium_tag, "DEPS")).group(1)
-    gn_prefetch: bytes = subprocess.check_output(
-        [
-            "nix-prefetch-git",
-            "--quiet",
-            "https://gn.googlesource.com/gn",
-            "--rev",
-            gn_commit,
-        ]
+
+    gn_commit_info = json.loads(
+        urlopen(f"https://gn.googlesource.com/gn/+/{gn_commit}?format=json")
+        .read()
+        .decode("utf-8")
+        .split(")]}'\n")[1]
     )
-    gn: dict = json.loads(gn_prefetch)
+
+    gn_commit_date = datetime.strptime(gn_commit_info["commiter"]["time"], "%a %b %d %H:%M:%S %Y %z")
+    gn_date = gn_commit_date.astimezone(UTC).date().isoformat()
+    gn_version = f"0-unstable-{gn_date}"
+
     return {
         "gn": {
-            "version": datetime.fromisoformat(gn["date"]).date().isoformat(),
-            "url": gn["url"],
-            "rev": gn["rev"],
-            "hash": gn["hash"],
+            "version": gn_version,
+            "rev": gn_commit,
+            "hash": get_gn_hash(gn_version, gn_commit),
         }
     }
 


### PR DESCRIPTION
Backport of #439726 with some of #419337 as explained in https://github.com/NixOS/nixpkgs/pull/419337#issuecomment-3172027941 and an additional fix to build chromium M140 with Rust <1.89.

Will cause a rebuild of all of chromium and electron due to the gn compat shim (0f34d64ab24f3a8d04953555e6690d92b567e5b1).

Cherry-pick CI check is expected to fail because of 0f34d64ab24f3a8d04953555e6690d92b567e5b1 and fd89e235b89571ad4a487855596f7e0a091f214c.

A full nixpkgs-review run is pending.

## Things done

- Built on platform:
  - [x] x86_64-linux (only `chromedriver` so far)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test