### PR TITLE
nixos/nvidia: add suspend-then-hibernate systemd service

### DIFF
--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -595,15 +595,24 @@ in
               (lib.mkIf cfg.powerManagement.enable {
                 nvidia-suspend = nvidiaService "suspend";
                 nvidia-hibernate = nvidiaService "hibernate";
+                nvidia-suspend-then-hibernate = (nvidiaService "suspend") // {
+                  description = "NVIDIA system suspend-then-hibernate actions";
+                  before = [ "systemd-suspend-then-hibernate.service" ];
+                  requiredBy = [ "systemd-suspend-then-hibernate.service" ];
+                };
                 nvidia-resume = (nvidiaService "resume") // {
                   before = [ ];
                   after = [
                     "systemd-suspend.service"
                     "systemd-hibernate.service"
+                    "systemd-hybrid-sleep.service"
+                    "systemd-suspend-then-hibernate.service"
                   ];
                   requiredBy = [
                     "systemd-suspend.service"
                     "systemd-hibernate.service"
+                    "systemd-hybrid-sleep.service"
+                    "systemd-suspend-then-hibernate.service"
                   ];
                 };
               })

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -595,8 +595,16 @@ in
               (lib.mkIf cfg.powerManagement.enable {
                 nvidia-suspend = nvidiaService "suspend";
                 nvidia-hibernate = nvidiaService "hibernate";
-                nvidia-suspend-then-hibernate = (nvidiaService "suspend") // {
+                nvidia-suspend-then-hibernate = {
                   description = "NVIDIA system suspend-then-hibernate actions";
+                  path = [ pkgs.kbd ];
+                  serviceConfig = {
+                    Type = "oneshot";
+                    ExecStart = [
+                      "${nvidia_x11.out}/bin/nvidia-sleep.sh 'is-suspend-then-hibernate-supported'"
+                      "${nvidia_x11.out}/bin/nvidia-sleep.sh 'suspend'"
+                    ];
+                  };
                   before = [ "systemd-suspend-then-hibernate.service" ];
                   requiredBy = [ "systemd-suspend-then-hibernate.service" ];
                 };

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -578,6 +578,18 @@ in
 
           systemd.packages = lib.optional cfg.powerManagement.enable nvidia_x11.out;
 
+          environment.etc."systemd/system-sleep/nvidia".source = lib.mkIf cfg.powerManagement.enable (
+            pkgs.writeShellScript "nvidia-sleep" ''
+              export PATH=${
+                lib.makeBinPath [
+                  pkgs.coreutils
+                  pkgs.kbd
+                ]
+              }:$PATH
+              exec "${nvidia_x11.out}/lib/systemd/system-sleep/nvidia" "$@"
+            ''
+          );
+
           systemd.services =
             let
               nvidiaService = state: {

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -588,7 +588,7 @@ in
                   ExecStart = "${nvidia_x11.out}/bin/nvidia-sleep.sh '${state}'";
                 };
                 before = [ "systemd-${state}.service" ];
-                requiredBy = [ "systemd-${state}.service" ];
+                wantedBy = [ "systemd-${state}.service" ];
               };
             in
             lib.mkMerge [
@@ -606,7 +606,7 @@ in
                     ];
                   };
                   before = [ "systemd-suspend-then-hibernate.service" ];
-                  requiredBy = [ "systemd-suspend-then-hibernate.service" ];
+                  wantedBy = [ "systemd-suspend-then-hibernate.service" ];
                 };
                 nvidia-resume = (nvidiaService "resume") // {
                   before = [ ];
@@ -616,7 +616,7 @@ in
                     "systemd-hybrid-sleep.service"
                     "systemd-suspend-then-hibernate.service"
                   ];
-                  requiredBy = [
+                  wantedBy = [
                     "systemd-suspend.service"
                     "systemd-hibernate.service"
                     "systemd-hybrid-sleep.service"


### PR DESCRIPTION
Allows to use systemd's suspend then hibernate functionality without throwing following error:

```
Sep 05 00:44:34 promethea kernel: nvidia 0000:01:00.0: PM: pci_pm_suspend(): nv_pmops_suspend [nvidia] returns -5
Sep 05 00:44:34 promethea kernel: nvidia 0000:01:00.0: PM: dpm_run_callback(): pci_pm_suspend returns -5
Sep 05 00:44:34 promethea kernel: nvidia 0000:01:00.0: PM: failed to suspend async: error -5
Sep 05 00:44:34 promethea kernel: queueing ieee80211 work while going to suspend
Sep 05 00:44:34 promethea kernel: PM: Some devices failed to suspend, or early wake event detected
```

see:

1. https://bbs.archlinux.org/viewtopic.php?pid=2224136#p2224136
2. https://gitlab.archlinux.org/archlinux/packaging/packages/nvidia-utils/-/merge_requests/24
3. https://forums.developer.nvidia.com/t/issues-resuming-from-hybrid-sleep/140369/10

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
