### PR TITLE
nixosTests.libresprite: improve test consistency

### DIFF
--- a/nixos/tests/libresprite.nix
+++ b/nixos/tests/libresprite.nix
@@ -23,10 +23,10 @@
 
   testScript = ''
     machine.wait_for_x()
-    machine.succeed("convert -font DejaVu-Sans +antialias label:'IT WORKS' image.png")
+    machine.succeed("convert -font DejaVu-Sans -pointsize 48 +antialias label:'WORKS' image.png")
     machine.execute("libresprite image.png >&2 &")
     machine.wait_for_window("LibreSprite ${pkgs.libresprite.version}-dev")
-    machine.wait_for_text("IT WORKS")
+    machine.wait_for_text("WORKS")
     machine.screenshot("screen")
   '';
 }


### PR DESCRIPTION
## Things done
The larger font and shorter test word is making the test far more frequently locally and should stop the hour long runs on hydra. https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.libresprite.x86_64-linux

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
