### PR TITLE
editline: 1.17.1 → 1.17.1-unstable-2025-05-24

### DIFF
--- a/pkgs/by-name/ed/editline/package.nix
+++ b/pkgs/by-name/ed/editline/package.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   autoreconfHook,
   nix-update-script,
-  fetchpatch,
   ncurses ? null,
 
   # Enable `termcap` (`ncurses`) support.
@@ -17,39 +16,13 @@ assert lib.assertMsg (
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "editline";
-  version = "1.17.1";
+  version = "1.17.1-unstable-2025-05-24";
   src = fetchFromGitHub {
     owner = "troglobit";
     repo = "editline";
-    rev = finalAttrs.version;
-    sha256 = "sha256-0FeDUVCUahbweH24nfaZwa7j7lSfZh1TnQK7KYqO+3g=";
+    rev = "f735e4d1d566cac3caa4a5e248179d07f0babefd";
+    sha256 = "sha256-MUXxSmhpQd8CZdGGC6Ln9eci85E+GBhlNk28VHUvjaU=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fix-for-home-end-in-tmux.patch";
-      url = "https://github.com/troglobit/editline/commit/265c1fb6a0b99bedb157dc7c320f2c9629136518.patch";
-      sha256 = "sha256-9fhQH0hT8BcykGzOUoT18HBtWjjoXnePSGDJQp8GH30=";
-    })
-
-    # Pending autoconf-2.72 upstream support:
-    #   https://github.com/troglobit/editline/pull/64
-    (fetchpatch {
-      name = "autoconf-2.72.patch";
-      url = "https://github.com/troglobit/editline/commit/f444a316f5178b8e20fe31e7b2d979e651da077e.patch";
-      hash = "sha256-m3jExTkPvE+ZBwHzf/A+ugzzfbLmeWYn726l7Po7f10=";
-    })
-
-    # Recognize `Alt-Left` and `Alt-Right` for navigating by words in more
-    # terminals/shells/platforms.
-    #
-    # See: https://github.com/troglobit/editline/pull/70
-    (fetchpatch {
-      name = "alt-left-alt-right-word-navigation.patch";
-      url = "https://github.com/troglobit/editline/commit/fb4d7268de024ed31ad2417f533cc0cbc2cd9b29.diff";
-      hash = "sha256-5zMsmpU5zFoffRUwFhI/vP57pEhGotcMPgn9AfI1SNg=";
-    })
-  ];
 
   configureFlags = [
     # Enable SIGSTOP (Ctrl-Z) behavior.


### PR DESCRIPTION
Mainly for compilation with GCC 15 ( https://github.com/NixOS/nixpkgs/pull/440456 )

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
