### PR TITLE
postgresqlPackages.vectorchord: fix building with gcc.arch alderlake

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/vectorchord/0003-backport-gcc-arch-fix.diff
+++ b/pkgs/servers/sql/postgresql/ext/vectorchord/0003-backport-gcc-arch-fix.diff
@@ -1,0 +1,24 @@
+diff --git a/crates/simd/cshim/x86_64.c b/crates/simd/cshim/x86_64.c
+index 8ba1357..f1b7b9e 100644
+--- a/crates/simd/cshim/x86_64.c
++++ b/crates/simd/cshim/x86_64.c
+@@ -27,7 +27,8 @@
+ typedef _Float16 f16;
+ typedef float f32;
+ 
+-__attribute__((target("arch=x86-64-v4,avx512fp16"))) float
++__attribute__((target("avx512bw,avx512cd,avx512dq,avx512vl,bmi,bmi2,lzcnt,"
++                      "movbe,popcnt,avx512fp16"))) float
+ fp16_reduce_sum_of_xy_v4fp16(f16 *restrict a, f16 *restrict b, size_t n) {
+   __m512h xy = _mm512_setzero_ph();
+   while (n >= 32) {
+@@ -47,7 +48,8 @@ fp16_reduce_sum_of_xy_v4fp16(f16 *restrict a, f16 *restrict b, size_t n) {
+   return _mm512_reduce_add_ph(xy);
+ }
+ 
+-__attribute__((target("arch=x86-64-v4,avx512fp16"))) float
++__attribute__((target("avx512bw,avx512cd,avx512dq,avx512vl,bmi,bmi2,lzcnt,"
++                      "movbe,popcnt,avx512fp16"))) float
+ fp16_reduce_sum_of_d2_v4fp16(f16 *restrict a, f16 *restrict b, size_t n) {
+   __m512h d2 = _mm512_setzero_ph();
+   while (n >= 32) {

--- a/pkgs/servers/sql/postgresql/ext/vectorchord/package.nix
+++ b/pkgs/servers/sql/postgresql/ext/vectorchord/package.nix
@@ -44,6 +44,10 @@ buildPgrxExtension (finalAttrs: {
     })
     # Add feature flags needed for features not yet stabilised in rustc stable
     ./0002-add-feature-flags.diff
+    # Fix building with gcc.arch = alderlake set
+    # Backport of fix in VectorChord 0.5.1
+    # https://github.com/tensorchord/VectorChord/pull/316
+    ./0003-backport-gcc-arch-fix.diff
   ];
 
   buildInputs = lib.optionals (useSystemJemalloc) [


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/433251

See https://github.com/NixOS/nixpkgs/issues/433251#issuecomment-3256106714

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
