### PR TITLE
vtk: 9.5.0 -> 9.5.1; vtkWithQt5: drop

### DIFF
--- a/pkgs/development/libraries/vtk/default.nix
+++ b/pkgs/development/libraries/vtk/default.nix
@@ -7,24 +7,7 @@ let
 in
 {
   vtk_9_5 = mkVtk {
-    version = "9.5.0";
-    sourceSha256 = "sha256-BK6GJGuVV8a2GvvFNKbfCZJE+8jzk3+C5rwFcJU6+H0=";
-    patches = [
-      # https://gitlab.kitware.com/vtk/vtk/-/issues/19699
-      (fetchpatch2 {
-        url = "https://gitlab.kitware.com/vtk/vtk/-/commit/6b4f7b853675c63e4831c366ca8f78e320c1bfb5.diff";
-        hash = "sha256-hWJc5RxW6iK+W/rTxp2GUWKcm/2+oxbP5nVZ0EUSKHE=";
-      })
-      # https://gitlab.kitware.com/vtk/vtk/-/issues/19705
-      (fetchpatch2 {
-        url = "https://gitlab.kitware.com/vtk/vtk/-/commit/ce10dfe82ffa19c8108885625a6f8b3f980bed3b.diff";
-        hash = "sha256-kyPM0whL4WeaV27sNM1fbbs5kwMYn+9E561HtvnwHRc=";
-      })
-      # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/12262
-      (fetchpatch2 {
-        url = "https://gitlab.kitware.com/vtk/vtk/-/commit/c0e0f793e6adf740f5b1c91ac330afdbc2a03b72.diff";
-        hash = "sha256-BinSv8sPqpAEcgkn8trnCPv2snR9MGcA8rkVflAhc5w=";
-      })
-    ];
+    version = "9.5.1";
+    sourceSha256 = "sha256-FEQ2YcewldBbTjdvs/QGE/Fz40/J1GWCNOnsHWJKYY8=";
   };
 }

--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -82,11 +82,10 @@
   libXcursor,
   gl2ps,
   libGL,
-  qt5,
   qt6,
 
   # custom options
-  qtVersion ? null,
+  withQt6 ? false,
   # To avoid conflicts between the propagated vtkPackages.hdf5
   # and the input hdf5 used by most downstream packages,
   # we set mpiSupport to false by default.
@@ -97,15 +96,6 @@
   testers,
 }:
 let
-  qtPackages =
-    if (isNull qtVersion) then
-      null
-    else if (qtVersion == "6") then
-      qt6
-    else if (qtVersion == "5") then
-      qt5
-    else
-      throw ''qtVersion must be "5", "6" or null'';
   vtkPackages = lib.makeScope newScope (self: {
     inherit
       tbb
@@ -174,7 +164,7 @@ stdenv.mkDerivation (finalAttrs: {
     libXrender
     libXcursor
   ]
-  ++ lib.optional (!(isNull qtPackages)) qtPackages.qttools
+  ++ lib.optional withQt6 qt6.qttools
   ++ lib.optional mpiSupport mpi
   ++ lib.optional pythonSupport tk;
 
@@ -235,12 +225,6 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  # wrapper script calls qmlplugindump, crashes due to lack of minimal platform plugin
-  # Could not find the Qt platform plugin "minimal" in ""
-  preConfigure = lib.optionalString (qtVersion == "5") ''
-    export QT_PLUGIN_PATH=${lib.getBin qt5.qtbase}/${qt5.qtbase.qtPluginPrefix}
-  '';
-
   env = {
     CMAKE_PREFIX_PATH = "${lib.getDev openvdb}/lib/cmake/OpenVDB";
     NIX_LDFLAGS = "-L${lib.getLib libmysqlclient}/lib/mariadb";
@@ -276,8 +260,8 @@ stdenv.mkDerivation (finalAttrs: {
     (vtkBool "VTK_MODULE_ENABLE_VTK_RenderingOpenVR" false) # openvr
     (vtkBool "VTK_MODULE_ENABLE_VTK_RenderingAnari" false) # anari
 
-    # qtSupport
-    (vtkBool "VTK_GROUP_ENABLE_Qt" (!(isNull qtPackages)))
+    # withQt6
+    (vtkBool "VTK_GROUP_ENABLE_Qt" withQt6)
     (lib.cmakeFeature "VTK_QT_VERSION" "Auto") # will search for Qt6 first
 
     # pythonSupport
@@ -325,9 +309,9 @@ stdenv.mkDerivation (finalAttrs: {
 
         package = finalAttrs.finalPackage;
 
-        nativeBuildInputs = lib.optionals (!(isNull qtPackages)) [
-          qtPackages.qttools
-          qtPackages.wrapQtAppsHook
+        nativeBuildInputs = lib.optionals withQt6 [
+          qt6.qttools
+          qt6.wrapQtAppsHook
         ];
       };
     };

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2562,7 +2562,8 @@ mapAliases {
   voxelands = throw "'voxelands' has been removed due to lack of upstream maintenance"; # Added 2025-08-30
   vtk_9 = lib.warnOnInstantiate "'vtk_9' has been renamed to 'vtk_9_5'" vtk_9_5; # Added 2025-07-18
   vtk_9_egl = lib.warnOnInstantiate "'vtk_9_5' now build with egl support by default, so `vtk_9_egl` is deprecated, consider using 'vtk_9_5' instead." vtk_9_5; # Added 2025-07-18
-  vtk_9_withQt5 = throw "'vtk_9_withQt5' has been removed, Consider using 'vtkWithQt5' instead."; # Added 2025-07-18
+  vtk_9_withQt5 = throw "'vtk_9_withQt5' has been removed, Consider using 'vtkWithQt6' instead."; # Added 2025-07-18
+  vtkWithQt5 = throw "'vtkWithQt5' has been removed. Consider using 'vtkWithQt6' instead."; # Added 2025-09-06
   vuze = throw "'vuze' was removed because it is unmaintained upstream and insecure (CVE-2018-13417). BiglyBT is a maintained fork."; # Added 2024-11-22
   vwm = throw "'vwm' was removed as it is broken and not maintained upstream"; # Added 2025-05-17
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9046,14 +9046,12 @@ with pkgs;
   vtk = vtk_9_5;
 
   vtk-full = vtk.override {
-    qtVersion = "6";
+    withQt6 = true;
     mpiSupport = true;
     pythonSupport = true;
   };
 
-  vtkWithQt5 = vtk.override { qtVersion = "5"; };
-
-  vtkWithQt6 = vtk.override { qtVersion = "6"; };
+  vtkWithQt6 = vtk.override { withQt6 = true; };
 
   vulkan-caps-viewer = libsForQt5.callPackage ../tools/graphics/vulkan-caps-viewer { };
 


### PR DESCRIPTION
1st commit:

vtk: 9.5.0 -> 9.5.1
Diff: https://gitlab.kitware.com/vtk/vtk/-/compare/v9.5.0...v9.5.1
Changelog: https://docs.vtk.org/en/latest/release_details/9.5.html

2nd commit:

Now no packages depend on vtkWithQt5, we can safely drop vtkWithQt5 before 25.11 release.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
