### PR TITLE
nixos/wpa_supplicant: allow duplicate network blocks

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -250,6 +250,8 @@
 
 - `services.gitea` supports sending notifications with sendmail again. To do this, activate the parameter `services.gitea.mailerUseSendmail` and configure SMTP server.
 
+- `networking.wireless.networks.<name>` now has an option to specify SSID, hence allowing duplicated SSID setup. The BSSID option is added along side with this.
+
 - Revamp of the ACME certificate acquisication and renewal process to help scale systems with lots (100+) of certificates.
 
   Units and targets have been reshaped to better support more specific dependency propagation and avoid

--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -37,7 +37,9 @@ let
   mkWPA2Fallback = opts: opts // { authProtocols = subtractLists wpa3Protocols opts.authProtocols; };
 
   # Networks attrset as a list
-  networkList = mapAttrsToList (ssid: opts: opts // { inherit ssid; }) cfg.networks;
+  # We use the ssid from the options, which defaults to the ssid but can be overridden.
+  # The ssid in attrNames is hence unused here.
+  networkList = attrValues cfg.networks;
 
   # List of all networks (normal + generated fallbacks)
   allNetworks =
@@ -89,6 +91,7 @@ let
             "key_mgmt=NONE"
         )
       ]
+      ++ optional (opts.bssid != null) "bssid=${opts.bssid}"
       ++ optional opts.hidden "scan_ssid=1"
       ++ optional (pskString != null) "psk=${pskString}"
       ++ optionals (opts.auth != null) (filter (x: x != "") (splitString "\n" opts.auth))
