### PR TITLE
[Backport release-25.05] signal-desktop: 7.66.0 -> 7.70.0

### DIFF
--- a/pkgs/by-name/si/signal-desktop/libsignal-node.nix
+++ b/pkgs/by-name/si/signal-desktop/libsignal-node.nix
@@ -24,23 +24,23 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "libsignal-node";
-  version = "0.76.7";
+  version = "0.78.3";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "libsignal";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7UXOCgjZYOOMMnBk1pvORJVTClQo9vbhSteKBE5RHw8=";
+    hash = "sha256-BRNgNE7BR4mlCKS4sydxx7rrfy+s4bTpQkX9GbEfhTg=";
   };
 
-  cargoHash = "sha256-beeR/tISks99+o/kdqaq96nznwoiNduyB/BBVvNTEn0=";
+  cargoHash = "sha256-T8kSQFTvwAYZad9rQRK6vY8vEiilEKv1+fd/1EBlxjI=";
 
   npmRoot = "node";
   npmDeps = fetchNpmDeps {
     name = "${finalAttrs.pname}-npm-deps";
     inherit (finalAttrs) version src;
     sourceRoot = "${finalAttrs.src.name}/${finalAttrs.npmRoot}";
-    hash = "sha256-nbGeT0Fyu9T/3EFoIDaAESIl9JOIOq2jC53GWU1Ofeo=";
+    hash = "sha256-e/WyQlea46qTx7x45QuYdlaShezHV5vuB3ptB2DRCVE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -3,7 +3,7 @@
   lib,
   nodejs_22,
   pnpm_10,
-  electron_36,
+  electron_37,
   gn_2233,
   python3,
   makeWrapper,
@@ -20,7 +20,7 @@
 let
   nodejs = nodejs_22;
   pnpm = pnpm_10.override { inherit nodejs; };
-  electron = electron_36;
+  electron = electron_37;
   gn = gn_2233;
 
   libsignal-node = callPackage ./libsignal-node.nix { inherit nodejs; };
@@ -50,13 +50,13 @@ let
     '';
   });
 
-  version = "7.66.0";
+  version = "7.68.0";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "Signal-Desktop";
     tag = "v${version}";
-    hash = "sha256-8IhY7m9beyfbs8Pnm8PeSW7vL+aBIgcN8HVmstgKFe8=";
+    hash = "sha256-jsNSRNgIS0ZroM2vwPSFpCVfC81slQ4mUoRq5jDYi8Y=";
   };
 
   sticker-creator = stdenv.mkDerivation (finalAttrs: {
@@ -120,15 +120,15 @@ stdenv.mkDerivation (finalAttrs: {
     fetcherVersion = 1;
     hash =
       if withAppleEmojis then
-        "sha256-XO+lbCndOupUncod2b6w7BdesGX84GgQQ3SYlX1yp0Q="
+        "sha256-iu/ZjIn5c4X0rxWUFqiNLLAjCGKFYihsYxfgWtfmqk4="
       else
-        "sha256-+pq4jGJzy0bg9rkN6jKyuiGiad2BP28mIy+/SgbyNWc=";
+        "sha256-gMtBdlcuiAZRV5eeh2NoyOusFheCmn0/NIQwVPrUH/U=";
   };
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     SIGNAL_ENV = "production";
-    SOURCE_DATE_EPOCH = 1755119611;
+    SOURCE_DATE_EPOCH = 1756327041;
   };
 
   preBuild = ''

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -50,13 +50,13 @@ let
     '';
   });
 
-  version = "7.68.0";
+  version = "7.70.0";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "Signal-Desktop";
     tag = "v${version}";
