### PR TITLE
nixVersions: add philiptaron as maintainer

### DIFF
--- a/pkgs/tools/package-management/nix/common-meson.nix
+++ b/pkgs/tools/package-management/nix/common-meson.nix
@@ -12,8 +12,9 @@
   },
   patches ? [ ],
   maintainers ? [
-    lib.maintainers.lovesegfault
     lib.maintainers.artturin
+    lib.maintainers.philiptaron
+    lib.maintainers.lovesegfault
   ],
   teams ? [ lib.teams.nix ],
   self_attribute_name,

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -120,8 +120,9 @@ let
     ];
 
   maintainers = [
-    lib.maintainers.lovesegfault
     lib.maintainers.artturin
+    lib.maintainers.philiptaron
+    lib.maintainers.lovesegfault
   ];
   teams = [ lib.teams.nix ];
 


### PR DESCRIPTION
As I discussed with @roberth at NixCon 2025, I'd like to help out with releasing Nix into Nixpkgs. 

My goal: a release PR opened within a few hours of the tag occurring upstream.

I also sorted the maintainers field alphabetically.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md