### PR TITLE
guile-hoot: 0.6.0 -> 0.6.1

### DIFF
--- a/pkgs/by-name/gu/guile-hoot/package.nix
+++ b/pkgs/by-name/gu/guile-hoot/package.nix
@@ -1,22 +1,24 @@
 {
   lib,
   stdenv,
-  fetchFromGitLab,
+  fetchFromGitea,
   autoreconfHook,
   guile,
   pkg-config,
   texinfo,
+  nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "guile-hoot";
-  version = "0.6.0";
+  version = "0.6.1";
 
-  src = fetchFromGitLab {
+  src = fetchFromGitea {
+    domain = "codeberg.org";
     owner = "spritely";
-    repo = "guile-hoot";
-    rev = "v${version}";
-    hash = "sha256-xPU4uLyh3gd2ubyGednCqB3uzKrabhXQhs6vBc8z0ps=";
+    repo = "hoot";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Y3UWKSjJQnYh+06p+Oi0Fa0ul2T8QWemgNm9A0su5WQ=";
   };
 
   nativeBuildInputs = [
@@ -32,16 +34,13 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "GUILE_AUTO_COMPILE=0" ];
 
-  configureFlags = [
-    "--with-guile-site-dir=$(out)/${guile.siteDir}"
-    "--with-guile-site-ccache-dir=$(out)/${guile.siteCcacheDir}"
-  ];
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Scheme to WebAssembly compiler backend for GNU Guile and a general purpose WASM toolchain";
-    homepage = "https://gitlab.com/spritely/guile-hoot";
+    homepage = "https://codeberg.org/spritely/hoot";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ jinser ];
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. Ipdate guile-hoot `v0.6.0` -> `v0.6.1`
2. Use `mkDerivation (finalAttrs: { ... })` instead of `rec`
3. Use `tag` instead of `rev`
4. Guile Hoot has migrated from gitlab to codeberg
5. Add `nix-update-script` for auto update
6. Remove unused `configureFlags`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
