### PR TITLE
jupyterLib: init

### DIFF
--- a/pkgs/applications/editors/jupyter/kernel.nix
+++ b/pkgs/applications/editors/jupyter/kernel.nix
@@ -2,16 +2,16 @@
   lib,
   stdenv,
   python3,
+  jupyterLib,
 }:
 
 let
-
   default = {
     python3 =
       let
         env = (python3.withPackages (ps: with ps; [ ipykernel ]));
       in
-      {
+      jupyterLib.mkKernelDefinition {
         displayName = "Python 3";
         argv = [
           env.interpreter

--- a/pkgs/applications/editors/jupyter/lib.nix
+++ b/pkgs/applications/editors/jupyter/lib.nix
@@ -1,0 +1,19 @@
+{
+
+  # creates definitions that can be passed on to jupyter-kernel.create like this:
+  # jupyter-kernel.create { definitions = { python3 = jupyterLib.mkKernelDefinition { ... } } }
+  mkKernelDefinition = {
+      # interpreter and its arguments
+      argv ? [],
+      displayName ? language,
+      # e.g. "python"
+      language,
+      interruptMode ? null,
+      metadata ? "",
+      logo32 ? null,
+      logo64 ? null,
+      extraPaths ? {},
+      ...
+    }@unfilteredKernel:
+      unfilteredKernel;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3279,6 +3279,8 @@ with pkgs;
 
   jupyter-kernel = callPackage ../applications/editors/jupyter/kernel.nix { };
 
+  jupyterLib = callPackage ../applications/editors/jupyter/kernel.nix { };
+
   wrapKakoune =
     kakoune: attrs:
     callPackage ../applications/editors/kakoune/wrapper.nix (attrs // { inherit kakoune; });


### PR DESCRIPTION
Initial effort to provide a better interface to jupyter in nixpkgs. There has been effort with jupyterWith then jupyenv but having some more foundations in nixpkgs could cover 80% usecases.

See https://github.com/NixOS/nixpkgs/pull/278315 for a first effort.

The starting point for me was when nixpkgs failed evaluating because I had not provided logo32 and logo64.
The evaluation failure was somewhere in a nix code which is kinda scary.  

Providing an interface/abstraction helps with documentation and renaming of arguments to be closer to jupyter (for instance interruptMode vs interrupt_mode ?).


Trying to get back into jupyter stuff.
Next I would like to merge some documentation (a consensual version of https://github.com/NixOS/nixpkgs/pull/278315)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
