### PR TITLE
linux_xanmod, linux_xanmod_latest: 2025-09-04

### DIFF
--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -21,8 +21,8 @@ let
     };
     # ./update-xanmod.sh main
     main = {
-      version = "6.16.4";
-      hash = "sha256-CWsGKAID9j24H5oDqlKPToKzl+1Y43F2DmGkc7b2YIg=";
+      version = "6.16.5";
+      hash = "sha256-XQ1blzX1sR7et0qKu+voKDKefjYLYZwHPFo7RbFYekg=";
     };
   };
 

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -15,8 +15,8 @@ let
   variants = {
     # ./update-xanmod.sh lts
     lts = {
-      version = "6.12.44";
-      hash = "sha256-wyT7vXrXVKYISDpm2QLKdmGCx2zQWUusYT6WzGgiiHw=";
+      version = "6.12.45";
+      hash = "sha256-JyRmRdSkskD3LHvaCUNZJOKEXNML4WRbUDN3+dVn4Kk=";
       isLTS = true;
     };
     # ./update-xanmod.sh main


### PR DESCRIPTION
## Changes

- **linux_xanmod (lts)**: 6.12.44 -> 6.12.45
  - Changelog: https://dl.xanmod.org/changelog/6.12/ChangeLog-6.12.45-xanmod1.gz
  - Diff: https://gitlab.com/xanmod/linux/-/compare/6.12.44-xanmod1..6.12.45-xanmod1?from_project_id=51590166

- **linux_xanmod_latest (main)**: 6.16.4 -> 6.16.5
  - Changelog: https://dl.xanmod.org/changelog/6.16/ChangeLog-6.16.5-xanmod1.gz
  - Diff: https://gitlab.com/xanmod/linux/-/compare/6.16.4-xanmod1..6.16.5-xanmod1?from_project_id=51590166

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
