### PR TITLE
deltalake: 0.25.5 -> 1.1.2

### DIFF
--- a/pkgs/development/python-modules/deltalake/default.nix
+++ b/pkgs/development/python-modules/deltalake/default.nix
@@ -3,8 +3,8 @@
   buildPythonPackage,
   fetchPypi,
   rustPlatform,
+  arro3-core,
   pyarrow,
-  pyarrow-hotfix,
   openssl,
   stdenv,
   libiconv,
@@ -14,30 +14,32 @@
   pytest-benchmark,
   pytest-cov-stub,
   pytest-mock,
+  pytest-timeout,
   pandas,
+  deprecated,
   azure-storage-blob,
 }:
 
 buildPythonPackage rec {
   pname = "deltalake";
-  version = "0.25.5";
+  version = "1.1.2";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-Fz5Lg/z/EPJkdK4RcWHD8r3V9EwwwgRjwktri1IOdlY=";
+    hash = "sha256-s/iWYoh2zARl3M+0DPdur5d8a1URl+jinaMPBFeruEE=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-6SGVKJu01MzZxJv29PZKea+Z2YwAnvzbdDlnA4R6Az0=";
+    hash = "sha256-JYstNjd/KC9xp2h72vkQfin/LXNTXeb0hLpGUiGgRlE=";
   };
 
   env.OPENSSL_NO_VENDOR = 1;
 
   dependencies = [
-    pyarrow
-    pyarrow-hotfix
+    arro3-core
+    deprecated
   ];
 
   buildInputs = [
@@ -64,25 +66,18 @@ buildPythonPackage rec {
     pytest-benchmark
     pytest-cov-stub
     pytest-mock
+    pytest-timeout
     azure-storage-blob
+    pyarrow
   ];
 
   preCheck = ''
     # For paths in test to work, we have to be in python dir
-    cp pyproject.toml python/
     cd python
 
     # In tests we want to use deltalake that we have built
     rm -rf deltalake
   '';
-
-  pytestFlags = [
-    "--benchmark-disable"
-  ];
-
-  disabledTestMarks = [
-    "integration"
-  ];
 
   meta = with lib; {
     description = "Native Rust library for Delta Lake, with bindings into Python";


### PR DESCRIPTION
Upgrade delta-rs package to stable version. Changes from using pyarrow to arro3. No need anymore for the pytest flags and `disabledTestMarks`  as the tests pass and the relevant tests are disabled by default: https://github.com/delta-io/delta-rs/blob/4036166ab08769ff8ae5b667fa0dc2be4f260f97/python/pyproject.toml#L73

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
