### PR TITLE
k3s: enable support for user namespaces

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -68,6 +68,7 @@ lib:
   socat,
   sqlite,
   stdenv,
+  su,
   systemdMinimal,
   util-linuxMinimal,
   yq-go,
@@ -371,6 +372,7 @@ buildGoModule (finalAttrs: {
     conntrack-tools
     runc
     bash
+    su
   ];
 
   k3sKillallDeps = [


### PR DESCRIPTION
User Namespaces, a kubelet feature that was made default in k8s 1.33, requires the binary `getsubids` to be on the PATH.

https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/#set-up-a-node-to-support-user-namespaces

To start using User Namespaces on k3s 1.33, a user can add a kubelet user like so:
```
  users.users.kubelet = {
    isSystemUser = true;
    group = "kubelet";
    subUidRanges = [{
        startUid = 65536;
        count = (110 * 65536);
    }];
    subGidRanges = [{
        startGid = 65536;
        count = (110 * 65536);
    }];
  };
  users.groups.kubelet = {};
```
(110 here should be changed to match what you have `maxPods` set to in your kubelet config) 
See full example in my environment: https://codeberg.org/jlh/h5b/src/commit/3961cd405f69782ce8a9fb1814ace60e94e02051/nodes/modules/k3s.nix#L44

However, currently, running k3s 1.33 on NixOS Unstable with this user created results in the following error:
```
k3s[13954]: Error: failed to run Kubelet: failed to create kubelet: create user namespace manager: kubelet mappings: exec: "getsubids": executable file not found in $PATH
k3s[13954]: time="2025-09-07T15:24:18Z" level=error msg="kubelet exited: failed to run Kubelet: failed to create kubelet: create user namespace manager: kubelet mappings: exec: \"getsubids\": executable file not found in $PATH"
systemd[1]: k3s.service: Main process exited, code=exited, status=1/FAILURE
systemd[1]: k3s.service: Failed with result 'exit-code'.
```

This PR adds the `su` module to the k3sRuntimeDeps, which I believe will resolve the k3s kubelet being unable to find `getsubids`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
