### PR TITLE
python3Packages.blurhash: 1.1.4 -> 1.1.5

### DIFF
--- a/pkgs/development/python-modules/blurhash/default.nix
+++ b/pkgs/development/python-modules/blurhash/default.nix
@@ -2,29 +2,29 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pytest-cov-stub,
   pytestCheckHook,
   pillow,
   numpy,
+  setuptools,
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "blurhash";
-  version = "1.1.4";
-  format = "setuptools";
+  version = "1.1.5";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "halcy";
     repo = "blurhash-python";
-    # There are no tags: https://github.com/halcy/blurhash-python/issues/4
-    rev = "22e081ef1c24da1bb5c5eaa2c1d6649724deaef8";
-    sha256 = "1qq6mhydlp7q3na4kmaq3871h43wh3pyfyxr4b79bia73wjdylxf";
+    tag = "v${version}";
+    hash = "sha256-lTPn2GTD7eQ9XkZyuttFqEvNgzcx6b7OdeMc5WOXrJs=";
   };
 
-  postPatch = ''
-    sed -i '/^addopts/d' setup.cfg
-  '';
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [
+    pytest-cov-stub
     pytestCheckHook
     pillow
     numpy
@@ -32,10 +32,11 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "blurhash" ];
 
-  meta = with lib; {
+  meta = {
+    changelog = "https://github.com/halcy/blurhash-python/releases/tag/${src.tag}";
     description = "Pure-Python implementation of the blurhash algorithm";
     homepage = "https://github.com/halcy/blurhash-python";
-    license = licenses.mit;
-    maintainers = with maintainers; [ dotlambda ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dotlambda ];
   };
 }


### PR DESCRIPTION
Diff: https://github.com/halcy/blurhash-python/compare/22e081ef1c24da1bb5c5eaa2c1d6649724deaef8..v1.1.5
Changelog: https://github.com/halcy/blurhash-python/releases/tag/v1.1.5

closes https://github.com/NixOS/nixpkgs/pull/436697
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
