### PR TITLE
gephgui-wry: init at `a85a632`

### DIFF
--- a/pkgs/by-name/ge/gephgui-wry/package.nix
+++ b/pkgs/by-name/ge/gephgui-wry/package.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  rustPlatform,
+  webkitgtk_4_1,
+  pkg-config,
+  buildNpmPackage,
+  makeDesktopItem,
+  fetchFromGitHub,
+  nix-update-script,
+  perl,
+}:
+let
+  version = "0-unstable-2025-09-04";
+  src = fetchFromGitHub {
+    owner = "geph-official";
+    repo = "gephgui-wry";
+    rev = "a85a632448e548f69f9d1eea3d06a4bdc8be3d57";
+    hash = "sha256-CmojbfO/8IzeW3Qh6MU4NCUgWarmvqNr38NJzmsyIO4=";
+    fetchSubmodules = true;
+  };
+
+  pac-real = fetchFromGitHub {
+    owner = "geph-official";
+    repo = "gephgui-pkg";
+    rev = "v5.2.0";
+    hash = "sha256-Y122+6E2pWGWYo5OZj4sPhWt5anz/AOhadcPOXY7hAU=";
+    sparseCheckout = [ "blobs/linux-x64/pac-real" ];
+  };
+
+  gephgui-frontend = buildNpmPackage {
+    pname = "gephgui-frontend";
+    inherit version src;
+
+    sourceRoot = "${src.name}/gephgui";
+
+    npmDepsHash = "sha256-dGzmdvzKp/JHCgDf3NJb0oolgW4Y/spagzpeVpMF28w=";
+
+    installPhase = ''
+      mkdir -p $out
+      cp -aR dist/* $out/
+    '';
+
+    meta = with lib; {
+      description = "Frontend for Geph GUI";
+      homepage = "https://github.com/geph-official/gephgui-wry";
+      license = licenses.gpl3Only;
+      platforms = platforms.all;
+    };
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "gephgui-wry";
+  inherit version src;
+
+  cargoHash = "sha256-Yjy4vabjD6fYskIq/TmEF279EOarFSzBVRMMUWU9q7Y=";
+
+  nativeBuildInputs = [
+    pkg-config
+    perl
+  ];
+
+  buildInputs = [ webkitgtk_4_1 ];
+
+  runtimeDependencies = [ webkitgtk_4_1 ];
+
+  preBuild = ''
+    cp -r ${gephgui-frontend}/ gephgui/dist/
+  '';
+
+  # pac-real might not work
+  postInstall = ''
+    mkdir -p $out/bin
+    cp ${pac-real}/blobs/linux-x64/pac-real $out/bin/pac
+    chmod +x $out/bin/pac
+
+    install -m 444 -D gephgui/public/gephlogo.png $out/share/icons/hicolor/512x512/apps/geph5.png
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Geph";
+      desktopName = "Geph";
+      icon = "geph";
+      exec = "gephgui-wry";
+      categories = [ "Network" ];
+      comment = "Modular Internet censorship circumvention system designed specifically to deal with national filtering";
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { }; # Not tested.
+
+  meta = with lib; {
+    description = "Modular Internet censorship circumvention system designed specifically to deal with national filtering";
+    homepage = "https://github.com/geph-official/gephgui-wry";
+    mainProgram = "gephgui-wry";
+    platforms = lib.platforms.linux; # Theoretically it's cross-platform, but I haven't been able to test it on Windows and macOS devices.
+    license = licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      penalty1083
+      MCSeekeri
+    ];
+  };
+}


### PR DESCRIPTION
The new geph GUI. This package is added to facilitate the removal of the now-unavailable geph5-client-gui.
## TODOs
- [ ] Fix the issue where the connection cannot be started
- [ ] Use stable tags instead of 0-unstable... (Maybe communicate with upstream? Seems somewhat difficult)
- [ ] Check if pac-real is necessary
- [ ] Ensure nix-update-script can update versions normally
- [ ] Perhaps add packaging support for macOS and even Windows?




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
