### PR TITLE
speedcrunch: unstable-2021-10-09 -> 0.12-unstable-2024-12-02

### DIFF
--- a/pkgs/by-name/sp/speedcrunch/package.nix
+++ b/pkgs/by-name/sp/speedcrunch/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation {
   pname = "speedcrunch";
-  version = "unstable-2021-10-09";
+  version = "0.12-unstable-2024-12-02";
 
   src = fetchFromBitbucket {
     owner = "heldercorreia";
     repo = "speedcrunch";
-    rev = "74756f3438149c01e9edc3259b0f411fa319a22f";
-    sha256 = "sha256-XxQv+A5SfYXFIRK7yacxGHHne1Q93pwCGeHhchIKizU=";
+    rev = "db51fc5e547aa83834761d874d3518c06d0fec9e";
+    hash = "sha256-rnl4z/HU3lAF9Y1JvdM8LZWIV1NGfR4q5gOMxlNU2EA=";
   };
 
   sourceRoot = "source/src";

--- a/pkgs/by-name/sp/speedcrunch/package.nix
+++ b/pkgs/by-name/sp/speedcrunch/package.nix
@@ -1,14 +1,12 @@
 {
   stdenv,
-  mkDerivation,
   lib,
   fetchFromBitbucket,
   cmake,
-  qtbase,
-  qttools,
+  libsForQt5,
 }:
 
-mkDerivation {
+stdenv.mkDerivation {
   pname = "speedcrunch";
   version = "unstable-2021-10-09";
 
@@ -19,19 +17,22 @@ mkDerivation {
     sha256 = "sha256-XxQv+A5SfYXFIRK7yacxGHHne1Q93pwCGeHhchIKizU=";
   };
 
-  buildInputs = [
+  sourceRoot = "source/src";
+
+  buildInputs = with libsForQt5; [
     qtbase
     qttools
   ];
 
-  nativeBuildInputs = [ cmake ];
-
-  preConfigure = ''
-    cd src
-  '';
+  nativeBuildInputs = [
+    cmake
+  ]
+  ++ [
+    libsForQt5.wrapQtAppsHook
+  ];
 
   meta = with lib; {
-    homepage = "http://speedcrunch.org";
+    homepage = "https://speedcrunch.org";
     license = licenses.gpl2Plus;
     description = "Fast power user calculator";
     mainProgram = "speedcrunch";
@@ -44,7 +45,7 @@ mkDerivation {
     maintainers = with maintainers; [
       j0hax
     ];
-    inherit (qtbase.meta) platforms;
+    inherit (libsForQt5.qtbase.meta) platforms;
     broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14525,8 +14525,6 @@ with pkgs;
     enableJupyter = false;
   };
 
-  speedcrunch = libsForQt5.callPackage ../applications/science/math/speedcrunch { };
-
   ### SCIENCE / MISC
 
   boinc-headless = boinc.override { headless = true; };


### PR DESCRIPTION
### Update Speedcrunch

Upstream: https://bitbucket.org/heldercorreia/speedcrunch/commits/branch/master

- Updated the version of Speedcrunch to the penultimate latest upstream commit. The actual latest upstream commit enforces the use of Qt6, and the build fails if Qt6 is used.

- Migrated from pkgs/applications/science/math/speedcrunch to pkgs/by-name/sp/speedcrunch.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
