### PR TITLE
haskell.compiler.ghc{948,967,984,9102,9103,9121,9122}: backport patches for LLVM support

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -269,7 +269,9 @@
       # Missing ELF symbols
       ++ lib.optionals stdenv.targetPlatform.isAndroid [
         ./ghc-define-undefined-elf-st-visibility.patch
-      ];
+      ]
+
+      ++ (import ./common-llvm-patches.nix { inherit lib version fetchpatch; });
 
     stdenv = stdenvNoCC;
   },
@@ -859,8 +861,6 @@ stdenv.mkDerivation (
       timeout = 24 * 3600;
       platforms = lib.platforms.all;
       inherit (bootPkgs.ghc.meta) license;
-      # To be fixed by <https://github.com/NixOS/nixpkgs/pull/440774>.
-      broken = useLLVM;
     };
 
     dontStrip = targetPlatform.useAndroidPrebuilt || targetPlatform.isWasm;

--- a/pkgs/development/compilers/ghc/common-llvm-patches.nix
+++ b/pkgs/development/compilers/ghc/common-llvm-patches.nix
@@ -1,0 +1,126 @@
+{
+  lib,
+  version,
+  fetchpatch,
+}:
+
+# Backports for LLVM support.
+#
+# These primarily focus on backporting patches that are relevant to
+# supporting newer LLVM versions, rather than aiming to backport every
+# LLVM backend bug fix or improvement from newer GHC releases.
+#
+# Potentially of interest for cross‐compiling GHC 9.4.8 to LoongArch64:
+#
+# * <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/9292>
+# * <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13620>
+
+[ ]
+
+++ lib.optionals (lib.versionOlder version "9.6") [
+  # <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/9857>
+  (fetchpatch {
+    name = "ghc-9.4-llvm-support-15.patch";
+    url = "https://gitlab.haskell.org/ghc/ghc/-/commit/0cc16aaf89d7dc3963764b7193ceac73e4e3329b.patch";
+    hash = "sha256-G0gqrj5iPuQ5JuC2+d151yka72XZMbrqMWPZd4EuT04=";
+  })
+
+  # <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13763>
+  ./ghc-9.4-llvm-fix-version-detection.patch
+]
+
+++ lib.optionals (lib.versionOlder version "9.8") [
+  (
+    # The upstream backport of !13763 in 9.6.7 removed an unused import
+    # that is required by the next series.
+    if lib.versionOlder version "9.6" then null else ./ghc-9.6-llvm-restore-import.patch
+  )
+]
+
+++ lib.optionals (lib.versionOlder version "9.10") [
+  # <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/11124>
+  (
+    if lib.versionOlder version "9.8" then
+      ./ghc-9.4-llvm-add-metadata-exports.patch
+    else
+      fetchpatch {
+        name = "ghc-9.8-llvm-add-metadata-exports.patch";
+        url = "https://gitlab.haskell.org/ghc/ghc/-/commit/fcfc1777c22ad47613256c3c5e7304cfd29bc761.patch";
+        hash = "sha256-9rpyeH8TUVeKoW4PA6qn7DG2+P9MhBCywmbi1O/NsTQ=";
+      }
+  )
+  (
+    if lib.versionOlder version "9.8" then
+      ./ghc-9.4-llvm-allow-llvmlits-in-metaexprs.patch
+    else
+      fetchpatch {
+        name = "ghc-9.8-llvm-allow-llvmlits-in-metaexprs.patch";
+        url = "https://gitlab.haskell.org/ghc/ghc/-/commit/5880fff6d353a14785c457999fded5a7100c9514.patch";
+        hash = "sha256-NDMGNc0PYpWJUW+nI2YvMsBOWRIfNix4oWHQZAIxrVY=";
+      }
+  )
+  (
+    # `GHC.Driver.DynFlags` was not split out until 9.8, so this can be
+    # omitted with no functional effect on the rest of the series on
+    # earlier versions.
+    if lib.versionOlder version "9.8" then
+      null
+    else
+      fetchpatch {
+        name = "ghc-9.8-move-feature-predicates-to-dynflags.patch";
+        url = "https://gitlab.haskell.org/ghc/ghc/-/commit/86ce92a2f81a04aa980da2891d0e300cb3cb7efd.patch";
+        hash = "sha256-SzJgzq4b5wAMPz+/QSa67iSOxB2enqejvV0lsF0+9L8=";
+      }
+  )
+  (fetchpatch {
+    name = "ghc-9.4-llvm-add-module-flag-metadata-infra.patch";
+    url = "https://gitlab.haskell.org/ghc/ghc/-/commit/a6a3874276ced1b037365c059dcd0a758e813a5b.patch";
+    hash = "sha256-tAYDRNXmpp5cZtyONpO8vlsDmnNEBbh4J3oSCy/uWWc=";
+  })
+  (
+    if lib.versionOlder version "9.8" then
+      ./ghc-9.4-llvm-fix-stack-alignment.patch
+    else
+      fetchpatch {
+        name = "ghc-9.8-llvm-fix-stack-alignment.patch";
+        url = "https://gitlab.haskell.org/ghc/ghc/-/commit/e9af2cf3f16ab60b5c79ed91df95359b11784df6.patch";
+        hash = "sha256-RmYwFN3c3AgJxF9KXWQLdwOgugzepCW1wcTdJX1h0C4=";
+      }
+  )
+
+  # <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/8999>
+  (
+    if lib.versionOlder version "9.6" then
+      ./ghc-9.4-llvm-use-new-pass-manager.patch
+    else if lib.versionOlder version "9.8" then
+      ./ghc-9.6-llvm-use-new-pass-manager.patch
+    else
+      ./ghc-9.8-llvm-use-new-pass-manager.patch
+  )
+]
+
+++ lib.optionals (lib.versionOlder version "9.12") [
+  # <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/12726>
+  (fetchpatch {
+    name = "ghc-9.4-llvm-support-16-17-18.patch";
+    url = "https://gitlab.haskell.org/ghc/ghc/-/commit/ae170155e82f1e5f78882f7a682d02a8e46a5823.patch";
+    hash = "sha256-U1znWqXZTORmAg480p5TjTL53T2Zn+1+9Fnk2V1Drfs=";
+  })
+
+  # <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13311>
+  (fetchpatch {
+    name = "ghc-9.4-llvm-support-19.patch";
+    url = "https://gitlab.haskell.org/ghc/ghc/-/commit/36bbb167f354a2fbc6c4842755f2b1e374e3580e.patch";
+    excludes = [ ".gitlab-ci.yml" ];
+    hash = "sha256-v8T/FtriDPbibcIDZmU2yotBoDVo+wU2+gw+CCdQlm0=";
+  })
+]
+
+++ lib.optionals (lib.versionOlder version "9.14") [
+  # <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/14600>
+  (fetchpatch {
+    name = "ghc-9.4-llvm-support-20.patch";
+    url = "https://gitlab.haskell.org/ghc/ghc/-/commit/ca03226db2db2696460bfcb8035dd3268d546706.patch";
+    hash = "sha256-7cO049DQtJHUAhwPujoFO+zQtXsMg6VFTHtMDwenrKs=";
+  })
+]

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -14,14 +14,12 @@
 
   # build-tools
   bootPkgs,
