### PR TITLE
postfix: add sasl authentication tests

### DIFF
--- a/nixos/tests/postfix.nix
+++ b/nixos/tests/postfix.nix
@@ -37,40 +37,40 @@ import ./make-test-python.nix {
 
       environment.systemPackages =
         let
-          sendTestMail = pkgs.writeScriptBin "send-testmail" ''
-            #!${pkgs.python3.interpreter}
+          sendTestMail = pkgs.writers.writePython3Bin "send-testmail" { } ''
             import smtplib
 
             with smtplib.SMTP('${domain}') as smtp:
-              smtp.sendmail('root@localhost', 'alice@localhost', 'Subject: Test\n\nTest data.')
-              smtp.quit()
+                smtp.sendmail('root@localhost', 'alice@localhost',
+                              'Subject: Test\n\nTest data.')
+                smtp.quit()
           '';
 
-          sendTestMailStarttls = pkgs.writeScriptBin "send-testmail-starttls" ''
-            #!${pkgs.python3.interpreter}
+          sendTestMailStarttls = pkgs.writers.writePython3Bin "send-testmail-starttls" { } ''
             import smtplib
             import ssl
 
             ctx = ssl.create_default_context()
 
             with smtplib.SMTP('${domain}') as smtp:
-              smtp.ehlo()
-              smtp.starttls(context=ctx)
-              smtp.ehlo()
-              smtp.sendmail('root@localhost', 'alice@localhost', 'Subject: Test STARTTLS\n\nTest data.')
-              smtp.quit()
+                smtp.ehlo()
+                smtp.starttls(context=ctx)
+                smtp.ehlo()
+                smtp.sendmail('root@localhost', 'alice@localhost',
+                              'Subject: Test STARTTLS\n\nTest data.')
+                smtp.quit()
           '';
 
-          sendTestMailSmtps = pkgs.writeScriptBin "send-testmail-smtps" ''
-            #!${pkgs.python3.interpreter}
+          sendTestMailSmtps = pkgs.writers.writePython3Bin "send-testmail-smtps" { } ''
             import smtplib
             import ssl
 
             ctx = ssl.create_default_context()
 
             with smtplib.SMTP_SSL(host='${domain}', context=ctx) as smtp:
-              smtp.sendmail('root@localhost', 'alice@localhost', 'Subject: Test SMTPS\n\nTest data.')
-              smtp.quit()
+                smtp.sendmail('root@localhost', 'alice@localhost',
+                              'Subject: Test SMTPS\n\nTest data.')
+                smtp.quit()
           '';
         in
         [


### PR DESCRIPTION
this was tricky to get set up correctly.  hopefully having it documented in the tests will be helpful to future users (and help ensure it keeps working for me).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
