### PR TITLE
nixos/uptimed: add `settings`, systemd-notify, `DynamicUser`, add nixos test

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -224,7 +224,7 @@ in
       zabbix = 180;
       #redis = 181; removed 2018-01-03
       #unifi = 183; dynamically allocated as of 2021-09-17
-      uptimed = 184;
+      #uptimed = 184; dynamically allocated as of 2025-09-05
       #zope2 = 185; # dynamically allocated as of 2021-09-18
       #ripple-data-api = 186; dynamically allocated as of 2021-09-17
       mediatomb = 187;

--- a/nixos/modules/services/system/uptimed.nix
+++ b/nixos/modules/services/system/uptimed.nix
@@ -26,14 +26,6 @@ in
 
     environment.systemPackages = [ pkgs.uptimed ];
 
-    users.users.uptimed = {
-      description = "Uptimed daemon user";
-      home = stateDir;
-      uid = config.ids.uids.uptimed;
-      group = "uptimed";
-    };
-    users.groups.uptimed = { };
-
     systemd.services.uptimed = {
       unitConfig.Documentation = "man:uptimed(8) man:uprecords(1)";
       description = "uptimed service";
@@ -43,6 +35,7 @@ in
         Type = "notify";
         Restart = "on-failure";
         User = "uptimed";
+        DynamicUser = true;
         Nice = 19;
         IOSchedulingClass = "idle";
         PrivateTmp = "yes";

--- a/nixos/modules/services/system/uptimed.nix
+++ b/nixos/modules/services/system/uptimed.nix
@@ -7,6 +7,7 @@
 let
   cfg = config.services.uptimed;
   stateDir = "/var/lib/uptimed";
+  runtimeDir = "/run/uptimed";
 in
 {
   options = {
@@ -17,6 +18,61 @@ in
         description = ''
           Enable `uptimed`, allowing you to track
           your highest uptimes.
+        '';
+      };
+
+      settings = lib.mkOption {
+        type = lib.types.submodule {
+          freeformType = with lib.types; attrsOf (either str (listOf str));
+          options = {
+            PIDFILE = lib.mkOption {
+              type = lib.types.path;
+              default = "${runtimeDir}/pid";
+              description = "Where to put uptimed's PID file";
+            };
+
+            SEND_EMAIL = lib.mkOption {
+              type = lib.types.enum [
+                "0"
+                "1"
+                "2"
+                "3"
+              ];
+              default = "0";
+              description = ''
+                Whether to send email. This assumes that you have a working MTA on your system.
+
+                - `0`: off
+                - `1`: on
+                - `2`: only for milestones
+                - `3`: only for records
+              '';
+            };
+
+            SENDMAIL = lib.mkOption {
+              type = lib.types.path;
+              default = "${pkgs.system-sendmail}/bin/sendmail -t";
+              defaultText = lib.literalExpression ''"''${pkgs.system-sendmail}/bin/sendmail -t"'';
+              description = ''
+                The command to use for sending mail.
+
+                The command needs to be {command}`sendmail` compatible.
+              '';
+            };
+
+            EMAIL = lib.mkOption {
+              type = lib.types.str;
+              description = "Which email to send";
+              example = "someone@example.com";
+              default = "root@localhost";
+            };
+          };
+        };
+        default = { };
+        description = ''
+          Settings for {file}`uptimed.conf`.
+
+          For available options, see <https://github.com/rpodgorny/uptimed/blob/master/etc/uptimed.conf-dist>.
         '';
       };
     };
@@ -42,8 +98,23 @@ in
         PrivateNetwork = "yes";
         NoNewPrivileges = "yes";
         StateDirectory = [ "uptimed" ];
+        RuntimeDirectory = [ "uptimed" ];
         InaccessibleDirectories = "/home";
-        ExecStart = "${pkgs.uptimed}/sbin/uptimed -f -p ${stateDir}/pid";
+        ExecStart = "${pkgs.uptimed}/sbin/uptimed -f";
+
+        BindReadOnlyPaths =
+          let
+            configFile = lib.pipe cfg.settings [
+              (lib.mapAttrsToList (
+                k: v: if builtins.isList v then lib.mapConcatStringsSep "\n" (v': "${k}=${v'}") v else "${k}=${v}"
+              ))
+              (lib.concatStringsSep "\n")
+              (pkgs.writeText "uptimed.conf")
+            ];
+          in
+          [
+            "${configFile}:/etc/uptimed/uptimed.conf"
+          ];
       };
 
       preStart = ''

--- a/nixos/modules/services/system/uptimed.nix
+++ b/nixos/modules/services/system/uptimed.nix
@@ -40,6 +40,7 @@ in
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {
+        Type = "notify";
         Restart = "on-failure";
         User = "uptimed";
         Nice = 19;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1545,6 +1545,7 @@ in
   upnp.nftables = handleTest ./upnp.nix { useNftables = true; };
   uptermd = runTest ./uptermd.nix;
   uptime-kuma = runTest ./uptime-kuma.nix;
+  uptimed = runTest ./uptimed.nix;
   urn-timer = runTest ./urn-timer.nix;
   usbguard = runTest ./usbguard.nix;
   user-activation-scripts = runTest ./user-activation-scripts.nix;

--- a/nixos/tests/uptimed.nix
+++ b/nixos/tests/uptimed.nix
@@ -1,0 +1,17 @@
+{ pkgs, lib, ... }:
+{
+  name = "uptimed";
+  meta.maintainers = with lib.maintainers; [ h7x4 ];
+
+  nodes.machine =
+    { ... }:
+    {
+      services.uptimed.enable = true;
+    };
+
+  testScript = ''
+    machine.wait_for_unit("uptimed.service")
+    machine.wait_for_file("/var/lib/uptimed/records")
+    machine.succeed("uprecords")
+  '';
+}

--- a/pkgs/by-name/up/uptimed/package.nix
+++ b/pkgs/by-name/up/uptimed/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
+  nixosTests,
 }:
 
 stdenv.mkDerivation rec {
@@ -29,6 +30,8 @@ stdenv.mkDerivation rec {
     substituteInPlace src/Makefile.am \
       --replace-fail '$(sysconfdir)/uptimed.conf' '/etc/uptimed/uptimed.conf'
   '';
+
+  passthru.tests.nixos = nixosTests.uptimed;
 
   meta = with lib; {
     description = "Uptime record daemon";

--- a/pkgs/by-name/up/uptimed/package.nix
+++ b/pkgs/by-name/up/uptimed/package.nix
@@ -22,6 +22,12 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace libuptimed/urec.h \
       --replace /var/spool /var/lib
+
+    substituteInPlace Makefile.am \
+      --replace-fail '$(sysconfdir)/uptimed.conf' '/etc/uptimed/uptimed.conf'
+
+    substituteInPlace src/Makefile.am \
+      --replace-fail '$(sysconfdir)/uptimed.conf' '/etc/uptimed/uptimed.conf'
   '';
 
   meta = with lib; {


### PR DESCRIPTION


## Things done

This PR gives a bit of rework to the `uptimed` service.

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
