### PR TITLE
apophenia: init at 1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19873,6 +19873,11 @@
     github = "peret";
     githubId = 617977;
   };
+  perihelion = {
+    name = "perihelion";
+    github = "perihelion00";
+    githubId = 218501404;
+  };
   periklis = {
     email = "theopompos@gmail.com";
     github = "periklis";

--- a/pkgs/development/libraries/apophenia/default.nix
+++ b/pkgs/development/libraries/apophenia/default.nix
@@ -1,0 +1,55 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  gsl,
+  sqlite,
+  lib,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "apophenia";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "b-k";
+    repo = "Apophenia";
+    rev = "pkg";
+    sha256 = "1rqz3chdjn98biijl3hyyall9pcbpf2hnkfmaq00k6ddd4g23paw";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    gsl.dev
+    sqlite.dev
+  ];
+  propagatedBuildInputs = [
+    gsl.dev
+    sqlite.dev
+  ];
+
+  enableParallelBuilding = true;
+
+  configurePhase = ''./configure --prefix=$out'';
+  buildPhase = "make";
+  installPhase = ''
+    make install
+
+    # Ensure callers get our include dir
+    if grep -q '^Cflags:[[:space:]]*$' "$out/lib/pkgconfig/apophenia.pc"; then
+      sed -i "s|^Cflags:.*$|Cflags: -I$out/include|" "$out/lib/pkgconfig/apophenia.pc"
+    fi
+
+    # Vendor dep .pc files so Requires: resolves without extra env
+    ln -sf ${gsl.dev}/lib/pkgconfig/gsl.pc        "$out/lib/pkgconfig/gsl.pc"
+    ln -sf ${sqlite.dev}/lib/pkgconfig/sqlite3.pc "$out/lib/pkgconfig/sqlite3.pc"
+  '';
+
+  meta = with lib; {
+    description = "Apophenia statistical C library (pkg branch)";
+    homepage = "http://apophenia.info/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ perihelion ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
**apophenia: init at 1.0**

Adds Apophenia statistical C library (pkg branch).

* Homepage: [http://apophenia.info/](http://apophenia.info/)
* License: GPL-2.0-or-later
* Maintainer: @perihelion00

### Notes

* Uses `fetchFromGitHub` at `rev = "pkg"`.
* `enableParallelBuilding = true`.
* Adds `gsl.dev` and `sqlite.dev` as `buildInputs` and `propagatedBuildInputs`.
* Fixes upstream `.pc` for smooth use in pure shells:

  * Ensures `Cflags: -I$out/include`.
  * Vendors `gsl.pc` and `sqlite3.pc` into `$out/lib/pkgconfig/` so `Requires:` resolves without extra env.
* Verified `pkg-config --cflags --libs apophenia` and a trivial compile work in a pure shell.

Build/usage sanity:

```sh
nix-build -A apophenia
nix-shell -I nixpkgs=. --pure -p apophenia pkg-config --run "pkg-config --cflags --libs apophenia"
nix-shell -I nixpkgs=. --pure -p apophenia gcc --run '
cat > t.c <<EOF
#include <apop.h>
int main(){ return 0; }
EOF
gcc t.c $(pkg-config --cflags --libs apophenia)
'
```

---

## Things done

* Built on platform:

  * [x] x86\_64-linux
  * [ ] aarch64-linux
  * [ ] x86\_64-darwin
  * [ ] aarch64-darwin
* Tested, as applicable:

  * [ ] [[NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)] in \[nixos/tests].
  * [ ] [[Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)] at `passthru.tests`.
  * [ ] Tests in \[lib/tests] or \[pkgs/test] for functions and "core" functionality.
* [ ] Ran `nixpkgs-review` on this PR. See [[nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)].
* [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
* Nixpkgs Release Notes

  * [ ] Package update: when the change is major or breaking.
* NixOS Release Notes

  * [ ] Module addition: when adding a new NixOS module.
  * [ ] Module update: when the change is significant.
* [x] Fits \[CONTRIBUTING.md], \[pkgs/README.md], \[maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

Additional reviewers: happy to adjust if maintainers prefer not to vendor `.pc` files; alternative is to rely solely on propagation and upstream `.pc` behavior.