### PR TITLE
digikam: 8.6.0 -> 8.7.0, fix cuda build

### DIFF
--- a/pkgs/by-name/di/digikam/package.nix
+++ b/pkgs/by-name/di/digikam/package.nix
@@ -4,7 +4,6 @@
   lib,
   fetchFromGitLab,
   fetchgit,
-  fetchpatch,
 
   cmake,
   ninja,
@@ -63,25 +62,18 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "digikam";
-  version = "8.6.0";
+  version = "8.7.0";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "graphics";
     repo = "digikam";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-CMyvNOAlIqD6OeqUquQ+/sOiBXmEowZe3/qmaXxh0X0=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9t6tXrege3A5x5caUEfho23Pin7dON+e6x94rXC8XYE=";
   };
 
   patches = [
     ./disable-tests-download.patch
-
-    # Fix build with Qt 6.9
-    # FIXME: remove in next update
-    (fetchpatch {
-      url = "https://invent.kde.org/graphics/digikam/-/commit/325b19fc7f0d04cdc1308f235c207c1ab43e945d.patch";
-      hash = "sha256-bsxaNuLuU9MyDRmenOqO4JuzsbpUvfKQwcSCDfLHoWQ=";
-    })
   ];
 
   strictDeps = true;
@@ -104,7 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
   # build inputs.
 
   buildInputs = [
-    opencv
+    opencv.cxxdev
     libtiff
     libpng
     # TODO: Figure out how on earth to get it to pick up libjpeg8 for


### PR DESCRIPTION
Changelog: https://invent.kde.org/graphics/digikam/-/blob/v8.7.0/NEWS

fixes #426836

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
