### PR TITLE
warp-terminal-update.yaml Warp-Terminal auto update and rebuild.

### DIFF
--- a/.github/workflows/warp-terminal-update.yaml
+++ b/.github/workflows/warp-terminal-update.yaml
@@ -1,0 +1,60 @@
+name: Update & Rebuild Warp Terminal Package
+
+on:
+  schedule:
+    # Run every two weeks on Monday at 9:00 AM UTC
+    - cron: '0 9 */14 * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write   # allow pushing directly to main
+
+jobs:
+  rebuild-and-update:
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner) }}
+    runs-on: ubuntu-latest
+    env:
+      NIXPKGS_ALLOW_UNFREE: "1"
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Install Nix (>=2.22.1)
+      uses: cachix/install-nix-action@v22
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+        install_url: https://releases.nixos.org/nix/nix-2.22.1/install
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+
+    - name: Run update.sh
+      run: |
+        cd pkgs/by-name/wa/warp-terminal
+        chmod +x update.sh
+        ./update.sh
+
+    - name: Check for changes in versions.json
+      id: git_changes
+      run: |
+        if git diff --quiet pkgs/by-name/wa/warp-terminal/versions.json; then
+          echo "update_needed=false" >> $GITHUB_OUTPUT
+        else
+          echo "update_needed=true" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Test build Warp Terminal
+      if: steps.git_changes.outputs.update_needed == 'true'
+      run: |
+        NIXPKGS_ALLOW_UNFREE=1 nix-build -E "with import <nixpkgs> {}; callPackage ./pkgs/by-name/wa/warp-terminal/package.nix {}"
+
+    - name: Commit & Push changes to main
+      if: steps.git_changes.outputs.update_needed == 'true'
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add pkgs/by-name/wa/warp-terminal/versions.json
+        git commit -m "warp-terminal: automatic update"
+        git push origin HEAD:main


### PR DESCRIPTION
Auto update for warp-terminal package versions.json
Auto run the update script in the package for updating versions.json every 2 weeks at 9AM UTC.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
