### PR TITLE
nitro: init at 0.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3601,6 +3601,13 @@
     githubId = 103979114;
     keys = [ { fingerprint = "17C7 95D4 871C 2F87 83C8  053D 0C61 C4E5 907F 76C8"; } ];
   };
+  boomshroom = {
+    name = "Angel Bulfone";
+    email = "mbulfone@gmail.com";
+    github = "boomshroom";
+    githubId = 628488;
+    keys = [ { fingerprint = "F9BA 86D2 B7AF FFF8 67A1  7313 23AC 71B9 B528 09FB"; } ];
+  };
   booniepepper = {
     name = "J.R. Hill";
     email = "justin@so.dang.cool";

--- a/pkgs/by-name/ni/nitro/package.nix
+++ b/pkgs/by-name/ni/nitro/package.nix
@@ -1,0 +1,46 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  installShellFiles,
+  lib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nitro";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "leahneukirchen";
+    repo = "nitro";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RabBawI3qXJwsbHpfuSEBM3n0RQ+Rk7kW8tHHcIIJJI=";
+  };
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  # Compile with size optimisations for minimal targets
+  buildFlags = lib.optionalString stdenv.hostPlatform.isStatic "tiny";
+  installPhase = ''
+    runHook preInstall
+    installBin nitro nitroctl
+
+    mv halt.8 nitro-halt.8
+    installManPage nitro.8 nitro-halt.8 nitroctl.1
+    runHook postInstall
+  '';
+
+  meta = {
+    mainProgram = "nitro";
+    description = "Tiny but flexible init system and process supervisor";
+    homepage = "https://github.com/leahneukirchen/nitro";
+    changelog = "https://raw.githubusercontent.com/leahneukirchen/nitro/refs/tags/v${finalAttrs.version}/NEWS.md";
+    maintainers = [ lib.maintainers.boomshroom ];
+    license = lib.licenses.bsd0;
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[nitro](https://github.com/leahneukirchen/nitro) is a very lightweight and portable process supervisor inspired by ruint, s6, and others. Beyond just its size and simplicity, it also supports both PID 1 functionality and unprivileged supervision to manage either system or user daemons. It also supports rescanning the services directory to automatically stop any removed services and start any new ones.

I've been running an earlier version of this package in `nix-on-droid` where it's worked very well in spite of all of the limitations imposed by that environment.

Path Size:|default|static
-|-|-
x86_64|65.8KiB|130KiB
Aarch64|144.7KiB|229.8KiB

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
