### PR TITLE
hidamari: init at 3.6

### DIFF
--- a/pkgs/by-name/hi/hidamari/package.nix
+++ b/pkgs/by-name/hi/hidamari/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  adwaita-icon-theme,
+  desktop-file-utils,
+  fetchFromGitHub,
+  ffmpeg,
+  gnome-desktop,
+  gobject-introspection,
+  libappindicator-gtk3,
+  libwnck,
+  mesa-demos,
+  meson,
+  ninja,
+  nix-update-script,
+  python3Packages,
+  vdpauinfo,
+  webkitgtk_4_1,
+  wrapGAppsHook3,
+  xdg-user-dirs,
+}:
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "hidamari";
+  version = "3.6";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "jeffshee";
+    repo = "hidamari";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-4hpznrnV1Mc2GVh2Oo4y6/M++YtEO3snHkfzP2kog50=";
+  };
+
+  pyproject = false;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    wrapGAppsHook3
+    gobject-introspection
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    ffmpeg
+    gnome-desktop
+    libappindicator-gtk3
+    libwnck
+    mesa-demos
+    vdpauinfo
+    webkitgtk_4_1
+    xdg-user-dirs
+  ];
+
+  dependencies = with python3Packages; [
+    pillow
+    pydbus
+    pygobject3
+    python-vlc
+    requests
+    setproctitle
+    yt-dlp
+  ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix XDG_DATA_DIRS : "${adwaita-icon-theme}/share"
+    )
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Video wallpaper for Linux";
+    homepage = "https://github.com/jeffshee/hidamari";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ PerchunPak ];
+    mainProgram = "hidamari";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/jeffshee/hidamari: Video wallpaper for Linux

Tested on KDE (nixos 25.05)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
