### PR TITLE
services.connman: remove `with` usage

### DIFF
--- a/nixos/modules/services/networking/connman.nix
+++ b/nixos/modules/services/networking/connman.nix
@@ -16,7 +16,7 @@ let
   enableIwd = cfg.wifi.backend == "iwd";
 in
 {
-  meta.maintainers = with lib.maintainers; [ ];
+  meta.maintainers = [ ];
 
   imports = [
     (lib.mkRenamedOptionModule [ "networking" "connman" ] [ "services" "connman" ])
@@ -59,7 +59,7 @@ in
       };
 
       networkInterfaceBlacklist = lib.mkOption {
-        type = with lib.types; listOf str;
+        type = lib.types.listOf lib.types.str;
         default = [
           "vmnet"
           "vboxnet"
@@ -87,7 +87,7 @@ in
       };
 
       extraFlags = lib.mkOption {
-        type = with lib.types; listOf str;
+        type = lib.types.listOf lib.types.str;
         default = [ ];
         example = [ "--nodnsproxy" ];
         description = ''


### PR DESCRIPTION
just be explicit in nixpkgs repo :)

does not change any functionality
