### PR TITLE
python3Packages.playwright-stealth: 1.0.6-unstable-2023-09-11 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/playwright-stealth/default.nix
+++ b/pkgs/development/python-modules/playwright-stealth/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   playwright,
-  pythonOlder,
   setuptools,
 }:
 
@@ -11,8 +10,6 @@ buildPythonPackage {
   pname = "playwright-stealth";
   version = "1.0.6-unstable-2023-09-11";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "AtuboDad";
@@ -22,19 +19,19 @@ buildPythonPackage {
     hash = "sha256-ZWmuVwjEgrPmfxjvws3TdocW6tyNH++fyRfKQ0oJ6bo=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [ playwright ];
+  dependencies = [ playwright ];
 
   # Tests require Chromium binary
   doCheck = false;
 
   pythonImportsCheck = [ "playwright_stealth" ];
 
-  meta = with lib; {
+  meta = {
     description = "Playwright stealth";
     homepage = "https://github.com/AtuboDad/playwright_stealth";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/playwright-stealth/default.nix
+++ b/pkgs/development/python-modules/playwright-stealth/default.nix
@@ -1,25 +1,24 @@
 {
-  lib,
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchPypi,
+  lib,
   playwright,
-  setuptools,
+  poetry-core,
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "playwright-stealth";
-  version = "1.0.6-unstable-2023-09-11";
+  version = "2.0.0";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "AtuboDad";
-    repo = "playwright_stealth";
-    # https://github.com/AtuboDad/playwright_stealth/issues/25
-    rev = "43f7433057906945b1648179304d7dbd8eb10874";
-    hash = "sha256-ZWmuVwjEgrPmfxjvws3TdocW6tyNH++fyRfKQ0oJ6bo=";
+  # Changes haven't been pushed to Github or Gitlab; pypi is the only source
+  src = fetchPypi {
+    inherit version;
+    pname = "playwright_stealth";
+    hash = "sha256-T0TUFtQiZomJWk0c+0Do0TchbAyXEOqPhLri2/EYb8U=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ poetry-core ];
 
   dependencies = [ playwright ];
 


### PR DESCRIPTION
1. Cleanup
2. Version bump (includes reversion to PyPi which appears to be the only source)

**NOTE** This fixes the [`lacus` build failures](https://hydra.nixos.org/build/306619495) by fixing [`python3Packages.playwrightcapture`](https://hydra.nixos.org/build/305650613)

See also: https://hydra.nixos.org/build/305650613
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
