### PR TITLE
ee: init at 1.5.2

### DIFF
--- a/pkgs/by-name/ee/ee/package.nix
+++ b/pkgs/by-name/ee/ee/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  nix-update-script,
+  fetchgit,
+  ncurses,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ee";
+  version = "1.5.2";
+
+  src = fetchgit {
+    url = "https://git.freebsd.org/src.git";
+    tag = "release/14.3.0";
+    outputHash = "sha256-nMhHXeoam9VtUuhhi0eoGZfcW9zZhpYQKVYbkAbfgc0=";
+    rootDir = "contrib/ee";
+  };
+
+  passthru.updateScript = nix-update-script { };
+
+  buildInputs = [ ncurses ];
+
+  postPatch = ''
+    substituteInPlace create.make --replace-fail "/usr/include/curses.h" "${ncurses.dev}/include/ncurses.h"
+    substituteInPlace create.make --replace-fail "-lcurses" "-lncurses"
+  '';
+
+  NIX_CFLAGS_COMPILE = "-DHAS_UNISTD=1 -DHAS_STDLIB=1 -DHAS_SYS_WAIT=1";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp ee $out/bin/ee
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "classic curses text editor";
+    homepage = "https://man.freebsd.org/cgi/man.cgi?ee";
+    longDescription = ''
+      An easy to use text editor. Intended to be usable with little or no
+      instruction. Provides a terminal (curses based) interface. Features
+      pop-up menus. Born in HP-UX, included in FreeBSD.
+    '';
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.unix;
+    mainProgram = "ee";
+  };
+})


### PR DESCRIPTION
This adds the ee easy editor famous used in FreeBSD as a beginner-friendly vi replacement in barebones systems.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [N/A] [NixOS tests] in [nixos/tests].
  - [N/A] [Package tests] at `passthru.tests`.
  - [N/A] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [N/A] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [N/A] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [N/A] Module addition: when adding a new NixOS module.
  - [N/A] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
