### PR TITLE
euporie: init at 2.8.12

### DIFF
--- a/pkgs/development/python-modules/euporie/default.nix
+++ b/pkgs/development/python-modules/euporie/default.nix
@@ -1,0 +1,116 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  hatchling,
+  aenum,
+  aiohttp,
+  prompt-toolkit,
+  pygments,
+  nbformat,
+  jupyter-client,
+  typing-extensions,
+  fastjsonschema,
+  platformdirs,
+  pyperclip,
+  imagesize,
+  markdown-it-py,
+  linkify-it-py,
+  mdit-py-plugins,
+  flatlatex,
+  timg,
+  pillow,
+  sixelcrop,
+  universal-pathlib,
+  fsspec,
+  jupytext,
+  ipykernel,
+  pytestCheckHook,
+  pytest-asyncio,
+  pytest-cov-stub,
+  python-magic,
+  html2text,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage rec {
+  pname = "euporie";
+  version = "2.8.13";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "joouha";
+    repo = "euporie";
+    tag = "v${version}";
+    hash = "sha256-T+Zec5vb+y5qf7Xvv+QtVG+olnv2C0933tCJbEQAJuU=";
+  };
+
+  build-system = [
+    setuptools
+    hatchling
+  ];
+
+  dependencies = [
+    aenum
+    aiohttp
+    prompt-toolkit
+    pygments
+    nbformat
+    jupyter-client
+    typing-extensions
+    fastjsonschema
+    platformdirs
+    pyperclip
+    imagesize
+    markdown-it-py
+    linkify-it-py
+    mdit-py-plugins
+    flatlatex
+    timg
+    pillow
+    sixelcrop
+    universal-pathlib
+    fsspec
+    jupytext
+    ipykernel
+  ];
+
+  pythonRelaxDeps = [
+    "aenum"
+    "linkify-it-py"
+    "markdown-it-py"
+    "mdit-py-plugins"
+    "platformdirs"
+  ];
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-cov-stub
+    python-magic
+    html2text
+    writableTmpDirAsHomeHook
+  ];
+
+  meta = {
+    description = "Jupyter notebooks in the terminal";
+    longDescription = ''
+      Similar to `jupyter lab` or `jupyter notebook`, This package
+      can only be used inside a python environment. To quickly summon
+      a python environment with euporie, you can use:
+      ```
+      nix-shell -p 'python3.withPackages (ps: with ps; [ euporie ])'
+      ```
+    '';
+    homepage = "https://euporie.readthedocs.io/";
+    license = lib.licenses.mit;
+    mainProgram = "euporie";
+    maintainers = with lib.maintainers; [
+      euxane
+      renesat
+    ];
+  };
+}

--- a/pkgs/development/python-modules/flatlatex/default.nix
+++ b/pkgs/development/python-modules/flatlatex/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  pytestCheckHook,
+  regex,
+}:
+
+buildPythonPackage rec {
+  pname = "flatlatex";
+  version = "0.15";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-UXDhvNT8y1K9vf8wCxS2hzBIO8RvaiqJ964rsCTk0Tk=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    regex
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "flatlatex"
+  ];
+
+  meta = {
+    description = "LaTeX math converter to unicode text";
+    homepage = "https://github.com/jb-leger/flatlatex";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [
+      euxane
+      renesat
+    ];
+  };
+}

--- a/pkgs/development/python-modules/sixelcrop/default.nix
+++ b/pkgs/development/python-modules/sixelcrop/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+}:
+
+buildPythonPackage rec {
+  pname = "sixelcrop";
+  version = "0.1.9";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-1sBaxPvW4gH3lK3tEjAPtCdXMXLAVEof0lpIpmpbyG8=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  pythonImportsCheck = [
+    "sixelcrop"
+  ];
+
+  meta = {
+    description = "Crop sixel images in sixel-space!";
+    homepage = "https://github.com/joouha/sixelcrop";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      euxane
+      renesat
+    ];
+  };
+}

--- a/pkgs/development/python-modules/timg/default.nix
+++ b/pkgs/development/python-modules/timg/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  pillow,
+}:
+
+buildPythonPackage rec {
+  pname = "timg";
+  version = "1.1.6";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-k42TmsNQIwD3ueParfXaD4jFuG/eWILXO0Op0Ci9S/0=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    pillow
+  ];
+
+  pythonImportsCheck = [
+    "timg"
+  ];
+
+  meta = {
+    description = "Display an image in terminal";
+    homepage = "https://github.com/adzierzanowski/timg";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      euxane
+      renesat
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18260,6 +18260,8 @@ self: super: with self; {
 
   timezonefinder = callPackage ../development/python-modules/timezonefinder { };
 
+  timg = callPackage ../development/python-modules/timg { };
+
   timing-asgi = callPackage ../development/python-modules/timing-asgi { };
 
   timm = callPackage ../development/python-modules/timm { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16740,6 +16740,8 @@ self: super: with self; {
 
   sixel = callPackage ../development/python-modules/sixel { };
 
+  sixelcrop = callPackage ../development/python-modules/sixelcrop { };
+
   sjcl = callPackage ../development/python-modules/sjcl { };
 
   skein = callPackage ../development/python-modules/skein { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4805,6 +4805,8 @@ self: super: with self; {
 
   eufylife-ble-client = callPackage ../development/python-modules/eufylife-ble-client { };
 
+  euporie = callPackage ../development/python-modules/euporie { };
+
   eval-type-backport = callPackage ../development/python-modules/eval-type-backport { };
 
   evaluate = callPackage ../development/python-modules/evaluate { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5355,6 +5355,8 @@ self: super: with self; {
 
   flatdict = callPackage ../development/python-modules/flatdict { };
 
+  flatlatex = callPackage ../development/python-modules/flatlatex { };
+
   flatten-dict = callPackage ../development/python-modules/flatten-dict { };
 
   flatten-json = callPackage ../development/python-modules/flatten-json { };


### PR DESCRIPTION
This adds a package for [Euporie] (Jupyter notebooks in the terminal) and its dependencies.

This package is added as a Python module so that its ipykernel can access other modules defined within a common environment.

The TUI notebook app can be tested with:

```sh
nix-shell \
    -I nixpkgs=./ \
    -p "python3.withPackages(ps: with ps; [ euporie ])" \
    --command euporie-notebook
```

[Euporie]: https://euporie.readthedocs.io/en/latest/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

CC: @renesat (https://github.com/NixOS/nixpkgs/issues/374033#issuecomment-2598767522)
