### PR TITLE
krename: re-init at 5.0.60

### DIFF
--- a/pkgs/by-name/kr/krename/package.nix
+++ b/pkgs/by-name/kr/krename/package.nix
@@ -1,0 +1,65 @@
+{
+  stdenv,
+  fetchFromGitLab,
+  lib,
+  extra-cmake-modules,
+  kdePackages,
+  taglib,
+  exiv2,
+  podofo_0_10,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "krename";
+  version = "5.0.60-unstable-2025-09-02";
+
+  # For when the next stable release is made
+  # src = fetchurl {
+  #   url = "mirror://kde/stable/krename/${version}/src/krename-${finalAttrs.version}.tar.xz";
+  #   hash = "sha256-sjxgp93Z9ttN1/VaxV/MqKVY+miq+PpcuJ4er2kvI+0=";
+  # };
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "utilities";
+    repo = "krename";
+
+    rev = "5ad5f5a1f0a1c7573fa1b872a1472dec96fe0dd7";
+    hash = "sha256-fGNiIGGq10F71wh37aKDB7Q3fCxSXqttg/176LH3nVM=";
+  };
+
+  buildInputs = with kdePackages; [
+    exiv2
+    podofo_0_10
+    kio
+    kxmlgui
+    qtbase
+    qtdeclarative
+    qt5compat
+    taglib
+  ];
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdePackages.kdoctools
+    kdePackages.wrapQtAppsHook
+  ];
+
+  env.NIX_LDFLAGS = "-ltag";
+
+  meta = {
+    description = "Powerful batch renamer for KDE";
+    mainProgram = "krename";
+    homepage = "https://kde.org/applications/utilities/krename/";
+    license = with lib.licenses; [
+      bsd3
+      cc0
+      gpl2Plus
+    ];
+    maintainers = with lib.maintainers; [
+      peterhoeg
+      kuflierl
+    ];
+    inherit (kdePackages.qtbase.meta) platforms;
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1259,7 +1259,6 @@ mapAliases {
   kramdown-rfc2629 = throw "'kramdown-rfc2629' has been renamed to/replaced by 'rubyPackages.kramdown-rfc2629'"; # Converted to throw 2024-10-17
   krb5Full = krb5;
   kreative-square-fonts = throw "'kreative-square-fonts' has been renamed to 'kreative-square'"; # Added 2025-04-16
-  krename = throw "'krename' has been removed, as it is unmaintained upstream"; # Added 2025-08-30
   krita-beta = throw "'krita-beta' has been renamed to/replaced by 'krita'"; # Converted to throw 2024-10-17
   krun = throw "'krun' has been renamed to/replaced by 'muvm'"; # Added 2025-05-01
   krunner-pass = throw "'krunner-pass' has been removed, as it only works on Plasma 5"; # Added 2025-08-30


### PR DESCRIPTION
krename was dropped in 40528dc1d684093743948f58789b643e9b5163ac

Upstream development is admittedly very slow, but it's still working properly (I use it every now and then) and there a preliminary version supporting qt6 which we introduce here.

@kuflierl has shown an interest in maintaining this as well in #413435.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
