### PR TITLE
[Backport release-25.05] jetbrains: 2025.1.2 -> 2025.2

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/versions.json
+++ b/pkgs/applications/editors/jetbrains/bin/versions.json
@@ -19,10 +19,10 @@
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.tar.gz",
-      "version": "2025.1.3",
-      "sha256": "b672b2b50e2ae539af24e32ac7678ff32a8b207e6692e12c8b891eaf78200d24",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.1.3.tar.gz",
-      "build_number": "251.26094.87"
+      "version": "2025.2",
+      "sha256": "5c44d4cb3e323f6913ef09a50b13028f92a7db6809b08a26763929555186df31",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.tar.gz",
+      "build_number": "252.23892.363"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
@@ -35,10 +35,10 @@
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "666ea22f7bdfdbf327dd77b7292e2abf5a3ac356ae043fe8b35102d78437d7f2",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.1.2.tar.gz",
-      "build_number": "251.26094.128"
+      "version": "2025.2",
+      "sha256": "195509b4e35ba3d31f71e3c39ea32e17dbfebddae857691234fc0683802ce448",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.2.tar.gz",
+      "build_number": "252.23892.437"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
@@ -51,18 +51,20 @@
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "70dc870bd31fda67de30d3a132cfed543d5e67c15c7db52f6f4c4691a044930a",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.2.tar.gz",
-      "build_number": "251.26094.121"
+      "version": "2025.2",
+      "sha256": "30e917c55507443c61674d0bdd5cbb40a5b02c628d5073f8a0028ef49e0c50b5",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2025.2.tar.gz",
+      "build_number": "252.23892.409"
+
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "1e675bda1314ae914b64b31a22309ba2eba6f35e6659e53d4b291e73c2fb856b",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.2.tar.gz",
-      "build_number": "251.26094.121"
+      "version": "2025.2",
+      "sha256": "d28d0d647cf5f0d2eedd49602493be4a3182aec83c73df01b887164f56db0ff4",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2025.2.tar.gz",
+      "build_number": "252.23892.409"
+
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -84,34 +86,38 @@
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "193fbbb638235c4c671bb6c6b432f43a2d46f7f7ebd6b5f2cc8a1db7db93c5d6",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.2.tar.gz",
-      "build_number": "251.26094.141"
+      "version": "2025.2",
+      "sha256": "356dc81511bbd361c7f106fda8597503c6b9797d36a3a04434bbf0ec35a02434",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.tar.gz",
+      "build_number": "252.23892.439"
+
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "4a407779c5df9728e29698eeabdb4533911e755ead224d0c1deff959876c3108",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.2.tar.gz",
-      "build_number": "251.26094.141"
+      "version": "2025.2",
+      "sha256": "bc3fbb31ea10e171686b9be8734051382233748502f124393c52848aefe97b32",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.tar.gz",
+      "build_number": "252.23892.439"
+
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "cdf8a824c7daa3247b09d76a29acb31cfa623b90643d3d2a814982cb0a32879d",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.2.tar.gz",
-      "build_number": "251.25410.119"
+      "version": "2025.1.5",
+      "sha256": "b10e21b764e504e33468ee93885fee1102c0b96bd628d1d7c0a19ce6e83910d6",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.5.tar.gz",
+      "build_number": "251.27812.87"
+
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "2d4127e0284a262acb015c9d4247b654592e045b61664043a4de56029b45174f",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.2.tar.gz",
-      "build_number": "251.26094.122"
+      "version": "2025.2",
+      "sha256": "2a9c2a4b4ed222bdf0038553f46424f8bea1a2ebe6542c764d9586d82351381d",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.2.tar.gz",
+      "build_number": "252.23892.415"
+
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
@@ -124,10 +130,11 @@
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "055510371e3c6a8d9fbfcd352645d847d2c092309c4746222babe4af240c2eac",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.2.tar.gz",
-      "build_number": "251.26094.131"
+      "version": "2025.2",
+      "sha256": "85c83e8ed716e9cda03be922fd10d95c482f9f3c27e095dd768ddefd1e69462f",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.2.tar.gz",
+      "build_number": "252.23892.411"
+
     },
     "writerside": {
       "update-channel": "Writerside EAP",
@@ -158,10 +165,10 @@
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.tar.gz",
-      "version": "2025.1.3",
-      "sha256": "ca0b5a6685e8494311e3276ad22c097ea3a2f8925baff39951a45c467f3c547c",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.1.3-aarch64.tar.gz",
-      "build_number": "251.26094.87"
+      "version": "2025.2",
+      "sha256": "fb358605d813007eea7e010cf642a822f04eea60d5808865d153429b4d5784dd",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2-aarch64.tar.gz",
+      "build_number": "252.23892.363"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
@@ -174,10 +181,10 @@
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "306a3eea012a9c398d95e1579fab38c5979297390ae048c98bd32026bd0fbe7f",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.128"
+      "version": "2025.2",
+      "sha256": "f0149112bf8813cd37cdf65fa098b2261914263854b025001cfffd0592fc2e69",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.2-aarch64.tar.gz",
+      "build_number": "252.23892.437"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
@@ -190,18 +197,20 @@
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "d98c8d7bdc3e274d278b81ba2b6c1baa38f67be9407b4bfd3bad3413c6f128f1",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.121"
+      "version": "2025.2",
+      "sha256": "dead5589e78a10e5b6df76c484139679c80c94d1ce9c9c5778721ced1ee02b5d",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2025.2-aarch64.tar.gz",
+      "build_number": "252.23892.409"
+
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "0f982a4f4424bde5a33206c20df053a7afe174fe9d590943665504814a273c9d",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.121"
+      "version": "2025.2",
+      "sha256": "eb6b322db2679b45d9d362fc4579b5ddbd1b7510b9f407ea8c34d18b90f62e7b",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2025.2-aarch64.tar.gz",
+      "build_number": "252.23892.409"
+
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -223,34 +232,38 @@
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "10e7426804d649d3c5bdbfc365cf85fe73dd7e74e67fd1e4c82645e8532d17e7",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.141"
+      "version": "2025.2",
+      "sha256": "2aab469f976c4aa7d6686c8cc81d647960a9496ea2f3aed01f1c09448b443efb",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2-aarch64.tar.gz",
+      "build_number": "252.23892.439"
+
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "831f5563a354e617158cd88c2a63c0bda80b21c3a64fc98a3b6dc7ae22151805",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.141"
+      "version": "2025.2",
+      "sha256": "27a88a70b8c97be56cdc759cdd7612e55156d67c8bed5a5e23a5af42776bade9",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2-aarch64.tar.gz",
+      "build_number": "252.23892.439"
+
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "c1ad139252fd3158aa86e9ac4532db5d9dd653807fc9f1dc4458170f3f1c3de6",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.25410.119"
+      "version": "2025.1.5",
+      "sha256": "15b70a589a0827c6408e15eb8e20dfc2e378df66bb528514a577eeae22079553",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.5-aarch64.tar.gz",
+      "build_number": "251.27812.87"
+
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "13ed96cc82771ec49ce8e9f72179ac12829f4bc2ffae6a9ab553708aec47d4a9",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.122"
+      "version": "2025.2",
+      "sha256": "2e657e0fc3458a4bef226fba0ed48f5a5997794efae5b0dc7dc6237e258b8fd9",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.2-aarch64.tar.gz",
+      "build_number": "252.23892.415"
+
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
@@ -263,10 +276,11 @@
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "c182bcd17ff4d0188c0e024952677dd21415456a421c5c1aaa356870f2efa009",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.131"
+      "version": "2025.2",
+      "sha256": "e7d22b83e0ca89d9aa7663c5444382d77296e7b71ec3e73133f85e83363c0a45",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.2-aarch64.tar.gz",
+      "build_number": "252.23892.411"
+
     },
     "writerside": {
       "update-channel": "Writerside EAP",
@@ -297,10 +311,10 @@
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.dmg",
-      "version": "2025.1.3",
-      "sha256": "006fb7a0875c8fd205cd1d4204dee3be87d1fe359375b75e20ee6e0d21ca7d00",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.1.3.dmg",
-      "build_number": "251.26094.87"
+      "version": "2025.2",
+      "sha256": "241a87b39b88b1e6e03ee3296f7839807ae926cc5bef9d1783bbab17d5951299",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.dmg",
+      "build_number": "252.23892.363"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
@@ -313,10 +327,10 @@
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "b4e45266159352598d0cbd7b03283cb53260d20866ca77d57a43150e81cf3d09",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.1.2.dmg",
-      "build_number": "251.26094.128"
+      "version": "2025.2",
+      "sha256": "637f096b34e8fb4425c570c3140de464ee96884b222cec5df1f630ea7aed833f",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.2.dmg",
+      "build_number": "252.23892.437"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
@@ -329,18 +343,20 @@
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "c64c7ff7fe2e73d7552f1727d912bb5f901d040c7269b4292f94190475580c2b",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.2.dmg",
-      "build_number": "251.26094.121"
+      "version": "2025.2",
+      "sha256": "ded2e2b6ade9040a8a32a690c34e1c1c90daa35ec6c3956217cf780c38380445",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2025.2.dmg",
+      "build_number": "252.23892.409"
+
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "bacfa3bcf48d57d8e8ca8d352895025ffc42ce395b9b0074b3b566dc217324c9",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.2.dmg",
-      "build_number": "251.26094.121"
+      "version": "2025.2",
+      "sha256": "a142bd47516ee184d3d76676d78451f3e9e05a32ba8fdf8778ac04579b3accab",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2025.2.dmg",
+      "build_number": "252.23892.409"
+
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -362,34 +378,38 @@
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "38283e62677079d7d830217087c563ac6daf5e71422c03e56082bde9572e3908",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.2.dmg",
-      "build_number": "251.26094.141"
+      "version": "2025.2",
+      "sha256": "ee808240caab0d50932fe25cd3d93aeeb8a531bfbc5b034f0eff72716c3eb6a5",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.dmg",
+      "build_number": "252.23892.439"
+
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "41c6187f4f044522d02749f979cef8f127337b2945772070a0ba44c53a6ebf0c",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.2.dmg",
-      "build_number": "251.26094.141"
+      "version": "2025.2",
+      "sha256": "66c6ae1e9e6531bc87f7527221d06647ce18fea15484ad9f371cc51f99a271a0",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.dmg",
+      "build_number": "252.23892.439"
+
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "23f3479d1cff5ee1726726bea866ff755b08930e9da43b7ad250e6cb620c1dcf",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.2.dmg",
-      "build_number": "251.25410.119"
+      "version": "2025.1.5",
+      "sha256": "ed39b7f3770bb186014e8cdd6e314b4dfbb0f90e8d24be8b175fbf71ef7957ac",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.5.dmg",
+      "build_number": "251.27812.87"
+
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "059d3d4c089b9277089bd7d64b8f6eedcf039fe791cddc694af434a1c5ad88c8",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.2.dmg",
-      "build_number": "251.26094.122"
+      "version": "2025.2",
+      "sha256": "b3a959fd9b08d9f21db1d1970f3786705090f334bd05e108cb6206be9d6e753a",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.2.dmg",
+      "build_number": "252.23892.415"
+
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
@@ -402,10 +422,11 @@
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "c33853a8d8a2dd47ce3a795202e2d802a9f1888b2c998c91cdfc9bc66f9bb19a",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.2.dmg",
-      "build_number": "251.26094.131"
+      "version": "2025.2",
+      "sha256": "c748bf829295f1d431c032ccbe88d3bcaf771699c8e654ea4bc9f419fb87b576",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.2.dmg",
+      "build_number": "252.23892.411"
+
     },
     "writerside": {
       "update-channel": "Writerside EAP",
@@ -436,10 +457,10 @@
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.dmg",
-      "version": "2025.1.3",
-      "sha256": "83da07ddd46fe95aed36d98cbb61c7f81097dc38abe5515933653746859b396c",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.1.3-aarch64.dmg",
-      "build_number": "251.26094.87"
+      "version": "2025.2",
+      "sha256": "86a4851e0ab9a74bb1c12c829752dc04b1e15b1ba668f7712ea6a0ecb5be058b",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2-aarch64.dmg",
+      "build_number": "252.23892.363"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
@@ -452,10 +473,10 @@
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "1cf7dcdbb5408c9c7711a436e4c763df147ce332ce2e1f260fa246af87b0a58e",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.128"
+      "version": "2025.2",
+      "sha256": "d8be067bdd845c3c61e8e9c214b1591c2658e0a59ba5e0a45f3b1129f9c6fa63",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.2-aarch64.dmg",
+      "build_number": "252.23892.437"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
@@ -468,18 +489,20 @@
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "61a64b8abf0b350cb14f963975fc87ec574bc4b50ae7944980c43c816ffad5a8",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.121"
+      "version": "2025.2",
+      "sha256": "a77e9808be00c2225504cd4710fca625027e46ab3d131b3cdfceb982286f4d94",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2025.2-aarch64.dmg",
+      "build_number": "252.23892.409"
+
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "1c1afc32c8edcf1d2057a505f7f0b0dd1f1a20a6859172c1dd6a91a311a3167b",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.121"
+      "version": "2025.2",
+      "sha256": "1055a85e2524a67cafa0aa51e75a6d7adf14e7e05a5e52d833a60de5112b60d7",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2025.2-aarch64.dmg",
+      "build_number": "252.23892.409"
+
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -501,34 +524,38 @@
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "cdcdea2e167c3621f5b5ea8e0150c62d24495192edd2282616676d3f53b06063",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.141"
+      "version": "2025.2",
+      "sha256": "9fd11b6e5fe28d5e3cac86cac554b4e04f775254d141f3c7ec07ee9801ce8a00",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2-aarch64.dmg",
+      "build_number": "252.23892.439"
+
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "89a463c896e4e7f6cf6a624b78305d881756b2a350780bfcecd15d6cb766e54b",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.141"
+      "version": "2025.2",
+      "sha256": "54b761294795146c575a22ea5d53bc7c0a05ab906836b544ff6b830b4b79b41b",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2-aarch64.dmg",
+      "build_number": "252.23892.439"
+
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "ab6645bba503f0a9d67b2838d1dd88a81ad81dd34e6015ccaea30400c35659e4",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.2-aarch64.dmg",
-      "build_number": "251.25410.119"
+      "version": "2025.1.5",
+      "sha256": "74decd2d7fb0ee97587e9de165b1630bac8a9ba8ad55aa8a64e9c5e173551adb",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.5-aarch64.dmg",
+      "build_number": "251.27812.87"
+
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "1da265fa947d5d1cf3075495414b9e65ec519a5bd9bee5ca2fa7df67bafdc352",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.122"
+      "version": "2025.2",
+      "sha256": "770651a99845dcf8f31ddab0a99e4c74df19a5adb1cfb776c7cf178ac2b8067e",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.2-aarch64.dmg",
+      "build_number": "252.23892.415"
+
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
@@ -541,10 +568,11 @@
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "298d53fcd1a979e6910f97d9a29ac9bc0ed12386838a93a6d279bb415cf4708f",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.131"
+      "version": "2025.2",
+      "sha256": "5f29ca9472c068f8086cb05c4ef3b0fb2b88d4888ef1c5430a0e1f2c771ccbce",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.2-aarch64.dmg",
+      "build_number": "252.23892.411"
+
     },
     "writerside": {
       "update-channel": "Writerside EAP",

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -82,15 +82,22 @@ let
     mkJetBrainsProductCore {
       inherit
         pname
+        extraLdPath
         jdk
-        extraBuildInputs
         ;
+      extraBuildInputs =
+        extraBuildInputs
+        ++ [ stdenv.cc.cc ]
+        ++ lib.optionals stdenv.hostPlatform.isLinux [
+          fontconfig
+          libGL
+          libX11
+        ];
       extraWrapperArgs =
         extraWrapperArgs
         ++ lib.optionals (stdenv.hostPlatform.isLinux && forceWayland) [
           ''--add-flags "\''${WAYLAND_DISPLAY:+-Dawt.toolkit.name=WLToolkit}"''
         ];
-      extraLdPath = extraLdPath ++ lib.optionals stdenv.hostPlatform.isLinux [ libGL ];
       src =
         if fromSource then
           communitySources."${pname}"
@@ -175,7 +182,6 @@ rec {
   aqua = mkJetBrainsProduct {
     pname = "aqua";
     extraBuildInputs = [
-      stdenv.cc.cc
       lldb
     ];
   };
@@ -185,9 +191,7 @@ rec {
       pname = "clion";
       extraBuildInputs =
         lib.optionals stdenv.hostPlatform.isLinux [
-          fontconfig
           python3
-          stdenv.cc.cc
           openssl
           libxcrypt-legacy
           lttng-ust_2_12
@@ -217,7 +221,6 @@ rec {
 
   datagrip = mkJetBrainsProduct {
     pname = "datagrip";
-    extraBuildInputs = [ stdenv.cc.cc ];
   };
 
   dataspell =
@@ -232,7 +235,6 @@ rec {
       extraBuildInputs = [
         libgcc
         libr
-        stdenv.cc.cc
       ];
     };
 
@@ -250,7 +252,6 @@ rec {
       ];
       extraBuildInputs = [
         libgcc
-        stdenv.cc.cc
       ];
     }).overrideAttrs
       (attrs: {
@@ -265,12 +266,10 @@ rec {
 
   idea-community-bin = buildIdea {
     pname = "idea-community";
-    extraBuildInputs = [ stdenv.cc.cc ];
   };
 
   idea-community-src = buildIdea {
     pname = "idea-community";
-    extraBuildInputs = [ stdenv.cc.cc ];
     fromSource = true;
   };
 
@@ -283,7 +282,6 @@ rec {
   idea-ultimate = buildIdea {
     pname = "idea-ultimate";
     extraBuildInputs = [
-      stdenv.cc.cc
       lldb
       musl
     ];
@@ -294,7 +292,6 @@ rec {
   phpstorm = mkJetBrainsProduct {
     pname = "phpstorm";
     extraBuildInputs = [
-      stdenv.cc.cc
       musl
     ];
   };
@@ -318,8 +315,6 @@ rec {
     (mkJetBrainsProduct {
       pname = "rider";
       extraBuildInputs = [
-        fontconfig
-        stdenv.cc.cc
         openssl
         libxcrypt
         lttng-ust_2_12
@@ -353,7 +348,6 @@ rec {
   ruby-mine = mkJetBrainsProduct {
     pname = "ruby-mine";
     extraBuildInputs = [
-      stdenv.cc.cc
       musl
     ];
   };
@@ -366,8 +360,6 @@ rec {
           python3
           openssl
           libxcrypt-legacy
-          fontconfig
-          xorg.libX11
         ]
         ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch) [
           expat
@@ -385,7 +377,6 @@ rec {
   webstorm = mkJetBrainsProduct {
     pname = "webstorm";
     extraBuildInputs = [
-      stdenv.cc.cc
       musl
     ];
   };
@@ -393,7 +384,6 @@ rec {
   writerside = mkJetBrainsProduct {
     pname = "writerside";
     extraBuildInputs = [
-      stdenv.cc.cc
       musl
     ];
   };

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -16,18 +16,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip"
+
       },
       "name": "ideavim"
     },
@@ -36,7 +37,8 @@
         "idea-ultimate"
       ],
       "builds": {
-        "251.26094.121": "https://plugins.jetbrains.com/files/631/766544/python-251.26094.121.zip"
+        "252.23892.409": "https://plugins.jetbrains.com/files/631/817162/python-252.23892.409.zip"
+
       },
       "name": "python"
     },
@@ -46,8 +48,9 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.22562.218": null,
-        "251.26094.121": "https://plugins.jetbrains.com/files/1347/770332/scala-intellij-bin-2025.1.25.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/1347/770332/scala-intellij-bin-2025.1.25.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/1347/815326/scala-intellij-bin-2025.2.26.zip"
+
       },
       "name": "scala"
     },
@@ -69,16 +72,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip"
+
       },
       "name": "string-manipulation"
     },
@@ -100,16 +105,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip"
+
       },
       "name": "handlebars-mustache"
     },
@@ -131,16 +138,18 @@
       "builds": {
         "243.22562.218": null,
         "251.23774.423": null,
-        "251.25410.119": null,
-        "251.25410.170": null,
-        "251.26094.121": null,
-        "251.26094.122": null,
-        "251.26094.123": null,
-        "251.26094.127": null,
-        "251.26094.131": null,
-        "251.26094.133": null,
-        "251.26094.141": null,
-        "251.26094.87": null
+        "251.25410.129": null,
+        "251.26927.79": null,
+        "251.27812.15": null,
+        "251.27812.52": null,
+        "251.27812.54": null,
+        "251.27812.87": null,
+        "252.23892.363": "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip"
+
       },
       "name": "kotlin"
     },
@@ -160,18 +169,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
-        "251.23774.423": "https://plugins.jetbrains.com/files/6981/724264/ini-251.23774.466.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip"
+        "251.23774.423": null,
+        "251.25410.129": null,
+        "251.26927.79": "https://plugins.jetbrains.com/files/6981/782326/ini-251.26927.70.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/6981/806736/ini-251.27812.54.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/6981/806736/ini-251.27812.54.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/6981/806736/ini-251.27812.54.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/6981/806736/ini-251.27812.54.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/6981/817734/ini-252.23892.419.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/6981/817734/ini-252.23892.419.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/6981/817734/ini-252.23892.419.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/6981/817734/ini-252.23892.419.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/6981/817734/ini-252.23892.419.zip"
+
       },
       "name": "ini"
     },
@@ -193,16 +203,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip"
+
       },
       "name": "acejump"
     },
@@ -224,16 +236,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip"
+
       },
       "name": "grep-console"
     },
