### PR TITLE
ariang: add desktop integration

### DIFF
--- a/pkgs/by-name/ar/ariang/package.nix
+++ b/pkgs/by-name/ar/ariang/package.nix
@@ -2,6 +2,10 @@
   lib,
   fetchFromGitHub,
   buildNpmPackage,
+  copyDesktopItems,
+  imagemagick,
+  xdg-utils,
+  makeDesktopItem,
   nix-update-script,
 }:
 
@@ -20,22 +24,54 @@ buildNpmPackage rec {
 
   makeCacheWritable = true;
 
+  nativeBuildInputs = [
+    copyDesktopItems
+    imagemagick
+  ];
+
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/share
-    cp -r dist $out/share/ariang
+    cp -r dist $out/share/${pname}
+
+    for size in 16 24 36 48 72; do
+      mkdir -p $out/share/icons/hicolor/''${size}x''${size}/apps
+      magick $out/share/${pname}/tileicon.png -resize ''${size}x''${size} \
+        $out/share/icons/hicolor/''${size}x''${size}/apps/${pname}.png
+    done
+
+    mkdir -p $out/bin
+    makeWrapper ${xdg-utils}/bin/xdg-open $out/bin/${pname} \
+      --add-flags "file://$out/share/${pname}/index.html"
 
     runHook postInstall
   '';
 
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      desktopName = "AriaNg";
+      genericName = meta.description;
+      comment = meta.description;
+      exec = pname;
+      icon = pname;
+      terminal = false;
+      type = "Application";
+      categories = [
+        "Network"
+        "WebBrowser"
+      ];
+    })
+  ];
+
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "Modern web frontend making aria2 easier to use";
     homepage = "http://ariang.mayswind.net/";
-    license = licenses.mit;
-    maintainers = with maintainers; [ stunkymonkey ];
-    platforms = platforms.unix;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ stunkymonkey ];
+    platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
This PR enhances usability by allowing users to launch AriaNg from their app menu or terminal, instead of the cumbersome process of manually handling `index.html` or calling it from nix store.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
