### PR TITLE
nixos/ax25/mheard: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1104,6 +1104,7 @@
   ./services/networking/avahi-daemon.nix
   ./services/networking/ax25/axlisten.nix
   ./services/networking/ax25/axports.nix
+  ./services/networking/ax25/mheard.nix
   ./services/networking/babeld.nix
   ./services/networking/bee.nix
   ./services/networking/biboumi.nix

--- a/nixos/modules/services/networking/ax25/axports.nix
+++ b/nixos/modules/services/networking/ax25/axports.nix
@@ -144,10 +144,9 @@ in
           Type = "exec";
           ExecStart = "${portCfg.package}/bin/kissattach ${portCfg.tty} ${portName}";
           # kissattach has a race condition that can sometimes lead to dependent services
-          # being unable to start when the ax* device has not yet been created. ax* device
-          # numbering doesn't seem to be declarative so for now well sleep.
+          # being unable to start when the ax* device has not yet been created.
           ExecStartPost = pkgs.writeShellScript "wait-for-ax25-axports" ''
-            sleep 2
+            until ${pkgs.iproute2}/bin/ip --json link show | ${pkgs.jq}/bin/jq -re '.[] | select(.address == "${portCfg.callsign}") | .ifname'; do sleep 0.5; done
           '';
         };
         postStart = optionalString (portCfg.kissParams != null) ''

--- a/nixos/modules/services/networking/ax25/axports.nix
+++ b/nixos/modules/services/networking/ax25/axports.nix
@@ -143,6 +143,12 @@ in
         serviceConfig = {
           Type = "exec";
           ExecStart = "${portCfg.package}/bin/kissattach ${portCfg.tty} ${portName}";
+          # kissattach has a race condition that can sometimes lead to dependent services
+          # being unable to start when the ax* device has not yet been created. ax* device
+          # numbering doesn't seem to be declarative so for now well sleep.
+          ExecStartPost = pkgs.writeShellScript "wait-for-ax25-axports" ''
+            sleep 2
+          '';
         };
         postStart = optionalString (portCfg.kissParams != null) ''
           ${portCfg.package}/bin/kissparms -p ${portName} ${portCfg.kissParams}

--- a/nixos/modules/services/networking/ax25/mheard.nix
+++ b/nixos/modules/services/networking/ax25/mheard.nix
@@ -1,0 +1,75 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    types
+    ;
+
+  inherit (lib.modules)
+    mkIf
+    ;
+
+  inherit (lib.options)
+    mkEnableOption
+    mkOption
+    literalExpression
+    ;
+
+  cfg = config.services.ax25.mheard;
+in
+{
+  options = {
+
+    services.ax25.mheard = {
+
+      enable = mkEnableOption "AX.25 mheard daemon";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.ax25-tools;
+        defaultText = literalExpression "pkgs.ax25-tools";
+        description = "The ax25-tools package to use.";
+      };
+
+      config = mkOption {
+        type = types.str;
+        default = "-l";
+        description = ''
+          Options that will be passed to the mheard daemon.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.services.ax25.axports != { };
+        message = ''
+          mheard cannot be used without axports.
+          Please define at least one axport with
+          <option>config.services.ax25.axports</option>.
+        '';
+      }
+    ];
+
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.mheard = {
+      description = "displays information about most recently heard AX.25 callsigns";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "ax25-axports.target" ];
+      requires = [ "ax25-axports.target" ];
+      serviceConfig = {
+        Type = "exec";
+        ExecStart = "${cfg.package}/bin/mheardd ${cfg.config}";
+        StateDirectory = "ax25/mheard";
+      };
+    };
+  };
+}

