### PR TITLE
emacs-macport: 29.4 -> 30.2

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -155,6 +155,11 @@
 
 - `rofi-emoji-wayland` has been merged into `rofi-emoji` as `rofi` has been updated to `2.0.0` and supports both X11 & Wayland.
 
+- `emacs-macport` has been moved to a fork of Mitsuharu Yamamoto's patched source code starting with Emacs v30 as the original project seems to be currently dormant. All older versions of this package have been dropped.
+  This introduces some backwards‐incompatible changes; see the NEWS for details.
+  NEWS can be viewed from Emacs by typing `C-h n`, or by clicking `Help->Emacs News` from the menu bar.
+  It can also be browsed [online](https://git.savannah.gnu.org/cgit/emacs.git/tree/etc/NEWS?h=emacs-30).
+
 ## Other Notable Changes {#sec-nixpkgs-release-25.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13360,6 +13360,13 @@
     githubId = 18579667;
     name = "Adam J.";
   };
+  kfiz = {
+    email = "doroerose@gmail.com";
+    github = "kfiz";
+    githubId = 5100646;
+    name = "kfiz";
+    matrix = "@kfiz:matrix.sopado.de";
+  };
   kfollesdal = {
     email = "kfollesdal@gmail.com";
     github = "kfollesdal";

--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -12,7 +12,7 @@ lib.makeScope pkgs.newScope (
     sources = import ./sources.nix {
       inherit lib;
       inherit (pkgs)
-        fetchFromBitbucket
+        fetchFromGitHub
         fetchzip
         ;
     };
@@ -31,7 +31,7 @@ lib.makeScope pkgs.newScope (
       withPgtk = true;
     };
 
-    emacs29-macport = callPackage (self.sources.emacs29-macport) (
+    emacs30-macport = callPackage (self.sources.emacs30-macport) (
       inheritedArgs
       // {
         srcRepo = true;

--- a/pkgs/applications/editors/emacs/sources.nix
+++ b/pkgs/applications/editors/emacs/sources.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromBitbucket,
+  fetchFromGitHub,
   fetchzip,
 }:
 
@@ -32,8 +32,8 @@ let
             }
           );
           "macport" = (
-            fetchFromBitbucket {
-              owner = "mituharu";
+            fetchFromGitHub {
+              owner = "jdtsmith";
               repo = "emacs-mac";
               inherit rev hash;
             }
@@ -68,13 +68,14 @@ let
         ''
         + lib.optionalString (variant == "macport") ''
 
-          This release is built from Mitsuharu Yamamoto's patched source code
-          tailored for macOS.
+          This release initially was built from Mitsuharu Yamamoto's patched source code
+          tailored for macOS. Moved to a fork of the latter starting with emacs v30 as the
+          original project seems to be currently dormant.
         '';
         changelog =
           {
             "mainline" = "https://www.gnu.org/savannah-checkouts/gnu/emacs/news/NEWS.${version}";
-            "macport" = "https://bitbucket.org/mituharu/emacs-mac/raw/${rev}/NEWS-mac";
+            "macport" = "https://github.com/jdtsmith/emacs-mac/blob/${rev}/NEWS-mac";
           }
           .${variant};
         license = lib.licenses.gpl3Plus;
@@ -88,7 +89,9 @@ let
               matthewbauer
               panchoh
             ];
-            "macport" = with lib.maintainers; [ ];
+            "macport" = with lib.maintainers; [
+              kfiz
+            ];
           }
           .${variant};
         platforms =
@@ -117,26 +120,11 @@ in
     ];
   });
 
-  emacs29-macport = import ./make-emacs.nix (mkArgs {
+  emacs30-macport = import ./make-emacs.nix (mkArgs {
     pname = "emacs-mac";
-    version = "29.4";
+    version = "30.2.50";
     variant = "macport";
-    rev = "emacs-29.4-mac-10.1";
-    hash = "sha256-8OQ+fon9tclbh/eUJ09uqKfMaz9M77QnLIp2R8QB6Ic=";
-    patches = fetchpatch: [
-      # CVE-2024-53920
-      (fetchpatch {
-        url = "https://gitweb.gentoo.org/proj/emacs-patches.git/plain/emacs/29.4/07_all_trusted-content.patch?id=f24370de4de0a37304958ec1569d5c50c1745b7f";
-        hash = "sha256-zUWM2HDO5MHEB5fC5TCUxzmSafMvXO5usRzCyp9Q7P4=";
-      })
-
-      # CVE-2025-1244
-      (fetchpatch {
-        url = "https://gitweb.gentoo.org/proj/emacs-patches.git/plain/emacs/29.4/06_all_man.patch?id=f24370de4de0a37304958ec1569d5c50c1745b7f";
-        hash = "sha256-Vdf6GF5YmGoHTkxiD9mdYH0hgvfovZwrqYN1NQ++U1w=";
-      })
-    ];
-
-    meta.knownVulnerabilities = [ ];
+    rev = "emacs-mac-30.2";
+    hash = "sha256-i/W2Xa6Vk1+T1fs6fa4wJVMLLB6BK8QAPcdmPrU8NwM=";
   });
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11405,10 +11405,10 @@ with pkgs;
     emacs30-nox
     emacs30-pgtk
 
-    emacs29-macport
+    emacs30-macport
     ;
 
-  emacs-macport = emacs29-macport;
+  emacs-macport = emacs30-macport;
   emacs = emacs30;
   emacs-gtk = emacs30-gtk3;
   emacs-nox = emacs30-nox;


### PR DESCRIPTION
For background and discussion see #393512. New PR  since author hasn't responded on that PR for a while. 
@jian-lin @AndersonTorres @amadaluzia @jasonjckn @emilazy 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
