### PR TITLE
u-root: 0.14.0-unstable-2024-09-26 -> 0.15.0; mkuimage: 0-unstable-2024-02-28 -> 0-unstable-2025-09-05; gobusybox: pin buildGoModule to 1.24

### DIFF
--- a/pkgs/by-name/go/gobusybox/package.nix
+++ b/pkgs/by-name/go/gobusybox/package.nix
@@ -1,10 +1,13 @@
 {
   lib,
-  buildGoModule,
+  # Build fails with Go 1.25, with the following error:
+  # 'vendor/golang.org/x/tools/internal/tokeninternal/tokeninternal.go:64:9: invalid array length -delta * delta (constant -256 of type int64)'
+  # Wait for upstream to update their vendored dependencies before unpinning.
+  buildGo124Module,
   fetchFromGitHub,
 }:
 
-buildGoModule (finalAttrs: {
+buildGo124Module (finalAttrs: {
   pname = "gobusybox";
   version = "0.2.0-unstable-2024-03-05";
 

--- a/pkgs/by-name/mk/mkuimage/package.nix
+++ b/pkgs/by-name/mk/mkuimage/package.nix
@@ -1,21 +1,24 @@
 {
   lib,
-  buildGoModule,
+  # Build fails with Go 1.25, with the following error:
+  # 'vendor/golang.org/x/tools/internal/tokeninternal/tokeninternal.go:64:9: invalid array length -delta * delta (constant -256 of type int64)'
+  # Wait for upstream to update their vendored dependencies before unpinning.
+  buildGo124Module,
   fetchFromGitHub,
   coreutils,
   bash,
   stdenv,
 }:
 
-buildGoModule {
+buildGo124Module {
   pname = "mkuimage";
-  version = "0-unstable-2024-02-28";
+  version = "0-unstable-2025-09-05";
 
   src = fetchFromGitHub {
     owner = "u-root";
     repo = "mkuimage";
-    rev = "899a47eaaa318bd2327dc94d964ccda40a784037";
-    hash = "sha256-sb/LtwAN7RN8jWG/x6pomz2Q+vKekA/teC7U5NVb2qY=";
+    rev = "9a40452f5d3ba67f236a83de54fa2c40f797b68b";
+    hash = "sha256-asC4j2DXkQnx6BZntxA8hSaM2k6p0CxraHYq3bK9vNQ=";
   };
 
   vendorHash = "sha256-KX9uv5m4N4+7gOgjhotRac9sz8tWSJ1krq98RWdsbzg=";

--- a/pkgs/by-name/u-/u-root/package.nix
+++ b/pkgs/by-name/u-/u-root/package.nix
@@ -1,23 +1,27 @@
 {
   lib,
-  buildGoModule,
+  # Build fails with Go 1.25, with the following error:
+  # 'vendor/golang.org/x/tools/internal/tokeninternal/tokeninternal.go:64:9: invalid array length -delta * delta (constant -256 of type int64)'
+  # Wait for upstream to update their vendored dependencies before unpinning.
+  buildGo124Module,
   fetchFromGitHub,
   coreutils,
   bash,
+  nix-update-script,
 
   linuxManualConfig,
   fetchurl,
   linux_latest,
 }:
 
-buildGoModule (finalAttrs: {
+buildGo124Module (finalAttrs: {
   pname = "u-root";
-  version = "0.14.0-unstable-2024-09-26";
+  version = "0.15.0";
 
   src = fetchFromGitHub {
     owner = "u-root";
     repo = "u-root";
-    rev = "a620c4fc0eeeaa71ea68c27d6ef96352ed814829";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-8B2H3AwGo9friveBk4bijOph9bSSNR7PPKJYEuywgm4=";
   };
 
@@ -52,6 +56,7 @@ buildGoModule (finalAttrs: {
       };
       allowImportFromDerivation = true;
     };
+    updateScript = nix-update-script { };
   };
 
   meta = {


### PR DESCRIPTION
Updating u-root and related packages. Also pinning the Go builder, as these are already failing on staging-next, which contains the 1.24 -> 1.25 bump.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
