### PR TITLE
anubis: 1.21.3 -> 1.22.0

### DIFF
--- a/pkgs/by-name/an/anubis/package.nix
+++ b/pkgs/by-name/an/anubis/package.nix
@@ -2,52 +2,44 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  fetchNpmDeps,
   nixosTests,
   stdenv,
-  buildNpmPackage,
-
+  npmHooks,
+  nodejs,
   esbuild,
   brotli,
   zstd,
+  nix-update-script,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "anubis";
-  version = "1.21.3";
+  version = "1.22.0";
 
   src = fetchFromGitHub {
     owner = "TecharoHQ";
     repo = "anubis";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CMFd9che+D1ot1Iqk0VcJmna0xIqHlRIvNnzYo+q+RU=";
+    hash = "sha256-LOYBl9r00AJljGvlacd506cLeMr8Ndh817/ZIw46Uu0=";
   };
 
-  vendorHash = "sha256-cWkC3Bqut5h3hHh5tPIPeHMnkwoqKMnG1x40uCtUIwI=";
+  vendorHash = "sha256-/iTAbwYSHTz9SrJ0vrAXsA+3yS0jUreJDF52gju9CgU=";
+
+  npmDeps = fetchNpmDeps {
+    name = "anubis-npm-deps";
+    inherit (finalAttrs) src;
+    hash = "sha256-s+OxVf6Iysobfuo0nAh5qF157opD2sR5D+7awAx6GTs=";
+  };
 
   nativeBuildInputs = [
     esbuild
     brotli
     zstd
+
+    nodejs
+    npmHooks.npmConfigHook
   ];
-
-  xess = buildNpmPackage {
-    pname = "anubis-xess";
-    inherit (finalAttrs) version src;
-
-    npmDepsHash = "sha256-NJMUXGXcaY8l1WIbvCn+aIknVuagR7X8gRkme9xpYQ0=";
-
-    buildPhase = ''
-      runHook preBuild
-      npx postcss ./xess/xess.css -o xess.min.css
-      runHook postBuild
-    '';
-
-    installPhase = ''
-      runHook preInstall
-      install -Dm644 xess.min.css $out/xess.min.css
-      runHook postInstall
-    '';
-  };
 
   subPackages = [ "cmd/anubis" ];
 
@@ -58,20 +50,35 @@ buildGoModule (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [ "-extldflags=-static" ];
 
+  prePatch = ''
+    # we must forcefully disable the hook when creating the go vendor archive
+    if [[ $name =~ go-modules ]]; then
+      npmConfigHook() { true; }
+    fi
+  '';
+
   postPatch = ''
-    patchShebangs ./web/build.sh
+    patchShebangs ./web/build.sh ./lib/challenge/preact/build.sh
   '';
 
   preBuild = ''
-    go generate ./... && ./web/build.sh && cp -r ${finalAttrs.xess}/xess.min.css ./xess
+    # do not run when creating go vendor archive
+    if [[ ! $name =~ go-modules ]]; then
+      # https://github.com/TecharoHQ/anubis/blob/main/xess/build.sh
+      npx postcss ./xess/xess.css -o xess/xess.min.css
+      go generate ./...
+      ./web/build.sh
+    fi
   '';
 
   preCheck = ''
     export DONT_USE_NETWORK=1
   '';
 
-  passthru.tests = { inherit (nixosTests) anubis; };
-  passthru.updateScript = ./update.sh;
+  passthru = {
+    tests = { inherit (nixosTests) anubis; };
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=^v(\\d+\\.\\d+\\.\\d+)$" ]; };
+  };
 
   meta = {
     description = "Weighs the soul of incoming HTTP requests using proof-of-work to stop AI crawlers";

--- a/pkgs/by-name/an/anubis/update.sh
+++ b/pkgs/by-name/an/anubis/update.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i bash -p nix-update
-
-set -euo pipefail
-
-nix-update anubis --src-only --version-regex='^v(\d+\.\d+\.\d+)$'
-nix-update anubis.xess --version=skip
-nix-update anubis --version=skip


### PR DESCRIPTION
Changelog: https://github.com/TecharoHQ/anubis/releases/tag/v1.22.0

The new preact challenge uses go generate and depends on the node_modules directory being available. To make things easier and more closely to how upstream builds things, I removed the xess package and added some, lets be honest to ourselves, hacks to build the new things without breaking the FODs.

I did not yet properly test this beyond building.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
