### PR TITLE
trafficserver: 9.2.11 -> 10.1.0

### DIFF
--- a/pkgs/by-name/tr/trafficserver/test-reset-root.patch
+++ b/pkgs/by-name/tr/trafficserver/test-reset-root.patch
@@ -1,0 +1,12 @@
+diff --git a/src/tscore/unit_tests/test_layout.cc b/src/tscore/unit_tests/test_layout.cc
+index 278728dc0..74471c44a 100644
+--- a/src/tscore/unit_tests/test_layout.cc
++++ b/src/tscore/unit_tests/test_layout.cc
+@@ -40,6 +40,7 @@ append_slash(const char *path)
+ 
+ TEST_CASE("constructor test", "[constructor]")
+ {
++  unsetenv("TS_ROOT");
+   Layout layout;
+   // test for constructor
+   REQUIRE(layout.prefix == TS_BUILD_PREFIX);


### PR DESCRIPTION
This updates trafficserver to the next major version.

Notably:
* it no longer builds the manpages, as those are part of building the 'docs' now, and building the 'docs' is complicated and needs a bunch of extra dependencies.
* it does not work yet because I don't quite understand how the build-time defaults and run-time settings interact (I already didn't understand that for 9.x ;) ). The `trafficserver.tests` nicely captures this though

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
