### PR TITLE
otterwiki: init at 2.20.6, add module and test

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1725,6 +1725,7 @@
   ./services/web-apps/opencloud.nix
   ./services/web-apps/openvscode-server.nix
   ./services/web-apps/openwebrx.nix
+  ./services/web-apps/otterwiki.nix
   ./services/web-apps/outline.nix
   ./services/web-apps/pairdrop.nix
   ./services/web-apps/part-db.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1795,6 +1795,7 @@
   ./services/web-servers/darkhttpd.nix
   ./services/web-servers/fcgiwrap.nix
   ./services/web-servers/garage.nix
+  ./services/web-servers/gunicorn
   ./services/web-servers/h2o/default.nix
   ./services/web-servers/hitch/default.nix
   ./services/web-servers/jboss/default.nix

--- a/nixos/modules/services/web-apps/otterwiki.nix
+++ b/nixos/modules/services/web-apps/otterwiki.nix
@@ -1,0 +1,178 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.otterwiki;
+  mapToUnits = f: lib.mapAttrs' (name: inst: lib.nameValuePair inst.process.unit (f inst));
+  secretKeyFile = inst: "/var/lib/${inst.process.unit}/secret.cfg";
+
+  gunicornInstanceOptions =
+    { config, ... }@moduleArgs:
+    lib.recursiveUpdate (import ../web-servers/gunicorn/instance-options.nix moduleArgs) {
+      options.process.unit.default = "otterwiki-${config._module.args.name}";
+    };
+
+  instanceOptions =
+    { config, ... }@moduleArgs:
+    {
+      options = {
+        inherit ((gunicornInstanceOptions moduleArgs).options) process socket;
+
+        package = lib.mkPackageOption pkgs "otterwiki" { };
+
+        repository = lib.mkOption {
+          type = lib.types.str;
+          default = "/var/lib/${config.process.unit}/repository";
+          description = ''
+            Path to the Git repository for the wiki content.
+
+            If this path is outside of the service's private data directory,
+            it is also necessary to also add it to
+            `systemd.services.''${config.process.unit}.serviceConfig.BindPaths`.
+          '';
+        };
+
+        databaseUri = lib.mkOption {
+          type = lib.types.str;
+          default = "sqlite:////var/lib/${config.process.unit}/db.sqlite";
+          description = ''
+            SQLAlchemy database connection URI.
+            Defaults to using an independent SQLite database.
+
+            If using a file or UNIX socket outside of the service's private data directory,
+            it is also necessary to also add it to
+            `systemd.services.''${config.process.unit}.serviceConfig.BindPaths`.
+          '';
+        };
+
+        settings = lib.mkOption {
+          type = lib.types.attrsOf lib.types.str;
+          default = { };
+          example = {
+            SITE_NAME = "Otterwiki";
+          };
+          description = ''
+            Configuration for Otter Wiki.
+            See <https://otterwiki.com/Configuration>.
+
+            A cookie secret is automatically generated at first start.
+          '';
+        };
+
+        environmentFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          description = ''
+            Path to an environment file.
+            This is suitable for supplying secrets such as the SMTP credentials.
+          '';
+        };
+      };
+    };
+
+in
+{
+  options.services.otterwiki.instances = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.submodule instanceOptions);
+    default = { };
+    description = "Configuration for instances of Otter Wiki.";
+  };
+
+  config = {
+    services.gunicorn.instances = mapToUnits (inst: {
+      inherit (inst) process socket;
+      app.package = inst.package;
+    }) cfg.instances;
+
+    systemd.services = mapToUnits (inst: {
+      environment = {
+        REPOSITORY = inst.repository;
+        SQLALCHEMY_DATABASE_URI = inst.databaseUri;
+        OTTERWIKI_SETTINGS = secretKeyFile inst;
+      }
+      // inst.settings;
+
+      path = [ pkgs.git ];
+
+      preStart = ''
+        # generate cookie secret
+        if [[ ! -f ${lib.escapeShellArg (secretKeyFile inst)} ]]; then
+          (
+            echo -n "SECRET_KEY='"
+            head -c128 /dev/urandom | tr -dc A-Za-z0-9
+            echo "'"
+          ) > ${lib.escapeShellArg (secretKeyFile inst)}
+        fi
+
+        # init wiki repo
+        if [[ ! -d ${lib.escapeShellArg inst.repository} ]]; then
+          mkdir -p $(dirname ${lib.escapeShellArg inst.repository})
+          git init --initial-branch=main ${lib.escapeShellArg inst.repository}
+        fi
+      '';
+
+      serviceConfig = {
+        EnvironmentFile = lib.mkIf (inst.environmentFile != null) inst.environmentFile;
+        StateDirectory = inst.process.unit;
+
+        StateDirectoryMode = "0700";
+        UMask = "0077";
+
+        TemporaryFileSystem = [ "/:ro" ];
+        BindPaths = [ ];
+        BindReadOnlyPaths = [ "/nix/store" ];
+
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
+        RestrictSUIDSGID = true;
+
+        ProtectKernelModules = true;
+        SystemCallArchitectures = "native";
+        PrivateMounts = true;
+
+        LockPersonality = true;
+        ProtectHostname = true;
+        RestrictRealtime = true;
+
+        ProtectSystem = "strict";
+        ProtectHome = true;
+
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+        ];
+
+        # needed to bind inet sockets and send emails
+        PrivateNetwork = lib.mkDefault false;
+
+        MemoryDenyWriteExecute = true;
+        PrivateUsers = true;
+
+        SystemCallErrorNumber = "EPERM";
+        SystemCallFilter = [ "@system-service" ];
+
+        ProtectKernelLogs = true;
+        DevicePolicy = "closed";
+        ProtectClock = true;
+        ProtectProc = "noaccess";
+        ProcSubset = "pid";
+        RestrictNamespaces = true;
+        RemoveIPC = true;
+      };
+    }) cfg.instances;
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ euxane ];
+  };
+}

