### PR TITLE
wireguard-go: 0.0.20230223 -> 0.0.20250522 and refactorings

### DIFF
--- a/pkgs/by-name/wi/wireguard-go/package.nix
+++ b/pkgs/by-name/wi/wireguard-go/package.nix
@@ -10,7 +10,6 @@ buildGoModule (
   finalAttrs:
   let
     version = "0.0.20250522";
-    shortVer = version;
   in
   {
     pname = "wireguard-go";
@@ -24,9 +23,6 @@ buildGoModule (
     postPatch = ''
       # Skip formatting tests
       rm -f format_test.go
-
-      # Inject version
-      printf 'package main\n\nconst Version = "${shortVer}"' > version.go
     '';
 
     vendorHash = "sha256-sCajxTV26jjlmgmbV4GG6hg9NkLGS773ZbFyKucvuBE=";
@@ -56,7 +52,7 @@ buildGoModule (
 
     passthru.tests.version = testers.testVersion {
       package = wireguard-go;
-      version = "v${shortVer}";
+      version = "v${version}";
     };
 
     meta = with lib; {

--- a/pkgs/by-name/wi/wireguard-go/package.nix
+++ b/pkgs/by-name/wi/wireguard-go/package.nix
@@ -9,15 +9,15 @@
 buildGoModule (
   finalAttrs:
   let
-    rev = "f333402bd9cbe0f3eeb02507bd14e23d7d639280";
-    shortVer = "${finalAttrs.version} (${lib.substring 0 7 rev})";
+    version = "0.0.20250522";
+    shortVer = version;
   in
   {
     pname = "wireguard-go";
-    version = "0.0.20250522";
+    inherit version;
 
     src = fetchzip {
-      url = "https://git.zx2c4.com/wireguard-go/snapshot/wireguard-go-${rev}.tar.xz";
+      url = "https://git.zx2c4.com/wireguard-go/snapshot/wireguard-go-${version}.tar.xz";
       hash = "sha256-GRr8NKKb4SHd0WxmNL84eiofFHcauDDmSyNNrXermcA=";
     };
 

--- a/pkgs/by-name/wi/wireguard-go/package.nix
+++ b/pkgs/by-name/wi/wireguard-go/package.nix
@@ -9,16 +9,16 @@
 buildGoModule (
   finalAttrs:
   let
-    rev = "12269c2761734b15625017d8565745096325392f";
+    rev = "f333402bd9cbe0f3eeb02507bd14e23d7d639280";
     shortVer = "${finalAttrs.version} (${lib.substring 0 7 rev})";
   in
   {
     pname = "wireguard-go";
-    version = "0-unstable-2023-12-11";
+    version = "0.0.20250522";
 
     src = fetchzip {
       url = "https://git.zx2c4.com/wireguard-go/snapshot/wireguard-go-${rev}.tar.xz";
-      hash = "sha256-br7/dwr/e4HvBGJXh+6lWqxBUezt5iZNy9BFqEA1bLk=";
+      hash = "sha256-GRr8NKKb4SHd0WxmNL84eiofFHcauDDmSyNNrXermcA=";
     };
 
     postPatch = ''
@@ -29,7 +29,7 @@ buildGoModule (
       printf 'package main\n\nconst Version = "${shortVer}"' > version.go
     '';
 
-    vendorHash = "sha256-RqZ/3+Xus5N1raiUTUpiKVBs/lrJQcSwr1dJib2ytwc=";
+    vendorHash = "sha256-sCajxTV26jjlmgmbV4GG6hg9NkLGS773ZbFyKucvuBE=";
 
     subPackages = [ "." ];
 


### PR DESCRIPTION
This series of commits upgrades wireguard-go to the latest version. In addition, the `package.nix` is refactored to become a lot simpler than before, removing "fixes" and workarounds that are not needed anymore.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
