### PR TITLE
treewide: migrate pcl/rtabmap from qt5 to qt6

### DIFF
--- a/pkgs/by-name/pc/pcl/package.nix
+++ b/pkgs/by-name/pc/pcl/package.nix
@@ -6,7 +6,7 @@
 
   # nativeBuildInputs
   cmake,
-  libsForQt5,
+  qt6,
   pkg-config,
 
   # buildInputs
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    libsForQt5.wrapQtAppsHook
+    qt6.wrapQtAppsHook
     pkg-config
   ]
   ++ lib.optionals cudaSupport [ cudaPackages.cuda_nvcc ];
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     eigen
     libXt
     libpcap
-    libsForQt5.qtbase
+    qt6.qtbase
     libusb1
     nanoflann
   ]

--- a/pkgs/by-name/rt/rtabmap/package.nix
+++ b/pkgs/by-name/rt/rtabmap/package.nix
@@ -6,7 +6,7 @@
 
   # nativeBuildInputs
   cmake,
-  libsForQt5,
+  qt6,
   pkg-config,
   wrapGAppsHook3,
 
@@ -28,14 +28,16 @@
   libGL,
   libGLU,
   librealsense,
-  vtkWithQt5,
+  vtkWithQt6,
   zed-open-capture,
   hidapi,
 
   # passthru
   gitUpdater,
 }:
-
+let
+  pcl' = pcl.override { vtk = vtkWithQt6; };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "rtabmap";
   version = "0.22.1";
@@ -49,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    libsForQt5.wrapQtAppsHook
+    qt6.wrapQtAppsHook
     pkg-config
     wrapGAppsHook3
   ];
@@ -57,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     ## Required
     opencv
     opencv.cxxdev
-    pcl
+    pcl'
     liblapack
     xorg.libSM
     xorg.libICE
@@ -75,21 +77,18 @@ stdenv.mkDerivation (finalAttrs: {
     freenect
     libdc1394
     librealsense
-    libsForQt5.qtbase
+    qt6.qtbase
     libGL
     libGLU
-    vtkWithQt5
     zed-open-capture
     hidapi
   ];
 
   # Configure environment variables
-  NIX_CFLAGS_COMPILE = "-Wno-c++20-extensions -I${vtkWithQt5}/include/vtk";
+  NIX_CFLAGS_COMPILE = "-Wno-c++20-extensions";
 
   cmakeFlags = [
-    (lib.cmakeFeature "VTK_QT_VERSION" "5")
-    (lib.cmakeFeature "VTK_DIR" "${vtkWithQt5}/lib/cmake/vtk-${lib.versions.majorMinor vtkWithQt5.version}")
-    (lib.cmakeFeature "CMAKE_INCLUDE_PATH" "${vtkWithQt5}/include/vtk:${pcl}/include/pcl-${lib.versions.majorMinor pcl.version}")
+    (lib.cmakeFeature "CMAKE_INCLUDE_PATH" "${pcl'}/include/pcl-${lib.versions.majorMinor pcl'.version}")
   ];
 
   passthru = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4037,10 +4037,6 @@ with pkgs;
 
   rocket = libsForQt5.callPackage ../tools/graphics/rocket { };
 
-  rtabmap = callPackage ../by-name/rt/rtabmap/package.nix {
-    pcl = pcl.override { vtk = vtkWithQt5; };
-  };
-
   rtaudio = callPackage ../development/libraries/audio/rtaudio {
     jack = libjack2;
   };


### PR DESCRIPTION
prepare for droping qt5/vtkWithQt5 before 25.11

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
