### PR TITLE
nixos/network-interfaces: IP types for interfaces, gateways, and routes

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -220,6 +220,43 @@ checkConfigError 'A definition for option .* is not of type .path in the Nix sto
 checkConfigError 'A definition for option .* is not of type .path in the Nix store.. Definition values:\n\s*- In .*: ".*/store/.links"' config.pathInStore.bad4 ./types.nix
 checkConfigError 'A definition for option .* is not of type .path in the Nix store.. Definition values:\n\s*- In .*: "/foo/bar"' config.pathInStore.bad5 ./types.nix
 
+# types.ipv4
+IPV4_TYPE_ERROR='A definition for option .* is not of type .valid IPv4 address [(]a\.b\.c\.d[)].. Definition values:\n\s*- In .*: '
+checkConfigOutput '"1.2.3.4"' config.ipv4.ok1 ./types.nix
+checkConfigOutput '"0.0.0.0"' config.ipv4.ok2 ./types.nix
+checkConfigOutput '"255.255.255.255"' config.ipv4.ok3 ./types.nix
+checkConfigError "${IPV4_TYPE_ERROR}\"\"" config.ipv4.bad1 ./types.nix
+checkConfigError "${IPV4_TYPE_ERROR}\"1.2.3\"" config.ipv4.bad2 ./types.nix
+checkConfigError "${IPV4_TYPE_ERROR}\"256.256.256.256\"" config.ipv4.bad3 ./types.nix
+
+# types.ipv6
+IPV6_TYPE_ERROR='A definition for option .* is not of type .valid IPv6 address following rfc5952, rfc6052, and rfc2765.. Definition values:\n\s*- In .*: '
+# Valid IPv6 addresses - testing each regex case
+checkConfigOutput '"2001:0db8:0000:0000:0000:ff00:0042:8329"' config.ipv6.ok1 ./types.nix
+checkConfigOutput '"2001:db8:0:0:1:0:0:1"' config.ipv6.ok2 ./types.nix
+checkConfigOutput '"2001:db8::"' config.ipv6.ok3 ./types.nix
+checkConfigOutput '"2001:db8:0:0:1:0:0::"' config.ipv6.ok4 ./types.nix
+checkConfigOutput '"2001:db8::8"' config.ipv6.ok5 ./types.nix
+checkConfigOutput '"2001:db8:0:0:1::8"' config.ipv6.ok6 ./types.nix
+checkConfigOutput '"2001:db8::1:0:0:1"' config.ipv6.ok7 ./types.nix
+checkConfigOutput '"::1"' config.ipv6.ok8 ./types.nix
+checkConfigOutput '"::"' config.ipv6.ok9 ./types.nix
+checkConfigOutput '"::ffff:192.0.2.1"' config.ipv6.ok10 ./types.nix
+checkConfigOutput '"::192.0.2.33"' config.ipv6.ok11 ./types.nix
+checkConfigOutput '"64:ff9b::192.0.2.33"' config.ipv6.ok12 ./types.nix
+checkConfigOutput '"2001:0DB8:0000:0000:0000:FF00:0042:8329"' config.ipv6.ok13 ./types.nix
+# Invalid IPv6 addresses
+checkConfigError "${IPV6_TYPE_ERROR}\"\"" config.ipv6.bad1 ./types.nix
+checkConfigError "${IPV6_TYPE_ERROR}\"gg::1\"" config.ipv6.bad2 ./types.nix
+checkConfigError "${IPV6_TYPE_ERROR}\"::ffff:256.0.0.1\"" config.ipv6.bad3 ./types.nix
+checkConfigError "${IPV6_TYPE_ERROR}\"2001:db8:::1\"" config.ipv6.bad4 ./types.nix
+checkConfigError "${IPV6_TYPE_ERROR}\"2001:db8:0:0:0:0:0:0:1\"" config.ipv6.bad5 ./types.nix
+checkConfigError "${IPV6_TYPE_ERROR}\"::ffff:192.0.2\"" config.ipv6.bad6 ./types.nix
+checkConfigError "${IPV6_TYPE_ERROR}\"2001:0db8:0000:0000:0000:gg00:0042:8329\"" config.ipv6.bad7 ./types.nix
+checkConfigError "${IPV6_TYPE_ERROR}\"12345::\"" config.ipv6.bad8 ./types.nix
+checkConfigError "${IPV6_TYPE_ERROR}\"1:2:3:4:5:6:7:8:9\"" config.ipv6.bad9 ./types.nix
+checkConfigError "${IPV6_TYPE_ERROR}\"::1::\"" config.ipv6.bad10 ./types.nix
+
 # Check boolean option.
 checkConfigOutput '^false$' config.enable ./declare-enable.nix
 checkConfigError 'The option .* does not exist. Definition values:\n\s*- In .*: true' config.enable ./define-enable.nix

