### PR TITLE
qbittorrent-exporter: init at 1.12.1

### DIFF
--- a/pkgs/by-name/pr/prometheus-qbittorrent-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-qbittorrent-exporter/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "prometheus-qbittorrent-exporter";
+  version = "1.12.1";
+
+  src = fetchFromGitHub {
+    owner = "martabal";
+    repo = "qbittorrent-exporter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9J4nGG52M7SSeXigLBJK/dqXRvSpPqOGRJ8BQx7+1eU=";
+  };
+  sourceRoot = "${finalAttrs.src.name}/src";
+
+  vendorHash = "sha256-jJmhRnjioeTq9Uol0lYLChPi4O1D9JnGqN7q1XK36yE=";
+
+  ldflags = [
+    "-s"
+    "-X 'qbit-exp/app.version=v${finalAttrs.version}'"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Prometheus exporter for qBittorrent";
+    homepage = "https://github.com/martabal/qbittorrent-exporter";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [
+      typedrat
+      undefined-landmark
+    ];
+    mainProgram = "qbit-exp";
+  };
+})


### PR DESCRIPTION
Adds [a Prometheus exporter for qBittorrent](https://github.com/martabal/qbittorrent-exporter). This should probably get wired into the Prometheus exporter module, but that code scared me when I looked at it. 😨  

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
