### PR TITLE
netbox_4_4: init at 4.4.2

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -183,9 +183,10 @@
 - `podofo` has been updated from `0.9.8` to `1.0.0`. These releases are by nature very incompatible due to major API changes. The legacy versions can be found under `podofo_0_10` and `podofo_0_9`.
   Changelog: https://github.com/podofo/podofo/blob/1.0.0/CHANGELOG.md, API-Migration-Guide: https://github.com/podofo/podofo/blob/1.0.0/API-MIGRATION.md.
 
-- NetBox was updated to `>= 4.3.0`. Have a look at the breaking changes
-  of the [4.3 release](https://github.com/netbox-community/netbox/releases/tag/v4.2.0),
-  make the required changes to your database, if needed, then upgrade by setting `services.netbox.package = pkgs.netbox_4_3;` in your configuration.
+- NetBox was updated to `>= 4.4.0`. Have a look at the breaking changes
+  of the [4.3 release](https://github.com/netbox-community/netbox/releases/tag/v4.3.0)
+  and the [4.4 release](https://github.com/netbox-community/netbox/releases/tag/v4.4.0),
+  make the required changes to your database, if needed, then upgrade by setting `services.netbox.package = pkgs.netbox_4_4;` in your configuration.
 
 - `pkgs.nextcloud30` has been removed since it's out of support upstream.
 

--- a/nixos/modules/services/web-apps/netbox.nix
+++ b/nixos/modules/services/web-apps/netbox.nix
@@ -110,14 +110,14 @@ in
       type = lib.types.package;
       default =
         if lib.versionAtLeast config.system.stateVersion "25.11" then
-          pkgs.netbox_4_3
+          pkgs.netbox_4_4
         else if lib.versionAtLeast config.system.stateVersion "25.05" then
           pkgs.netbox_4_2
         else
           pkgs.netbox_4_1;
       defaultText = lib.literalExpression ''
         if lib.versionAtLeast config.system.stateVersion "25.11"
-        then pkgs.netbox_4_3
+        then pkgs.netbox_4_4
         else if lib.versionAtLeast config.system.stateVersion "25.05"
         then pkgs.netbox_4_2
         else pkgs.netbox_4_1;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -985,6 +985,7 @@ in
   netbox_4_1 = handleTest ./web-apps/netbox/default.nix { netbox = pkgs.netbox_4_1; };
   netbox_4_2 = handleTest ./web-apps/netbox/default.nix { netbox = pkgs.netbox_4_2; };
   netbox_4_3 = handleTest ./web-apps/netbox/default.nix { netbox = pkgs.netbox_4_3; };
+  netbox_4_4 = handleTest ./web-apps/netbox/default.nix { netbox = pkgs.netbox_4_4; };
   netdata = runTest ./netdata.nix;
   networking.networkd = handleTest ./networking/networkd-and-scripted.nix { networkd = true; };
   networking.networkmanager = handleTest ./networking/networkmanager.nix { };

--- a/nixos/tests/web-apps/netbox-upgrade.nix
+++ b/nixos/tests/web-apps/netbox-upgrade.nix
@@ -1,7 +1,7 @@
 { lib, pkgs, ... }:
 let
-  oldNetbox = "netbox_4_2";
-  newNetbox = "netbox_4_3";
+  oldNetbox = "netbox_4_3";
+  newNetbox = "netbox_4_4";
 
   apiVersion =
     version:

--- a/nixos/tests/web-apps/netbox/testScript.py
+++ b/nixos/tests/web-apps/netbox/testScript.py
@@ -61,7 +61,7 @@ def compare(a: str, b: str):
     return 0
 
 with subtest("Home screen loads"):
-    machine.succeed(
+    machine.wait_until_succeeds(
         "curl -sSfL http://[::1]:8001 | grep '<title>Home | NetBox</title>'"
     )
 

--- a/pkgs/by-name/ne/netbox_4_3/package.nix
+++ b/pkgs/by-name/ne/netbox_4_3/package.nix
@@ -121,6 +121,9 @@ py.pkgs.buildPythonApplication rec {
     description = "IP address management (IPAM) and data center infrastructure management (DCIM) tool";
     mainProgram = "netbox";
     license = lib.licenses.asl20;
+    knownVulnerabilities = [
+      "Netbox Version ${version} is EOL; please upgrade by following the current release notes instructions"
+    ];
     maintainers = with lib.maintainers; [
       minijackson
       raitobezarius

--- a/pkgs/by-name/ne/netbox_4_4/custom-static-root.patch
+++ b/pkgs/by-name/ne/netbox_4_4/custom-static-root.patch
@@ -1,0 +1,13 @@
+diff --git a/netbox/netbox/settings.py b/netbox/netbox/settings.py
+index 2de06dd10..00406af48 100644
+--- a/netbox/netbox/settings.py
++++ b/netbox/netbox/settings.py
+@@ -410,7 +412,7 @@ USE_X_FORWARDED_HOST = True
+ X_FRAME_OPTIONS = 'SAMEORIGIN'
+ 
+ # Static files (CSS, JavaScript, Images)
+-STATIC_ROOT = BASE_DIR + '/static'
++STATIC_ROOT = getattr(configuration, 'STATIC_ROOT', os.path.join(BASE_DIR, 'static')).rstrip('/')
+ STATIC_URL = f'/{BASE_PATH}static/'
+ STATICFILES_DIRS = (
+     os.path.join(BASE_DIR, 'project-static', 'dist'),

--- a/pkgs/by-name/ne/netbox_4_4/package.nix
+++ b/pkgs/by-name/ne/netbox_4_4/package.nix
@@ -1,0 +1,132 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+  plugins ? _ps: [ ],
+  nixosTests,
+  nix-update-script,
+}:
+let
+  py = python3.override {
+    self = py;
+    packageOverrides = _final: prev: { django = prev.django_5_2; };
+  };
+
+  extraBuildInputs = plugins py.pkgs;
+in
+py.pkgs.buildPythonApplication rec {
+  pname = "netbox";
+  version = "4.4.2";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "netbox-community";
+    repo = "netbox";
+    tag = "v${version}";
+    hash = "sha256-1POwxp7BTCZo7JlGrLVGNzBGCplmhZ0Y6wujunIVGsA=";
+  };
+
+  patches = [
+    ./custom-static-root.patch
+  ];
+
+  dependencies =
+    (
+      with py.pkgs;
+      [
+        colorama
+        django
+        django-cors-headers
+        django-debug-toolbar
+        django-filter
+        django-graphiql-debug-toolbar
+        django-htmx
+        django-mptt
+        django-pglocks
+        django-prometheus
+        django-redis
+        django-rq
+        django-storages
+        django-tables2
+        django-taggit
+        django-timezone-field
+        djangorestframework
+        drf-spectacular
+        drf-spectacular-sidecar
+        feedparser
+        jinja2
+        markdown
+        netaddr
+        nh3
+        pillow
+        psycopg
+        pyyaml
+        requests
+        social-auth-core
+        social-auth-app-django
+        sorl-thumbnail
+        strawberry-graphql
+        strawberry-django
+        svgwrite
+        tablib
+
+        # Optional dependencies, kept here for backward compatibility
+
+        # for the S3 data source backend
+        boto3
+        # for Git data source backend
+        dulwich
+        # for error reporting
+        sentry-sdk
+      ]
+      ++ psycopg.optional-dependencies.c
+      ++ psycopg.optional-dependencies.pool
+      ++ social-auth-core.optional-dependencies.openidconnect
+    )
+    ++ extraBuildInputs;
+
+  nativeBuildInputs = with py.pkgs; [
+    mkdocs-material
+    mkdocs-material-extensions
+    mkdocstrings
+    mkdocstrings-python
+  ];
+
+  postBuild = ''
+    PYTHONPATH=$PYTHONPATH:netbox/
+    ${py.interpreter} -m mkdocs build
+  '';
+
+  installPhase = ''
+    mkdir -p $out/opt/netbox
+    cp -r . $out/opt/netbox
+    chmod +x $out/opt/netbox/netbox/manage.py
+    makeWrapper $out/opt/netbox/netbox/manage.py $out/bin/netbox \
+      --prefix PYTHONPATH : "$PYTHONPATH"
+  '';
+
+  passthru = {
+    python = py;
+    # PYTHONPATH of all dependencies used by the package
+    pythonPath = py.pkgs.makePythonPath dependencies;
+    inherit (py.pkgs) gunicorn;
+    tests = {
+      netbox = nixosTests.netbox_4_3;
+      inherit (nixosTests) netbox-upgrade;
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    homepage = "https://github.com/netbox-community/netbox";
+    changelog = "https://github.com/netbox-community/netbox/blob/${src.tag}/docs/release-notes/version-${lib.versions.majorMinor version}.md";
+    description = "IP address management (IPAM) and data center infrastructure management (DCIM) tool";
+    mainProgram = "netbox";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      minijackson
+      raitobezarius
+      transcaffeine
+    ];
+  };
+}

--- a/pkgs/development/python-modules/inline-snapshot/default.nix
+++ b/pkgs/development/python-modules/inline-snapshot/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage rec {
   pname = "inline-snapshot";
-  version = "0.24.0";
+  version = "0.28.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "15r10nk";
     repo = "inline-snapshot";
     tag = version;
-    hash = "sha256-UiVxG9W1lwvvoflVey4250iL8gL8Tm41LBo0ab0tTqk=";
+    hash = "sha256-f572H7jeolv9nONuRBtZR/pcVDs5oX/dOiEjXlJyiio=";
   };
 
   build-system = [ hatchling ];

--- a/pkgs/development/python-modules/mkdocstrings-python/default.nix
+++ b/pkgs/development/python-modules/mkdocstrings-python/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "mkdocstrings-python";
-  version = "1.16.12";
+  version = "1.18.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mkdocstrings";
     repo = "python";
     tag = version;
-    hash = "sha256-NL5gn8HgT0hvIlUDs//sErAaSVXvxLDJGT7nZX65ZVU=";
+    hash = "sha256-BdUNj7EJAbOs8Ff+IGbd7be+lRG6MQCIgNAi5oH9OgA=";
   };
 
   build-system = [ pdm-backend ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3533,7 +3533,7 @@ with pkgs;
   };
 
   # Not in aliases because it wouldn't get picked up by callPackage
-  netbox = netbox_4_3;
+  netbox = netbox_4_4;
 
   netcap-nodpi = callPackage ../by-name/ne/netcap/package.nix {
     withDpi = false;


### PR DESCRIPTION
Release Notes: https://github.com/netbox-community/netbox/releases/tag/v4.4.0

## Things done

- updated `mkdocstrings-python` to `1.18.2` due to failing build, causing quite some rebuilds
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