@@ -255,16 +269,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/7177/636663/fileWatcher-243.22562.13.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip"
+
       },
       "name": "file-watchers"
     },
@@ -274,8 +290,9 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip"
+
       },
       "name": "maven-helper"
     },
@@ -297,16 +314,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/7212/636678/cucumber-java-243.22562.13.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip"
+
       },
       "name": "cucumber-for-java"
     },
@@ -316,8 +335,9 @@
         "phpstorm"
       ],
       "builds": {
-        "251.26094.121": "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip"
+        "251.27812.52": "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip"
+
       },
       "name": "symfony-plugin"
     },
@@ -327,8 +347,9 @@
         "phpstorm"
       ],
       "builds": {
-        "251.26094.121": "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip"
+        "251.27812.52": "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip"
+
       },
       "name": "php-annotations"
     },
@@ -345,15 +366,16 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
-        "251.25410.119": "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/7322/782358/python-ce-251.26927.70.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/7322/805188/python-ce-251.27812.49.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/7322/805188/python-ce-251.27812.49.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/7322/805188/python-ce-251.27812.49.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/7322/817156/python-ce-252.23892.409.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/7322/817156/python-ce-252.23892.409.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/7322/817156/python-ce-252.23892.409.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/7322/817156/python-ce-252.23892.409.zip"
+
       },
       "name": "python-community-edition"
     },
