### PR TITLE
lightway: init at 0-unstable-2025-09-04

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7029,6 +7029,13 @@
     name = "Duncan Dean";
     keys = [ { fingerprint = "9484 44FC E03B 05BA 5AB0  591E C37B 1C1D 44C7 86EE"; } ];
   };
+  dustyhorizon = {
+    name = "Kenneth Tan";
+    email = "i.am@kennethtan.xyz";
+    github = "dustyhorizon";
+    githubId = 4987132;
+    keys = [ { fingerprint = "1021 2207 286B F15B 0CF1  C5EA D70C C9F5 CEF4 EEB8"; } ];
+  };
   DutchGerman = {
     name = "Stefan Visser";
     email = "stefan.visser@apm-ecampus.de";

--- a/pkgs/by-name/li/lightway/package.nix
+++ b/pkgs/by-name/li/lightway/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoconf,
+  automake,
+  libtool,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "lightway";
+  version = "0-unstable-2025-09-04";
+
+  src = fetchFromGitHub {
+    owner = "expressvpn";
+    repo = "lightway";
+    rev = "4eb836158607c83d47226703de5a043519586782";
+    hash = "sha256-sNhTdJTxNxHMVswyzizgBfGbmJhYmMZY/5nVD7ScLjM=";
+  };
+
+  cargoHash = "sha256-3/6yEyGntyxxCqrMy2M9dtV2pWiD4M0Rtnb52I4n9nU=";
+  cargoDepsName = "lightway";
+
+  cargoBuildFlags = lib.cli.toGNUCommandLine { } {
+    package = [
+      "lightway-client"
+      "lightway-server"
+    ];
+
+    features = lib.optionals stdenv.hostPlatform.isLinux [
+      "io-uring"
+    ];
+  };
+
+  # Some tests rely on debug_assert! and fail in release.
+  # https://github.com/expressvpn/lightway/issues/274
+  checkType = "debug";
+
+  # For wolfSSL.
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+    rustPlatform.bindgenHook
+  ];
+
+  meta = {
+    description = "A modern VPN protocol in Rust";
+    homepage = "https://expressvpn.com/lightway";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [
+      dustyhorizon
+      usertam
+    ];
+    platforms = with lib.platforms; darwin ++ linux;
+    mainProgram = "lightway-client";
+  };
+}


### PR DESCRIPTION
Init lightway package and add myself as maintainer along with @usertam 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
