### PR TITLE
rename: 1.11 -> 1.16.3

### DIFF
--- a/pkgs/by-name/re/rename/package.nix
+++ b/pkgs/by-name/re/rename/package.nix
@@ -6,13 +6,13 @@
 
 perlPackages.buildPerlPackage rec {
   pname = "rename";
-  version = "1.11";
+  version = "1.16.3";
   outputs = [ "out" ];
   src = fetchFromGitHub {
     owner = "pstray";
     repo = "rename";
     rev = "v${version}";
-    sha256 = "SK6wS3IxjCftuDiiZU27TFnn9GVd137zmzvGH88cNLI=";
+    sha256 = "KQsBO94fsa4CbTHNyJxOD96AwUfKNLa9p44odlNgQao=";
   };
   meta = with lib; {
     description = "Rename files according to a Perl rewrite expression";
@@ -20,6 +20,7 @@ perlPackages.buildPerlPackage rec {
     maintainers = with maintainers; [
       mkg
       cyplo
+      cfouche
     ];
     license = with licenses; [ gpl1Plus ];
     mainProgram = "rename";


### PR DESCRIPTION
rename has been somewhat improved since 2021 (shell-completion, other commands, git support, copy), and thus may merits a bit of an upgrade.