### PR TITLE
buck2: fix by disabling autoPatchelfHook on darwin

### DIFF
--- a/pkgs/by-name/bu/buck2/package.nix
+++ b/pkgs/by-name/bu/buck2/package.nix
@@ -81,8 +81,10 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
   nativeBuildInputs = [
     installShellFiles
-    autoPatchelfHook
     zstd
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
   ];
 
   buildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

```
Running phase: fixupPhase
checking for references to /private/tmp/nix-build-buck2-unstable-2025-08-15.drv-0/ in /nix/store/pb3lkiqmxdljgrwaf7r87304qppaixlh-buck2-unstable-2025-08-15...
patching script interpreter paths in /nix/store/pb3lkiqmxdljgrwaf7r87304qppaixlh-buck2-unstable-2025-08-15
stripping (with command strip and flags -S) in  /nix/store/pb3lkiqmxdljgrwaf7r87304qppaixlh-buck2-unstable-2025-08-15/bin
Traceback (most recent call last):
  File "/nix/store/f6lzas1nrrjb5a78rvd115dc6blry2mq-auto-patchelf-0-unstable-2024-08-14/bin/auto-patchelf", line 477, in <module>
    with open_elf(interpreter_path) as interpreter:
         ~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/nix/store/9px7zzsfnlmj61yy2fpl6z14w93j05is-python3-3.13.6/lib/python3.13/contextlib.py", line 141, in __enter__
    return next(self.gen)
  File "/nix/store/f6lzas1nrrjb5a78rvd115dc6blry2mq-auto-patchelf-0-unstable-2024-08-14/bin/auto-patchelf", line 30, in open_elf
    yield ELFFile(stream)
          ~~~~~~~^^^^^^^^
  File "/nix/store/gs41myv43d1q36742vhggb0j4pcz8zhf-python3-3.13.6-env/lib/python3.13/site-packages/elftools/elf/elffile.py", line 73, in __init__
    self._identify_file()
    ~~~~~~~~~~~~~~~~~~~^^
  File "/nix/store/gs41myv43d1q36742vhggb0j4pcz8zhf-python3-3.13.6-env/lib/python3.13/site-packages/elftools/elf/elffile.py", line 631, in _identify_file
    elf_assert(magic == b'\x7fELF', 'Magic number does not match')
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/gs41myv43d1q36742vhggb0j4pcz8zhf-python3-3.13.6-env/lib/python3.13/site-packages/elftools/common/utils.py", line 80, in elf_assert
    _assert_with_exception(cond, msg, ELFError)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/gs41myv43d1q36742vhggb0j4pcz8zhf-python3-3.13.6-env/lib/python3.13/site-packages/elftools/common/utils.py", line 143, in _assert_with_exception
    raise exception_type(msg)
elftools.common.exceptions.ELFError: Magic number does not match
```

cc @thoughtpolice @lf- @9999years

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
