### PR TITLE
haskell.compiler.ghc902Binary: bump LLVM by wrapping `opt(1)`

### DIFF
--- a/pkgs/development/compilers/ghc/9.0.2-binary.nix
+++ b/pkgs/development/compilers/ghc/9.0.2-binary.nix
@@ -11,6 +11,7 @@
   numactl,
   libffi,
   llvmPackages,
+  replaceVarsWith,
   coreutils,
   targetPackages,
 
@@ -214,6 +215,20 @@ let
     coreutils # for cat
   ]
   ++ lib.optionals useLLVM [
+    # Allow the use of newer LLVM versions; see the script for details.
+    (replaceVarsWith {
+      name = "subopt";
+      src = ./subopt.bash;
+      dir = "bin";
+      isExecutable = true;
+      preBuild = ''
+        name=opt
+      '';
+      replacements = {
+        inherit (stdenv) shell;
+        opt = lib.getExe' llvmPackages.llvm "opt";
+      };
+    })
     (lib.getBin llvmPackages.llvm)
   ]
   # On darwin, we need unwrapped bintools as well (for otool)

--- a/pkgs/development/compilers/ghc/9.2.4-binary.nix
+++ b/pkgs/development/compilers/ghc/9.2.4-binary.nix
@@ -10,7 +10,6 @@
   libiconv,
   numactl,
   libffi,
-  llvmPackages,
   coreutils,
   targetPackages,
 
@@ -193,8 +192,6 @@ let
       ) binDistUsed.archSpecificLibraries
     )).nixPackage;
 
-  useLLVM = !(import ./common-have-ncg.nix { inherit lib stdenv version; });
-
   libPath = lib.makeLibraryPath (
     # Add arch-specific libraries.
     map ({ nixPackage, ... }: nixPackage) binDistUsed.archSpecificLibraries
@@ -207,15 +204,14 @@ let
     targetPackages.stdenv.cc.bintools
     coreutils # for cat
   ]
-  ++ lib.optionals useLLVM [
-    (lib.getBin llvmPackages.llvm)
-  ]
   # On darwin, we need unwrapped bintools as well (for otool)
   ++ lib.optionals (stdenv.targetPlatform.linker == "cctools") [
     targetPackages.stdenv.cc.bintools.bintools
   ];
 
 in
+
+assert import ./common-have-ncg.nix { inherit lib stdenv version; };
 
 stdenv.mkDerivation {
   inherit version;
@@ -470,7 +466,7 @@ stdenv.mkDerivation {
     targetPrefix = "";
     enableShared = true;
 
-    inherit llvmPackages;
+    llvmPackages = null;
 
     # Our Cabal compiler name
     haskellCompilerName = "ghc-${version}";

--- a/pkgs/development/compilers/ghc/9.6.3-binary.nix
+++ b/pkgs/development/compilers/ghc/9.6.3-binary.nix
@@ -10,7 +10,6 @@
   libiconv,
   numactl,
   libffi,
-  llvmPackages,
   coreutils,
   targetPackages,
 
@@ -192,8 +191,6 @@ let
       ) binDistUsed.archSpecificLibraries
     )).nixPackage;
 
-  useLLVM = !(import ./common-have-ncg.nix { inherit lib stdenv version; });
-
   libPath = lib.makeLibraryPath (
     # Add arch-specific libraries.
     map ({ nixPackage, ... }: nixPackage) binDistUsed.archSpecificLibraries
@@ -206,15 +203,14 @@ let
     targetPackages.stdenv.cc.bintools
     coreutils # for cat
   ]
-  ++ lib.optionals useLLVM [
-    (lib.getBin llvmPackages.llvm)
-  ]
   # On darwin, we need unwrapped bintools as well (for otool)
   ++ lib.optionals (stdenv.targetPlatform.linker == "cctools") [
     targetPackages.stdenv.cc.bintools.bintools
   ];
 
 in
