### PR TITLE
treewide/nixos: move number typed port options to types.port

### DIFF
--- a/nixos/modules/services/cluster/hadoop/hbase.nix
+++ b/nixos/modules/services/cluster/hadoop/hbase.nix
@@ -178,12 +178,12 @@ in
       let
         ports = port: infoPort: {
           port = lib.mkOption {
-            type = lib.types.int;
+            type = lib.types.port;
             default = port;
             description = "RPC port";
           };
           infoPort = lib.mkOption {
-            type = lib.types.int;
+            type = lib.types.port;
             default = infoPort;
             description = "web UI port";
           };

--- a/nixos/modules/services/databases/monetdb.nix
+++ b/nixos/modules/services/databases/monetdb.nix
@@ -38,7 +38,7 @@ in
       };
 
       port = lib.mkOption {
-        type = lib.types.ints.u16;
+        type = lib.types.port;
         default = 50000;
         description = "Port to listen on.";
       };

--- a/nixos/modules/services/development/athens.nix
+++ b/nixos/modules/services/development/athens.nix
@@ -861,7 +861,7 @@ in
           default = "localhost";
         };
         port = lib.mkOption {
-          type = lib.types.int;
+          type = lib.types.port;
           description = "Port for the MySQL database.";
           default = 3306;
         };
@@ -901,7 +901,7 @@ in
           default = "localhost";
         };
         port = lib.mkOption {
-          type = lib.types.int;
+          type = lib.types.port;
           description = "Port for the Postgres database.";
           default = 5432;
         };

--- a/nixos/modules/services/games/minetest-server.nix
+++ b/nixos/modules/services/games/minetest-server.nix
@@ -135,7 +135,7 @@ in
       };
 
       port = lib.mkOption {
-        type = lib.types.nullOr lib.types.int;
+        type = lib.types.nullOr lib.types.port;
         default = null;
         description = ''
           Port number to bind to.

--- a/nixos/modules/services/mail/postgrey.nix
+++ b/nixos/modules/services/mail/postgrey.nix
@@ -26,7 +26,7 @@ let
         description = "The address to bind to. Localhost if null";
       };
       port = mkOption {
-        type = natural';
+        type = port;
         default = 10030;
         description = "Tcp port to bind to";
       };

--- a/nixos/modules/services/misc/headphones.nix
+++ b/nixos/modules/services/misc/headphones.nix
@@ -42,7 +42,7 @@ in
         description = "Host to listen on.";
       };
       port = lib.mkOption {
-        type = lib.types.ints.u16;
+        type = lib.types.port;
         default = 8181;
         description = "Port to bind to.";
       };

--- a/nixos/modules/services/misc/moonraker.nix
+++ b/nixos/modules/services/misc/moonraker.nix
@@ -75,7 +75,7 @@ in
       };
 
       port = lib.mkOption {
-        type = lib.types.ints.unsigned;
+        type = lib.types.port;
         default = 7125;
         description = "The port to listen on.";
       };

--- a/nixos/modules/services/misc/servarr/settings-options.nix
+++ b/nixos/modules/services/misc/servarr/settings-options.nix
@@ -26,7 +26,7 @@
           };
           server = {
             port = lib.mkOption {
-              type = lib.types.int;
+              type = lib.types.port;
               description = "Port Number";
               default = port;
             };

--- a/nixos/modules/services/misc/sickbeard.nix
+++ b/nixos/modules/services/misc/sickbeard.nix
@@ -44,7 +44,7 @@ in
         description = "Path to config file.";
       };
       port = lib.mkOption {
-        type = lib.types.ints.u16;
+        type = lib.types.port;
         default = 8081;
         description = "Port to bind to.";
       };

