### PR TITLE
mdsf: remove cargoCheck to fix build failure; 0.10.5 -> 0.10.6

### DIFF
--- a/pkgs/by-name/md/mdsf/package.nix
+++ b/pkgs/by-name/md/mdsf/package.nix
@@ -21,44 +21,8 @@ rustPlatform.buildRustPackage {
 
   cargoHash = "sha256-AMo2LPC6RviYu2qx202o0gFIIJdjNJxS/zY06TEcpKw=";
 
-  checkFlags = [
-    # Failing due to the method under test trying to create a directory & write to the filesystem
-    "--skip=caching::test_cache_entry::it_should_work"
-    # Permissions denied due to the test trying to remove a directory
-    "--skip=commands::prune_cache::test_run::it_should_remove_cache_directory"
-    # Permissions denied due to the test trying to write to a file
-    "--skip=config::test_config::it_should_error_on_broken_config"
-    # The following tests try to create tmp files
-    "--skip=format::accepts_multiple_file_paths"
-    "--skip=format::accepts_multiple_file_paths_with_thread_argument"
-    "--skip=format::accepts_multiple_file_paths_with_thread_argument_zero"
-    "--skip=format::format_with_cache_arg"
-    "--skip=format::formats_broken_input"
-    "--skip=format::formats_broken_input_stdin"
-    "--skip=format::formats_broken_input_with_debug_arg"
-    "--skip=format::on_missing_tool_binary_fail_cli"
-    "--skip=format::on_missing_tool_binary_fail_config"
-    "--skip=format::on_missing_tool_binary_fail_fast_cli"
-    "--skip=format::on_missing_tool_binary_fail_fast_config"
-    "--skip=format::on_missing_tool_binary_ignore_cli"
-    "--skip=format::on_missing_tool_binary_ignore_config"
-    "--skip=format::on_missing_tool_binary_prioritize_cli"
-    "--skip=format::supports_config_path_argument"
-    # Depends on one of gofumpt, gofmt, or crlfmt being available
-    "--skip=test_lib::it_should_add_go_package_if_missing"
-    # The following tests depend on rustfmt being available
-    "--skip=test_lib::it_should_format_the_code"
-    "--skip=test_lib::it_should_format_the_codeblocks_that_start_with_whitespace"
-    "--skip=test_lib::it_should_not_care_if_go_package_is_set"
-    "--skip=test_lib::it_should_not_modify_outside_blocks"
-    # The following tests try to interact with the file system
-    "--skip=verify::accepts_multiple_file_paths_broken"
-    "--skip=verify::accepts_multiple_file_paths_mixed"
-    "--skip=verify::fails_with_broken_input"
-    # The following tests try to interact with stdin
-    "--skip=verify::success_with_formatted_input_stdin"
-    "--skip=verify::supports_log_level_argument"
-  ];
+  # many tests fail for various reasons of which most depend on the build sandbox
+  doCheck = false;
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;

--- a/pkgs/by-name/md/mdsf/package.nix
+++ b/pkgs/by-name/md/mdsf/package.nix
@@ -7,7 +7,7 @@
 }:
 let
   pname = "mdsf";
-  version = "0.10.5";
+  version = "0.10.6";
 in
 rustPlatform.buildRustPackage {
   inherit pname version;
@@ -16,10 +16,10 @@ rustPlatform.buildRustPackage {
     owner = "hougesen";
     repo = "mdsf";
     tag = "v${version}";
-    hash = "sha256-m7VoGozJShEw6qVXScxgX7CCyIh62unVvzjq/W7Ynu8=";
+    hash = "sha256-fWJSCYWbt1P9Y2mZQ3n36SOnW7s3Cu7nmDS9dOv9hII=";
   };
 
-  cargoHash = "sha256-AMo2LPC6RviYu2qx202o0gFIIJdjNJxS/zY06TEcpKw=";
+  cargoHash = "sha256-qwROKSUiTvBix3mxnwtoS9pTlemi9U7oCa/nlERq9sw=";
 
   # many tests fail for various reasons of which most depend on the build sandbox
   doCheck = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- fix #440134 ,  remove check on build.
- update from 0.10.5 to 0.10.6

maintainer ping: @luftmensch-luftmensch 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
