### PR TITLE
postgresqlPackages.pg_cron: 1.6.5 -> 1.6.6

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_cron.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_cron.nix
@@ -7,22 +7,16 @@
 
 postgresqlBuildExtension (finalAttrs: {
   pname = "pg_cron";
-  version = "1.6.5";
+  version = "1.6.6";
 
   src = fetchFromGitHub {
     owner = "citusdata";
     repo = "pg_cron";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Llksil7Fk7jvJJmCpfCN0Qm2b2I4J1VOA7/ibytO+KM=";
+    hash = "sha256-N6lLmfegUeHCpwXztMifTRvajlVLyxL0j+8edouKIOQ=";
   };
 
   meta = {
-    # PostgreSQL 18 support issue upstream: https://github.com/citusdata/pg_cron/issues/396
-    # Note: already fixed on `main` branch.
-    # Check after next package update.
-    broken = lib.warnIf (
-      finalAttrs.version != "1.6.5"
-    ) "Is postgresql18Packages.pg_cron still broken?" (lib.versionAtLeast postgresql.version "18");
     description = "Run Cron jobs through PostgreSQL";
     homepage = "https://github.com/citusdata/pg_cron";
     changelog = "https://github.com/citusdata/pg_cron/releases/tag/v${finalAttrs.version}";


### PR DESCRIPTION
Release Notes:
https://github.com/citusdata/pg_cron/releases/tag/v1.6.6

Now supports PostgreSQL 18.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
