### PR TITLE
qemu-vm: retain gcroots while qemu is running

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -169,24 +169,33 @@ let
         TMPDIR=$(mktemp -d nix-vm.XXXXXXXXXX --tmpdir)
     fi
 
-    ${lib.optionalString (cfg.useNixStoreImage) ''
-      echo "Creating Nix store image..."
+    ${
+      if cfg.useNixStoreImage then
+        ''
+          echo "Creating Nix store image..."
 
-      ${import ../../lib/erofs-store-image.nix {
-        inherit hostPkgs;
-        storePaths = "${
-          hostPkgs.closureInfo {
-            rootPaths = [
-              config.system.build.toplevel
-              regInfo
-            ];
-          }
-        }/store-paths";
-        label = nixStoreFilesystemLabel;
-        destination = ''"$TMPDIR"/store.img'';
-      }}
-      echo "Created Nix store image."
-    ''}
+          ${import ../../lib/erofs-store-image.nix {
+            inherit hostPkgs;
+            storePaths = "${
+              hostPkgs.closureInfo {
+                rootPaths = [
+                  config.system.build.toplevel
+                  regInfo
+                ];
+              }
+            }/store-paths";
+            label = nixStoreFilesystemLabel;
+            destination = ''"$TMPDIR"/store.img'';
+          }}
+
+          echo "Created Nix store image."
+        ''
+      else
+        ''
+          # Retain gcroots in the host Nix store while the VM is running.
+          export NIX_GCROOTS="${concatStringsSep ":" config.virtualisation.additionalPaths}"
+        ''
+    }
 
     # Create a directory for exchanging data with the VM.
     mkdir -p "$TMPDIR/xchg"


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