+
+assert import ./common-have-ncg.nix { inherit lib stdenv version; };
 
 stdenv.mkDerivation {
   inherit version;
@@ -449,7 +445,7 @@ stdenv.mkDerivation {
     targetPrefix = "";
     enableShared = true;
 
-    inherit llvmPackages;
+    llvmPackages = null;
 
     # Our Cabal compiler name
     haskellCompilerName = "ghc-${version}";

--- a/pkgs/development/compilers/ghc/9.8.4-binary.nix
+++ b/pkgs/development/compilers/ghc/9.8.4-binary.nix
@@ -9,7 +9,6 @@
   libiconv,
   numactl,
   libffi,
-  llvmPackages,
   coreutils,
   targetPackages,
 
@@ -206,8 +205,6 @@ let
       ) binDistUsed.archSpecificLibraries
     )).nixPackage;
 
-  useLLVM = !(import ./common-have-ncg.nix { inherit lib stdenv version; });
-
   libPath = lib.makeLibraryPath (
     # Add arch-specific libraries.
     map ({ nixPackage, ... }: nixPackage) binDistUsed.archSpecificLibraries
@@ -220,15 +217,14 @@ let
     targetPackages.stdenv.cc.bintools
     coreutils # for cat
   ]
-  ++ lib.optionals useLLVM [
-    (lib.getBin llvmPackages.llvm)
-  ]
   # On darwin, we need unwrapped bintools as well (for otool)
   ++ lib.optionals (stdenv.targetPlatform.linker == "cctools") [
     targetPackages.stdenv.cc.bintools.bintools
   ];
 
 in
+
+assert import ./common-have-ncg.nix { inherit lib stdenv version; };
 
 stdenv.mkDerivation {
   inherit version;
@@ -464,7 +460,7 @@ stdenv.mkDerivation {
     targetPrefix = "";
     enableShared = true;
 
-    inherit llvmPackages;
+    llvmPackages = null;
 
     # Our Cabal compiler name
     haskellCompilerName = "ghc-${version}";

--- a/pkgs/development/compilers/ghc/subopt.bash
+++ b/pkgs/development/compilers/ghc/subopt.bash
@@ -1,0 +1,80 @@
+#!@shell@
+
+# This script wraps the LLVM `opt(1)` executable and maps the options
+# passed by old versions of GHC to the equivalents passed by newer
+# versions that support recent versions of LLVM.
+#
+# It achieves the same effect as the following GHC change externally:
+# <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/8999>.
+#
+# This is used solely for bootstrapping newer GHCs from the GHC 9.0.2
+# binary on AArch64, as that is the only architecture supported by that
+# binary distribution that requires LLVM, and our later binary packages
+# all use the native code generator for all supported platforms.
+#
+# No attempt is made to support custom LLVM optimization flags, or the
+# undocumented flag to disable TBAA, or avoid
+# <https://gitlab.haskell.org/ghc/ghc/-/issues/23870>, as these are not
+# required to bootstrap GHC and at worst will produce an error message.
+#
+# It is called `subopt` to reflect the fact that it uses `opt(1)` as a
+# subprocess, and the fact that the GHC build system situation
+# requiring this hack is suboptimal.
+
+set -e
+
+expect() {
+  if [[ $1 != $2 ]]; then
+    printf >&2 'subopt: got %q; expected %q\n' "$1" "$2"
+    return 2
+  fi
+}
+
+if [[ $NIX_DEBUG -ge 1 ]]; then
+  printf >&2 'subopt: before:'
+  printf >&2 ' %q' "$@"
+  printf >&2 '\n'
+fi
+
+args=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -enable-new-pm=0)
+      shift 1
+      ;;
+    -mem2reg)
+      expect "$2" -globalopt
+      expect "$3" -lower-expect
+      expect "$4" -enable-tbaa
+      expect "$5" -tbaa
+      args+=('-passes=function(require<tbaa>),function(mem2reg),globalopt,function(lower-expect)')
+      shift 5
+      ;;
+    -O1)
+      expect "$2" -globalopt
+      expect "$3" -enable-tbaa
+      expect "$4" -tbaa
+      args+=('-passes=default<O1>')
+      shift 4
+      ;;
+    -O2)
+      expect "$2" -enable-tbaa
+      expect "$3" -tbaa
+      args+=('-passes=default<O2>')
+      shift 3
+      ;;
+    *)
+      args+=("$1")
+      shift 1
+      ;;
+  esac
+done
+
+if [[ $NIX_DEBUG -ge 1 ]]; then
+  printf >&2 'subopt: after:'
+  printf >&2 ' %q' "${args[@]}"
+  printf >&2 '\n'
+fi
+
+exec @opt@ "${args[@]}"

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -74,17 +74,11 @@ in
         llvmPackages = pkgs.llvmPackages_12;
       };
 
