### PR TITLE
ostui: init at 1.0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15300,6 +15300,12 @@
     github = "M0NsTeRRR";
     githubId = 37785089;
   };
+  m0streng0 = {
+    name = "Henrique Oliveira";
+    email = "ho.henrique@proton.me";
+    github = "M0streng0";
+    githubId = 85799811;
+  };
   m0ustache3 = {
     name = "M0ustach3";
     github = "M0ustach3";

--- a/pkgs/by-name/os/ostui/package.nix
+++ b/pkgs/by-name/os/ostui/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromSourcehut,
+  pkg-config,
+  mpv-unwrapped,
+  stdenv,
+}:
+buildGoModule (finalAttrs: {
+  pname = "ostui";
+  version = "1.0.4";
+
+  src = fetchFromSourcehut {
+    owner = "~ser";
+    repo = "ostui";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-efX19jkJnXyO4iuY2EZqhtLJZ7R/Q2JQZf72gyLgY8k=";
+  };
+
+  vendorHash = "sha256-Vmjd0bbeR9+PZCjh1cczE5MWeH5PDVE6obJLmV0wCLQ=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    mpv-unwrapped
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${finalAttrs.version}"
+  ];
+
+  env = {
+    CGO_ENABLED = "1";
+  };
+
+  doCheck = !stdenv.hostPlatform.isDarwin;
+
+  meta = {
+    homepage = "https://git.sr.ht/~ser/ostui";
+    description = "Terminal client for *sonic music servers, inspired by ncmpcpp and musickube";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    mainProgram = "ostui";
+    maintainers = with lib.maintainers; [ m0streng0 ];
+  };
+})


### PR DESCRIPTION
Init ostui package and add myself as maintainer.

Source-code of the project: https://git.sr.ht/~ser/ostui

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

### Additional Notes

**Platform Testing**: I was only able to test on x86_64-linux locally. However, the package includes proper Darwin framework support based on upstream documentation which mentions macOS MediaPlayer integration.

I welcome testing from macOS users to verify the MediaPlayer framework integration works as expected.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
