### PR TITLE
cp2k: split outputs

### DIFF
--- a/pkgs/by-name/cp/cp2k/package.nix
+++ b/pkgs/by-name/cp/cp2k/package.nix
@@ -249,6 +249,11 @@ stdenv.mkDerivation rec {
     inherit mpi;
   };
 
+  outputs = [
+    "out"
+    "dev"
+  ];
+
   postInstall = ''
     mkdir -p $out/share/cp2k
     cp -r ../data/* $out/share/cp2k

--- a/pkgs/by-name/cp/cp2k/pkgconfig.patch
+++ b/pkgs/by-name/cp/cp2k/pkgconfig.patch
@@ -7,8 +7,8 @@ index 618af55e28..8d08a51a0c 100644
  exec_prefix="${prefix}"
 -libdir="${prefix}/@CMAKE_INSTALL_LIBDIR@"
 -includedir="${prefix}/@CMAKE_INSTALL_INCLUDEDIR@"
-+libdir=CMAKE_INSTALL_FULL_LIBDIR@"
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@"
 +includedir="@CMAKE_INSTALL_FULL_INCLUDEDIR@"
- 
+
  Name: @PROJECT_NAME@
  Description: @CMAKE_PROJECT_DESCRIPTION@


### PR DESCRIPTION
With the switch to cmake, cp2k now installs ~1300 include files that take up 366 MB.
No need to have that in the run-time closure.


## Things done
Fixed also a typo in the pkg-config patch.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
