### PR TITLE
envoy-bin: 1.35.1 -> 1.35.2

### DIFF
--- a/pkgs/by-name/en/envoy-bin/package.nix
+++ b/pkgs/by-name/en/envoy-bin/package.nix
@@ -8,7 +8,7 @@
   versionCheckHook,
 }:
 let
-  version = "1.35.1";
+  version = "1.35.2";
   inherit (stdenv.hostPlatform) system;
   throwSystem = throw "envoy-bin is not available for ${system}.";
 
@@ -21,8 +21,8 @@ let
 
   hash =
     {
-      aarch64-linux = "sha256-tIBXnm6bGdA6tlYFL+aDf1bOjlUVof0MDNDpFi0tcbE=";
-      x86_64-linux = "sha256-emAbbVhEw0MA21rPxQD/z/p3yVuDi5JZg1yjuRkkmlo=";
+      aarch64-linux = "sha256-XfV0d4l8yTsEF9hDXAFnd0wgtu+Hm6VaEfPfXHF9wdE=";
+      x86_64-linux = "sha256-6Uo9Gya7lpkb5GAiB8yxIX81Yw1BWurBUF1ooDuJc9w=";
     }
     .${system} or throwSystem;
 in

--- a/pkgs/by-name/en/envoy-bin/package.nix
+++ b/pkgs/by-name/en/envoy-bin/package.nix
@@ -65,9 +65,7 @@ stdenv.mkDerivation {
     description = "Cloud-native edge and service proxy";
     license = lib.licenses.asl20;
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
-    maintainers = with lib.maintainers; [
-      adamcstephens
-    ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "envoy";
     platforms = [
       "x86_64-linux"

--- a/pkgs/by-name/en/envoy-bin/update.sh
+++ b/pkgs/by-name/en/envoy-bin/update.sh
@@ -1,24 +1,24 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl gnused gawk nix-prefetch common-updater-scripts jq
+#!nix-shell -i bash -p common-updater-scripts coreutils gnused ripgrep
 
 set -euo pipefail
 
 ROOT="$(dirname "$(readlink -f "$0")")"
 NIX_DRV="$ROOT/package.nix"
 if [ ! -f "$NIX_DRV" ]; then
-    echo "ERROR: cannot find package.nix in $ROOT"
-    exit 1
+  echo "ERROR: cannot find package.nix in $ROOT"
+  exit 1
 fi
 
 fetch_arch() {
-    VER="$1"
-    ARCH="$2"
-    URL="https://github.com/envoyproxy/envoy/releases/download/v${VER}/envoy-${VER}-linux-${ARCH}"
-    nix --extra-experimental-features nix-command hash convert --to sri --hash-algo sha256 "$(nix-prefetch-url --type sha256 "$URL")"
+  VER="$1"
+  ARCH="$2"
+  URL="https://github.com/envoyproxy/envoy/releases/download/v${VER}/envoy-${VER}-linux-${ARCH}"
+  nix --extra-experimental-features nix-command hash convert --to sri --hash-algo sha256 "$(nix-prefetch-url --type sha256 "$URL")"
 }
 
 replace_hash() {
-    sed -i "s#$1 = \"sha256-.\{44\}\"#$1 = \"$2\"#" "$NIX_DRV"
+  sed -i "s#$1 = \"sha256-.\{44\}\"#$1 = \"$2\"#" "$NIX_DRV"
 }
 
 VER=$(list-git-tags --url=https://github.com/envoyproxy/envoy | rg 'v[0-9\.]*$' | sed -e 's/^v//' | sort -V | tail -n 1)


### PR DESCRIPTION
Changelog: https://github.com/envoyproxy/envoy/releases/tag/v1.35.2

I've stopped using envoy, and thus should not be a maintainer of this any longer. It's relatively simple to maintain though, so I'll ping @lukegb and @katexochen in case they're interested. Though I imagine they've got enough work on the source package to deal with.

I'll keep maintainership in 25.05 for now to help keep stable up to date, and will check back next release to make sure the update script fixes get the bot unstuck.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
