### PR TITLE
render-cli: init at 2.1.5

### DIFF
--- a/pkgs/by-name/re/render-cli/package.nix
+++ b/pkgs/by-name/re/render-cli/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "render-cli";
+  version = "2.1.5";
+
+  src = fetchFromGitHub {
+    owner = "render-oss";
+    repo = "cli";
+    rev = "v${version}";
+    hash = "sha256-SvWU88VwTLYUmVfG5/qs7jazIX7hjV4x+6ZT/7ZBKuQ=";
+  };
+
+  vendorHash = "sha256-BExwkK0EKR0Mtk+bphPD3/4iyAnj942gkGWWTYUIceU=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/render-oss/cli/pkg/cfg.Version=${version}"
+  ];
+
+  # Skip network-dependent tests that fail in sandbox
+  checkFlags = [
+    "-skip"
+    "TestE2E|TestClient_NewVersionAvailable"
+  ];
+
+  doCheck = true;
+
+  postInstall = ''
+    mv $out/bin/{cli,render}
+  '';
+
+  meta = {
+    description = "Official CLI for Render cloud platform";
+    homepage = "https://github.com/render-oss/cli";
+    changelog = "https://github.com/render-oss/cli/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ tennox ];
+    mainProgram = "render";
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
Command line interface for Render cloud services management. This package provides the official Render CLI tool for managing services, datastores, and environments from the command line.
https://github.com/render-oss/cli

Features:
- Service and datastore management
- Deploy management and logs viewing
- Interactive and non-interactive modes
- SSH and database connection utilities

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