@@ -373,18 +395,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip"
+
       },
       "name": "asciidoc"
     },
@@ -406,16 +429,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "251.23774.423": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.25410.170": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.141": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar"
+        "251.25410.129": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.26927.79": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.27812.15": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.27812.52": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.27812.54": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.27812.87": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.23892.363": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.23892.409": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.23892.411": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.23892.415": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.23892.439": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar"
+
       },
       "name": "wakatime"
     },
@@ -435,18 +460,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip"
+
       },
       "name": "gittoolbox"
     },
@@ -466,18 +492,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
-        "251.23774.423": "https://plugins.jetbrains.com/files/7724/724240/clouds-docker-impl-251.23774.466.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip"
+        "251.23774.423": null,
+        "251.25410.129": null,
+        "251.26927.79": "https://plugins.jetbrains.com/files/7724/782341/clouds-docker-impl-251.26927.70.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/7724/805402/clouds-docker-impl-251.27812.52.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/7724/805402/clouds-docker-impl-251.27812.52.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/7724/805402/clouds-docker-impl-251.27812.52.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/7724/805402/clouds-docker-impl-251.27812.52.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/7724/817741/clouds-docker-impl-252.23892.419.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/7724/817741/clouds-docker-impl-252.23892.419.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/7724/817741/clouds-docker-impl-252.23892.419.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/7724/817741/clouds-docker-impl-252.23892.419.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/7724/817741/clouds-docker-impl-252.23892.419.zip"
+
       },
       "name": "docker"
     },
