### PR TITLE
Fix freeform usages in some modules

### DIFF
--- a/nixos/modules/hardware/fw-fanctrl.nix
+++ b/nixos/modules/hardware/fw-fanctrl.nix
@@ -30,7 +30,7 @@ in
         Additional config entries for the fw-fanctrl service (documentation: <https://github.com/TamtamHero/fw-fanctrl/blob/main/doc/configuration.md>)
       '';
       type = lib.types.submodule {
-        freeformType = configFormat.type;
+        freeformType = lib.types.attrsOf configFormat.type;
         options = {
           defaultStrategy = lib.mkOption {
             type = lib.types.str;

--- a/nixos/modules/programs/openvpn3.nix
+++ b/nixos/modules/programs/openvpn3.nix
@@ -18,7 +18,12 @@ let
     options
     lists
     ;
-  inherit (lib.types) bool submodule ints;
+  inherit (lib.types)
+    bool
+    submodule
+    ints
+    attrsOf
+    ;
 in
 {
   options.programs.openvpn3 = {
@@ -33,7 +38,7 @@ in
             description = "Options stored in {file}`/etc/openvpn3/netcfg.json` configuration file";
             default = { };
             type = submodule {
-              freeformType = json.type;
+              freeformType = attrsOf json.type;
               options = {
                 systemd_resolved = mkOption {
                   type = bool;
@@ -57,7 +62,7 @@ in
             description = "Options stored in {file}`/etc/openvpn3/log-service.json` configuration file";
             default = { };
             type = submodule {
-              freeformType = json.type;
+              freeformType = attrsOf json.type;
               options = {
                 journald = mkOption {
                   description = "Use systemd-journald";

--- a/nixos/modules/security/agnos.nix
+++ b/nixos/modules/security/agnos.nix
@@ -15,7 +15,7 @@ let
       inherit (lib) types mkOption;
     in
     types.submodule {
-      freeformType = format.type;
+      freeformType = types.attrsOf format.type;
 
       options = {
         email = mkOption {
@@ -53,7 +53,7 @@ let
       inherit (lib) types literalExpression mkOption;
     in
     types.submodule {
-      freeformType = format.type;
+      freeformType = types.attrsOf format.type;
 
       options = {
         domains = mkOption {
@@ -91,7 +91,7 @@ in
       settings = mkOption {
         description = "Settings";
         type = types.submodule {
-          freeformType = format.type;
+          freeformType = types.attrsOf format.type;
 
           options = {
             dns_listen_addr = mkOption {

--- a/nixos/modules/services/admin/meshcentral.nix
+++ b/nixos/modules/services/admin/meshcentral.nix
@@ -24,7 +24,7 @@ with lib;
         - [Old homepage with documentation link](https://www.meshcommander.com/meshcentral2)
       '';
       type = types.submodule {
-        freeformType = configFormat.type;
+        freeformType = attrsOf configFormat.type;
       };
       example = {
         settings = {


### PR DESCRIPTION
This PR fixes a bunch of modules.

freeformType needs to be an `attrsOf` type. Otherwise its behavior is bugged, and can lead to weird bugs, depending on the used type.

There are still many more modules that use `freeformType` wrongly. I would appreciate help on migrating them.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
