### PR TITLE
globus-cli: init at 3.36.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21766,6 +21766,18 @@
     githubId = 10631029;
     name = "Richard Ipsum";
   };
+  richardjacton = {
+    email = "richardjacton@richardjacton.net";
+    github = "richardjacton";
+    githubId = 6893043;
+    name = "Richard J. Acton";
+    matrix = "@richardjacton:matrix.org";
+    keys = [
+      {
+        fingerprint = "5EE1 1764 8462 E5A3 610C  1964 8E5D EFCF C330 7916";
+      }
+    ];
+  };
   richiejp = {
     email = "io@richiejp.com";
     github = "richiejp";

--- a/pkgs/by-name/gl/globus-cli/package.nix
+++ b/pkgs/by-name/gl/globus-cli/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  installShellFiles,
+  versionCheckHook,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "globus-cli";
+  version = "3.36.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "globus";
+    repo = "globus-cli";
+    tag = version;
+    hash = "sha256-Phu7nXMICSBFUX8wfzwA4ORBJIkhTDCMCqTyZvcG93c=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    ruamel-yaml
+  ];
+
+  dependencies = with python3Packages; [
+    globus-sdk
+    click
+    jmespath
+    packaging
+    typing-extensions
+    requests
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytest
+    pytest-xdist
+    pytest-timeout
+    responses
+
+    click
+    requests
+    pyjwt
+    cryptography
+    packaging
+    typing-extensions
+
+    pytestCheckHook
+    versionCheckHook
+  ];
+
+  versionCheckProgramArg = "version";
+
+  postInstall = ''
+    mkdir -p completions/{bash,zsh}
+    $out/bin/globus --bash-completer > completions/bash/globus
+    $out/bin/globus --zsh-completer > completions/zsh/_globus
+    installShellCompletion \
+      --bash completions/bash/globus \
+      --zsh completions/zsh/_globus
+  '';
+
+  meta = {
+    mainProgram = "globus";
+    description = "Command-line interface to Globus REST APIs, including the Transfer API and the Globus Auth API";
+    homepage = "https://github.com/globus/globus-cli";
+    changelog = "https://github.com/globus/globus-cli/releases/tag/${src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.richardjacton ];
+  };
+}


### PR DESCRIPTION
Adds the [globus-cli](https://github.com/globus/globus-cli) [[docs](https://docs.globus.org/cli/)] application. The [Globus python SDK](https://github.com/NixOS/nixpkgs/blob/nixos-25.05/pkgs/development/python-modules/globus-sdk/default.nix) that this uses is already packaged in nixpkgs @bot-wxt1221 would you be interested in co-maintaining given you maintain this related package?

> a standalone application that can be installed on the user’s machine and used to access the Globus service. ... provides an interface to Globus services from the shell, and is suited to both interactive and simple scripting use cases.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