--- a/lib/tests/modules/types.nix
+++ b/lib/tests/modules/types.nix
@@ -11,6 +11,8 @@ in
 {
   options = {
     pathInStore = mkOption { type = types.lazyAttrsOf types.pathInStore; };
+    ipv4 = mkOption { type = types.lazyAttrsOf types.address.ipv4; };
+    ipv6 = mkOption { type = types.lazyAttrsOf types.address.ipv6; };
   };
   config = {
     pathInStore.ok1 = "${storeDir}/0lz9p8xhf89kb1c1kk6jxrzskaiygnlh-bash-5.2-p15.drv";
@@ -21,5 +23,52 @@ in
     pathInStore.bad3 = "${storeDir}/";
     pathInStore.bad4 = "${storeDir}/.links"; # technically true, but not reasonable
     pathInStore.bad5 = "/foo/bar";
+
+    # Standard IPv4 addresses
+    ipv4.ok1 = "1.2.3.4";
+    ipv4.ok2 = "0.0.0.0";
+    ipv4.ok3 = "255.255.255.255";
+
+    # Bad IPv4 addresses
+    ipv4.bad1 = "";
+    ipv4.bad2 = "1.2.3";
+    ipv4.bad3 = "256.256.256.256";
+
+    # Full address: 1:2:3:4:5:6:7:8
+    ipv6.ok1 = "2001:0db8:0000:0000:0000:ff00:0042:8329";
+    ipv6.ok2 = "2001:db8:0:0:1:0:0:1";
+
+    # Leading compression: 1::, 1:2:3:4:5:6:7::
+    ipv6.ok3 = "2001:db8::";
+    ipv6.ok4 = "2001:db8:0:0:1:0:0::";
+
+    # Middle compression: 1::8, 1:2:3:4:5:6::8
+    ipv6.ok5 = "2001:db8::8";
+    ipv6.ok6 = "2001:db8:0:0:1::8";
+
+    # Various compression patterns
+    ipv6.ok7 = "2001:db8::1:0:0:1"; # 1::7:8
+    ipv6.ok8 = "::1"; # loopback
+    ipv6.ok9 = "::"; # all zeros
+
+    # IPv4-mapped/translated addresses
+    ipv6.ok10 = "::ffff:192.0.2.1"; # IPv4-mapped
+    ipv6.ok11 = "::192.0.2.33"; # IPv4-compatible
+    ipv6.ok12 = "64:ff9b::192.0.2.33"; # Well-known prefix
+
+    # Case variations
+    ipv6.ok13 = "2001:0DB8:0000:0000:0000:FF00:0042:8329"; # All uppercase
+
+    # Bad IPv6 addresses
+    ipv6.bad1 = ""; # Empty string
+    ipv6.bad2 = "gg::1"; # Invalid hex
+    ipv6.bad3 = "::ffff:256.0.0.1"; # Invalid IPv4 part
+    ipv6.bad4 = "2001:db8:::1"; # Triple colon
+    ipv6.bad5 = "2001:db8:0:0:0:0:0:0:1"; # Too many groups
+    ipv6.bad6 = "::ffff:192.0.2"; # Incomplete IPv4
+    ipv6.bad7 = "2001:0db8:0000:0000:0000:gg00:0042:8329"; # Invalid hex digit
+    ipv6.bad8 = "12345::"; # Group too long
+    ipv6.bad9 = "1:2:3:4:5:6:7:8:9"; # Too many groups
+    ipv6.bad10 = "::1::"; # Multiple compressions
   };
 }

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1586,6 +1586,63 @@ let
           // {
             check = x: elemType.check x && check x;
           };
