### PR TITLE
shadowsocks-qtun-plugin: init at 0.3.0

### DIFF
--- a/pkgs/by-name/sh/shadowsocks-qtun-plugin/package.nix
+++ b/pkgs/by-name/sh/shadowsocks-qtun-plugin/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "shadowsocks-qtun-plugin";
+  version = "0.3.0-unstable-2026-02-07";
+
+  src = fetchFromGitHub {
+    owner = "shadowsocks";
+    repo = "qtun";
+    rev = "ab58110075488f8411b0eafd3d9412be2ace3c61";
+    hash = "sha256-hA/XoSZcnci2PqfeyR0ELi4dty9jE3Lsq/lgOfZ0zQ0=";
+  };
+
+  cargoHash = "sha256-iIqN25t9GxQ4jC5NtpOuDztdS+mCnEh7oDJXm9PivOo=";
+
+  meta = {
+    description = "Yet another SIP003 plugin based on IETF-QUIC";
+    homepage = "https://github.com/shadowsocks/qtun";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ neverbehave ];
+    mainProgram = "qtun-server";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
