### PR TITLE
ax25-tools: new src target and enforce strictDeps

### DIFF
--- a/pkgs/by-name/ax/ax25-tools/package.nix
+++ b/pkgs/by-name/ax/ax25-tools/package.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
   pname = "ax25-tools";
   version = "0.0.10-rc5";
 
+  strictDeps = true;
+
   nativeBuildInputs = [ autoreconfHook ];
 
   buildInputs = [ libax25 ];

--- a/pkgs/by-name/ax/ax25-tools/package.nix
+++ b/pkgs/by-name/ax/ax25-tools/package.nix
@@ -6,7 +6,7 @@
   libax25,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ax25-tools";
   version = "0.0.10-rc5";
 
@@ -37,4 +37,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ sarcasticadmin ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/ax/ax25-tools/package.nix
+++ b/pkgs/by-name/ax/ax25-tools/package.nix
@@ -1,7 +1,8 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  autoreconfHook,
   libax25,
 }:
 
@@ -9,13 +10,17 @@ stdenv.mkDerivation rec {
   pname = "ax25-tools";
   version = "0.0.10-rc5";
 
+  nativeBuildInputs = [ autoreconfHook ];
+
   buildInputs = [ libax25 ];
 
-  # Due to recent unsolvable administrative domain problems with linux-ax25.org,
-  # the new domain is linux-ax25.in-berlin.de
-  src = fetchurl {
-    url = "https://linux-ax25.in-berlin.de/pub/ax25-tools/ax25-tools-${version}.tar.gz";
-    sha256 = "sha256-kqnLi1iobcufVWMPxUyaRsWKIPyTvtUkuMERGQs2qgY=";
+  # src from linux-ax25.in-berlin.de remote has been
+  # unreliable, pointing to github mirror from the radiocatalog
+  src = fetchFromGitHub {
+    owner = "radiocatalog";
+    repo = "ax25-tools";
+    tag = "ax25-tools-${finalAttrs.version}";
+    hash = "sha256-yoFflC3KU3cKQEENj4MF793TvUdf38C2Q9B7nMuLgMg=";
   };
 
   configureFlags = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Relates to: https://github.com/NixOS/nixpkgs/pull/439888

Moving to a mirror of the src at radiocatalog on GitHub since https://linux-ax25.in-berlin.de is unreliable. `autoreconfHook` is now needed in `nativeBuildInputs` after moving from `fetchurl`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
