### PR TITLE
cobra-cli: fix generated zsh completion function

### DIFF
--- a/pkgs/by-name/co/cobra-cli/package.nix
+++ b/pkgs/by-name/co/cobra-cli/package.nix
@@ -44,6 +44,12 @@ buildGoModule rec {
       --bash <($out/bin/cobra-cli completion bash) \
       --fish <($out/bin/cobra-cli completion fish) \
       --zsh <($out/bin/cobra-cli completion zsh) \
+
+    # Ironically, cobra-cli still uses old, slightly buggy completion code
+    # This will correct the #compdef tag and add separate compdef line
+    # allowing direct sourcing to also activate the completion
+    substituteInPlace "$out/share/zsh/site-functions/_cobra-cli" \
+      --replace-fail '#compdef _cobra-cli cobra-cli' "#compdef cobra-cli''\ncompdef _cobra-cli cobra-cli"
   '';
 
   meta = {


### PR DESCRIPTION
Ironically, the last tagged release of cobra-cli uses an old version of cobra, which generates slightly incorrect zsh completion files. This commit adds a simple substitute in place to bring the zsh completion file in line with current cobra files, without needing to upgrade the cobra dependency which might become a bigger refactor.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
