### PR TITLE
nixos/tests: RFC: change `Machine.systemctl` to use `Machine.succeed`

### DIFF
--- a/nixos/tests/aesmd.nix
+++ b/nixos/tests/aesmd.nix
@@ -53,8 +53,7 @@
     in
     ''
       def get_aesmd_pid():
-        status, main_pid = machine.systemctl("show --property MainPID --value aesmd.service")
-        assert status == 0, "Could not get MainPID of aesmd.service"
+        main_pid = machine.systemctl("show --property MainPID --value aesmd.service")
         return main_pid.strip()
 
       with subtest("aesmd.service starts"):
@@ -88,8 +87,7 @@
         assert aesmd_config == "whitelist url = http://nixos.org\nproxy type = direct\ndefault quoting type = ecdsa_256\n", "aesmd.conf differs"
 
       with subtest("aesmd.service without quote provider library has correct LD_LIBRARY_PATH"):
-        status, environment = machine.systemctl("show --property Environment --value aesmd.service")
-        assert status == 0, "Could not get Environment of aesmd.service"
+        environment = machine.systemctl("show --property Environment --value aesmd.service")
         env_by_name = dict(entry.split("=", 1) for entry in environment.split())
         assert not env_by_name["LD_LIBRARY_PATH"], "LD_LIBRARY_PATH is not empty"
 

--- a/nixos/tests/incus/lxd-to-incus.nix
+++ b/nixos/tests/incus/lxd-to-incus.nix
@@ -80,7 +80,7 @@ import ../make-test-python.nix (
 
     testScript = ''
       def lxd_wait_for_preseed(_) -> bool:
-        _, output = machine.systemctl("is-active lxd-preseed.service")
+        output = machine.systemctl("is-active lxd-preseed.service")
         return ("inactive" in output)
 
       def lxd_instance_is_up(_) -> bool:

--- a/nixos/tests/lxd/preseed.nix
+++ b/nixos/tests/lxd/preseed.nix
@@ -54,7 +54,7 @@ import ../make-test-python.nix (
 
     testScript = ''
       def wait_for_preseed(_) -> bool:
-        _, output = machine.systemctl("is-active lxd-preseed.service")
+        output = machine.systemctl("is-active lxd-preseed.service")
         return ("inactive" in output)
 
       machine.wait_for_unit("sockets.target")

--- a/nixos/tests/paretosecurity.nix
+++ b/nixos/tests/paretosecurity.nix
@@ -70,8 +70,7 @@
         'paretosecurity-user',
         'paretosecurity-user.timer'
     ]:
-        status, out = xfce.systemctl("is-enabled " + unit, "alice")
-        assert status == 0, f"Unit {unit} is not enabled (status: {status}): {out}"
+        xfce.systemctl("is-enabled " + unit, "alice")
     xfce.succeed("xdotool mousemove 460 10")
     xfce.wait_for_text("Pareto Security")
     xfce.succeed("xdotool click 1")

--- a/nixos/tests/pass-secret-service.nix
+++ b/nixos/tests/pass-secret-service.nix
@@ -61,13 +61,13 @@
           machine.send_chars("${user.password}\n")
           machine.wait_until_succeeds("pgrep -u alice bash")
 
-          _, output = machine.systemctl("status dbus-org.freedesktop.secrets --no-pager", "alice")
+          output = machine.systemctl("status dbus-org.freedesktop.secrets --no-pager", "alice")
           assert "Active: inactive (dead)" in output
 
       with subtest("Service starts after a client tries to talk to the D-Bus API"):
           machine.send_chars("secrets-dbus-init; touch ${ready-file}\n")
           machine.wait_for_file("${ready-file}")
-          _, output = machine.systemctl("status dbus-org.freedesktop.secrets --no-pager", "alice")
+          output = machine.systemctl("status dbus-org.freedesktop.secrets --no-pager", "alice")
           assert "Active: active (running)" in output
     '';
 }

--- a/nixos/tests/rtkit.nix
+++ b/nixos/tests/rtkit.nix
@@ -135,12 +135,8 @@
 
       def get_pid(node: Machine, unit: str, user: Optional[str] = None) -> int:
           node.wait_for_unit(unit, user=user)
-          (status, out) = node.systemctl(f"show -P MainPID {unit}", user=user)
-          if status == 0:
-              return int(out.strip())
-          else:
-              node.log(out)
-              raise Exception(f"unable to determine MainPID of {unit} (systemctl exit code {status})")
+          out = node.systemctl(f"show -P MainPID {unit}", user=user)
+          return int(out.strip())
 
       def assert_sched(node: Machine, pid: int, policy: Optional[str] = None, priority: Optional[int] = None):
           out = node.succeed(f"chrt -p {pid}")

--- a/nixos/tests/xscreensaver.nix
+++ b/nixos/tests/xscreensaver.nix
@@ -59,21 +59,21 @@
   testScript = ''
     ok.wait_for_x()
     ok.wait_for_unit("xscreensaver", "alice")
-    _, output_ok = ok.systemctl("status xscreensaver", "alice")
+    output_ok = ok.systemctl("status xscreensaver", "alice")
     assert 'To prevent the kernel from randomly unlocking' not in output_ok
     assert 'your screen via the out-of-memory killer' not in output_ok
     assert '"xscreensaver-auth" must be setuid root' not in output_ok
 
     empty_wrapperPrefix.wait_for_x()
     empty_wrapperPrefix.wait_for_unit("xscreensaver", "alice")
-    _, output_empty_wrapperPrefix = empty_wrapperPrefix.systemctl("status xscreensaver", "alice")
+    output_empty_wrapperPrefix = empty_wrapperPrefix.systemctl("status xscreensaver", "alice")
     assert 'To prevent the kernel from randomly unlocking' in output_empty_wrapperPrefix
     assert 'your screen via the out-of-memory killer' in output_empty_wrapperPrefix
     assert '"xscreensaver-auth" must be setuid root' in output_empty_wrapperPrefix
 
     bad_wrapperPrefix.wait_for_x()
     bad_wrapperPrefix.wait_for_unit("xscreensaver", "alice")
-    _, output_bad_wrapperPrefix = bad_wrapperPrefix.systemctl("status xscreensaver", "alice")
+    output_bad_wrapperPrefix = bad_wrapperPrefix.systemctl("status xscreensaver", "alice")
     assert 'To prevent the kernel from randomly unlocking' in output_bad_wrapperPrefix
     assert 'your screen via the out-of-memory killer' in output_bad_wrapperPrefix
     assert '"xscreensaver-auth" must be setuid root' in output_bad_wrapperPrefix


### PR DESCRIPTION
Previously we used `Machine.execute`, which doesn't actually check that the command succeeded (it just returns the (status code, output).

I grepped around and didn't find anywhere in nixpkgs where we do anything with a failing `Machine.systemctl` call. We did have a number of places that explicitly check the result and fail the test, which now no longer needs to happen.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