--- a/nixos/modules/services/web-servers/gunicorn/default.nix
+++ b/nixos/modules/services/web-servers/gunicorn/default.nix
@@ -1,0 +1,115 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  instanceOptions = import ./instance-options.nix;
+  cfg = config.services.gunicorn;
+
+  mapToUnits = f: lib.mapAttrs' (_: inst: lib.nameValuePair inst.process.unit (f inst));
+
+  gunicornArgs =
+    inst:
+    lib.cli.toCommandLineShellGNU { } (
+      {
+        bind = if inst.socket.type == "unix" then "unix:${inst.socket.address}" else inst.socket.address;
+      }
+      // inst.process.extraArgs
+    );
+
+  mkPythonEnv =
+    app:
+    app.python.buildEnv.override {
+      extraLibs = with app.python.pkgs; [
+        (toPythonModule app.package)
+        gunicorn
+      ];
+    };
+
+in
+{
+  options.services.gunicorn.instances = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.submodule instanceOptions);
+    default = { };
+    description = ''
+      Configuration for instances of gunicorn.
+      Each instance is isolated in its own systemd service.
+      Corresponding sockets are exposed and managed by systemd.
+    '';
+  };
+
+  config = {
+    assertions = lib.concatLists (
+      lib.mapAttrsToList (name: inst: [
+        {
+          assertion = inst.socket.type == "unix" -> inst.socket.user != null;
+          message = "Socket owner is required for the UNIX socket type.";
+        }
+        {
+          assertion = inst.socket.type == "unix" -> inst.socket.group != null;
+          message = "Socket owner is required for the UNIX socket type.";
+        }
+        {
+          assertion = inst.socket.user != null -> inst.socket.type == "unix";
+          message = "Socket owner can only be set for the UNIX socket type.";
+        }
+        {
+          assertion = inst.socket.group != null -> inst.socket.type == "unix";
+          message = "Socket owner can only be set for the UNIX socket type.";
+        }
+        {
+          assertion = inst.socket.mode != null -> inst.socket.type == "unix";
+          message = "Socket mode can only be set for the UNIX socket type.";
+        }
+      ]) cfg.instances
+    );
+
+    systemd.services = mapToUnits (inst: {
+      after = [ "network.target" ];
+      wantedBy = lib.optional (inst.socket.type != "unix") "multi-user.target";
+
+      # from https://docs.gunicorn.org/en/latest/deploy.html#systemd
+      serviceConfig = {
+        User = inst.process.user;
+        Group = inst.process.group;
+        DynamicUser = true;
+
+        Type = "notify";
+        NotifyAccess = "main";
+        KillMode = "mixed";
+        TimeoutStopSec = 5;
+        PrivateTmp = true;
+
+        ExecReload = ''
+          ${lib.getExe' pkgs.coreutils "kill"} -s HUP $MAINPID
+        '';
+
+        ExecStart = ''
+          ${lib.getExe' (mkPythonEnv inst.app) "gunicorn"} \
+            ${gunicornArgs inst} \
+            ${lib.escapeShellArg inst.app.module}
+        '';
+      };
+    }) cfg.instances;
+
+    systemd.sockets = mapToUnits (
+      inst:
+      lib.mkIf (inst.socket.type == "unix") {
+        wantedBy = [ "sockets.target" ];
+        socketConfig = {
+          ListenStream = inst.socket.address;
+          SocketUser = inst.socket.user;
+          SocketGroup = inst.socket.group;
+          SocketMode = inst.socket.mode;
+        };
+      }
+    ) cfg.instances;
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ euxane ];
+  };
+}

