### PR TITLE
mup: 6.8 -> 7.2

### DIFF
--- a/pkgs/applications/audio/mup/default.nix
+++ b/pkgs/applications/audio/mup/default.nix
@@ -14,15 +14,18 @@
   libjpeg,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "mup";
-  version = "6.8";
+  version = "7.2";
 
   src = fetchurl {
-    url = "http://www.arkkra.com/ftp/pub/unix/mup${
-      builtins.replaceStrings [ "." ] [ "" ] version
-    }src.tar.gz";
-    sha256 = "06bv5nyl8rcibyb83zzrfdq6x6f93g3rgnv47i5gsjcaw5w6l31y";
+    urls = [
+      # Since the original site is geo-blocked in the EU, we may revert to the archived version;
+      # please update both URLs during future updates!
+      "http://www.arkkra.com/ftp/pub/unix/mup72src.tar.gz"
+      "https://web.archive.org/web/20250907143445/http://www.arkkra.com/ftp/pub/unix/mup72src.tar.gz"
+    ];
+    hash = "sha256-XbfIsSzE7cwdK0DlOyS8PEJbBGc7Doa1HGLsVfx2ZaY=";
   };
 
   nativeBuildInputs = [
@@ -45,14 +48,16 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     for f in Makefile.am doc/Makefile.am doc/htmldocs/Makefile.am src/mupmate/Preferences.C; do
-      substituteInPlace $f --replace doc/packages doc
+      substituteInPlace $f --replace-fail doc/packages doc
     done
-    substituteInPlace src/mupprnt/mupprnt --replace 'mup ' $out/bin/mup' '
-    substituteInPlace src/mupdisp/genfile.c --replace '"mup"' '"'$out/bin/mup'"'
+    substituteInPlace src/mupprnt/mupprnt \
+      --replace-fail 'mup ' $out/bin/mup' '
+    substituteInPlace src/mupdisp/genfile.c \
+      --replace-fail '"mup"' '"'$out/bin/mup'"'
     substituteInPlace src/mupmate/Preferences.C \
-      --replace '"mup"' '"'$out/bin/mup'"' \
-      --replace '"gv"' '"xdg-open"' \
-      --replace /usr/share/doc $out/share/doc
+      --replace-fail '"mup"' '"'$out/bin/mup'"' \
+      --replace-fail '"gv"' '"xdg-open"' \
+      --replace-fail /usr/share/doc $out/share/doc
   '';
 
   enableParallelBuilding = false; # Undeclared dependencies + https://stackoverflow.com/a/19822767/1687334 for prolog.ps.

--- a/pkgs/applications/audio/mup/ghostscript-permit-file-write.patch
+++ b/pkgs/applications/audio/mup/ghostscript-permit-file-write.patch
@@ -1,5 +1,5 @@
 --- a/src/mup/Makefile.am
 +++ b/src/mup/Makefile.am
-@@ -39 +39 @@ fontdata.c:	prolog.ps ../../tools/mup/getfontinfo.ps ../../LICENSE
--	$(GS) -sDEVICE=nullpage -sOutputFile=/dev/null -dQUIET - < ../../tools/mup/getfontinfo.ps | $(SED) -e "/Warning:/d" >> fontdata.c
-+	$(GS) -sDEVICE=nullpage -sOutputFile=/dev/null -dQUIET --permit-file-write=charnames:fontinit - < ../../tools/mup/getfontinfo.ps | $(SED) -e "/Warning:/d" >> fontdata.c
+@@ -37 +37 @@ fontdata.c:	prolog.ps ../../tools/mup/getfontinfo.ps ../../LICENSE
+-	$(GS) -dNOSAFER -sDEVICE=nullpage -sOutputFile=/dev/null -dQUIET - < ../../tools/mup/getfontinfo.ps | $(SED) -e "/Warning:/d" >> fontdata.c
++	$(GS) -dNOSAFER -sDEVICE=nullpage -sOutputFile=/dev/null -dQUIET --permit-file-write=charnames:fontinit - < ../../tools/mup/getfontinfo.ps | $(SED) -e "/Warning:/d" >> fontdata.c

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12469,9 +12469,7 @@ with pkgs;
 
   mumble_overlay = (callPackages ../applications/networking/mumble { }).overlay;
 
-  mup = callPackage ../applications/audio/mup {
-    autoreconfHook = buildPackages.autoreconfHook269;
-  };
+  mup = callPackage ../applications/audio/mup { };
 
   musescore = qt6.callPackage ../applications/audio/musescore { };
 


### PR DESCRIPTION
http://www.arkkra.com/doc/whatsnew.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