-  autoconf,
-  automake,
+  autoreconfHook,
   coreutils,
   fetchpatch,
   fetchurl,
   perl,
   python3,
-  m4,
   sphinx,
   xattr,
   autoSignDarwinBinariesHook,
@@ -546,10 +544,8 @@ stdenv.mkDerivation (
     dontAddExtraLibs = true;
 
     nativeBuildInputs = [
+      autoreconfHook
       perl
-      autoconf
-      automake
-      m4
       python3
       bootPkgs.alex
       bootPkgs.happy

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -476,8 +476,7 @@ stdenv.mkDerivation (
       grep linux-musl llvm-targets | sed 's/^/  /'
 
       echo "And now patching to preserve '-musleabi' as done with '-gnueabi'"
-      # (aclocal.m4 is actual source, but patch configure as well since we don't re-gen)
-      for x in configure aclocal.m4; do
+      for x in aclocal.m4; do
         substituteInPlace $x \
           --replace '*-android*|*-gnueabi*)' \
                     '*-android*|*-gnueabi*|*-musleabi*)'

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -444,7 +444,6 @@ stdenv.mkDerivation (
       export AR_STAGE0="$AR_FOR_BUILD"
 
       echo -n "${buildMK}" > mk/build.mk
-      sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
     ''
     # Haddock and sphinx need a working locale
     + lib.optionalString (enableDocs || enableHaddockProgram) (

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -386,7 +386,9 @@ stdenv.mkDerivation (
       # elimination on aarch64-darwin. (see
       # https://github.com/NixOS/nixpkgs/issues/140774 for details).
       ./Cabal-at-least-3.6-paths-fix-cycle-aarch64-darwin.patch
-    ];
+    ]
+
+    ++ (import ./common-llvm-patches.nix { inherit lib version fetchpatch; });
 
     postPatch = "patchShebangs .";
 
@@ -671,8 +673,6 @@ stdenv.mkDerivation (
       timeout = 24 * 3600;
       platforms = lib.platforms.all;
       inherit (bootPkgs.ghc.meta) license;
-      # To be fixed by <https://github.com/NixOS/nixpkgs/pull/440774>.
-      broken = useLLVM;
     };
 
   }

--- a/pkgs/development/compilers/ghc/ghc-9.4-llvm-add-metadata-exports.patch
+++ b/pkgs/development/compilers/ghc/ghc-9.4-llvm-add-metadata-exports.patch
@@ -1,0 +1,31 @@
+From 701154fdbceff2edb121768eb660713a98580af8 Mon Sep 17 00:00:00 2001
+From: Ben Gamari <ben@smart-cactus.org>
+Date: Tue, 22 Aug 2023 12:23:26 -0400
+Subject: [PATCH] llvmGen: Add export list to GHC.Llvm.MetaData
+
+(cherry picked from commit fcfc1777c22ad47613256c3c5e7304cfd29bc761)
+---
+ compiler/GHC/Llvm/MetaData.hs | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/compiler/GHC/Llvm/MetaData.hs b/compiler/GHC/Llvm/MetaData.hs
+index f46ae0a101..3526c11bc3 100644
+--- a/compiler/GHC/Llvm/MetaData.hs
++++ b/compiler/GHC/Llvm/MetaData.hs
+@@ -1,6 +1,12 @@
+ {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+ 
+-module GHC.Llvm.MetaData where
++module GHC.Llvm.MetaData
++  ( MetaId(..)
++  , ppr
++  , MetaExpr(..)
++  , MetaAnnot(..)
++  , MetaDecl(..)
++  ) where
+ 
+ import GHC.Prelude
+ 
+-- 
+2.50.1
+

--- a/pkgs/development/compilers/ghc/ghc-9.4-llvm-allow-llvmlits-in-metaexprs.patch
+++ b/pkgs/development/compilers/ghc/ghc-9.4-llvm-allow-llvmlits-in-metaexprs.patch
@@ -1,0 +1,40 @@
+From 51765e343e9829f1d3e95d1d7303fa3594ae91cc Mon Sep 17 00:00:00 2001
+From: Ben Gamari <ben@smart-cactus.org>
+Date: Tue, 22 Aug 2023 12:24:53 -0400
+Subject: [PATCH] llvmGen: Allow LlvmLits in MetaExprs
+
+This omission appears to be an oversight.
+
+(cherry picked from commit 5880fff6d353a14785c457999fded5a7100c9514)
+---
+ compiler/GHC/Llvm/MetaData.hs | 1 +
+ compiler/GHC/Llvm/Ppr.hs      | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/compiler/GHC/Llvm/MetaData.hs b/compiler/GHC/Llvm/MetaData.hs
+index f46ae0a101..121cdd5788 100644
+--- a/compiler/GHC/Llvm/MetaData.hs
++++ b/compiler/GHC/Llvm/MetaData.hs
+@@ -68,6 +68,7 @@ instance Outputable MetaId where
+ 
+ -- | LLVM metadata expressions
+ data MetaExpr = MetaStr !LMString
++              | MetaLit !LlvmLit
+               | MetaNode !MetaId
+               | MetaVar !LlvmVar
+               | MetaStruct [MetaExpr]
+diff --git a/compiler/GHC/Llvm/Ppr.hs b/compiler/GHC/Llvm/Ppr.hs
+index f48e7aa034..bc88a13439 100644
+--- a/compiler/GHC/Llvm/Ppr.hs
++++ b/compiler/GHC/Llvm/Ppr.hs
+@@ -256,6 +256,7 @@ ppMetaExpr :: LlvmCgConfig -> MetaExpr -> SDoc
+ ppMetaExpr opts = \case
+   MetaVar (LMLitVar (LMNullLit _)) -> text "null"
+   MetaStr    s                     -> char '!' <> doubleQuotes (ftext s)
++  MetaLit    l                     -> ppTypeLit opts l
+   MetaNode   n                     -> ppr n
+   MetaVar    v                     -> ppVar opts v
+   MetaStruct es                    -> char '!' <> braces (ppCommaJoin (map (ppMetaExpr opts) es))
+-- 
+2.50.1
+

--- a/pkgs/development/compilers/ghc/ghc-9.4-llvm-fix-stack-alignment.patch
+++ b/pkgs/development/compilers/ghc/ghc-9.4-llvm-fix-stack-alignment.patch
@@ -1,0 +1,137 @@
+From 646d62e74c16be785ef08735ae5b24f4af6bcf78 Mon Sep 17 00:00:00 2001
+From: Ben Gamari <ben@smart-cactus.org>
+Date: Tue, 22 Aug 2023 13:26:58 -0400
+Subject: [PATCH] llvmGen: Don't pass stack alignment via command line
+
+As of https://reviews.llvm.org/D103048 LLVM no longer supports the
+`-stack-alignment=...` flag. Instead this information is passed via a
+module flag metadata node.
+
+This requires dropping support for LLVM 11 and 12.
+
+Fixes #23870
+
+(cherry picked from commit e9af2cf3f16ab60b5c79ed91df95359b11784df6)
+---
+ compiler/GHC/CmmToLlvm.hs               | 29 ++++++++++++++++++++++++-
+ compiler/GHC/CmmToLlvm/Config.hs        |  1 +
+ compiler/GHC/Driver/Config/CmmToLlvm.hs |  1 +
+ compiler/GHC/Driver/Pipeline/Execute.hs |  7 ------
+ configure.ac                            |  2 +-
+ 5 files changed, 31 insertions(+), 9 deletions(-)
+
+diff --git a/compiler/GHC/CmmToLlvm.hs b/compiler/GHC/CmmToLlvm.hs
+index 7d48693765..b9036daef1 100644
+--- a/compiler/GHC/CmmToLlvm.hs
++++ b/compiler/GHC/CmmToLlvm.hs
+@@ -190,7 +190,7 @@ cmmLlvmGen _ = return ()
+ 
+ cmmMetaLlvmPrelude :: LlvmM ()
+ cmmMetaLlvmPrelude = do
+-  metas <- flip mapM stgTBAA $ \(uniq, name, parent) -> do
++  tbaa_metas <- flip mapM stgTBAA $ \(uniq, name, parent) -> do
+     -- Generate / lookup meta data IDs
+     tbaaId <- getMetaUniqueId
+     setUniqMeta uniq tbaaId
+@@ -203,9 +203,36 @@ cmmMetaLlvmPrelude = do
+               -- just a name on its own. Previously `null` was accepted as the
+               -- name.
+               Nothing -> [ MetaStr name ]
++
++  platform <- getPlatform
++  cfg <- getConfig
++  let stack_alignment_metas =
++          case platformArch platform of
++            ArchX86_64 | llvmCgAvxEnabled cfg -> [mkStackAlignmentMeta 32]
++            _                                 -> []
++  module_flags_metas <- mkModuleFlagsMeta stack_alignment_metas
++  let metas = tbaa_metas ++ module_flags_metas
+   cfg <- getConfig
+   renderLlvm $ ppLlvmMetas cfg metas
+ 
++mkNamedMeta :: LMString -> [MetaExpr] -> LlvmM [MetaDecl]
++mkNamedMeta name exprs = do
++    (ids, decls) <- unzip <$> mapM f exprs
++    return $ decls ++ [MetaNamed name ids]
++  where
++    f expr = do
++      i <- getMetaUniqueId
++      return (i, MetaUnnamed i expr)
++
++mkModuleFlagsMeta :: [ModuleFlag] -> LlvmM [MetaDecl]
++mkModuleFlagsMeta =
++    mkNamedMeta "llvm.module.flags" . map moduleFlagToMetaExpr
++
++mkStackAlignmentMeta :: Integer -> ModuleFlag
++mkStackAlignmentMeta alignment =
++    ModuleFlag MFBError "override-stack-alignment" (MetaLit $ LMIntLit alignment i32)
++
++
+ -- -----------------------------------------------------------------------------
+ -- | Marks variables as used where necessary
+ --
+diff --git a/compiler/GHC/CmmToLlvm/Config.hs b/compiler/GHC/CmmToLlvm/Config.hs
+index 649a33c2f6..ecab7fdcc1 100644
+--- a/compiler/GHC/CmmToLlvm/Config.hs
++++ b/compiler/GHC/CmmToLlvm/Config.hs
+@@ -36,6 +36,7 @@ data LlvmCgConfig = LlvmCgConfig
+   , llvmCgContext           :: !SDocContext  -- ^ Context for LLVM code generation
+   , llvmCgFillUndefWithGarbage :: !Bool      -- ^ Fill undefined literals with garbage values
+   , llvmCgSplitSection      :: !Bool         -- ^ Split sections
++  , llvmCgAvxEnabled        :: !Bool
+   , llvmCgBmiVersion        :: Maybe BmiVersion  -- ^ (x86) BMI instructions
+   , llvmCgLlvmVersion       :: Maybe LlvmVersion -- ^ version of Llvm we're using
+   , llvmCgDoWarn            :: !Bool         -- ^ True ==> warn unsupported Llvm version
+diff --git a/compiler/GHC/Driver/Config/CmmToLlvm.hs b/compiler/GHC/Driver/Config/CmmToLlvm.hs
+index 8097bbec7e..752ba987ca 100644
+--- a/compiler/GHC/Driver/Config/CmmToLlvm.hs
++++ b/compiler/GHC/Driver/Config/CmmToLlvm.hs
+@@ -23,6 +23,7 @@ initLlvmCgConfig logger config_cache dflags = do
+     , llvmCgContext              = initSDocContext dflags PprCode
+     , llvmCgFillUndefWithGarbage = gopt Opt_LlvmFillUndefWithGarbage dflags
+     , llvmCgSplitSection         = gopt Opt_SplitSections dflags
++    , llvmCgAvxEnabled           = isAvxEnabled dflags
+     , llvmCgBmiVersion           = case platformArch (targetPlatform dflags) of
+                                       ArchX86_64 -> bmiVersion dflags
+                                       ArchX86    -> bmiVersion dflags
+diff --git a/compiler/GHC/Driver/Pipeline/Execute.hs b/compiler/GHC/Driver/Pipeline/Execute.hs
+index fac2a595f2..4fa72be475 100644
+--- a/compiler/GHC/Driver/Pipeline/Execute.hs
++++ b/compiler/GHC/Driver/Pipeline/Execute.hs
+@@ -992,8 +992,6 @@ llvmOptions llvm_config dflags =
+        [("-enable-tbaa -tbaa",  "-enable-tbaa") | gopt Opt_LlvmTBAA dflags ]
+     ++ [("-relocation-model=" ++ rmodel
+         ,"-relocation-model=" ++ rmodel) | not (null rmodel)]
+-    ++ [("-stack-alignment=" ++ (show align)
+-        ,"-stack-alignment=" ++ (show align)) | align > 0 ]
+ 
+     -- Additional llc flags
+     ++ [("", "-mcpu=" ++ mcpu)   | not (null mcpu)
+@@ -1012,11 +1010,6 @@ llvmOptions llvm_config dflags =
+ 
+         platform = targetPlatform dflags
+ 
+-        align :: Int
+-        align = case platformArch platform of
+-                  ArchX86_64 | isAvxEnabled dflags -> 32
+-                  _                                -> 0
+-
+         attrs :: String
+         attrs = intercalate "," $ mattr
+               ++ ["+sse42"   | isSse4_2Enabled dflags   ]
+diff --git a/configure.ac b/configure.ac
+index 16f2e8b339..0440d5051b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -555,7 +555,7 @@ AC_SUBST(InstallNameToolCmd)
+ # tools we are looking for. In the past, GHC supported a number of
+ # versions of LLVM simultaneously, but that stopped working around
+ # 3.5/3.6 release of LLVM.
+-LlvmMinVersion=11  # inclusive
++LlvmMinVersion=13  # inclusive
+ LlvmMaxVersion=16 # not inclusive
+ AC_SUBST([LlvmMinVersion])
+ AC_SUBST([LlvmMaxVersion])
+-- 
+2.50.1
+

--- a/pkgs/development/compilers/ghc/ghc-9.4-llvm-fix-version-detection.patch
+++ b/pkgs/development/compilers/ghc/ghc-9.4-llvm-fix-version-detection.patch
@@ -1,0 +1,103 @@
+From c1229507e29e5c44b6f23d6f2afb5d55e7fb9606 Mon Sep 17 00:00:00 2001
+From: ARATA Mizuki <minorinoki@gmail.com>
+Date: Wed, 25 Dec 2024 22:50:46 +0900
+Subject: [PATCH] Fix LLVM version detection
+
+With a recent LLVM, `llc -version` emits the version on the first line
+if the vendor is set.  It emits the version on the second line
+otherwise.
+
+Therefore, we need to check the both lines to detect the version.
+
+GHC now emits a warning if it fails to detect the LLVM version,
+so we can notice if the output of `llc -version` changes in the future.
+
+Also, the warning for using LLVM < 10 on s390x is removed, because
+we assume LLVM >= 13 now.
+
+This fixes the definition of __GLASGOW_HASKELL_LLVM__ macro.
+
+Fixes #25606
+
+(cherry picked from commit a928c326011f1a6bef3289a4c36d4e19b5951229)
+---
+ compiler/GHC/CmmToLlvm.hs      | 14 ++++++++------
+ compiler/GHC/SysTools/Tasks.hs | 13 ++++++++-----
+ docs/users_guide/phases.rst    |  2 +-
+ 3 files changed, 17 insertions(+), 12 deletions(-)
+
+diff --git a/compiler/GHC/CmmToLlvm.hs b/compiler/GHC/CmmToLlvm.hs
+index ecf111c636..76541c477c 100644
+--- a/compiler/GHC/CmmToLlvm.hs
++++ b/compiler/GHC/CmmToLlvm.hs
+@@ -38,7 +38,7 @@ import GHC.Utils.Logger
+ import qualified GHC.Data.Stream as Stream
+ 
+ import Control.Monad ( when, forM_ )
+-import Data.Maybe ( fromMaybe, catMaybes )
++import Data.Maybe ( fromMaybe, catMaybes, isNothing )
+ import System.IO
+ 
+ -- -----------------------------------------------------------------------------
+@@ -68,11 +68,13 @@ llvmCodeGen logger cfg h cmm_stream
+            "up to" <+> text (llvmVersionStr supportedLlvmVersionUpperBound) <+> "(non inclusive) is supported." <+>
+            "System LLVM version: " <> text (llvmVersionStr ver) $$
+            "We will try though..."
+-         let isS390X = platformArch (llvmCgPlatform cfg)  == ArchS390X
+-         let major_ver = head . llvmVersionList $ ver
+-         when (isS390X && major_ver < 10 && doWarn) $ putMsg logger $
+-           "Warning: For s390x the GHC calling convention is only supported since LLVM version 10." <+>
+-           "You are using LLVM version: " <> text (llvmVersionStr ver)
++
++       when (isNothing mb_ver) $ do
++         let doWarn = llvmCgDoWarn cfg
++         when doWarn $ putMsg logger $
++           "Failed to detect LLVM version!" $$
++           "Make sure LLVM is installed correctly." $$
++           "We will try though..."
+ 
+        -- HACK: the Nothing case here is potentially wrong here but we
+        -- currently don't use the LLVM version to guide code generation
+diff --git a/compiler/GHC/SysTools/Tasks.hs b/compiler/GHC/SysTools/Tasks.hs
+index 7cd5188d5f..165e1602cf 100644
+--- a/compiler/GHC/SysTools/Tasks.hs
++++ b/compiler/GHC/SysTools/Tasks.hs
+@@ -236,14 +236,17 @@ figureLlvmVersion logger dflags = traceToolCommand logger "llc" $ do
+               (pin, pout, perr, p) <- runInteractiveProcess pgm args'
+                                               Nothing Nothing
+               {- > llc -version
+-                  LLVM (http://llvm.org/):
+-                    LLVM version 3.5.2
++                  <vendor> LLVM version 15.0.7
+                     ...
++                  OR
++                  LLVM (http://llvm.org/):
++                    LLVM version 14.0.6
+               -}
+               hSetBinaryMode pout False
+-              _     <- hGetLine pout
+-              vline <- hGetLine pout
+-              let mb_ver = parseLlvmVersion vline
++              line1 <- hGetLine pout
++              mb_ver <- case parseLlvmVersion line1 of
++                mb_ver@(Just _) -> return mb_ver
++                Nothing -> parseLlvmVersion <$> hGetLine pout -- Try the second line
+               hClose pin
+               hClose pout
+               hClose perr
+diff --git a/docs/users_guide/phases.rst b/docs/users_guide/phases.rst
+index 6a2d4b3c20..9ccd2aa034 100644
+--- a/docs/users_guide/phases.rst
++++ b/docs/users_guide/phases.rst
+@@ -474,7 +474,7 @@ defined by your local GHC installation, the following trick is useful:
+     .. index::
+        single: __GLASGOW_HASKELL_LLVM__
+ 
+-    Only defined when `:ghc-flag:`-fllvm` is specified. When GHC is using version
++    Only defined when :ghc-flag:`-fllvm` is specified. When GHC is using version
+     ``x.y.z`` of LLVM, the value of ``__GLASGOW_HASKELL_LLVM__`` is the
+     integer ⟨xyy⟩ (if ⟨y⟩ is a single digit, then a leading zero
+     is added, so for example when using version 3.7 of LLVM,
+-- 
+2.50.1
+

--- a/pkgs/development/compilers/ghc/ghc-9.4-llvm-use-new-pass-manager.patch
+++ b/pkgs/development/compilers/ghc/ghc-9.4-llvm-use-new-pass-manager.patch
@@ -1,0 +1,87 @@
+From 857d84f43f288019d6b926ac562f0d3eff30bc1e Mon Sep 17 00:00:00 2001
+From: Ben Gamari <ben@smart-cactus.org>
+Date: Wed, 31 Jan 2024 08:58:58 -0500
+Subject: [PATCH] llvmGen: Adapt to allow use of new pass manager.
+
+We now must use `-passes` in place of `-O<n>` due to #21936.
+
+Closes #21936.
+
+(cherry picked from commit 77db84aba1ba00f6d146e9107b24c6203798e796)
+---
+ compiler/GHC/Driver/Flags.hs            | 2 --
+ compiler/GHC/Driver/Pipeline/Execute.hs | 3 +--
+ compiler/GHC/Driver/Session.hs          | 2 --
+ llvm-passes                             | 6 +++---
+ 4 files changed, 4 insertions(+), 9 deletions(-)
+
+diff --git a/compiler/GHC/Driver/Flags.hs b/compiler/GHC/Driver/Flags.hs
+index 8f6c37d5a7..2e5189f42f 100644
+--- a/compiler/GHC/Driver/Flags.hs
++++ b/compiler/GHC/Driver/Flags.hs
+@@ -213,7 +213,6 @@ data GeneralFlag
+    | Opt_RegsGraph                      -- do graph coloring register allocation
+    | Opt_RegsIterative                  -- do iterative coalescing graph coloring register allocation
+    | Opt_PedanticBottoms                -- Be picky about how we treat bottom
+-   | Opt_LlvmTBAA                       -- Use LLVM TBAA infrastructure for improving AA (hidden flag)
+    | Opt_LlvmFillUndefWithGarbage       -- Testing for undef bugs (hidden flag)
+    | Opt_IrrefutableTuples
+    | Opt_CmmSink
+@@ -446,7 +445,6 @@ optimisationFlags = EnumSet.fromList
+    , Opt_RegsGraph
+    , Opt_RegsIterative
+    , Opt_PedanticBottoms
+-   , Opt_LlvmTBAA
+    , Opt_LlvmFillUndefWithGarbage
+    , Opt_IrrefutableTuples
+    , Opt_CmmSink
+diff --git a/compiler/GHC/Driver/Pipeline/Execute.hs b/compiler/GHC/Driver/Pipeline/Execute.hs
+index b78ed19160..8c752f5546 100644
+--- a/compiler/GHC/Driver/Pipeline/Execute.hs
++++ b/compiler/GHC/Driver/Pipeline/Execute.hs
+@@ -882,8 +882,7 @@ getOutputFilename logger tmpfs stop_phase output basename dflags next_phase mayb
+ llvmOptions :: DynFlags
+             -> [(String, String)]  -- ^ pairs of (opt, llc) arguments
+ llvmOptions dflags =
+-       [("-enable-tbaa -tbaa",  "-enable-tbaa") | gopt Opt_LlvmTBAA dflags ]
+-    ++ [("-relocation-model=" ++ rmodel
++       [("-relocation-model=" ++ rmodel
+         ,"-relocation-model=" ++ rmodel) | not (null rmodel)]
+ 
+     -- Additional llc flags
+diff --git a/compiler/GHC/Driver/Session.hs b/compiler/GHC/Driver/Session.hs
+index 51d27cd0f8..ae8566ffb2 100644
+--- a/compiler/GHC/Driver/Session.hs
++++ b/compiler/GHC/Driver/Session.hs
+@@ -3457,7 +3457,6 @@ fFlagsDeps = [
+   flagSpec "late-dmd-anal"                    Opt_LateDmdAnal,
+   flagSpec "late-specialise"                  Opt_LateSpecialise,
+   flagSpec "liberate-case"                    Opt_LiberateCase,
+-  flagHiddenSpec "llvm-tbaa"                  Opt_LlvmTBAA,
+   flagHiddenSpec "llvm-fill-undef-with-garbage" Opt_LlvmFillUndefWithGarbage,
+   flagSpec "loopification"                    Opt_Loopification,
+   flagSpec "block-layout-cfg"                 Opt_CfgBlocklayout,
+@@ -3992,7 +3991,6 @@ optLevelFlags :: [([Int], GeneralFlag)]
+ optLevelFlags -- see Note [Documenting optimisation flags]
+   = [ ([0,1,2], Opt_DoLambdaEtaExpansion)
+     , ([0,1,2], Opt_DoEtaReduction)       -- See Note [Eta-reduction in -O0]
+-    , ([0,1,2], Opt_LlvmTBAA)
+     , ([0,1,2], Opt_ProfManualCcs )
+     , ([2], Opt_DictsStrict)
+ 
+diff --git a/llvm-passes b/llvm-passes
+index 52d203e745..0ee2889d32 100644
+--- a/llvm-passes
++++ b/llvm-passes
+@@ -1,5 +1,5 @@
+ [
+-(0, "-enable-new-pm=0 -mem2reg -globalopt -lower-expect"),
+-(1, "-enable-new-pm=0 -O1 -globalopt"),
+-(2, "-enable-new-pm=0 -O2")
++(0, "-passes=function(require<tbaa>),function(mem2reg),globalopt,function(lower-expect)"),
++(1, "-passes=default<O1>"),
++(2, "-passes=default<O2>")
+ ]
+-- 
+2.50.1
+

--- a/pkgs/development/compilers/ghc/ghc-9.6-llvm-restore-import.patch
+++ b/pkgs/development/compilers/ghc/ghc-9.6-llvm-restore-import.patch
@@ -1,0 +1,12 @@
+diff --git a/compiler/GHC/CmmToLlvm.hs b/compiler/GHC/CmmToLlvm.hs
+index 7d48693765..6290779a44 100644
+--- a/compiler/GHC/CmmToLlvm.hs
++++ b/compiler/GHC/CmmToLlvm.hs
+@@ -28,6 +28,7 @@
+ 
+ import GHC.Utils.BufHandle
+ import GHC.Driver.Session
++import GHC.Platform ( platformArch, Arch(..) )
+ import GHC.Utils.Error
+ import GHC.Data.FastString
+ import GHC.Utils.Outputable

--- a/pkgs/development/compilers/ghc/ghc-9.6-llvm-use-new-pass-manager.patch
+++ b/pkgs/development/compilers/ghc/ghc-9.6-llvm-use-new-pass-manager.patch
@@ -1,0 +1,87 @@
+From 291a336ac81d009b66a2d09c3bb5271e40646e15 Mon Sep 17 00:00:00 2001
+From: Ben Gamari <ben@smart-cactus.org>
+Date: Wed, 31 Jan 2024 08:58:58 -0500
+Subject: [PATCH] llvmGen: Adapt to allow use of new pass manager.
+
+We now must use `-passes` in place of `-O<n>` due to #21936.
+
+Closes #21936.
+
+(cherry picked from commit 77db84aba1ba00f6d146e9107b24c6203798e796)
+---
+ compiler/GHC/Driver/Flags.hs            | 2 --
+ compiler/GHC/Driver/Pipeline/Execute.hs | 3 +--
+ compiler/GHC/Driver/Session.hs          | 2 --
+ llvm-passes                             | 6 +++---
+ 4 files changed, 4 insertions(+), 9 deletions(-)
+
+diff --git a/compiler/GHC/Driver/Flags.hs b/compiler/GHC/Driver/Flags.hs
+index bd9e3355f0..970dba81d0 100644
+--- a/compiler/GHC/Driver/Flags.hs
++++ b/compiler/GHC/Driver/Flags.hs
+@@ -273,7 +273,6 @@ data GeneralFlag
+    | Opt_RegsGraph                      -- do graph coloring register allocation
+    | Opt_RegsIterative                  -- do iterative coalescing graph coloring register allocation
+    | Opt_PedanticBottoms                -- Be picky about how we treat bottom
+-   | Opt_LlvmTBAA                       -- Use LLVM TBAA infrastructure for improving AA (hidden flag)
+    | Opt_LlvmFillUndefWithGarbage       -- Testing for undef bugs (hidden flag)
+    | Opt_IrrefutableTuples
+    | Opt_CmmSink
+@@ -511,7 +510,6 @@ optimisationFlags = EnumSet.fromList
+    , Opt_EnableRewriteRules
+    , Opt_RegsGraph
+    , Opt_RegsIterative
+-   , Opt_LlvmTBAA
+    , Opt_IrrefutableTuples
+    , Opt_CmmSink
+    , Opt_CmmElimCommonBlocks
+diff --git a/compiler/GHC/Driver/Pipeline/Execute.hs b/compiler/GHC/Driver/Pipeline/Execute.hs
+index 4fa72be475..d63b409fc1 100644
+--- a/compiler/GHC/Driver/Pipeline/Execute.hs
++++ b/compiler/GHC/Driver/Pipeline/Execute.hs
+@@ -989,8 +989,7 @@ llvmOptions :: LlvmConfig
+             -> DynFlags
+             -> [(String, String)]  -- ^ pairs of (opt, llc) arguments
+ llvmOptions llvm_config dflags =
+-       [("-enable-tbaa -tbaa",  "-enable-tbaa") | gopt Opt_LlvmTBAA dflags ]
+-    ++ [("-relocation-model=" ++ rmodel
++       [("-relocation-model=" ++ rmodel
+         ,"-relocation-model=" ++ rmodel) | not (null rmodel)]
+ 
+     -- Additional llc flags
+diff --git a/compiler/GHC/Driver/Session.hs b/compiler/GHC/Driver/Session.hs
+index 21d27c406e..9656f1d247 100644
+--- a/compiler/GHC/Driver/Session.hs
++++ b/compiler/GHC/Driver/Session.hs
+@@ -3431,7 +3431,6 @@ fFlagsDeps = [
+   flagSpec "late-dmd-anal"                    Opt_LateDmdAnal,
+   flagSpec "late-specialise"                  Opt_LateSpecialise,
+   flagSpec "liberate-case"                    Opt_LiberateCase,
+-  flagHiddenSpec "llvm-tbaa"                  Opt_LlvmTBAA,
+   flagHiddenSpec "llvm-fill-undef-with-garbage" Opt_LlvmFillUndefWithGarbage,
+   flagSpec "loopification"                    Opt_Loopification,
+   flagSpec "block-layout-cfg"                 Opt_CfgBlocklayout,
+@@ -3992,7 +3991,6 @@ optLevelFlags :: [([Int], GeneralFlag)]
+ optLevelFlags -- see Note [Documenting optimisation flags]
+   = [ ([0,1,2], Opt_DoLambdaEtaExpansion)
+     , ([0,1,2], Opt_DoEtaReduction)       -- See Note [Eta-reduction in -O0]
+-    , ([0,1,2], Opt_LlvmTBAA)
+     , ([0,1,2], Opt_ProfManualCcs )
+     , ([2], Opt_DictsStrict)
+ 
+diff --git a/llvm-passes b/llvm-passes
+index 52d203e745..0ee2889d32 100644
+--- a/llvm-passes
++++ b/llvm-passes
+@@ -1,5 +1,5 @@
+ [
+-(0, "-enable-new-pm=0 -mem2reg -globalopt -lower-expect"),
+-(1, "-enable-new-pm=0 -O1 -globalopt"),
+-(2, "-enable-new-pm=0 -O2")
++(0, "-passes=function(require<tbaa>),function(mem2reg),globalopt,function(lower-expect)"),
++(1, "-passes=default<O1>"),
++(2, "-passes=default<O2>")
+ ]
+-- 
+2.50.1
+

--- a/pkgs/development/compilers/ghc/ghc-9.8-llvm-use-new-pass-manager.patch
+++ b/pkgs/development/compilers/ghc/ghc-9.8-llvm-use-new-pass-manager.patch
@@ -1,0 +1,92 @@
+From c7667212c958ef00926986782b8e1ac173bce0f9 Mon Sep 17 00:00:00 2001
+From: Ben Gamari <ben@smart-cactus.org>
+Date: Wed, 31 Jan 2024 08:58:58 -0500
+Subject: [PATCH] llvmGen: Adapt to allow use of new pass manager.
+
+We now must use `-passes` in place of `-O<n>` due to #21936.
+
+Closes #21936.
+
+(cherry picked from commit 77db84aba1ba00f6d146e9107b24c6203798e796)
+---
+ compiler/GHC/Driver/DynFlags.hs         | 1 -
+ compiler/GHC/Driver/Flags.hs            | 2 --
+ compiler/GHC/Driver/Pipeline/Execute.hs | 3 +--
+ compiler/GHC/Driver/Session.hs          | 1 -
+ llvm-passes                             | 6 +++---
+ 5 files changed, 4 insertions(+), 9 deletions(-)
+
+diff --git a/compiler/GHC/Driver/DynFlags.hs b/compiler/GHC/Driver/DynFlags.hs
+index ac9e6581cf..edc92e35ad 100644
+--- a/compiler/GHC/Driver/DynFlags.hs
++++ b/compiler/GHC/Driver/DynFlags.hs
+@@ -1261,7 +1261,6 @@ optLevelFlags :: [([Int], GeneralFlag)]
+ optLevelFlags -- see Note [Documenting optimisation flags]
+   = [ ([0,1,2], Opt_DoLambdaEtaExpansion)
+     , ([0,1,2], Opt_DoEtaReduction)       -- See Note [Eta-reduction in -O0]
+-    , ([0,1,2], Opt_LlvmTBAA)
+     , ([0,1,2], Opt_ProfManualCcs )
+     , ([2], Opt_DictsStrict)
+ 
+diff --git a/compiler/GHC/Driver/Flags.hs b/compiler/GHC/Driver/Flags.hs
+index 0f6715f3cb..32e52b4b9a 100644
+--- a/compiler/GHC/Driver/Flags.hs
++++ b/compiler/GHC/Driver/Flags.hs
+@@ -285,7 +285,6 @@ data GeneralFlag
+    | Opt_RegsGraph                      -- do graph coloring register allocation
+    | Opt_RegsIterative                  -- do iterative coalescing graph coloring register allocation
+    | Opt_PedanticBottoms                -- Be picky about how we treat bottom
+-   | Opt_LlvmTBAA                       -- Use LLVM TBAA infrastructure for improving AA (hidden flag)
+    | Opt_LlvmFillUndefWithGarbage       -- Testing for undef bugs (hidden flag)
+    | Opt_IrrefutableTuples
+    | Opt_CmmSink
+@@ -525,7 +524,6 @@ optimisationFlags = EnumSet.fromList
+    , Opt_EnableRewriteRules
+    , Opt_RegsGraph
+    , Opt_RegsIterative
+-   , Opt_LlvmTBAA
+    , Opt_IrrefutableTuples
+    , Opt_CmmSink
+    , Opt_CmmElimCommonBlocks
+diff --git a/compiler/GHC/Driver/Pipeline/Execute.hs b/compiler/GHC/Driver/Pipeline/Execute.hs
+index 40d0aec44a..ca5c13442a 100644
+--- a/compiler/GHC/Driver/Pipeline/Execute.hs
++++ b/compiler/GHC/Driver/Pipeline/Execute.hs
+@@ -968,8 +968,7 @@ llvmOptions :: LlvmConfig
+             -> DynFlags
+             -> [(String, String)]  -- ^ pairs of (opt, llc) arguments
+ llvmOptions llvm_config dflags =
+-       [("-enable-tbaa -tbaa",  "-enable-tbaa") | gopt Opt_LlvmTBAA dflags ]
+-    ++ [("-relocation-model=" ++ rmodel
++       [("-relocation-model=" ++ rmodel
+         ,"-relocation-model=" ++ rmodel) | not (null rmodel)]
+ 
+     -- Additional llc flags
+diff --git a/compiler/GHC/Driver/Session.hs b/compiler/GHC/Driver/Session.hs
+index 582fa5bd8d..1c19f8368b 100644
+--- a/compiler/GHC/Driver/Session.hs
++++ b/compiler/GHC/Driver/Session.hs
+@@ -2401,7 +2401,6 @@ fFlagsDeps = [
+   flagSpec "late-dmd-anal"                    Opt_LateDmdAnal,
+   flagSpec "late-specialise"                  Opt_LateSpecialise,
+   flagSpec "liberate-case"                    Opt_LiberateCase,
+-  flagHiddenSpec "llvm-tbaa"                  Opt_LlvmTBAA,
+   flagHiddenSpec "llvm-fill-undef-with-garbage" Opt_LlvmFillUndefWithGarbage,
+   flagSpec "loopification"                    Opt_Loopification,
+   flagSpec "block-layout-cfg"                 Opt_CfgBlocklayout,
+diff --git a/llvm-passes b/llvm-passes
+index 52d203e745..0ee2889d32 100644
+--- a/llvm-passes
++++ b/llvm-passes
+@@ -1,5 +1,5 @@
+ [
+-(0, "-enable-new-pm=0 -mem2reg -globalopt -lower-expect"),
+-(1, "-enable-new-pm=0 -O1 -globalopt"),
+-(2, "-enable-new-pm=0 -O2")
++(0, "-passes=function(require<tbaa>),function(mem2reg),globalopt,function(lower-expect)"),
++(1, "-passes=default<O1>"),
++(2, "-passes=default<O2>")
+ ]
+-- 
+2.50.1
+

--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -182,7 +182,7 @@ else
     + postBuild;
     preferLocalBuild = true;
     passthru = {
-      inherit (ghc) version targetPrefix;
+      inherit (ghc) version meta targetPrefix;
 
       hoogle = hoogleWithPackages';
 
@@ -202,10 +202,5 @@ else
 
           Also note that withLLVM has been renamed to useLLVM for consistency with
           the GHC Nix expressions.'';
-    };
-    pos = __curPos;
-    meta = ghc.meta // {
-      # To be fixed by <https://github.com/NixOS/nixpkgs/pull/440774>.
-      broken = useLLVM;
     };
   }

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -46,6 +46,16 @@ let
   # Use this rather than `rec { ... }` below for sake of overlays.
   inherit (pkgs.haskell) compiler packages;
 
+  # The GHC LLVM backend rarely sees significant changes relating to
+  # LLVM version support, as it uses the textual IR format and invokes
+  # the LLVM binary tools rather than linking to the C++ libraries.
+  #
+  # Consider backporting upstream GHC changes to support new LLVM
+  # versions in `common-llvm-patches.nix` to allow the version to be
+  # shared across our supported versions of GHC. If the required
+  # changes are too invasive, it’s fine to decouple individual versions
+  # from this default or disable their LLVM support if it’s not load‐
+  # bearing (e.g. GHC 9.4.8 is important for cross‐compiling GHC).
   buildTargetLlvmPackages = pkgsBuildTarget.llvmPackages_20;
   llvmPackages = pkgs.llvmPackages_20;
 


### PR DESCRIPTION
The rebuild‐heavy portion of https://github.com/NixOS/nixpkgs/pull/440271. Only the last commit is relevant here, and is all that this one will contain, once the previous PR is merged. See the commit message for details.

I have not built all of these GHCs again on top of the LLVM 20 bump; some amount of re‐verification would be appreciated.

Not sure whether this should target `staging` or `haskell-updates`; I’ll defer to @NixOS/haskell on that one.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
