### PR TITLE
python310Packages.pytest-asyncio: fix python 3.10 build with backported asyncio runner

### DIFF
--- a/pkgs/development/python-modules/backports-asyncio-runner/default.nix
+++ b/pkgs/development/python-modules/backports-asyncio-runner/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  pytestCheckHook,
+  fetchFromGitHub,
+  hatchling,
+  hatch-fancy-pypi-readme,
+}:
+
+let
+  pname = "backports-asyncio-runner";
+  version = "1.2.0";
+  src = fetchFromGitHub {
+    owner = "samypr100";
+    repo = "backports.asyncio.runner";
+    tag = "v${version}";
+    hash = "sha256-F8x7MZgu0VItH7kBke7C7+ZBoM6Iyj8xOeQ2t56ff3k=";
+  };
+in
+buildPythonPackage {
+  inherit pname version src;
+  pyproject = true;
+
+  build-system = [
+    hatch-fancy-pypi-readme
+    hatchling
+  ];
+
+  pythonImportsCheck = [ "backports.asyncio.runner" ];
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # These tests depend on the test.test_asyncio module in cpython which is
+  # removed at build time.
+  disabledTestPaths = [
+    "tests/test_tasks_py38.py"
+    "tests/test_tasks_py39.py"
+    "tests/test_tasks_py310.py"
+  ];
+
+  meta = {
+    changelog = "https://github.com/samypr100/backports.asyncio.runner/releases/tag/${src.tag}";
+    description = "Backport of Python 3.11 asyncio.Runner";
+    homepage = "https://github.com/samypr100/backports.asyncio.runner";
+    license = lib.licenses.psfl;
+    maintainers = with lib.maintainers; [ detroyejr ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-asyncio/default.nix
+++ b/pkgs/development/python-modules/pytest-asyncio/default.nix
@@ -3,8 +3,10 @@
   buildPythonPackage,
   callPackage,
   fetchFromGitHub,
+  pythonOlder,
   pytest,
   setuptools-scm,
+  backports-asyncio-runner,
 }:
 
 buildPythonPackage rec {
@@ -27,6 +29,9 @@ buildPythonPackage rec {
   build-system = [ setuptools-scm ];
 
   buildInputs = [ pytest ];
+  dependencies = lib.optionals (pythonOlder "3.11") [
+    backports-asyncio-runner
+  ];
 
   postInstall = ''
     mkdir $testout

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1659,6 +1659,12 @@ self: super: with self; {
 
   backoff = callPackage ../development/python-modules/backoff { };
 
+  backports-asyncio-runner =
+    if pythonAtLeast "3.11" then
+      null
+    else
+      callPackage ../development/python-modules/backports-asyncio-runner { };
+
   backports-datetime-fromisoformat =
     callPackage ../development/python-modules/backports-datetime-fromisoformat
       { };


### PR DESCRIPTION
Adds [`backports.asyncio.runner`](https://github.com/samypr100/backports.asyncio.runner) in order to fix the python 3.10 version of `pytest-asyncio`.

Closes https://github.com/NixOS/nixpkgs/issues/441146
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
