### PR TITLE
agenda: 1.1.2 -> 1.2.1

### DIFF
--- a/pkgs/by-name/ag/agenda/package.nix
+++ b/pkgs/by-name/ag/agenda/package.nix
@@ -3,10 +3,10 @@
   stdenv,
   fetchFromGitHub,
   nix-update-script,
+  desktop-file-utils,
   pantheon,
   meson,
   ninja,
-  python3,
   pkg-config,
   vala,
   gettext,
@@ -18,22 +18,22 @@
 
 stdenv.mkDerivation rec {
   pname = "agenda";
-  version = "1.1.2";
+  version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "dahenson";
     repo = "agenda";
-    rev = version;
-    sha256 = "sha256-tzGcqCxIkoBNskpadEqv289Sj5bij9u+LdYySiGdop8=";
+    tag = version;
+    hash = "sha256-CjlGkG43FFDdKGuwevBeCCazOzLcH114bqihMWTykC8=";
   };
 
   nativeBuildInputs = [
+    desktop-file-utils
     gettext
     glib # for glib-compile-schemas
     meson
     ninja
     pkg-config
-    python3
     vala
     wrapGAppsHook3
   ];
@@ -45,13 +45,6 @@ stdenv.mkDerivation rec {
     pantheon.granite
   ];
 
-  postPatch = ''
-    chmod +x meson/post_install.py
-    patchShebangs meson/post_install.py
-  '';
-
-  doCheck = true;
-
   passthru = {
     updateScript = nix-update-script { };
   };
@@ -62,7 +55,7 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ xiorcale ];
     teams = [ teams.pantheon ];
     platforms = platforms.linux;
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     mainProgram = "com.github.dahenson.agenda";
   };
 }


### PR DESCRIPTION
https://github.com/dahenson/agenda/compare/1.1.2...1.2.1



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