@@ -280,170 +283,195 @@ in
 
       networks = mkOption {
         type = types.attrsOf (
-          types.submodule {
-            options = {
-              psk = mkOption {
-                type = types.nullOr (types.strMatching "[[:print:]]{8,63}");
-                default = null;
-                description = ''
-                  The network's pre-shared key in plaintext defaulting
-                  to being a network without any authentication.
+          types.submodule (
+            { name, ... }:
+            {
+              options = {
+                ssid = mkOption {
+                  type = types.str;
+                  default = name;
+                  description = ''
+                    You could use this field to override the network's ssid.
+                    This can be useful to, for example, specify two networks
+                    that share the same SSID but not the same password.
+                    Specifying the BSSID of the network can make two entries of
+                    the same SSID show up as different ones in wpa_cli.
+                  '';
+                };
 
-                  ::: {.warning}
-                  Be aware that this will be written to the Nix store
-                  in plaintext! Use {var}`pskRaw` with an external
-                  reference to keep it safe.
-                  :::
+                bssid = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  example = "02:00:00:00:00:01";
+                  description = ''
+                    If set, this network block is used only when associating with
+                    the AP using the configured BSSID.
+                  '';
+                };
 
-                  ::: {.note}
-                  Mutually exclusive with {var}`pskRaw`.
-                  :::
-                '';
-              };
+                psk = mkOption {
+                  type = types.nullOr (types.strMatching "[[:print:]]{8,63}");
+                  default = null;
+                  description = ''
+                    The network's pre-shared key in plaintext defaulting
+                    to being a network without any authentication.
 
-              pskRaw = mkOption {
-                type = types.nullOr (types.strMatching "([[:xdigit:]]{64})|(ext:[^=]+)");
-                default = null;
-                example = "ext:name_of_the_secret_here";
-                description = ''
-                  Either the raw pre-shared key in hexadecimal format
-                  or the name of the secret (as defined inside
-                  [](#opt-networking.wireless.secretsFile) and prefixed
-                  with `ext:`) containing the network pre-shared key.
+                    ::: {.warning}
+                    Be aware that this will be written to the Nix store
+                    in plaintext! Use {var}`pskRaw` with an external
+                    reference to keep it safe.
+                    :::
 
-                  ::: {.warning}
-                  Be aware that this will be written to the Nix store
-                  in plaintext! Always use an external reference.
-                  :::
+                    ::: {.note}
+                    Mutually exclusive with {var}`pskRaw`.
+                    :::
+                  '';
+                };
 
-                  ::: {.note}
-                  The external secret can be either the plaintext
-                  passphrase or the raw pre-shared key.
-                  :::
+                pskRaw = mkOption {
+                  type = types.nullOr (types.strMatching "([[:xdigit:]]{64})|(ext:[^=]+)");
+                  default = null;
+                  example = "ext:name_of_the_secret_here";
+                  description = ''
+                    Either the raw pre-shared key in hexadecimal format
+                    or the name of the secret (as defined inside
+                    [](#opt-networking.wireless.secretsFile) and prefixed
+                    with `ext:`) containing the network pre-shared key.
 
-                  ::: {.note}
-                  Mutually exclusive with {var}`psk` and {var}`auth`.
-                  :::
-                '';
-              };
+                    ::: {.warning}
+                    Be aware that this will be written to the Nix store
+                    in plaintext! Always use an external reference.
+                    :::
 
-              authProtocols = mkOption {
-                default = [
-                  # WPA2 and WPA3
-                  "WPA-PSK"
-                  "WPA-EAP"
-                  "SAE"
-                  # 802.11r variants of the above
-                  "FT-PSK"
-                  "FT-EAP"
-                  "FT-SAE"
-                ];
-                # The list can be obtained by running this command
-                # awk '
-                #   /^# key_mgmt: /{ run=1 }
-                #   /^#$/{ run=0 }
-                #   /^# [A-Z0-9-]{2,}/{ if(run){printf("\"%s\"\n", $2)} }
-                # ' /run/current-system/sw/share/doc/wpa_supplicant/wpa_supplicant.conf.example
-                type = types.listOf (
-                  types.enum [
+                    ::: {.note}
+                    The external secret can be either the plaintext
+                    passphrase or the raw pre-shared key.
+                    :::
+
+                    ::: {.note}
+                    Mutually exclusive with {var}`psk` and {var}`auth`.
+                    :::
+                  '';
+                };
+
+                authProtocols = mkOption {
+                  default = [
+                    # WPA2 and WPA3
                     "WPA-PSK"
                     "WPA-EAP"
-                    "IEEE8021X"
-                    "NONE"
-                    "WPA-NONE"
+                    "SAE"
+                    # 802.11r variants of the above
                     "FT-PSK"
                     "FT-EAP"
-                    "FT-EAP-SHA384"
-                    "WPA-PSK-SHA256"
-                    "WPA-EAP-SHA256"
-                    "SAE"
                     "FT-SAE"
-                    "WPA-EAP-SUITE-B"
-                    "WPA-EAP-SUITE-B-192"
-                    "OSEN"
-                    "FILS-SHA256"
-                    "FILS-SHA384"
-                    "FT-FILS-SHA256"
-                    "FT-FILS-SHA384"
-                    "OWE"
-                    "DPP"
-                  ]
-                );
-                description = ''
-                  The list of authentication protocols accepted by this network.
-                  This corresponds to the `key_mgmt` option in wpa_supplicant.
-                '';
+                  ];
+                  # The list can be obtained by running this command
+                  # awk '
+                  #   /^# key_mgmt: /{ run=1 }
+                  #   /^#$/{ run=0 }
+                  #   /^# [A-Z0-9-]{2,}/{ if(run){printf("\"%s\"\n", $2)} }
+                  # ' /run/current-system/sw/share/doc/wpa_supplicant/wpa_supplicant.conf.example
+                  type = types.listOf (
+                    types.enum [
+                      "WPA-PSK"
+                      "WPA-EAP"
+                      "IEEE8021X"
+                      "NONE"
+                      "WPA-NONE"
+                      "FT-PSK"
+                      "FT-EAP"
+                      "FT-EAP-SHA384"
+                      "WPA-PSK-SHA256"
+                      "WPA-EAP-SHA256"
+                      "SAE"
+                      "FT-SAE"
+                      "WPA-EAP-SUITE-B"
+                      "WPA-EAP-SUITE-B-192"
+                      "OSEN"
+                      "FILS-SHA256"
+                      "FILS-SHA384"
+                      "FT-FILS-SHA256"
+                      "FT-FILS-SHA384"
+                      "OWE"
+                      "DPP"
+                    ]
+                  );
+                  description = ''
+                    The list of authentication protocols accepted by this network.
+                    This corresponds to the `key_mgmt` option in wpa_supplicant.
+                  '';
+                };
+
+                auth = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  example = ''
+                    eap=PEAP
+                    identity="user@example.com"
+                    password=ext:example_password
+                  '';
+                  description = ''
+                    Use this option to configure advanced authentication methods
+                    like EAP. See {manpage}`wpa_supplicant.conf(5)` for example
+                    configurations.
+
+                    ::: {.warning}
+                    Be aware that this will be written to the Nix store
+                    in plaintext! Use an external reference like
+                    `ext:secretname` for secrets.
+                    :::
+
+                    ::: {.note}
+                    Mutually exclusive with {var}`psk` and {var}`pskRaw`.
+                    :::
+                  '';
+                };
+
+                hidden = mkOption {
+                  type = types.bool;
+                  default = false;
+                  description = ''
+                    Set this to `true` if the SSID of the network is hidden.
+                  '';
+                  example = literalExpression ''
+                    { echelon = {
+                        hidden = true;
+                        psk = "abcdefgh";
+                      };
+                    }
+                  '';
+                };
+
+                priority = mkOption {
+                  type = types.nullOr types.int;
+                  default = null;
+                  description = ''
+                    By default, all networks will get same priority group (0). If
+                    some of the networks are more desirable, this field can be used
+                    to change the order in which wpa_supplicant goes through the
+                    networks when selecting a BSS. The priority groups will be
+                    iterated in decreasing priority (i.e., the larger the priority
+                    value, the sooner the network is matched against the scan
+                    results). Within each priority group, networks will be selected
+                    based on security policy, signal strength, etc.
+                  '';
+                };
+
+                extraConfig = mkOption {
+                  type = types.str;
+                  default = "";
+                  example = ''
+                    bssid_blacklist=02:11:22:33:44:55 02:22:aa:44:55:66
+                  '';
+                  description = ''
+                    Extra configuration lines appended to the network block.
+                    See {manpage}`wpa_supplicant.conf(5)` for available options.
+                  '';
+                };
+
               };
-
-              auth = mkOption {
-                type = types.nullOr types.str;
-                default = null;
-                example = ''
-                  eap=PEAP
-                  identity="user@example.com"
-                  password=ext:example_password
-                '';
-                description = ''
-                  Use this option to configure advanced authentication methods
-                  like EAP. See {manpage}`wpa_supplicant.conf(5)` for example
-                  configurations.
-
-                  ::: {.warning}
-                  Be aware that this will be written to the Nix store
-                  in plaintext! Use an external reference like
-                  `ext:secretname` for secrets.
-                  :::
-
-                  ::: {.note}
-                  Mutually exclusive with {var}`psk` and {var}`pskRaw`.
-                  :::
-                '';
-              };
-
-              hidden = mkOption {
-                type = types.bool;
-                default = false;
-                description = ''
-                  Set this to `true` if the SSID of the network is hidden.
-                '';
-                example = literalExpression ''
-                  { echelon = {
-                      hidden = true;
-                      psk = "abcdefgh";
-                    };
-                  }
-                '';
-              };
-
-              priority = mkOption {
-                type = types.nullOr types.int;
-                default = null;
-                description = ''
-                  By default, all networks will get same priority group (0). If
-                  some of the networks are more desirable, this field can be used
-                  to change the order in which wpa_supplicant goes through the
-                  networks when selecting a BSS. The priority groups will be
-                  iterated in decreasing priority (i.e., the larger the priority
-                  value, the sooner the network is matched against the scan
-                  results). Within each priority group, networks will be selected
-                  based on security policy, signal strength, etc.
-                '';
-              };
-
-              extraConfig = mkOption {
-                type = types.str;
-                default = "";
-                example = ''
-                  bssid_blacklist=02:11:22:33:44:55 02:22:aa:44:55:66
-                '';
-                description = ''
-                  Extra configuration lines appended to the network block.
-                  See {manpage}`wpa_supplicant.conf(5)` for available options.
-                '';
-              };
-
-            };
-          }
+            }
+          )
         );
         description = ''
           The network definitions to automatically connect to when

--- a/nixos/tests/wpa_supplicant.nix
+++ b/nixos/tests/wpa_supplicant.nix
@@ -13,8 +13,31 @@ let
 
   naughtyPassphrase = ''!,./;'[]\-=<>?:"{}|_+@$%^&*()`~ # ceci n'est pas un commentaire'';
 
+  runBssidTest =
+    name: expectedBssid: extraConfig:
+    runSimulatorTest name extraConfig ''
+      with subtest("Daemon can connect to the right access point"):
+          machine.wait_for_unit("wpa_supplicant-wlan1.service")
+          machine.wait_until_succeeds(
+            "wpa_cli -i wlan1 status | grep -q wpa_state=COMPLETED"
+          )
+          machine.wait_until_succeeds(
+            "wpa_cli -i wlan1 status | grep -q bssid=${expectedBssid}"
+          )
+    '';
+
   runConnectionTest =
     name: extraConfig:
+    runSimulatorTest name extraConfig ''
+      with subtest("Daemon can connect to the access point"):
+          machine.wait_for_unit("wpa_supplicant-wlan1.service")
+          machine.wait_until_succeeds(
+            "wpa_cli -i wlan1 status | grep -q wpa_state=COMPLETED"
+          )
+    '';
+
+  runSimulatorTest =
+    name: extraConfig: extraTestScript:
     runTest {
       name = "wpa_supplicant-${name}";
       inherit meta;
@@ -50,12 +73,22 @@ let
                 bssid = "02:00:00:00:00:01";
               };
               wlan0-2 = {
+                ssid = "nixos-test-mixed";
+                authentication = {
+                  mode = "wpa3-sae-transition";
+                  saeAddToMacAllow = true;
+                  saePasswordsFile = pkgs.writeText "password" naughtyPassphrase;
+                  wpaPasswordFile = pkgs.writeText "password" naughtyPassphrase;
+                };
+                bssid = "02:00:00:00:00:02";
+              };
+              wlan0-3 = {
                 ssid = "nixos-test-wpa2";
                 authentication = {
                   mode = "wpa2-sha256";
                   wpaPassword = naughtyPassphrase;
                 };
-                bssid = "02:00:00:00:00:02";
+                bssid = "02:00:00:00:00:03";
               };
             };
           };
