### PR TITLE
lovely-injector: fix compilation with rustc 1.89.0

### DIFF
--- a/pkgs/by-name/lo/lovely-injector/package.nix
+++ b/pkgs/by-name/lo/lovely-injector/package.nix
@@ -1,5 +1,6 @@
 {
   fetchFromGitHub,
+  fetchpatch,
   rustPlatform,
   lib,
   versionCheckHook,
@@ -8,16 +9,28 @@
 }:
 let
   version = "0.7.1";
+
+  # retour-rs PR #67 (unmerged) fixes compilation with rustc 1.89.0
+  retourPatch = fetchpatch {
+    url = "https://patch-diff.githubusercontent.com/raw/Hpmason/retour-rs/pull/67.patch";
+    hash = "sha256-zajJdc1ml5UKPi6yOUwW1rPxiTx3VhVig3dh/xSBrc8=";
+  };
 in
 rustPlatform.buildRustPackage {
   pname = "lovely-injector";
   inherit version;
+
   src = fetchFromGitHub {
     owner = "ethangreen-dev";
     repo = "lovely-injector";
     tag = "v${version}";
     hash = "sha256-j03/DOnLFfFYTwGGh+7BalS779jyg+p0UqtcTTyHgv4=";
   };
+
+  # Apply retour patch to the vendored crate
+  postPatch = ''
+    patch -p1 -d "/build/lovely-injector-${version}-vendor/retour-0.4.0-alpha.2" < ${retourPatch}
+  '';
 
   cargoHash = "sha256-hHq26kSKcqEldxUb6bn1laTpKGFplP9/2uogsal8T5A=";
   # no tests


### PR DESCRIPTION
Since https://github.com/NixOS/nixpkgs/commit/dc402c1fc646b5aeb6e50bdd06e1509981ce2af0, lovely-injector has been unable to build due to rustc compiler changes. https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.lovely-injector.x86_64-linux

See also:
- https://github.com/Hpmason/retour-rs/issues/69
- https://github.com/Hpmason/retour-rs/pull/67

This is my first time patching a Rust crate, so maybe I've taken the wrong approach. I did consider patching Cargo.toml/Cargo.lock, maybe this would be preferred instead.

Nonetheless, this patch allows me to run Balatro on master branch. The PR which fixes this upstream is not yet merged, but I did leave a comment on their open issue, noting that the patch works for me.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
