### PR TITLE
python3Packages.deepdiff: 8.5.0 -> 8.6.1

### DIFF
--- a/pkgs/development/python-modules/deepdiff/default.nix
+++ b/pkgs/development/python-modules/deepdiff/default.nix
@@ -20,21 +20,23 @@
   numpy,
   pytestCheckHook,
   python-dateutil,
+  pydantic,
   tomli-w,
   polars,
   pandas,
+  uuid6,
 }:
 
 buildPythonPackage rec {
   pname = "deepdiff";
-  version = "8.5.0";
+  version = "8.6.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "seperman";
     repo = "deepdiff";
     tag = version;
-    hash = "sha256-JIxlWy2uVpI98BmpH2+EyOxfYBoO2G2S0D9krduVo08=";
+    hash = "sha256-1DB1OgIS/TSMd+Pqd2vvW+qwM/b5+Dy3qStlg+asidE=";
   };
 
   build-system = [
@@ -60,16 +62,15 @@ buildPythonPackage rec {
     numpy
     pytestCheckHook
     python-dateutil
+    pydantic
     tomli-w
     polars
     pandas
+    uuid6
   ]
   ++ lib.flatten (lib.attrValues optional-dependencies);
 
   disabledTests = [
-    # not compatible with pydantic 2.x
-    "test_pydantic1"
-    "test_pydantic2"
     # Require pytest-benchmark
     "test_cache_deeply_nested_a1"
     "test_lfu"


### PR DESCRIPTION
Critical security vulnerability fixed:
- CVE-2025-58367/https://github.com/seperman/deepdiff/security/advisories/GHSA-mw26-5g2v-hqw3

Changelog:
- https://github.com/seperman/deepdiff/releases/tag/8.6.1
- https://github.com/seperman/deepdiff/releases/tag/8.6.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
