### PR TITLE
opentelemetry-cpp: 1.20.0 -> 1.22.0, opentelemetry-proto: 1.5.0 -> 1.7.0

### DIFF
--- a/pkgs/by-name/op/opentelemetry-cpp/package.nix
+++ b/pkgs/by-name/op/opentelemetry-cpp/package.nix
@@ -21,19 +21,19 @@ let
   opentelemetry-proto = fetchFromGitHub {
     owner = "open-telemetry";
     repo = "opentelemetry-proto";
-    rev = "v1.5.0";
-    hash = "sha256-PkG0npG3nKQwq6SxWdIliIQ/wrYAOG9qVb26IeVkBfc=";
+    rev = "v1.7.0";
+    hash = "sha256-3SFf/7fStrglxcpwEya7hDp8Sr3wBG9OYyBoR78IUgs=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "opentelemetry-cpp";
-  version = "1.20.0";
+  version = "1.22.0";
 
   src = fetchFromGitHub {
     owner = "open-telemetry";
     repo = "opentelemetry-cpp";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-ibLuHIg01wGYPhLRz+LVYA34WaWzlUlNtg7DSONLe9g=";
+    hash = "sha256-vprHCexKtXvbiHz7JfuTbVFyLy0VL1s4e/hNyaN3nY0=";
   };
 
   patches = [
@@ -84,11 +84,6 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
     "dev"
   ];
-
-  postInstall = ''
-    substituteInPlace $out/lib/cmake/opentelemetry-cpp/opentelemetry-cpp*-target.cmake \
-      --replace-quiet "\''${_IMPORT_PREFIX}/include" "$dev/include"
-  '';
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
opentelemetry-proto:
* https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v1.6.0
* https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v1.7.0
* https://github.com/open-telemetry/opentelemetry-proto/compare/v1.5.0...v1.7.0

opentelemetry: 
* https://github.com/open-telemetry/opentelemetry-cpp/releases/tag/v1.21.0
* https://github.com/open-telemetry/opentelemetry-cpp/releases/tag/v1.22.0
* https://github.com/open-telemetry/opentelemetry-cpp/compare/v1.20.0...v1.22.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `1fb65454b1f88cd00da1c1e93b00eeecc00f5598`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>opentelemetry-cpp</li>
    <li>opentelemetry-cpp.dev</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
