### PR TITLE
postgresql_18: 18beta3 -> 18rc1

### DIFF
--- a/pkgs/servers/sql/postgresql/18.nix
+++ b/pkgs/servers/sql/postgresql/18.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "18beta2";
-  rev = "refs/tags/REL_18_BETA3";
-  hash = "sha256-QpJONriQnRN75cCcsdu9TGt8Km7NQLs5diZx1pVruc4=";
+  version = "18rc1";
+  rev = "refs/tags/REL_18_RC1";
+  hash = "sha256-PDycGuKrEa00N1h/BsWUiwG7naE0f2wFFXpQSOhs/hY=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";

--- a/pkgs/servers/sql/postgresql/ext/pg_hll.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_hll.nix
@@ -1,5 +1,6 @@
 {
   fetchFromGitHub,
+  fetchpatch,
   lib,
   postgresql,
   postgresqlBuildExtension,
@@ -16,8 +17,13 @@ postgresqlBuildExtension (finalAttrs: {
     hash = "sha256-Latdxph1Ura8yKEokEjalJ+/GY+pAKOT3GXjuLprj6c=";
   };
 
-  # https://github.com/citusdata/postgresql-hll/issues/166#issuecomment-3165489050
-  NIX_CFLAGS_COMPILE = "-Wno-error=missing-variable-declarations";
+  patches = [
+    (fetchpatch {
+      name = "fix-postgresql-18.patch";
+      url = "https://github.com/citusdata/postgresql-hll/commit/f998e234653ea397ddddc1278d1c02d8d011bd16.patch";
+      hash = "sha256-gF4f+B4Gu/QEyCGMfKLmRK6lNwgfd8lML55wMkhsSY4=";
+    })
+  ];
 
   meta = {
     description = "HyperLogLog for PostgreSQL";

--- a/pkgs/servers/sql/postgresql/ext/pg_ivm.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_ivm.nix
@@ -23,14 +23,11 @@ postgresqlBuildExtension (finalAttrs: {
     maintainers = with lib.maintainers; [ ivan ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.postgresql;
-    broken =
-      lib.versionOlder postgresql.version "13"
-      ||
-        # PostgreSQL 18 support issue upstream: https://github.com/sraoss/pg_ivm/issues/133
-        # Note: already fixed on `main` branch.
-        # Check after next package update.
-        lib.warnIf (finalAttrs.version != "1.11") "Is postgresql18Packages.pg_ivm still broken?" (
-          lib.versionAtLeast postgresql.version "18"
-        );
+    # PostgreSQL 18 support issue upstream: https://github.com/sraoss/pg_ivm/issues/133
+    # Note: already fixed on `main` branch.
+    # Check after next package update.
+    broken = lib.warnIf (finalAttrs.version != "1.11") "Is postgresql18Packages.pg_ivm still broken?" (
+      lib.versionAtLeast postgresql.version "18"
+    );
   };
 })

--- a/pkgs/servers/sql/postgresql/ext/pg_uuidv7.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_uuidv7.nix
@@ -23,6 +23,5 @@ postgresqlBuildExtension (finalAttrs: {
     maintainers = with lib.maintainers; [ gaelreyrol ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.mpl20;
-    broken = lib.versionOlder postgresql.version "13";
   };
 })


### PR DESCRIPTION
Release Notes for v18:
https://www.postgresql.org/docs/18/release-18.html

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
