### PR TITLE
forgejo: 12.0.2 -> 12.0.3, forgejo-lts: 11.0.4 -> 11.0.5

### DIFF
--- a/pkgs/by-name/fo/forgejo/lts.nix
+++ b/pkgs/by-name/fo/forgejo/lts.nix
@@ -1,8 +1,8 @@
 import ./generic.nix {
-  version = "11.0.4";
-  hash = "sha256-RI6eCJx1QTDkzY1oFKwCQyOrRXMd0TFihWofC4ZCv44=";
-  npmDepsHash = "sha256-wsjosyZ5J5mU7ixbWjXnbqkvgnOE0dGz81vVqaI61go=";
-  vendorHash = "sha256-Zfjp6EKiO74wYgvc85AwtDg+3Nf7lEa1ZKQMMcYPM34=";
+  version = "11.0.5";
+  hash = "sha256-r1PR2WfJUvt+5K9RQi+9+xJmhtpqP6cGzEk77DiZUlE=";
+  npmDepsHash = "sha256-1lY08jBTx3DRhoaup02076EL9n85y57WCsS/cNcM4aw=";
+  vendorHash = "sha256-Jh8u+iCBhYdKcLj4IzcKtJBnzvclvUeYbR/hjMN+cPs=";
   lts = true;
   nixUpdateExtraArgs = [
     "--override-filename"

--- a/pkgs/by-name/fo/forgejo/package.nix
+++ b/pkgs/by-name/fo/forgejo/package.nix
@@ -1,8 +1,8 @@
 import ./generic.nix {
-  version = "12.0.2";
-  hash = "sha256-BkyzOrpwKkROKiZgSCr8Z7n8WO6qnkDyCBJ4HWO71Ws=";
-  npmDepsHash = "sha256-kq2AV1D0xA4Csm8XUTU5D0iCmyuajcnwlLdPjJ/mj1g=";
-  vendorHash = "sha256-B9menPCDUOYHPCS0B5KpxuE03FdFXmA8XqkiYEAxs5Y=";
+  version = "12.0.3";
+  hash = "sha256-3uXGDX1uKxXehiMBG1cMIttJFRACIm3UE8U2OtUWjOQ=";
+  npmDepsHash = "sha256-V8FUoL9y36bagkg8Scttv/IzKg+MIIqp7witvT8bSWA=";
+  vendorHash = "sha256-GE3trnaWuAVSEfi11tZo5JXedWOYOMzcHQ3GFyISVTQ=";
   lts = false;
   nixUpdateExtraArgs = [
     "--override-filename"


### PR DESCRIPTION
Contains security fixes for Mermaid (XSS) and <https://github.com/ulikunitz/xz>.

https://codeberg.org/forgejo/forgejo/releases/tag/v12.0.3
https://codeberg.org/forgejo/forgejo/src/commit/eaa83f52f29a287719d1537fe82c5c8baed8ddf5/release-notes-published/12.0.3.md

https://codeberg.org/forgejo/forgejo/releases/tag/v11.0.5
https://codeberg.org/forgejo/forgejo/src/commit/eaa83f52f29a287719d1537fe82c5c8baed8ddf5/release-notes-published/11.0.5.md

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test