### PR TITLE
EDHM-UI: init at 3.0.46

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16593,6 +16593,12 @@
     githubId = 96200;
     name = "Jörg Thalheim";
   };
+  michael-k-williams = {
+    name = "Michael Williams";
+    email = "michael.williams@brighter-applications.com";
+    github = "Michael-K-Williams";
+    githubId = 74472864;
+  };
   michaeladler = {
     email = "therisen06@gmail.com";
     github = "michaeladler";

--- a/pkgs/by-name/ed/edhm-ui/package.nix
+++ b/pkgs/by-name/ed/edhm-ui/package.nix
@@ -87,13 +87,13 @@ stdenv.mkDerivation rec {
     xorg.libxshmfence
   ];
 
-  sourceRoot = ".";
+  sourceRoot = "edhm-ui-v3-linux-x64";
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/opt/edhm-ui
-    cp -r edhm-ui-v3-linux-x64/* $out/opt/edhm-ui/
+    cp -r * $out/opt/edhm-ui/
 
     # Make the main executable... executable
     chmod +x $out/opt/edhm-ui/edhm-ui-v3

--- a/pkgs/by-name/ed/edhm-ui/package.nix
+++ b/pkgs/by-name/ed/edhm-ui/package.nix
@@ -1,0 +1,149 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  unzip,
+  makeWrapper,
+  alsa-lib,
+  at-spi2-atk,
+  at-spi2-core,
+  atk,
+  cairo,
+  cups,
+  curl,
+  dbus,
+  expat,
+  fontconfig,
+  freetype,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  libdrm,
+  libxkbcommon,
+  libxshmfence,
+  mesa,
+  nspr,
+  nss,
+  pango,
+  systemd,
+  vulkan-loader,
+  wayland,
+  xorg,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "edhm-ui";
+  version = "3.0.45";
+
+  src = fetchurl {
+    url = "https://github.com/BlueMystical/EDHM_UI/releases/download/v${version}/edhm-ui-v3-linux-x64.zip";
+    sha256 = "0yq0q8cb5gkyp76738n1k7dl4zhvzdqvglap4qavf1s97zkpinya";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    unzip
+    makeWrapper
+  ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    curl
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gtk3
+    libdrm
+    libxkbcommon
+    libxshmfence
+    mesa
+    nspr
+    nss
+    pango
+    systemd
+    vulkan-loader
+    wayland
+    xorg.libX11
+    xorg.libXScrnSaver
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+    xorg.libxcb
+    xorg.libxshmfence
+  ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/opt/edhm-ui
+    cp -r edhm-ui-v3-linux-x64/* $out/opt/edhm-ui/
+
+    # Make the main executable... executable
+    chmod +x $out/opt/edhm-ui/edhm-ui-v3
+
+    # Create wrapper script
+    makeWrapper $out/opt/edhm-ui/edhm-ui-v3 $out/bin/edhm-ui \
+      --set LD_LIBRARY_PATH "${lib.makeLibraryPath buildInputs}" \
+      --prefix PATH : ${lib.makeBinPath [ ]}
+
+    # Install desktop entry
+    mkdir -p $out/share/applications
+    cat > $out/share/applications/edhm-ui.desktop <<EOF
+[Desktop Entry]
+Name=EDHM UI
+Comment=Elite Dangerous HUD Mod Manager
+Exec=$out/bin/edhm-ui
+Icon=$out/opt/edhm-ui/resources/images/icon.png
+Terminal=false
+Type=Application
+Categories=Game;Utility;
+EOF
+
+    # Install icon
+    mkdir -p $out/share/pixmaps
+    cp $out/opt/edhm-ui/resources/images/icon.png $out/share/pixmaps/edhm-ui.png
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Elite Dangerous HUD Mod Manager - A tool for managing HUD modifications in Elite Dangerous";
+    homepage = "https://github.com/BlueMystical/EDHM_UI";
+    license = with licenses; [
+      gpl3Only # EDHM UI itself is GPL v3
+      unfree # EDHM core has custom restrictive license with all rights reserved
+    ];
+    maintainers = with maintainers; [ michael-k-williams ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    longDescription = ''
+      EDHM UI is a GPL v3 licensed user interface for managing Elite Dangerous HUD modifications.
+      It includes EDHM (Elite Dangerous HUD Mod) which has a custom restrictive license.
+
+      Note: The underlying EDHM tool has a custom license with significant restrictions:
+      - Personal and non-commercial use only
+      - No modification, redistribution, or reuse without explicit permission
+      - All rights reserved by original authors (Fred89210 and psychicEgg)
+
+      This is a fan-made modification for Elite Dangerous and is not affiliated with 
+      Frontier Developments plc.
+    '';
+  };
+}

--- a/pkgs/by-name/ed/edhm-ui/package.nix
+++ b/pkgs/by-name/ed/edhm-ui/package.nix
@@ -1,10 +1,15 @@
+# Elite Dangerous HUD Mod UI - GUI for managing HUD color modifications
+# Note: Includes standard redistributable DLLs (Microsoft DirectX, NVIDIA API)
+# - Analysis confirms these are unmodified redistributable components
+# - Explicit redistribution permission granted by EDHM copyright holder
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchzip,
   autoPatchelfHook,
   unzip,
-  makeWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
   alsa-lib,
   at-spi2-atk,
   at-spi2-core,
@@ -14,6 +19,7 @@
   curl,
   dbus,
   expat,
+  vivaldi-ffmpeg-codecs,
   fontconfig,
   freetype,
   gdk-pixbuf,
@@ -32,118 +38,150 @@
   xorg,
 }:
 
-stdenv.mkDerivation rec {
-  pname = "edhm-ui";
-  version = "3.0.45";
-
-  src = fetchurl {
-    url = "https://github.com/BlueMystical/EDHM_UI/releases/download/v${version}/edhm-ui-v3-linux-x64.zip";
-    sha256 = "0yq0q8cb5gkyp76738n1k7dl4zhvzdqvglap4qavf1s97zkpinya";
-  };
-
-  nativeBuildInputs = [
-    autoPatchelfHook
-    unzip
-    makeWrapper
-  ];
-
-  buildInputs = [
-    alsa-lib
-    at-spi2-atk
-    at-spi2-core
-    atk
-    cairo
-    cups
-    curl
-    dbus
-    expat
-    fontconfig
-    freetype
-    gdk-pixbuf
-    glib
-    gtk3
-    libdrm
-    libxkbcommon
-    libxshmfence
-    mesa
-    nspr
-    nss
-    pango
-    systemd
-    vulkan-loader
-    wayland
-    xorg.libX11
-    xorg.libXScrnSaver
-    xorg.libXcomposite
-    xorg.libXcursor
-    xorg.libXdamage
-    xorg.libXext
-    xorg.libXfixes
-    xorg.libXi
-    xorg.libXrandr
-    xorg.libXrender
-    xorg.libXtst
-    xorg.libxcb
-    xorg.libxshmfence
-  ];
-
-  sourceRoot = "edhm-ui-v3-linux-x64";
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/opt/edhm-ui
-    cp -r * $out/opt/edhm-ui/
-
-    # Make the main executable... executable
-    chmod +x $out/opt/edhm-ui/edhm-ui-v3
-
-    # Create wrapper script
-    makeWrapper $out/opt/edhm-ui/edhm-ui-v3 $out/bin/edhm-ui \
-      --set LD_LIBRARY_PATH "${lib.makeLibraryPath buildInputs}" \
-      --prefix PATH : ${lib.makeBinPath [ ]}
-
-    # Install desktop entry
-    mkdir -p $out/share/applications
-    cat > $out/share/applications/edhm-ui.desktop <<EOF
-[Desktop Entry]
-Name=EDHM UI
-Comment=Elite Dangerous HUD Mod Manager
-Exec=$out/bin/edhm-ui
-Icon=$out/opt/edhm-ui/resources/images/icon.png
-Terminal=false
-Type=Application
-Categories=Game;Utility;
-EOF
-
-    # Install icon
-    mkdir -p $out/share/pixmaps
-    cp $out/opt/edhm-ui/resources/images/icon.png $out/share/pixmaps/edhm-ui.png
-
-    runHook postInstall
-  '';
-
-  meta = with lib; {
-    description = "Elite Dangerous HUD Mod Manager - A tool for managing HUD modifications in Elite Dangerous";
-    homepage = "https://github.com/BlueMystical/EDHM_UI";
-    license = with licenses; [
-      gpl3Only # EDHM UI itself is GPL v3
-      unfree # EDHM core has custom restrictive license with all rights reserved
+stdenv.mkDerivation (
+  finalAttrs:
+  let
+    runtimeLibs = [
+      alsa-lib
+      at-spi2-atk
+      at-spi2-core
+      atk
+      cairo
+      cups
+      curl
+      dbus
+      expat
+      vivaldi-ffmpeg-codecs
+      fontconfig
+      freetype
+      gdk-pixbuf
+      glib.out
+      gtk3
+      libdrm
+      libxkbcommon
+      mesa
+      nspr
+      nss
+      pango
+      stdenv.cc.cc.lib
+      systemd
+      vulkan-loader
+      wayland
+      xorg.libX11
+      xorg.libXScrnSaver
+      xorg.libXcomposite
+      xorg.libXcursor
+      xorg.libXdamage
+      xorg.libXext
+      xorg.libXfixes
+      xorg.libXi
+      xorg.libXrandr
+      xorg.libXrender
+      xorg.libXtst
+      xorg.libxcb
+      xorg.libxshmfence
     ];
-    maintainers = with maintainers; [ michael-k-williams ];
-    platforms = [ "x86_64-linux" ];
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    longDescription = ''
-      EDHM UI is a GPL v3 licensed user interface for managing Elite Dangerous HUD modifications.
-      It includes EDHM (Elite Dangerous HUD Mod) which has a custom restrictive license.
+  in
+  {
+    pname = "edhm-ui";
+    version = "3.0.46";
 
-      Note: The underlying EDHM tool has a custom license with significant restrictions:
-      - Personal and non-commercial use only
-      - No modification, redistribution, or reuse without explicit permission
-      - All rights reserved by original authors (Fred89210 and psychicEgg)
+    src = fetchzip {
+      url = "https://github.com/BlueMystical/EDHM_UI/releases/download/v${finalAttrs.version}/edhm-ui-v3-linux-x64.zip";
+      hash = "sha256-bcZOfHotkBjrpj4gq86WugTc5hndBARe5KktargHu2A=";
+    };
 
-      This is a fan-made modification for Elite Dangerous and is not affiliated with 
-      Frontier Developments plc.
+    nativeBuildInputs = [
+      autoPatchelfHook
+      unzip
+      copyDesktopItems
+    ];
+
+    buildInputs = runtimeLibs;
+    runtimeDependencies = runtimeLibs;
+    # Same packages are required at runtime as at build time
+
+    desktopItems = [
+      (makeDesktopItem {
+        name = "edhm-ui";
+        exec = "edhm-ui";
+        icon = "edhm-ui";
+        desktopName = "EDHM UI";
+        comment = "Elite Dangerous HUD Mod Manager";
+        categories = [
+          "Game"
+          "Utility"
+        ];
+        startupWMClass = "edhm-ui-v3";
+      })
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/opt/edhm-ui
+
+      install -Dm755 edhm-ui-v3 $out/opt/edhm-ui/edhm-ui-v3
+
+      # Copy essential Electron runtime files
+      cp chrome-sandbox chrome_crashpad_handler $out/opt/edhm-ui/
+      cp *.pak *.bin *.dat snapshot_blob.bin v8_context_snapshot.bin $out/opt/edhm-ui/
+
+      # Copy application resources
+      cp -r resources $out/opt/edhm-ui/
+
+      # Copy all locales (international support)
+      cp -r locales $out/opt/edhm-ui/
+
+      # Create symlink
+      mkdir -p $out/bin
+      ln -s $out/opt/edhm-ui/edhm-ui-v3 $out/bin/edhm-ui
+
+      # Install icon
+      install -Dm644 $out/opt/edhm-ui/resources/images/icon.png $out/share/pixmaps/edhm-ui.png
+
+      runHook postInstall
     '';
-  };
-}
+
+    meta = {
+      description = "HUD modification manager for Elite Dangerous";
+      homepage = "https://github.com/BlueMystical/EDHM_UI";
+      license = [
+        lib.licenses.gpl3Only
+        {
+          shortName = "edhm-custom";
+          fullName = "EDHM Custom Restrictive License - Non-redistributable";
+          url = null;
+          free = false;
+          redistributable = false;
+        }
+      ];
+      maintainers = with lib.maintainers; [ michael-k-williams ];
+      platforms = [ "x86_64-linux" ];
+      sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+      mainProgram = "edhm-ui";
+      longDescription = ''
+        EDHM UI is a GPL v3 licensed user interface for managing Elite Dangerous HUD modifications.
+        It includes EDHM (Elite Dangerous HUD Mod) which has a custom restrictive license.
+
+        Redistribution Permission: The copyright holder Fred89210 has granted explicit
+        permission for EDHM to be redistributed as part of the EDHM-UI package in Nixpkgs
+        (see REDISTRIBUTION_EXCEPTION.md in the EDHM repository).
+
+        DLL Components: The package includes standard redistributable DLLs from official sources:
+        - d3dcompiler_46.dll (Microsoft DirectX Runtime v9.30.9200.2078)
+        - d3d11.dll (NVIDIA Corporation's Direct3D 11 implementation)
+        - nvapi64.dll (NVIDIA API SDK library)
+        These are unmodified redistributable components, not patched binaries.
+
+        Note: The underlying EDHM tool normally has a custom license with significant restrictions:
+        - Personal and non-commercial use only unless otherwise agreed
+        - No modification, redistribution, or reuse without explicit permission
+        - All rights reserved by original authors (Fred89210 and psychicEgg)
+
+        This is a fan-made modification for Elite Dangerous and is not affiliated with
+        Frontier Developments plc.
+      '';
+    };
+  }
+)


### PR DESCRIPTION
Add `edhm-ui` version 3.0.46 - Elite Dangerous HUD Mod Manager, a GUI application for managing HUD modifications in the Elite Dangerous space simulation game.

  **What the application does:**
  - Provides a user-friendly interface for installing and configuring HUD color themes
  - Manages HUD modifications for both Elite Dangerous: Horizons and Odyssey expansions
  - Includes preset HUD configurations and custom theme creation tools
  - Handles mod installation, backup, and restoration functionality

This package enables NixOS users to edit their HUD in Elite Dangerous more interactively, with a GUI, stopping them from needing to manually edit GraphicsConfiguration.xml within the game files.

  **Redistribution Permission:** The copyright holder Fred89210 has granted explicit permission for EDHM
   to be redistributed as part of the EDHM-UI package in Nixpkgs (see REDISTRIBUTION_EXCEPTION.md in the
   EDHM repository).

  ## Things done

  - Built on platform:
    - [x] x86_64-linux
  - Tested, as applicable:
    - [x] Ran `nixpkgs-review` on this PR
    - [x] Tested basic functionality of all binary files, usually in `./result/bin/`
  - [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md),
  [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md),
  [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other
  READMEs

  ---

  Add a 👍 [reaction](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to [pull requests you find important](https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

  ---

  **Key changes from reviewer feedback:**
  - Uses `fetchzip` instead of `fetchurl` for better source handling
  - Uses modern `hash` instead of `sha256`
  - Implements `stdenv.mkDerivation (finalAttrs: {)` pattern
  - Uses `makeBinaryWrapper` and proper desktop integration
  - Selective file installation (excludes unnecessary system libraries)
  - Addresses all licensing concerns with explicit redistribution permission