### PR TITLE
xmrig-cuda{,-mo}: init at 6.22.1{,-mo1}

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1062,6 +1062,13 @@
     githubId = 22500561;
     name = "Albert Ilagan";
   };
+  albertlarsan68 = {
+    email = "albertlarsan@albertlarsan.fr";
+    github = "albertlarsan68";
+    githubId = 74931857;
+    matrix = "@albertlarsan68:albertlarsan.fr";
+    name = "Albert Larsan";
+  };
   albertodvp = {
     email = "alberto.fanton@protonmail.com";
     github = "albertodvp";

--- a/pkgs/by-name/xm/xmrig-cuda-mo/package.nix
+++ b/pkgs/by-name/xm/xmrig-cuda-mo/package.nix
@@ -1,0 +1,70 @@
+{
+  autoAddDriverRunpath,
+  cmake,
+  cudaPackages,
+  fetchFromGitHub,
+  fetchpatch,
+  lib,
+}:
+cudaPackages.backendStdenv.mkDerivation (finalAttrs: {
+  pname = "xmrig-cuda-mo";
+  version = "6.22.1-mo1";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "MoneroOcean";
+    repo = "xmrig-cuda";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-O6VFZUuCrR2/or4BZQaqBXcmHMCbeCNqyvSKJ0Pef/Y=";
+  };
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/xmrig/xmrig-cuda/commit/5947ae05f87eb7966fbe0ad2db149a496f908e87.patch";
+      hash = "sha256-5fxlc09DnJ2uNZAdhYdLv67RHCha7+SfMg9XzwwrN9o=";
+    })
+    (fetchpatch {
+      url = "https://github.com/xmrig/xmrig-cuda/commit/d0065c315779b28f12944a74694f81e13fb01ece.patch";
+      hash = "sha256-8lU3s2b1eh7fvcMze/FIiaURFrkypVGJisrE7w0aDM4=";
+    })
+  ];
+  postPatch = ''
+    substituteInPlace cmake/flags.cmake \
+      --replace-fail 'set(CMAKE_CXX_STANDARD 11)' 'set(CMAKE_CXX_STANDARD 17)' \
+      --replace-fail '-std=c++11' '-std=c++17'
+    substituteInPlace src/cuda_cryptonight_gpu.hpp \
+      --replace-fail 'int_as_float' '__int_as_float' \
+      --replace-fail 'int2float' '__int2float_rn' \
+      --replace-fail 'float_as_int' '__float_as_int'
+  '';
+
+  nativeBuildInputs = [
+    autoAddDriverRunpath
+    cmake
+    cudaPackages.cuda_nvcc
+  ];
+
+  buildInputs = [
+    cudaPackages.cuda_nvrtc
+    cudaPackages.cuda_nvcc
+    cudaPackages.cuda_cudart
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -vD libxmrig-cuda.so $out/lib/libxmrig-cuda.so
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Fork of the XMRig CPU miner (CUDA plugin) with support for algorithm switching";
+    homepage = "https://github.com/MoneroOcean/xmrig-cuda";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      albertlarsan68
+    ];
+  };
+})

--- a/pkgs/by-name/xm/xmrig-cuda/package.nix
+++ b/pkgs/by-name/xm/xmrig-cuda/package.nix
@@ -1,0 +1,66 @@
+{
+  autoAddDriverRunpath,
+  cmake,
+  cudaPackages,
+  fetchFromGitHub,
+  fetchpatch,
+  lib,
+}:
+cudaPackages.backendStdenv.mkDerivation (finalAttrs: {
+  pname = "xmrig-cuda";
+  version = "6.22.1";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "xmrig";
+    repo = "xmrig-cuda";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-krS0ygKclXDLti24PDnBFUetOAYkYM8jty4C3PSOEWY=";
+  };
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/xmrig/xmrig-cuda/commit/5947ae05f87eb7966fbe0ad2db149a496f908e87.patch";
+      hash = "sha256-5fxlc09DnJ2uNZAdhYdLv67RHCha7+SfMg9XzwwrN9o=";
+    })
+    (fetchpatch {
+      url = "https://github.com/xmrig/xmrig-cuda/commit/d0065c315779b28f12944a74694f81e13fb01ece.patch";
+      hash = "sha256-8lU3s2b1eh7fvcMze/FIiaURFrkypVGJisrE7w0aDM4=";
+    })
+  ];
+  postPatch = ''
+    substituteInPlace cmake/flags.cmake \
+      --replace-fail 'set(CMAKE_CXX_STANDARD 11)' 'set(CMAKE_CXX_STANDARD 17)' \
+      --replace-fail '-std=c++11' '-std=c++17'
+  '';
+
+  nativeBuildInputs = [
+    autoAddDriverRunpath
+    cmake
+    cudaPackages.cuda_nvcc
+  ];
+
+  buildInputs = [
+    cudaPackages.cuda_nvrtc
+    cudaPackages.cuda_nvcc
+    cudaPackages.cuda_cudart
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -vD libxmrig-cuda.so $out/lib/libxmrig-cuda.so
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Monero (XMR) CPU miner, CUDA plugin";
+    homepage = "https://github.com/xmrig/xmrig-cuda";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      albertlarsan68
+    ];
+  };
+})


### PR DESCRIPTION
Adds the CUDA plugin for xmrig and xmrig-mo.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
