### PR TITLE
shadowsocks-v2ray-plugin: 1.3.1 -> 1.3.2-unstable-2025-09-05

### DIFF
--- a/pkgs/by-name/sh/shadowsocks-v2ray-plugin/package.nix
+++ b/pkgs/by-name/sh/shadowsocks-v2ray-plugin/package.nix
@@ -6,26 +6,25 @@
 
 buildGoModule rec {
   pname = "shadowsocks-v2ray-plugin";
-  version = "1.3.1";
-  # Version 1.3.2 has runtime failures with Go 1.19
-  # https://github.com/NixOS/nixpkgs/issues/219343
-  # https://github.com/shadowsocks/v2ray-plugin/issues/292
-  # nixpkgs-update: no auto update
+  version = "1.3.2-unstable-2025-09-05";
 
   src = fetchFromGitHub {
     owner = "shadowsocks";
     repo = "v2ray-plugin";
-    rev = "v${version}";
-    hash = "sha256-iwfjINY/NQP9poAcCHz0ETxu0Nz58AmD7i1NbF8hBCs=";
+    rev = "e9af1cdd2549d528deb20a4ab8d61c5fbe51f306";
+    hash = "sha256-VkyK+Ee+RJkBixHiduFP2ET18fDNXuOf8x3h1LN9pbY=";
   };
 
-  vendorHash = "sha256-3/1te41U4QQTMeoA1y43QMfJyiM5JhaLE0ORO8ZO7W8=";
+  vendorHash = "sha256-FSYv2jC0NU21GtqRkPHjxPcdmXbiIiOM1HsL8x44gZw=";
 
-  meta = with lib; {
+  meta = {
     description = "Yet another SIP003 plugin for shadowsocks, based on v2ray";
     homepage = "https://github.com/shadowsocks/v2ray-plugin/";
-    license = licenses.mit;
-    maintainers = [ maintainers.ahrzb ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      ahrzb
+      neverbehave
+    ];
     mainProgram = "v2ray-plugin";
   };
 }


### PR DESCRIPTION
## Things done

The official repo haven't released new version for a while, and the master branch upgrades fix previous build issue: https://github.com/NixOS/nixpkgs/issues/219343

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
