### PR TITLE
archipelago: avoid bwrap

### DIFF
--- a/pkgs/by-name/ar/archipelago/package.nix
+++ b/pkgs/by-name/ar/archipelago/package.nix
@@ -1,35 +1,87 @@
 {
   lib,
+  pkgs,
+  stdenvNoCC,
   appimageTools,
+  autoPatchelfHook,
+  makeWrapper,
+  gobject-introspection,
+  openssl,
+  lttng-ust,
+  mtdev,
+  xsel,
+  xclip,
+  zenity,
   fetchurl,
   nix-update-script,
-  extraPackages ? [ ],
 }:
-let
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "archipelago";
   version = "0.6.3";
   src = fetchurl {
-    url = "https://github.com/ArchipelagoMW/Archipelago/releases/download/${version}/Archipelago_${version}_linux-x86_64.AppImage";
+    url = "https://github.com/ArchipelagoMW/Archipelago/releases/download/${finalAttrs.version}/Archipelago_${finalAttrs.version}_linux-x86_64.AppImage";
     hash = "sha256-PetlGYsdhyvThIFqy+7wbPLAXDcgN2Kcl2WF3rta8PA=";
   };
 
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
-in
-appimageTools.wrapType2 {
-  inherit pname version src;
-  extraPkgs =
-    pkgs:
-    [
-      pkgs.xsel
-      pkgs.xclip
-      pkgs.mtdev
-    ]
-    ++ extraPackages;
-  extraInstallCommands = ''
-    install -Dm444 ${appimageContents}/archipelago.desktop -t $out/share/applications
+  dontUnpack = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = finalAttrs.runtimeDependencies;
+
+  runtimeDependencies = [
+    gobject-introspection
+    lttng-ust
+    openssl
+  ]
+  ++ appimageTools.defaultFhsEnvArgs.targetPkgs pkgs
+  ++ appimageTools.defaultFhsEnvArgs.multiPkgs pkgs;
+
+  libraryPath = lib.makeLibraryPath [
+    mtdev
+  ];
+
+  binPath = lib.makeBinPath [
+    xsel
+    xclip
+    zenity
+  ];
+
+  appimageContents = appimageTools.extractType2 { inherit (finalAttrs) pname version src; };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp ${finalAttrs.appimageContents}/AppRun $out/bin/archipelago
+
+    mkdir -p $out/lib/opt
+    cp -r ${finalAttrs.appimageContents}/opt/* $out/lib/opt
+
+    wrapProgram $out/bin/archipelago \
+      --set APPDIR $out/lib \
+      --prefix LD_LIBRARY_PATH : "${finalAttrs.libraryPath}" \
+      --prefix PATH : "${finalAttrs.binPath}"
+
+    install -Dm444 ${finalAttrs.appimageContents}/archipelago.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/archipelago.desktop \
       --replace-fail 'opt/Archipelago/ArchipelagoLauncher' "archipelago"
-    cp -r ${appimageContents}/usr/share/icons $out/share
+    cp -r ${finalAttrs.appimageContents}/usr/share/icons $out/share
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    patchelf \
+      --replace-needed libcrypto.so.1.0.0 libcrypto.so \
+      --replace-needed libssl.so.1.0.0 libssl.so \
+      $out/lib/opt/Archipelago/EnemizerCLI/System.Security.Cryptography.Native.OpenSsl.so
+
+    patchelf --replace-needed liblttng-ust.so.0 liblttng-ust.so \
+      $out/lib/opt/Archipelago/EnemizerCLI/libcoreclrtraceptprovider.so
   '';
 
   passthru.updateScript = nix-update-script { };
@@ -37,7 +89,7 @@ appimageTools.wrapType2 {
   meta = {
     description = "Multi-Game Randomizer and Server";
     homepage = "https://archipelago.gg";
-    changelog = "https://github.com/ArchipelagoMW/Archipelago/releases/tag/${version}";
+    changelog = "https://github.com/ArchipelagoMW/Archipelago/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     mainProgram = "archipelago";
     maintainers = with lib.maintainers; [
@@ -46,4 +98,4 @@ appimageTools.wrapType2 {
     ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
Resolves #440284. Archipelago clients that rely on reading/writing memory of other processes (such as The Wind Waker Client with Dolphin Emulator) cannot do so under `bwrap`, which is what is used by `appimageTools.wrapType2` to create an FHS environment. Instead, extract the contents of the AppImage directly and run that with a wrapper.

I would've liked to see a way to set some attribute on the `wrapType2` attrset that gets passed to `buildFHSEnv` allowing this interaction but trying various attributes such as `unsharePid = false;` and `unshareUser = false;` didn't seem to help so I went with the approach above.

## Notify maintainers

@pyrox0 @iqubic

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 441078`
Commit: `b8485829e54be9e028a39e0ad79f1eefea5ac08b`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>archipelago</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
