### PR TITLE
uradvd: init at 0-unstable-2025-08-16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -887,6 +887,12 @@
     githubId = 4717906;
     name = "Jakub Skokan";
   };
+  aiyion = {
+    email = "git@aiyionpri.me";
+    github = "AiyionPrime";
+    githubId = 6937725;
+    name = "Jan-Niklas Burfeind";
+  };
   ajaxbits = {
     email = "contact@ajaxbits.com";
     github = "ajaxbits";

--- a/pkgs/by-name/ur/uradvd/package.nix
+++ b/pkgs/by-name/ur/uradvd/package.nix
@@ -1,0 +1,34 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation {
+  pname = "uradvd";
+  version = "0-unstable-2025-08-16";
+
+  src = fetchFromGitHub {
+    owner = "freifunk-gluon";
+    repo = "uradvd";
+    rev = "b37524dfb0292c425fd61f5bffb3101fb1979264";
+    hash = "sha256-PyOAt9dTFdHHF7OlHi9BBTjCN2Hmk8BsHkD2rV94ZDM=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D --mode=0755 uradvd -t "$out/bin"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Tiny IPv6 Router Advertisement Daemon";
+    homepage = "https://github.com/freifunk-gluon/uradvd";
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ aiyion ];
+    mainProgram = "uradvd";
+  };
+}


### PR DESCRIPTION
uradvd is a small IPv6 RA daemon mainly used for Freifunk in Germany.
https://github.com/freifunk-gluon/uradvd/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
