### PR TITLE
nh: 4.1.2 -> 4.2.0

### DIFF
--- a/pkgs/by-name/nh/nh/package.nix
+++ b/pkgs/by-name/nh/nh/package.nix
@@ -6,25 +6,23 @@
   makeBinaryWrapper,
   fetchFromGitHub,
   nix-update-script,
-  nvd,
   nix-output-monitor,
   buildPackages,
 }:
 let
   runtimeDeps = [
-    nvd
     nix-output-monitor
   ];
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nh";
-  version = "4.1.2";
+  version = "4.2.0";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "nh";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-v02NsZ589zzPq5xsCxyrG1/ZkFbbMkUthly50QdmYKo=";
+    hash = "sha256-6n5SVO8zsdVTD691lri7ZcO4zpqYFU8GIvjI6dbxkA8=";
   };
 
   strictDeps = true;
@@ -46,6 +44,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
       done
 
       installShellCompletion completions/*
+
+      cargo xtask man --out-dir gen
+      installManPage gen/nh.1
     ''
   );
 
@@ -54,7 +55,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --prefix PATH : ${lib.makeBinPath runtimeDeps}
   '';
 
-  cargoHash = "sha256-R2S0gbT3DD/Dtx8edqhD0fpDqe8AJgyLmlPoNEKm4BA=";
+  cargoHash = "sha256-cxZsePgraYevuYQSi3hTU2EsiDyn1epSIcvGi183fIU=";
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
New NH version, we're so back.

- [Changelog](https://github.com/nix-community/nh/blob/master/CHANGELOG.md#420)
- [Diff](https://github.com/nix-community/nh/compare/v4.1.2...v4.2.0)

Drops the nvd dependency in favor of [dix](https://github.com/faukah/dix), a Rust crate that we use for a near 100% increase in diffing speed. I've also added *manpages* to nh, which are available in this release and reflected in the package change :')

