### PR TITLE
imbalanced-learn: 0.13.0->0.14.0

### DIFF
--- a/pkgs/development/python-modules/imbalanced-learn/default.nix
+++ b/pkgs/development/python-modules/imbalanced-learn/default.nix
@@ -14,13 +14,12 @@
   tensorflow,
   threadpoolctl,
   pytestCheckHook,
-  sklearn-compat,
   python,
 }:
 
 buildPythonPackage rec {
   pname = "imbalanced-learn";
-  version = "0.13.0";
+  version = "0.14.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -29,7 +28,7 @@ buildPythonPackage rec {
     owner = "scikit-learn-contrib";
     repo = "imbalanced-learn";
     tag = version;
-    hash = "sha256-osmALi5vTV+3kgldY/VhYkNvpXX11KwJ/dIX/5E7Uhc=";
+    hash = "sha256-1R7jHOkTO3zK9bkUvvOPQ420ofqIO7J1rqixFEbApR0=";
   };
 
   build-system = [
@@ -43,7 +42,6 @@ buildPythonPackage rec {
     scikit-learn
     scipy
     threadpoolctl
-    sklearn-compat
   ];
 
   optional-dependencies = {
@@ -82,6 +80,7 @@ buildPythonPackage rec {
   disabledTests = [
     # Broken upstream test https://github.com/scikit-learn-contrib/imbalanced-learn/issues/1131
     "test_estimators_compatibility_sklearn"
+    "test_balanced_bagging_classifier_with_function_sampler"
   ];
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

disabled `test_balanced_bagging_classifier_with_function_sampler` as it flaked at least once

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
