### PR TITLE
installShellFiles: Add elvish support to installShellCompletion

### DIFF
--- a/doc/hooks/installShellFiles.section.md
+++ b/doc/hooks/installShellFiles.section.md
@@ -89,15 +89,15 @@ The `installShellCompletion` function takes one or more paths to shell
 completion files.
 
 By default it will autodetect the shell type from the completion file extension,
-but you may also specify it by passing one of `--bash`, `--fish`, `--zsh`, or
-`--nushell`. These flags apply to all paths listed after them (up until another
-shell flag is given). Each path may also have a custom installation name
-provided by providing a flag `--name NAME` before the path. If this flag is not
-provided, zsh completions will be renamed automatically such that `foobar.zsh`
-becomes `_foobar`. A root name may be provided for all paths using the flag
-`--cmd NAME`; this synthesizes the appropriate name depending on the shell
-(e.g. `--cmd foo` will synthesize the name `foo.bash` for bash and `_foo` for
-zsh).
+but you may also specify it by passing one of `--bash`, `--fish`, `--zsh`,
+`--elvish` or `--nushell`. These flags apply to all paths listed after them (up
+until another shell flag is given). Each path may also have a custom
+installation name provided by providing a flag `--name NAME` before the path. If
+this flag is not provided, zsh completions will be renamed automatically such
+that `foobar.zsh` becomes `_foobar`. A root name may be provided for all paths
+using the flag `--cmd NAME`; this synthesizes the appropriate name depending on
+the shell (e.g. `--cmd foo` will synthesize the name `foo.bash` for bash and
+`_foo` for zsh).
 
 ### Example Usage {#installshellfiles-installshellcompletion-exampleusage}
 
@@ -107,11 +107,12 @@ zsh).
   postInstall = ''
     # explicit behavior
     installShellCompletion --bash --name foobar.bash share/completions.bash
+    installShellCompletion --elvish --name foobar share/completions.elv
     installShellCompletion --fish --name foobar.fish share/completions.fish
     installShellCompletion --nushell --name foobar share/completions.nu
     installShellCompletion --zsh --name _foobar share/completions.zsh
     # implicit behavior
