### PR TITLE
haskell-language-server: Fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -75,9 +75,6 @@ in
 
   # Upgrade to accommodate new core library versions, where the authors have
   # already made the relevant changes.
-  fourmolu = doDistribute self.fourmolu_0_16_0_0;
-  ormolu = doDistribute self.ormolu_0_7_7_0;
-  stylish-haskell = doDistribute self.stylish-haskell_0_15_0_1;
 
   # 2025-08-10: Tests fail, but fix is not released yet https://github.com/clash-lang/ghc-typelits-natnormalise/issues/89
   ghc-typelits-natnormalise = doDistribute (doJailbreak self.ghc-typelits-natnormalise_0_7_12);
@@ -90,7 +87,6 @@ in
   haddock-library =
     assert super.haddock-library.version == "1.11.0";
     doJailbreak super.haddock-library;
-  large-generics = doJailbreak super.large-generics; # base <4.20
   tree-sitter = doJailbreak super.tree-sitter; # containers <0.7, filepath <1.5
 
   #

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -47,6 +47,7 @@ extra-packages:
   - Cabal == 3.12.*
   - Cabal == 3.14.*
   - Cabal == 3.16.*                     # version required for cabal-install and other packages
+  - cabal-add == 0.1                    # 2025-09-09: Only needed for hls 2.11 can be removed once we are past it.
   - Cabal-syntax == 3.6.*               # Dummy package that ensures packages depending on Cabal-syntax can work for Cabal < 3.8
   - Cabal-syntax == 3.8.*               # version required for ormolu and fourmolu on ghc 9.0
   - Cabal-syntax == 3.10.*
@@ -54,7 +55,6 @@ extra-packages:
   - Cabal-syntax == 3.14.*
   - Cabal-syntax == 3.16.*              # version required for cabal-install and other packages
   - fourmolu == 0.14.0.0                # 2023-11-13: for ghc-lib-parser 9.6 compat
-  - fourmolu == 0.16.0.0                # 2025-01-27: for ghc 9.10 compat
   - fsnotify < 0.4                      # 2024-04-22: required by spago-0.21
   - fuzzyset == 0.2.4                   # 2023-12-20: Needed for building postgrest > 10
   - ghc-exactprint == 0.6.*             # 2022-12-12: needed for GHC < 9.2
@@ -92,7 +92,6 @@ extra-packages:
   - network-run == 0.4.0                # 2024-10-20: for GHC 9.10/network == 3.1.*
   - ormolu == 0.5.2.0                   # 2023-08-08: preserve for ghc 9.0
   - ormolu == 0.7.2.0                   # 2023-11-13: for ghc-lib-parser 9.6 compat
-  - ormolu == 0.7.7.0                   # 2025-01-27: for ghc 9.10 compat
   - os-string == 1.*                    # 2025-07-30: dummy package we need for pre os-string GHCs
   - postgresql-binary < 0.14            # 2025-01-19: Needed for building postgrest
   - primitive-unlifted == 0.1.3.1       # 2024-03-16: preserve for ghc 9.2


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This was a pain to figure out … Still wondering whether there could have been a better way.

My hope is that these overrides should work for 9.12, 9.10 and 9.8 together. Will have too look into 9.6 and 9.4 later.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
