### PR TITLE
fbv: 1.0b -> 1.0c

### DIFF
--- a/pkgs/by-name/fb/fbv/package.nix
+++ b/pkgs/by-name/fb/fbv/package.nix
@@ -1,39 +1,28 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  fetchpatch,
+  fetchFromGitHub,
   getopt,
   libjpeg,
   libpng12,
-  giflib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "fbv";
-  version = "1.0b";
+  version = "1.0c";
 
-  src = fetchurl {
-    url = "http://s-tech.elsat.net.pl/fbv/fbv-${version}.tar.gz";
-    sha256 = "0g5b550vk11l639y8p5sx1v1i6ihgqk0x1hd0ri1bc2yzpdbjmcv";
+  src = fetchFromGitHub {
+    owner = "jstkdng";
+    repo = "fbv";
+    tag = finalAttrs.version;
+    hash = "sha256-4tAIFklKsx2uI+FQjq9vdolYm6d6YWugioG6k2ZUMrs=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/void-linux/void-packages/4a5bfe522ea5afd8203e804dc6a642d0871cd6dd/srcpkgs/fbv/patches/giflib-5.1.patch";
-      sha256 = "00q1zcn92yvvyij68bnq0m1sr3a411w914f4nyp6mpz0j5xc6dc7";
-    })
-  ];
-
-  patchFlags = [ "-p0" ];
 
   buildInputs = [
     getopt
     libjpeg
     libpng12
-    giflib
   ];
-  makeFlags = [ "LDFLAGS=-lgif" ];
 
   enableParallelBuilding = true;
 
@@ -41,11 +30,11 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{bin,man/man1}
   '';
 
-  meta = with lib; {
+  meta = {
     description = "View pictures on a linux framebuffer device";
-    homepage = "http://s-tech.elsat.net.pl/fbv/";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ peterhoeg ];
+    homepage = "https://github.com/jstkdng/fbv";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ peterhoeg ];
     mainProgram = "fbv";
   };
-}
+})


### PR DESCRIPTION
Fixes the build.

Backport of fix from unstable.

(cherry picked from commit da06e88307b993febde8155e9f90f444a6bfb3a0)

Cc: @UlyssesZh


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
