### PR TITLE
services.hostapd: add assertions and warnings to detect conflict with `networking.wireless.iwd` or `networking.wireless`

### DIFF
--- a/nixos/modules/services/networking/hostapd.nix
+++ b/nixos/modules/services/networking/hostapd.nix
@@ -1325,10 +1325,34 @@ in
     ];
 
   config = mkIf cfg.enable {
+    warnings =
+      let
+        wirelessEnabled = config.networking.wireless.enable;
+        wirelessInterfaces = config.networking.wireless.interfaces;
+        hostapdInterfaces = lib.attrNames cfg.radios;
+        hasInterfaceConflict = lib.intersectLists hostapdInterfaces wirelessInterfaces != [ ];
+        # we check if wirelessInterfaces is empty as that means all interfaces implicit
+        shouldWarn = wirelessEnabled && (wirelessInterfaces == [ ] || hasInterfaceConflict);
+      in
+      if shouldWarn then
+        [
+          ''
+            Some wireless interface is configured for both for client and access point mode:
+            this is not allowed. Either specify `networking.wireless.interfaces` and exclude
+            those from `services.hostapd.radios` or make sure to not run the `wpa_supplicant`
+            and `hostapd` services simultaneously.
+          ''
+        ]
+      else
+        [ ];
     assertions = [
       {
         assertion = cfg.radios != { };
         message = "At least one radio must be configured with hostapd!";
+      }
+      {
+        assertion = !config.networking.wireless.iwd.enable;
+        message = "hostapd and iwd conflict, use `networking.wireless.enable` in combination with `networking.wireless.interfaces`";
       }
     ]
     # Radio warnings


### PR DESCRIPTION
close #137221



- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
