### PR TITLE
python3Packages.dynaconf: Fix spurious check failures

### DIFF
--- a/pkgs/development/python-modules/dynaconf/default.nix
+++ b/pkgs/development/python-modules/dynaconf/default.nix
@@ -14,7 +14,6 @@
   ipython,
   pytest-cov-stub,
   pytest-mock,
-  pytest-xdist,
   pytestCheckHook,
   python-dotenv,
   radon,
@@ -50,7 +49,6 @@ buildPythonPackage rec {
     ipython
     pytest-cov-stub
     pytest-mock
-    pytest-xdist
     pytestCheckHook
     python-dotenv
     radon

--- a/pkgs/development/python-modules/dynaconf/default.nix
+++ b/pkgs/development/python-modules/dynaconf/default.nix
@@ -57,6 +57,8 @@ buildPythonPackage rec {
     versionCheckHook
   ];
 
+  # Parallel tests do not work as some of the tests modify env variables.
+  # pytest-xdist plugin is removed to disable parallel tests
   disabledTestPaths = [
     # import file mismatch
     # imported module 'app_test' has this __file__ attribute:


### PR DESCRIPTION
These tests can't be run in parallel as some of them modify env variables. Remove pytest-xdist plugin, so that we don't have spurious build failures


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
