### PR TITLE
boehmgc: Fix support for multiple flags in CFLAGS_EXTRAS

### DIFF
--- a/pkgs/by-name/bo/boehmgc/package.nix
+++ b/pkgs/by-name/bo/boehmgc/package.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   separateDebugInfo = stdenv.hostPlatform.isLinux && stdenv.hostPlatform.libc != "musl";
 
+  __structuredAttrs = true;
+
   nativeBuildInputs = [
     autoreconfHook
   ];


### PR DESCRIPTION
Addresses the issue commented on in https://github.com/NixOS/nixpkgs/pull/439943#pullrequestreview-3201036075.

Fixes building the `boehmgc` that Nix needs for POWER. For example, `pkgsCross.powernv.nixVersions.nix_2_28.passthru.boehmgc`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] powerpc64-linux (cross, ELFv1, via `pkgsCross.ppc64-elfv1.nixVersions.nix_2_28.passthru.boehmgc`)
  - [x] powerpc64le-linux (cross, via `pkgsCross.powernv.nixVersions.nix_2_28.passthru.boehmgc`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