--- a/nixos/tests/ax25.nix
+++ b/nixos/tests/ax25.nix
@@ -39,12 +39,12 @@ let
     systemd.services.ax25-mock-hardware = {
       description = "mock AX.25 TNC and Radio";
       wantedBy = [ "default.target" ];
-      before = [
+      requiredBy = [
         "ax25-kissattach-${port}.service"
         "axlisten.service"
         "mheard.service"
       ];
-      after = [ "network.target" ];
+      requires = [ "network.target" ];
       serviceConfig = {
         Type = "exec";
         ExecStart = "${pkgs.socat}/bin/socat -d -d tcp:192.168.1.1:${toString socatPort} pty,link=${tty},b${toString baud},raw";
@@ -63,7 +63,7 @@ in
           description = "mock radio ether";
           wantedBy = [ "default.target" ];
           requires = [ "network.target" ];
-          before = [ "ax25-mock-hardware.service" ];
+          requiredBy = [ "ax25-mock-hardware.service" ];
           # broken needs access to "ss" or "netstat"
           path = [ pkgs.iproute2 ];
           serviceConfig = {

--- a/nixos/tests/ax25.nix
+++ b/nixos/tests/ax25.nix
@@ -42,6 +42,7 @@ let
       before = [
         "ax25-kissattach-${port}.service"
         "axlisten.service"
+        "mheard.service"
       ];
       after = [ "network.target" ];
       serviceConfig = {

--- a/nixos/tests/ax25.nix
+++ b/nixos/tests/ax25.nix
@@ -85,6 +85,22 @@ in
         m.wait_for_unit("axlisten.service")
         m.fail("journalctl -o cat -u axlisten.service | grep -i \"no AX.25 port data configured\"")
 
+      def get_machine(key):
+        the_machines = {m.name: m for m in machines}
+        return the_machines[key]
+
+      def on_air(m):
+        peers = [ machine.name for machine in machines ]
+        peers.remove(m.name)
+        nodeId = m.name[-1]
+        for peer in peers:
+          peerId = peer[-1]
+          targetNode = get_machine(peer)
+          m.sleep(5)
+          m.succeed(f"echo hello | ax25_call ${port} NOCALL-{nodeId} NOCALL-{peerId}")
+          targetNode.sleep(1)
+          targetNode.succeed(f"journalctl -o cat -u axlisten.service | grep -A1 \"NOCALL-{nodeId} to NOCALL-{peerId} ctl I00\" | grep hello")
+
       def whos_heard(m):
         peers = [ machine.name for machine in machines ]
         peers.remove(m.name)
@@ -103,40 +119,12 @@ in
       wait_for_machine(node2)
       wait_for_machine(node3)
 
-      # Node 1 -> Node 2
-      node1.succeed("echo hello | ax25_call ${port} NOCALL-1 NOCALL-2")
-      node2.sleep(1)
-      node2.succeed("journalctl -o cat -u axlisten.service | grep -A1 \"NOCALL-1 to NOCALL-2 ctl I00\" | grep hello")
+      # transmit packets
+      on_air(node1)
+      on_air(node2)
+      on_air(node3)
 
-      # Node 1 -> Node 3
-      node1.succeed("echo hello | ax25_call ${port} NOCALL-1 NOCALL-3")
-      node3.sleep(1)
-      node3.succeed("journalctl -o cat -u axlisten.service | grep -A1 \"NOCALL-1 to NOCALL-3 ctl I00\" | grep hello")
-
-      # Node 2 -> Node 1
-      # must sleep due to previous ax25_call lingering
-      node2.sleep(5)
-      node2.succeed("echo hello | ax25_call ${port} NOCALL-2 NOCALL-1")
-      node1.sleep(1)
-      node1.succeed("journalctl -o cat -u axlisten.service | grep -A1 \"NOCALL-2 to NOCALL-1 ctl I00\" | grep hello")
-
-      # Node 2 -> Node 3
-      node2.succeed("echo hello | ax25_call ${port} NOCALL-2 NOCALL-3")
-      node3.sleep(1)
-      node3.succeed("journalctl -o cat -u axlisten.service | grep -A1 \"NOCALL-2 to NOCALL-3 ctl I00\" | grep hello")
-
-      # Node 3 -> Node 1
-      # must sleep due to previous ax25_call lingering
-      node3.sleep(5)
-      node3.succeed("echo hello | ax25_call ${port} NOCALL-3 NOCALL-1")
-      node1.sleep(1)
-      node1.succeed("journalctl -o cat -u axlisten.service | grep -A1 \"NOCALL-3 to NOCALL-1 ctl I00\" | grep hello")
-
-      # Node 3 -> Node 2
-      node3.succeed("echo hello | ax25_call ${port} NOCALL-3 NOCALL-2")
-      node2.sleep(1)
-      node2.succeed("journalctl -o cat -u axlisten.service | grep -A1 \"NOCALL-3 to NOCALL-2 ctl I00\" | grep hello")
-
+      # did we hear everything
       whos_heard(node1)
       whos_heard(node2)
       whos_heard(node3)

--- a/nixos/tests/ax25.nix
+++ b/nixos/tests/ax25.nix
@@ -25,11 +25,16 @@ let
       description = "mocked tnc";
     };
 
-    services.ax25.axlisten = {
-      enable = true;
+    services.ax25 = {
+      axlisten = {
+        enable = true;
+      };
+      mheard = {
+        enable = true;
+      };
     };
 
-    # All mocks radios will connect back to socat-broker on node 1 in order to get
+    # Each mock radio will connect back to socat-broker on node 1 in order to get
     # all messages that are "broadcasted over the ether"
     systemd.services.ax25-mock-hardware = {
       description = "mock AX.25 TNC and Radio";
@@ -80,6 +85,14 @@ in
         m.wait_for_unit("axlisten.service")
         m.fail("journalctl -o cat -u axlisten.service | grep -i \"no AX.25 port data configured\"")
 
+      def whos_heard(m):
+        peers = [ machine.name for machine in machines ]
+        peers.remove(m.name)
+        for peer in peers:
+          peerId = peer[-1]
+          packets = m.succeed(f"mheard | grep -i NOCALL-{peerId}" + " | awk '{ print $3 }'")
+          assert int(packets) == len(peers) * 5
+
       # start the first node since the socat-broker needs to be running
       node1.start()
       node1.wait_for_unit("ax25-mock-ether.service")
@@ -123,5 +136,9 @@ in
       node3.succeed("echo hello | ax25_call ${port} NOCALL-3 NOCALL-2")
       node2.sleep(1)
       node2.succeed("journalctl -o cat -u axlisten.service | grep -A1 \"NOCALL-3 to NOCALL-2 ctl I00\" | grep hello")
+
+      whos_heard(node1)
+      whos_heard(node2)
+      whos_heard(node3)
     '';
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Initializing ax25.mheard module and incorporate it into `nixosTests.ax25`


> Mheard displays information about most recently heard AX.25 callsigns, the interface upon which they were heard, the total packets heard, the time at which the last one was heard and other information. 
>
> ref: https://manpages.debian.org/unstable/ax25-tools/mheard.1.en.html

Output from `mheard`:
<img width="573" height="106" alt="ss-202509051757086746" src="https://github.com/user-attachments/assets/5929efe1-f57d-4ab5-b2bf-36f292d2ccad" />


Additional improves to the `ax25` vmTest:

- Loop over tx/rx logic for `nixosTests.ax25`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
