### PR TITLE
fetchsmb: init

### DIFF
--- a/pkgs/build-support/fetchsmb/default.nix
+++ b/pkgs/build-support/fetchsmb/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  fetchurl,
+}:
+
+lib.extendMkDerivation (
+  {
+    host,
+    path,
+    workgroup,
+
+    tls ? false,
+    private ? false,
+    varPrefix ? null,
+    ... # For hash agility
+  }@args:
+  let
+    baseUrl = "${if tls then "smbs" else "smb"}://${host}/${path}";
+    passthruAttrs = removeAttrs args [
+      "host"
+      "path"
+      "workgroup"
+      "tls"
+      "private"
+      "varPrefix"
+    ];
+    varBase = "NIX${lib.optionalString (varPrefix != null) "_${varPrefix}"}_SMB_PRIVATE_";
+    privateAttrs = lib.optionalAttrs private {
+      netrcPhase = ''
+        if [ -z "''$${varBase}USERNAME" -o -z "''$${varBase}PASSWORD" ]; then
+          echo "Error: Private fetchsmb requires the nix building process (nix-daemon in multi user mode) to have the ${varBase}USERNAME and ${varBase}PASSWORD env vars set." >&2
+          exit 1
+        fi
+        cat > netrc <<EOF
+        machine ${host}
+          login ''$${varBase}USERNAME
+          password ''$${varBase}PASSWORD
+        EOF
+      '';
+      netrcImpureEnvVars = [
+        "${varBase}USERNAME"
+        "${varBase}PASSWORD"
+      ];
+    };
+
+    fetcherArgs = {
+      url = baseUrl;
+      curlOpts = "-w ${workgroup}";
+    }
+    // passthruAttrs
+    // privateAttrs;
+
+  in
+  fetchurl fetcherArgs
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -480,6 +480,8 @@ with pkgs;
 
   fetchpijul = callPackage ../build-support/fetchpijul { };
 
+  fetchsmb = callPackage ../build-support/fetchsmb { };
+
   inherit (callPackages ../build-support/node/fetch-yarn-deps { })
     fixup-yarn-lock
     prefetch-yarn-deps


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Upstreams @4a-42 fetchSMB fetcher to nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
