### PR TITLE
postgresqlPackages.pv_ivm: 1.11 -> 1.12

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_ivm.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_ivm.nix
@@ -7,13 +7,13 @@
 
 postgresqlBuildExtension (finalAttrs: {
   pname = "pg_ivm";
-  version = "1.11";
+  version = "1.12";
 
   src = fetchFromGitHub {
     owner = "sraoss";
     repo = "pg_ivm";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-fPtDwP+IZ/RQOriRklSvpUnJ8qEwJaxIrcfnAReRQeQ=";
+    hash = "sha256-UeRcxoUkpPw4EcQXKUxHamjczOaE59d00kSrYsijnH8=";
   };
 
   meta = {
@@ -23,11 +23,5 @@ postgresqlBuildExtension (finalAttrs: {
     maintainers = with lib.maintainers; [ ivan ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.postgresql;
-    # PostgreSQL 18 support issue upstream: https://github.com/sraoss/pg_ivm/issues/133
-    # Note: already fixed on `main` branch.
-    # Check after next package update.
-    broken = lib.warnIf (finalAttrs.version != "1.11") "Is postgresql18Packages.pg_ivm still broken?" (
-      lib.versionAtLeast postgresql.version "18"
-    );
   };
 })


### PR DESCRIPTION
Release Notes:
https://github.com/sraoss/pg_ivm/releases/tag/v1.12

Adds support for PostgreSQL 18.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
