### PR TITLE
rtorrent: 0.15.5 -> 0.15.6

### DIFF
--- a/pkgs/by-name/rt/rtorrent/package.nix
+++ b/pkgs/by-name/rt/rtorrent/package.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rakshasa-rtorrent";
-  version = "0.15.5";
+  version = "0.15.6";
 
   src = fetchFromGitHub {
     owner = "rakshasa";
     repo = "rtorrent";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-ZUZR/ydGhxLbjMEDAlbU5IbAxU1dCd0vvATdsn0NMQc=";
+    hash = "sha256-B/5m1JXdUpczUMNN4cy5p6YurjmRFxMQHG3cQFSmZSs=";
   };
 
   outputs = [


### PR DESCRIPTION
updated to the next ["RTorrent stable release version 0.15.6"](https://github.com/rakshasa/rtorrent/releases/tag/v0.15.6)

- Built on platform:
  - [x] x86_64-linux