--- a/nixos/modules/services/web-servers/gunicorn/instance-options.nix
+++ b/nixos/modules/services/web-servers/gunicorn/instance-options.nix
@@ -1,0 +1,119 @@
+{
+  config,
+  lib,
+  ...
+}:
+
+{
+  options = {
+    app.package = lib.mkOption {
+      type = lib.types.package;
+      description = "Package of the WSGI Python application.";
+    };
+
+    app.python = lib.mkOption {
+      type = lib.types.package;
+      default = config.app.package.python;
+      defaultText = lib.literalExpression "config.services.gunicorn.instances.<name>.app.package.python";
+      description = ''
+        Python interpreter package to use.
+        Defaults to the one exposed by the WSGI application package
+        through its `passthru.python` attribute, if it is defined.
+      '';
+    };
+
+    app.module = lib.mkOption {
+      type = lib.types.str;
+      default = config.app.package.wsgiModule;
+      defaultText = lib.literalExpression "config.services.gunicorn.instances.<name>.app.package.wsgiModule";
+      description = ''
+        Module entry-point of the WSGI app.
+        Defaults to the one exposed by the WSGI application package
+        through its `passthru.wsgiModule` attribute, if it is defined.
+      '';
+    };
+
+    process.extraArgs = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      description = "Extra command line arguments to pass to gunicorn.";
+    };
+
+    process.unit = lib.mkOption {
+      type = lib.types.str;
+      default = "gunicorn-${config._module.args.name}";
+      defaultText = lib.literalExpression "gunicorn-\${config.services.gunicorn.instances.<name>.name}";
+      description = "Name for the systemd unit of this instance.";
+    };
+
+    process.user = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        User as which this instance of gunicorn will be run.
+
+        It will be dynamically allocated if unspecified or if the name does not match a static user.
+      '';
+    };
+
+    process.group = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Group as which this instance of gunicorn will be run.
+
+        It will be dynamically allocated if unspecified or if the name does not match a static group.
+      '';
+    };
+
+    socket.type = lib.mkOption {
+      type = lib.types.enum [
+        "unix"
+        "tcp"
+      ];
+      default = "unix";
+      description = "Socket type: 'unix' or 'tcp'.";
+    };
+
+    socket.address = lib.mkOption {
+      type = lib.types.str;
+      default = "/run/${config.process.unit}.sock";
+      defaultText = lib.literalExpression ''
+        /run/''${config.services.gunicorn.instances.<name>.process.unit}.sock
+      '';
+      example = "1.2.3.4:5678";
+      description = ''
+        Socket address.
+        In case of a UNIX socket, this should be its filesystem path.
+      '';
+    };
+
+    socket.user = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        User to be set as owner of the UNIX socket.
+      '';
+    };
+
+    socket.group = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Group to be set as owner of the UNIX socket.
+      '';
+    };
+
+    socket.mode = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = if config.socket.type == "unix" then "0600" else null;
+      defaultText = lib.literalExpression ''
+        if config.services.gunicorn.instances.<name>.socket.type == "unix" then "0600" else null
+      '';
+      description = ''
+        Mode to be set on the UNIX socket.
+        Defaults to private to the socket's owner.
+      '';
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -698,6 +698,7 @@ in
   grub = runTest ./grub.nix;
   guacamole-server = runTest ./guacamole-server.nix;
   guix = handleTest ./guix { };