-      ghc924Binary = callPackage ../development/compilers/ghc/9.2.4-binary.nix {
-        llvmPackages = pkgs.llvmPackages_12;
-      };
+      ghc924Binary = callPackage ../development/compilers/ghc/9.2.4-binary.nix { };
 
-      ghc963Binary = callPackage ../development/compilers/ghc/9.6.3-binary.nix {
-        llvmPackages = pkgs.llvmPackages_15;
-      };
+      ghc963Binary = callPackage ../development/compilers/ghc/9.6.3-binary.nix { };
 
-      ghc984Binary = callPackage ../development/compilers/ghc/9.8.4-binary.nix {
-        llvmPackages = pkgs.llvmPackages_15;
-      };
+      ghc984Binary = callPackage ../development/compilers/ghc/9.8.4-binary.nix { };
 
       ghc948 = callPackage ../development/compilers/ghc/9.4.8.nix {
         bootPkgs =

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -70,8 +70,9 @@ in
       bb = pkgsBuildBuild.haskell;
     in
     {
+      # Required to bootstrap 9.4.8.
       ghc902Binary = callPackage ../development/compilers/ghc/9.0.2-binary.nix {
-        llvmPackages = pkgs.llvmPackages_12;
+        llvmPackages = pkgs.llvmPackages_20;
       };
 
       ghc924Binary = callPackage ../development/compilers/ghc/9.2.4-binary.nix { };


### PR DESCRIPTION
Implement a wrapper script to translate the `opt(1)` arguments passed by the GHC 9.0.2 binary distribution to the equivalent arguments for the new LLVM pass manager passed by GHC ≥ 9.10 and our soon‐to‐be‐patched compilers. This ensures that the bootstrap of GHC 9.4 continues to work on AArch64.

On an earlier version of this change, I built `haskell.compiler.ghc948` on both `aarch64-linux` and `aarch64-darwin`, and `haskell.compiler.ghc924` on `aarch64-linux` only (it is already broken on Darwin). I confirmed that we get functionally identical store outputs before and after this change, modulo self‐references:

    $ cp -a result-before/ before
    $ cp -a result-after/ after
    $ chmod -R +w before after
    $ LANG=C find before -type f -exec \
        remove-references-to \
        -t $(readlink result-before) \
        -t $(readlink result-before-doc) \
        '{}' ';'
    $ LANG=C find after -type f -exec \
        remove-references-to \
        -t $(readlink result-after) \
        -t $(readlink result-after-doc) \
        '{}' ';'
    # Darwin only: normalize build user UIDs in the archive files…
    $ LANG=C find before -name '*.a' -exec \
        sed -i 's/ 360 / 351 /g' '{}' ';'
    $ diff -r before after
    # Linux only: the `package.cache` files differ, presumably due to
    # an unrelated reproducibility issue.

Therefore, bumping this LLVM dependency did not affect the end result of the bootstrap for the only compilers it is used for.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
