### PR TITLE
home-assistant-custom-components.meshcore_ha: init at 2.1.3

### DIFF
--- a/pkgs/by-name/me/meshcore-cli/package.nix
+++ b/pkgs/by-name/me/meshcore-cli/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "meshcore-cli";
+  version = "0-unstable-2025-09-06";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "fdlamotte";
+    repo = "meshcore-cli";
+    rev = "0cb9b908bfbf0e49fe507b29ccfae9d371d28a10";
+    hash = "sha256-OtwYeLLCFs850HyM+Cc7CbukgG5ajs4MTB6mumrI8F0=";
+  };
+
+  build-system = with python3Packages; [ hatchling ];
+
+  dependencies = with python3Packages; [
+    meshcore
+    prompt-toolkit
+    requests
+  ];
+
+  pythonImportsCheck = [
+    "meshcore_cli"
+  ];
+  postFixup = ''
+    rm $out/nix-support/propagated-build-inputs
+  '';
+
+  meta = {
+    description = "Command line interface to MeshCore node";
+    homepage = "https://github.com/fdlamotte/meshcore-cli";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.haylin ];
+    mainProgram = "meshcore-cli";
+  };
+}

--- a/pkgs/by-name/me/meshcore-cli/package.nix
+++ b/pkgs/by-name/me/meshcore-cli/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication meshcore-cli

--- a/pkgs/development/python-modules/meshcore-cli/default.nix
+++ b/pkgs/development/python-modules/meshcore-cli/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  bleak,
+  meshcore,
+  prompt-toolkit,
+  requests,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "meshcore-cli";
+  version = "1.5.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "fdlamotte";
+    repo = "meshcore-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-wby97e9Xulk2pwNJ9mnvKxWlTsWmH4n3zlTtYi7WS6I=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    meshcore
+    bleak
+    prompt-toolkit
+    requests
+  ];
+
+  pythonImportsCheck = [
+    "meshcore_cli"
+  ];
+
+  doCheck = false; # no tests
+
+  __structuredAttrs = true;
+
+  meta = {
+    changelog = "https://github.com/meshcore-dev/meshcore-cli/releases/tag/${finalAttrs.src.tag}";
+    description = "Command line interface to MeshCore node";
+    homepage = "https://github.com/fdlamotte/meshcore-cli";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.haylin ];
+    mainProgram = "meshcore-cli";
+  };
+})

--- a/pkgs/development/python-modules/meshcore/default.nix
+++ b/pkgs/development/python-modules/meshcore/default.nix
@@ -2,24 +2,41 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
+
+  # build-system
   hatchling,
+
   # dependencies
   bleak,
   pycayennelpp,
   pyserial-asyncio-fast,
+  pycryptodome,
+
+  # tests
+  pytest-asyncio,
+  pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "meshcore";
-  version = "2.2.8";
+  version = "2.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "meshcore-dev";
     repo = "meshcore_py";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-S3hyA2TsgEHwB0gv5xFMTbwnAoGbceq0C5+8MBedD70=";
+    hash = "sha256-Vz2LQaP44Yojf9h2rSBvKRjW99IOj7C5MxqQnIUoIRE=";
   };
+
+  patches = [
+    (fetchpatch {
+      # https://github.com/meshcore-dev/meshcore_py/pull/71
+      url = "https://github.com/meshcore-dev/meshcore_py/commit/9294e574739844e0e291b972b40e1a0a40149e47.patch";
+      hash = "sha256-Ufr+5rDDO32W6dtD7wEU34iLJai3H0dBCEtLS5j4u/0=";
+    })
+  ];
 
   build-system = [ hatchling ];
 
