### PR TITLE
python3Packages.ffmpeg-progress-yield: fix build on Darwin

### DIFF
--- a/pkgs/development/python-modules/ffmpeg-progress-yield/default.nix
+++ b/pkgs/development/python-modules/ffmpeg-progress-yield/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
@@ -39,6 +40,16 @@ buildPythonPackage rec {
   ];
 
   enabledTestPaths = [ "test/test.py" ];
+
+  disabledTests = lib.optional stdenv.hostPlatform.isDarwin [
+    # cannot access /usr/bin/pgrep from the sandbox
+    "test_context_manager"
+    "test_context_manager_with_exception"
+    "test_automatic_cleanup_on_exception"
+    "test_async_context_manager"
+    "test_async_context_manager_with_exception"
+    "test_async_automatic_cleanup_on_exception"
+  ];
 
   pythonImportsCheck = [ "ffmpeg_progress_yield" ];
 


### PR DESCRIPTION
Darwin builds can't access `pgrep` from the sandbox (or at least I assume that to be the case based on mobly[1]), and tests for this module use it[2].

Thus we disable the failing tests on Darwin

[1] https://github.com/slhck/ffmpeg-progress-yield/blob/9c60183950404cca2e660d3f26c9a6f06bd1fc26/tests/test_ffmpeg_progress.py#L20
[2] https://github.com/NixOS/nixpkgs/blob/9aaf71a4a74d835ec05ac3ddf5fc1b859e005c41/pkgs/development/python-modules/mobly/default.nix#L52


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 440714`
Commit: `8b185270358381402451114deb3c14d235b1c74a`

---
### `aarch64-darwin`
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>ffmpeg-normalize</li>
    <li>ffmpeg-normalize.dist</li>
    <li>python312Packages.ffmpeg-progress-yield</li>
    <li>python312Packages.ffmpeg-progress-yield.dist</li>
    <li>python313Packages.ffmpeg-progress-yield</li>
    <li>python313Packages.ffmpeg-progress-yield.dist</li>
  </ul>
</details>

Current state on Darwin
```
error: builder for '/nix/store/5804dhs2v5fzhaza6cj2lni56243a18y-python3.13-ffmpeg-progress-yield-1.0.2.drv' failed with exit code 1;
       last 25 log lines:
       >                 errno_num = int(hex_errno, 16)
       >                 if err_msg == "noexec:chdir":
       >                     err_msg = ""
       >                     # The error must be from chdir(cwd).
       >                     err_filename = cwd
       >                 elif err_msg == "noexec":
       >                     err_msg = ""
       >                     err_filename = None
       >                 else:
       >                     err_filename = orig_executable
       >                 if errno_num != 0:
       >                     err_msg = os.strerror(errno_num)
       >                 if err_filename is not None:
       > >                   raise child_exception_type(errno_num, err_msg, err_filename)
       > E                   FileNotFoundError: [Errno 2] No such file or directory: 'pgrep'
       >
       > /nix/store/9px7zzsfnlmj61yy2fpl6z14w93j05is-python3-3.13.6/lib/python3.13/subprocess.py:1972: FileNotFoundError
       > =========================== short test summary info ============================
       > FAILED test/test.py::TestLibrary::test_context_manager - FileNotFoundError: [Errno 2] No such file or directory: 'pgrep'
       > FAILED test/test.py::TestLibrary::test_context_manager_with_exception - FileNotFoundError: [Errno 2] No such file or directory: 'pgrep'
       > FAILED test/test.py::TestLibrary::test_automatic_cleanup_on_exception - FileNotFoundError: [Errno 2] No such file or directory: 'pgrep'
       > FAILED test/test.py::TestAsyncLibrary::test_async_context_manager - FileNotFoundError: [Errno 2] No such file or directory: 'pgrep'
       > FAILED test/test.py::TestAsyncLibrary::test_async_context_manager_with_exception - FileNotFoundError: [Errno 2] No such file or directory: 'pgrep'
       > FAILED test/test.py::TestAsyncLibrary::test_async_automatic_cleanup_on_exception - FileNotFoundError: [Errno 2] No such file or directory: 'pgrep'
       > ======================== 6 failed, 14 passed in 26.93s =========================
```

Post-change
```
ffmpeg-progress-yield> Check whether the following modules can be imported: ffmpeg_progress_yield
ffmpeg-progress-yield> Running phase: pytestCheckPhase
ffmpeg-progress-yield> Executing pytestCheckPhase
ffmpeg-progress-yield> pytest flags: -m pytest test/test.py -k not\ \(test_context_manager\)\ and\ not\ \(test_context_manager_with_exception\)\ and\ not\ \(test_automatic_cleanup_on_exception\)\ and\ not\ \(test_async_context_manager\)\ and\ not\ \(test_async_context_manager_with_exception\)\ and\ not\ \(test_async_automatic_cleanup_on_exception\)
ffmpeg-progress-yield> ============================= test session starts ==============================
ffmpeg-progress-yield> platform darwin -- Python 3.13.6, pytest-8.4.1, pluggy-1.6.0
ffmpeg-progress-yield> rootdir: /nix/var/nix/builds/nix-build-python3.13-ffmpeg-progress-yield-1.0.2.drv-0/b/source
ffmpeg-progress-yield> configfile: pytest.ini
ffmpeg-progress-yield> plugins: asyncio-1.1.0
ffmpeg-progress-yield> asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope="function", asyncio_default_test_loop_scope=function
ffmpeg-progress-yield> collected 20 items / 6 deselected / 14 selected
ffmpeg-progress-yield>
ffmpeg-progress-yield> test/test.py ..............                                              [100%]
ffmpeg-progress-yield>
ffmpeg-progress-yield> ====================== 14 passed, 6 deselected in 18.26s =======================
ffmpeg-progress-yield> Finished executing pytestCheckPhase
ffmpeg-progress-yield> Running phase: pytestcachePhase
ffmpeg-progress-yield> Running phase: pytestRemoveBytecodePhase
```

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
