### PR TITLE
nrfutil: 7.13.0 -> 8.1.1, package all installables

### DIFF
--- a/doc/packages/index.md
+++ b/doc/packages/index.md
@@ -22,6 +22,7 @@ lhapdf.section.md
 locales.section.md
 etc-files.section.md
 nginx.section.md
+nrfutil.section.md
 opengl.section.md
 shell-helpers.section.md
 python-tree-sitter.section.md

--- a/doc/packages/nrfutil.section.md
+++ b/doc/packages/nrfutil.section.md
@@ -1,0 +1,13 @@
+# nrfutil {#sec-nrfutil}
+
+nrfutil can be built with its installables as following:
+
+```nix
+(nrfutil.withExtensions [
+  "nrfutil-completion"
+  "nrfutil-device"
+  "nrfutil-trace"
+])
+```
+
+Keep in mind that all installables might not be available for every supported platform.

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -322,6 +322,9 @@
   "sec-nixpkgs-release-25.05-notable-changes": [
     "release-notes.html#sec-nixpkgs-release-25.05-notable-changes"
   ],
+  "sec-nrfutil": [
+    "index.html#sec-nrfutil"
+  ],
   "sec-overlays-install": [
     "index.html#sec-overlays-install"
   ],

--- a/pkgs/by-name/nr/nrfutil/package.nix
+++ b/pkgs/by-name/nr/nrfutil/package.nix
@@ -96,7 +96,9 @@ symlinkJoin {
   nativeBuildInputs = [ makeWrapper ];
 
   postBuild = ''
-    wrapProgram $out/bin/nrfutil --prefix PATH ":" "$out/bin"
+    wrapProgram $out/bin/nrfutil \
+      --prefix PATH ":" "$out/bin" \
+      --set NRF_JLINK_DLL_PATH "${segger-jlink-headless}/lib/libjlinkarm.so"
   '';
 
   passthru = {

--- a/pkgs/by-name/nr/nrfutil/package.nix
+++ b/pkgs/by-name/nr/nrfutil/package.nix
@@ -2,69 +2,109 @@
   lib,
   stdenvNoCC,
   fetchurl,
+
+  xz,
   zlib,
   libusb1,
   segger-jlink-headless,
   gcc,
+
   autoPatchelfHook,
   versionCheckHook,
+  makeWrapper,
+
+  symlinkJoin,
+  extensions ? [ ],
+  nrfutil,
 }:
 
 let
-  source = import ./source.nix;
-  supported = removeAttrs source [ "version" ];
+  sources = import ./source.nix;
+  platformSources =
+    sources.${stdenvNoCC.system} or (throw "unsupported platform ${stdenvNoCC.system}");
 
-  platform = supported.${stdenvNoCC.system} or (throw "unsupported platform ${stdenvNoCC.system}");
-
-in
-stdenvNoCC.mkDerivation (finalAttrs: {
-  pname = "nrfutil";
-  inherit (source) version;
-
-  src = fetchurl {
-    url = "https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/packages/nrfutil/nrfutil-${platform.name}-${finalAttrs.version}.tar.gz";
-    inherit (platform) hash;
-  };
-
-  nativeBuildInputs = [
-    autoPatchelfHook
-  ];
-
-  buildInputs = [
-    zlib
-    libusb1
-    gcc.cc.lib
-    segger-jlink-headless
-  ];
-
-  dontConfigure = true;
-  dontBuild = true;
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out
-    mv data/* $out/
-
-    runHook postInstall
-  '';
-
-  doInstallCheck = true;
-  nativeInstallCheckInputs = [
-    versionCheckHook
-  ];
-  passthru.updateScript = ./update.sh;
-
-  meta = with lib; {
+  sharedMeta = with lib; {
     description = "CLI tool for managing Nordic Semiconductor devices";
     homepage = "https://www.nordicsemi.com/Products/Development-tools/nRF-Util";
     changelog = "https://docs.nordicsemi.com/bundle/nrfutil/page/guides/revision_history.html";
     license = licenses.unfree;
-    platforms = lib.attrNames supported;
+    platforms = lib.attrNames sources;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     maintainers = with maintainers; [
       h7x4
       ezrizhu
     ];
+  };
+
+  packages = map (
+    name:
+    let
+      package = platformSources.packages.${name};
+    in
+    stdenvNoCC.mkDerivation (finalAttrs: {
+      pname = name;
+      inherit (package) version;
+
+      src = fetchurl {
+        url = "https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/packages/${name}/${name}-${platformSources.triplet}-${package.version}.tar.gz";
+        inherit (package) hash;
+      };
+
+      nativeBuildInputs = [
+        autoPatchelfHook
+      ];
+
+      buildInputs = [
+        xz
+        zlib
+        libusb1
+        gcc.cc.lib
+        segger-jlink-headless
+      ];
+
+      dontConfigure = true;
+      dontBuild = true;
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out
+        mv data/* $out/
+
+        runHook postInstall
+      '';
+
+      doInstallCheck = true;
+      nativeInstallCheckInputs = [
+        versionCheckHook
+      ];
+      versionCheckProgramArg = "--version";
+
+      meta = sharedMeta // {
+        mainProgram = name;
+      };
+    })
+  ) ([ "nrfutil" ] ++ extensions);
+
+in
+symlinkJoin {
+  pname = "nrfutil";
+  inherit (platformSources.packages.nrfutil) version;
+
+  paths = packages;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    wrapProgram $out/bin/nrfutil --prefix PATH ":" "$out/bin"
+  '';
+
+  passthru = {
+    updateScript = ./update.sh;
+    withExtensions = extensions: nrfutil.override { inherit extensions; };
+  };
+
+  meta = sharedMeta // {
     mainProgram = "nrfutil";
   };
-})
+}

--- a/pkgs/by-name/nr/nrfutil/source.nix
+++ b/pkgs/by-name/nr/nrfutil/source.nix
@@ -1,7 +1,84 @@
 {
-  version = "7.13.0";
+  aarch64-linux = {
+    triplet = "aarch64-unknown-linux-gnu";
+    packages = {
+      nrfutil = {
+        version = "8.1.1";
+        hash = "sha256-y7ywCr9Ze3Uz1JQh0hNg2BOPKW2yEftYDaD8WzHWSxY=";
+      };
+      nrfutil-ble-sniffer = {
+        version = "0.16.2";
+        hash = "sha256-vCpSs9oUcqKPDKVoEtrqqY9Jy0AtbMwK8s398xvQ7Us=";
+      };
+      nrfutil-device = {
+        version = "2.15.1";
+        hash = "sha256-u8JlM7bxkR5x0fhTQRIkElpxot6jpKyL2SljFfoKj54=";
+      };
+      nrfutil-mcu-manager = {
+        version = "0.8.0";
+        hash = "sha256-jLsLN/Ny5zL4MSaKS3cb2L4WBCKZHVLiR2RkPAL8JnY=";
+      };
+      nrfutil-sdk-manager = {
+        version = "1.8.0";
+        hash = "sha256-DsGuOQ6rzwit5oeG4ZLObCOaxMt8WB+YYnuXRYtqq4U=";
+      };
+      nrfutil-trace = {
+        version = "4.0.1";
+        hash = "sha256-IR4P1tK/0P3d96Wnwciq7b3TJurENF2pYKaHu2yZIPk=";
+      };
+    };
+  };
   x86_64-linux = {
-    name = "x86_64-unknown-linux-gnu";
-    hash = "sha256-R3OF/340xEab+0zamfwvejY16fjy/3TrzMvQaBlVxHw=";
+    triplet = "x86_64-unknown-linux-gnu";
+    packages = {
+      nrfutil = {
+        version = "8.1.1";
+        hash = "sha256-asX1UbAE6X03lLC3l9e/9G2WgVRezfmRD6dyXJKb18Y=";
+      };
+      nrfutil-91 = {
+        version = "0.5.0";
+        hash = "sha256-ACQ+csYVIoANKV+CyAAD+drXQSb7CVUdvDYe76LELqs=";
+      };
+      nrfutil-ble-sniffer = {
+        version = "0.16.2";
+        hash = "sha256-4TGbn0HdlER5k76Hc5rCSVvyx89VdLQ56fMiGgWUvrU=";
+      };
+      nrfutil-completion = {
+        version = "1.5.0";
+        hash = "sha256-KA5h9/hJA66nkAAW1Tui+m60E/Iv9wzVPdeQqIQWpxc=";
+      };
+      nrfutil-device = {
+        version = "2.15.1";
+        hash = "sha256-zH/QtM1vM6BIiZHPLM23TRt2LCRUdJvmYN9oveotsH0=";
+      };
+      nrfutil-mcu-manager = {
+        version = "0.8.0";
+        hash = "sha256-ItU3kys1HMd06srLTzPtRoAW1YxwOt39LqjIQPMvmaI=";
+      };
+      nrfutil-npm = {
+        version = "0.3.1";
+        hash = "sha256-kQ63fVWR8RdGTQLA27Sg7jegYhtlkvXvLJsucifH4I0=";
+      };
+      nrfutil-nrf5sdk-tools = {
+        version = "1.1.0";
+        hash = "sha256-hLQhTEa5F2lrFxppKmVrD5PnIA3JPcP/M/r9bYizHk8=";
+      };
+      nrfutil-sdk-manager = {
+        version = "1.8.0";
+        hash = "sha256-+Z1xfEdTAcvYj+hjsW0z/dHRoIzVGWXjD6lSqoQvOPg=";
+      };
+      nrfutil-suit = {
+        version = "0.9.0";
+        hash = "sha256-uwbUgjpJNC27bSINyhfzTrOXIUi7GjFnPebg38apRKc=";
+      };
+      nrfutil-toolchain-manager = {
+        version = "0.15.0";
+        hash = "sha256-/bQx4yu1ybCO2TBd7MctxCANiYO5c1qCDYSjXm7hLcE=";
+      };
+      nrfutil-trace = {
+        version = "4.0.1";
+        hash = "sha256-YmsMQOD1vylaRwMWOhOA9xXePJR779P8im4Lcs7EcWk=";
+      };
+    };
   };
 }


### PR DESCRIPTION
This commit introduces a `withExtensions` function, to allow for downloading and using the other installable parts of nrfutil.

It also introduces support for aarch64-linux, as well as updating the program

Fixes #437836
Also ref #398197
Superseeds #397288

Built and tested for patchelf deps with:

```bash
NIXPKGS_ALLOW_UNFREE=1 nix build --expr 'with (import ./. { }); (nrfutil.withExtensions [ "nrfutil-device" "nrfutil-trace" "nrfutil-ble-sniffer" "nrfutil-completion" "nrfutil-mcu-manager" "nrfutil-npm" "nrfutil-nrf5sdk-tools" "nrfutil-sdk-manager" "nrfutil-suit" "nrfutil-toolchain-manager" ]).override { segger-jlink-headless = (segger-jlink-headless.override { acceptLicense = true; }); }' --impure -L
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
