### PR TITLE
taplo: add shell completions

### DIFF
--- a/pkgs/by-name/ta/taplo/package.nix
+++ b/pkgs/by-name/ta/taplo/package.nix
@@ -1,10 +1,12 @@
 {
+  stdenv,
   lib,
   rustPlatform,
   fetchCrate,
   pkg-config,
   openssl,
   withLsp ? true,
+  installShellFiles,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -20,6 +22,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-tvijtB5fwOzQnnK/ClIvTbjCcMeqZpXcRdWWKZPIulM=";
 
   nativeBuildInputs = [
+    installShellFiles
     pkg-config
   ];
 
@@ -28,6 +31,21 @@ rustPlatform.buildRustPackage rec {
   ];
 
   buildFeatures = lib.optional withLsp "lsp";
+
+  postInstall =
+    lib.optionalString
+      (
+        stdenv.buildPlatform.canExecute stdenv.hostPlatform
+        &&
+          # Creation of the completions fails on Darwin platforms.
+          !stdenv.hostPlatform.isDarwin
+      )
+      ''
+        installShellCompletion --cmd taplo \
+          --bash <($out/bin/taplo completions bash) \
+          --fish <($out/bin/taplo completions fish) \
+          --zsh <($out/bin/taplo completions zsh)
+      '';
 
   meta = with lib; {
     description = "TOML toolkit written in Rust";


### PR DESCRIPTION
### Add Shell Completions to Taplo

- Version 0.10.0 of Taplo CLI added the ability to generate completions for shells (see https://github.com/tamasfe/taplo/releases/tag/0.10.0).

- This commit adds the generated shell completions to the derivation output.

- Resolves https://github.com/NixOS/nixpkgs/issues/440875.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
