### PR TITLE
multiviewer-for-f1: 1.43.2 -> 2.1.0, fix build issues

### DIFF
--- a/pkgs/by-name/mu/multiviewer-for-f1/package.nix
+++ b/pkgs/by-name/mu/multiviewer-for-f1/package.nix
@@ -25,15 +25,15 @@
   writeScript,
 }:
 let
-  id = "243289393";
+  id = "289869947";
 in
 stdenvNoCC.mkDerivation rec {
   pname = "multiviewer-for-f1";
-  version = "1.43.2";
+  version = "2.1.0";
 
   src = fetchurl {
-    url = "https://releases.multiviewer.dev/download/${id}/multiviewer-for-f1_${version}_amd64.deb";
-    sha256 = "sha256-wdA5f/80GkKP6LrrP2E6M9GY5bl6rg7Spz7NWB7cQjg=";
+    url = "https://releases.multiviewer.dev/download/${id}/multiviewer_${version}_amd64.deb";
+    sha256 = "sha256-H+tt2FiT1UxkWBxpuyOIUjRMOMl7kN/SFH/WqoRdVUU=";
   };
 
   nativeBuildInputs = [
@@ -83,13 +83,11 @@ stdenvNoCC.mkDerivation rec {
     runHook preInstall
 
     mkdir -p $out/bin $out/share
-    mv -t $out/share usr/share/* usr/lib/multiviewer-for-f1
+    mv -t $out/share usr/share/* usr/lib/multiviewer
 
-    makeWrapper "$out/share/multiviewer-for-f1/MultiViewer for F1" $out/bin/multiviewer-for-f1 \
+    makeWrapper "$out/share/multiviewer/multiviewer" $out/bin/multiviewer \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
-      --prefix LD_LIBRARY_PATH : "${
-        lib.makeLibraryPath [ libudev0-shim ]
-      }:\"$out/share/Multiviewer for F1\""
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libudev0-shim ]}:\"$out/share/multiviewer\""
 
     runHook postInstall
   '';
@@ -125,6 +123,6 @@ stdenvNoCC.mkDerivation rec {
     license = licenses.unfree;
     maintainers = with maintainers; [ babeuh ];
     platforms = [ "x86_64-linux" ];
-    mainProgram = "multiviewer-for-f1";
+    mainProgram = "multiviewer";
   };
 }


### PR DESCRIPTION
This pull request updates the packaging for `multiviewer-for-f1` to support the latest upstream release and reflect significant changes in the application's structure and naming. The most important changes are grouped below:

Version and source update:

* Updated the package to version `2.1.0` and changed the release ID and SHA256 hash to match the new upstream release.

Renaming and installation adjustments:

* Changed installation paths and wrapper script to use `multiviewer` instead of `multiviewer-for-f1`, reflecting the new application name and directory structure. **(without this change the build fail)**
* Updated the main program entry from `multiviewer-for-f1` to `multiviewer` to match the new binary name.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
---