### PR TITLE
bisq2: add webcam support

### DIFF
--- a/pkgs/by-name/bi/bisq2/package.nix
+++ b/pkgs/by-name/bi/bisq2/package.nix
@@ -1,8 +1,7 @@
 {
-  stdenvNoCC,
+  stdenv,
   lib,
   makeBinaryWrapper,
-  runtimeShell,
   fetchurl,
   makeDesktopItem,
   copyDesktopItems,
@@ -10,11 +9,18 @@
   jdk23,
   dpkg,
   writeShellScript,
-  bash,
   tor,
   zip,
   gnupg,
   coreutils,
+
+  # Used by the bundled webcam-app
+  libv4l,
+
+  # Used by the testing package bisq2-webcam-app
+  callPackage,
+  socat,
+  unzip,
 }:
 
 let
@@ -44,8 +50,18 @@ let
       hash = "sha256-PrRYZLT0xv82dUscOBgQGKNf6zwzWUDhriAffZbNpmI=";
     };
   };
+
+  binPath = lib.makeBinPath [
+    coreutils
+    tor
+  ];
+
+  libraryPath = lib.makeLibraryPath [
+    stdenv.cc.cc
+    libv4l
+  ];
 in
-stdenvNoCC.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: rec {
   inherit version;
 
   pname = "bisq2";
@@ -137,21 +153,11 @@ stdenvNoCC.mkDerivation rec {
 
     install -D -m 777 ${bisq-launcher ""} $out/bin/bisq2
     substituteAllInPlace $out/bin/bisq2
-    wrapProgram $out/bin/bisq2 --prefix PATH : ${
-      lib.makeBinPath [
-        coreutils
-        tor
-      ]
-    }
+    wrapProgram $out/bin/bisq2 --prefix PATH : ${binPath} --prefix LD_LIBRARY_PATH : ${libraryPath}
 
     install -D -m 777 ${bisq-launcher "-Dglass.gtk.uiScale=2.0"} $out/bin/bisq2-hidpi
     substituteAllInPlace $out/bin/bisq2-hidpi
-    wrapProgram $out/bin/bisq2-hidpi --prefix PATH : ${
-      lib.makeBinPath [
-        coreutils
-        tor
-      ]
-    }
+    wrapProgram $out/bin/bisq2-hidpi --prefix PATH : ${binPath} --prefix LD_LIBRARY_PATH : ${libraryPath}
 
     for n in 16 24 32 48 64 96 128 256; do
       size=$n"x"$n
@@ -161,6 +167,15 @@ stdenvNoCC.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  # The bisq2.webcam-app package is for maintainers to test scanning QR codes.
+  passthru.webcam-app = callPackage ./webcam-app.nix {
+    inherit
+      jdk
+      libraryPath
+      ;
+    bisq2 = finalAttrs.finalPackage.out;
+  };
 
   meta = {
     description = "Decentralized bitcoin exchange network";
@@ -176,4 +191,4 @@ stdenvNoCC.mkDerivation rec {
       "aarch64-linux"
     ];
   };
-}
+})

--- a/pkgs/by-name/bi/bisq2/webcam-app.nix
+++ b/pkgs/by-name/bi/bisq2/webcam-app.nix
@@ -1,0 +1,56 @@
+# bisq2 contains a separate Java app which is used to scan Bitcoin Lightning QR codes.
+# bisq2 communicates with the webcam app via a local TCP connection using a simple one-way protocol.
+# Since the webcam app dynamically loads native code, this package is for maintainers to test QR code scanning without having to spend bitcoin to execute a trade.
+# This package is exposed as an attribute of the bisq2 package; bisq2.webcam-app.
+{
+  stdenv,
+  lib,
+  makeBinaryWrapper,
+  jdk,
+  writeShellScript,
+  unzip,
+  bisq2,
+  socat,
+  libraryPath,
+}:
+
+let
+  version = "1.0.0";
+
+  launcher = writeShellScript "bisq2-webcam-app-launcher" ''
+    ${socat}/bin/socat TCP-LISTEN:8000,keepalive,fork STDIO &
+    socat_pid=$!
+    LD_LIBRARY_PATH=${libraryPath} "${lib.getExe jdk}" -classpath @out@/lib/app/webcam-app-${version}-all.jar:${bisq2}/lib/app/* bisq.webcam.WebcamAppLauncher "$@"
+    kill $socat_pid
+  '';
+in
+stdenv.mkDerivation rec {
+  inherit version;
+
+  pname = "bisq2-webcam-app";
+  src = bisq2;
+  dontUnpack = true;
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    unzip
+  ];
+
+  buildPhase = ''
+    # Extract the webcam app from Bisq2.
+
+    unzip ${bisq2}/lib/app/desktop.jar 'webcam-app/*'
+    unzip webcam-app/webcam-app-1.0.0.zip
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/app $out/bin
+    cp webcam-app-${version}-all.jar $out/lib/app/
+    install -D -m 777 ${launcher} $out/bin/bisq2-webcam-app
+    substituteAllInPlace $out/bin/bisq2-webcam-app
+
+    runHook postInstall
+  '';
+}


### PR DESCRIPTION
- Adds QR code scanning support via bundled webcam app.
- Adds webcam app testing package, for maintainer use.

## Background

Bisq2 provides QR code scanning via a bundled Java app named `webcam-app`. This app bundles various native libraries which are used to process the image from the webcam. Bisq2 and `webcam-app` communicate via a minimal TCP-based protocol.

This PR adds:

- The native libraries needed to support `webcam-app`, namely Video4Linux and the standard C library.
- A testing package which I (as the maintainer) can use to run `webcam-app` independently of Bisq2. This makes it possible to test QR code scanning without having to execute a Bitcoin trade.

Lastly, this PR removes unused dependencies (inputs).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
