### PR TITLE
hdf5-threadsafe: fix cmake flag, disable c++ api.

### DIFF
--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -23,7 +23,7 @@
 }:
 
 # cpp and mpi options are mutually exclusive
-# (--enable-unsupported could be used to force the build)
+# "-DALLOW_UNSUPPORTED=ON" could be used to force the build.
 assert !cppSupport || !mpiSupport;
 
 let
@@ -90,7 +90,7 @@ stdenv.mkDerivation rec {
   ++ lib.optional javaSupport "-DHDF5_BUILD_JAVA=ON"
   ++ lib.optional usev110Api "-DDEFAULT_API_VERSION=v110"
   ++ lib.optionals threadsafe [
-    "-DDHDF5_ENABLE_THREADSAFE:BOOL=ON"
+    "-DHDF5_ENABLE_THREADSAFE:BOOL=ON"
     "-DHDF5_BUILD_HL_LIB=OFF"
   ]
   # broken in nixpkgs since around 1.14.3 -> 1.14.4.3

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3139,7 +3139,10 @@ with pkgs;
     cppSupport = false;
   };
 
-  hdf5-threadsafe = hdf5.override { threadsafe = true; };
+  hdf5-threadsafe = hdf5.override {
+    cppSupport = false;
+    threadsafe = true;
+  };
 
   heaptrack = kdePackages.callPackage ../development/tools/profiling/heaptrack { };
 


### PR DESCRIPTION
Short:
 - fix incorrect cmake flag `"-DDHDF5_ENABLE_THREADSAFE:BOOL=ON"` -> `"-DHDF5_ENABLE_THREADSAFE:BOOL=ON"`.
 - disable unsupported c++ api in hdf5-threadsafe.

Breaking:
Note: this bug means that historically nixpkgs was building hdf5-threadsafe without threadsafety enabled, but with c++ support. C++ and threadsafe are unsupported, so this fix is a slight breaking change if downstream users were relying on hdf5-threadsafe exposing the c++ api. If we instead want to expose both c++ and threadsafe, we would need "-DALLOW_UNSUPPORTED=ON", but then we are exposing a combination not supported or tested by upstream.

Related:
typo introduced in https://github.com/NixOS/nixpkgs/commit/cbd4d659e34c27cae5f48d7fdf6b2863f6492e6f in the transition to cmake `"--enable-threadsafe"` was changed to `"-DDHDF5_ENABLE_THREADSAFE:BOOL=ON"`. Note the double `D`, the correct syntax is `-DFLAG_NAME=VALUE`.

C++ was enabled by default in https://github.com/NixOS/nixpkgs/commit/9046690c73d913972e510566f03fad33fbe7eaf1

Longer:
```
$ nix build .#legacyPackages.aarch64-darwin.hdf5-threadsafe
$ nix log $(nix eval --raw .#legacyPackages.aarch64-darwin.hdf5-threadsafe.drvPath)
[...]
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_EXPORT_NO_PACKAGE_REGISTRY
    CMAKE_INSTALL_BINDIR
    CMAKE_INSTALL_DOCDIR
    CMAKE_INSTALL_INCLUDEDIR
    CMAKE_INSTALL_INFODIR
    CMAKE_INSTALL_LIBDIR
    CMAKE_INSTALL_LIBEXECDIR
    CMAKE_INSTALL_LOCALEDIR
    CMAKE_INSTALL_MANDIR
    CMAKE_INSTALL_SBINDIR
    CMAKE_POLICY_DEFAULT_CMP0025
    DHDF5_ENABLE_THREADSAFE

[...]
```

```
$ git grep -ni 'DHDF5_ENABLE_THREADSAFE'
pkgs/tools/misc/hdf5/default.nix:93:    "-DDHDF5_ENABLE_THREADSAFE:BOOL=ON"
```

We can see the correct version of this flag in the hdf5 repo
```
$ git grep -ni 'HDF5_ENABLE_THREADSAFE'
.github/workflows/arm-main-cmake.yml:94:            -DHDF5_ENABLE_THREADSAFE:BOOL=ON \
[...]
CMakeBuildOptions.cmake:59:option (HDF5_ENABLE_THREADSAFE "Enable thread-safety" OFF)
[...]
```

after this fix we can again inspect the cmake output, and we no longer see a warning for this unsupported variable

```
$ nix build .#legacyPackages.aarch64-darwin.hdf5-threadsafe
$ nix log $(nix eval --raw .#legacyPackages.aarch64-darwin.hdf5-threadsafe.drvPath)
[...]

CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_EXPORT_NO_PACKAGE_REGISTRY
    CMAKE_INSTALL_BINDIR
    CMAKE_INSTALL_DOCDIR
    CMAKE_INSTALL_INCLUDEDIR
    CMAKE_INSTALL_INFODIR
    CMAKE_INSTALL_LIBDIR
    CMAKE_INSTALL_LIBEXECDIR
    CMAKE_INSTALL_LOCALEDIR
    CMAKE_INSTALL_MANDIR
    CMAKE_INSTALL_SBINDIR
    CMAKE_POLICY_DEFAULT_CMP0025

[...]
```

if we try to compile with both cppSupport and threadsafe we receive
```
> CMake Error at CMakeLists.txt:959 (message):
>    **** C++ and thread-safety options are not supported, override with ALLOW_UNSUPPORTED option ****
```

Testing:
Builds clean on aarch64-darwin and x86_64-linux.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
