### PR TITLE
[Backport release-25.05] firebird_3: 3.0.12 -> 3.0.13

### DIFF
--- a/pkgs/servers/firebird/default.nix
+++ b/pkgs/servers/firebird/default.nix
@@ -2,8 +2,9 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchDebianPatch,
   libedit,
-  autoreconfHook271,
+  autoreconfHook,
   zlib,
   unzip,
   libtommath,
@@ -32,7 +33,7 @@ let
       ];
     };
 
-    nativeBuildInputs = [ autoreconfHook271 ];
+    nativeBuildInputs = [ autoreconfHook ];
 
     buildInputs = [
       libedit
@@ -59,14 +60,24 @@ rec {
   firebird_3 = stdenv.mkDerivation (
     base
     // rec {
-      version = "3.0.12";
+      version = "3.0.13";
 
       src = fetchFromGitHub {
         owner = "FirebirdSQL";
         repo = "firebird";
         rev = "v${version}";
-        hash = "sha256-po8tMrOahfwayVXa7Eadr9+ZEmZizHlCmxi094cOJSY=";
+        hash = "sha256-ti3cFfByM2wxOLkAebwtFe25B5W7jOwi3f7MPYo/yUA=";
       };
+
+      patches = [
+        (fetchDebianPatch {
+          pname = "firebird3.0";
+          version = "3.0.13.ds7";
+          debianRevision = "2";
+          patch = "no-binary-gbaks.patch";
+          hash = "sha256-LXUMM38PBYeLPdgaxLPau4HWB4ItJBBnx7oGwalL6Pg=";
+        })
+      ];
 
       buildInputs = base.buildInputs ++ [
         zlib


### PR DESCRIPTION
Backport to `release-25.05` of #441313.

* [x] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
  * Even as a non-committer, if you find that it is not acceptable, leave a comment.