### PR TITLE
ocamlPackages.conan: init at 0.0.6

### DIFF
--- a/pkgs/development/ocaml-modules/conan/cli.nix
+++ b/pkgs/development/ocaml-modules/conan/cli.nix
@@ -1,0 +1,36 @@
+{
+  buildDunePackage,
+  conan-unix,
+  dune-site,
+  alcotest,
+  conan-database,
+  crowbar,
+  fmt,
+  rresult,
+}:
+
+buildDunePackage {
+  pname = "conan-cli";
+  inherit (conan-unix) version src meta;
+
+  buildInputs = [
+    conan-unix
+    dune-site
+  ];
+
+  doCheck = true;
+
+  preCheck = ''
+    export DUNE_CACHE=disabled
+  '';
+
+  nativeCheckInputs = [ conan-database ];
+
+  checkInputs = [
+    alcotest
+    conan-database
+    crowbar
+    fmt
+    rresult
+  ];
+}

--- a/pkgs/development/ocaml-modules/conan/database.nix
+++ b/pkgs/development/ocaml-modules/conan/database.nix
@@ -1,0 +1,28 @@
+{
+  buildDunePackage,
+  conan,
+  alcotest,
+  crowbar,
+  fmt,
+  rresult,
+}:
+
+buildDunePackage {
+  pname = "conan-database";
+  inherit (conan) version src;
+
+  propagatedBuildInputs = [ conan ];
+
+  doCheck = true;
+
+  checkInputs = [
+    alcotest
+    crowbar
+    fmt
+    rresult
+  ];
+
+  meta = conan.meta // {
+    description = "Database of decision trees to recognize MIME type";
+  };
+}

--- a/pkgs/development/ocaml-modules/conan/default.nix
+++ b/pkgs/development/ocaml-modules/conan/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  fetchurl,
+  buildDunePackage,
+  version ? "0.0.6",
+  ptime,
+  re,
+  uutf,
+  alcotest,
+  crowbar,
+  fmt,
+  rresult,
+}:
+
+buildDunePackage {
+  pname = "conan";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/mirage/conan/releases/download/v${version}/conan-${version}.tbz";
+    hash = "sha256-shAle4gXFf+53L+IZ4yFWewq7yZ5WlMEr9WotLvxHhY=";
+  };
+
+  propagatedBuildInputs = [
+    ptime
+    re
+    uutf
+  ];
+
+  doCheck = true;
+
+  checkInputs = [
+    alcotest
+    crowbar
+    fmt
+    rresult
+  ];
+
+  minimalOCamlVersion = "4.12";
+
+  meta = {
+    description = "Identify type of your file (such as the MIME type)";
+    homepage = "https://github.com/mirage/conan";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/conan/lwt.nix
+++ b/pkgs/development/ocaml-modules/conan/lwt.nix
@@ -1,0 +1,30 @@
+{
+  buildDunePackage,
+  conan,
+  lwt,
+  bigstringaf,
+  alcotest,
+  crowbar,
+  fmt,
+  rresult,
+}:
+
+buildDunePackage {
+  pname = "conan-lwt";
+  inherit (conan) version src meta;
+
+  propagatedBuildInputs = [
+    conan
+    lwt
+    bigstringaf
+  ];
+
+  doCheck = true;
+
+  checkInputs = [
+    alcotest
+    crowbar
+    fmt
+    rresult
+  ];
+}

--- a/pkgs/development/ocaml-modules/conan/unix.nix
+++ b/pkgs/development/ocaml-modules/conan/unix.nix
@@ -1,0 +1,32 @@
+{
+  buildDunePackage,
+  fetchpatch,
+  conan,
+  alcotest,
+  crowbar,
+  fmt,
+  rresult,
+}:
+
+buildDunePackage {
+  pname = "conan-unix";
+  inherit (conan) version src meta;
+
+  patches = fetchpatch {
+    url = "https://github.com/mirage/conan/commit/16872a71be3ef2870d32df849e7abcbaec4fe95d.patch";
+    hash = "sha256-/j9nNGOklzNrdIPW7SMNhKln9EMXiXmvPmNRpXc/l/Y=";
+  };
+
+  propagatedBuildInputs = [
+    conan
+  ];
+
+  doCheck = true;
+
+  checkInputs = [
+    alcotest
+    crowbar
+    fmt
+    rresult
+  ];
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -276,6 +276,8 @@ let
 
         conan-lwt = callPackage ../development/ocaml-modules/conan/lwt.nix { };
 
+        conan-unix = callPackage ../development/ocaml-modules/conan/unix.nix { };
+
         conduit = callPackage ../development/ocaml-modules/conduit { };
 
         conduit-async = callPackage ../development/ocaml-modules/conduit/async.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -270,6 +270,8 @@ let
 
         colors = callPackage ../development/ocaml-modules/colors { };
 
+        conan = callPackage ../development/ocaml-modules/conan { };
+
         conduit = callPackage ../development/ocaml-modules/conduit { };
 
         conduit-async = callPackage ../development/ocaml-modules/conduit/async.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -272,6 +272,8 @@ let
 
         conan = callPackage ../development/ocaml-modules/conan { };
 
+        conan-database = callPackage ../development/ocaml-modules/conan/database.nix { };
+
         conduit = callPackage ../development/ocaml-modules/conduit { };
 
         conduit-async = callPackage ../development/ocaml-modules/conduit/async.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -274,6 +274,8 @@ let
 
         conan-database = callPackage ../development/ocaml-modules/conan/database.nix { };
 
+        conan-lwt = callPackage ../development/ocaml-modules/conan/lwt.nix { };
+
         conduit = callPackage ../development/ocaml-modules/conduit { };
 
         conduit-async = callPackage ../development/ocaml-modules/conduit/async.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -272,6 +272,8 @@ let
 
         conan = callPackage ../development/ocaml-modules/conan { };
 
+        conan-cli = callPackage ../development/ocaml-modules/conan/cli.nix { };
+
         conan-database = callPackage ../development/ocaml-modules/conan/database.nix { };
 
         conan-lwt = callPackage ../development/ocaml-modules/conan/lwt.nix { };


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
