### PR TITLE
onyx: init at 2.0.12

### DIFF
--- a/pkgs/by-name/on/onyx/package.nix
+++ b/pkgs/by-name/on/onyx/package.nix
@@ -1,0 +1,64 @@
+{
+  fetchFromGitHub,
+  flutter335,
+  lib,
+  libsecret,
+  makeDesktopItem,
+}:
+
+flutter335.buildFlutterApplication rec {
+  pname = "onyx";
+  version = "2.0.12";
+
+  src = fetchFromGitHub {
+    owner = "onyx-lyon1";
+    repo = "onyx";
+    tag = "v${version}";
+    hash = "sha256-WQH1qhu5UFB/RToraO/zEU6BjzwhNWrsk+U8ZIs1VLM=";
+  };
+
+  sourceRoot = "${src.name}/apps/onyx";
+
+  buildInputs = [
+    libsecret
+  ];
+
+  pubspecLock = lib.importJSON ./pubspec.lock.json;
+
+  gitHashes = {
+    drag_and_drop_lists = "sha256-moyKVIaqCCLeR5dvvd+DW7cpgPG4NCBp3+ohMEwT3FE=";
+    geolocator_android = "sha256-qXk7Tg/e2oc8/0eGcTCJ4Po+wCzUqfqWZMaHXflgyrE=";
+    dart_mappable = "sha256-i4KJXxZCV5L+er1pOkknh3hmZ/y+HcBKly29hG3+lDc=";
+    dart_mappable_builder = "sha256-i4KJXxZCV5L+er1pOkknh3hmZ/y+HcBKly29hG3+lDc=";
+    json_theme = "sha256-OuJBQDqytLds6BB4/GS01A4H9OZYt4g4QsK7ugO3o+I=";
+    workmanager = "sha256-a+IPLiWrRxKmWCJ9Bpv3WVH6JwTRiFPQdxSkeQEbfp4=";
+  };
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "onyx";
+      exec = "Onyx";
+      icon = "onyx";
+      desktopName = "Onyx";
+      genericName = "App for Claude Bernard University";
+      categories = [
+        "Education"
+        "Office"
+      ];
+      startupWMClass = "Onyx";
+    })
+  ];
+
+  postInstall = ''
+    install -Dm644 assets/icon_transparent.png $out/share/icons/hicolor/512x512/apps/onyx.png
+  '';
+
+  meta = {
+    description = "App for Claude Bernard University";
+    homepage = "https://onyx-lyon1.github.io/";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "Onyx";
+    maintainers = with lib.maintainers; [ eymeric ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/on/onyx/pubspec.lock.json
+++ b/pkgs/by-name/on/onyx/pubspec.lock.json
@@ -1,0 +1,2724 @@
+{
+  "packages": {
+    "_fe_analyzer_shared": {
+      "dependency": "transitive",
+      "description": {
+        "name": "_fe_analyzer_shared",
+        "sha256": "da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "85.0.0"
+    },
+    "analyzer": {
+      "dependency": "transitive",
+      "description": {
+        "name": "analyzer",
+        "sha256": "974859dc0ff5f37bc4313244b3218c791810d03ab3470a579580279ba971a48d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "7.7.1"
+    },
+    "animated_stack_widget": {
+      "dependency": "transitive",
+      "description": {
+        "name": "animated_stack_widget",
+        "sha256": "ce4788dd158768c9d4388354b6fb72600b78e041a37afc4c279c63ecafcb9408",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.0.4"
+    },
+    "animations": {
+      "dependency": "direct main",
+      "description": {
+        "name": "animations",
+        "sha256": "d3d6dcfb218225bbe68e87ccf6378bbb2e32a94900722c5f81611dad089911cb",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.11"
+    },
+    "ansicolor": {
+      "dependency": "transitive",
+      "description": {
+        "name": "ansicolor",
+        "sha256": "50e982d500bc863e1d703448afdbf9e5a72eb48840a4f766fa361ffd6877055f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.3"
+    },
+    "archive": {
+      "dependency": "transitive",
+      "description": {
+        "name": "archive",
+        "sha256": "2fde1607386ab523f7a36bb3e7edb43bd58e6edaf2ffb29d8a6d578b297fdbbd",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.0.7"
+    },
+    "args": {
+      "dependency": "transitive",
+      "description": {
+        "name": "args",
+        "sha256": "d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.7.0"
+    },
+    "asn1lib": {
+      "dependency": "transitive",
+      "description": {
+        "name": "asn1lib",
+        "sha256": "9a8f69025044eb466b9b60ef3bc3ac99b4dc6c158ae9c56d25eeccf5bc56d024",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.6.5"
+    },
+    "async": {
+      "dependency": "transitive",
+      "description": {
+        "name": "async",
+        "sha256": "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.13.0"
+    },
+    "auto_size_text": {
+      "dependency": "direct main",
+      "description": {
+        "name": "auto_size_text",
+        "sha256": "3f5261cd3fb5f2a9ab4e2fc3fba84fd9fcaac8821f20a1d4e71f557521b22599",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.0"
+    },
+    "basic_utils": {
+      "dependency": "transitive",
+      "description": {
+        "name": "basic_utils",
+        "sha256": "2064b21d3c41ed7654bc82cc476fd65542e04d60059b74d5eed490a4da08fc6c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "5.7.0"
+    },
+    "beautiful_soup_dart": {
+      "dependency": "transitive",
+      "description": {
+        "name": "beautiful_soup_dart",
+        "sha256": "57e23946c85776dd9515a4e9a14263fff37dbedbd559bc4412bf565886e12b10",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.3.0"
+    },
+    "biometric_storage": {
+      "dependency": "direct main",
+      "description": {
+        "name": "biometric_storage",
+        "sha256": "2cc569f2dbab39950812a6ae7fefa28c7d1c1eb07d2035c88f5e27da09022f5f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "5.0.1"
+    },
+    "bloc": {
+      "dependency": "transitive",
+      "description": {
+        "name": "bloc",
+        "sha256": "52c10575f4445c61dd9e0cafcc6356fdd827c4c64dd7945ef3c4105f6b6ac189",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "9.0.0"
+    },
+    "boolean_selector": {
+      "dependency": "transitive",
+      "description": {
+        "name": "boolean_selector",
+        "sha256": "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.2"
+    },
+    "build": {
+      "dependency": "transitive",
+      "description": {
+        "name": "build",
+        "sha256": "ce76b1d48875e3233fde17717c23d1f60a91cc631597e49a400c89b475395b1d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.0"
+    },
+    "build_config": {
+      "dependency": "transitive",
+      "description": {
+        "name": "build_config",
+        "sha256": "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.2.0"
+    },
+    "build_daemon": {
+      "dependency": "transitive",
+      "description": {
+        "name": "build_daemon",
+        "sha256": "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.0.4"
+    },
+    "build_resolvers": {
+      "dependency": "transitive",
+      "description": {
+        "name": "build_resolvers",
+        "sha256": "d1d57f7807debd7349b4726a19fd32ec8bc177c71ad0febf91a20f84cd2d4b46",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.3"
+    },
+    "build_runner": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "build_runner",
+        "sha256": "b24597fceb695969d47025c958f3837f9f0122e237c6a22cb082a5ac66c3ca30",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.7.1"
+    },
+    "build_runner_core": {
+      "dependency": "transitive",
+      "description": {
+        "name": "build_runner_core",
+        "sha256": "066dda7f73d8eb48ba630a55acb50c4a84a2e6b453b1cb4567f581729e794f7b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "9.3.1"
+    },
+    "built_collection": {
+      "dependency": "transitive",
+      "description": {
+        "name": "built_collection",
+        "sha256": "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "5.1.1"
+    },
+    "built_value": {
+      "dependency": "transitive",
+      "description": {
+        "name": "built_value",
+        "sha256": "ba95c961bafcd8686d1cf63be864eb59447e795e124d98d6a27d91fcd13602fb",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "8.11.1"
+    },
+    "cached_network_image": {
+      "dependency": "direct main",
+      "description": {
+        "name": "cached_network_image",
+        "sha256": "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.4.1"
+    },
+    "cached_network_image_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "cached_network_image_platform_interface",
+        "sha256": "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.1.1"
+    },
+    "cached_network_image_web": {
+      "dependency": "transitive",
+      "description": {
+        "name": "cached_network_image_web",
+        "sha256": "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.3.1"
+    },
+    "camera": {
+      "dependency": "transitive",
+      "description": {
+        "name": "camera",
+        "sha256": "d6ec2cbdbe2fa8f5e0d07d8c06368fe4effa985a4a5ddade9cc58a8cd849557d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.11.2"
+    },
+    "camera_android_camerax": {
+      "dependency": "transitive",
+      "description": {
+        "name": "camera_android_camerax",
+        "sha256": "2d438248554f44766bf9ea34c117a5bb0074e241342ef7c22c768fb431335234",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.6.21"
+    },
+    "camera_avfoundation": {
+      "dependency": "transitive",
+      "description": {
+        "name": "camera_avfoundation",
+        "sha256": "951ef122d01ebba68b7a54bfe294e8b25585635a90465c311b2f875ae72c412f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.9.21+2"
+    },
+    "camera_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "camera_platform_interface",
+        "sha256": "2f757024a48696ff4814a789b0bd90f5660c0fb25f393ab4564fb483327930e2",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.10.0"
+    },
+    "camera_web": {
+      "dependency": "transitive",
+      "description": {
+        "name": "camera_web",
+        "sha256": "595f28c89d1fb62d77c73c633193755b781c6d2e0ebcd8dc25b763b514e6ba8f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.3.5"
+    },
+    "characters": {
+      "dependency": "transitive",
+      "description": {
+        "name": "characters",
+        "sha256": "f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.4.0"
+    },
+    "charcode": {
+      "dependency": "transitive",
+      "description": {
+        "name": "charcode",
+        "sha256": "fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.4.0"
+    },
+    "charset": {
+      "dependency": "transitive",
+      "description": {
+        "name": "charset",
+        "sha256": "27802032a581e01ac565904ece8c8962564b1070690794f0072f6865958ce8b9",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.1"
+    },
+    "checked_yaml": {
+      "dependency": "transitive",
+      "description": {
+        "name": "checked_yaml",
+        "sha256": "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.4"
+    },
+    "cli_config": {
+      "dependency": "transitive",
+      "description": {
+        "name": "cli_config",
+        "sha256": "ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.0"
+    },
+    "cli_util": {
+      "dependency": "transitive",
+      "description": {
+        "name": "cli_util",
+        "sha256": "ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.4.2"
+    },
+    "clock": {
+      "dependency": "transitive",
+      "description": {
+        "name": "clock",
+        "sha256": "fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.2"
+    },
+    "code_builder": {
+      "dependency": "transitive",
+      "description": {
+        "name": "code_builder",
+        "sha256": "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.10.1"
+    },
+    "collection": {
+      "dependency": "transitive",
+      "description": {
+        "name": "collection",
+        "sha256": "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.19.1"
+    },
+    "connectivity_plus": {
+      "dependency": "direct main",
+      "description": {
+        "name": "connectivity_plus",
+        "sha256": "b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.1.5"
+    },
+    "connectivity_plus_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "connectivity_plus_platform_interface",
+        "sha256": "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.1"
+    },
+    "convert": {
+      "dependency": "transitive",
+      "description": {
+        "name": "convert",
+        "sha256": "b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.2"
+    },
+    "coverage": {
+      "dependency": "transitive",
+      "description": {
+        "name": "coverage",
+        "sha256": "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.15.0"
+    },
+    "cross_file": {
+      "dependency": "transitive",
+      "description": {
+        "name": "cross_file",
+        "sha256": "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.3.4+2"
+    },
+    "crypto": {
+      "dependency": "direct main",
+      "description": {
+        "name": "crypto",
+        "sha256": "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.6"
+    },
+    "csslib": {
+      "dependency": "transitive",
+      "description": {
+        "name": "csslib",
+        "sha256": "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.2"
+    },
+    "dart_earcut": {
+      "dependency": "transitive",
+      "description": {
+        "name": "dart_earcut",
+        "sha256": "e485001bfc05dcbc437d7bfb666316182e3522d4c3f9668048e004d0eb2ce43b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.2.0"
+    },
+    "dart_mappable": {
+      "dependency": "direct main",
+      "description": {
+        "path": "packages/dart_mappable",
+        "ref": "HEAD",
+        "resolved-ref": "215adf5e6c17a36ca94328cdece035b9b09fccf4",
+        "url": "https://github.com/hatch01/dart_mappable.git"
+      },
+      "source": "git",
+      "version": "4.6.0"
+    },
+    "dart_mappable_builder": {
+      "dependency": "direct dev",
+      "description": {
+        "path": "packages/dart_mappable_builder",
+        "ref": "HEAD",
+        "resolved-ref": "215adf5e6c17a36ca94328cdece035b9b09fccf4",
+        "url": "https://github.com/hatch01/dart_mappable.git"
+      },
+      "source": "git",
+      "version": "4.6.0"
+    },
+    "dart_quill_delta": {
+      "dependency": "transitive",
+      "description": {
+        "name": "dart_quill_delta",
+        "sha256": "bddb0b2948bd5b5a328f1651764486d162c59a8ccffd4c63e8b2c5e44be1dac4",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "10.8.3"
+    },
+    "dart_style": {
+      "dependency": "transitive",
+      "description": {
+        "name": "dart_style",
+        "sha256": "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.1"
+    },
+    "dbus": {
+      "dependency": "transitive",
+      "description": {
+        "name": "dbus",
+        "sha256": "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.7.11"
+    },
+    "desktop_window": {
+      "dependency": "direct main",
+      "description": {
+        "name": "desktop_window",
+        "sha256": "d0590e75a0a8f91245b439fb7f2bf0ebb62d9cd9fdc7aa0622a5d50615c46845",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.4.2"
+    },
+    "diacritic": {
+      "dependency": "direct main",
+      "description": {
+        "name": "diacritic",
+        "sha256": "12981945ec38931748836cd76f2b38773118d0baef3c68404bdfde9566147876",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.6"
+    },
+    "diff_match_patch": {
+      "dependency": "transitive",
+      "description": {
+        "name": "diff_match_patch",
+        "sha256": "2efc9e6e8f449d0abe15be240e2c2a3bcd977c8d126cfd70598aee60af35c0a4",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.4.1"
+    },
+    "dio": {
+      "dependency": "transitive",
+      "description": {
+        "name": "dio",
+        "sha256": "d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "5.9.0"
+    },
+    "dio_cache_interceptor": {
+      "dependency": "transitive",
+      "description": {
+        "name": "dio_cache_interceptor",
+        "sha256": "c1cbf8be886b3e077165dda50a1b3bb299b8a72694af94d065b4d2ac0fee67d7",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.0.3"
+    },
+    "dio_web_adapter": {
+      "dependency": "transitive",
+      "description": {
+        "name": "dio_web_adapter",
+        "sha256": "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.1"
+    },
+    "dotenv": {
+      "dependency": "transitive",
+      "description": {
+        "name": "dotenv",
+        "sha256": "379e64b6fc82d3df29461d349a1796ecd2c436c480d4653f3af6872eccbc90e1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.2.0"
+    },
+    "drag_and_drop_lists": {
+      "dependency": "direct main",
+      "description": {
+        "path": ".",
+        "ref": "HEAD",
+        "resolved-ref": "746286eec26806187aac4f34a70aa8a2d51ddc09",
+        "url": "https://github.com/onyx-lyon1/DragAndDropLists.git"
+      },
+      "source": "git",
+      "version": "0.3.3"
+    },
+    "encrypt": {
+      "dependency": "direct main",
+      "description": {
+        "name": "encrypt",
+        "sha256": "62d9aa4670cc2a8798bab89b39fc71b6dfbacf615de6cf5001fb39f7e4a996a2",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "5.0.3"
+    },
+    "enough_convert": {
+      "dependency": "transitive",
+      "description": {
+        "name": "enough_convert",
+        "sha256": "c67d85ca21aaa0648f155907362430701db41f7ec8e6501a58ad9cd9d8569d01",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.6.0"
+    },
+    "enough_mail": {
+      "dependency": "direct main",
+      "description": {
+        "name": "enough_mail",
+        "sha256": "a88d8c56907caeffdebc4cf34f3a5665c09a8d7496ef5e09b3166f41cf409f81",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.6"
+    },
+    "enough_mail_html": {
+      "dependency": "transitive",
+      "description": {
+        "name": "enough_mail_html",
+        "sha256": "c661c5a1299377682e28edaadbde0fc8cd0d9497abba0824d5d6cda7911a6c83",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.1"
+    },
+    "equatable": {
+      "dependency": "direct main",
+      "description": {
+        "name": "equatable",
+        "sha256": "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.7"
+    },
+    "event_bus": {
+      "dependency": "transitive",
+      "description": {
+        "name": "event_bus",
+        "sha256": "1a55e97923769c286d295240048fc180e7b0768902c3c2e869fe059aafa15304",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.1"
+    },
+    "fake_async": {
+      "dependency": "transitive",
+      "description": {
+        "name": "fake_async",
+        "sha256": "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.3.3"
+    },
+    "ffi": {
+      "dependency": "transitive",
+      "description": {
+        "name": "ffi",
+        "sha256": "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.4"
+    },
+    "file": {
+      "dependency": "transitive",
+      "description": {
+        "name": "file",
+        "sha256": "a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "7.0.1"
+    },
+    "file_picker": {
+      "dependency": "direct main",
+      "description": {
+        "name": "file_picker",
+        "sha256": "e7e16c9d15c36330b94ca0e2ad8cb61f93cd5282d0158c09805aed13b5452f22",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "10.3.2"
+    },
+    "file_selector_linux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "file_selector_linux",
+        "sha256": "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.9.3+2"
+    },
+    "file_selector_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "file_selector_platform_interface",
+        "sha256": "a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.6.2"
+    },
+    "file_selector_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "file_selector_windows",
+        "sha256": "320fcfb6f33caa90f0b58380489fc5ac05d99ee94b61aa96ec2bff0ba81d3c2b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.9.3+4"
+    },
+    "fixnum": {
+      "dependency": "transitive",
+      "description": {
+        "name": "fixnum",
+        "sha256": "b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.1"
+    },
+    "flutter": {
+      "dependency": "direct main",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
+    "flutter_bloc": {
+      "dependency": "direct main",
+      "description": {
+        "name": "flutter_bloc",
+        "sha256": "cf51747952201a455a1c840f8171d273be009b932c75093020f9af64f2123e38",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "9.1.1"
+    },
+    "flutter_cache_manager": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_cache_manager",
+        "sha256": "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.4.1"
+    },
+    "flutter_colorpicker": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_colorpicker",
+        "sha256": "969de5f6f9e2a570ac660fb7b501551451ea2a1ab9e2097e89475f60e07816ea",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.0"
+    },
+    "flutter_compass": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_compass",
+        "sha256": "1b4d7e6c95a675ec8482b5c9c9ccf1ebf0ced3dbec59dce28ad609da953de850",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.8.1"
+    },
+    "flutter_file_dialog": {
+      "dependency": "direct main",
+      "description": {
+        "name": "flutter_file_dialog",
+        "sha256": "9344b8f07be6a1b6f9854b723fb0cf84a8094ba94761af1d213589d3cb087488",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.2"
+    },
+    "flutter_keyboard_visibility_linux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_keyboard_visibility_linux",
+        "sha256": "6fba7cd9bb033b6ddd8c2beb4c99ad02d728f1e6e6d9b9446667398b2ac39f08",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.0"
+    },
+    "flutter_keyboard_visibility_macos": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_keyboard_visibility_macos",
+        "sha256": "c5c49b16fff453dfdafdc16f26bdd8fb8d55812a1d50b0ce25fc8d9f2e53d086",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.0"
+    },
+    "flutter_keyboard_visibility_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_keyboard_visibility_platform_interface",
+        "sha256": "e43a89845873f7be10cb3884345ceb9aebf00a659f479d1c8f4293fcb37022a4",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.0"
+    },
+    "flutter_keyboard_visibility_temp_fork": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_keyboard_visibility_temp_fork",
+        "sha256": "e3d02900640fbc1129245540db16944a0898b8be81694f4bf04b6c985bed9048",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.5"
+    },
+    "flutter_keyboard_visibility_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_keyboard_visibility_windows",
+        "sha256": "fc4b0f0b6be9b93ae527f3d527fb56ee2d918cd88bbca438c478af7bcfd0ef73",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.0"
+    },
+    "flutter_launcher_icons": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "flutter_launcher_icons",
+        "sha256": "10f13781741a2e3972126fae08393d3c4e01fa4cd7473326b94b72cf594195e7",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.14.4"
+    },
+    "flutter_lints": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "flutter_lints",
+        "sha256": "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.0.0"
+    },
+    "flutter_local_notifications": {
+      "dependency": "direct main",
+      "description": {
+        "name": "flutter_local_notifications",
+        "sha256": "a9966c850de5e445331b854fa42df96a8020066d67f125a5964cbc6556643f68",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "19.4.1"
+    },
+    "flutter_local_notifications_linux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_local_notifications_linux",
+        "sha256": "e3c277b2daab8e36ac5a6820536668d07e83851aeeb79c446e525a70710770a5",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.0.0"
+    },
+    "flutter_local_notifications_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_local_notifications_platform_interface",
+        "sha256": "277d25d960c15674ce78ca97f57d0bae2ee401c844b6ac80fcd972a9c99d09fe",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "9.1.0"
+    },
+    "flutter_local_notifications_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_local_notifications_windows",
+        "sha256": "ed46d7ae4ec9d19e4c8fa2badac5fe27ba87a3fe387343ce726f927af074ec98",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.2"
+    },
+    "flutter_localizations": {
+      "dependency": "direct main",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
+    "flutter_localized_locales": {
+      "dependency": "direct main",
+      "description": {
+        "name": "flutter_localized_locales",
+        "sha256": "478d10535edf07292e34cb4c757882edeeaf96d5e3dbb04b42733038bd41dd3f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.5"
+    },
+    "flutter_map": {
+      "dependency": "direct main",
+      "description": {
+        "name": "flutter_map",
+        "sha256": "2ecb34619a4be19df6f40c2f8dce1591675b4eff7a6857bd8f533706977385da",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "7.0.2"
+    },
+    "flutter_map_animations": {
+      "dependency": "direct main",
+      "description": {
+        "name": "flutter_map_animations",
+        "sha256": "08233f89919049a3601e785d32e9d1d9e1faac6578190150f1d7495fc1050d36",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.8.0"
+    },
+    "flutter_map_cache": {
+      "dependency": "direct main",
+      "description": {
+        "name": "flutter_map_cache",
+        "sha256": "fc9697760dc95b6adf75110a23a800ace5d95a735a58ec43f05183bc675c7246",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.0+1"
+    },
+    "flutter_map_location_marker": {
+      "dependency": "direct main",
+      "description": {
+        "name": "flutter_map_location_marker",
+        "sha256": "1971d9ad7c8bedb15cb6a03598c0a3ad66ac6f7f165ad90d801bd5f636120f38",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "9.1.1"
+    },
+    "flutter_map_marker_cluster_2": {
+      "dependency": "direct main",
+      "description": {
+        "name": "flutter_map_marker_cluster_2",
+        "sha256": "16dea922529a1db18994bb14546ab4c80d473753e5fbc5c32768dfb5311be304",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.4"
+    },
+    "flutter_map_marker_popup": {
+      "dependency": "direct main",
+      "description": {
+        "name": "flutter_map_marker_popup",
+        "sha256": "a7540538114b5d1627ab67b498273d66bc36090385412ae49ef215af4a2861c5",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "7.0.0"
+    },
+    "flutter_plugin_android_lifecycle": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_plugin_android_lifecycle",
+        "sha256": "b0694b7fb1689b0e6cc193b3f1fcac6423c4f93c74fb20b806c6b6f196db0c31",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.30"
+    },
+    "flutter_quill": {
+      "dependency": "direct main",
+      "description": {
+        "name": "flutter_quill",
+        "sha256": "8e33ef670abad16405582a37ce63ac82b7531998682e8bd8348d0f3da998b8ce",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "11.4.2"
+    },
+    "flutter_quill_delta_from_html": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_quill_delta_from_html",
+        "sha256": "0eb801ea8dd498cadc057507af5da794d4c9599ce58b2569cb3d4bb53ba8bed2",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.5.3"
+    },
+    "flutter_test": {
+      "dependency": "direct dev",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
+    "flutter_web_plugins": {
+      "dependency": "transitive",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
+    "frontend_server_client": {
+      "dependency": "transitive",
+      "description": {
+        "name": "frontend_server_client",
+        "sha256": "f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.0.0"
+    },
+    "geolocator": {
+      "dependency": "direct main",
+      "description": {
+        "name": "geolocator",
+        "sha256": "f62bcd90459e63210bbf9c35deb6a51c521f992a78de19a1fe5c11704f9530e2",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "13.0.4"
+    },
+    "geolocator_android": {
+      "dependency": "direct main",
+      "description": {
+        "path": "geolocator_android",
+        "ref": "floss",
+        "resolved-ref": "86997898ef254e2a5afb4f0cdca9875eb3d48022",
+        "url": "https://github.com/onyx-lyon1/flutter-geolocator.git"
+      },
+      "source": "git",
+      "version": "5.0.2"
+    },
+    "geolocator_apple": {
+      "dependency": "transitive",
+      "description": {
+        "name": "geolocator_apple",
+        "sha256": "dbdd8789d5aaf14cf69f74d4925ad1336b4433a6efdf2fce91e8955dc921bf22",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.3.13"
+    },
+    "geolocator_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "geolocator_platform_interface",
+        "sha256": "30cb64f0b9adcc0fb36f628b4ebf4f731a2961a0ebd849f4b56200205056fe67",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.2.6"
+    },
+    "geolocator_web": {
+      "dependency": "transitive",
+      "description": {
+        "name": "geolocator_web",
+        "sha256": "b1ae9bdfd90f861fde8fd4f209c37b953d65e92823cb73c7dee1fa021b06f172",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.1.3"
+    },
+    "geolocator_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "geolocator_windows",
+        "sha256": "175435404d20278ffd220de83c2ca293b73db95eafbdc8131fe8609be1421eb6",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.5"
+    },
+    "glob": {
+      "dependency": "transitive",
+      "description": {
+        "name": "glob",
+        "sha256": "c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.3"
+    },
+    "graphs": {
+      "dependency": "transitive",
+      "description": {
+        "name": "graphs",
+        "sha256": "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.3.2"
+    },
+    "hex": {
+      "dependency": "transitive",
+      "description": {
+        "name": "hex",
+        "sha256": "4e7cd54e4b59ba026432a6be2dd9d96e4c5205725194997193bf871703b82c4a",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.0"
+    },
+    "hive_ce": {
+      "dependency": "transitive",
+      "description": {
+        "name": "hive_ce",
+        "sha256": "708bb39050998707c5d422752159f91944d3c81ab42d80e1bd0ee37d8e130658",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.11.3"
+    },
+    "html": {
+      "dependency": "transitive",
+      "description": {
+        "name": "html",
+        "sha256": "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.15.6"
+    },
+    "html_unescape": {
+      "dependency": "transitive",
+      "description": {
+        "name": "html_unescape",
+        "sha256": "15362d7a18f19d7b742ef8dcb811f5fd2a2df98db9f80ea393c075189e0b61e3",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.0"
+    },
+    "http": {
+      "dependency": "transitive",
+      "description": {
+        "name": "http",
+        "sha256": "bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.5.0"
+    },
+    "http_cache_core": {
+      "dependency": "transitive",
+      "description": {
+        "name": "http_cache_core",
+        "sha256": "b0accfa821e73085b5252dd42a6908d19ea0c29badd46db3668af6f8e510cfe1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.1"
+    },
+    "http_cache_hive_store": {
+      "dependency": "direct main",
+      "description": {
+        "name": "http_cache_hive_store",
+        "sha256": "85847efdb18094961a66b74d3b856da093ddcbaf7739adecdc28149e871fb8fe",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "5.0.1"
+    },
+    "http_multi_server": {
+      "dependency": "transitive",
+      "description": {
+        "name": "http_multi_server",
+        "sha256": "aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.2.2"
+    },
+    "http_parser": {
+      "dependency": "transitive",
+      "description": {
+        "name": "http_parser",
+        "sha256": "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.1.2"
+    },
+    "icalendar_parser": {
+      "dependency": "transitive",
+      "description": {
+        "name": "icalendar_parser",
+        "sha256": "107f936d286723346660df88191888562fc44c2def46ed8858a301a4777ad821",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.0"
+    },
+    "image": {
+      "dependency": "transitive",
+      "description": {
+        "name": "image",
+        "sha256": "4e973fcf4caae1a4be2fa0a13157aa38a8f9cb049db6529aa00b4d71abc4d928",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.5.4"
+    },
+    "intl": {
+      "dependency": "direct main",
+      "description": {
+        "name": "intl",
+        "sha256": "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.20.2"
+    },
+    "io": {
+      "dependency": "transitive",
+      "description": {
+        "name": "io",
+        "sha256": "dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.5"
+    },
+    "isolate_channel": {
+      "dependency": "transitive",
+      "description": {
+        "name": "isolate_channel",
+        "sha256": "f3d36f783b301e6b312c3450eeb2656b0e7d1db81331af2a151d9083a3f6b18d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.2+1"
+    },
+    "izlyclient": {
+      "dependency": "direct main",
+      "description": {
+        "name": "izlyclient",
+        "sha256": "c5d5681722a1e00384c556514f3041cdf22487b42c7d8ddf8549ddc25e9cc8ac",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.11"
+    },
+    "js": {
+      "dependency": "transitive",
+      "description": {
+        "name": "js",
+        "sha256": "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.7.2"
+    },
+    "json_annotation": {
+      "dependency": "transitive",
+      "description": {
+        "name": "json_annotation",
+        "sha256": "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.9.0"
+    },
+    "json_class": {
+      "dependency": "transitive",
+      "description": {
+        "name": "json_class",
+        "sha256": "f27de435c3b47ceea23c13d0516afa98c71c62c7a762a6c8f1df665189eb855e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.1"
+    },
+    "json_schema": {
+      "dependency": "transitive",
+      "description": {
+        "name": "json_schema",
+        "sha256": "fc8c3e280c7647ed8e94f2565ba107ef4aff94b096764b8460a7e1ae39f20382",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "5.2.1"
+    },
+    "json_theme": {
+      "dependency": "direct main",
+      "description": {
+        "path": "packages/json_theme",
+        "ref": "HEAD",
+        "resolved-ref": "8fdb092be6b5ba34f19042b8856879e5f1f0c4bb",
+        "url": "https://github.com/wardbj93/json_theme"
+      },
+      "source": "git",
+      "version": "9.0.2"
+    },
+    "json_theme_annotation": {
+      "dependency": "transitive",
+      "description": {
+        "name": "json_theme_annotation",
+        "sha256": "38432c9ffed562851ef142dbeb34f9ac85d73b9b91cfbbcafaa4d5c03c99fc4a",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.3+18"
+    },
+    "latlong2": {
+      "dependency": "direct main",
+      "description": {
+        "name": "latlong2",
+        "sha256": "98227922caf49e6056f91b6c56945ea1c7b166f28ffcd5fb8e72fc0b453cc8fe",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.9.1"
+    },
+    "leak_tracker": {
+      "dependency": "transitive",
+      "description": {
+        "name": "leak_tracker",
+        "sha256": "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "11.0.1"
+    },
+    "leak_tracker_flutter_testing": {
+      "dependency": "transitive",
+      "description": {
+        "name": "leak_tracker_flutter_testing",
+        "sha256": "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.10"
+    },
+    "leak_tracker_testing": {
+      "dependency": "transitive",
+      "description": {
+        "name": "leak_tracker_testing",
+        "sha256": "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.2"
+    },
+    "lints": {
+      "dependency": "transitive",
+      "description": {
+        "name": "lints",
+        "sha256": "a5e2b223cb7c9c8efdc663ef484fdd95bb243bff242ef5b13e26883547fce9a0",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.0.0"
+    },
+    "lists": {
+      "dependency": "transitive",
+      "description": {
+        "name": "lists",
+        "sha256": "4ca5c19ae4350de036a7e996cdd1ee39c93ac0a2b840f4915459b7d0a7d4ab27",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.1"
+    },
+    "logger": {
+      "dependency": "direct main",
+      "description": {
+        "name": "logger",
+        "sha256": "55d6c23a6c15db14920e037fe7e0dc32e7cdaf3b64b4b25df2d541b5b6b81c0c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.6.1"
+    },
+    "logging": {
+      "dependency": "transitive",
+      "description": {
+        "name": "logging",
+        "sha256": "c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.3.0"
+    },
+    "lyon1agendaclient": {
+      "dependency": "direct main",
+      "description": {
+        "name": "lyon1agendaclient",
+        "sha256": "db4f3aaeaad9eb73a6b76d22785093c1402ce50b75a4dc5e5654a1c5d75944bc",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.11"
+    },
+    "lyon1casclient": {
+      "dependency": "direct main",
+      "description": {
+        "name": "lyon1casclient",
+        "sha256": "cefed48aaced20ec1eb34f03e91a906e9832578d32669c576ae75ff428227451",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.10"
+    },
+    "lyon1examenclient": {
+      "dependency": "direct main",
+      "description": {
+        "name": "lyon1examenclient",
+        "sha256": "e7209ae738b3bdc99b90eb50b34f946672a9294444eaa5134b4b67de6953b660",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.10"
+    },
+    "lyon1mailclient": {
+      "dependency": "direct main",
+      "description": {
+        "name": "lyon1mailclient",
+        "sha256": "30e28afc647ee403fb5310e4a906884e9320534749c907bc6118d44363b20121",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.11"
+    },
+    "lyon1tomussclient": {
+      "dependency": "direct main",
+      "description": {
+        "name": "lyon1tomussclient",
+        "sha256": "8fac0ac2f102ddd174597d88614ee16b11b5d97b4196e9f77487ee54224f005a",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.13"
+    },
+    "markdown": {
+      "dependency": "transitive",
+      "description": {
+        "name": "markdown",
+        "sha256": "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "7.3.0"
+    },
+    "matcher": {
+      "dependency": "transitive",
+      "description": {
+        "name": "matcher",
+        "sha256": "dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.12.17"
+    },
+    "material_color_utilities": {
+      "dependency": "transitive",
+      "description": {
+        "name": "material_color_utilities",
+        "sha256": "f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.11.1"
+    },
+    "meta": {
+      "dependency": "transitive",
+      "description": {
+        "name": "meta",
+        "sha256": "e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.16.0"
+    },
+    "mgrs_dart": {
+      "dependency": "transitive",
+      "description": {
+        "name": "mgrs_dart",
+        "sha256": "fb89ae62f05fa0bb90f70c31fc870bcbcfd516c843fb554452ab3396f78586f7",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.0"
+    },
+    "mime": {
+      "dependency": "transitive",
+      "description": {
+        "name": "mime",
+        "sha256": "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.0"
+    },
+    "modal_bottom_sheet": {
+      "dependency": "direct main",
+      "description": {
+        "name": "modal_bottom_sheet",
+        "sha256": "eac66ef8cb0461bf069a38c5eb0fa728cee525a531a8304bd3f7b2185407c67e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.0"
+    },
+    "nested": {
+      "dependency": "transitive",
+      "description": {
+        "name": "nested",
+        "sha256": "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.0"
+    },
+    "nm": {
+      "dependency": "transitive",
+      "description": {
+        "name": "nm",
+        "sha256": "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.5.0"
+    },
+    "node_preamble": {
+      "dependency": "transitive",
+      "description": {
+        "name": "node_preamble",
+        "sha256": "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.2"
+    },
+    "octo_image": {
+      "dependency": "transitive",
+      "description": {
+        "name": "octo_image",
+        "sha256": "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.0"
+    },
+    "open_filex": {
+      "dependency": "direct main",
+      "description": {
+        "name": "open_filex",
+        "sha256": "9976da61b6a72302cf3b1efbce259200cd40232643a467aac7370addf94d6900",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.7.0"
+    },
+    "package_config": {
+      "dependency": "transitive",
+      "description": {
+        "name": "package_config",
+        "sha256": "f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.0"
+    },
+    "path": {
+      "dependency": "direct main",
+      "description": {
+        "name": "path",
+        "sha256": "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.9.1"
+    },
+    "path_provider": {
+      "dependency": "direct main",
+      "description": {
+        "name": "path_provider",
+        "sha256": "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.5"
+    },
+    "path_provider_android": {
+      "dependency": "transitive",
+      "description": {
+        "name": "path_provider_android",
+        "sha256": "993381400e94d18469750e5b9dcb8206f15bc09f9da86b9e44a9b0092a0066db",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.18"
+    },
+    "path_provider_foundation": {
+      "dependency": "transitive",
+      "description": {
+        "name": "path_provider_foundation",
+        "sha256": "16eef174aacb07e09c351502740fa6254c165757638eba1e9116b0a781201bbd",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.4.2"
+    },
+    "path_provider_linux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "path_provider_linux",
+        "sha256": "f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.1"
+    },
+    "path_provider_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "path_provider_platform_interface",
+        "sha256": "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.2"
+    },
+    "path_provider_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "path_provider_windows",
+        "sha256": "bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.3.0"
+    },
+    "permission_handler": {
+      "dependency": "direct main",
+      "description": {
+        "name": "permission_handler",
+        "sha256": "bc917da36261b00137bbc8896bf1482169cd76f866282368948f032c8c1caae1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "12.0.1"
+    },
+    "permission_handler_android": {
+      "dependency": "transitive",
+      "description": {
+        "name": "permission_handler_android",
+        "sha256": "1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "13.0.1"
+    },
+    "permission_handler_apple": {
+      "dependency": "transitive",
+      "description": {
+        "name": "permission_handler_apple",
+        "sha256": "f000131e755c54cf4d84a5d8bd6e4149e262cc31c5a8b1d698de1ac85fa41023",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "9.4.7"
+    },
+    "permission_handler_html": {
+      "dependency": "transitive",
+      "description": {
+        "name": "permission_handler_html",
+        "sha256": "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.3+5"
+    },
+    "permission_handler_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "permission_handler_platform_interface",
+        "sha256": "eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.3.0"
+    },
+    "permission_handler_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "permission_handler_windows",
+        "sha256": "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.1"
+    },
+    "petitparser": {
+      "dependency": "transitive",
+      "description": {
+        "name": "petitparser",
+        "sha256": "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "7.0.1"
+    },
+    "platform": {
+      "dependency": "transitive",
+      "description": {
+        "name": "platform",
+        "sha256": "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.6"
+    },
+    "plugin_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "plugin_platform_interface",
+        "sha256": "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.8"
+    },
+    "pointycastle": {
+      "dependency": "transitive",
+      "description": {
+        "name": "pointycastle",
+        "sha256": "4be0097fcf3fd3e8449e53730c631200ebc7b88016acecab2b0da2f0149222fe",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.9.1"
+    },
+    "polylabel": {
+      "dependency": "transitive",
+      "description": {
+        "name": "polylabel",
+        "sha256": "41b9099afb2aa6c1730bdd8a0fab1400d287694ec7615dd8516935fa3144214b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.1"
+    },
+    "polytechcolloscopeclient": {
+      "dependency": "direct main",
+      "description": {
+        "name": "polytechcolloscopeclient",
+        "sha256": "da09a7eb625559015181947d2df843194a6da864bb542fc65c4ce6fa72b3521c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.12"
+    },
+    "pool": {
+      "dependency": "transitive",
+      "description": {
+        "name": "pool",
+        "sha256": "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.5.1"
+    },
+    "posix": {
+      "dependency": "transitive",
+      "description": {
+        "name": "posix",
+        "sha256": "6323a5b0fa688b6a010df4905a56b00181479e6d10534cecfecede2aa55add61",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.0.3"
+    },
+    "proj4dart": {
+      "dependency": "transitive",
+      "description": {
+        "name": "proj4dart",
+        "sha256": "c8a659ac9b6864aa47c171e78d41bbe6f5e1d7bd790a5814249e6b68bc44324e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.0"
+    },
+    "provider": {
+      "dependency": "transitive",
+      "description": {
+        "name": "provider",
+        "sha256": "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.1.5+1"
+    },
+    "pub_semver": {
+      "dependency": "transitive",
+      "description": {
+        "name": "pub_semver",
+        "sha256": "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.0"
+    },
+    "pubspec_parse": {
+      "dependency": "transitive",
+      "description": {
+        "name": "pubspec_parse",
+        "sha256": "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.5.0"
+    },
+    "qr_code_dart_decoder": {
+      "dependency": "transitive",
+      "description": {
+        "name": "qr_code_dart_decoder",
+        "sha256": "4044f13a071da6102f7e9bc44a6b1ce577604d7846bcbeb1be412a137b825017",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.2"
+    },
+    "qr_code_dart_scan": {
+      "dependency": "direct main",
+      "description": {
+        "name": "qr_code_dart_scan",
+        "sha256": "1b317b47f475f6995c19e0f41d790902a8cd158b23c435d936763d86ba44309c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.11.3"
+    },
+    "quill_native_bridge": {
+      "dependency": "transitive",
+      "description": {
+        "name": "quill_native_bridge",
+        "sha256": "00752aca7d67cbd3254709a47558be78427750cb81aa42cfbed354d4a079bcfa",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "11.0.1"
+    },
+    "quill_native_bridge_android": {
+      "dependency": "transitive",
+      "description": {
+        "name": "quill_native_bridge_android",
+        "sha256": "b75c7e6ede362a7007f545118e756b1f19053994144ec9eda932ce5e54a57569",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.0.1+2"
+    },
+    "quill_native_bridge_ios": {
+      "dependency": "transitive",
+      "description": {
+        "name": "quill_native_bridge_ios",
+        "sha256": "d23de3cd7724d482fe2b514617f8eedc8f296e120fb297368917ac3b59d8099f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.0.1"
+    },
+    "quill_native_bridge_linux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "quill_native_bridge_linux",
+        "sha256": "388aaa62017dbd746742ce0bfae99f4ffe1dda2462e8a866df630c67b63c54fe",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.0.2"
+    },
+    "quill_native_bridge_macos": {
+      "dependency": "transitive",
+      "description": {
+        "name": "quill_native_bridge_macos",
+        "sha256": "1c0631bd1e2eee765a8b06017c5286a4e829778f4585736e048eb67c97af8a77",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.0.1"
+    },
+    "quill_native_bridge_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "quill_native_bridge_platform_interface",
+        "sha256": "8264a2bdb8a294c31377a27b46c0f8717fa9f968cf113f7dc52d332ed9c84526",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.0.2+1"
+    },
+    "quill_native_bridge_web": {
+      "dependency": "transitive",
+      "description": {
+        "name": "quill_native_bridge_web",
+        "sha256": "7c723f6824b0250d7f33e8b6c23f2f8eb0103fe48ee7ebf47ab6786b64d5c05d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.0.2"
+    },
+    "quill_native_bridge_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "quill_native_bridge_windows",
+        "sha256": "3f96ced19e3206ddf4f6f7dde3eb16bdd05e10294964009ea3a806d995aa7caa",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.0.2"
+    },
+    "quiver": {
+      "dependency": "transitive",
+      "description": {
+        "name": "quiver",
+        "sha256": "ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.2.2"
+    },
+    "requests_plus": {
+      "dependency": "direct main",
+      "description": {
+        "name": "requests_plus",
+        "sha256": "b1d6e2c4fbe47643c46d3d27a773dbe9c1592464a8b7ed4d4ea20a3b1ea1bd3c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.8.6"
+    },
+    "responsive_sizer": {
+      "dependency": "direct main",
+      "description": {
+        "name": "responsive_sizer",
+        "sha256": "6aefee6065c0883681bc7559147a24d8fa1846d296a216abcda25ff349340712",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.3.1"
+    },
+    "rfc_6901": {
+      "dependency": "transitive",
+      "description": {
+        "name": "rfc_6901",
+        "sha256": "df1bbfa3d023009598f19636d6114c6ac1e0b7bb7bf6a260f0e6e6ce91416820",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.0"
+    },
+    "rxdart": {
+      "dependency": "transitive",
+      "description": {
+        "name": "rxdart",
+        "sha256": "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.28.0"
+    },
+    "screen_brightness": {
+      "dependency": "direct main",
+      "description": {
+        "name": "screen_brightness",
+        "sha256": "5f70754028f169f059fdc61112a19dcbee152f8b293c42c848317854d650cba3",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.7"
+    },
+    "screen_brightness_android": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_brightness_android",
+        "sha256": "d34f5321abd03bc3474f4c381f53d189117eba0b039eac1916aa92cca5fd0a96",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.3"
+    },
+    "screen_brightness_ios": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_brightness_ios",
+        "sha256": "2493953340ecfe8f4f13f61db50ce72533a55b0bbd58ba1402893feecf3727f5",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.2"
+    },
+    "screen_brightness_macos": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_brightness_macos",
+        "sha256": "4edf330ad21078686d8bfaf89413325fbaf571dcebe1e89254d675a3f288b5b9",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.1"
+    },
+    "screen_brightness_ohos": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_brightness_ohos",
+        "sha256": "a93a263dcd39b5c56e589eb495bcd001ce65cdd96ff12ab1350683559d5c5bb7",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.2"
+    },
+    "screen_brightness_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_brightness_platform_interface",
+        "sha256": "737bd47b57746bc4291cab1b8a5843ee881af499514881b0247ec77447ee769c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.0"
+    },
+    "screen_brightness_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_brightness_windows",
+        "sha256": "d3518bf0f5d7a884cee2c14449ae0b36803802866de09f7ef74077874b6b2448",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.0"
+    },
+    "screenshot": {
+      "dependency": "direct main",
+      "description": {
+        "name": "screenshot",
+        "sha256": "63817697a7835e6ce82add4228e15d233b74d42975c143ad8cfe07009fab866b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.0"
+    },
+    "sembast": {
+      "dependency": "direct main",
+      "description": {
+        "name": "sembast",
+        "sha256": "7119cf6f79bd1d48c8ec7943f4facd96c15ab26823021ed0792a487c7cd34441",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.8.5+1"
+    },
+    "share_plus": {
+      "dependency": "direct main",
+      "description": {
+        "name": "share_plus",
+        "sha256": "d7dc0630a923883c6328ca31b89aa682bacbf2f8304162d29f7c6aaff03a27a1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "11.1.0"
+    },
+    "share_plus_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "share_plus_platform_interface",
+        "sha256": "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.1.0"
+    },
+    "shelf": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shelf",
+        "sha256": "e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.4.2"
+    },
+    "shelf_packages_handler": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shelf_packages_handler",
+        "sha256": "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.2"
+    },
+    "shelf_static": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shelf_static",
+        "sha256": "c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.3"
+    },
+    "shelf_web_socket": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shelf_web_socket",
+        "sha256": "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.0"
+    },
+    "sky_engine": {
+      "dependency": "transitive",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
+    "source_gen": {
+      "dependency": "transitive",
+      "description": {
+        "name": "source_gen",
+        "sha256": "7b19d6ba131c6eb98bfcbf8d56c1a7002eba438af2e7ae6f8398b2b0f4f381e3",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.0"
+    },
+    "source_map_stack_trace": {
+      "dependency": "transitive",
+      "description": {
+        "name": "source_map_stack_trace",
+        "sha256": "c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.2"
+    },
+    "source_maps": {
+      "dependency": "transitive",
+      "description": {
+        "name": "source_maps",
+        "sha256": "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.10.13"
+    },
+    "source_span": {
+      "dependency": "transitive",
+      "description": {
+        "name": "source_span",
+        "sha256": "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.10.1"
+    },
+    "sprintf": {
+      "dependency": "transitive",
+      "description": {
+        "name": "sprintf",
+        "sha256": "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "7.0.0"
+    },
+    "sqflite": {
+      "dependency": "transitive",
+      "description": {
+        "name": "sqflite",
+        "sha256": "e2297b1da52f127bc7a3da11439985d9b536f75070f3325e62ada69a5c585d03",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.4.2"
+    },
+    "sqflite_android": {
+      "dependency": "transitive",
+      "description": {
+        "name": "sqflite_android",
+        "sha256": "ecd684501ebc2ae9a83536e8b15731642b9570dc8623e0073d227d0ee2bfea88",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.4.2+2"
+    },
+    "sqflite_common": {
+      "dependency": "transitive",
+      "description": {
+        "name": "sqflite_common",
+        "sha256": "6ef422a4525ecc601db6c0a2233ff448c731307906e92cabc9ba292afaae16a6",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.5.6"
+    },
+    "sqflite_darwin": {
+      "dependency": "transitive",
+      "description": {
+        "name": "sqflite_darwin",
+        "sha256": "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.4.2"
+    },
+    "sqflite_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "sqflite_platform_interface",
+        "sha256": "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.4.0"
+    },
+    "stack_trace": {
+      "dependency": "transitive",
+      "description": {
+        "name": "stack_trace",
+        "sha256": "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.12.1"
+    },
+    "stream_channel": {
+      "dependency": "transitive",
+      "description": {
+        "name": "stream_channel",
+        "sha256": "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.4"
+    },
+    "stream_transform": {
+      "dependency": "transitive",
+      "description": {
+        "name": "stream_transform",
+        "sha256": "ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.1"
+    },
+    "string_scanner": {
+      "dependency": "transitive",
+      "description": {
+        "name": "string_scanner",
+        "sha256": "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.4.1"
+    },
+    "synchronized": {
+      "dependency": "transitive",
+      "description": {
+        "name": "synchronized",
+        "sha256": "c254ade258ec8282947a0acbbc90b9575b4f19673533ee46f2f6e9b3aeefd7c0",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.4.0"
+    },
+    "term_glyph": {
+      "dependency": "transitive",
+      "description": {
+        "name": "term_glyph",
+        "sha256": "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.2.2"
+    },
+    "test": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "test",
+        "sha256": "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.26.2"
+    },
+    "test_api": {
+      "dependency": "transitive",
+      "description": {
+        "name": "test_api",
+        "sha256": "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.7.6"
+    },
+    "test_core": {
+      "dependency": "transitive",
+      "description": {
+        "name": "test_core",
+        "sha256": "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.6.11"
+    },
+    "timezone": {
+      "dependency": "transitive",
+      "description": {
+        "name": "timezone",
+        "sha256": "dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.10.1"
+    },
+    "timing": {
+      "dependency": "transitive",
+      "description": {
+        "name": "timing",
+        "sha256": "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.2"
+    },
+    "type_plus": {
+      "dependency": "transitive",
+      "description": {
+        "name": "type_plus",
+        "sha256": "d5d1019471f0d38b91603adb9b5fd4ce7ab903c879d2fbf1a3f80a630a03fcc9",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.1"
+    },
+    "typed_data": {
+      "dependency": "transitive",
+      "description": {
+        "name": "typed_data",
+        "sha256": "f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.4.0"
+    },
+    "unicode": {
+      "dependency": "transitive",
+      "description": {
+        "name": "unicode",
+        "sha256": "0f69e46593d65245774d4f17125c6084d2c20b4e473a983f6e21b7d7762218f1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.3.1"
+    },
+    "uri": {
+      "dependency": "transitive",
+      "description": {
+        "name": "uri",
+        "sha256": "889eea21e953187c6099802b7b4cf5219ba8f3518f604a1033064d45b1b8268a",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.0"
+    },
+    "url_launcher": {
+      "dependency": "direct main",
+      "description": {
+        "name": "url_launcher",
+        "sha256": "f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.3.2"
+    },
+    "url_launcher_android": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher_android",
+        "sha256": "69ee86740f2847b9a4ba6cffa74ed12ce500bbe2b07f3dc1e643439da60637b7",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.3.18"
+    },
+    "url_launcher_ios": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher_ios",
+        "sha256": "d80b3f567a617cb923546034cc94bfe44eb15f989fe670b37f26abdb9d939cb7",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.3.4"
+    },
+    "url_launcher_linux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher_linux",
+        "sha256": "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.2.1"
+    },
+    "url_launcher_macos": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher_macos",
+        "sha256": "c043a77d6600ac9c38300567f33ef12b0ef4f4783a2c1f00231d2b1941fea13f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.2.3"
+    },
+    "url_launcher_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher_platform_interface",
+        "sha256": "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.3.2"
+    },
+    "url_launcher_web": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher_web",
+        "sha256": "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.4.1"
+    },
+    "url_launcher_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher_windows",
+        "sha256": "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.4"
+    },
+    "uuid": {
+      "dependency": "transitive",
+      "description": {
+        "name": "uuid",
+        "sha256": "a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.5.1"
+    },
+    "vector_math": {
+      "dependency": "transitive",
+      "description": {
+        "name": "vector_math",
+        "sha256": "d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.0"
+    },
+    "vm_service": {
+      "dependency": "transitive",
+      "description": {
+        "name": "vm_service",
+        "sha256": "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "15.0.2"
+    },
+    "vsc_quill_delta_to_html": {
+      "dependency": "direct main",
+      "description": {
+        "name": "vsc_quill_delta_to_html",
+        "sha256": "9aca60d53ed1b700e922dabff8cd8b3490daecbf99c258f19eb45820b794fa45",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.5"
+    },
+    "watcher": {
+      "dependency": "transitive",
+      "description": {
+        "name": "watcher",
+        "sha256": "5bf046f41320ac97a469d506261797f35254fa61c641741ef32dacda98b7d39c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.3"
+    },
+    "web": {
+      "dependency": "transitive",
+      "description": {
+        "name": "web",
+        "sha256": "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.1"
+    },
+    "web_socket": {
+      "dependency": "transitive",
+      "description": {
+        "name": "web_socket",
+        "sha256": "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.1"
+    },
+    "web_socket_channel": {
+      "dependency": "transitive",
+      "description": {
+        "name": "web_socket_channel",
+        "sha256": "d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.3"
+    },
+    "webkit_inspection_protocol": {
+      "dependency": "transitive",
+      "description": {
+        "name": "webkit_inspection_protocol",
+        "sha256": "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.2.1"
+    },
+    "webview_flutter": {
+      "dependency": "direct main",
+      "description": {
+        "name": "webview_flutter",
+        "sha256": "c3e4fe614b1c814950ad07186007eff2f2e5dd2935eba7b9a9a1af8e5885f1ba",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.13.0"
+    },
+    "webview_flutter_android": {
+      "dependency": "transitive",
+      "description": {
+        "name": "webview_flutter_android",
+        "sha256": "9a25f6b4313978ba1c2cda03a242eea17848174912cfb4d2d8ee84a556f248e3",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.10.1"
+    },
+    "webview_flutter_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "webview_flutter_platform_interface",
+        "sha256": "63d26ee3aca7256a83ccb576a50272edd7cfc80573a4305caa98985feb493ee0",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.14.0"
+    },
+    "webview_flutter_wkwebview": {
+      "dependency": "transitive",
+      "description": {
+        "name": "webview_flutter_wkwebview",
+        "sha256": "fb46db8216131a3e55bcf44040ca808423539bc6732e7ed34fb6d8044e3d512f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.23.0"
+    },
+    "win32": {
+      "dependency": "transitive",
+      "description": {
+        "name": "win32",
+        "sha256": "66814138c3562338d05613a6e368ed8cfb237ad6d64a9e9334be3f309acfca03",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "5.14.0"
+    },
+    "wkt_parser": {
+      "dependency": "transitive",
+      "description": {
+        "name": "wkt_parser",
+        "sha256": "8a555fc60de3116c00aad67891bcab20f81a958e4219cc106e3c037aa3937f13",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.0"
+    },
+    "workmanager": {
+      "dependency": "direct main",
+      "description": {
+        "path": "workmanager",
+        "ref": "main",
+        "resolved-ref": "7f4f870d593f858b0f55bd344c9863a6099cb30f",
+        "url": "https://github.com/fluttercommunity/flutter_workmanager.git"
+      },
+      "source": "git",
+      "version": "0.9.0+3"
+    },
+    "workmanager_android": {
+      "dependency": "transitive",
+      "description": {
+        "name": "workmanager_android",
+        "sha256": "9ae744db4ef891f5fcd2fb8671fccc712f4f96489a487a1411e0c8675e5e8cb7",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.9.0+2"
+    },
+    "workmanager_apple": {
+      "dependency": "transitive",
+      "description": {
+        "name": "workmanager_apple",
+        "sha256": "1cc12ae3cbf5535e72f7ba4fde0c12dd11b757caf493a28e22d684052701f2ca",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.9.1+2"
+    },
+    "workmanager_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "workmanager_platform_interface",
+        "sha256": "f40422f10b970c67abb84230b44da22b075147637532ac501729256fcea10a47",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.9.1+1"
+    },
+    "xdg_directories": {
+      "dependency": "transitive",
+      "description": {
+        "name": "xdg_directories",
+        "sha256": "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.0"
+    },
+    "xml": {
+      "dependency": "transitive",
+      "description": {
+        "name": "xml",
+        "sha256": "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.6.1"
+    },
+    "yaml": {
+      "dependency": "transitive",
+      "description": {
+        "name": "yaml",
+        "sha256": "b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.3"
+    },
+    "zxing_lib": {
+      "dependency": "transitive",
+      "description": {
+        "name": "zxing_lib",
+        "sha256": "f9170470b6bc947d21a6783486f88ef48aad66fc1380c8acd02b118418ec0ce0",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.4"
+    }
+  },
+  "sdks": {
+    "dart": ">=3.9.0 <4.0.0",
+    "flutter": ">=3.32.8"
+  }
+}


### PR DESCRIPTION
Onyx init at 2.0.12

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
