### PR TITLE
benchmark: init at 1.9.4

### DIFF
--- a/pkgs/by-name/be/benchmark/package.nix
+++ b/pkgs/by-name/be/benchmark/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  gtest,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "benchmark";
+  version = "1.9.5";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "benchmark";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Mm4pG7zMB00iof32CxreoNBFnduPZTMp3reHMCIAFPQ=";
+  };
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ gtest ];
+
+  cmakeFlags = [
+    "-DBENCHMARK_USE_BUNDLED_GTEST=OFF"
+    "-DBENCHMARK_ENABLE_GTEST_TESTS=OFF"
+    "-DBENCHMARK_ENABLE_TESTING=OFF"
+    "-DBENCHMARK_DOWNLOAD_DEPENDENCIES=OFF"
+  ];
+
+  strictDeps = true;
+
+  meta = {
+    description = "A microbenchmark support library";
+    downloadPage = "https://github.com/google/benchmark";
+    homepage = "https://github.com/google/benchmark/blob/main/docs/user_guide.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ guelakais ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
