### PR TITLE
Vscode extensions

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/congyiwu.vscode-jupytext/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/congyiwu.vscode-jupytext/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "vscode-jupytext";
+    publisher = "congyiwu";
+    version = "0.1.2";
+    hash = "sha256-V9V4O1fdhY/ReKskixn113O0G1Mu1x9Z9SdChw9uVqU=";
+  };
+  meta = {
+    changelog = "https://marketplace.visualstudio.com/items/congyiwu.vscode-jupytext/changelog";
+    description = "Visual Studio Code extension for Jupytext support";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=congyiwu.vscode-jupytext";
+    homepage = "https://github.com/congyiwu/vscode-jupytext";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.smissingham ];
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1084,6 +1084,8 @@ let
         };
       };
 
+      congyiwu.vscode-jupytext = callPackage ./congyiwu.vscode-jupytext { };
+
       contextmapper.context-mapper-vscode-extension =
         callPackage ./contextmapper.context-mapper-vscode-extension
           { };

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3314,7 +3314,7 @@ let
           description = "Data viewing, cleaning and preparation for tabular datasets";
           downloadPage = "https://marketplace.visualstudio.com/items?itemName=ms-toolsai.datawrangler";
           homepage = "https://github.com/microsoft/vscode-data-wrangler";
-          license = lib.licenses.mit;
+          license = lib.licenses.unfree;
           maintainers = [ lib.maintainers.katanallama ];
         };
       };

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -2660,6 +2660,8 @@ let
 
       johnpapa.winteriscoming = callPackage ./johnpapa.winteriscoming { };
 
+      joshmu.periscope = callPackage ./joshmu.periscope { };
+
       jgclark.vscode-todo-highlight = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "vscode-todo-highlight";

--- a/pkgs/applications/editors/vscode/extensions/joshmu.periscope/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/joshmu.periscope/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "periscope";
+    publisher = "joshmu";
+    version = "1.15.1";
+    hash = "sha256-Ssa3qoookSa/JnmZl1AmlT48exAgd6pbwdzzsmTcEqs=";
+  };
+  meta = {
+    changelog = "https://marketplace.visualstudio.com/items/joshmu.periscope/changelog";
+    description = "Visual Studio Code extension for fuzzy search and navigation";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=joshmu.periscope";
+    homepage = "https://github.com/joshmu/periscope";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.smissingham ];
+  };
+}


### PR DESCRIPTION
- Add congyiwu.vscode-jupytext extension
- Add joshmu.periscope extension
- Update incorrect license currently set for mstools-ai.datawrangler
    - Project was never MIT, nor open source. Set to unfree, for Microsoft VS Marketplace license 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

# Maintainers
@katanallama fyi, updated your datawrangler extension