### PR TITLE
python313Packages.colcon-override-check: init at 0.0.1

### DIFF
--- a/pkgs/development/python-modules/colcon-override-check/default.nix
+++ b/pkgs/development/python-modules/colcon-override-check/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  colcon,
+  colcon-installed-package-information,
+  fetchFromGitHub,
+  pytestCheckHook,
+  pytest-cov-stub,
+  scspell,
+  setuptools,
+  writableTmpDirAsHomeHook,
+}:
+buildPythonPackage rec {
+  pname = "colcon-override-check";
+  version = "0.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = "colcon-override-check";
+    tag = version;
+    hash = "sha256-5ypJjC11ypfh9p/s1RBYHQuSXVTFyZaZVyR/jj+r4zw=";
+  };
+  build-system = [ setuptools ];
+
+  dependencies = [
+    colcon
+    colcon-installed-package-information
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+    scspell
+    writableTmpDirAsHomeHook
+  ];
+
+  disabledTestPaths = [
+    "test/test_flake8.py"
+  ];
+
+  pythonImportsCheck = [
+    "colcon_override_check"
+  ];
+
+  meta = {
+    description = "Extension for colcon-core to check for potential problems when overriding installed packages";
+    homepage = "http://colcon.readthedocs.io/";
+    downloadPage = "https://github.com/colcon/colcon-override-check";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ guelakais ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3034,6 +3034,8 @@ self: super: with self; {
 
   colcon-output = callPackage ../development/python-modules/colcon-output { };
 
+  colcon-override-check = callPackage ../development/python-modules/colcon-override-check { };
+
   colcon-package-information =
     callPackage ../development/python-modules/colcon-package-information
       { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
