### PR TITLE
haskell.packages.native-bignum: exclude recurseForDerivations

### DIFF
--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -10,8 +10,6 @@
 let
   # These are attributes in compiler that support integer-simple.
   integerSimpleIncludes = [
-    "ghc88"
-    "ghc884"
     "ghc810"
     "ghc8107"
   ];

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -679,7 +679,7 @@ in
       native-bignum =
         let
           nativeBignumGhcNames = pkgs.lib.filter (name: !(builtins.elem name nativeBignumExcludes)) (
-            pkgs.lib.attrNames compiler
+            pkgs.lib.attrNames packages
           );
         in
         pkgs.lib.genAttrs nativeBignumGhcNames (


### PR DESCRIPTION
This was accidentally introduced when it was added to `haskell.compiler`. This code is a bit odd, because it iterates through the compiler attributes and then tries to access the same name in packages, which fails in this case.

~~I opted not to clean this up by changing to iterate through the packages instead, because this would need formatting changes for the whole block of package set definitions and would cause conflicts with a few PRs removing older GHC versions. We can do that later.~~ Seems like this was just a copy-paste error, this should iterate through packages instead.

Fixes https://github.com/NixOS/nixpkgs/pull/437195#issuecomment-3255712133

cc @trofi 

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
