### PR TITLE
python3Packages.colorize-pinyin: init at 2.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11456,6 +11456,12 @@
     githubId = 5283991;
     name = "Jake Waksbaum";
   };
+  jakobgetz = {
+    email = "jakob@getz.de";
+    github = "jakobgetz";
+    githubId = 64084560;
+    name = "Jakob Getz";
+  };
   jakubgs = {
     email = "jakub@gsokolowski.pl";
     github = "jakubgs";

--- a/pkgs/development/python-modules/colorize-pinyin/default.nix
+++ b/pkgs/development/python-modules/colorize-pinyin/default.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+buildPythonPackage rec {
+  pname = "colorize-pinyin";
+  version = "2.1.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "colorize_pinyin";
+    inherit version;
+    hash = "sha256-0qqa2uUOqaLVkEJxDugwtQIKF8Ba5cRVeGww4oS+j7k=";
+  };
+
+  build-system = [ setuptools ];
+
+  meta = {
+    description = "Search for chinese pinyin and wrap it with HTML";
+    homepage = "https://pypi.org/project/colorize-pinyin/";
+    license = lib.licenses.wtfpl;
+    maintainers = with lib.maintainers; [ jakobgetz ];
+    mainProgram = "colorize_pinyin";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2849,6 +2849,8 @@ self: super: with self; {
 
   colorful = callPackage ../development/python-modules/colorful { };
 
+  colorize-pinyin = callPackage ../development/python-modules/colorize-pinyin { };
+
   colorlog = callPackage ../development/python-modules/colorlog { };
 
   colorlover = callPackage ../development/python-modules/colorlover { };


### PR DESCRIPTION
Added python package colorize pinyin. Needed for pyglossary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
