### PR TITLE
Add `override` function back to `buildArmTrustedFirmware` results for backward compatibility

### DIFF
--- a/nixos/tests/optee.nix
+++ b/nixos/tests/optee.nix
@@ -21,8 +21,8 @@ import ./make-test-python.nix (
           '';
         });
 
-        bios = armTrustedFirmwareQemu.override {
-          extraMakeFlags = [
+        bios = armTrustedFirmwareQemu.overrideAttrs (old: {
+          makeFlags = old.makeFlags ++ [
             "SPD=opteed"
             "BL32=${opteeQemuAarch64}/tee-header_v2.bin"
             "BL32_EXTRA1=${opteeQemuAarch64}/tee-pager_v2.bin"
@@ -36,10 +36,11 @@ import ./make-test-python.nix (
             "build/qemu/release/fip.bin"
           ];
           postInstall = ''
+            ${old.postInstall or ""}
             dd if=$out/bl1.bin of=$out/bios.bin bs=4096 conv=notrunc
             dd if=$out/fip.bin of=$out/bios.bin seek=64 bs=4096 conv=notrunc
           '';
-        };
+        });
       in
       {
         virtualisation = {

--- a/pkgs/misc/arm-trusted-firmware/build-arm-trusted-firmware.nix
+++ b/pkgs/misc/arm-trusted-firmware/build-arm-trusted-firmware.nix
@@ -119,6 +119,13 @@ lib.extendMkDerivation {
       # breaks secondary CPU bringup on at least RK3588, maybe others
       env.NIX_CFLAGS_COMPILE = "-fomit-frame-pointer";
 
+      # TODO: remove this passthru function after some time to allow for soft-deprecation
+      passthru.override =
+        overrideArgs:
+        lib.warn "Using override with buildArmTrustedFirmware is no longer supported, please use overrideAttrs instead" (
+          finalAttrs.finalPackage.overrideAttrs overrideArgs
+        );
+
       meta = {
         homepage = "https://github.com/ARM-software/arm-trusted-firmware";
         description = "Reference implementation of secure world software for ARMv8-A";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The work done in 1898fb4be4cc634fa60939683d05574dce436528 introduced a breaking change since the `override` function was removed. This adds back support for that, with an eval warning encouraging users to switch to the more extensible `overrideAttrs` for ATF related build parameters.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
