### PR TITLE
clash-rs: 0.8.2 -> 0.9.0

### DIFF
--- a/pkgs/by-name/cl/clash-rs/Cargo.patch
+++ b/pkgs/by-name/cl/clash-rs/Cargo.patch
@@ -1,0 +1,50 @@
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1462,7 +1462,7 @@
+  "sha2",
+  "shadowquic",
+  "shadowsocks",
+- "smoltcp 0.12.0 (git+https://github.com/smoltcp-rs/smoltcp.git?rev=ac32e64)",
++ "smoltcp 0.12.0",
+  "socket2 0.6.0",
+  "tempfile",
+  "thiserror 2.0.15",
+@@ -4439,7 +4439,7 @@
+  "etherparse 0.16.0",
+  "futures",
+  "rand 0.8.5",
+- "smoltcp 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "smoltcp 0.12.0",
+  "spin 0.9.8",
+  "tokio",
+  "tokio-util",
+@@ -6892,20 +6892,6 @@
+ ]
+
+ [[package]]
+-name = "smoltcp"
+-version = "0.12.0"
+-source = "git+https://github.com/smoltcp-rs/smoltcp.git?rev=ac32e64#ac32e643a4b7e09161193071526b3ca5a0deedb5"
+-dependencies = [
+- "bitflags 1.3.2",
+- "byteorder",
+- "cfg-if",
+- "defmt 0.3.100",
+- "heapless",
+- "log",
+- "managed",
+-]
+-
+-[[package]]
+ name = "socket2"
+ version = "0.4.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -9231,7 +9217,7 @@
+  "netstack-lwip",
+  "netstack-smoltcp",
+  "rand 0.9.2",
+- "smoltcp 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "smoltcp 0.12.0",
+  "socket2 0.6.0",
+  "tokio",
+  "tracing",

--- a/pkgs/by-name/cl/clash-rs/package.nix
+++ b/pkgs/by-name/cl/clash-rs/package.nix
@@ -6,23 +6,31 @@
   versionCheckHook,
   cmake,
   pkg-config,
+  nix-update-script,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "clash-rs";
-  version = "0.8.2";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "Watfaq";
     repo = "clash-rs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-HkIsflsLTQdvetgamLt6LbYxOpv1+FQ/e/PzJjKOfq4=";
+    hash = "sha256-OwoDvcGpuU2x6O3+rBJSXGS2VoeFt/oVgFWUaCUyC8E=";
   };
 
-  cargoHash = "sha256-Qh/YxNO/DtVBj6Eiloc3+Fs+dQqvAXSe+5lCer0F2zs=";
+  cargoHash = "sha256-HKW6bOkHkBINwA2tgaKHEozKzT4n54roj6W989JUoAQ=";
+
+  cargoPatches = [ ./Cargo.patch ];
 
   patches = [
     ./unbounded-shifts.patch
   ];
+
+  postPatch = ''
+    substituteInPlace clash-lib/Cargo.toml \
+      --replace-fail ', git = "https://github.com/smoltcp-rs/smoltcp.git", rev = "ac32e64"' ""
+  '';
 
   nativeBuildInputs = [
     cmake
@@ -55,6 +63,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^v([0-9.]+)$"
+    ];
+  };
 
   meta = {
     description = "Custom protocol, rule based network proxy software";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/Watfaq/clash-rs/releases/tag/v0.9.0
https://github.com/Watfaq/clash-rs/compare/v0.8.2...v0.9.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