@@ -85,11 +118,7 @@ let
         machine.wait_for_unit("hostapd.service")
         machine.copy_from_vm("/run/hostapd/wlan0.hostapd.conf")
 
-        with subtest("Daemon can connect to the access point"):
-            machine.wait_for_unit("wpa_supplicant-wlan1.service")
-            machine.wait_until_succeeds(
-              "wpa_cli -i wlan1 status | grep -q wpa_state=COMPLETED"
-            )
+        ${extraTestScript}
       '';
     };
 
@@ -129,6 +158,18 @@ in
             psk = "password";
             authProtocols = [ "SAE" ];
           };
+
+          # Test duplicate SSID generation
+          duplicate1 = {
+            ssid = "duplicate";
+            bssid = "00:00:00:00:00:01";
+            psk = "password";
+          };
+          duplicate2 = {
+            ssid = "duplicate";
+            bssid = "00:00:00:00:00:02";
+            psk = "password";
+          };
         };
       };
     };
@@ -147,6 +188,12 @@ in
       with subtest("WPA2 fallbacks have been generated"):
           assert int(machine.succeed(f"grep -c sae-only {config_file}")) == 1
           assert int(machine.succeed(f"grep -c mixed-wpa {config_file}")) == 2
+
+      with subtest("Duplicate SSID network blocks have been generated"):
+          # more duplication due to fallbacks
+          assert int(machine.succeed(f"grep -c duplicate {config_file}")) == 4
+          assert int(machine.succeed(f"grep -c bssid=00:00:00:00:00:01 {config_file}")) == 2
+          assert int(machine.succeed(f"grep -c bssid=00:00:00:00:00:02 {config_file}")) == 2
 
       # save file for manual inspection
       machine.copy_from_vm(config_file)