--- a/nixos/modules/services/monitoring/statsd.nix
+++ b/nixos/modules/services/monitoring/statsd.nix
@@ -73,7 +73,7 @@ in
     port = lib.mkOption {
       description = "Port that stats listens for messages on over UDP";
       default = 8125;
-      type = lib.types.int;
+      type = lib.types.port;
     };
 
     mgmt_address = lib.mkOption {
@@ -85,7 +85,7 @@ in
     mgmt_port = lib.mkOption {
       description = "Port to run the management TCP interface on";
       default = 8126;
-      type = lib.types.int;
+      type = lib.types.port;
     };
 
     backends = lib.mkOption {

--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -417,7 +417,7 @@ in
       };
 
       port = mkOption {
-        type = with types; nullOr int;
+        type = with types; nullOr port;
         default = null;
         description = ''
           I2P listen port. If no one is given the router will pick between 9111 and 30777.

--- a/nixos/modules/services/networking/iperf3.nix
+++ b/nixos/modules/services/networking/iperf3.nix
@@ -12,7 +12,7 @@ let
     enable = mkEnableOption "iperf3 network throughput testing server";
     package = mkPackageOption pkgs "iperf3" { };
     port = mkOption {
-      type = types.ints.u16;
+      type = types.port;
       default = 5201;
       description = "Server port to listen on for iperf3 client requests.";
     };

--- a/nixos/modules/services/networking/nghttpx/server-options.nix
+++ b/nixos/modules/services/networking/nghttpx/server-options.nix
@@ -9,7 +9,7 @@
       '';
     };
     port = lib.mkOption {
-      type = lib.types.int;
+      type = lib.types.port;
       example = 5088;
       description = ''
         Server host port.

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -319,7 +319,7 @@ in
                 '';
               };
               port = lib.mkOption {
-                type = lib.types.nullOr lib.types.int;
+                type = lib.types.nullOr lib.types.port;
                 default = null;
                 description = ''
                   Port to listen to.

--- a/nixos/modules/services/networking/tinyproxy.nix
+++ b/nixos/modules/services/networking/tinyproxy.nix
@@ -70,7 +70,7 @@ in
                 '';
               };
               Port = mkOption {
-                type = types.int;
+                type = types.port;
                 default = 8888;
                 description = ''
                   Specify which port to listen to.

--- a/nixos/modules/services/torrent/flood.nix
+++ b/nixos/modules/services/torrent/flood.nix
@@ -19,7 +19,7 @@ in
       description = "Whether to open the firewall for the port in {option}`services.flood.port`.";
     };
     port = lib.mkOption {
-      type = lib.types.int;
+      type = lib.types.port;
       description = "Port to bind webserver.";
       default = 3000;
       example = 3001;

--- a/nixos/modules/services/web-apps/selfoss.nix
+++ b/nixos/modules/services/web-apps/selfoss.nix
@@ -100,7 +100,7 @@ in
         };
 
         port = mkOption {
-          type = types.nullOr types.int;
+          type = types.nullOr types.port;
           default = null;
           description = ''
             The database's port. If not set, the default ports will be

--- a/nixos/modules/services/web-servers/varnish/default.nix
+++ b/nixos/modules/services/web-servers/varnish/default.nix
@@ -80,7 +80,7 @@ let
       port = mkOption {
         description = "The port to use for IP sockets. If port is not specified, port 80 (http) is used.";
         default = null;
-        type = with types; nullOr int;
+        type = with types; nullOr port;
       };
       proto = mkOption {
         description = "PROTO can be 'HTTP' (the default) or 'PROXY'.  Both version 1 and 2 of the proxy protocol can be used.";

--- a/nixos/modules/virtualisation/waagent.nix
+++ b/nixos/modules/virtualisation/waagent.nix
@@ -220,7 +220,7 @@ let
         };
 
         Port = lib.mkOption {
-          type = types.nullOr types.int;
+          type = types.nullOr types.port;
           default = null;
           description = ''
             If you set http proxy, waagent will use this proxy to access the Internet.


### PR DESCRIPTION
I went around and moved the port type in any module I could find that was not using the `types.port` type.

I used the following script (along-side other attempts) to attempt to identify cases where a port option was created and then the type was not set to port. I am undoubtedly missing a few cases hence the 'various', but have tried every way I can think of to mass triage the cases.
```
for file in $(rg -l " port = mkOption"); do
    perl -0777 -ne 'while (/(\s+port = mkOption\s*\{(?:[^{}]++|(?1))*\})/g) {
        $match = $1;
        if ($match !~ /type\s*=\s*.*port/) {
            print "File: '"$file"'\n";
            print "$match\n";
            print "-" x 40, "\n";
        }
    }' "$file"
done
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
