### PR TITLE
lcevcdec: 3.3.8 -> 4.0.1

### DIFF
--- a/pkgs/by-name/lc/lcevcdec/package.nix
+++ b/pkgs/by-name/lc/lcevcdec/package.nix
@@ -14,7 +14,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lcevcdec";
-  version = "3.3.8";
+  version = "4.0.1";
 
   outputs = [
     "out"
@@ -26,15 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "v-novaltd";
     repo = "LCEVCdec";
     tag = finalAttrs.version;
-    hash = "sha256-s7gY3l5ML+7T7i6DsstC75XXgxQgTWyITfa+8OhHl+w=";
+    hash = "sha256-azY4xle2wwopT9qEHa4+nXPkGzscWz9tYof1qN7Nw8c=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/010-lcevcdec-fix-pkgconfig-libs.patch?h=lcevcdec&id=a3470fad7d64dfc9d5ebd7ed0c09cb1fb5e2488f";
-      hash = "sha256-z65W3k2OA/QDX0jJu4nmXtpi8kTcUFN7cK82PsI4jrQ=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace cmake/tools/version_files.py \
@@ -43,20 +36,11 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "args.git_date" '"1970-01-01"'
     substituteInPlace cmake/templates/lcevc_dec.pc.in \
       --replace-fail "@GIT_SHORT_VERSION@" "${finalAttrs.version}"
-
-  ''
-  + lib.optionalString (!stdenv.hostPlatform.avxSupport) ''
-    substituteInPlace cmake/modules/Compiler/GNU.cmake \
-      --replace-fail "-mavx" ""
-
-     substituteInPlace src/core/decoder/src/common/simd.c \
-      --replace-fail "((_xgetbv(kControlRegister) & kOSXSaveMask) == kOSXSaveMask)" "false"
   '';
 
   env = {
     includedir = "${placeholder "dev"}/include";
     libdir = "${placeholder "out"}/lib";
-    NIX_CFLAGS_COMPILE = "-Wno-error=unused-variable";
   };
 
   nativeBuildInputs = [
@@ -78,6 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "VN_CORE_AVX2" stdenv.hostPlatform.avx2Support)
     # Requires avx for checking on runtime
     (lib.cmakeBool "VN_CORE_SSE" stdenv.hostPlatform.avxSupport)
+    (lib.cmakeBool "VN_SDK_SIMD" stdenv.hostPlatform.avxSupport)
   ];
 
   passthru = {

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -512,6 +512,11 @@ stdenv.mkDerivation (
           url = "https://gitlab.archlinux.org/archlinux/packaging/packages/ffmpeg/-/raw/a02c1a15706ea832c0d52a4d66be8fb29499801a/add-av_stream_get_first_dts-for-chromium.patch";
           hash = "sha256-DbH6ieJwDwTjKOdQ04xvRcSLeeLP2Z2qEmqeo8HsPr4=";
         })
+        (fetchpatch2 {
+          name = "lcevcdec-4.0.0-compat.patch";
+          url = "https://code.ffmpeg.org/FFmpeg/FFmpeg/commit/fa23202cc7baab899894e8d22d82851a84967848.patch";
+          hash = "sha256-Ixkf1xzuDGk5t8J/apXKtghY0X9cfqSj/q987zrUuLQ=";
+        })
       ]
       ++ optionals (lib.versionOlder version "7.2") [
         (fetchpatch2 {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