+  gunicorn = runTest ./gunicorn.nix;
   gvisor = runTest ./gvisor.nix;
   h2o = import ./web-servers/h2o {
     inherit runTest;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1226,6 +1226,7 @@ in
   os-prober = handleTestOn [ "x86_64-linux" ] ./os-prober.nix { };
   osquery = handleTestOn [ "x86_64-linux" ] ./osquery.nix { };
   osrm-backend = runTest ./osrm-backend.nix;
+  otterwiki = runTest ./otterwiki.nix;
   outline = runTest ./outline.nix;
   overlayfs = runTest ./overlayfs.nix;
   overseerr = runTest ./overseerr.nix;

--- a/nixos/tests/gunicorn.nix
+++ b/nixos/tests/gunicorn.nix
@@ -1,0 +1,86 @@
+{ lib, pkgs, ... }:
+
+let
+  writeSimplePythonApp =
+    pname: text:
+    pkgs.python3.pkgs.buildPythonApplication {
+      inherit pname;
+      version = "0.0";
+      pyproject = false;
+      src = pkgs.writeText "${pname}.py" text;
+      unpackPhase = "true";
+      installPhase = ''
+        OUTDIR=$out/${pkgs.python3.sitePackages}
+        mkdir -p $OUTDIR
+        cp $src $OUTDIR/${pname}.py
+      '';
+    };
+
+  dummyApp = {
+    python = pkgs.python3;
+    module = "dummy-wsgi:app";
+    package =
+      writeSimplePythonApp "dummy-wsgi" # python
+        ''
+          def app(environ, start_response):
+              data = b'Up and running!\n'
+              status = '200 OK'
+              response_headers = [
+                  ('Content-type', 'text/plain'),
+                  ('Content-Length', str(len(data)))
+              ]
+              start_response(status, response_headers)
+              return iter([data])
+        '';
+  };
+
+in
+{
+  name = "gunicorn";
+
+  meta = {
+    maintainers = with lib.maintainers; [ euxane ];
+  };
+
+  nodes.machine =
+    { config, ... }:
+    {
+      services.gunicorn.instances."standalone" = {
+        app = dummyApp;
+        socket = {
+          type = "tcp";
+          address = "127.0.0.1:8080";
+        };
+      };
+
+      services.gunicorn.instances."unix-socket" = {
+        app = dummyApp;
+        socket = {
+          inherit (config.services.nginx) user group;
+        };
+      };
+
+      services.nginx = {
+        enable = true;
+        recommendedProxySettings = true;
+        virtualHosts."localhost".locations."/" = {
+          proxyPass = "http://unix:${config.services.gunicorn.instances."unix-socket".socket.address}";
+        };
+      };
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    machine.wait_for_unit("gunicorn-standalone.service")
+    machine.wait_for_open_port(8080)
+    machine.succeed("curl -sSf localhost:8080 | grep -q 'Up and running!'")
+
+    machine.wait_for_unit("nginx.service")
+    machine.wait_for_open_port(80)
+    machine.succeed("curl -sSf localhost | grep -q 'Up and running!'")
+
+    machine.shutdown()
+  '';
+}

--- a/nixos/tests/otterwiki.nix
+++ b/nixos/tests/otterwiki.nix
@@ -1,0 +1,40 @@
+{ lib, ... }:
+{
+  name = "otterwiki";
+
+  meta = {
+    maintainers = with lib.maintainers; [ euxane ];
+  };
+
+  nodes.machine =
+    { config, ... }:
+    {
+      services.otterwiki.instances."test" = {
+        settings = {
+          SITE_NAME = "My test wiki";
+          READ_ACCESS = "ANONYMOUS";
+        };
+
+        socket = {
+          inherit (config.services.nginx) user group;
+        };
+      };
+
+      services.nginx = {
+        enable = true;
+        recommendedProxySettings = true;
+        virtualHosts."localhost".locations."/" = {
+          proxyPass = "http://unix:${config.services.otterwiki.instances."test".socket.address}";
+        };
+      };
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_for_unit("nginx.service")
+    machine.wait_for_open_port(80)
+    machine.succeed("curl -sSf localhost | grep -q 'Your Otter Wiki is up and running.'")
+    machine.shutdown()
+  '';
+}

--- a/pkgs/by-name/ot/otterwiki/package.nix
+++ b/pkgs/by-name/ot/otterwiki/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   nix-update-script,
+  nixosTests,
   python3,
   fetchPypi,
 }:
@@ -60,6 +61,7 @@ python.pkgs.buildPythonApplication rec {
     inherit python;
     wsgiModule = "otterwiki.server:app";
     updateScript = nix-update-script { };
+    tests.simple = nixosTests.otterwiki;
   };
 
   meta = {

--- a/pkgs/by-name/ot/otterwiki/package.nix
+++ b/pkgs/by-name/ot/otterwiki/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  python3,
+  fetchPypi,
+}:
+
+let
+  python = python3;
+
+in
+python.pkgs.buildPythonApplication rec {
+  pname = "otterwiki";
+  version = "2.17.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "redimp";
+    repo = "otterwiki";
+    tag = "v${version}";
+    hash = "sha256-qvSA2SrU2TD2tEb4LS1d2piKC6k3QSBNvR0a7tLGMYA=";
+  };
+
+  build-system = with python.pkgs; [ setuptools ];
+
+  pythonRelaxDeps = true;
+  dependencies = with python.pkgs; [
+    werkzeug
+    flask-login
+    flask-mail
+    sqlalchemy
+    flask-sqlalchemy
+    flask
+    jinja2
+    gitpython
+    cython
+
+    # app depends on a version of mistune older than the one in nixpkgs
+    (mistune.overridePythonAttrs (oldAttrs: rec {
+      version = "2.0.5";
+      src = fetchPypi {
+        inherit (oldAttrs) pname;
+        inherit version;
+        hash = "sha256-AkYRPLJJLbh1xr5Wl0p8iTMzvybNkokchfYxUc7gnTQ=";
+      };
+    }))
+
+    pygments
+    pillow
+    pyyaml
+    unidiff
+    beautifulsoup4
+    pluggy
+    regex
+    feedgen
+  ];
+
+  passthru = {
+    inherit python;
+    wsgiModule = "otterwiki.server:app";
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Minimalistic wiki powered by python, markdown and git";
+    homepage = "https://otterwiki.com/";
+    changelog = "https://github.com/redimp/otterwiki/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ euxane ];
+  };
+}

--- a/pkgs/by-name/ot/otterwiki/package.nix
+++ b/pkgs/by-name/ot/otterwiki/package.nix
@@ -13,6 +13,7 @@ in
 python.pkgs.buildPythonApplication rec {
   pname = "otterwiki";
   version = "2.20.5";
+  __structuredAttrs = true;
   pyproject = true;
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/ot/otterwiki/package.nix
+++ b/pkgs/by-name/ot/otterwiki/package.nix
@@ -4,7 +4,6 @@
   nix-update-script,
   nixosTests,
   python3,
-  fetchPypi,
 }:
 
 let
@@ -13,14 +12,14 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "otterwiki";
-  version = "2.17.3";
+  version = "2.20.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "redimp";
     repo = "otterwiki";
     tag = "v${version}";
-    hash = "sha256-qvSA2SrU2TD2tEb4LS1d2piKC6k3QSBNvR0a7tLGMYA=";
+    hash = "sha256-Yov80c5LjofVMh45uz4gVUF7nTiy/tNB9wEyVM/ppro=";
   };
 
   build-system = with python.pkgs; [ setuptools ];
