### PR TITLE
acl2: 8.5 -> 8.6 and mark darwin builds as compatible

### DIFF
--- a/pkgs/development/interpreters/acl2/0001-path-changes-for-nix.patch
+++ b/pkgs/development/interpreters/acl2/0001-path-changes-for-nix.patch
@@ -1,16 +1,16 @@
-From aed1c4b0be7576d20eed81070da2c6f92573df18 Mon Sep 17 00:00:00 2001
-From: Keshav Kini <keshav.kini@gmail.com>
-Date: Sat, 30 May 2020 21:27:47 -0700
-Subject: [PATCH] Fix some paths for Nix build
+From 2c7829aec41f6915bda2a23af57f0b39b075a70b Mon Sep 17 00:00:00 2001
+From: C4 Patino <c4patino@gmail.com>
+Date: Wed, 3 Sep 2025 22:43:05 -0500
+Subject: [PATCH] path changes for nix
 
 ---
  books/build/features.sh                                     | 1 +
  books/centaur/ipasir/load-ipasir-sharedlib-raw.lsp          | 6 +-----
- .../bundle/software/cl+ssl-20220707-git/src/reload.lisp     | 3 +++
- 3 files changed, 5 insertions(+), 5 deletions(-)
+ .../bundle/software/cl+ssl-20231021-git/src/reload.lisp     | 2 ++
+ 3 files changed, 4 insertions(+), 5 deletions(-)
 
 diff --git a/books/build/features.sh b/books/build/features.sh
-index feb5b2b59c..4b654e08bc 100755
+index 20ef1f1cc7..e8a16396e3 100755
 --- a/books/build/features.sh
 +++ b/books/build/features.sh
 @@ -125,6 +125,7 @@ EOF
@@ -22,7 +22,7 @@ index feb5b2b59c..4b654e08bc 100755
      cat >> Makefile-features <<EOF
  export OS_HAS_IPASIR ?= 1
 diff --git a/books/centaur/ipasir/load-ipasir-sharedlib-raw.lsp b/books/centaur/ipasir/load-ipasir-sharedlib-raw.lsp
-index 762e4ad4c0..c9802cb582 100644
+index 762e4ad4c0..abc95d0ad8 100644
 --- a/books/centaur/ipasir/load-ipasir-sharedlib-raw.lsp
 +++ b/books/centaur/ipasir/load-ipasir-sharedlib-raw.lsp
 @@ -30,11 +30,7 @@
@@ -34,24 +34,23 @@ index 762e4ad4c0..c9802cb582 100644
 -           (cw "WARNING: $IPASIR_SHARED_LIBRARY not specified, ~
 -                defaulting to \"libipasirglucose4.so\"")
 -           "libipasirglucose4.so"))
-+      (cffi::load-foreign-library (or libname "@libipasir@"))
++(cffi::load-foreign-library (or libname "@libipasir@"))
      (error () (er hard? 'load-ipasir-shardlib-raw
                    "Couldn't load ipasir shared library from ~s0."
                    libname))))
-diff --git a/books/quicklisp/bundle/software/cl+ssl-20220707-git/src/reload.lisp b/books/quicklisp/bundle/software/cl+ssl-20220707-git/src/reload.lisp
-index d409b4440f..5c65c5b4da 100644
---- a/books/quicklisp/bundle/software/cl+ssl-20220707-git/src/reload.lisp
-+++ b/books/quicklisp/bundle/software/cl+ssl-20220707-git/src/reload.lisp
-@@ -87,6 +87,9 @@ sudo rm /usr/local/lib/libcrypto.dylib /usr/local/lib/libssl.dylib
- ;;
- ;; These are 32-bit only.
+diff --git a/books/quicklisp/bundle/software/cl+ssl-20231021-git/src/reload.lisp b/books/quicklisp/bundle/software/cl+ssl-20231021-git/src/reload.lisp
+index 05ab8837d0..fb60937580 100644
+--- a/books/quicklisp/bundle/software/cl+ssl-20231021-git/src/reload.lisp
++++ b/books/quicklisp/bundle/software/cl+ssl-20231021-git/src/reload.lisp
+@@ -14,6 +14,8 @@
+ ;;;     put this directly into ffi.lisp
  
+ (in-package :cl+ssl)
 +(cl+ssl/config:define-libssl-path "@libssl@")
 +(cl+ssl/config:define-libcrypto-path "@libcrypto@")
-+
- (unless cl+ssl/config::*libcrypto-override*
-   (cffi:define-foreign-library libcrypto
-     (:windows (:or #+(and windows x86-64) "libcrypto-1_1-x64.dll"
+ 
+ ;; The default OS-X libssl seems have had insufficient crypto algos
+ ;; (missing TLSv1_[1,2]_XXX methods,
 -- 
-2.31.1
+2.50.1
 

--- a/pkgs/development/interpreters/acl2/default.nix
+++ b/pkgs/development/interpreters/acl2/default.nix
@@ -3,12 +3,10 @@
   stdenv,
   callPackage,
   fetchFromGitHub,
-  fetchpatch,
   runCommandLocal,
   makeWrapper,
   replaceVars,
   sbcl,
-  bash,
   which,
   perl,
   hostname,
@@ -35,13 +33,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "acl2";
-  version = "8.5";
+  version = "8.6";
 
   src = fetchFromGitHub {
     owner = "acl2-devel";
     repo = "acl2-devel";
     rev = version;
-    sha256 = "12cv5ms1j3vfrq066km020nwxb6x2dzh12g8nz6xxyxysn44wzzi";
+    sha256 = "sha256-fF9bbEacwCHP1m/eVgFrTD4Ne7L2mzq0K9vJ1tiy9go=";
   };
 
   # You can swap this out with any other IPASIR implementation at
@@ -52,15 +50,10 @@ stdenv.mkDerivation rec {
   libipasir = callPackage ./libipasirglucose4 { };
 
   patches = [
-    (replaceVars ./0001-Fix-some-paths-for-Nix-build.patch {
+    (replaceVars ./0001-path-changes-for-nix.patch {
       libipasir = "${libipasir}/lib/${libipasir.libname}";
       libssl = "${lib.getLib openssl}/lib/libssl${stdenv.hostPlatform.extensions.sharedLibrary}";
       libcrypto = "${lib.getLib openssl}/lib/libcrypto${stdenv.hostPlatform.extensions.sharedLibrary}";
-    })
-    (fetchpatch {
-      name = "fix-fastnumio-on-newer-sbcl.patch";
-      url = "https://github.com/acl2-devel/acl2-devel/commit/84f5a6cd4a1aaf204e8bae3eab4c21e8c061f469.patch";
-      hash = "sha256-VA9giXZMb/Ob8ablxfbBAaZ2+2PGcv7WtooXwKDgT08=";
     })
   ];
 
@@ -204,6 +197,5 @@ stdenv.mkDerivation rec {
       raskin
     ];
     platforms = platforms.all;
-    broken = stdenv.hostPlatform.isDarwin;
   };
 }


### PR DESCRIPTION
- Updated patchfiles and builds for the new version of acl2
- Marked darwin builds as compatible again

Resolves #387755

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
