### PR TITLE
fsuae-launcher: add maintainer, updateScript, 3.1.70 -> 3.2.20

### DIFF
--- a/pkgs/by-name/fs/fsuae-launcher/package.nix
+++ b/pkgs/by-name/fs/fsuae-launcher/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchurl,
+  fetchFromGitHub,
   fsuae,
   gettext,
   python3Packages,
@@ -11,11 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fs-uae-launcher";
-  version = "3.1.70";
+  version = "3.2.20";
 
-  src = fetchurl {
-    url = "https://fs-uae.net/files/FS-UAE-Launcher/Stable/${finalAttrs.version}/fs-uae-launcher-${finalAttrs.version}.tar.xz";
-    hash = "sha256-yvJ8sa44V13SEUJ6C9SgS+N2ZFH5+20TTL2ICY9A36c=";
+  src = fetchFromGitHub {
+    owner = "FrodeSolheim";
+    repo = "fs-uae-launcher";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-JuCwcVKuc0EzsKQiPXobH9tiIWEFD3tjcXneRXzjsH0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fs/fsuae-launcher/package.nix
+++ b/pkgs/by-name/fs/fsuae-launcher/package.nix
@@ -58,6 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "fs-uae-launcher";
     maintainers = with lib.maintainers; [
       sander
+      c4patino
     ];
     platforms = with lib.systems.inspect; patternLogicalAnd patterns.isx86 patterns.isLinux;
   };

--- a/pkgs/by-name/fs/fsuae-launcher/package.nix
+++ b/pkgs/by-name/fs/fsuae-launcher/package.nix
@@ -6,6 +6,7 @@
   python3Packages,
   stdenv,
   libsForQt5,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -50,6 +51,8 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s ${fsuae}/bin/fs-uae-device-helper $out/bin
     ln -s ${fsuae}/share/fs-uae $out/share/fs-uae
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://fs-uae.net";


### PR DESCRIPTION
- added maintainer @c4patino
- added updateScript using `nix-update-script`
- updated package from 3.1.70 -> 3.2.20

Resolves #440934

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
