### PR TITLE
python3Packages.wiktextract: init at 1.99.7-unstable-2026-03-26

### DIFF
--- a/pkgs/development/python-modules/mediawiki-langcodes/default.nix
+++ b/pkgs/development/python-modules/mediawiki-langcodes/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  setuptools,
+  fetchPypi,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "mediawiki-langcodes";
+  version = "0.2.18";
+  pyproject = true;
+
+  # Using fetchPypi instead of fetching from source for technical reason.
+  # It required Internet and Python scripts to build the database.
+  src = fetchPypi {
+    pname = "mediawiki_langcodes";
+    inherit (finalAttrs) version;
+    hash = "sha256-9wHlISFD2Pc4qA+kAGR2yRXRby6NGkQRTOoamaoFCxU=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "mediawiki_langcodes" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Convert MediaWiki language names and language codes";
+    homepage = "https://github.com/xxyzz/mediawiki_langcodes";
+    changelog = "https://github.com/xxyzz/mediawiki_langcodes/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ theobori ];
+  };
+})

--- a/pkgs/development/python-modules/wikitextprocessor/default.nix
+++ b/pkgs/development/python-modules/wikitextprocessor/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  dateparser,
+  lupa,
+  lxml,
+  mediawiki-langcodes,
+  psutil,
+  requests,
+  pytestCheckHook,
+  unstableGitUpdater,
+}:
+
+buildPythonPackage {
+  pname = "wikitextprocessor";
+  version = "0.4.96-unstable-2026-03-06";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tatuylonen";
+    repo = "wikitextprocessor";
+    fetchSubmodules = true;
+    rev = "9d9a410c45c06d30239bcc0d8c1a57718a3f7a2c";
+    hash = "sha256-qhl9yRF2MUQvKXgcuxu20h6cEQofN1xMMb4JJZcFHS0=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonRelaxDeps = [ "dateparser" ];
+
+  dependencies = [
+    dateparser
+    lupa
+    lxml
+    mediawiki-langcodes
+    psutil
+    requests
+  ];
+
+  pythonImportsCheck = [ "wikitextprocessor" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # It requires Internet
+    "test_process_dump"
+    # It attempts to write a readonly database
+    "test_fetchlanguage"
+    "test_language_parser_function"
+  ];
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Parser and expander for Wikipedia, Wiktionary etc. dump files, with Lua execution support";
+    homepage = "https://github.com/tatuylonen/wikitextprocessor";
+    license = with lib.licenses; [
+      mit
+      cc-by-sa-40 # Needed for certain test files under Wiktionary licence
+      gpl2Plus # Needed for certain files in lua/mediawiki-extensions-Scribunto/
+    ];
+    maintainers = with lib.maintainers; [ theobori ];
+  };
+}

--- a/pkgs/development/python-modules/wiktextract/default.nix
+++ b/pkgs/development/python-modules/wiktextract/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  levenshtein,
+  nltk,
+  pydantic,
+  wikitextprocessor,
+  unstableGitUpdater,
+}:
+
+buildPythonPackage {
+  pname = "wiktextract";
+  version = "1.99.7-unstable-2026-03-26";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tatuylonen";
+    repo = "wiktextract";
+    rev = "f47b8fc87a0e17f4dcca68f534e73f4c6fa8e8e7";
+    hash = "sha256-U9Xm3vRAvONN/DwyhEEM54eiBnv7JKAEXPolK9HfJU8=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    levenshtein
+    nltk
+    pydantic
+    wikitextprocessor
+  ];
+
+  # It requires Internet
+  doCheck = false;
+
+  pythonImportsCheck = [ "wiktextract" ];
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Wiktionary dump file parser and multilingual data extractor";
+    homepage = "https://github.com/tatuylonen/wiktextract";
+    license = with lib.licenses; [
+      mit
+      cc-by-sa-40 # Needed for certain test files under Wiktionary licence
+    ];
+    maintainers = with lib.maintainers; [ theobori ];
+    mainProgram = "wiktwords";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9687,6 +9687,8 @@ self: super: with self; {
 
   mediapy = callPackage ../development/python-modules/mediapy { };
 
+  mediawiki-langcodes = callPackage ../development/python-modules/mediawiki-langcodes { };
+
   medpy = callPackage ../development/python-modules/medpy { };
 
   medvol = callPackage ../development/python-modules/medvol { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21065,6 +21065,8 @@ self: super: with self; {
 
   wikitextparser = callPackage ../development/python-modules/wikitextparser { };
 
+  wikitextprocessor = callPackage ../development/python-modules/wikitextprocessor { };
+
   willow = callPackage ../development/python-modules/willow { };
 
   winacl = callPackage ../development/python-modules/winacl { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21067,6 +21067,8 @@ self: super: with self; {
 
   wikitextprocessor = callPackage ../development/python-modules/wikitextprocessor { };
 
+  wiktextract = callPackage ../development/python-modules/wiktextract { };
+
   willow = callPackage ../development/python-modules/willow { };
 
   winacl = callPackage ../development/python-modules/winacl { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This initialize https://github.com/tatuylonen/wiktextract and its dependencies.

- [x] `wiktextract` https://github.com/NixOS/nixpkgs/commit/158756b2209c2e5c31288a612e4bc10ea0afc4b0
	- [x] `wikitextprocessor` https://github.com/NixOS/nixpkgs/commit/f750dd7e14e9ae248b93a38f24e158f267aaeeef
		- [x] `mediawiki-langcodes` https://github.com/NixOS/nixpkgs/commit/595e53600f236ad10383884c700ddedcaca59e08

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
