### PR TITLE
python3Packages.safetensors: add fsspec

### DIFF
--- a/pkgs/development/python-modules/safetensors/default.nix
+++ b/pkgs/development/python-modules/safetensors/default.nix
@@ -19,6 +19,7 @@
   pytest,
   pytest-benchmark,
   hypothesis,
+  fsspec,
 
   # tests
   pytestCheckHook,
@@ -81,6 +82,7 @@ buildPythonPackage rec {
       pytest
       pytest-benchmark
       hypothesis
+      fsspec
     ];
     all = self.torch ++ self.numpy ++ self.pinned-tf ++ self.jax ++ self.paddlepaddle ++ self.testing;
     dev = self.all;
@@ -91,6 +93,7 @@ buildPythonPackage rec {
     numpy
     pytestCheckHook
     torch
+    fsspec
   ];
 
   enabledTestPaths = [ "tests" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Building with `torch-bin` in place of `torch` causes a build failure in safetensors because safetensors does not declare its [test-time dependency](https://github.com/huggingface/safetensors/blob/0816a1ae1d6b731cefd67f061d80d1cadd0dd7bb/bindings/python/tests/test_handle.py#L31-L32) on `fsspec` (see https://github.com/huggingface/safetensors/pull/640). This PR adds the dependency.

```
=================================== FAILURES ===================================
__________________________ ReadmeTestCase.test_fsspec __________________________

self = <test_handle.ReadmeTestCase testMethod=test_fsspec>

    def test_fsspec(self):
>       import fsspec
E       ModuleNotFoundError: No module named 'fsspec'

tests/test_handle.py:32: ModuleNotFoundError
=========================== short test summary info ============================
FAILED tests/test_handle.py::ReadmeTestCase::test_fsspec - ModuleNotFoundError: No module named 'fsspec'
============ 1 failed, 44 passed, 13 skipped, 3 deselected in 1.32s ============
```

The main motivation for using `torch-bin` is to avoid lengthy compiles of magma with cuda.

cc @GaetanLepage

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
