### PR TITLE
chessx: 1.6.0 -> 1.6.2

### DIFF
--- a/pkgs/by-name/ch/chessx/package.nix
+++ b/pkgs/by-name/ch/chessx/package.nix
@@ -3,18 +3,17 @@
   lib,
   pkg-config,
   zlib,
-  fetchpatch,
   fetchurl,
   libsForQt5,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "chessx";
-  version = "1.6.0";
+  version = "1.6.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/chessx/chessx-${finalAttrs.version}.tgz";
-    hash = "sha256-76YOe1WpB+vdEoEKGTHeaWJLpCVE4RoyYu1WLy3Dxhg=";
+    hash = "sha256-uwkdhJywLWMJl4/ihMnxqFwnTzUSL+kca5wwiabiD4A=";
   };
 
   nativeBuildInputs = [
@@ -35,30 +34,20 @@ stdenv.mkDerivation (finalAttrs: {
     qttools
   ]);
 
-  patches =
-    # needed to backport patches to successfully build, due to broken release
-    let
-      repo = "https://github.com/Isarhamster/chessx/";
-    in
-    [
-      (fetchpatch {
-        url = "${repo}/commit/9797d46aa28804282bd58ce139b22492ab6881e6.diff";
-        hash = "sha256-RnIf6bixvAvyp1CKuri5LhgYFqhDNiAVYWUmSUDMgVw=";
-      })
-      (fetchpatch {
-        url = "${repo}/commit/4fab4d2f649d1cae2b54464c4e28337d1f20c214.diff";
-        hash = "sha256-EJVHricN+6uabKLfn77t8c7JjO7tMmZGsj7ZyQUGcXA=";
-      })
-    ];
-
   enableParallelBuilding = true;
+
+  # Fails to start on Native Wayland.
+  # See https://sourceforge.net/p/chessx/bugs/299/
+  qtWrapperArgs = [
+    "--set"
+    "QT_QPA_PLATFORM"
+    "xcb"
+  ];
 
   installPhase = ''
     runHook preInstall
-
     install -Dm555 release/chessx -t "$out/bin"
     install -Dm444 unix/chessx.desktop -t "$out/share/applications"
-
     runHook postInstall
   '';
 


### PR DESCRIPTION
Source: https://sourceforge.net/projects/chessx/files/chessx/1.6.2/

Notes:

- Release 1.6.4 is the latest upstream release but it does not provide a tgz source archive, so the application cannot be built from source.

- The official code repository (https://github.com/Isarhamster/chessx/) does not provide up-to-date release tags.

- Hence, only bump to version 1.6.2.

- Previously applied patches have been removed, as they are now included in the upstream release.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
