### PR TITLE
nixVersions.stable: nix_2_28 -> nix_2_31

### DIFF
--- a/nixos/modules/installer/tools/nix-fallback-paths.nix
+++ b/nixos/modules/installer/tools/nix-fallback-paths.nix
@@ -1,8 +1,8 @@
 {
-  x86_64-linux = "/nix/store/0bvxg6fr61zrlhi93azhp8yfhb5rcrs9-nix-2.28.5";
-  i686-linux = "/nix/store/m5na49mxl4xpcs3xh086s5v08jqjhbmb-nix-2.28.5";
-  aarch64-linux = "/nix/store/95rhdhjfwbi7ilwy5j0knj1852p7x6c6-nix-2.28.5";
-  riscv64-linux = "/nix/store/cqiiv36c773023p6lp9h4ff57fjlzisk-nix-riscv64-unknown-linux-gnu-2.28.5";
-  x86_64-darwin = "/nix/store/xiw5636h616yi3balx96pmdk6b052rhk-nix-2.28.5";
-  aarch64-darwin = "/nix/store/sax8chv80d9fy4s0y3ahsr9y4kc2f0ib-nix-2.28.5";
+  x86_64-linux = "/nix/store/x30lnlgk1s16rynrfslbf8phr6h6rqf2-nix-2.31.2";
+  i686-linux = "/nix/store/ix94q6rrdg6cr4893cjpzdbmibhlm0dv-nix-2.31.2";
+  aarch64-linux = "/nix/store/xnybj9lk0kwvmr2va253avanq7m3cpyg-nix-2.31.2";
+  riscv64-linux = "/nix/store/33as1vqp8mq36nr5bb5gr7ziw1nf4q1v-nix-riscv64-unknown-linux-gnu-2.31.2";
+  x86_64-darwin = "/nix/store/b9dvary8rcljj7ajv1x64hwwch4cvyvp-nix-2.31.2";
+  aarch64-darwin = "/nix/store/lvv1j8qbrvlnl3aagcjrhf42d458zgb5-nix-2.31.2";
 }

--- a/pkgs/by-name/ni/nix-serve/package.nix
+++ b/pkgs/by-name/ni/nix-serve/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   bzip2,
   nix,
+  perl,
   makeWrapper,
   nixosTests,
 }:
@@ -11,6 +12,7 @@
 let
   rev = "a7e046db4b29d422fc9aac60ea6b82b31399951a";
   sha256 = "sha256-6ZQ0OLijq6UtOtUqRdFC19+helhU0Av6MvGCZf6XmcQ=";
+  inherit (nix.libs) nix-perl-bindings;
 in
 
 stdenv.mkDerivation {
@@ -31,11 +33,11 @@ stdenv.mkDerivation {
     install -Dm0755 nix-serve.psgi $out/libexec/nix-serve/nix-serve.psgi
 
     makeWrapper ${
-      nix.perl-bindings.perl.withPackages (p: [
+      perl.withPackages (p: [
         p.DBDSQLite
         p.Plack
         p.Starman
-        nix.perl-bindings
+        nix-perl-bindings
       ])
     }/bin/starman $out/bin/nix-serve \
       --prefix PATH : "${

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -196,7 +196,7 @@ lib.makeExtensible (
       latest = self.nix_2_31;
 
       # Read ./README.md before bumping a major release
-      stable = addFallbackPathsCheck self.nix_2_28;
+      stable = addFallbackPathsCheck self.nix_2_31;
     }
     // lib.optionalAttrs config.allowAliases (
       lib.listToAttrs (

--- a/pkgs/tools/package-management/nix/modular/packaging/components.nix
+++ b/pkgs/tools/package-management/nix/modular/packaging/components.nix
@@ -151,18 +151,6 @@ let
     ];
     separateDebugInfo = !stdenv.hostPlatform.isStatic;
     hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
-    env =
-      prevAttrs.env or { }
-      // lib.optionalAttrs (
-        stdenv.isLinux
-        && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")
-        && !(
-          stdenv.buildPlatform.config != stdenv.hostPlatform.config
-          && stdenv.hostPlatform.system == "powerpc64-linux"
-        )
-        && !(stdenv.system == "loongarch64-linux")
-        && !(stdenv.hostPlatform.useLLVM or false)
-      ) { LDFLAGS = "-fuse-ld=gold"; };
   };
 
   mesonLibraryLayer = finalAttrs: prevAttrs: {

--- a/pkgs/tools/package-management/nix/tests.nix
+++ b/pkgs/tools/package-management/nix/tests.nix
@@ -56,7 +56,8 @@
   };
 }
 // lib.optionalAttrs stdenv.hostPlatform.isLinux {
-  nixStatic = pkgsStatic.nixVersions.${self_attribute_name};
+  # unfortunally nixpkgs pkgsStatic is too often broken including the dependency closure of nix
+  # nixStatic = pkgsStatic.nixVersions.${self_attribute_name};
 
   # Basic smoke tests that needs to pass when upgrading nix.
   # Note that this test does only test the nixVersions.stable attribute.


### PR DESCRIPTION
NixCon 2025 has been a wonderful experience. Let's make it even better for the whole world by giving them a new, fresh, well-tested Nix version. 

Per [the readme](https://github.com/NixOS/nixpkgs/blob/a4716b0e8b18ffb120aff902016f6e846e50bd2f/pkgs/tools/package-management/nix/README.md#L31-L35), we're targeting staging.

Previous bump:
- https://github.com/NixOS/nixpkgs/pull/375820

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
