### PR TITLE
bash-preexec: improve overridability

### DIFF
--- a/pkgs/by-name/ba/bash-preexec/package.nix
+++ b/pkgs/by-name/ba/bash-preexec/package.nix
@@ -26,20 +26,28 @@ stdenvNoCC.mkDerivation {
   dontBuild = true;
 
   patchPhase = ''
+    runHook prePatch
+
     # Needed since the tests expect that HISTCONTROL is set.
     sed -i '/setup()/a HISTCONTROL=""' test/bash-preexec.bats
 
     # Skip tests failing with Bats 1.5.0.
     # See https://github.com/rcaloras/bash-preexec/issues/121
     sed -i '/^@test.*IFS/,/^}/d' test/bash-preexec.bats
+
+    runHook postPatch
   '';
 
   checkPhase = ''
+    runHook preCheck
     bats test
+    runHook postCheck
   '';
 
   installPhase = ''
-    install -Dm755 $src/bash-preexec.sh $out/share/bash/bash-preexec.sh
+    runHook preInstall
+    install -Dm755 bash-preexec.sh $out/share/bash/bash-preexec.sh
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/ba/bash-preexec/package.nix
+++ b/pkgs/by-name/ba/bash-preexec/package.nix
@@ -15,8 +15,8 @@ stdenvNoCC.mkDerivation {
   src = fetchFromGitHub {
     owner = "rcaloras";
     repo = "bash-preexec";
-    rev = version;
-    sha256 = "sha256-4DzbeIiUX7iXy2CeSvRC2X+XnjVk+/UiMbM/dLHx7zU=";
+    tag = version;
+    hash = "sha256-4DzbeIiUX7iXy2CeSvRC2X+XnjVk+/UiMbM/dLHx7zU=";
   };
 
   nativeCheckInputs = [ bats ];
@@ -50,14 +50,15 @@ stdenvNoCC.mkDerivation {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Preexec and precmd functions for Bash just like Zsh";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     homepage = "https://github.com/rcaloras/bash-preexec";
-    maintainers = [
-      maintainers.hawkw
-      maintainers.rycee
+    changelog = "https://github.com/rcaloras/bash-preexec/releases/tag/${version}";
+    maintainers = with lib.maintainers; [
+      hawkw
+      rycee
     ];
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
Current situation:

- `bash-preexec.sh` is copied directly from `$src` to `$out` in `installPhase`. This hinders any overriding that would patch this file.
- `pre*` and `post*` hooks are not run in the phases that are manually defined.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
