### PR TITLE
weechat: replace `systemd` with `systemdLibs`

### DIFF
--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -32,7 +32,7 @@
   tcl,
   phpSupport ? !stdenv.hostPlatform.isDarwin,
   php,
-  systemd,
+  systemdLibs,
   libxml2,
   pcre2,
   libargon2,
@@ -94,7 +94,7 @@ let
         pcre2
         libargon2
       ]
-      ++ lib.optional stdenv.hostPlatform.isLinux systemd;
+      ++ lib.optionals stdenv.hostPlatform.isLinux [ systemdLibs ];
     }
   ];
   enabledPlugins = builtins.filter (p: p.enabled) plugins;
@@ -113,7 +113,9 @@ stdenv.mkDerivation rec {
   };
 
   # Why is this needed? https://github.com/weechat/weechat/issues/2031
-  patches = lib.optional gettext.gettextNeedsLdflags ./gettext-intl.patch;
+  patches = lib.optionals gettext.gettextNeedsLdflags [
+    ./gettext-intl.patch
+  ];
 
   outputs = [
     "out"
@@ -137,7 +139,7 @@ stdenv.mkDerivation rec {
     pkg-config
     asciidoctor
   ]
-  ++ lib.optional enableTests cpputest;
+  ++ lib.optionals enableTests [ cpputest ];
 
   buildInputs = [
     ncurses

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -38,6 +38,7 @@
   libargon2,
   extraBuildInputs ? [ ],
   writeScript,
+  versionCheckHook,
 }:
 
 let
@@ -172,10 +173,8 @@ stdenv.mkDerivation rec {
   '';
 
   doInstallCheck = true;
-
-  installCheckPhase = ''
-    $out/bin/weechat --version
-  '';
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
 
   passthru.updateScript = writeScript "update-weechat" ''
     #!/usr/bin/env nix-shell


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