@@ -499,16 +526,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/8097/780447/graphql-251.26927.39.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/8097/802996/graphql-251.27812.12.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/8097/802996/graphql-251.27812.12.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/8097/802996/graphql-251.27812.12.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/8097/802996/graphql-251.27812.12.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip"
+
       },
       "name": "graphql"
     },
@@ -529,15 +558,17 @@
       "builds": {
         "243.22562.218": null,
         "251.23774.423": null,
-        "251.25410.119": null,
-        "251.26094.121": null,
-        "251.26094.122": null,
-        "251.26094.123": null,
-        "251.26094.127": null,
-        "251.26094.131": null,
-        "251.26094.133": null,
-        "251.26094.141": null,
-        "251.26094.87": null
+        "251.25410.129": null,
+        "251.27812.15": null,
+        "251.27812.52": null,
+        "251.27812.54": null,
+        "251.27812.87": null,
+        "252.23892.363": null,
+        "252.23892.409": null,
+        "252.23892.411": null,
+        "252.23892.415": null,
+        "252.23892.439": null
+
       },
       "name": "-deprecated-rust"
     },
@@ -558,15 +589,17 @@
       "builds": {
         "243.22562.218": null,
         "251.23774.423": null,
-        "251.25410.119": null,
-        "251.26094.121": null,
-        "251.26094.122": null,
-        "251.26094.123": null,
-        "251.26094.127": null,
-        "251.26094.131": null,
-        "251.26094.133": null,
-        "251.26094.141": null,
-        "251.26094.87": null
+        "251.25410.129": null,
+        "251.27812.15": null,
+        "251.27812.52": null,
+        "251.27812.54": null,
+        "251.27812.87": null,
+        "252.23892.363": null,
+        "252.23892.409": null,
+        "252.23892.411": null,
+        "252.23892.415": null,
+        "252.23892.439": null
+
       },
       "name": "-deprecated-rust-beta"
     },
@@ -586,18 +619,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
-        "251.23774.423": "https://plugins.jetbrains.com/files/8195/715934/toml-251.23774.429.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip"
+        "251.23774.423": null,
+        "251.25410.129": null,
+        "251.26927.79": "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/8195/817202/toml-252.23892.415.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/8195/817202/toml-252.23892.415.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/8195/817202/toml-252.23892.415.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/8195/817202/toml-252.23892.415.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/8195/817202/toml-252.23892.415.zip"
+
       },
       "name": "toml"
     },
@@ -607,8 +641,9 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/8327/615097/Minecraft_Development-2024.3-1.8.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/8327/770049/Minecraft_Development-2025.1-1.8.5.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/8327/809293/Minecraft_Development-2025.1-1.8.6.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/8327/809294/Minecraft_Development-2025.2-1.8.6.zip"
+
       },
       "name": "minecraft-development"
     },
@@ -628,18 +663,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
-        "251.23774.423": "https://plugins.jetbrains.com/files/8554/716074/featuresTrainer-251.23774.436.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip"
+        "251.23774.423": null,
+        "251.25410.129": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/8554/811140/featuresTrainer-252.23892.374.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/8554/811140/featuresTrainer-252.23892.374.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/8554/811140/featuresTrainer-252.23892.374.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/8554/811140/featuresTrainer-252.23892.374.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/8554/811140/featuresTrainer-252.23892.374.zip"
+
       },
       "name": "ide-features-trainer"
     },
@@ -659,18 +695,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip"
+
       },
       "name": "nixidea"
     },
@@ -692,16 +729,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/9164/636661/gherkin-243.22562.13.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip"
+
       },
       "name": "gherkin"
     },
@@ -723,16 +762,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip"
+
       },
       "name": "-env-files"
     },
@@ -742,8 +783,9 @@
         "idea-ultimate"
       ],
       "builds": {
-        "251.26094.121": "https://plugins.jetbrains.com/files/9568/766540/go-plugin-251.26094.121.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/9568/766540/go-plugin-251.26094.121.zip"
+        "251.27812.54": "https://plugins.jetbrains.com/files/9568/802993/go-plugin-251.27812.12.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/9568/808965/go-plugin-252.23892.360.zip"
+
       },
       "name": "go"
     },
@@ -765,16 +807,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/9707/702582/ANSI_Highlighter_Premium-24.3.4.jar",
         "251.23774.423": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.25410.170": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.121": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.122": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.123": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.127": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.131": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.133": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.141": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.87": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar"
+        "251.25410.129": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.26927.79": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.27812.15": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.27812.52": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.27812.54": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.27812.87": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "252.23892.363": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.23892.409": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.23892.411": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.23892.415": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.23892.439": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar"
+
       },
       "name": "ansi-highlighter-premium"
     },
@@ -796,16 +840,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
+
       },
       "name": "key-promoter-x"
     },
@@ -825,18 +871,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip"
+
       },
       "name": "randomness"
     },
@@ -858,16 +905,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip"
+
       },
       "name": "csv-editor"
     },
@@ -887,18 +936,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip"
+
       },
       "name": "rainbow-brackets"
     },
@@ -920,16 +970,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
+
       },
       "name": "dot-language"
     },
@@ -951,16 +1003,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip"
+
       },
       "name": "hocon"
     },
@@ -981,15 +1035,17 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/10581/629973/go-template-243.21565.122.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip"
+
       },
       "name": "go-template"
     },
@@ -1009,18 +1065,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip"
+
       },
       "name": "extra-icons"
     },
@@ -1040,18 +1097,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/11349/768106/aws-toolkit-jetbrains-standalone-3.74.243.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/11349/817799/aws-toolkit-jetbrains-standalone-3.88.251.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/11349/817799/aws-toolkit-jetbrains-standalone-3.88.251.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/11349/817799/aws-toolkit-jetbrains-standalone-3.88.251.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/11349/817799/aws-toolkit-jetbrains-standalone-3.88.251.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/11349/817799/aws-toolkit-jetbrains-standalone-3.88.251.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/11349/817799/aws-toolkit-jetbrains-standalone-3.88.251.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/11349/817799/aws-toolkit-jetbrains-standalone-3.88.251.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/11349/817795/aws-toolkit-jetbrains-standalone-3.88.252.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/11349/817795/aws-toolkit-jetbrains-standalone-3.88.252.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/11349/817795/aws-toolkit-jetbrains-standalone-3.88.252.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/11349/817795/aws-toolkit-jetbrains-standalone-3.88.252.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/11349/817795/aws-toolkit-jetbrains-standalone-3.88.252.zip"
+
       },
       "name": "aws-toolkit"
     },
@@ -1060,7 +1118,8 @@
         "rider"
       ],
       "builds": {
-        "251.25410.119": "https://plugins.jetbrains.com/files/12024/667413/ReSharperPlugin.CognitiveComplexity-2025.1.0-eap01.zip"
+        "251.27812.87": "https://plugins.jetbrains.com/files/12024/667413/ReSharperPlugin.CognitiveComplexity-2025.1.0-eap01.zip"
+
       },
       "name": "cognitivecomplexity"
     },
@@ -1082,16 +1141,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip"
+
       },
       "name": "vscode-keymap"
     },
@@ -1113,16 +1174,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip"
+
       },
       "name": "eclipse-keymap"
     },
@@ -1144,16 +1207,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
+
       },
       "name": "rainbow-csv"
     },
@@ -1175,16 +1240,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip"
+
       },
       "name": "visual-studio-keymap"
     },
@@ -1206,16 +1273,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
+
       },
       "name": "indent-rainbow"
     },
@@ -1237,16 +1306,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/14004/803006/protoeditor-251.27812.12.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/14004/803006/protoeditor-251.27812.12.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/14004/803006/protoeditor-251.27812.12.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/14004/803006/protoeditor-251.27812.12.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip"
+
       },
       "name": "protocol-buffers"
     },
