### PR TITLE
python3Packages.warp-lang: 1.8.1 -> 1.9.0

### DIFF
--- a/pkgs/development/python-modules/warp-lang/default.nix
+++ b/pkgs/development/python-modules/warp-lang/default.nix
@@ -37,13 +37,13 @@ let
   effectiveStdenv = if cudaSupport then cudaPackages.backendStdenv else args.stdenv;
   stdenv = builtins.throw "Use effectiveStdenv instead of stdenv directly, as it may be replaced by cudaPackages.backendStdenv";
 
-  version = "1.8.1";
+  version = "1.9.0";
 
   libmathdx = effectiveStdenv.mkDerivation (finalAttrs: {
     # NOTE: The version used should match the version Warp requires:
     # https://github.com/NVIDIA/warp/blob/${version}/deps/libmathdx-deps.packman.xml
     pname = "libmathdx";
-    version = "0.2.2";
+    version = "0.2.3";
 
     outputs = [
       "out"
@@ -53,24 +53,27 @@ let
     src =
       let
         baseURL = "https://developer.download.nvidia.com/compute/cublasdx/redist/cublasdx";
+        cudaMajorVersion = cudaPackages.cudaMajorVersion; # only 12, 13 supported
+        cudaVersion = "${cudaMajorVersion}.0"; # URL example: ${baseURL}/cuda12/${name}-${version}-cuda12.0.zip
         name = lib.concatStringsSep "-" [
           finalAttrs.pname
           "Linux"
           effectiveStdenv.hostPlatform.parsed.cpu.name
           finalAttrs.version
+          "cuda${cudaVersion}"
         ];
 
         # nix-hash --type sha256 --to-sri $(nix-prefetch-url "https://...")
         hashes = {
-          aarch64-linux = "sha256-uadBl2HTWIzpYyUxHqnLZtqq42v13KYXSOJXz0Wgtrk=";
-          x86_64-linux = "sha256-YU26l3q+HH1fyBD96oMrl+e96gmiC/krzJv6VJss3mY=";
+          aarch64-linux = "sha256-d/aBC+zU2ciaw3isv33iuviXYaLGLdVDdzynGk9SFck=";
+          x86_64-linux = "sha256-CHIH0s4SnA67COtHBkwVCajW/3f0VxNBmuDLXy4LFIg=";
         };
       in
       lib.mapNullable (
         hash:
         fetchurl {
           inherit hash name;
-          url = "${baseURL}/${name}.tar.gz";
+          url = "${baseURL}/cuda${cudaMajorVersion}/${name}.tar.gz";
         }
       ) (hashes.${effectiveStdenv.hostPlatform.system} or null);
 
@@ -139,7 +142,7 @@ buildPythonPackage {
     owner = "NVIDIA";
     repo = "warp";
     tag = "v${version}";
-    hash = "sha256-cSG8uncJMl4rbQ48L8XJY1Illr6usVX8no0jDhECwbo=";
+    hash = "sha256-OEg2mUsEdRKhgx0fIraqme4moKNh1RSdN7/yCT1V5+g=";
   };
 
   patches =
@@ -198,18 +201,6 @@ buildPythonPackage {
         --replace-fail \
           '-lmathdx_static' \
           '-lmathdx'
-    ''
-    # Broken tests on aarch64. Since unittest doesn't support disabling a
-    # single test, and pytest isn't compatible, we patch the test file directly
-    # instead.
-    #
-    # See: https://github.com/NVIDIA/warp/issues/552
-    + lib.optionalString effectiveStdenv.hostPlatform.isAarch64 ''
-      nixLog "patching $PWD/warp/tests/test_fem.py to disable broken tests on aarch64"
-      substituteInPlace "$PWD/warp/tests/test_fem.py" \
-        --replace-fail \
-          'add_function_test(TestFem, "test_integrate_gradient", test_integrate_gradient, devices=devices)' \
-          ""
     ''
     # AssertionError: 0.4082476496696472 != 0.40824246406555176 within 5 places
     + lib.optionalString effectiveStdenv.hostPlatform.isDarwin ''
@@ -351,12 +342,6 @@ buildPythonPackage {
                 writableTmpDirAsHomeHook
               ];
               requiredSystemFeatures = lib.optionals cudaSupport [ "cuda" ];
-              # Many unit tests fail with segfaults on aarch64-linux, especially in the sim
-              # and grad modules. However, other functionality generally works, so we don't
-              # mark the package as broken.
-              #
-              # See: https://www.github.com/NVIDIA/warp/issues/{356,372,552}
-              meta.broken = effectiveStdenv.hostPlatform.isAarch64 && effectiveStdenv.hostPlatform.isLinux;
             }
             ''
               nixLog "running ${name}"


### PR DESCRIPTION
- **Release**: https://github.com/NVIDIA/warp/releases/tag/v1.9.0
- **Diff**: https://github.com/NVIDIA/warp/compare/v1.8.1...v1.9.0
- **Homepage**: https://github.com/NVIDIA/warp

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