-    hash = "sha256-jsNSRNgIS0ZroM2vwPSFpCVfC81slQ4mUoRq5jDYi8Y=";
+    hash = "sha256-y9i9YQPsLt3SLqROyEZsyIkVy/os3hy+1UMUSFMZJTY=";
   };
 
   sticker-creator = stdenv.mkDerivation (finalAttrs: {
@@ -120,15 +120,15 @@ stdenv.mkDerivation (finalAttrs: {
     fetcherVersion = 1;
     hash =
       if withAppleEmojis then
-        "sha256-iu/ZjIn5c4X0rxWUFqiNLLAjCGKFYihsYxfgWtfmqk4="
+        "sha256-uVVUHvYhBCplKPyuS2+PKCxox8uWU2E/2EXLCG1ot54="
       else
-        "sha256-gMtBdlcuiAZRV5eeh2NoyOusFheCmn0/NIQwVPrUH/U=";
+        "sha256-tbfk/tIgqpjDtDiULbTVUOJf5i9eLX9xY7vUPrrjmu0=";
   };
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     SIGNAL_ENV = "production";
-    SOURCE_DATE_EPOCH = 1756327041;
+    SOURCE_DATE_EPOCH = 1757542492;
   };
 
   preBuild = ''

--- a/pkgs/by-name/si/signal-desktop/ringrtc.nix
+++ b/pkgs/by-name/si/signal-desktop/ringrtc.nix
@@ -20,16 +20,16 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ringrtc";
-  version = "2.56.0";
+  version = "2.57.0";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "ringrtc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KEwN6x24hXmK9lqU2M9/5qbBk7zDxeTRbB0vJ1K9d3U=";
+    hash = "sha256-m73SXjTES1sHGbQRtn9CjurFd/Xby5Yyn6uLVLigfiU=";
   };
 
-  cargoHash = "sha256-ghuF1wxAf5psZoWNYOCAubGo0KDwJlqcBXgUbPMD9ac=";
+  cargoHash = "sha256-LRCgK/w+GcYBCWUKjytErQCxDtS15EnsVOr5Uq6F8ww=";
 
   cargoBuildFlags = [
     "-p"

--- a/pkgs/by-name/si/signal-desktop/signal-sqlcipher.nix
+++ b/pkgs/by-name/si/signal-desktop/signal-sqlcipher.nix
@@ -11,13 +11,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "node-sqlcipher";
-  version = "2.2.2";
+  version = "2.4.4";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "node-sqlcipher";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vrY2cu8yfwMX7O6h2GgLhdvQvYOgl916E2z1Pf77ZI0=";
+    hash = "sha256-70kObW6jYzaquMrj20VMTQg/rDWqIu8o2/m7S3mUZB8=";
   };
 
   pnpmDeps = pnpm.fetchDeps {
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   cargoDeps = rustPlatform.fetchCargoVendor {
     name = "sqlcipher-signal-exentsion";
     inherit (finalAttrs) src cargoRoot;
-    hash = "sha256-qT4HM/FRL8qugKKNlMYM/0zgUsC6cDOa9fgd1d4VIrc=";
+    hash = "sha256-NtJPwRvjU1WsOxgb2vpokes9eL4DkEcbDaEmML7zsqQ=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/si/signal-desktop/webrtc-sources.json
+++ b/pkgs/by-name/si/signal-desktop/webrtc-sources.json
@@ -1,10 +1,10 @@
 {
     "src": {
         "args": {
-            "hash": "sha256-3hgBFFu2m+s9qzqNgbJSAmHH4ouHaQCL9nz2sFMy7hc=",
+            "hash": "sha256-Qj0UFRWfZrBG9WUX4zkyiatIekNSYXsneP5aLvufNh4=",
             "owner": "signalapp",
             "repo": "webrtc",
-            "tag": "7204a"
+            "tag": "7204c"
         },
         "fetcher": "fetchFromGitHub"
     },


### PR DESCRIPTION
Manual backport of https://github.com/NixOS/nixpkgs/pull/437968 and https://github.com/NixOS/nixpkgs/pull/442176 to release-25.05.

- [x] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
  - Even as a non-committer, if you find that it is not acceptable, leave a comment.