### PR TITLE
python3Packages.tree-sitter-markdown: remove update script override

### DIFF
--- a/pkgs/development/python-modules/tree-sitter-markdown/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-markdown/default.nix
@@ -5,12 +5,10 @@
   setuptools,
   tree-sitter,
   pytestCheckHook,
-  nix-update-script,
 }:
 
 buildPythonPackage rec {
   pname = "tree-sitter-markdown";
-  # only update to the latest version on PyPI
   version = "0.5.0";
   pyproject = true;
 
@@ -37,15 +35,6 @@ buildPythonPackage rec {
     pytestCheckHook
     tree-sitter
   ];
-
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      # later versions have incompatible changes, pin it to the latest on PyPI
-      # reverse-dependencies also pull packages from PyPI, see:
-      # https://github.com/Textualize/textual/issues/5868
-      "--version=0.3.2"
-    ];
-  };
 
   meta = {
     description = "Markdown grammar for tree-sitter";


### PR DESCRIPTION
Fixes creating PRs like https://github.com/NixOS/nixpkgs/pull/441010.

This was added in https://github.com/NixOS/nixpkgs/pull/425177 with the
idea of freezing updates and manually bumping the version in the update script,
but turns out python updates don't care about custom update scripts
and that was ignored.

Until there's another issue with this package being ahead of PyPi
releases (eg. with textual), we can use the latest GitHub release for simplicity. The best
would be fetching this from PyPi instead.



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
