### PR TITLE
fishPlugins.aws: init at 0-unstable-2023-08-03

### DIFF
--- a/pkgs/shells/fish/plugins/aws.nix
+++ b/pkgs/shells/fish/plugins/aws.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  buildFishPlugin,
+  fetchFromGitHub,
+}:
+buildFishPlugin {
+  pname = "aws";
+  version = "0-unstable-2023-08-03";
+
+  src = fetchFromGitHub {
+    owner = "oh-my-fish";
+    repo = "plugin-aws";
+    rev = "e53a1de3f826916cb83f6ebd34a7356af8f754d1";
+    hash = "sha256-l17v/aJ4PkjYM8kJDA0zUo87UTsfFqq+Prei/Qq0DRA=";
+  };
+
+  meta = {
+    description = "Completions and integrations with the AWS CLI";
+    homepage = "https://github.com/oh-my-fish/plugin-aws";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ theobori ];
+  };
+}

--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -12,6 +12,8 @@ lib.makeScope newScope (
 
     autopair = callPackage ./autopair.nix { };
 
+    aws = callPackage ./aws.nix { };
+
     bang-bang = callPackage ./bang-bang.nix { };
 
     bobthefish = callPackage ./bobthefish.nix { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Initialize https://github.com/oh-my-fish/plugin-aws.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
