### PR TITLE
tests.cc-wrapper.supported: update list of aliases

### DIFF
--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -11,13 +11,8 @@ with pkgs;
         let
           pkgSets = lib.pipe pkgNames [
             (filter (lib.hasPrefix "llvmPackages"))
-            (filter (n: n != "rocmPackages.llvm"))
-            # Are throw aliases.
-            (filter (n: n != "llvmPackages_rocm"))
+            # Are aliases.
             (filter (n: n != "llvmPackages_latest"))
-            (filter (n: n != "llvmPackages_6"))
-            (filter (n: n != "llvmPackages_7"))
-            (filter (n: n != "llvmPackages_8"))
             (filter (n: n != "llvmPackages_9"))
             (filter (n: n != "llvmPackages_10"))
             (filter (n: n != "llvmPackages_11"))
@@ -42,6 +37,10 @@ with pkgs;
               (filter (n: n != "gcc6Stdenv"))
               (filter (n: n != "gcc7Stdenv"))
               (filter (n: n != "gcc8Stdenv"))
+              (filter (n: n != "gcc9Stdenv"))
+              (filter (n: n != "gcc10Stdenv"))
+              (filter (n: n != "gcc11Stdenv"))
+              (filter (n: n != "gcc12Stdenv"))
             ]
             ++
               lib.optionals


### PR DESCRIPTION
This is pretty horrible and we should figure out a better way of doing this…


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
