### PR TITLE
abra: init at 0.11.0-beta

### DIFF
--- a/pkgs/by-name/ab/abra/package.nix
+++ b/pkgs/by-name/ab/abra/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitea,
+  writeScript,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "abra";
+  version = "0.11.0-beta";
+
+  src = fetchFromGitea {
+    domain = "git.coopcloud.tech";
+    owner = "toolshed";
+    repo = "abra";
+    rev = finalAttrs.version;
+    hash = "sha256-m0x5uC6E5p3Yj/oFw37s1e0biaF8Qh3hP4d9jew8mlA=";
+  };
+
+  vendorHash = null;
+
+  subPackages = [ "cmd/abra" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${finalAttrs.version}"
+  ];
+
+  passthru.updateScript = writeScript "update-abra" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl jq nix-update
+
+    set -euo pipefail
+
+    # Get latest release from Gitea API, sorted by published date
+    latest_version=$(curl -s "https://git.coopcloud.tech/api/v1/repos/toolshed/abra/releases" | \
+      jq -r 'sort_by(.published_at) | reverse | .[0].tag_name')
+
+    if [ -z "$latest_version" ] || [ "$latest_version" = "null" ]; then
+      echo "Could not find latest release"
+      exit 1
+    fi
+
+    echo "Latest version by release date: $latest_version"
+
+    nix-update --version="$latest_version" abra
+  '';
+
+  meta = {
+    description = "The Co-op Cloud utility belt - command-line tool for Co-op Cloud";
+    mainProgram = "abra";
+    homepage = "https://docs.coopcloud.tech/abra";
+    changelog = "https://git.coopcloud.tech/toolshed/abra/releases/tag/${finalAttrs.version}";
+    platforms = lib.platforms.unix;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ kolaente ];
+  };
+})


### PR DESCRIPTION
This adds [abra](https://git.coopcloud.tech/toolshed/abra), the coop-cloud utility belt. From their readme:

> `abra` is the flagship client & command-line tool for Co-op Cloud. It has been developed specifically for the purpose of making the day-to-day operations of [operators](https://docs.coopcloud.tech/operators/) and [maintainers](https://docs.coopcloud.tech/maintainers/) pleasant & convenient. It is libre software, written in [Go](https://go.dev/) and maintained and extended by the community 💖

More about coop-cloud: https://coopcloud.tech/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
