### PR TITLE
vtk-dicom: init at 0.8.17

### DIFF
--- a/pkgs/by-name/vt/vtk-dicom/package.nix
+++ b/pkgs/by-name/vt/vtk-dicom/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  vtk,
+  gdcm,
+  testers,
+  vtk-dicom,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vtk-dicom";
+  version = "0.8.17";
+
+  src = fetchFromGitHub {
+    owner = "dgobbi";
+    repo = "vtk-dicom";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1lI2qsV4gymWqjeouEHZ5FRlmlh9vimH7J5rzA+eOds=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    vtk
+    gdcm
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "USE_GDCM" true)
+    (lib.cmakeBool "DICOM_VERSIONED_INSTALL" false)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeFeature "CMAKE_INSTALL_BINDIR" "bin")
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
+    (lib.cmakeFeature "CMAKE_INSTALL_INCLUDEDIR" "include")
+  ]
+  ++ lib.optional finalAttrs.finalPackage.doCheck [
+    # vtkBool does not accept TRUE, we have to use STRING "ON"
+    (lib.cmakeFeature "BUILD_TESTING" "ON")
+  ];
+
+  doCheck = true;
+
+  passthru.tests = {
+    python = vtk-dicom.override {
+      vtk = vtk.override { pythonSupport = true; };
+    };
+
+    cmake-config = testers.hasCmakeConfigModules {
+      moduleNames = [ "DICOM" ];
+      package = finalAttrs.finalPackage;
+    };
+  };
+
+  meta = {
+    description = "DICOM for VTK";
+    homepage = "https://github.com/dgobbi/vtk-dicom";
+    changelog = "https://github.com/dgobbi/vtk-dicom/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      qbisi
+      bcdarwin
+    ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -47,7 +47,6 @@
   libgeotiff,
   laszip_2,
   gdal,
-  gdcm,
   pdal,
   alembic,
   imath,
@@ -138,19 +137,6 @@ stdenv.mkDerivation (finalAttrs: {
     hash = sourceSha256;
   };
 
-  postPatch =
-    let
-      vtk-dicom = fetchFromGitHub {
-        owner = "dgobbi";
-        repo = "vtk-dicom";
-        tag = "v0.8.17";
-        hash = "sha256-1lI2qsV4gymWqjeouEHZ5FRlmlh9vimH7J5rzA+eOds=";
-      };
-    in
-    ''
-      cp --no-preserve=mode -r ${vtk-dicom} ./Remote/vtkDICOM
-    '';
-
   nativeBuildInputs = [
     cmake
     pkg-config # required for finding MySQl
@@ -168,7 +154,6 @@ stdenv.mkDerivation (finalAttrs: {
     libgeotiff
     laszip_2
     gdal
-    (gdcm.override { enableVTK = false; })
     pdal
     alembic
     imath
@@ -305,9 +290,6 @@ stdenv.mkDerivation (finalAttrs: {
     # mpiSupport
     (lib.cmakeBool "VTK_USE_MPI" mpiSupport)
     (vtkBool "VTK_GROUP_ENABLE_MPI" mpiSupport)
-
-    # Remote module options
-    (lib.cmakeBool "USE_GDCM" true) # for vtkDicom
   ];
 
   pythonImportsCheck = [ "vtk" ];


### PR DESCRIPTION
vtk-dicom is a remote module of vtk for DICOM.
homepage: https://github.com/dgobbi/vtk-dicom

This pr migrate this in-tree module out-of vtk package as a standalone package.
Debian also package vtk-dicom as a standalone package c.f. https://sources.debian.org/src/vtk-dicom/0.8.17-1/debian/rules

FYI @bcdarwin  @kurnevsky 

I dont really use vtk-dicom and its downstream package. The purpose of this pr is to move the in-tree source vtk-dicom
out of vtk package. I would be happy if @bcdarwin  @kurnevsky could be the co-maintainer of this package.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
