### PR TITLE
ee: 1.5.2 -> 1.5.2-unstable-2024-06-20, adopt

### DIFF
--- a/pkgs/by-name/ee/ee/package.nix
+++ b/pkgs/by-name/ee/ee/package.nix
@@ -1,23 +1,23 @@
 {
   lib,
   stdenv,
-  nix-update-script,
-  fetchgit,
+  fetchFromGitHub,
   ncurses,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation {
   pname = "ee";
-  version = "1.5.2";
+  version = "1.5.2-unstable-2024-06-20";
 
-  src = fetchgit {
-    url = "https://git.freebsd.org/src.git";
-    tag = "release/14.3.0";
-    outputHash = "sha256-nMhHXeoam9VtUuhhi0eoGZfcW9zZhpYQKVYbkAbfgc0=";
+  src = fetchFromGitHub {
+    owner = "freebsd";
+    repo = "freebsd-src";
+    rev = "0667538b888c1171932c6cf28b62fc19d393e119";
+    hash = "sha256-nMhHXeoam9VtUuhhi0eoGZfcW9zZhpYQKVYbkAbfgc0=";
     rootDir = "contrib/ee";
   };
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = ./update.sh;
 
   buildInputs = [ ncurses ];
 
@@ -49,4 +49,4 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.unix;
     mainProgram = "ee";
   };
-})
+}

--- a/pkgs/by-name/ee/ee/package.nix
+++ b/pkgs/by-name/ee/ee/package.nix
@@ -48,5 +48,6 @@ stdenv.mkDerivation {
     license = lib.licenses.bsd2;
     platforms = lib.platforms.unix;
     mainProgram = "ee";
+    maintainers = with lib.maintainers; [ qweered ];
   };
 }

--- a/pkgs/by-name/ee/ee/update.sh
+++ b/pkgs/by-name/ee/ee/update.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p curl jq common-updater-scripts
+set -euo pipefail
+
+owner=freebsd
+repo=freebsd-src
+path=contrib/ee
+pkg_file=./pkgs/by-name/ee/ee/package.nix
+
+api_url_latest="https://api.github.com/repos/$owner/$repo/commits?path=$path&per_page=1"
+json_latest=$(curl -sSfL -H "Accept: application/vnd.github+json" ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "$api_url_latest")
+latest_rev=$(printf '%s' "$json_latest" | jq -r '.[0].sha')
+latest_date=$(printf '%s' "$json_latest" | jq -r '.[0].commit.committer.date' | cut -dT -f1)
+
+if [[ -z "${latest_rev:-}" || "$latest_rev" == "null" ]]; then
+  echo "Failed to fetch latest commit for path $path" >&2
+  exit 1
+fi
+
+# Fetch EE_VERSION from that commit
+raw_url="https://raw.githubusercontent.com/$owner/$repo/$latest_rev/$path/ee_version.h"
+ee_version=$(curl -sSfL ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "$raw_url" | sed -n 's/^#define[[:space:]]*EE_VERSION[[:space:]]*"\([^"]*\)".*/\1/p')
+if [[ -z "${ee_version:-}" ]]; then
+  echo "Failed to parse EE_VERSION from ee_version.h at $latest_rev" >&2
+  exit 1
+fi
+
+new_version="${ee_version}-unstable-${latest_date}"
+
+update-source-version ee "$new_version" --rev="$latest_rev" --file="$pkg_file" --ignore-same-version --print-changes


### PR DESCRIPTION
Follow up to #440047 
Fixed update script

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
