### PR TITLE
vapor: init at 4.105.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8221,6 +8221,12 @@
     githubId = 7670450;
     name = "Federico Beffa";
   };
+  fbettag = {
+    email = "franz@bett.ag";
+    github = "fbettag";
+    githubId = 79918;
+    name = "Franz Bettag";
+  };
   fbergroth = {
     email = "fbergroth@gmail.com";
     github = "fbergroth";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8221,17 +8221,17 @@
     githubId = 7670450;
     name = "Federico Beffa";
   };
-  fbettag = {
-    email = "franz@bett.ag";
-    github = "fbettag";
-    githubId = 79918;
-    name = "Franz Bettag";
-  };
   fbergroth = {
     email = "fbergroth@gmail.com";
     github = "fbergroth";
     githubId = 1211003;
     name = "Fredrik Bergroth";
+  };
+  fbettag = {
+    email = "franz@bett.ag";
+    github = "fbettag";
+    githubId = 79918;
+    name = "Franz Bettag";
   };
   fbrs = {
     email = "yuuki@protonmail.com";

--- a/pkgs/by-name/va/vapor/package.nix
+++ b/pkgs/by-name/va/vapor/package.nix
@@ -1,4 +1,9 @@
-{ lib, fetchFromGitHub, stdenv, nix-update-script, }:
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  nix-update-script,
+}:
 
 stdenv.mkDerivation rec {
   pname = "vapor";
@@ -16,13 +21,11 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
         runHook preInstall
-        
         # Install the package sources and manifest for Swift Package Manager integration
         mkdir -p $out/share/vapor
         cp -r Sources/ $out/share/vapor/
         cp Package.swift $out/share/vapor/
         cp -r README.md LICENSE $out/share/vapor/ 2>/dev/null || true
-        
         # Create a simple wrapper script for easy Swift Package Manager usage
         mkdir -p $out/bin
         cat > $out/bin/vapor-version << 'EOF'
@@ -33,7 +36,6 @@ stdenv.mkDerivation rec {
     echo '.package(path: "'$out'/share/vapor")'
     EOF
         chmod +x $out/bin/vapor-version
-        
         runHook postInstall
   '';
 
@@ -42,9 +44,9 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Server-side Swift HTTP web framework";
     longDescription = ''
-      Vapor is an HTTP web framework for Swift. It provides a beautifully 
-      expressive and easy-to-use foundation for your next website, API, or 
-      cloud project. Built with a non-blocking, event-driven architecture, 
+      Vapor is an HTTP web framework for Swift. It provides a beautifully
+      expressive and easy-to-use foundation for your next website, API, or
+      cloud project. Built with a non-blocking, event-driven architecture,
       Vapor allows you to build high-performant, scalable APIs and HTTP servers.
     '';
     homepage = "https://vapor.codes";

--- a/pkgs/by-name/va/vapor/package.nix
+++ b/pkgs/by-name/va/vapor/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://vapor.codes";
     changelog = "https://github.com/vapor/vapor/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ fbettag ];
     platforms = lib.platforms.darwin ++ lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/va/vapor/package.nix
+++ b/pkgs/by-name/va/vapor/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vapor";
-  version = "4.105.0";
+  version = "4.115.1";
 
   src = fetchFromGitHub {
     owner = "vapor";
     repo = "vapor";
-    rev = "7aa836b77626bf07e71d5f50b9ad87cbe439ed81";
-    hash = "sha256-AyuxnJFUoo+l5xOCyXl74dh/WzH9TiZmNLzPAT0P7uM=";
+    tag = finalAttrs.version;
+    hash = "sha256-mOTZucGKOCjNghdGC3H7g5Kwjgn9DTn7mI6Q91Oitis=";
   };
 
   dontBuild = true;

--- a/pkgs/by-name/va/vapor/package.nix
+++ b/pkgs/by-name/va/vapor/package.nix
@@ -1,0 +1,56 @@
+{ lib, fetchFromGitHub, stdenv, nix-update-script, }:
+
+stdenv.mkDerivation rec {
+  pname = "vapor";
+  version = "4.105.0";
+
+  src = fetchFromGitHub {
+    owner = "vapor";
+    repo = "vapor";
+    rev = "7aa836b77626bf07e71d5f50b9ad87cbe439ed81";
+    hash = "sha256-AyuxnJFUoo+l5xOCyXl74dh/WzH9TiZmNLzPAT0P7uM=";
+  };
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  installPhase = ''
+        runHook preInstall
+        
+        # Install the package sources and manifest for Swift Package Manager integration
+        mkdir -p $out/share/vapor
+        cp -r Sources/ $out/share/vapor/
+        cp Package.swift $out/share/vapor/
+        cp -r README.md LICENSE $out/share/vapor/ 2>/dev/null || true
+        
+        # Create a simple wrapper script for easy Swift Package Manager usage
+        mkdir -p $out/bin
+        cat > $out/bin/vapor-version << 'EOF'
+    #!/bin/sh
+    echo "Vapor ${version}"
+    echo "Sources available at: $out/share/vapor"
+    echo "To use in your Swift project, add the following to your Package.swift:"
+    echo '.package(path: "'$out'/share/vapor")'
+    EOF
+        chmod +x $out/bin/vapor-version
+        
+        runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { attrPath = pname; };
+
+  meta = with lib; {
+    description = "Server-side Swift HTTP web framework";
+    longDescription = ''
+      Vapor is an HTTP web framework for Swift. It provides a beautifully 
+      expressive and easy-to-use foundation for your next website, API, or 
+      cloud project. Built with a non-blocking, event-driven architecture, 
+      Vapor allows you to build high-performant, scalable APIs and HTTP servers.
+    '';
+    homepage = "https://vapor.codes";
+    changelog = "https://github.com/vapor/vapor/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+    platforms = with platforms; darwin ++ linux;
+  };
+}

--- a/pkgs/by-name/va/vapor/package.nix
+++ b/pkgs/by-name/va/vapor/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://vapor.codes";
     changelog = "https://github.com/vapor/vapor/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ fbettag ];
+    maintainers = [ lib.maintainers.fbettag ];
     platforms = lib.platforms.darwin ++ lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/va/vapor/package.nix
+++ b/pkgs/by-name/va/vapor/package.nix
@@ -5,7 +5,7 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "vapor";
   version = "4.105.0";
 
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
         mkdir -p $out/bin
         cat > $out/bin/vapor-version << 'EOF'
     #!/bin/sh
-    echo "Vapor ${version}"
+    echo "Vapor ${finalAttrs.version}"
     echo "Sources available at: $out/share/vapor"
     echo "To use in your Swift project, add the following to your Package.swift:"
     echo '.package(path: "'$out'/share/vapor")'
@@ -39,9 +39,9 @@ stdenv.mkDerivation rec {
         runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script { attrPath = pname; };
+  passthru.updateScript = nix-update-script { attrPath = finalAttrs.pname; };
 
-  meta = with lib; {
+  meta = {
     description = "Server-side Swift HTTP web framework";
     longDescription = ''
       Vapor is an HTTP web framework for Swift. It provides a beautifully
@@ -50,9 +50,9 @@ stdenv.mkDerivation rec {
       Vapor allows you to build high-performant, scalable APIs and HTTP servers.
     '';
     homepage = "https://vapor.codes";
-    changelog = "https://github.com/vapor/vapor/releases/tag/${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ ];
-    platforms = with platforms; darwin ++ linux;
+    changelog = "https://github.com/vapor/vapor/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    platforms = lib.platforms.darwin ++ lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
## Summary
- Add Vapor, a server-side Swift HTTP web framework at version 4.105.0
- Package provides Vapor framework source code for Swift Package Manager integration
- Includes auto-update script for maintaining latest version
- Compatible with existing Swift 5.8 toolchain in nixpkgs

## Test plan
- [x] Package builds successfully with `nix-build -A vapor`
- [x] Sources are properly installed in `/nix/store/.../share/vapor/`
- [x] Package.swift manifest is available for Swift Package Manager
- [x] Auto-update script is functional
- [x] Follows nixpkgs by-name structure conventions