### PR TITLE
houdini: 20.5.684 -> 21.0.440

### DIFF
--- a/pkgs/by-name/ho/houdini/package.nix
+++ b/pkgs/by-name/ho/houdini/package.nix
@@ -33,6 +33,7 @@ buildFHSEnv {
       nspr
       expat
       pciutils
+      libdrm
       libxkbcommon
       libudev0-shim
       tbb
@@ -63,6 +64,8 @@ buildFHSEnv {
       libXScrnSaver
       libXrandr
       libxcb
+      libxkbfile
+      libxshmfence
       xcbutil
       xcbutilimage
       xcbutilrenderutil

--- a/pkgs/by-name/ho/houdini/runtime.nix
+++ b/pkgs/by-name/ho/houdini/runtime.nix
@@ -1,12 +1,12 @@
 { requireFile, callPackage }:
 
 callPackage ./runtime-build.nix rec {
-  version = "20.5.684";
+  version = "21.0.440";
   eulaDate = "2021-10-13";
   src = requireFile {
     name = "houdini-${version}-linux_x86_64_gcc11.2.tar.gz";
-    hash = "sha256-cyFeeKBCV1EGdgruQ71EnEJOVndn1SKSiCtD6WRc878=";
+    hash = "sha256-qHRR+RRtUgUam6FC1TWTZjg1FSakjLoMYVaiIfO+WOY=";
     url = "https://www.sidefx.com/download/daily-builds/?production=true";
   };
-  outputHash = "sha256-mAX4jSdV0/DC+48O7d1hgmKjC1leKm1QgSBMbyAxyFs=";
+  outputHash = "sha256-SSBiqNZRnxz6tnvusYRi2UASY1k3voiblDpkiu+qU0w=";
 }


### PR DESCRIPTION
Update houdini to 21.0.440, add some new dependencies.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@canndrew @kwohlfahrt @pedohorse 