### PR TITLE
ci: have eval.full return the report as displayed in CI

### DIFF
--- a/ci/eval/README.md
+++ b/ci/eval/README.md
@@ -43,3 +43,6 @@ nix-build ci -A eval.full --arg baseline $BASELINE
 ```
 
 Keep in mind to otherwise pass the same set of arguments for both commands (`evalSystems`, `quickTest`, `chunkSize`).
+Running this command will evaluate the difference between the baseline statistics and the ones at the time of running the command.
+From that difference, it will produce a human-readable report in `$out/step-summary.md`.
+If no packages were added or removed, then performance statistics will also be generated as part of this report.


### PR DESCRIPTION
I found that I wanted to run the report automatically when evaluating performance locally.

Previously:
- https://github.com/NixOS/nixpkgs/pull/437934

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md