+
+      address =
+        let
+          isIpv4 =
+            x:
+            str.check x
+            &&
+              builtins.match "^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$" x
+              != null;
+          isIpv6 =
+            x:
+            str.check x
+            &&
+              # This is a variation of the regex from https://stackoverflow.com/a/17871737
+              builtins.match (lib.concatStrings [
+                "^("
+                "([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|" # 1:2:3:4:5:6:7:8
+                "([0-9a-fA-F]{1,4}:){1,7}:|" # 1::, 1:2:3:4:5:6:7::
+                "([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|" # 1::8, 1:2:3:4:5:6::8
+                "([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|" # 1::7:8, 1:2:3:4:5::7:8, 1:2:3:4:5::8
+                "([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|" # 1::6:7:8, 1:2:3:4::6:7:8, 1:2:3:4::8
+                "([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|" # 1::5:6:7:8, 1:2:3::5:6:7:8, 1:2:3::8
+                "([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|" # 1::4:5:6:7:8, 1:2::4:5:6:7:8, 1:2::8
+                "[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|" # 1::3:4:5:6:7:8, 1::8
+                ":((:[0-9a-fA-F]{1,4}){1,7}|:)|" # ::2:3:4:5:6:7:8, ::8, ::
+                "::(ffff(:0{1,4}){0,1}:){0,1}" # IPv4-mapped/translated prefix
+                "((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}"
+                "(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|" # ::255.255.255.255, ::ffff:255.255.255.255
+                "([0-9a-fA-F]{1,4}:){1,4}:" # IPv4-embedded prefix
+                "((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}"
+                "(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])" # 2001:db8:3:4::192.0.2.33, 64:ff9b::192.0.2.33
+                ")$"
+              ]) x != null;
+        in
+        {
+          ipv4 = mkOptionType {
+            name = "IPv4 address";
+            description = "valid IPv4 address (a.b.c.d)";
+            descriptionClass = "noun";
+            check = isIpv4;
+            inherit (str) merge;
+          };
+          ipv6 = mkOptionType {
+            name = "IPv6 address";
+            description = "valid IPv6 address following rfc5952, rfc6052, and rfc2765";
+            descriptionClass = "noun";
+            check = isIpv6;
+            inherit (str) merge;
+          };
+          ip = mkOptionType {
+            name = "IP address";
+            description = "valid IPv4 or IPv6 address";
+            descriptionClass = "conjunction";
+            check = x: isIpv6 x || isIpv4 x;
+            inherit (str) merge;
+          };
+        };
     };
 
     /**

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -232,6 +232,23 @@ merging is handled.
     definitions cannot be merged. The regular expression is processed
     using `builtins.match`.
 
+`types.address.ipv4`
+
+:   An IPv4 address in dot-decimal notation (e.g. `"192.168.1.1"`).
+    Multiple definitions cannot be merged.
+
+`types.address.ipv6`
+
+:   An IPv6 address in standard notation as defined by RFC 5952,
+    including compressed format (e.g. `"2001:db8::1"`), IPv4-mapped
+    addresses (e.g. `"::ffff:192.0.2.128"`), and IPv4-embedded
+    addresses. Multiple definitions cannot be merged.
+
+`types.address.ip`
+
+:   Either an IPv4 or IPv6 address. Accepts any valid IP address in
+    either format. Multiple definitions cannot be merged.
+
 ### Specialised types {#sec-option-types-specialised}
 
 `types.luaInline`

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -267,7 +267,9 @@ let
                 route:
                 let
                   cidr = "${route.address}/${toString route.prefixLength}";
-                  via = optionalString (route.via != null) ''via "${route.via}"'';
+                  # Required for IPv6 next-hop for IPv4 route
+                  inet = "inet" + (if lib.types.address.ipv6.check route.via then "6" else "");
+                  via = optionalString (route.via != null) ''via ${inet} "${route.via}"'';
                   options = concatStrings (mapAttrsToList (name: val: "${name} ${val} ") route.options);
                   type = toString route.type;
                 in

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -162,7 +162,9 @@ let
   gatewayCoerce = address: { inherit address; };
 
   gatewayOpts =
+    v:
     { ... }:
+    assert v == 4 || v == 6;
     {
 
       options = {
@@ -670,7 +672,7 @@ in
         interface = "enp3s0";
         source = "131.211.84.2";
       };
-      type = types.nullOr (types.coercedTo types.str gatewayCoerce (types.submodule gatewayOpts));
+      type = types.nullOr (types.coercedTo types.str gatewayCoerce (types.submodule (gatewayOpts 4)));
       description = ''
         The default gateway. It can be left empty if it is auto-detected through DHCP.
         It can be specified as a string or an option set along with a network interface.
@@ -684,7 +686,7 @@ in
         interface = "enp3s0";
         source = "2001:4d0:1e04:895::2";
       };
-      type = types.nullOr (types.coercedTo types.str gatewayCoerce (types.submodule gatewayOpts));
+      type = types.nullOr (types.coercedTo types.str gatewayCoerce (types.submodule (gatewayOpts 6)));
       description = ''
         The default ipv6 gateway. It can be left empty if it is auto-detected through DHCP.
         It can be specified as a string or an option set along with a network interface.

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -99,7 +99,7 @@ let
   routeOpts = v: {
     options = {
       address = mkOption {
-        type = types.str;
+        type = addrTypeDynamic v;
         description = "IPv${toString v} address of the network.";
       };
 
@@ -133,9 +133,9 @@ let
       };
 
       via = mkOption {
-        type = types.nullOr types.str;
+        type = types.nullOr (if v == 6 then lib.types.address.ipv6 else lib.types.address.ip);
         default = null;
-        description = "IPv${toString v} address of the next hop.";
+        description = "IP${if v == 4 then "v4" else ""} address of the next hop.";
       };
 
       options = mkOption {

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -68,13 +68,18 @@ let
   # We must escape interfaces due to the systemd interpretation
   subsystemDevice = interface: "sys-subsystem-net-devices-${escapeSystemdPath interface}.device";
 
+  addrTypeDynamic =
+    v:
+    assert v == 4 || v == 6;
+    if v == 4 then lib.types.address.ipv4 else lib.types.address.ipv6;
+
   addrOpts =
     v:
     assert v == 4 || v == 6;
     {
       options = {
         address = mkOption {
-          type = types.str;
+          type = addrTypeDynamic v;
           description = ''
             IPv${toString v} address of the interface. Leave empty to configure the
             interface using DHCP.

--- a/nixos/tests/networking/networkd-and-scripted.nix
+++ b/nixos/tests/networking/networkd-and-scripted.nix
@@ -1256,6 +1256,11 @@ let
               prefixLength = 24;
               via = "192.168.1.1";
             }
+            {
+              address = "192.168.3.0";
+              prefixLength = 24;
+              via = "2001:1470:fffd:2097::1";
+            }
           ];
         };
         virtualisation.vlans = [ ];
@@ -1266,6 +1271,7 @@ let
             "10.0.0.0/16 proto static scope link mtu 1500",
             "192.168.1.0/24 proto kernel scope link src 192.168.1.2",
             "192.168.2.0/24 via 192.168.1.1 proto static",
+            "192.168.3.0/24 via inet6 2001:1470:fffd:2097::1 proto static",
         ]
 
         targetIPv6Table = [
@@ -1278,7 +1284,7 @@ let
         machine.wait_for_unit("network.target")
 
         with subtest("test routing tables"):
-            ipv4Table = machine.succeed("ip -4 route list dev eth0 | head -n3").strip()
+            ipv4Table = machine.succeed("ip -4 route list dev eth0 | head -n4").strip()
             ipv6Table = machine.succeed("ip -6 route list dev eth0 | head -n3").strip()
             assert [
                 l.strip() for l in ipv4Table.splitlines()


### PR DESCRIPTION
In this PR I intend to add a IPv4 and IPv6 type and transition some module uses of IP addresses into the properly typed variants. As part of properly typing the IP routes I fixed an issue we could not use IPv6 next-hops on IPv4 routes in scripted mode. This functionality worked on networkd mode though.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
