### PR TITLE
uutils-coreutils: 0.1.0 -> 0.2.0

### DIFF
--- a/pkgs/by-name/uu/uutils-coreutils/package.nix
+++ b/pkgs/by-name/uu/uutils-coreutils/package.nix
@@ -21,19 +21,19 @@ assert selinuxSupport -> lib.meta.availableOn stdenv.hostPlatform libselinux;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "uutils-coreutils";
-  version = "0.1.0";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "uutils";
     repo = "coreutils";
     tag = finalAttrs.version;
-    hash = "sha256-nKKjc6Bui7k50SR7BY09dRGt3Za1Ch/E+3KiCO5KtOg=";
+    hash = "sha256-jxjg2RIZaemA6jgfdE1KX8G6c/NWumecoJMFx7dspz8=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     name = "uutils-coreutils-${finalAttrs.version}";
-    hash = "sha256-PTIypl9uqFkp6GrF7Pp40AItbWFlXT2V2x/C8L2J8S0=";
+    hash = "sha256-SFuAWzmYd1N7czUyC/7CYrCObYfoKrC5oORFxXtbwhE=";
   };
 
   patches = [

--- a/pkgs/by-name/uu/uutils-coreutils/selinux_no_auto_detect.diff
+++ b/pkgs/by-name/uu/uutils-coreutils/selinux_no_auto_detect.diff
@@ -1,12 +1,11 @@
 diff --git a/GNUmakefile b/GNUmakefile
-index f46126a82..44be8f13b 100644
+index 20dc731d3..400e5b84f 100644
 --- a/GNUmakefile
 +++ b/GNUmakefile
-@@ -57,20 +57,6 @@ TOYBOX_ROOT := $(BASEDIR)/tmp
- TOYBOX_VER  := 0.8.12
- TOYBOX_SRC  := $(TOYBOX_ROOT)/toybox-$(TOYBOX_VER)
+@@ -69,19 +69,6 @@ TOYBOX_SRC  := $(TOYBOX_ROOT)/toybox-$(TOYBOX_VER)
+ #------------------------------------------------------------------------
+ OS ?= $(shell uname -s)
  
--
 -ifdef SELINUX_ENABLED
 -	override SELINUX_ENABLED := 0
 -# Now check if we should enable it (only on non-Windows)
@@ -23,7 +22,7 @@ index f46126a82..44be8f13b 100644
  # Possible programs
  PROGS       := \
  	base32 \
-@@ -181,8 +167,10 @@ SELINUX_PROGS := \
+@@ -200,8 +187,10 @@ endif
  
  ifneq ($(OS),Windows_NT)
  	PROGS := $(PROGS) $(UNIX_PROGS)
@@ -32,6 +31,6 @@ index f46126a82..44be8f13b 100644
 -	PROGS := $(PROGS) $(SELINUX_PROGS)
 +		PROGS := $(PROGS) $(SELINUX_PROGS)
 +	endif
+ # Always use external libstdbuf when building with make (Unix only)
+ 	CARGOFLAGS += --features feat_external_libstdbuf
  endif
- 
- UTILS ?= $(PROGS)


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/uutils/coreutils/compare/0.1.0...0.2.0
Changelog: https://github.com/uutils/coreutils/releases/tag/0.2.0

cc @siraben @matthiasbeyer


- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc