### PR TITLE
haskell.compiler.ghc963: drop

### DIFF
--- a/pkgs/development/compilers/ghc/9.6.3.nix
+++ b/pkgs/development/compilers/ghc/9.6.3.nix
@@ -1,4 +1,0 @@
-import ./common-hadrian.nix {
-  version = "9.6.3";
-  sha256 = "1xbpxchmvm9gswrwwz1rsvx9kjaxhc2q3fx9l6wa0l5599xydkfz";
-}

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -183,51 +183,29 @@
           || (lib.versionAtLeast version "9.8" && lib.versionOlder version "9.11");
       in
 
-      # Fix docs build with Sphinx >= 7 https://gitlab.haskell.org/ghc/ghc/-/issues/24129
-      lib.optionals (lib.versionOlder version "9.6.7") [
-        ./docs-sphinx-7.patch
-      ]
-      ++ lib.optionals (lib.versionAtLeast version "9.6" && lib.versionOlder version "9.6.5") [
-        # Fix aarch64-linux builds of 9.6.0 - 9.6.4.
-        # Fixes a pointer type mismatch in the RTS.
-        # https://gitlab.haskell.org/ghc/ghc/-/issues/24348
-        (fetchpatch {
-          name = "fix-incompatible-pointer-types.patch";
-          url = "https://gitlab.haskell.org/ghc/ghc/-/commit/1e48c43483693398001bfb0ae644a3558bf6a9f3.diff";
-          hash = "sha256-zUlzpX7J1n+MCEv9AWpj69FTy2uzJH8wrQDkTexGbgM=";
-        })
-      ]
-      ++
-        lib.optionals
-          (
-            # 2025-01-16: unix >= 2.8.6.0 is unaffected which is shipped by GHC 9.12.1 and 9.8.4
-            lib.versionOlder version "9.11"
-            && !(lib.versionAtLeast version "9.6.7" && lib.versionOlder version "9.8")
-            && !(lib.versionAtLeast version "9.8.4" && lib.versionOlder version "9.9")
-            && !(lib.versionAtLeast version "9.10.2" && lib.versionOlder version "9.11")
-          )
-          [
-            # Determine size of time related types using hsc2hs instead of assuming CLong.
-            # Prevents failures when e.g. stat(2)ing on 32bit systems with 64bit time_t etc.
-            # https://github.com/haskell/ghcup-hs/issues/1107
-            # https://gitlab.haskell.org/ghc/ghc/-/issues/25095
-            # Note that in normal situations this shouldn't be the case since nixpkgs
-            # doesn't set -D_FILE_OFFSET_BITS=64 and friends (yet).
-            (fetchpatch {
-              name = "unix-fix-ctimeval-size-32-bit.patch";
-              url = "https://github.com/haskell/unix/commit/8183e05b97ce870dd6582a3677cc82459ae566ec.patch";
-              sha256 = "17q5yyigqr5kxlwwzb95sx567ysfxlw6bp3j4ji20lz0947aw6gv";
-              stripLen = 1;
-              extraPrefix = "libraries/unix/";
-            })
-          ]
-      ++ lib.optionals (lib.versionAtLeast version "9.6" && lib.versionOlder version "9.6.6") [
-        (fetchpatch {
-          name = "fix-fully_static.patch";
-          url = "https://gitlab.haskell.org/ghc/ghc/-/commit/1bb24432ff77e11a0340a7d8586e151e15bba2a1.diff";
-          hash = "sha256-MpvTmFFsNiPDoOp9BhZyWeapeibQ77zgEV+xzZ1UAXs=";
-        })
-      ]
+      lib.optionals
+        (
+          # 2025-01-16: unix >= 2.8.6.0 is unaffected which is shipped by GHC 9.12.1 and 9.8.4
+          lib.versionOlder version "9.11"
+          && !(lib.versionAtLeast version "9.6.7" && lib.versionOlder version "9.8")
+          && !(lib.versionAtLeast version "9.8.4" && lib.versionOlder version "9.9")
+          && !(lib.versionAtLeast version "9.10.2" && lib.versionOlder version "9.11")
+        )
+        [
+          # Determine size of time related types using hsc2hs instead of assuming CLong.
+          # Prevents failures when e.g. stat(2)ing on 32bit systems with 64bit time_t etc.
+          # https://github.com/haskell/ghcup-hs/issues/1107
+          # https://gitlab.haskell.org/ghc/ghc/-/issues/25095
+          # Note that in normal situations this shouldn't be the case since nixpkgs
+          # doesn't set -D_FILE_OFFSET_BITS=64 and friends (yet).
+          (fetchpatch {
+            name = "unix-fix-ctimeval-size-32-bit.patch";
+            url = "https://github.com/haskell/unix/commit/8183e05b97ce870dd6582a3677cc82459ae566ec.patch";
+            sha256 = "17q5yyigqr5kxlwwzb95sx567ysfxlw6bp3j4ji20lz0947aw6gv";
+            stripLen = 1;
+            extraPrefix = "libraries/unix/";
+          })
+        ]
       ++ lib.optionals (lib.versionAtLeast version "9.6" && lib.versionOlder version "9.8") [
         # Fix unlit being installed under a different name than is used in the
         # settings file: https://gitlab.haskell.org/ghc/ghc/-/issues/23317

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -189,16 +189,3 @@ in
   # A given major version of ghc-exactprint only supports one version of GHC.
   ghc-exactprint = addBuildDepend self.extra super.ghc-exactprint_1_7_1_0;
 }
