### PR TITLE
teams/cachix: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22809,6 +22809,13 @@
     githubId = 96694484;
     name = "Sandeep Patel";
   };
+  sandydoo = {
+    name = "Sander";
+    github = "sandydoo";
+    githubId = 7572407;
+    email = "hey@sandydoo.me";
+    matrix = "@sandydoo:matrix.org";
+  };
   Sanskarzz = {
     email = "sanskar.gur@gmail.com";
     github = "Sanskarzz";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -168,6 +168,16 @@ with lib.maintainers;
     shortName = "c3d2";
   };
 
+  cachix = {
+    # Verify additions to this team with at least one existing member of the team.
+    members = [
+      domenkozar
+      sandydoo
+    ];
+    scope = "Group registration for packages maintained by Cachix.";
+    shortName = "Cachix employees";
+  };
+
   categorization = {
     members = [
       aleksana

--- a/nixos/modules/services/system/cachix-agent/default.nix
+++ b/nixos/modules/services/system/cachix-agent/default.nix
@@ -8,7 +8,7 @@ let
   cfg = config.services.cachix-agent;
 in
 {
-  meta.maintainers = [ lib.maintainers.domenkozar ];
+  meta.maintainers = lib.teams.cachix.members;
 
   options.services.cachix-agent = {
     enable = lib.mkEnableOption "Cachix Deploy Agent: <https://docs.cachix.org/deploy/>";

--- a/nixos/modules/services/system/cachix-watch-store.nix
+++ b/nixos/modules/services/system/cachix-watch-store.nix
@@ -8,10 +8,9 @@ let
   cfg = config.services.cachix-watch-store;
 in
 {
-  meta.maintainers = [
-    lib.maintainers.jfroche
-    lib.maintainers.domenkozar
-  ];
+  meta = {
+    maintainers = lib.teams.cachix.members ++ [ lib.maintainers.jfroche ];
+  };
 
   options.services.cachix-watch-store = {
     enable = lib.mkEnableOption "Cachix Watch Store: <https://docs.cachix.org>";

--- a/pkgs/by-name/de/devenv/package.nix
+++ b/pkgs/by-name/de/devenv/package.nix
@@ -101,6 +101,6 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/cachix/devenv";
     license = lib.licenses.asl20;
     mainProgram = "devenv";
-    maintainers = with lib.maintainers; [ domenkozar ];
+    teams = [ lib.teams.cachix ];
   };
 }

--- a/pkgs/by-name/se/secretspec/package.nix
+++ b/pkgs/by-name/se/secretspec/package.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Declarative secrets, every environment, any provider";
     homepage = "https://secretspec.dev";
     license = with lib.licenses; [ asl20 ];
-    maintainers = with lib.maintainers; [ domenkozar ];
+    teams = [ lib.teams.cachix ];
     mainProgram = "secretspec";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Adds a `cachix` team whose members are employees of [Cachix](https://cachix.org/).
- Adds [`sandydoo`](https://github.com/sandydoo) (me) to the maintainers list.
- Sets the `cachix` team responsible for Cachix-related packages and modules, where possible. The cachix CLI remains under @domenkozar as it's not clear to me whether hackage2nix supports configuring multiple maintainers.

cc @domenkozar

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Verified with:

`nix-build lib/tests/maintainers.nix`

and 

`nix-build lib/tests/teams.nix`

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
