### PR TITLE
python3Packages.pyqt6: fix QtMultimediaWidgets

### DIFF
--- a/pkgs/development/python-modules/pyqt/6.x.nix
+++ b/pkgs/development/python-modules/pyqt/6.x.nix
@@ -118,6 +118,7 @@ buildPythonPackage rec {
       qtquicktimeline
     ]
     # ++ lib.optional withConnectivity qtconnectivity
+    ++ lib.optional withMultimedia qtmultimedia
     ++ lib.optional withWebSockets qtwebsockets
     ++ lib.optional withLocation qtlocation
     ++ lib.optional withSerialPort qtserialport;


### PR DESCRIPTION
PyQt6.QtMultimediaWidgets wasn't built due to a link error as QtMultimedia was missing from buildInputs.

Fixes the following failure during configure which skipped QtMultimediaWidgets:

```
Checking to see if the QtMultimediaWidgets bindings can be built...
/nix/store/9wrby1l822pmbvfn9kfxmvh5dhfnpgyb-qtbase-6.9.1/bin/qmake QtMultimediaWidgets.pro
Info: creating stash file /build/tmpgk570a4k/cfgtest_QtMultimediaWidgets/.qmake.stash
make
g++ -c -pipe -O2 -Wall -Wextra -fPIC -D_REENTRANT -DQT_NO_DEBUG -DQT_MULTIMEDIAWIDGETS_LIB -DQT_MULTIMEDIA_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -I. -I/nix/store/6i3jdlw1m524r9qclrcp92www1j1cbz2-qtmultimedia-6.9.1/include -I/nix/store/6i3jdlw1m524r9qclrcp92www1j1cbz2-qtmultimedia-6.9.1/include/QtMultimediaWidgets -I/nix/store/6i3jdlw1m524r9qclrcp92www1j1cbz2-qtmultimedia-6.9.1/include/QtMultimedia -I/nix/store/9wrby1l822pmbvfn9kfxmvh5dhfnpgyb-qtbase-6.9.1/include/QtWidgets -I/nix/store/9wrby1l822pmbvfn9kfxmvh5dhfnpgyb-qtbase-6.9.1/include/QtGui -I/nix/store/9wrby1l822pmbvfn9kfxmvh5dhfnpgyb-qtbase-6.9.1/include/QtNetwork -I/nix/store/9wrby1l822pmbvfn9kfxmvh5dhfnpgyb-qtbase-6.9.1/include/QtCore -I. -I/nix/store/9wrby1l822pmbvfn9kfxmvh5dhfnpgyb-qtbase-6.9.1/mkspecs/linux-g++ -o cfgtest_QtMultimediaWidgets.o cfgtest_QtMultimediaWidgets.cpp
g++ -Wl,-O1 -Wl,-rpath,/nix/store/9wrby1l822pmbvfn9kfxmvh5dhfnpgyb-qtbase-6.9.1/lib -Wl,-rpath-link,/nix/store/9wrby1l822pmbvfn9kfxmvh5dhfnpgyb-qtbase-6.9.1/lib -o QtMultimediaWidgets  cfgtest_QtMultimediaWidgets.o   /nix/store/6i3jdlw1m524r9qclrcp92www1j1cbz2-qtmultimedia-6.9.1/lib/libQt6MultimediaWidgets.so -lQt6Multimedia -lQt6Widgets /nix/store/6i3jdlw1m524r9qclrcp92www1j1cbz2-qtmultimedia-6.9.1/lib/libQt6Multimedia.so -lQt6Network /nix/store/9wrby1l822pmbvfn9kfxmvh5dhfnpgyb-qtbase-6.9.1/lib/libQt6Widgets.so -lQt6Gui /nix/store/9wrby1l822pmbvfn9kfxmvh5dhfnpgyb-qtbase-6.9.1/lib/libQt6Gui.so /nix/store/9wrby1l822pmbvfn9kfxmvh5dhfnpgyb-qtbase-6.9.1/lib/libQt6Network.so -lQt6Core /nix/store/9wrby1l822pmbvfn9kfxmvh5dhfnpgyb-qtbase-6.9.1/lib/libQt6Core.so -lpthread -lGLX -lOpenGL   
/nix/store/xrwdb41dqi2ia6lr2s61w5bzfg2m71pi-binutils-2.44/bin/ld: cannot find -lQt6Multimedia: No such file or directory
collect2: error: ld returned 1 exit status
make: *** [Makefile:634: QtMultimediaWidgets] Error 1
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
