### PR TITLE
yggdrasil-jumper: 0.3.1 -> 0.4.1, update module

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -116,6 +116,8 @@
 
 - `vmware-horizon-client` was renamed to `omnissa-horizon-client`, following [VMware's sale of their end-user business to Omnissa](https://www.omnissa.com/insights/introducing-omnissa-the-former-vmware-end-user-computing-business/). The binary has been renamed from `vmware-view` to `horizon-client`.
 
+- `yggdrasil-jumper` has been updated to v0.4, changing traversal protocol. See [release notes](https://github.com/one-d-wide/yggdrasil-jumper/releases/tag/v0.4.0).
+
 - `neovimUtils.makeNeovimConfig` now uses `customLuaRC` parameter instead of accepting `luaRcContent`. The old usage is deprecated but still works with a warning.
 
 - `telegram-desktop` packages now uses `Telegram` for its binary. The previous name was `telegram-desktop`. This is due to [an upstream decision](https://github.com/telegramdesktop/tdesktop/commit/56ff5808a3d766f892bc3c3305afb106b629ef6f) to make the name consistent with other platforms.

--- a/nixos/modules/services/networking/yggdrasil-jumper.nix
+++ b/nixos/modules/services/networking/yggdrasil-jumper.nix
@@ -10,11 +10,14 @@ let
     escapeShellArgs
     filter
     hasPrefix
+    makeBinPath
     mapAttrsToList
     mkEnableOption
     mkIf
     mkOption
     mkPackageOption
+    optional
+    optionals
     ;
   format = pkgs.formats.toml { };
 in
@@ -55,14 +58,23 @@ in
           '';
         };
 
+        detectWireguard = mkOption {
+          type = bool;
+          default = true;
+          description = ''
+            Control whether `settings.wireguard = true` should automatically
+            provide CAP_NET_ADMIN capability and make the necessary packages
+            available to Yggdrasil Jumper service.
+          '';
+        };
+
         settings = mkOption {
           type = format.type;
           default = { };
           example = {
             listen_port = 9999;
-            whitelist = [
-              "<IPv6 address of a remote node>"
-            ];
+            whitelist = [ "<IPv6 address of a remote node>" ];
+            wireguard = true;
           };
           description = ''
             Configuration for Yggdrasil Jumper as a Nix attribute set.
@@ -114,10 +126,22 @@ in
     let
       cfg = config.services.yggdrasil-jumper;
 
+      wg = cfg.detectWireguard && (cfg.settings ? wireguard) && cfg.settings.wireguard;
+      wgExtraPkgs = optionals wg (
+        with pkgs;
+        [
+          iproute2
+          iptables
+          wireguard-tools
+          conntrack-tools
+        ]
+      );
+
       # Generate, concatenate and validate config file
       jumperSettings = format.generate "yggdrasil-jumper-settings" cfg.settings;
       jumperExtraConfig = pkgs.writeText "yggdrasil-jumper-extra-config" cfg.extraConfig;
       jumperConfig = pkgs.runCommand "yggdrasil-jumper-config" { } ''
+        export PATH="${makeBinPath wgExtraPkgs}:$PATH"
         cat ${jumperSettings} ${jumperExtraConfig} \
           | tee $out \
           | ${cfg.package}/bin/yggdrasil-jumper --validate --config -
@@ -158,6 +182,7 @@ in
         unitConfig.BindsTo = [ "yggdrasil.service" ];
         wantedBy = [ "multi-user.target" ];
 
+        path = wgExtraPkgs;
         serviceConfig = {
           User = "yggdrasil";
           DynamicUser = true;
@@ -179,9 +204,16 @@ in
           MemoryDenyWriteExecute = true;
           ProtectControlGroups = true;
           ProtectHome = "tmpfs";
-          RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6";
+          RestrictAddressFamilies = [
+            "AF_UNIX"
+            "AF_INET"
+            "AF_INET6"
+          ]
+          ++ optional wg "AF_NETLINK";
           RestrictNamespaces = true;
           RestrictRealtime = true;
+          AmbientCapabilities = optional wg "CAP_NET_ADMIN";
+          CapabilityBoundingSet = optional wg "CAP_NET_ADMIN";
           SystemCallArchitectures = "native";
           SystemCallFilter = [
             "@system-service"

--- a/pkgs/by-name/yg/yggdrasil-jumper/package.nix
+++ b/pkgs/by-name/yg/yggdrasil-jumper/package.nix
@@ -7,16 +7,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "yggdrasil-jumper";
-  version = "0.3.1";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "one-d-wide";
     repo = "yggdrasil-jumper";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Op3KBJ911AjB7BIJuV4xR8KHMxBtQj7hf++tC1g7SlM=";
+    hash = "sha256-e/QTLWqRlEFMl3keQMeJaxfVJh28W/WbuUsmEAaLAf4=";
   };
 
-  cargoHash = "sha256-EbG83rGlUbiJC1qm9H1+YrCFSq23kSDeW7KMHP8Wee8=";
+  cargoHash = "sha256-aWDeRcOV/5x0BB0aunp52en9hIuPrYr+pNgLCjiscaE=";
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
https://github.com/one-d-wide/yggdrasil-jumper/releases/tag/v0.4.1

## Changes

- Bump package version.
- Update the module to support wireguard option (provide cap_net_admin and the required packages).
- Apply nixfmt (rfc style).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
