### PR TITLE
 xlayoutdisplay: fix build

### DIFF
--- a/pkgs/by-name/xl/xlayoutdisplay/package.nix
+++ b/pkgs/by-name/xl/xlayoutdisplay/package.nix
@@ -9,14 +9,14 @@
   gtest,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "xlayoutdisplay";
   version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "alex-courtis";
     repo = "xlayoutdisplay";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-A37jFhVTW/3QNEf776Oi3ViRK+ebOPRTsEQqdmNhA7E=";
   };
 
@@ -44,12 +44,12 @@ stdenv.mkDerivation rec {
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
     description = "Detects and arranges linux display outputs, using XRandR for detection and xrandr for arrangement";
     homepage = "https://github.com/alex-courtis/xlayoutdisplay";
-    maintainers = with maintainers; [ dtzWill ];
-    license = licenses.asl20;
-    platforms = platforms.linux;
+    maintainers = with lib.maintainers; [ dtzWill ];
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
     mainProgram = "xlayoutdisplay";
   };
-}
+})

--- a/pkgs/by-name/xl/xlayoutdisplay/package.nix
+++ b/pkgs/by-name/xl/xlayoutdisplay/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   pkg-config,
   xorg,
   boost,
@@ -18,6 +19,15 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-A37jFhVTW/3QNEf776Oi3ViRK+ebOPRTsEQqdmNhA7E=";
   };
+
+  patches = [
+    # https://github.com/alex-courtis/xlayoutdisplay/pull/34
+    (fetchpatch2 {
+      name = "cpp-version.patch";
+      url = "https://github.com/alex-courtis/xlayoutdisplay/commit/56983b45070edde78cc816d9cff4111315e94a7a.patch";
+      hash = "sha256-zd28Nkw8Kmm20zGT6wvdBHcHfE4p+RFotUO9zJwPQMc=";
+    })
+  ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = with xorg; [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

xlayoutdisplay fails to build ([hydra](https://hydra.nixos.org/build/306557733)) with

```text
In file included from /nix/store/i4jy5k3i83gdcz76d7i7ymp500rz63pw-gtest-1.17.0-dev/include/gtest/gtest-message.h:57,
                 from /nix/store/i4jy5k3i83gdcz76d7i7ymp500rz63pw-gtest-1.17.0-dev/include/gtest/gtest-assertion-result.h:46,
                 from /nix/store/i4jy5k3i83gdcz76d7i7ymp500rz63pw-gtest-1.17.0-dev/include/gtest/gtest.h:63,
                 from test/gtest_main.cpp:31:
/nix/store/i4jy5k3i83gdcz76d7i7ymp500rz63pw-gtest-1.17.0-dev/include/gtest/internal/gtest-port.h:273:2: error: #error C++ versions less than C++17 are not supported.
  273 | #error C++ versions less than C++17 are not supported.
      |  ^~~~~
```

since [GoogleTest](https://github.com/google/googletest/blob/7917641ff965959afae189afb5f052524395525c/README.md?plain=1#L16-L17) now requires C++17 ([Google support table](https://github.com/google/oss-policies-info/blob/48076331ab65825e27552573a57460c1f617986c/foundational-cxx-support-matrix.md?plain=1#L5)).

This PR applies the patch from https://github.com/alex-courtis/xlayoutdisplay/pull/34 bumping the C++ version from 14 to 17.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
