### PR TITLE
nixos/i2pd: add tunnel type options

### DIFF
--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -224,7 +224,7 @@ let
         let
           outTunOpts = [
             (sec tun.name)
-            (intOpt "type" tun.type)
+            (strOpt "type" tun.type)
             (intOpt "port" tun.port)
             (strOpt "destination" tun.destination)
           ]
@@ -246,7 +246,7 @@ let
         let
           inTunOpts = [
             (sec tun.name)
-            (intOpt "type" tun.type)
+            (strOpt "type" tun.type)
             (intOpt "port" tun.port)
             (strOpt "host" tun.address)
           ]
@@ -705,6 +705,14 @@ in
                   default = null;
                   description = "Connect to particular port at destination.";
                 };
+                type = mkOption {
+                  type = types.enum [
+                    "client"
+                    "udpclient"
+                  ];
+                  default = "client";
+                  description = "Tunnel type for outbound tunnels.";
+                };
               }
               // commonTunOpts name;
               config = {
@@ -739,6 +747,16 @@ in
                   type = types.port;
                   default = 0;
                   description = "Service port. Default to the tunnel's listen port.";
+                };
+                type = mkOption {
+                  type = types.enum [
+                    "irc"
+                    "http"
+                    "server"
+                    "udpserver"
+                  ];
+                  default = "server";
+                  description = "Tunnel type for inbound tunnels.";
                 };
                 accessList = mkOption {
                   type = listOf str;


### PR DESCRIPTION
Added options services.i2pd.outTunnels.<name>.type and services.i2pd.inTunnels.<name>.type in accordance with the i2pd documentation https://i2pd.readthedocs.io/en/latest/user-guide/tunnels/
Previously, tunnel types were hardcoded; the previously hardcoded values are now the default.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
