### PR TITLE
zexy: 2.2.4 -> 2.4.3

### DIFF
--- a/pkgs/applications/audio/pd-plugins/zexy/default.nix
+++ b/pkgs/applications/audio/pd-plugins/zexy/default.nix
@@ -1,46 +1,30 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  autoconf,
-  automake,
+  fetchFromGitLab,
   puredata,
 }:
 
 stdenv.mkDerivation rec {
   pname = "zexy";
-  version = "2.2.4";
+  version = "2.4.3";
 
-  src = fetchurl {
-    url = "https://puredata.info/downloads/zexy/releases/${version}/${pname}-${version}.tar.gz";
-    sha256 = "1xpgl82c2lc6zfswjsa7z10yhv5jb7a4znzh3nc7ffrzm1z8vylp";
+  src = fetchFromGitLab {
+    domain = "git.iem.at";
+    owner = "pd";
+    repo = "zexy";
+    tag = "v${version}";
+    hash = "sha256-9f0uYBDBq5lcN/N0uJwC/HBEFcj9b8ZtBHnPAce2s/A=";
   };
 
-  nativeBuildInputs = [
-    autoconf
-    automake
-  ];
   buildInputs = [ puredata ];
 
-  preBuild = ''
-    export LD=$CXX
-    cd src/
-    for i in ${puredata}/include/pd/*; do
-      ln -s $i .
-    done
-    ./bootstrap.sh
-    ./configure --enable-lpt=no --prefix=$out
-  '';
-
-  postInstall = ''
-    mv $out/lib/pd/extra/zexy $out
-    rm -rf $out/lib
-  '';
+  makeFlags = [ "PDLIBDIR=$(out)" ];
 
   meta = {
     description = "Swiss army knife for puredata";
-    homepage = "http://puredata.info/downloads/zexy";
-    license = lib.licenses.gpl2;
+    homepage = "https://git.iem.at/pd/zexy";
+    license = lib.licenses.gpl2Plus;
     maintainers = [ lib.maintainers.magnetophon ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13626,9 +13626,7 @@ with pkgs;
 
   zeroc-ice-cpp11 = zeroc-ice.override { cpp11 = true; };
 
-  zexy = callPackage ../applications/audio/pd-plugins/zexy {
-    autoconf = buildPackages.autoconf269;
-  };
+  zexy = callPackage ../applications/audio/pd-plugins/zexy { };
 
   zed-editor-fhs = zed-editor.fhs;
 


### PR DESCRIPTION
https://git.iem.at/pd/zexy/-/blob/v2.4.3/ChangeLog?ref_type=tags

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
