### PR TITLE
ci/github-script/labels: keep "needs reviewer" if only automated reviews

### DIFF
--- a/ci/github-script/labels.js
+++ b/ci/github-script/labels.js
@@ -93,6 +93,13 @@ module.exports = async ({ github, context, core, dry }) => {
     log('Last eval run', run_id ?? '<n/a>')
 
     if (conclusion === 'success') {
+      // Check for any human reviews other than GitHub actions and other GitHub apps.
+      // Accounts could be deleted as well, so don't count them.
+      const humanReviews = reviews.filter(
+        (r) =>
+          r.user && !r.user.login.endsWith('[bot]') && r.user.type !== 'Bot',
+      )
+
       Object.assign(prLabels, {
         // We only set this label if the latest eval run was successful, because if it was not, it
         // *could* have requested reviewers. We will let the PR author fix CI first, before "escalating"
@@ -105,7 +112,7 @@ module.exports = async ({ github, context, core, dry }) => {
         '9.needs: reviewer':
           !pull_request.draft &&
           pull_request.requested_reviewers.length === 0 &&
-          reviews.length === 0,
+          humanReviews.length === 0,
       })
     }
 


### PR DESCRIPTION
Fixes #441361

Most of the time, GitHub Actions or any other GitHub app should not be counted as a reviewer (in the sense) IMO.
Even if CI is fixed, the label isn't kept.

I haven't tested this but should work.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
