### PR TITLE
tesseract: fix passthru override

### DIFF
--- a/pkgs/applications/graphics/tesseract/wrapper.nix
+++ b/pkgs/applications/graphics/tesseract/wrapper.nix
@@ -58,34 +58,42 @@ let
   passthru = { inherit tesseractBase languages tessdata; };
 
   # Only run test when all languages are available
-  test = lib.optionalAttrs (enableLanguages == null) {
-    tests.default =
-      runCommand "tesseract-test-ocr"
-        {
-          buildInputs = [
-            tesseractWithData
-            imagemagick
-          ];
-        }
-        ''
-          text="hello nix"
+  test =
+    runCommand "tesseract-test-ocr"
+      {
+        buildInputs = [
+          tesseractWithData
+          imagemagick
+        ];
+      }
+      ''
+        text="hello nix"
 
-          convert -size 400x40 xc:white -font 'DejaVu-Sans' -pointsize 20 \
-            -fill black -annotate +5+20 "$text" /tmp/test-img.png 2>/dev/null
-          ocrResult=$(tesseract /tmp/test-img.png - | tr -d "\f")
+        convert -size 400x40 xc:white -font 'DejaVu-Sans' -pointsize 20 \
+          -fill black -annotate +5+20 "$text" /tmp/test-img.png 2>/dev/null
+        ocrResult=$(tesseract /tmp/test-img.png - | tr -d "\f")
 
-          if [[ $ocrResult != $text ]]; then
-            echo "OCR test failed"
-            echo "expected: '$text'"
-            echo "actual: '$ocrResult'"
-            exit 1
-          fi
-          touch $out
-        '';
-  };
+        if [[ $ocrResult != $text ]]; then
+          echo "OCR test failed"
+          echo "expected: '$text'"
+          echo "actual: '$ocrResult'"
+          exit 1
+        fi
+        touch $out
+      '';
 
   tesseract =
-    (if enableLanguages == [ ] then tesseractBase else tesseractWithData) // passthru // test;
+    (if enableLanguages == [ ] then tesseractBase else tesseractWithData).overrideAttrs
+      (old: {
+        passthru =
+          (old.passthru or { })
+          // passthru
+          // lib.optionalAttrs (enableLanguages == null) {
+            tests = (old.passthru.tests or { }) // {
+              default = test;
+            };
+          };
+      });
 in
 if enableLanguagesHash == null then
   tesseract


### PR DESCRIPTION
fixes tesseract passthru. 
error was surfaced by: #423615
fixes: #440907

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