@@ -1268,16 +1339,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "251.23774.423": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.25410.170": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.121": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.122": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.123": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.127": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.131": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.133": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.141": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.87": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
+        "251.25410.129": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.26927.79": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.27812.15": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.27812.52": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.27812.54": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.27812.87": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.23892.363": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.23892.409": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.23892.411": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.23892.415": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.23892.439": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
+
       },
       "name": "darcula-pitch-black"
     },
@@ -1299,16 +1372,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "251.23774.423": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.25410.170": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.121": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.122": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.123": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.127": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.131": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.133": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.141": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.87": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
+        "251.25410.129": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.26927.79": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.27812.15": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.27812.52": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.27812.54": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.27812.87": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.23892.363": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.23892.409": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.23892.411": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.23892.415": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.23892.439": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
+
       },
       "name": "mario-progress-bar"
     },
@@ -1330,16 +1405,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
         "251.23774.423": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.25410.170": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.121": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.122": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.123": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.127": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.131": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.133": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.141": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.87": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar"
+        "251.25410.129": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.26927.79": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.27812.15": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.27812.52": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.27812.54": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.27812.87": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "252.23892.363": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "252.23892.409": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "252.23892.411": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "252.23892.415": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "252.23892.439": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar"
+
       },
       "name": "which-key"
     },
@@ -1359,18 +1436,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip"
+
       },
       "name": "extra-toolwindow-colorful-icons"
     },
@@ -1390,18 +1468,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip"
+
       },
       "name": "github-copilot"
     },
@@ -1423,16 +1502,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
+
       },
       "name": "netbeans-6-5-keymap"
     },
@@ -1454,16 +1535,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip"
+
       },
       "name": "catppuccin-theme"
     },
@@ -1485,16 +1568,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/18824/694222/CodeGlancePro-1.9.7-signed.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip"
+
       },
       "name": "codeglance-pro"
     },
@@ -1514,18 +1599,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.23774.423": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.25410.170": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.121": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.122": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.123": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.127": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.131": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.133": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.141": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.87": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar"
+        "251.23774.423": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
+        "251.25410.129": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
+        "251.26927.79": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
+        "251.27812.15": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
+        "251.27812.52": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
+        "251.27812.54": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
+        "251.27812.87": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
+        "252.23892.363": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
+        "252.23892.409": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
+        "252.23892.411": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
+        "252.23892.415": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar",
+        "252.23892.439": "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar"
+
       },
       "name": "gerry-themes"
     },
@@ -1547,16 +1633,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
+
       },
       "name": "better-direnv"
     },
@@ -1576,18 +1664,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip"
+
       },
       "name": "mermaid"
     },
@@ -1609,16 +1698,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
+
       },
       "name": "ferris"
     },
@@ -1640,16 +1731,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "252.23892.363": null,
+        "252.23892.409": null,
+        "252.23892.411": null,
+        "252.23892.415": null,
+        "252.23892.439": null
+
       },
       "name": "code-complexity"
     },
@@ -1671,16 +1764,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip"
+
       },
       "name": "developer-tools"
     },
@@ -1696,14 +1791,15 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.119": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip"
+        "251.26927.79": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/21962/810863/clouds-docker-gateway-252.23892.363.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/21962/810863/clouds-docker-gateway-252.23892.363.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/21962/810863/clouds-docker-gateway-252.23892.363.zip"
+
       },
       "name": "dev-containers"
     },
@@ -1714,9 +1810,10 @@
         "rust-rover"
       ],
       "builds": {
-        "251.25410.170": "https://plugins.jetbrains.com/files/22407/757316/intellij-rust-251.25410.170.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/22407/757316/intellij-rust-251.25410.170.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/22407/757316/intellij-rust-251.25410.170.zip"
+        "251.26927.79": "https://plugins.jetbrains.com/files/22407/786178/intellij-rust-251.26927.79.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/22407/786178/intellij-rust-251.26927.79.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/22407/802824/intellij-rust-252.23892.300.zip"
+
       },
       "name": "rust"
     },
@@ -1736,18 +1833,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip"
+
       },
       "name": "continue"
     },
@@ -1769,16 +1867,18 @@
       "builds": {
         "243.22562.218": null,
         "251.23774.423": "https://plugins.jetbrains.com/files/22857/716106/vcs-gitlab-IU-251.23774.435-IU.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/22857/810975/vcs-gitlab-IU-252.23892.364-IU.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/22857/810975/vcs-gitlab-IU-252.23892.364-IU.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/22857/810975/vcs-gitlab-IU-252.23892.364-IU.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/22857/810975/vcs-gitlab-IU-252.23892.364-IU.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/22857/810975/vcs-gitlab-IU-252.23892.364-IU.zip"
+
       },
       "name": "gitlab"
     },
@@ -1800,16 +1900,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip"
+
       },
       "name": "catppuccin-icons"
     },
@@ -1831,16 +1933,18 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
+
       },
       "name": "mermaid-chart"
     },
@@ -1860,18 +1964,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/23806/664310/Oxocarbon-1.4.5.zip",
-        "251.23774.423": null,
-        "251.25410.119": null,
-        "251.25410.170": null,
-        "251.26094.121": null,
-        "251.26094.122": null,
-        "251.26094.123": null,
-        "251.26094.127": null,
-        "251.26094.131": null,
-        "251.26094.133": null,
-        "251.26094.141": null,
-        "251.26094.87": null
+        "251.23774.423": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
+        "252.23892.363": null,
+        "252.23892.409": null,
+        "252.23892.411": null,
+        "252.23892.415": null,
+        "252.23892.439": null
+
       },
       "name": "oxocarbon"
     },
@@ -1891,18 +1996,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip"
+
       },
       "name": "extra-ide-tweaks"
     },
@@ -1922,18 +2028,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "252.23892.409": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "252.23892.411": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "252.23892.415": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "252.23892.439": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip"
+
       },
       "name": "extra-tools-pack"
     },
@@ -1950,15 +2057,16 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.119": null,
-        "251.25410.170": null,
-        "251.26094.121": null,
-        "251.26094.122": null,
-        "251.26094.123": null,
-        "251.26094.127": null,
-        "251.26094.131": null,
-        "251.26094.133": null,
-        "251.26094.87": null
+        "251.26927.79": null,
+        "251.27812.15": null,
+        "251.27812.52": null,
+        "251.27812.54": null,
+        "251.27812.87": null,
+        "252.23892.363": null,
+        "252.23892.409": null,
+        "252.23892.411": null,
+        "252.23892.415": null
+
       },
       "name": "nix-lsp"
     },
