### PR TITLE
fsuae: add maintainer, added updateScript, update to 3.2.35

### DIFF
--- a/pkgs/by-name/fs/fsuae/package.nix
+++ b/pkgs/by-name/fs/fsuae/package.nix
@@ -69,7 +69,9 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl2Plus;
     mainProgram = "fs-uae";
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [
+      c4patino
+    ];
     platforms = with lib.systems.inspect; patternLogicalAnd patterns.isx86 patterns.isLinux;
   };
 })

--- a/pkgs/by-name/fs/fsuae/package.nix
+++ b/pkgs/by-name/fs/fsuae/package.nix
@@ -22,13 +22,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fs-uae";
-  version = "3.1.66";
+  version = "3.2.35";
 
   src = fetchFromGitHub {
     owner = "FrodeSolheim";
     repo = "fs-uae";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-zPVRPazelmNaxcoCStB0j9b9qwQDTgv3O7Bg3VlW9ys=";
+    hash = "sha256-e+Q+PC6Kpq3OBKsgoRvmu2p9dQfJeRCdFO1agXIGcU8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fs/fsuae/package.nix
+++ b/pkgs/by-name/fs/fsuae/package.nix
@@ -17,6 +17,7 @@
   stdenv,
   zip,
   zlib,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -57,6 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     strip-nondeterminism --type zip $out/share/fs-uae/fs-uae.dat
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://fs-uae.net";


### PR DESCRIPTION
- added maintainer @c4patino
- added updateScript using `nix-update-script`
- updated package from 3.1.66 -> 3.2.35

Resolves #440933

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
