### PR TITLE
graalvm-oracle_25-ea: 25-ea-35 -> 25-ea-36

### DIFF
--- a/pkgs/development/compilers/graalvm/default.nix
+++ b/pkgs/development/compilers/graalvm/default.nix
@@ -24,7 +24,7 @@ lib.makeScope pkgs.newScope (
     truffleruby = self.callPackage ./community-edition/truffleruby { };
 
     graalvm-oracle_25-ea =
-      (self.callPackage ./graalvm-oracle { version = "25-ea-35"; }).overrideAttrs
+      (self.callPackage ./graalvm-oracle { version = "25-ea-36"; }).overrideAttrs
         (prev: {
           autoPatchelfIgnoreMissingDeps = [ "libonnxruntime.so.1" ];
         });

--- a/pkgs/development/compilers/graalvm/graalvm-oracle/hashes.nix
+++ b/pkgs/development/compilers/graalvm/graalvm-oracle/hashes.nix
@@ -4,22 +4,22 @@
 # $ rg -No "(https://.+)\"" -r '$1' pkgs/development/compilers/graalvm/graalvm-oracle/hashes.nix | \
 #   parallel -k 'echo {}; nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri $(curl -s {}.sha256)'
 {
-  "25-ea-35" = {
+  "25-ea-36" = {
     "aarch64-linux" = {
-      hash = "sha256-DbESXsX/saJSizZ/s6ENsL3W9VASRRGYArKzjvqlRk8=";
-      url = "https://github.com/graalvm/oracle-graalvm-ea-builds/releases/download/jdk-25.0.0-ea.35/graalvm-jdk-25.0.0-ea.35_linux-aarch64_bin.tar.gz";
+      hash = "sha256-NbN5UYIRgyqMXuGZcf0OQhghBa1v4/jpMJvOih8+7Nk=";
+      url = "https://github.com/graalvm/oracle-graalvm-ea-builds/releases/download/jdk-25.0.0-ea.36/graalvm-jdk-25.0.0-ea.36_linux-aarch64_bin.tar.gz";
     };
     "x86_64-linux" = {
-      hash = "sha256-fR9cA8vwV7/w4eRAkrzft0cNW29tM2rCCjSoUEDcX1A=";
-      url = "https://github.com/graalvm/oracle-graalvm-ea-builds/releases/download/jdk-25.0.0-ea.35/graalvm-jdk-25.0.0-ea.35_linux-x64_bin.tar.gz";
+      hash = "sha256-LQCwzhYDsbhR+ij8zYh37H7xhxbfxzZxAVFNLBzmFVs=";
+      url = "https://github.com/graalvm/oracle-graalvm-ea-builds/releases/download/jdk-25.0.0-ea.36/graalvm-jdk-25.0.0-ea.36_linux-x64_bin.tar.gz";
     };
     "x86_64-darwin" = {
-      hash = "sha256-OZHBmZqwC5DpGmXSDah4f002XGBhreoumBXv0IEalRs=";
-      url = "https://github.com/graalvm/oracle-graalvm-ea-builds/releases/download/jdk-25.0.0-ea.35/graalvm-jdk-25.0.0-ea.35_macos-x64_bin.tar.gz";
+      hash = "sha256-GU57RhQJK4SHOigRMsCPwXkLo9SKJ/73GVZw2QzcIVM=";
+      url = "https://github.com/graalvm/oracle-graalvm-ea-builds/releases/download/jdk-25.0.0-ea.36/graalvm-jdk-25.0.0-ea.36_macos-x64_bin.tar.gz";
     };
     "aarch64-darwin" = {
-      hash = "sha256-Q2HU2wHIPdanGTKFLNdllEEPXmERgqTyeVNMWKj/CvE=";
-      url = "https://github.com/graalvm/oracle-graalvm-ea-builds/releases/download/jdk-25.0.0-ea.35/graalvm-jdk-25.0.0-ea.35_macos-aarch64_bin.tar.gz";
+      hash = "sha256-nOJ6Ngsy/EMZ93R1WIQ6AMD//QSaKBvNqAd3CxLdJ74=";
+      url = "https://github.com/graalvm/oracle-graalvm-ea-builds/releases/download/jdk-25.0.0-ea.36/graalvm-jdk-25.0.0-ea.36_macos-aarch64_bin.tar.gz";
     };
   };
   "24" = {


### PR DESCRIPTION
Update graalvm-oracle_25-ea-35 to 25-ea-36, currently the latest version available at:
https://github.com/graalvm/oracle-graalvm-ea-builds/releases

This is likely the final release candidate for 25.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
