### PR TITLE
uhd: 4.8.0.0 -> 4.9.0.0

### DIFF
--- a/pkgs/by-name/uh/uhd/fix-pkg-config.patch
+++ b/pkgs/by-name/uh/uhd/fix-pkg-config.patch
@@ -1,0 +1,48 @@
+From 32944bbdbf2c7611e72ec9828464978ca42824ce Mon Sep 17 00:00:00 2001
+From: Jakob Kukla <jakob.kukla@gmail.com>
+Date: Fri, 12 Sep 2025 10:31:22 +0000
+Subject: [PATCH] cmake: support absolute paths for install dirs in pkg-config
+
+The GNUInstallDirs module supports absolute paths for CMAKE_INSTALL_LIBDIR and CMAKE_INSTALL_INCLUDEDIR. Some package managers like Nix depend on this behaviour. See https://github.com/NixOS/nixpkgs/issues/144170 for the nixpkgs tracking issue.
+---
+ host/CMakeLists.txt | 12 ++++++++++++
+ host/uhd.pc.in      |  4 ++--
+ 2 files changed, 14 insertions(+), 2 deletions(-)
+
+diff --git a/host/CMakeLists.txt b/host/CMakeLists.txt
+index 3e93ea1f0c..4cd0afad9d 100644
+--- a/host/CMakeLists.txt
++++ b/host/CMakeLists.txt
+@@ -559,6 +559,18 @@ if(CMAKE_CROSSCOMPILING)
+     set(UHD_PC_LIBS)
+ endif(CMAKE_CROSSCOMPILING)
+ 
++# Support absolute paths for LIBDIR and INCLUDEDIR
++if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
++    set(UHD_PC_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
++else()
++    set(UHD_PC_LIBDIR "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
++endif()
++if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
++    set(UHD_PC_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
++else()
++    set(UHD_PC_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
++endif()
++
+ configure_file(
+     ${CMAKE_CURRENT_SOURCE_DIR}/uhd.pc.in
+     ${CMAKE_CURRENT_BINARY_DIR}/uhd.pc
+diff --git a/host/uhd.pc.in b/host/uhd.pc.in
+index 4a5f67c969..f121e2fb70 100644
+--- a/host/uhd.pc.in
++++ b/host/uhd.pc.in
+@@ -1,7 +1,7 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
++libdir=@UHD_PC_LIBDIR@
++includedir=@UHD_PC_INCLUDEDIR@
+ 
+ Name: @CPACK_PACKAGE_NAME@
+ Description: @CPACK_PACKAGE_DESCRIPTION_SUMMARY@

--- a/pkgs/by-name/uh/uhd/package.nix
+++ b/pkgs/by-name/uh/uhd/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   #
   #     nix-shell maintainers/scripts/update.nix --argstr package uhd --argstr commit true
   #
-  version = "4.8.0.0";
+  version = "4.9.0.0";
 
   outputs = [
     "out"
@@ -57,14 +57,14 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     # The updateScript relies on the `src` using `hash`, and not `sha256. To
     # update the correct hash for the `src` vs the `uhdImagesSrc`
-    hash = "sha256-1HnXFeja4g1o64IPUkv/YyP/3upgYsjCVWal8t/hcuc=";
+    hash = "sha256-XA/ADJ0HjD6DxqFTVMwFa7tRgM56mHAEL+a0paWxKyM=";
   };
   # Firmware images are downloaded (pre-built) from the respective release on Github
   uhdImagesSrc = fetchurl {
     url = "https://github.com/EttusResearch/uhd/releases/download/v${finalAttrs.version}/uhd-images_${finalAttrs.version}.tar.xz";
     # Please don't convert this to a hash, in base64, see comment near src's
     # hash.
-    sha256 = "0i5zagajj0hzdnavvzaixbn6nkh8p9aqw1lv1bj9lpbdh2wy4bk0";
+    sha256 = "194gsmvn7gmwj7b1lw9sq0d0y0babbd0q1229qbb3qjc6f6m0p0y";
   };
   # This are the minimum required Python dependencies, this attribute might
   # be useful if you want to build a development environment with a python
@@ -175,6 +175,10 @@ stdenv.mkDerivation (finalAttrs: {
     ++ optionals (enableDpdk) [
       dpdk
     ];
+
+  patches = [
+    ./fix-pkg-config.patch
+  ];
 
   # many tests fails on darwin, according to ofborg
   doCheck = !stdenv.hostPlatform.isDarwin;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
