### PR TITLE
epkowa: add plugin for DS-30

### DIFF
--- a/pkgs/by-name/ep/epkowa/package.nix
+++ b/pkgs/by-name/ep/epkowa/package.nix
@@ -436,6 +436,42 @@ let
         description = "iscan GT-1500 for " + passthru.hw;
       };
     };
+    ds30 = stdenv.mkDerivation rec {
+      name = "iscan-ds-30-bundle";
+      version = "2.30.4";
+
+      src = fetchurl {
+        urls = [
+          "https://download2.ebz.epson.net/iscan/plugin/ds-30/rpm/x64/iscan-ds-30-bundle-${version}.x64.rpm.tar.gz"
+          "https://web.archive.org/web/https://download2.ebz.epson.net/iscan/plugin/ds-30/rpm/x64/iscan-ds-30-bundle-${version}.x64.rpm.tar.gz"
+        ];
+        sha256 = "0d5ef9b83999c56c14bd17ca63537f63ad4f0d70056870dc00888af1b36f4153";
+      };
+
+      nativeBuildInputs = [
+        autoPatchelfHook
+        rpm
+      ];
+
+      installPhase = ''
+        ${rpm}/bin/rpm2cpio plugins/iscan-plugin-ds-30-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+        mkdir $out
+        cp -r usr/share $out
+        cp -r usr/lib64 $out/lib
+        mv $out/lib/iscan $out/lib/esci
+        mkdir $out/share/esci
+      '';
+
+      passthru = {
+        registrationCommand = ''
+          $registry --add interpreter usb 0x04b8 0x0147 "$plugin/lib/esci/libiscan-plugin-ds-30.so"
+        '';
+        hw = "DS-30";
+      };
+      meta = common_meta // {
+        description = "Plugin to support " + passthru.hw + " scanner in sane";
+      };
+    };
     network = stdenv.mkDerivation rec {
       pname = "iscan-nt-bundle";
       # for the version, look for the driver of XP-750 in the search page


### PR DESCRIPTION
Adds plugin supporting the Epson DS-30 scanner, which is not supported by any other drivers.
## Things done
I have tested this with the scanner and verified that it is working.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