@@ -1977,119 +2085,139 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
+        "251.27812.87": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
+        "252.23892.363": null,
+        "252.23892.409": null,
+        "252.23892.411": null,
+        "252.23892.415": null,
+        "252.23892.439": null
+
       },
       "name": "markdtask"
     }
   },
   "files": {
     "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip": "sha256-frvQ+Dm1ueID6+vNlja0HtecGyn+ppq9GTgmU3kQ+58=",
-    "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip": "sha256-ekeCyyUhzP32v8nu+U/LS0a/eW6onhBX0qCQmNQ/pgg=",
+    "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip": "sha256-X02u3BiuX9V2pQqgrs4qcKbN2IlcXhuVb56knZKMwzU=",
+
     "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip": "sha256-25vtwXuBNiYL9E0pKG4dqJDkwX1FckAErdqRPKXybQA=",
     "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip": "sha256-Bnnvy+HDNkx2DQM7N+JUa8hQzIA3H/5Y0WpWAjPmhUI=",
     "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip": "sha256-GO0bXJsHx9O1A6M9NUCv9m4JwKHs5plwSssgx+InNqE=",
     "https://plugins.jetbrains.com/files/10581/629973/go-template-243.21565.122.zip": "sha256-6pZ8vHw8C08IUvU76meMTGShoSMntQABv/KBX4BRDYs=",
     "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip": "sha256-zX1nEdq84wwQvGhV664V5bNBPVTI4zWo306JtjXcGkE=",
-    "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip": "sha256-trVQyV4PcxI1BeLtIg3fP1dOITiFRheIGpxU3GuA83w=",
-    "https://plugins.jetbrains.com/files/11349/768106/aws-toolkit-jetbrains-standalone-3.74.243.zip": "sha256-eWAEs18QSUate1bvO1412v+XniVEhjykgNsEn/rhGH0=",
-    "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip": "sha256-yklhTCVPh6vJo/ppVh3W6d7Cy8mfzfHbfOiXZT/vyI4=",
+    "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip": "sha256-XKv4jEKOk2O++VdHycGoLgICsusULbWRlQ0J5p+KgAE=",
+    "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip": "sha256-c2ICvJaEt4xyblIb5LOuLxaLGzuV/uHENiJO+4t0ves=",
+    "https://plugins.jetbrains.com/files/11349/817795/aws-toolkit-jetbrains-standalone-3.88.252.zip": "sha256-LUGbKTrAuGIMGWzkAu7bIaVcm1GSRADrrh3JhSgdmRc=",
+    "https://plugins.jetbrains.com/files/11349/817799/aws-toolkit-jetbrains-standalone-3.88.251.zip": "sha256-MuUz3CUqmxTiXZuZJ/TieFXOfVR/u4eHLoaCeBoKWrc=",
+
     "https://plugins.jetbrains.com/files/12024/667413/ReSharperPlugin.CognitiveComplexity-2025.1.0-eap01.zip": "sha256-SWIXjxnwAf9dju1oOgzePrTY0lPNNX54Afp5OIkGGi4=",
     "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip": "sha256-phv8MTGKNGzRviKzX+nIVTbkX4WkU82QVO5zXUQLtAo=",
     "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip": "sha256-obbLL8n6gK8oFw8NnJbdAylPHfTv4GheBDnVFOUpwL0=",
-    "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip": "sha256-/g1ucT18ywVJnCePH7WyMWKgM9umowBz5wFObmO7cws=",
+    "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip": "sha256-V3Vk6UYLUSiSmypD+g0DCX1sPw3/wZqvLxFhbkTqY34=",
+
     "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip": "sha256-HC1s5FqSLVgPNKc5Wiw0RFC6KpozxmjKzbh9rS9nFwc=",
+    "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip": "sha256-VotPAC/wcz5QveJMlgzGZktKHRpqW/KalckEMRU66cU=",
     "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip": "sha256-Q+gqKG/2bHD49Xtn9MNlYJQGtNF/7tIay9F7ndi8uwA=",
     "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip": "sha256-VQqK0Cm9ddXN63KYIqimuGOh7EB9VvdlErp/VrWx8SA=",
     "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip": "sha256-DKkgt0z/ui0bOLSbnKy51RL7+9HIqeriroi2otZ64mQ=",
+    "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip": "sha256-5qDjLRMNwn+1QVN8cKUYlakQ8aBRiTyGuA7se3l9BI0=",
     "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip": "sha256-eKwDE+PMtYhrGbDDZPS5cimssH+1xV4GF6RXXg/3urU=",
     "https://plugins.jetbrains.com/files/1347/770332/scala-intellij-bin-2025.1.25.zip": "sha256-h9GNGjqTc+h+x/0TRilKmqGoPsxhPmXIKoGC/s4/PKg=",
-    "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip": "sha256-Tgu8CfDhO6KugfuLNhmxe89dMm+Qo3fmAg/8hwjUaoc=",
+    "https://plugins.jetbrains.com/files/1347/815326/scala-intellij-bin-2025.2.26.zip": "sha256-rcFM+JlWk6dG17yci/nfwAkZQBlr+vV/ZoaKC3zahSo=",
     "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip": "sha256-ZYn365EY8+VP1TKM4wBotMj1hYbSSr4J1K5oIZlE2SE=",
+    "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip": "sha256-WK9ukN6g2tCmeljFXwv3F+xFI/VZKlIeFs8DXqPcIKA=",
+    "https://plugins.jetbrains.com/files/14004/803006/protoeditor-251.27812.12.zip": "sha256-EPL6bUZmdBXrkfeGyx7uf73kWGM/drxic/poSXJinS8=",
+
     "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar": "sha256-eXInfAqY3yEZRXCAuv3KGldM1pNKEioNwPB0rIGgJFw=",
     "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar": "sha256-mB09zvUg1hLXl9lgW1NEU+DyVel1utZv6s+mFykckYY=",
     "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar": "sha256-2FlEaHf2rO6xgG3LnZIPt/XKgRGjpLSiEXCncfAf3bI=",
     "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar": "sha256-Z3q0d4jCqeBwzW0jSSM3q4MTAPaTqQuwnV3ZVHfOMR4=",
-    "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip": "sha256-yKpWQZGxfsKwPVTJLHpF4KGJ5ANCd73uxHlfdFE4Qf4=",
-    "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip": "sha256-W5CtJqmejx2braLiJEYGPU29fCSOZNSQG0HZxqdOJIk=",
-    "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip": "sha256-9DLY2HIyQR2w8xPVVKa2l7OZWqfoTvHkLGZYEnDV7/A=",
-    "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip": "sha256-GKCOuZJerzhkhbl4zXWukonkygCT/Dm/tV4zRxFAP+g=",
+    "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip": "sha256-6YPspMAtSM0L3nbvnloeO65Xp5HTXgqx9DHxItvf2NY=",
+    "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip": "sha256-YmbPcb3ghZbzzOlF3bGUNLY8HgfvQPLOFXl48VsH48I=",
+    "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip": "sha256-rP2PplN9rOnKGWMdmXphdMeV0AqoauT0aIoKkgM7Hjw=",
+
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
     "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip": "sha256-fa9GiD/PNGy8AEao99vW3DBF1FKSulu3t+wO7mdr5fk=",
     "https://plugins.jetbrains.com/files/18824/694222/CodeGlancePro-1.9.7-signed.zip": "sha256-8RjKjmadd1o/M+WTLtKPn354bbKgEht4nvWnMcRPN9w=",
     "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip": "sha256-/1lyQq7JANhcKmIaaBHZ8ZCR4p23sLjLTTq9/68Fz+c=",
-    "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar": "sha256-NjhQX8TY9B+aOPm3RrR42OyPM2GnZ5d0/+L83fcaGM0=",
+    "https://plugins.jetbrains.com/files/18922/817874/GerryThemes.jar": "sha256-Njx/k4fTX1U8jgh1oSvGg/32I5cdVryhHxNqBs7L1fg=",
     "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip": "sha256-hoFfIid7lClHDiT+ZH3H+tFSvWYb1tSRZH1iif+kWrM=",
-    "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip": "sha256-jGWRU0g120qYvvFiUFI10zvprTsemuIq3XmIjYxZGts=",
-    "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip": "sha256-QqEjnN6lUUtHkDRFWPeV3vqgGB/ZfWGVDqtk8gwJEqY=",
+    "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip": "sha256-QTh77pyi4lh7V0DGPFx9kERjFCop219d76wTDwD0SYY=",
+
     "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip": "sha256-N66Bh0AwHmg5N9PNguRAGtpJ/dLMWMp3rxjTgz9poFo=",
     "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip": "sha256-TZPup3EJ0cBv4i2eVAQwVmmzy0rmt4KptEsk3C7baEM=",
     "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip": "sha256-2qDeC2Fxp4/IfiLPL1JDquJDCzONCp4m92Ht2fnCn/M=",
     "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip": "sha256-lOPUSxlbgagD0SuXTw+fEdwTxxfUHP1Kl6L+u/oa4fs=",
     "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip": "sha256-kfXB36mIOn82pq+22ryztxY9K6CgwwNarNKcLuIH9G4=",
-    "https://plugins.jetbrains.com/files/22407/757316/intellij-rust-251.25410.170.zip": "sha256-drL4D+lWFdKkmjMHDsPl8nJ+0oMldR6fs4MpyuiVWYg=",
-    "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip": "sha256-Jdt7S5goBdA8kf09pjDdLLyRXi3AVy2BdnC1zUDm46Y=",
+    "https://plugins.jetbrains.com/files/21962/810863/clouds-docker-gateway-252.23892.363.zip": "sha256-ZAhVR7fPls5Xgwmsm+LFYcj+PENF4F7Nh4F3R4SXzH0=",
+    "https://plugins.jetbrains.com/files/22407/786178/intellij-rust-251.26927.79.zip": "sha256-+mxjAEsOdotjp8w/9gkun4VbASFIp5JM7efVkHWiqk0=",
+    "https://plugins.jetbrains.com/files/22407/802824/intellij-rust-252.23892.300.zip": "sha256-0MF6eKxCnGH7+SQrhPOfpE9EOTbuscrBgZY4hKsrEXg=",
+    "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip": "sha256-UxVzxs2ToLkq1/q6s44pggUMNFoObdxNbJdPJVUTNBA=",
     "https://plugins.jetbrains.com/files/22857/716106/vcs-gitlab-IU-251.23774.435-IU.zip": "sha256-zNNFPPPnYLkSzXX3CA1IMA0cjeXMcPY58+v80/KjVkg=",
     "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip": "sha256-PwxExt+Dlq11Y5UdEwFr/2BJPST3EYY7r/3gsXoxGzo=",
-    "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip": "sha256-0x7t3Lo29Bwmo5pItUD/D+na2yIfd2shPiAVCZp9j/w=",
+    "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip": "sha256-pLB6vIl7bgtu2tu/7OpcnAkMFEc+iEVyRJgxmSl35hk=",
+    "https://plugins.jetbrains.com/files/22857/810975/vcs-gitlab-IU-252.23892.364-IU.zip": "sha256-ubzjpn46yI0oP1xZKH/Hz6ag+4WXghVpOWmK05WgthA=",
     "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip": "sha256-TZNCi4kRc7NNcV89j2UhT6y1+l1L512xTN/yTztjQfY=",
     "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip": "sha256-ssaSY1I6FopLBgVKHUyjBrqzxHLSuI/swtDfQWJ7gxU=",
-    "https://plugins.jetbrains.com/files/23806/664310/Oxocarbon-1.4.5.zip": "sha256-zF89Q1LE6xwBeDKv4FSQ6H6cbABjz74Z/qGwddRWp7M=",
-    "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip": "sha256-bwZSaUkfJ2D6XLr0e7EoismsTmvNCyRzGd4OWu6u9n0=",
-    "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip": "sha256-SC8IMca0EYEmZFrMsaK3oadaemM4FQnYiTxOTt1zQGg=",
-    "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip": "sha256-rRSyr7nShG1q9tVSO7VRo3KoGnBcrND4D4+38gNBtqI=",
-    "https://plugins.jetbrains.com/files/631/766544/python-251.26094.121.zip": "sha256-gj3s+D04AcmPxzhKDWdYFED8Ab+iHIp6fpZhxasofUQ=",
-    "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip": "sha256-pFKAZ8xFNfUh7/Hi4NYPDQAhRRYm4WKTpCQELqBfb40=",
+    "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip": "sha256-+cLKIu8abGXZqJ3GutQsoQQg3s0wkmk5qKosW0O8RII=",
+    "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip": "sha256-b+1tyiMuQ3g/adLBfRnB/8tmUxlpqemI0O3VZmTzIWk=",
+    "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip": "sha256-eOUdDQDEaxDxEx9Osa8elZiBEqhWs3grGiS4Z/iY7IE=",
+    "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip": "sha256-2Vrm9k4ZqqpWl/EgDrAFNTpUeBhDSYt48JhAWlSWY1A=",
+    "https://plugins.jetbrains.com/files/631/817162/python-252.23892.409.zip": "sha256-3Z1a/BKzLIFYv6/SIf+VruH4rNTnLTeKcfU8ghwFtro=",
     "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip": "sha256-34s7pOsqMaGoVYhCuAZtylNwplQOtNQJUppepsl4F4Q=",
-    "https://plugins.jetbrains.com/files/6981/724264/ini-251.23774.466.zip": "sha256-CnoNNfcsbP9IipuqsBV1OZu+l3h7Yrs6MSofriDvI34=",
-    "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip": "sha256-dcFDO0/mzbjkrsgM+RdHBAA5davTqD5is2D7JYQiTxc=",
-    "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip": "sha256-pyB9/Rutax3lp69NcvbVKy4b4OpZZ3cJst6UrrsQCho=",
+    "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip": "sha256-iWKLgk+eWhUmv/lH9+B2HI97d++EYvLwGgtRsJf4aSE=",
+    "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip": "sha256-pQGVguF7zzzasLm2tlmtvqiPtdFN4Q5NKRwYx1r62fM=",
+    "https://plugins.jetbrains.com/files/6981/782326/ini-251.26927.70.zip": "sha256-SWxabTcZDL1HoF9ou62ABvHOjK9vPQG+1S60kXskuwk=",
+    "https://plugins.jetbrains.com/files/6981/806736/ini-251.27812.54.zip": "sha256-olPIXYib4IUF/qmTzTOmEEXq01I8ji7no4dqSTJvqhY=",
+    "https://plugins.jetbrains.com/files/6981/817734/ini-252.23892.419.zip": "sha256-ntavNZdWXNkFDZnSQrJJgqVmS+OQm8l139yhVoc6g7Y=",
+
     "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip": "sha256-BW47ZEUINVnhV0RZ1np7Dkf3lfyrtKoZ9ej/SVct2Xs=",
     "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip": "sha256-KY5VRiLJJwa9OVVog1W3MboZjwVboYwYm+i4eqooo44=",
     "https://plugins.jetbrains.com/files/7177/636663/fileWatcher-243.22562.13.zip": "sha256-8IHS3kmmbL8uQYnaMW7NgBIpBKT+XDJ4QDiiPZa5pzo=",
     "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip": "sha256-jNHP/vaCaolmvNUQRGmIgSR1ykjDtKqyJ69UIn5cz70=",
+    "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip": "sha256-ac4h2uwF6h2L5Cax40t36wTBNFzQn38EVGEL2gts8jQ=",
     "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip": "sha256-Xsw4P/KddgOuwcNBzT3UWkaQBYXLqGop+fQhoL65Dfg=",
     "https://plugins.jetbrains.com/files/7212/636678/cucumber-java-243.22562.13.zip": "sha256-q8LjYzKuTK5da+A/29Z2+bHhWKmvsIUVG1MprbsIoLM=",
     "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip": "sha256-I7gwjCnW8OXzM5eioM7h6RW9qYaQX0MWJPfHOOL9KJA=",
+    "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip": "sha256-ypJOPmcl4881TpMboomVvmspJ3I1sfm5a26l54cfFpo=",
     "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip": "sha256-SgldikXjVx6hUw3LqcN8/NxLLBfnr/LUc/SrIIACl7k=",
     "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip": "sha256-HfTd3zT/7sOrYutEkEzpFAu6AijrFrpHJg1ftP3N87Y=",
     "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip": "sha256-gN9XqO/x41scgJ9dzTdC4i4hIZJpwSeR7OjU2BG8gzU=",
-    "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip": "sha256-8om1u4KfXRkMUV8YzXWa1cgMeqTCRKSvDUh86ZBzPTE=",
-    "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip": "sha256-3RJ7YVFtynyqeLIzdrirCMbWNZmUkJ+DT/9my71H0Dk=",
-    "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip": "sha256-//bXaBJI+eIAYCuXek0pl9h7Utmrtui68QC1vrxPY8c=",
+    "https://plugins.jetbrains.com/files/7322/782358/python-ce-251.26927.70.zip": "sha256-Lole5M9TXN6tuEb4Y39qqhQ0RwGZaCLyPnzBtfH2XGk=",
+    "https://plugins.jetbrains.com/files/7322/805188/python-ce-251.27812.49.zip": "sha256-53cIBQbvP13Py0nN5ZXJBLH3xA5/tz2ba4hhVWRaFSM=",
+    "https://plugins.jetbrains.com/files/7322/817156/python-ce-252.23892.409.zip": "sha256-AdqRuyFZM+huPDwbRKfnI0zoAfb9bLSE/yan2SZF2YU=",
+    "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip": "sha256-6VpRIidsf8iWJeR3OarwwgS1NDXj9j6bLnxU/YBskeY=",
     "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar": "sha256-DobKZKokueqq0z75d2Fo3BD8mWX9+LpGdT9C7Eu2fHc=",
-    "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip": "sha256-cnVK5tsExjEAqP3cuh1PgNjrZYt2dVGQ/RL/jr89Zew=",
-    "https://plugins.jetbrains.com/files/7724/724240/clouds-docker-impl-251.23774.466.zip": "sha256-2o1CaX3Xe86ZksIMW9ZqvnuvfvnqSddDDxEU/SFWER8=",
-    "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip": "sha256-p+7U17bTsrxGFVR+Kguma43FOHW0d3NQKRjwxONqL1g=",
-    "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip": "sha256-+WJP3tXjIC4eGkssPrNf+tGEIKGQeLP3CcFtyXYUlQg=",
-    "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip": "sha256-rr2pO0mIsqWXYZgwEhcQJlk0lQabxnIPxqRCGdTFaTw=",
+    "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip": "sha256-lSgPEqhTvr+xm+9Or01IQABgjNugoUZHLUgUFZaOLs0=",
+    "https://plugins.jetbrains.com/files/7724/782341/clouds-docker-impl-251.26927.70.zip": "sha256-jEiC6Ro30ZGR3d5ODZ7lzHjwdzarxVVdWmFOKinIhW4=",
+    "https://plugins.jetbrains.com/files/7724/805402/clouds-docker-impl-251.27812.52.zip": "sha256-irzstm3qMkiJSVsXGunYdMvThvPX1KU4Cf85ZDf3/9o=",
+    "https://plugins.jetbrains.com/files/7724/817741/clouds-docker-impl-252.23892.419.zip": "sha256-h9KjGLm2k+A0zfN+cKR3w6VC3JDagmqkTPWe4zwtcrU=",
     "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip": "sha256-O+gSW36MwqQqUiZBQl8J4NFNK+jFowtT9k1ykhSraxM=",
-    "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip": "sha256-5QQ3zmfgtcy4cSyGale9GvENuiWV8cQmzTEfxPkox2A=",
-    "https://plugins.jetbrains.com/files/8195/715934/toml-251.23774.429.zip": "sha256-cNWs+ycKlqednnqJAm4AkqF3LTdMt8jhwWWiEDdKQE4=",
-    "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip": "sha256-DYgGpnlqpr/d/hJXD6uYsa2tzErM4uCofgok/3WayYs=",
-    "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip": "sha256-l1dKtjk1YkO2Bd5H/4MDIGAyqi3tNMsDIrVNoMDwzEs=",
-    "https://plugins.jetbrains.com/files/8327/615097/Minecraft_Development-2024.3-1.8.2.zip": "sha256-4c1nxjbEsNs9twmQnJllk1OIVmm0nnUYZ0R7f/6bJt4=",
-    "https://plugins.jetbrains.com/files/8327/770049/Minecraft_Development-2025.1-1.8.5.zip": "sha256-JD/OcG0B/KUMNmNsnRmiWzZ3QWVcFjaqNnQW8WbV1zc=",
-    "https://plugins.jetbrains.com/files/8554/716074/featuresTrainer-251.23774.436.zip": "sha256-P6ux6UgbjeJW3lF4w696bZ73zumY8hEm1iM98IsKgTQ=",
+    "https://plugins.jetbrains.com/files/8097/780447/graphql-251.26927.39.zip": "sha256-zPSBubfibs8dTxOLzJusinLn0ejkHNwEO1E4Ryi72HI=",
+    "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip": "sha256-eLh0p5vDNG7fUV7pqbIbkL30dpPj19NE9JbwcDwxZXs=",
+    "https://plugins.jetbrains.com/files/8097/802996/graphql-251.27812.12.zip": "sha256-Pju+Kre4EKRoKYEPsj74+JFvd+VyXSb7EMDo00eCz10=",
+    "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip": "sha256-WGGDyxE1ElguDMm7dONA2f0k3u+Tl1vZp3HMLkr5bFw=",
+    "https://plugins.jetbrains.com/files/8195/817202/toml-252.23892.415.zip": "sha256-TAv+MHU6bW2A/uJ72IiekraaMxKbjU/nznkkemv0wew=",
+    "https://plugins.jetbrains.com/files/8327/809293/Minecraft_Development-2025.1-1.8.6.zip": "sha256-mePVZa+63bheH85ylkbX9oOX1Nq/IYLAGHHseOJx520=",
+    "https://plugins.jetbrains.com/files/8327/809294/Minecraft_Development-2025.2-1.8.6.zip": "sha256-NOuzQ+CL+Z8n5gwMBaberLyMvS5KNmXKwZ+j88+SFqU=",
     "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip": "sha256-iK3cy0Nf87rLV0m/t3LJv65Klij/9L5l9ad2UW9O00w=",
     "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip": "sha256-qcMxLM2Y/Q18r718VasRMAlKppbH+ra/6eKCkmVL88s=",
-    "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip": "sha256-OFisV6Vs/xlbDvchxfrREDVgVh7wcfGnot+zUrgQU6M=",
-    "https://plugins.jetbrains.com/files/9164/636661/gherkin-243.22562.13.zip": "sha256-aG15ecfrsvNkpLjHclJEVKEW95GvBH+dEaqa+VCRkUo=",
+    "https://plugins.jetbrains.com/files/8554/811140/featuresTrainer-252.23892.374.zip": "sha256-wodhIhiPRsuBqfzYSEJo4reSrwh0yJbPu0W/kaoTUOE=",
+    "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip": "sha256-JShheBoOBiWM9HubMUJvBn4H3DnWykvqPyrmetaCZiM=",
     "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip": "sha256-Boy61dRieXmWrnTMfqqYZbdG/DNQ24KdguKN2fcZ+eg=",
-    "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip": "sha256-hR7hC2phDJnHXxPy80WlEDFAhZHtMCu7nqYvAb0VeTI=",
+    "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip": "sha256-KrC3EK4wYLSxWywF8I8nVx6tkclr1wAMya1Z1XF0QY8=",
     "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip": "sha256-0c/2qbuu+M6z0gvpme+Mkv23JlQKNTUU+9GL9mh2IFw=",
-    "https://plugins.jetbrains.com/files/9568/766540/go-plugin-251.26094.121.zip": "sha256-P6XLFObtTrnxNWvNZag73hFVVY82t3+YQ2G31cwAVgg=",
+    "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip": "sha256-N0DNEtF3FDcRirfjfSCCVUbDIA4SB35F/9XY1tPXXmg=",
+    "https://plugins.jetbrains.com/files/9568/802993/go-plugin-251.27812.12.zip": "sha256-7U44Ri396isqwV2s9E6WnlyWTLKdAwFVZ/qpW3lagto=",
+    "https://plugins.jetbrains.com/files/9568/808965/go-plugin-252.23892.360.zip": "sha256-7RuJXLGB5bcfHQnp/p69hjccgJKbCvYCGG634WQ8wQ4=",
     "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar": "sha256-XYCD4kOHDeIKhti0T175xhBHR8uscaFN4c9CNlUaCDs=",
-    "https://plugins.jetbrains.com/files/9707/702582/ANSI_Highlighter_Premium-24.3.4.jar": "sha256-STDhSOshNJU8YOjd1ZMxNl4WaHEp81t9TimFVQGZgWw=",
+    "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar": "sha256-mp1k2BdksxbGH4zUp/7DnjcGi5OXJ7UekCfX6dWZOtU=",
+
     "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip": "sha256-Mzmmq0RzMKZeKfBSo7FHvzeEtPGIrwqEDLAONQEsR1M=",
     "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip": "sha256-ArwC2HO2cHlTcFKXQBuKzZTuOiiIDEc/SGDsDQUCZmI="
   }


### PR DESCRIPTION
Manual backport of #431088 (and #419026). The primary reason for this is that [2025.1.5 included a fix for the Rust plugin allowing use of a Rust compiler newer than June 2025 again](https://youtrack.jetbrains.com/issue/RUST-18090/False-positive-E0277-with-nightly-rust).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