@@ -30,23 +29,14 @@ python.pkgs.buildPythonApplication rec {
     werkzeug
     flask-login
     flask-mail
+    flask-wtf
     sqlalchemy
     flask-sqlalchemy
     flask
     jinja2
     gitpython
     cython
-
-    # app depends on a version of mistune older than the one in nixpkgs
-    (mistune.overridePythonAttrs (oldAttrs: rec {
-      version = "2.0.5";
-      src = fetchPypi {
-        inherit (oldAttrs) pname;
-        inherit version;
-        hash = "sha256-AkYRPLJJLbh1xr5Wl0p8iTMzvybNkokchfYxUc7gnTQ=";
-      };
-    }))
-
+    mistune
     pygments
     pillow
     pyyaml

--- a/pkgs/by-name/ot/otterwiki/package.nix
+++ b/pkgs/by-name/ot/otterwiki/package.nix
@@ -12,7 +12,7 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "otterwiki";
-  version = "2.20.5";
+  version = "2.20.6";
   __structuredAttrs = true;
   pyproject = true;
 
@@ -20,7 +20,7 @@ python.pkgs.buildPythonApplication rec {
     owner = "redimp";
     repo = "otterwiki";
     tag = "v${version}";
-    hash = "sha256-Yov80c5LjofVMh45uz4gVUF7nTiy/tNB9wEyVM/ppro=";
+    hash = "sha256-eb5Ugq3dAqeJ34Twq1fuWjmfxFFeGTHAeZ/EGdpFX+o=";
   };
 
   build-system = with python.pkgs; [ setuptools ];

--- a/pkgs/development/python-modules/gunicorn/default.nix
+++ b/pkgs/development/python-modules/gunicorn/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  nixosTests,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -50,6 +51,10 @@ buildPythonPackage rec {
     pytest-cov-stub
   ]
   ++ lib.concatAttrValues optional-dependencies;
+
+  passthru = {
+    tests.simple = nixosTests.gunicorn;
+  };
 
   meta = {
     description = "WSGI HTTP Server for UNIX, fast clients and sleepy applications";


### PR DESCRIPTION
This adds a package and a module for [An Otter Wiki], "a minimalistic wiki powered by python, markdown and git".

[An Otter Wiki]: https://otterwiki.com/

This also adds an intermediate module for Gunicorn as the WSGI HTTP server used here, to facilitate proper separation of service and socket permissions.

NixOS tests are added for both the Otter Wiki and Gunicorn modules.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module. (new module section now missing for 26.05?)
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
