### PR TITLE
tidal-dl-ng: init at 0.33.0

### DIFF
--- a/pkgs/by-name/ti/tidal-dl-ng/package.nix
+++ b/pkgs/by-name/ti/tidal-dl-ng/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+
+  replaceVars,
+  ffmpeg-headless,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "tidal-dl-ng";
+  version = "0.33.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "exislow";
+    repo = "tidal-dl-ng";
+    tag = "v${version}";
+    hash = "sha256-zMozgnCy6w25WFwpKyVQiQQe6KT3arme4woOXBkSmqc=";
+  };
+
+  patches = [
+    (replaceVars ./use-system-ffmpeg.patch {
+      ffmpeg = lib.getExe ffmpeg-headless;
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace tidal_dl_ng/__init__.py \
+      --replace-fail 'url: str = f"https://api.github.com/repos{repo_path}/releases/latest"' 'url = "https://api.github.com/repos/exislow/tidal-dl-ng/releases/latest"'
+  '';
+
+  build-system = [
+    python3Packages.poetry-core
+  ];
+
+  dependencies = with python3Packages; [
+    ansi2html
+    coloredlogs
+    dataclasses-json
+    m3u8
+    mpegdash
+    mutagen
+    pycryptodome
+    python-ffmpeg
+    rich
+    tidalapi
+    toml
+
+    pathvalidate
+    requests
+    typer
+
+    pyside6
+    pyqtdarktheme
+  ];
+
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+  ];
+
+  pythonRelaxDeps = [
+    "requests"
+    "rich"
+    "typer"
+  ];
+
+  disabledTests = [
+    "test_download_segments_cancellation"
+    "test_download_segments_global_abort"
+  ];
+
+  meta = {
+    description = "Multithreaded TIDAL media downloader";
+    homepage = "https://github.com/exislow/tidal-dl-ng";
+    changelog = "https://github.com/exislow/tidal-dl-ng/releases/tag/v${version}";
+    license = lib.licenses.agpl3Plus;
+    maintainers = [ lib.maintainers.ryand56 ];
+  };
+}

--- a/pkgs/by-name/ti/tidal-dl-ng/use-system-ffmpeg.patch
+++ b/pkgs/by-name/ti/tidal-dl-ng/use-system-ffmpeg.patch
@@ -1,0 +1,41 @@
+diff --git a/tidal_dl_ng/download.py b/tidal_dl_ng/download.py
+index 40f4976..e94751d 100644
+--- a/tidal_dl_ng/download.py
++++ b/tidal_dl_ng/download.py
+@@ -158,18 +158,6 @@ class Download:
+         self.event_abort = event_abort
+         self.event_run = event_run
+ 
+-        if not self.settings.data.path_binary_ffmpeg and (
+-            self.settings.data.video_convert_mp4 or self.settings.data.extract_flac
+-        ):
+-            self.settings.data.video_convert_mp4 = False
+-            self.settings.data.extract_flac = False
+-
+-            self.fn_logger.error(
+-                "FFmpeg path is not set. Videos can be downloaded but will not be processed. FLAC cannot be "
+-                "extracted from MP4 containers. Make sure FFmpeg is installed. The path to the FFmpeg binary must "
+-                "be set in (`path_binary_ffmpeg`)."
+-            )
+-
+     def _get_media_urls(
+         self,
+         media: Track | Video,
+@@ -1712,7 +1700,7 @@ class Download:
+         self.fn_logger.debug(f"Converting video: {path_file.name} -> {path_file_out.name}")
+ 
+         ffmpeg = (
+-            FFmpeg(executable=self.settings.data.path_binary_ffmpeg)
++            FFmpeg(executable="@ffmpeg@")
+             .option("y")
+             .option("hide_banner")
+             .option("nostdin")
+@@ -1738,7 +1726,7 @@ class Download:
+         path_media_out = path_media_src.with_suffix(AudioExtensions.FLAC)
+ 
+         ffmpeg = (
+-            FFmpeg(executable=self.settings.data.path_binary_ffmpeg)
++            FFmpeg(executable="@ffmpeg@")
+             .option("hide_banner")
+             .option("nostdin")
+             .input(url=path_media_src)


### PR DESCRIPTION
Adds [tidal-dl-ng](https://github.com/exislow/tidal-dl-ng), a multithreaded TIDAL media downloader, capable of downloading hi-res audio and video.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