-    installShellCompletion share/completions/foobar.{bash,fish,zsh,nu}
+    installShellCompletion share/completions/foobar.{bash,fish,zsh,elv,nu}
   '';
 }
 ```
@@ -135,6 +136,7 @@ failure. To prevent this, guard the completion generation commands.
     # using process substitution
     installShellCompletion --cmd foobar \
       --bash <($out/bin/foobar --bash-completion) \
+      --elvish <($out/bin/foobar --elvish-completion) \
       --fish <($out/bin/foobar --fish-completion) \
       --nushell <($out/bin/foobar --nushell-completion) \
       --zsh <($out/bin/foobar --zsh-completion)

--- a/pkgs/by-name/in/installShellFiles/tests/install-completion-cmd.nix
+++ b/pkgs/by-name/in/installShellFiles/tests/install-completion-cmd.nix
@@ -15,16 +15,19 @@ runCommandLocal "install-shell-files--install-completion-cmd"
     echo baz > baz.fish
     echo qux > qux.fish
     echo buzz > buzz.nu
+    echo corge > corge.elv
 
     installShellCompletion \
       --cmd foobar --bash foo.bash \
       --zsh bar.zsh \
       --fish baz.fish --name qux qux.fish \
-      --nushell --cmd buzzbar buzz.nu
+      --nushell --cmd buzzbar buzz.nu \
+      --elvish --cmd grault corge.elv
 
     cmp foo.bash $out/share/bash-completion/completions/foobar.bash
     cmp bar.zsh $out/share/zsh/site-functions/_foobar
     cmp baz.fish $out/share/fish/vendor_completions.d/foobar.fish
     cmp qux.fish $out/share/fish/vendor_completions.d/qux
     cmp buzz.nu $out/share/nushell/vendor/autoload/buzzbar.nu
+    cmp corge.elv $out/share/elvish/completions/grault.elv
   ''

--- a/pkgs/by-name/in/installShellFiles/tests/install-completion-fifo.nix
+++ b/pkgs/by-name/in/installShellFiles/tests/install-completion-fifo.nix
@@ -14,10 +14,12 @@ runCommandLocal "install-shell-files--install-completion-fifo"
       --bash --name foo.bash <(echo foo) \
       --zsh --name _foo <(echo bar) \
       --fish --name foo.fish <(echo baz) \
-      --nushell --name foo.nu <(echo bucks)
+      --nushell --name foo.nu <(echo bucks) \
+      --elvish --name foo.elv <(echo qux)
 
     [[ $(<$out/share/bash-completion/completions/foo.bash) == foo ]] || { echo "foo.bash comparison failed"; exit 1; }
     [[ $(<$out/share/zsh/site-functions/_foo) == bar ]] || { echo "_foo comparison failed"; exit 1; }
     [[ $(<$out/share/fish/vendor_completions.d/foo.fish) == baz ]] || { echo "foo.fish comparison failed"; exit 1; }
     [[ $(<$out/share/nushell/vendor/autoload/foo.nu) == bucks ]] || { echo "foo.nu comparison failed"; exit 1; }
+    [[ $(<$out/share/elvish/completions/foo.elv) == qux ]] || { echo "foo.elv comparison failed"; exit 1; }
   ''

--- a/pkgs/by-name/in/installShellFiles/tests/install-completion-inference.nix
+++ b/pkgs/by-name/in/installShellFiles/tests/install-completion-inference.nix
@@ -14,11 +14,13 @@ runCommandLocal "install-shell-files--install-completion-inference"
     echo bar > bar.zsh
     echo baz > baz.fish
     echo buzz > buzz.nu
+    echo corge > corge.elv
 
-    installShellCompletion foo.bash bar.zsh baz.fish buzz.nu
+    installShellCompletion foo.bash bar.zsh baz.fish buzz.nu corge.elv
 
     cmp foo.bash $out/share/bash-completion/completions/foo.bash
     cmp bar.zsh $out/share/zsh/site-functions/_bar
     cmp baz.fish $out/share/fish/vendor_completions.d/baz.fish
     cmp buzz.nu $out/share/nushell/vendor/autoload/buzz.nu
+    cmp corge.elv $out/share/elvish/completions/corge.elv
   ''

--- a/pkgs/by-name/in/installShellFiles/tests/install-completion-name.nix
+++ b/pkgs/by-name/in/installShellFiles/tests/install-completion-name.nix
@@ -14,15 +14,18 @@ runCommandLocal "install-shell-files--install-completion-name"
     echo bar > bar
     echo baz > baz
     echo bucks > bucks
+    echo corge > corge
 
     installShellCompletion \
       --bash --name foobar.bash foo \
       --zsh --name _foobar bar \
       --fish baz \
-      --nushell --name foobar.nu bucks
+      --nushell --name foobar.nu bucks \
+      --elvish --name grault.elv corge
 
     cmp foo $out/share/bash-completion/completions/foobar.bash
     cmp bar $out/share/zsh/site-functions/_foobar
     cmp baz $out/share/fish/vendor_completions.d/baz
     cmp bucks $out/share/nushell/vendor/autoload/foobar.nu
+    cmp corge $out/share/elvish/completions/grault.elv
   ''


### PR DESCRIPTION
## Things done

Opening this PR to get the conversation going on #384084 for elvish.

Unfortunately I couldn't find documentation on what the standard directory is to package completions for elvish, hence I settled on `$out/share/elvish/completions`. Feel free to bikeshed on this choice (we'll need to make the same one for most missing shells...).

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
There is no standard path for completions with that shell, hence I
settled on using `$out/share/elvish/completions` as it "looks right".