### PR TITLE
home-assistant-custom-components.heatmiserneo: init at 3.2.2

### DIFF
--- a/pkgs/development/python-modules/async-property/default.nix
+++ b/pkgs/development/python-modules/async-property/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytest-asyncio,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "async-property";
+  version = "0.2.2";
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  src = fetchFromGitHub {
+    owner = "ryananguiano";
+    repo = "async_property";
+    rev = "v${version}";
+    sha256 = "sha256-Bn8PDAGNLeL3/g6mB9lGQm1jblHIOJl2w248McJ3oaE=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "pytest-runner" ""
+  '';
+
+  nativeCheckInputs = [
+    pytest-asyncio
+  ];
+
+  pythonImportsCheck = [ "async_property" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/ryananguiano/async_property";
+    description = "Python decorator for async properties";
+    license = licenses.mit;
+    maintainers = with maintainers; [ graham33 ];
+  };
+}

--- a/pkgs/development/python-modules/neohubapi/default.nix
+++ b/pkgs/development/python-modules/neohubapi/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitLab,
+  async-property,
+  pytest-asyncio,
+  setuptools,
+  websockets,
+}:
+
+buildPythonPackage rec {
+  pname = "neohubapi";
+  version = "3.1";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    owner = "neohubapi";
+    repo = "neohubapi";
+    rev = "v${version}";
+    hash = "sha256-niRDUiKtpDq6mTlSln2tMrUDN2WRaRRbQQk3gaRIAUc=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    async-property
+    websockets
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+  ];
+
+  pythonImportsCheck = [
+    "neohubapi"
+  ];
+
+  meta = {
+    description = "Async library to communicate with Heatmiser NeoHub 2 API";
+    homepage = "https://gitlab.com/neohubapi/neohubapi/";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/heatmiserneo/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/heatmiserneo/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  neohubapi,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "MindrustUK";
+  domain = "heatmiserneo";
+  version = "3.2.2";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "Heatmiser-for-home-assistant";
+    tag = "v${version}";
+    hash = "sha256-74VELIDrZOLnQELej0iwnXQIqZAdr0O5IrWWgOBW8zc=";
+  };
+
+  dependencies = [
+    neohubapi
+  ];
+
+  meta = {
+    changelog = "https://github.com/MindrustUK/Heatmiser-for-home-assistant/releases/tag/v${version}/docs/changelog.md";
+    description = "An integration for Home Assistant to add support for Heatmiser's Neo-Hub and 'Neo' range of products.";
+    homepage = "https://github.com/MindrustUK/Heatmiser-for-home-assistant";
+    maintainers = with lib.maintainers; [ graham33 ];
+    license = with lib.licenses; [
+      asl20
+      gpl2Only
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1033,6 +1033,8 @@ self: super: with self; {
 
   async-modbus = callPackage ../development/python-modules/async-modbus { };
 
+  async-property = callPackage ../development/python-modules/async-property { };
+
   async-stagger = callPackage ../development/python-modules/async-stagger { };
 
   async-timeout = callPackage ../development/python-modules/async-timeout { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10319,6 +10319,8 @@ self: super: with self; {
 
   neo4j = callPackage ../development/python-modules/neo4j { };
 
+  neohubapi = callPackage ../development/python-modules/neohubapi { };
+
   neoteroi-mkdocs = callPackage ../development/python-modules/neoteroi-mkdocs { };
 
   nessclient = callPackage ../development/python-modules/nessclient { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added home-assistant-custom-components.heatmiserneo and python dependency neohubapi, which depends on async-property. async-property is not very maintained, but it's hopefully stable enough to package safely (i've been using it for a couple of years).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
