### PR TITLE
envoy: 1.35.1 -> 1.35.2

### DIFF
--- a/pkgs/by-name/en/envoy/0002-nixpkgs-use-system-Go.patch
+++ b/pkgs/by-name/en/envoy/0002-nixpkgs-use-system-Go.patch
@@ -10,14 +10,14 @@ Signed-off-by: Luke Granger-Brown <git@lukegb.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/bazel/dependency_imports.bzl b/bazel/dependency_imports.bzl
-index 4615eed5c9ade5279f8174cf1bd3987a8b2d52f1..10be4b0b3f65e486c1dc8419337a5cf823431774 100644
+index ecfe356b3f9c44dbc00877e57b72a675e9e5baf0..10be4b0b3f65e486c1dc8419337a5cf823431774 100644
 --- a/bazel/dependency_imports.bzl
 +++ b/bazel/dependency_imports.bzl
 @@ -24,7 +24,7 @@ load("@rules_rust//rust:defs.bzl", "rust_common")
  load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains", "rust_repository_set")
  
  # go version for rules_go
--GO_VERSION = "1.23.1"
+-GO_VERSION = "1.24.6"
 +GO_VERSION = "host"
  
  JQ_VERSION = "1.7"

--- a/pkgs/by-name/en/envoy/package.nix
+++ b/pkgs/by-name/en/envoy/package.nix
@@ -39,9 +39,9 @@ let
     # However, the version string is more useful for end-users.
     # These are contained in a attrset of their own to make it obvious that
     # people should update both.
-    version = "1.35.1";
-    rev = "6e9539d0366baf85baf9acb3e618cb3384765f13";
-    hash = "sha256-c1c8j/BCRrvAEqjt4EQ/d7zsM1zUe4Qr5EHzpuGblIk=";
+    version = "1.35.2";
+    rev = "2c2cd7efd119a5c9028b68a97d88a540248f8d18";
+    hash = "sha256-HhjIewZMOr9hzcnFPIckfK5PIozqdypSdmYgvb7ccds=";
   };
 
   # these need to be updated for any changes to fetchAttrs
@@ -50,8 +50,8 @@ let
       depsHash
     else
       {
-        x86_64-linux = "sha256-t4Xv4UGYW5YU0kmv+1rdf2JvM1BYQyNWdtpz6Cdmxm4=";
-        aarch64-linux = "sha256-aIBnNGzc0hTdlTgRyJ7eLnWvHqZ5ywhqOM+mHfH3/18=";
+        x86_64-linux = "sha256-pih2EaVFDSTaCDpqkVSt39wBFGc4MFrhc1BioeHBp+w=";
+        aarch64-linux = "sha256-RpgZSsDJctTzqm8M3u0+jyEi51HaNC2RZH0Hrelovo8=";
       }
       .${stdenv.system} or (throw "unsupported system ${stdenv.system}");
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://www.envoyproxy.io/docs/envoy/v1.35.2/version_history/v1.35/v1.35.2

* **dns**: Fixed an UAF in DNS cache that can occur when the Host header is modified between the Dynamic Forwarding and Router filters.

* **oauth2**: Fixed an issue where cookies prefixed with `__Secure-` or `__Host-` were not receiving a Secure attribute.

* **stats**: Fixed a bug where the metric name `expiration_unix_time_seconds` of `cluster.<cluster_name>.ssl.certificate.<cert_name>.<metric_name>` and `listener.<address>.ssl.certificate.<cert_name>.<metric_name>` was not being properly extracted in the final prometheus stat name.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
