### PR TITLE
python313Packages.nilearn: 0.12.0 -> 0.12.1

### DIFF
--- a/pkgs/development/python-modules/nilearn/default.nix
+++ b/pkgs/development/python-modules/nilearn/default.nix
@@ -19,18 +19,20 @@
   packaging,
 
   pytestCheckHook,
+  pytest-timeout,
+  numpydoc,
 }:
 
 buildPythonPackage rec {
   pname = "nilearn";
-  version = "0.12.0";
+  version = "0.12.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nilearn";
     repo = "nilearn";
     tag = version;
-    hash = "sha256-olA3Yqf+upMJZiwpQp6HDSMxe9OssGLGMdHbZARg0+Y=";
+    hash = "sha256-jUP/gUMUVveX8m2VbyilTsx5OppuYVXH1qKeEfEVajQ=";
   };
 
   postPatch = ''
@@ -39,8 +41,8 @@ buildPythonPackage rec {
   '';
 
   build-system = [
-    hatch-vcs
     hatchling
+    hatch-vcs
   ];
 
   dependencies = [
@@ -55,14 +57,10 @@ buildPythonPackage rec {
     packaging
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  disabledTests = [
-    # https://github.com/nilearn/nilearn/issues/2608
-    "test_clean_confounds"
-
-    # [XPASS(strict)] invalid checks should fail
-    "test_check_estimator_invalid_group_sparse_covariance"
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-timeout
+    numpydoc
   ];
 
   # do subset of tests which don't fetch resources

--- a/pkgs/development/python-modules/niworkflows/default.nix
+++ b/pkgs/development/python-modules/niworkflows/default.nix
@@ -102,6 +102,7 @@ buildPythonPackage rec {
     "test_GenerateCifti"
     "test_SimpleShowMaskRPT"
     "test_cifti_surfaces_plot"
+    "test_brain_extraction_wf_smoketest"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
Diff: https://github.com/nilearn/nilearn/compare/0.12.0...0.12.1

Changelog: https://github.com/nilearn/nilearn/releases/tag/0.12.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
