### PR TITLE
ceph: patch getopt path at build time

### DIFF
--- a/nixos/modules/services/network-filesystems/ceph.nix
+++ b/nixos/modules/services/network-filesystems/ceph.nix
@@ -45,8 +45,6 @@ let
       partOf = [ "ceph-${daemonType}.target" ];
       wantedBy = [ "ceph-${daemonType}.target" ];
 
-      path = [ pkgs.getopt ];
-
       # Don't start services that are not yet initialized
       unitConfig.ConditionPathExists = "/var/lib/${stateDirectory}/keyring";
       startLimitBurst =

--- a/pkgs/by-name/ce/ceph/package.nix
+++ b/pkgs/by-name/ce/ceph/package.nix
@@ -52,6 +52,7 @@
   cunit,
   e2fsprogs,
   doxygen,
+  getopt,
   gperf,
   graphviz,
   gnugrep,
@@ -518,6 +519,10 @@ stdenv.mkDerivation {
     substituteInPlace src/client/fuse_ll.cc \
       --replace-fail "mount -i -o remount" "${util-linux}/bin/mount -i -o remount"
 
+    substituteInPlace src/{ceph-osd-prestart.sh,ceph-post-file.in,init-ceph.in} \
+       --replace-fail "GETOPT=/usr/local/bin/getopt" "GETOPT=${getopt}/bin/getopt" \
+       --replace-fail "GETOPT=getopt" "GETOPT=${getopt}/bin/getopt"
+
     # The install target needs to be in PYTHONPATH for "*.pth support" check to succeed
     export PYTHONPATH=$PYTHONPATH:$lib/${sitePackages}:$out/${sitePackages}
     patchShebangs src/
@@ -583,6 +588,10 @@ stdenv.mkDerivation {
     # Test that ceph-volume exists since the build system has a tendency to
     # silently drop it with misconfigurations.
     test -f $out/bin/ceph-volume
+
+    # Assert that getopt patch from preConfigure covered all instances
+    ! grep -F -r 'GETOPT=getopt' $out
+    ! grep -F -r 'GETOPT=/usr/local/bin/getopt' $out
 
     mkdir -p $client/{bin,etc,${sitePackages},share/bash-completion/completions}
     cp -r $out/bin/{ceph,.ceph-wrapped,rados,rbd,rbdmap} $client/bin


### PR DESCRIPTION
This patches the getopt path directly into Ceph during package build, so that ceph-osd-prestart.sh no longer depends on the NixOS module adding getopt via systemd’s path.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
