### PR TITLE
nixos/firmware: remove restrictive hardware.enableAllFirmware assertion

### DIFF
--- a/nixos/modules/hardware/all-firmware.nix
+++ b/nixos/modules/hardware/all-firmware.nix
@@ -85,16 +85,6 @@ in
         ++ lib.optional pkgs.stdenv.hostPlatform.isAarch raspberrypiWirelessFirmware;
     })
     (lib.mkIf cfg.enableAllFirmware {
-      assertions = [
-        {
-          assertion = cfg.enableAllFirmware -> pkgs.config.allowUnfree;
-          message = ''
-            the list of hardware.enableAllFirmware contains non-redistributable licensed firmware files.
-              This requires nixpkgs.config.allowUnfree to be true.
-              An alternative is to use the hardware.enableRedistributableFirmware option.
-          '';
-        }
-      ];
       hardware.firmware =
         with pkgs;
         [

--- a/nixos/modules/hardware/all-firmware.nix
+++ b/nixos/modules/hardware/all-firmware.nix
@@ -36,7 +36,18 @@ in
 
   options = {
 
-    hardware.enableAllFirmware = lib.mkEnableOption "all firmware regardless of license";
+    hardware.enableAllFirmware = lib.mkOption {
+      default = false;
+      example = true;
+
+      description = ''
+        Whether to enable all firmware, including [unfree packages that must be explictly allowed](https://nixos.org/manual/nixpkgs/unstable/#sec-allow-unfree).
+
+        Alternatively, use the {option}`hardware.enableRedistributableFirmware` option.
+      '';
+
+      type = lib.types.bool;
+    };
 
     hardware.enableRedistributableFirmware =
       lib.mkEnableOption "firmware with a license allowing redistribution"

--- a/nixos/modules/hardware/all-firmware.nix
+++ b/nixos/modules/hardware/all-firmware.nix
@@ -76,7 +76,7 @@ in
     (lib.mkIf cfg.enableAllFirmware {
       assertions = [
         {
-          assertion = !cfg.enableAllFirmware || pkgs.config.allowUnfree;
+          assertion = cfg.enableAllFirmware -> pkgs.config.allowUnfree;
           message = ''
             the list of hardware.enableAllFirmware contains non-redistributable licensed firmware files.
               This requires nixpkgs.config.allowUnfree to be true.


### PR DESCRIPTION
```
commit 8f1b798f6a2d53e153703a439f7d2fe80935df85
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-09-08 17:47:37 +0200

    nixos/firmware: simplify hardware.enableAllFirmware assertion condition

 nixos/modules/hardware/all-firmware.nix | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

commit aa047cc668e925fe6dbc8c4e5b166ff07fc0c038
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-09-08 20:38:44 +0200

    nixos/firmware: mention enableAllFirmware including unfree packages

 nixos/modules/hardware/all-firmware.nix | 13 ++++++++++++-
 1 file changed, 12 insertions(+), 1 deletion(-)

commit ea7e940d6fbcbed1a4a92b8eed0198543b7c3261
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-09-08 17:47:38 +0200

    nixos/firmware: remove restrictive hardware.enableAllFirmware assertion

    Remove the too restrictive hardware.enableAllFirmware assertion
    introduced in commit 05aa80c06ab4 ("hardware: add
    enableRedistributalFirmware").

    This assertion is too restrictive because it enforces globally enabling
    unfree packages without allowing explicit whitelisting:

         hardware.enableAllFirmware = true;

        -nixpkgs.config.allowUnfree = true;
        +nixpkgs.config.allowUnfreePredicate = pkg:
        +    builtins.elem (lib.getName pkg) [
        +      "b43-firmware"
        +      "broadcom-bt-firmware"
        +      "facetimehd-calibration"
        +      "facetimehd-firmware"
        +      "xow_dongle-firmware"
        +    ];

    Declaring neither nixpkgs.config.allowUnfree nor
    nixpkgs.config.allowUnfreePredicate without this
    hardware.enableAllFirmware assertion results in detailed and instructive
    evaluation error messages.

 nixos/modules/hardware/all-firmware.nix | 10 ----------
 1 file changed, 10 deletions(-)
```

Maybe the mentioned evaluation error message did not yet exist at the time of commit 05aa80c06ab4 ("hardware: add enableRedistributalFirmware") in 2017.

CC: @Mic92

## Things done

I have successfully tested the diff from the commit message in my NixOS configuration when using this PR.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