@@ -27,6 +44,12 @@ buildPythonPackage (finalAttrs: {
     bleak
     pycayennelpp
     pyserial-asyncio-fast
+    pycryptodome
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
   ];
 
   pythonImportsCheck = [ "meshcore" ];

--- a/pkgs/servers/home-assistant/build-custom-component/default.nix
+++ b/pkgs/servers/home-assistant/build-custom-component/default.nix
@@ -52,13 +52,10 @@ lib.extendMkDerivation {
         runHook postInstall
       '';
 
-      nativeBuildInputs =
-        with home-assistant.python3Packages;
-        [
-          manifestRequirementsCheckHook
-          packaging
-        ]
-        ++ (args.nativeBuildInputs or [ ]);
+      nativeBuildInputs = [
+        manifestRequirementsCheckHook
+      ]
+      ++ (args.nativeBuildInputs or [ ]);
 
       passthru = {
         isHomeAssistantComponent = true;

--- a/pkgs/servers/home-assistant/build-custom-component/manifest-requirements-check-hook.nix
+++ b/pkgs/servers/home-assistant/build-custom-component/manifest-requirements-check-hook.nix
@@ -6,6 +6,7 @@
 
 makeSetupHook {
   name = "manifest-check-hook";
+  propagatedNativeBuildInputs = [ python3Packages.packaging ];
   substitutions = {
     pythonCheckInterpreter = python3Packages.python.interpreter;
     checkManifest = ./check_manifest.py;

--- a/pkgs/servers/home-assistant/custom-components/meshcore/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/meshcore/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildHomeAssistantComponent,
+  cachetools,
+  meshcore,
+  meshcore-cli,
+  paho-mqtt,
+  pynacl,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildHomeAssistantComponent (finalAttrs: {
+  owner = "meshcore-dev";
+  domain = "meshcore";
+  version = "2.7.0";
+
+  src = fetchFromGitHub {
+    owner = "meshcore-dev";
+    repo = "meshcore-ha";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DykWjoMVVKzDa05UtytrkwUej80zteZThi8E3e7M+ZU=";
+  };
+
+  dependencies = [
+    cachetools
+    meshcore
+    meshcore-cli
+    paho-mqtt
+    pynacl
+  ];
+
+  ignoreVersionRequirement = [
+    "meshcore"
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  meta = {
+    changelog = "https://github.com/meshcore-dev/meshcore-ha/releases/tag/${finalAttrs.src.tag}";
+    description = "Home Assistant integration for MeshCore";
+    homepage = "https://github.com/meshcore-dev/meshcore-ha/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.haylin ];
+  };
+})

--- a/pkgs/servers/home-assistant/custom-components/meshcore_ha/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/meshcore_ha/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildHomeAssistantComponent,
+  ruff,
+  meshcore,
+  meshcore-cli,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "meshcore-dev";
+  domain = "meshcore";
+  version = "2.1.3";
+
+  src = fetchFromGitHub {
+    owner = "meshcore-dev";
+    repo = "meshcore-ha";
+    tag = "v${version}";
+    hash = "sha256-+DOekvuhd3M00cRNBsWiI+idz80JFQ7XPQ6g4Ecq2R0=";
+  };
+
+  dependencies = [
+    meshcore
+    meshcore-cli
+  ];
+
+  meta = {
+    description = "Home Assistant integration for MeshCore";
+    homepage = "https://github.com/meshcore-dev/meshcore-ha/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.haylin ];
+  };
+}

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/meshcore-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/meshcore-card/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "meshcore-card";
+  version = "0.3.5";
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "jpettitt";
+    repo = "meshcore-card";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XfqtCGSDrfkNIqWuH8Y8DLacJf9x7iaZXDiKDWdqzhw=";
+  };
+
+  npmDepsHash = "sha256-KgG6PGSGw9zCOPboZjo/gpAs2OwLg3LRl3rqenIvTG8=";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    cp dist/${finalAttrs.pname}.js $out/
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "MeshCore Lovelace card for Home Assistant";
+    homepage = "https://github.com/jpettitt/meshcore-card";
+    changelog = "https://github.com/jpettitt/meshcore-card/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hexa ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9898,6 +9898,8 @@ self: super: with self; {
 
   meshcore = callPackage ../development/python-modules/meshcore { };
 
+  meshcore-cli = callPackage ../development/python-modules/meshcore-cli { };
+
   meshio = callPackage ../development/python-modules/meshio { };
 
   meshlabxml = callPackage ../development/python-modules/meshlabxml { };


### PR DESCRIPTION
## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
