### PR TITLE
spark: initialize 4.0.1 as spark_4_0 and update default vers.

### DIFF
--- a/pkgs/applications/networking/cluster/spark/default.nix
+++ b/pkgs/applications/networking/cluster/spark/default.nix
@@ -8,6 +8,8 @@
   RSupport ? true,
   R,
   nixosTests,
+  # needeed in situations where hadoop's jdk version is too old
+  jdk21_headless,
 }:
 
 let
@@ -28,7 +30,15 @@ let
         R
         pysparkPython
         ;
-      inherit (finalAttrs.hadoop) jdk;
+      jdk =
+        if
+          (
+            (lib.versionAtLeast finalAttrs.version "4") && (lib.versionOlder finalAttrs.hadoop.jdk.version "21")
+          )
+        then
+          jdk21_headless
+        else
+          finalAttrs.hadoop.jdk;
       src = fetchzip {
         url =
           with finalAttrs;
@@ -96,12 +106,17 @@ in
   # we strictly adhere to the EOL timeline, despite 3.3.4 being released one day before (2023-12-08).
   # A better policy is to keep these versions around, and clean up EOL versions just before
   # a new NixOS release.
+  spark_4_0 = spark {
+    pname = "spark";
+    version = "4.0.1";
+    hash = "sha256-AW+EQ83b4orJO3+dUPPDlTRAH/D94U7KQBKvKjguChY=";
+  };
   spark_3_5 = spark {
     pname = "spark";
     version = "3.5.5";
     hash = "sha256-vzcWgIfHPhN3nyrxdk3f0p4fW3MpQ+FuEPnWPw0xNPg=";
   };
-  spark_3_4 = spark rec {
+  spark_3_4 = spark {
     pname = "spark";
     version = "3.4.4";
     hash = "sha256-GItHmthLhG7y0XSF3QINCyE7wYFb0+lPZmYLUuMa4Ww=";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6359,11 +6359,13 @@ with pkgs;
   samplebrain = libsForQt5.callPackage ../applications/audio/samplebrain { };
 
   inherit (callPackages ../applications/networking/cluster/spark { })
+    spark_4_0
     spark_3_5
     spark_3_4
     ;
   spark3 = spark_3_5;
   spark = spark3;
+  spark4 = spark_4_0;
 
   inherit
     ({

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6364,8 +6364,8 @@ with pkgs;
     spark_3_4
     ;
   spark3 = spark_3_5;
-  spark = spark3;
   spark4 = spark_4_0;
+  spark = spark_4_0;
 
   inherit
     ({


### PR DESCRIPTION
- Initialized `spark_4_0` package definition at 4.0.1
- Updated default spark package to use `spark_4_0` instead of `spark_3_0`

Resolves #440752

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
