### PR TITLE
ntrviewer-hr: init at 0.3.5.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1092,6 +1092,17 @@
     githubId = 1078000;
     name = "Alejandro Sánchez Medina";
   };
+  alejoheu = {
+    email = "alex@alejoh.eu";
+    github = "alejoheu";
+    githubId = 144659394;
+    name = "Alexander Johansen";
+    keys = [
+      {
+        fingerprint = "602C 67BD 90DE 3A4A 2318 75AD BF7F 4F95 FE2D 3F0B";
+      }
+    ];
+  };
   aleksana = {
     email = "me@aleksana.moe";
     github = "Aleksanaa";

--- a/pkgs/by-name/nt/ntrviewer-hr/package.nix
+++ b/pkgs/by-name/nt/ntrviewer-hr/package.nix
@@ -15,31 +15,46 @@
   libunwind,
   shaderc,
   nasm,
+  libretro-shaders-slang,
 }:
+let
+  slang_shader_location = "${libretro-shaders-slang}/share/libretro/shaders/shaders_slang";
+  version = "0.3.5.6";
+  srcs = {
+    src = fetchFromGitHub {
+      owner = "xzn";
+      repo = "ntrviewer-hr";
+      tag = "v${version}";
+      sha256 = "0ir9q3j84gnbn7fiwmx9mrnhpl82gxplhqni2q7cf6y9i1mqm1wb";
+    };
 
+    gitAnime4k = fetchFromGitHub {
+      owner = "bloc97";
+      repo = "Anime4K";
+      rev = "7684e9586f8dcc738af08a1cdceb024cc184f426";
+      sha256 = "sha256-F5/n/KmJ7iOiI0qcpwX6q8zvF4ACv6zcJTOxcAv6HSE=";
+    };
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "ntrviewer-hr";
-  version = "0.3.5.6";
+  version = "${version}";
 
-  src = fetchFromGitHub {
-    owner = "xzn";
-    repo = "ntrviewer-hr";
-    tag = "v${finalAttrs.version}";
-    sha256 = "0ir9q3j84gnbn7fiwmx9mrnhpl82gxplhqni2q7cf6y9i1mqm1wb";
-  };
+  src = srcs.src;
 
   buildInputs = [
     sdl3
+    libplacebo
+    librashader
+    shaderc
+    lcms
+    libunwind
+    libretro-shaders-slang
   ];
 
   nativeBuildInputs = [
-    libplacebo
     vulkan-headers
-    librashader
     pkg-config
-    lcms
-    libunwind
-    shaderc
     nasm
   ];
 
@@ -49,8 +64,19 @@ stdenv.mkDerivation (finalAttrs: {
 
   installPhase = ''
     runHook preInstall
+    ls -la
     mkdir -p $out/bin
     install -m755 ntrviewer $out/bin/ntrviewer
+    cp rashader.json $out/bin
+    cp placebo.json $out/bin
+    mkdir -p $out/bin/placebo-shaders/Anime4K
+    cp -R ${srcs.gitAnime4k}/glsl/* "$out/bin/placebo-shaders/Anime4K/"
+    mkdir -p $out/bin/slang-shaders
+    cp -R ${slang_shader_location}/anti-aliasing $out/bin/slang-shaders/
+    cp -R ${slang_shader_location}/edge-smoothing $out/bin/slang-shaders/
+    cp -R ${slang_shader_location}/interpolation $out/bin/slang-shaders/
+    cp -R ${slang_shader_location}/pixel-art-scaling $out/bin/slang-shaders/
+    cp -R ${slang_shader_location}/stock.slang $out/bin/slang-shaders/
     runHook postInstall
   '';
 

--- a/pkgs/by-name/nt/ntrviewer-hr/package.nix
+++ b/pkgs/by-name/nt/ntrviewer-hr/package.nix
@@ -1,4 +1,5 @@
-{ callPackage,
+{
+  callPackage,
   lib,
   stdenv,
   fetchFromGitHub,
@@ -13,7 +14,7 @@
   lcms,
   libunwind,
   shaderc,
-  nasm
+  nasm,
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/nt/ntrviewer-hr/package.nix
+++ b/pkgs/by-name/nt/ntrviewer-hr/package.nix
@@ -29,11 +29,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     sdl3
-    libplacebo
-    vulkan-headers
   ];
 
   nativeBuildInputs = [
+    libplacebo
+    vulkan-headers
     librashader
     pkg-config
     lcms
@@ -48,7 +48,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   installPhase = ''
     runHook preInstall
-    ls -la
     mkdir -p $out/bin
     install -m755 ntrviewer $out/bin/ntrviewer
     runHook postInstall

--- a/pkgs/by-name/nt/ntrviewer-hr/package.nix
+++ b/pkgs/by-name/nt/ntrviewer-hr/package.nix
@@ -1,0 +1,66 @@
+{ callPackage,
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nixos,
+  testers,
+  versionCheckHook,
+  sdl3,
+  pkg-config,
+  vulkan-headers,
+  libplacebo,
+  librashader,
+  lcms,
+  libunwind,
+  shaderc,
+  nasm
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ntrviewer-hr";
+  version = "0.3.5.6";
+
+  src = fetchFromGitHub {
+    owner = "xzn";
+    repo = "ntrviewer-hr";
+    tag = "v${finalAttrs.version}";
+    sha256 = "0ir9q3j84gnbn7fiwmx9mrnhpl82gxplhqni2q7cf6y9i1mqm1wb";
+  };
+
+  buildInputs = [
+    sdl3
+    libplacebo
+    vulkan-headers
+  ];
+
+  nativeBuildInputs = [
+    librashader
+    pkg-config
+    lcms
+    libunwind
+    shaderc
+    nasm
+  ];
+
+  env.NIX_CFLAGS_COMPILE = "-I${librashader}/include/librashader"; # necessary because the librashader package works differently from the other build packages
+
+  doCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+    ls -la
+    mkdir -p $out/bin
+    install -m755 ntrviewer $out/bin/ntrviewer
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Viewer for wireless screen casting from New 3DS/New 2DS to PC (Windows/Linux/macOS)";
+    homepage = "https://github.com/xzn/ntrviewer-hr";
+    changelog = "https://github.com/xzn/ntrviewer-hr/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ alejoheu ];
+    mainProgram = "ntrviewer";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
ntrviewer-hr is an application used to view video streams coming from NTR, which is a firmware modification for modified Nintendo 3DS systems. This is a very useful way to get a video feed from the console, and seeing as no other NTR viewers were available in nixpkgs, I decided to make a package for ntrviewer-hr. Please see the [ntrviewer-hr GitHub repository](https://github.com/xzn/ntrviewer-hr/) for more details.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
