### PR TITLE
radio-active: init at 2.9.1

### DIFF
--- a/pkgs/by-name/ra/radio-active/package.nix
+++ b/pkgs/by-name/ra/radio-active/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  ffmpeg,
+}:
+
+let
+  ## https://github.com/deep5050/radio-active/blob/main/requirements.txt
+  pyradios_1-0-2 = python3Packages.pyradios.overrideAttrs (
+    finalAttrs: previousAttrs:
+    let
+      version = "1.0.2";
+    in
+    {
+      inherit version;
+
+      src = previousAttrs.src.override {
+        inherit version;
+        hash = "sha256-O30ExmvWu4spwDytFVPWGjR8w3XSTaWd2Z0LGQibq9g=";
+      };
+    }
+  );
+
+  pname = "radio-active";
+  version = "2.9.1";
+in
+python3Packages.buildPythonApplication {
+  inherit pname version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "S0AndS0";
+    repo = "radio-active";
+    rev = "2befa6a309d9c411ef1ea522e706ed3e098e5341";
+    hash = "sha256-wqETmdqvxsKnjkjQADq59J83QkOhLA74SPtuWTpsvO0=";
+  };
+
+  postPatch = ''
+    substituteInPlace radioactive/recorder.py \
+      --replace-fail '"ffmpeg",' '"${lib.getExe ffmpeg}",'
+
+    substituteInPlace radioactive/ffplay.py \
+      --replace-fail 'self.exe_path = which(self.program_name)' \
+      'self.exe_path = "${ffmpeg.outPath}/bin/ffplay"'
+  '';
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    requests
+    urllib3
+    psutil
+    pyradios_1-0-2
+    zenlog
+    requests-cache
+    rich
+    pick
+  ];
+
+  meta = {
+    description = "Play any radios from around the globe right from the terminal";
+    homepage = "https://www.radio-browser.info/";
+    changelog = "https://github.com/deep5050/radio-active/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ S0AndS0 ];
+  };
+}

--- a/pkgs/development/python-modules/zenlog/default.nix
+++ b/pkgs/development/python-modules/zenlog/default.nix
@@ -1,0 +1,32 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  colorlog,
+  setuptools,
+}:
+let
+  pname = "zenlog";
+  version = "1.1";
+in
+buildPythonPackage {
+  inherit pname version;
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-g0YKhfpySbgAfANoGmoLV1zm/gRDSTidPT1D9Y1Gh94=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ colorlog ];
+
+  meta = {
+    description = "Python script logging for the lazy";
+    homepage = "https://github.com/ManufacturaInd/python-zenlog";
+    changelog = "https://github.com/ManufacturaInd/python-zenlog/releases/tag/v${version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ S0AndS0 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20437,6 +20437,8 @@ self: super: with self; {
 
   zeitgeist = (toPythonModule (pkgs.zeitgeist.override { python3 = python; })).py;
 
+  zenlog = callPackage ../development/python-modules/zenlog { };
+
   zenoh = callPackage ../development/python-modules/zenoh { };
 
   zephyr-python-api = callPackage ../development/python-modules/zephyr-python-api { };


### PR DESCRIPTION
Radio Active is a Python CLI TUI for listening to radio streaming stations.

> Check commit message for additional notes.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
   > 2025-09-07 20:06 UTC `nix run 'nixpkgs#nixpkgs-review' rev HEAD` ran device out of resources, like OOM and non-responsive :-|
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

---

## 2025-09-07 21:29 -- Edit

Hmm, seems like "it works on my machine" troubles exist x-)
I'll get to sorting-out why that is once `e2fsck` reports all's good after the forced shutdown that `nix run 'nixpkgs#nixpkgs-review' rev HEAD` required.