-# super.ghc is required to break infinite recursion as Nix is strict in the attrNames
-//
-  lib.optionalAttrs (pkgs.stdenv.hostPlatform.isAarch64 && lib.versionOlder super.ghc.version "9.6.4")
-    {
-      # The NCG backend for aarch64 generates invalid jumps in some situations,
-      # the workaround on 9.6 is to revert to the LLVM backend (which is used
-      # for these sorts of situations even on 9.2 and 9.4).
-      # https://gitlab.haskell.org/ghc/ghc/-/issues/23746#note_525318
-      inherit (lib.mapAttrs (_: self.forceLlvmCodegenBackend) super)
-        tls
-        mmark
-        ;
-    }

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -97,15 +97,6 @@ in
         inherit buildTargetLlvmPackages llvmPackages;
       };
       ghc94 = compiler.ghc948;
-      ghc963 = callPackage ../development/compilers/ghc/9.6.3.nix {
-        bootPkgs = bb.packages.ghc924Binary;
-        inherit (buildPackages.python3Packages) sphinx;
-        # Need to use apple's patched xattr until
-        # https://github.com/xattr/xattr/issues/44 and
-        # https://github.com/xattr/xattr/issues/55 are solved.
-        inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
-        inherit buildTargetLlvmPackages llvmPackages;
-      };
       ghc967 = callPackage ../development/compilers/ghc/9.6.7.nix {
         bootPkgs = bb.packages.ghc924Binary;
         inherit (buildPackages.python3Packages) sphinx;
@@ -138,7 +129,7 @@ in
             # that 9.6.4 bindists pass linker flags our ld doesn't support).
             # With both 9.6.3 and 9.6.4 binary it is impossible to link against
             # the clock package (probably a hsc2hs problem).
-            bb.packages.ghc963
+            bb.packages.ghc967
           else
             bb.packages.ghc963Binary;
         inherit (buildPackages.python3Packages) sphinx;
@@ -156,7 +147,7 @@ in
             # that 9.6.4 bindists pass linker flags our ld doesn't support).
             # With both 9.6.3 and 9.6.4 binary it is impossible to link against
             # the clock package (probably a hsc2hs problem).
-            bb.packages.ghc963
+            bb.packages.ghc967
           else
             bb.packages.ghc963Binary;
         inherit (buildPackages.python3Packages) sphinx;
@@ -174,7 +165,7 @@ in
             # that 9.6.4 bindists pass linker flags our ld doesn't support).
             # With both 9.6.3 and 9.6.4 binary it is impossible to link against
             # the clock package (probably a hsc2hs problem).
-            bb.packages.ghc963
+            bb.packages.ghc967
           else
             bb.packages.ghc963Binary;
         inherit (buildPackages.python3Packages) sphinx;
@@ -283,11 +274,6 @@ in
         compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.4.x.nix { };
       };
       ghc94 = packages.ghc948;
-      ghc963 = callPackage ../development/haskell-modules {
-        buildHaskellPackages = bh.packages.ghc963;
-        ghc = bh.compiler.ghc963;
-        compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.6.x.nix { };
-      };
       ghc967 = callPackage ../development/haskell-modules {
         buildHaskellPackages = bh.packages.ghc967;
         ghc = bh.compiler.ghc967;

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -64,7 +64,6 @@ let
   # list of all compilers to test specific packages on
   released = with compilerNames; [
     ghc948
-    ghc963
     ghc967
     ghc984
     ghc9101


### PR DESCRIPTION
Latest 9.6.x minor release is 9.6.7, which is also in Stackage 22.44.

Thus, dropping according to the GHC Deprecation Policy.

This requires to change the bootstrap for GHC 9.8.x and GHC 9.10.x on some platforms.

## Things done

- Built on platform:
  - :heavy_check_mark: aarch64-darwin
  - :grey_question: armv7l-linux: tried on the aarch64 community builder, but segfaults in `ghc8107Binary` already, so unrelated to this PR.
  - :grey_question: powerpc64le-linux: don't have a system available & proposed to drop in #440400
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
