### PR TITLE
xiaomi-cloud-tokens-extractor: init at 1.4.0

### DIFF
--- a/pkgs/by-name/xi/xiaomi-cloud-tokens-extractor/package.nix
+++ b/pkgs/by-name/xi/xiaomi-cloud-tokens-extractor/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+let
+  pname = "xiaomi-cloud-tokens-extractor";
+  version = "1.4.0";
+in
+python3Packages.buildPythonApplication {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "PiotrMachowski";
+    repo = "Xiaomi-cloud-tokens-extractor";
+    tag = "v${version}";
+    hash = "sha256-ssaNjYB4JkshnMtPjxdiTOa80O3f69ytPLvjRqzx20o=";
+  };
+
+  pyproject = false;
+
+  dependencies = with python3Packages; [
+    requests
+    pycryptodome
+    charset-normalizer
+    pillow
+    colorama
+  ];
+
+  dontBuild = true;
+  doCheck = false;
+
+  postPatch = ''
+    chmod +x token_extractor.py
+
+    # Add shebang so we can patch it
+    sed -i -e '1i#!/usr/bin/python' token_extractor.py
+    patchShebangs token_extractor.py
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin"
+    cp token_extractor.py "$out/bin/"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/PiotrMachowski/Xiaomi-cloud-tokens-extractor";
+    description = "Retrieves tokens for all devices connected to Xiaomi cloud and encryption keys for BLE devices";
+    mainProgram = "token_extractor.py";
+    maintainers = with lib.maintainers; [ MakiseKurisu ];
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add Xiaomi-cloud-tokens-extractor, which is used to extract encryption key for Xiaomi smart home IoT devices, so they can be adapted by Home Assistant.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
