### PR TITLE
snowemu: init at 1.1.0

### DIFF
--- a/pkgs/by-name/sn/snowemu/package.nix
+++ b/pkgs/by-name/sn/snowemu/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  makeWrapper,
+  makeDesktopItem,
+  SDL2,
+  pkg-config,
+  xorg,
+  wayland,
+  libxkbcommon,
+  libGL,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "snowemu";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "twvd";
+    repo = "snow";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-m3CPKswOB2j2r/BTf9RzCvwPVq3gbKemtk11HKS1nHk=";
+    fetchSubmodules = true;
+  };
+  cargoHash = "sha256-+FS5785F8iWPt6Db+IKRbOFAYNEfHC+jvPVdwkLZ5YI=";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    SDL2.dev
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXrandr
+    xorg.libXi
+  ];
+
+  postInstall = ''
+    mv $out/bin/snow_frontend_egui $out/bin/snowemu
+
+    install -Dm644 docs/images/snow_icon.png $out/share/icons/hicolor/apps/snowemu.png
+
+    wrapProgram $out/bin/snowemu \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          wayland
+          libxkbcommon
+          libGL
+        ]
+      }
+  '';
+
+  desktopItems = makeDesktopItem {
+    name = "snowemu";
+    exec = "snowemu";
+    icon = "snowemu";
+    desktopName = "Snow Emulator";
+    comment = finalAttrs.meta.description;
+    genericName = "Vintage Macintosh emulator";
+    categories = [
+      "Game"
+      "Emulator"
+    ];
+  };
+
+  meta = {
+    description = "Early Macintosh emulator";
+    longDescription = ''
+      Snow emulates classic (Motorola 680x0-based) Macintosh computers. It features a graphical user interface to operate the emulated machine and provides extensive debugging capabilities. The aim of this project is to emulate the Macintosh on a hardware-level as much as possible, as opposed to emulators that patch the ROM or intercept system calls.
+      It currently emulates the Macintosh 128K, Macintosh 512K, Macintosh Plus, Macintosh SE, Macintosh Classic and Macintosh II.
+    '';
+    homepage = "https://snowemu.com/";
+    changelog = "https://github.com/twvd/snow/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nulleric ];
+    platforms = lib.platforms.linux;
+    mainProgram = "snowemu";
+  };
+})


### PR DESCRIPTION
Initial packaging of snowemu v1.1.0

[SnowEMU](https://snowemu.com/) is an actively developed Macintosh emulator focused on accuracy.

I am an active contributor to the project and am willing to keep it updated in nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
