### PR TITLE
linuxPackages.tuxedo-drivers: 4.14.0 -> 4.15.4

### DIFF
--- a/pkgs/os-specific/linux/tuxedo-drivers/default.nix
+++ b/pkgs/os-specific/linux/tuxedo-drivers/default.nix
@@ -23,6 +23,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [ ./no-cp-etc-usr.patch ];
 
+  postInstall = ''
+    echo "Running postInstallhook"
+    install -Dm 0644 -t $out/etc/udev/rules.d usr/lib/udev/rules.d/*
+  '';
+
   buildInputs = [ pahole ];
   nativeBuildInputs = [ kmod ] ++ kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/tuxedo-drivers/default.nix
+++ b/pkgs/os-specific/linux/tuxedo-drivers/default.nix
@@ -7,6 +7,7 @@
   kmod,
   pahole,
   gitUpdater,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -29,13 +30,19 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   buildInputs = [ pahole ];
-  nativeBuildInputs = [ kmod ] ++ kernel.moduleBuildDependencies;
+  nativeBuildInputs = [
+    kmod
+    udevCheckHook
+  ]
+  ++ kernel.moduleBuildDependencies;
 
   makeFlags = kernelModuleMakeFlags ++ [
     "KERNELRELEASE=${kernel.modDirVersion}"
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=${placeholder "out"}"
   ];
+
+  doInstallCheck = true;
 
   passthru.updateScript = gitUpdater {
     rev-prefix = "v";

--- a/pkgs/os-specific/linux/tuxedo-drivers/default.nix
+++ b/pkgs/os-specific/linux/tuxedo-drivers/default.nix
@@ -11,15 +11,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tuxedo-drivers-${kernel.version}";
-  version = "4.14.0";
+  version = "4.15.4";
 
   src = fetchFromGitLab {
     group = "tuxedocomputers";
     owner = "development/packages";
     repo = "tuxedo-drivers";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-79YZaK8WrHOxSUJWxi4lc+foh4xz3EgRnjw+OrL8yqU=";
+    hash = "sha256-WJeju+czbCw03ALW7yzGAFENCEAvDdKqHvedchd7NVY=";
   };
+
+  patches = [ ./no-cp-etc-usr.patch ];
 
   buildInputs = [ pahole ];
   nativeBuildInputs = [ kmod ] ++ kernel.moduleBuildDependencies;

--- a/pkgs/os-specific/linux/tuxedo-drivers/no-cp-etc-usr.patch
+++ b/pkgs/os-specific/linux/tuxedo-drivers/no-cp-etc-usr.patch
@@ -1,0 +1,12 @@
+diff --git a/Makefile b/Makefile
+index 75a6bc1..6021d42 100644
+--- a/Makefile
++++ b/Makefile
+@@ -30,7 +30,6 @@ all:
+ 
+ install: all
+ 	make -C $(KDIR) M=$(PWD) $(MAKEFLAGS) modules_install
+-	cp -r etc usr /
+ 
+ clean:
+ 	make -C $(KDIR) M=$(PWD) $(MAKEFLAGS) clean


### PR DESCRIPTION
Updates the [tuxedo-drivers](https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers) from [v4.14.0](https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers/-/tags/v4.14.0) to [v4.15.4](https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers/-/tags/v4.15.4) to enable bugfixes for NB02 devices.

The [changelog](https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers/-/blob/65ef8c866bc15c4f3fcae3115d52654c426e758c/debian/changelog) does not contain any breaking changes, it seems to build nicely on my machine. I have never contributed to nixos before so maybe double-check for any first-time-errors.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs. (afaik)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
