### PR TITLE
nota: 1.0 -> 1.0-unstable-2023-03-01

### DIFF
--- a/pkgs/by-name/no/nota/package.nix
+++ b/pkgs/by-name/no/nota/package.nix
@@ -1,22 +1,21 @@
 {
   haskellPackages,
-  fetchurl,
+  fetchFromGitHub,
   lib,
 }:
 
 haskellPackages.mkDerivation rec {
   pname = "nota";
-  version = "1.0";
+  version = "1.0-unstable-2023-03-01";
 
-  # Can't use fetchFromGitLab since codes.kary.us doesn't support https
-  src = fetchurl {
-    url = "http://codes.kary.us/nota/nota/-/archive/V${version}/nota-V${version}.tar.bz2";
-    sha256 = "0bbs6bm9p852hvqadmqs428ir7m65h2prwyma238iirv42pk04v8";
+  src = fetchFromGitHub {
+    owner = "pouyakary";
+    repo = "Nota";
+    rev = "3548b864e5aa30ffbf1704a79dbb3bd3aab813be";
+    hash = "sha256-96T9uxUEV22/vn6aoInG1UPXbzlDHswOSkywkdwsMeY=";
   };
 
-  postUnpack = ''
-    export sourceRoot=$sourceRoot/source
-  '';
+  sourceRoot = "${src.name}/source";
 
   isLibrary = false;
   isExecutable = true;
@@ -37,8 +36,8 @@ haskellPackages.mkDerivation rec {
     time
   ];
 
-  description = "Most beautiful command line calculator";
-  homepage = "https://kary.us/nota";
+  description = "Command line calculator";
+  homepage = "https://pouyakary.org/nota/";
   license = lib.licenses.mpl20;
   maintainers = [ ];
   mainProgram = "nota";

--- a/pkgs/by-name/no/nota/package.nix
+++ b/pkgs/by-name/no/nota/package.nix
@@ -1,11 +1,10 @@
 {
-  mkDerivation,
   haskellPackages,
   fetchurl,
   lib,
 }:
 
-mkDerivation rec {
+haskellPackages.mkDerivation rec {
   pname = "nota";
   version = "1.0";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14464,8 +14464,6 @@ with pkgs;
 
   liblapack = lapack-reference;
 
-  nota = haskellPackages.callPackage ../applications/science/math/nota { };
-
   notus-scanner = with python3Packages; toPythonApplication notus-scanner;
 
   openblas = callPackage ../development/libraries/science/math/openblas {


### PR DESCRIPTION
### Nota Updates

Homepage: https://github.com/pouyakary/Nota

- Migrated from `pkgs/applications/science/math/nota/default.nix` to `pkgs/by-name/no/nota/package.nix`.

- The url in the fetchurl function no longer exists, the website domain is for sale. The same holds for the homepage listed. Therefore, the urls have been updated to current active versions.

- The description has been updated to align with the README for pkgs contributions, namely, that the description should "Avoid subjective language."

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