@@ -222,4 +269,23 @@ in
       authProtocols = [ "WPA-PSK-SHA256" ];
     };
   };
+
+  # Test connection with the highest prio "matching" network block found.
+  # "Matching" meaning with the right SSID and BSSID
+  bssidGuard = runBssidTest "bssid-guard" "02:00:00:00:00:02" {
+    networks = {
+      "1_first" = {
+        ssid = "nixos-test-mixed";
+        bssid = "02:00:00:00:00:01";
+        pskRaw = "ext:psk_nixos_test";
+      };
+      "2_second" = {
+        ssid = "nixos-test-mixed";
+        bssid = "02:00:00:00:00:02";
+        pskRaw = "ext:psk_nixos_test";
+        priority = 1;
+      };
+    };
+  };
+
 }


### PR DESCRIPTION
Allow users to specify more than one network block of the same SSID.
In addition, allow the specification of its BSSID to better distinguish these network blocks.

An example usecase is that a lot of the local café shop of the same brand share the same SSID but not the same password. It would be necessary for me to set up these passwords in independent network blocks to make it work.

In `.../share/doc/wpa_supplicant/wpa_supplicant.conf.example` packaged in the `wpa_supplicant` package, I found this documentation somewhat confirming my idea that it is possible to have duplicate SSID name while BSSID differs.

```
# network block
#
# Each network (usually AP's sharing the same SSID) is configured as a separate
# block in this configuration file. The network blocks are in preference order
# (the first match is used).
#
# network block fields:
#
... elided
# ssid: SSID (mandatory); network name in one of the optional formats:
#       - an ASCII string with double quotation
#       - a hex string (two characters per octet of SSID)
#       - a printf-escaped ASCII string P"<escaped string>"
... elided
# bssid: BSSID (optional); if set, this network block is used only when
#       associating with the AP using the configured BSSID
#
```   

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
