### PR TITLE
[release-25.05] xen: patch with XSA-472 and XSA-473

### DIFF
--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -1,5 +1,6 @@
 {
   buildXenPackage,
+  fetchpatch,
   python3Packages,
 }:
 
@@ -8,4 +9,20 @@ buildXenPackage.override { inherit python3Packages; } {
   version = "4.19.3";
   rev = "077419f04a3125c58dcf9724c954f98d1e927392";
   hash = "sha256-e9aPLgzNVxUn7WnLbBHwFIN02DAObfA24VjiqdiP+jA=";
+
+  patches = [
+    # XSA 472
+    (fetchpatch {
+      url = "https://xenbits.xen.org/xsa/xsa472-1.patch";
+      hash = "sha256-6k/X7KFno9uBG0mUtJxl7TMavaRs2Xlj9JlW9ai6p0k=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xen.org/xsa/xsa472-2.patch";
+      hash = "sha256-BisdztU9Wa5nIGmHo4IikqYPHdEhBehHaNqj1IuBe6I=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xen.org/xsa/xsa472-3.patch";
+      hash = "sha256-rikOofQeuLNMBkdQS3xzmwh7BlgMOTMSsQcAOEzNOso=";
+    })
+  ];
 }

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -24,5 +24,15 @@ buildXenPackage.override { inherit python3Packages; } {
       url = "https://xenbits.xen.org/xsa/xsa472-3.patch";
       hash = "sha256-rikOofQeuLNMBkdQS3xzmwh7BlgMOTMSsQcAOEzNOso=";
     })
+
+    # XSA 473
+    (fetchpatch {
+      url = "https://xenbits.xen.org/xsa/xsa473-1.patch";
+      hash = "sha256-594tTalWcGJSLj3++4QB/ADkHH1qJNrdvg7FG6kOuB8=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xen.org/xsa/xsa473-2.patch";
+      hash = "sha256-tGuIGxJFBXbckIruSUeTyrM6GabdIj6Pr3cVxeDvNNY=";
+    })
   ];
 }


### PR DESCRIPTION
Manual backport of #441454 due to the differences between the Xen builder in 25.05 and 25.11.

https://xenbits.xen.org/xsa/advisory-472.html
https://xenbits.xen.org/xsa/advisory-473.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
