### PR TITLE
linux: fix include path when build with ccache warpped clang

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-flags.nix
+++ b/pkgs/os-specific/linux/kernel/common-flags.nix
@@ -26,9 +26,15 @@
   "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
 ]
 # Add the built in headers the kernel needs
-++ lib.optionals (stdenv.cc.isClang) [
-  "CFLAGS_MODULE=-I${lib.getLib stdenv.cc.cc}/lib/clang/${lib.versions.major stdenv.cc.cc.version}/include"
-  "CFLAGS_KERNEL=-I${lib.getLib stdenv.cc.cc}/lib/clang/${lib.versions.major stdenv.cc.cc.version}/include"
-]
+++ lib.optionals (stdenv.cc.isClang) (
+  let
+    clangLib = lib.getLib stdenv.cc.cc;
+    majorVer = lib.versions.major clangLib.version;
+  in
+  [
+    "CFLAGS_MODULE=-I${clangLib}/lib/clang/${majorVer}/include"
+    "CFLAGS_KERNEL=-I${clangLib}/lib/clang/${majorVer}/include"
+  ]
+)
 ++ (stdenv.hostPlatform.linux-kernel.makeFlags or [ ])
 ++ extraMakeFlags


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fix e9b2edb4916328647571aee01b2a83c02e585df5
Close https://github.com/NixOS/nixpkgs/issues/438900

With ccache, the `stdenv.cc.cc.version` is ccache version(in this case 4.11.3), instead of real clang version.
So using `-I${lib.getLib stdenv.cc.cc}/lib/clang/${lib.versions.major stdenv.cc.cc.version}/include` will not work.
Use the version of the cc's lib instead.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
