### PR TITLE
tk-safe: 25.8.1 -> 25.8.2

### DIFF
--- a/pkgs/by-name/tk/tk-safe/package.nix
+++ b/pkgs/by-name/tk/tk-safe/package.nix
@@ -20,12 +20,12 @@
 
 stdenv.mkDerivation rec {
   pname = "tk-safe";
-  version = "25.8.1";
+  version = "25.8.2";
 
   # To update, check https://search.apps.ubuntu.com/api/v1/package/tk-safe and copy the anon_download_url and version.
   src = fetchurl {
-    url = "https://api.snapcraft.io/api/v1/snaps/download/rLNeIGEaag0TKFQLO0TxF3ARXg3rcTNx_18.snap";
-    hash = "sha256-OrDbxLcmbL/yTANCMHcJsdGE+LK8rondGQvj+YBqS0E=";
+    url = "https://api.snapcraft.io/api/v1/snaps/download/rLNeIGEaag0TKFQLO0TxF3ARXg3rcTNx_19.snap";
+    hash = "sha256-bjlkLCTHkGH2LdeGd3LIp7L8f7SzZetpEpvGpPEzjcA=";
   };
 
   desktopItems = [


### PR DESCRIPTION
From Mac App Store release notes (since the snap doesn't have one):

> Mit diesem Release beheben wir Fehler im Login mit Kartenlesegerät und im Registrierungsprozess.
>
> Zusätzlich erweitern wir die Produktpalette an kompatiblen Kartenlesegeräten.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
