### PR TITLE
amass: 4.2.0 -> 5.0.1, fix build issues

### DIFF
--- a/pkgs/by-name/am/amass/package.nix
+++ b/pkgs/by-name/am/amass/package.nix
@@ -2,31 +2,24 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  pkg-config,
+  libpostalWithData,
 }:
-
 buildGoModule rec {
   pname = "amass";
-  version = "4.2.0";
+  version = "5.0.1";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libpostalWithData ];
 
   src = fetchFromGitHub {
     owner = "OWASP";
     repo = "Amass";
     tag = "v${version}";
-    hash = "sha256-lhvU2fUnjQ+D+EZDRircNg/np4Ynk+HzOBgxT1L8BaQ=";
+    hash = "sha256-uAuBWzEwppnmYacfPI7MZUW+7PdSs3EqYm1WQI4fthQ=";
   };
 
-  vendorHash = "sha256-PdFIWK4yBh8Bb9mzYdU2h7pDPK8FZMhu8meTd9snP48=";
-
-  outputs = [
-    "out"
-    "wordlists"
-  ];
-
-  postInstall = ''
-    mkdir -p $wordlists
-    cp -R examples/wordlists/*.txt $wordlists
-    gzip $wordlists/*.txt
-  '';
+  vendorHash = "sha256-/AowoZfOk2tib996oC2hsMnzbe/CVbCBesTWXp6xE6Y=";
 
   # https://github.com/OWASP/Amass/issues/640
   doCheck = false;
@@ -40,9 +33,6 @@ buildGoModule rec {
       uses the IP addresses obtained during resolution to discover associated
       netblocks and ASNs. All the information is then used to build maps of the
       target networks.
-
-      Amass ships with a set of wordlist (to be used with the amass -w flag)
-      that are found under the wordlists output.
     '';
     homepage = "https://owasp.org/www-project-amass/";
     changelog = "https://github.com/OWASP/Amass/releases/tag/v${version}";


### PR DESCRIPTION
This pull request updates the `amass` package to a newer version and revises its build configuration to improve dependency management and simplify outputs. The most significant changes are the version upgrade, changes to build inputs, and removal of custom wordlist handling.

**Version and Dependency Updates:**

* Upgraded `amass` from version `4.2.0` to `5.0.1`, updating both the source and vendor hashes to match the new release.
* Added `pkg-config` to `nativeBuildInputs` and `libpostalWithData` to `buildInputs` to ensure proper compilation with required libraries without issues:

```bash
# amass binary
ERR   Error loading transliteration module, dir=(null)
   at libpostal_setup_datadir (libpostal.c:290) errno: No such file or directory
```

**Build and Output Simplification:**

* Removed the custom `wordlists` output and associated `postInstall` script that copied and compressed wordlist files; the package now only produces the default output because wordlists doesn't exists anymore.
* Deleted the documentation note about the location of wordlists in the package description.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.