### PR TITLE
tidgi: 0.12.1 -> 0.12.4

### DIFF
--- a/pkgs/by-name/ti/tidgi/package.nix
+++ b/pkgs/by-name/ti/tidgi/package.nix
@@ -8,18 +8,19 @@
   ast-grep,
   common-updater-scripts,
 }:
-stdenv.mkDerivation rec {
+
+stdenv.mkDerivation (finalAttrs: {
   pname = "tidgi";
   version = "0.12.4";
 
   src =
     {
       x86_64-darwin = fetchurl {
-        url = "https://github.com/tiddly-gittly/TidGi-Desktop/releases/download/v${version}/TidGi-darwin-x64-${version}.zip";
+        url = "https://github.com/tiddly-gittly/TidGi-Desktop/releases/download/v${finalAttrs.version}/TidGi-darwin-x64-${finalAttrs.version}.zip";
         hash = "sha256-nxfnPz2oxsYUsT2Q9ADDxVq5xcJvkNDQTBX8EkGUF4g=";
       };
       aarch64-darwin = fetchurl {
-        url = "https://github.com/tiddly-gittly/TidGi-Desktop/releases/download/v${version}/TidGi-darwin-arm64-${version}.zip";
+        url = "https://github.com/tiddly-gittly/TidGi-Desktop/releases/download/v${finalAttrs.version}/TidGi-darwin-arm64-${finalAttrs.version}.zip";
         hash = "sha256-bSJFM67+KVECUqjwu1HYipn+zOps1ahNzM721yZL52c=";
       };
     }
@@ -62,7 +63,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    changelog = "https://github.com/tiddly-gittly/TidGi-Desktop/releases/tag/v${version}";
+    changelog = "https://github.com/tiddly-gittly/TidGi-Desktop/releases/tag/v${finalAttrs.version}";
     description = "Customizable personal knowledge-base and blogging platform with git as backup manager";
     homepage = "https://github.com/tiddly-gittly/TidGi-Desktop";
     license = lib.licenses.mpl20;
@@ -73,4 +74,4 @@ stdenv.mkDerivation rec {
     ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
-}
+})

--- a/pkgs/by-name/ti/tidgi/package.nix
+++ b/pkgs/by-name/ti/tidgi/package.nix
@@ -3,20 +3,24 @@
   stdenv,
   fetchurl,
   unzip,
+  writeShellScript,
+  jq,
+  ast-grep,
+  common-updater-scripts,
 }:
 stdenv.mkDerivation rec {
   pname = "tidgi";
-  version = "0.12.1";
+  version = "0.12.4";
 
   src =
     {
       x86_64-darwin = fetchurl {
-        url = "https://github.com/tiddly-gittly/TidGi-Desktop/releases/download/v${version}-update/TidGi-darwin-x64-${version}.zip";
-        hash = "sha256-XZraotf6ewsrb2LBbZTTRMrT+B52NNWsZY/Qxju8hNw=";
+        url = "https://github.com/tiddly-gittly/TidGi-Desktop/releases/download/v${version}/TidGi-darwin-x64-${version}.zip";
+        hash = "sha256-nxfnPz2oxsYUsT2Q9ADDxVq5xcJvkNDQTBX8EkGUF4g=";
       };
       aarch64-darwin = fetchurl {
-        url = "https://github.com/tiddly-gittly/TidGi-Desktop/releases/download/v${version}-update/TidGi-darwin-arm64-${version}.zip";
-        hash = "sha256-/fcMCS7k2LT0ELcrFPpiQ/WNJtxaJoYOLLhROHTgIdY=";
+        url = "https://github.com/tiddly-gittly/TidGi-Desktop/releases/download/v${version}/TidGi-darwin-arm64-${version}.zip";
+        hash = "sha256-bSJFM67+KVECUqjwu1HYipn+zOps1ahNzM721yZL52c=";
       };
     }
     .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
@@ -34,6 +38,27 @@ stdenv.mkDerivation rec {
     cp -r *.app "$out/Applications"
 
     runHook postInstall
+  '';
+
+  passthru.updateScript = writeShellScript "update-tidgi" ''
+    version=$(nix eval --raw --file . tidgi.version)
+    latestVersion=$(curl ''${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} --fail --silent https://api.github.com/repos/tiddly-gittly/TidGi-Desktop/releases/latest | ${lib.getExe jq} --raw-output .tag_name | sed 's/^v//')
+    if [[ "$latestVersion" == "$version" ]]; then
+      exit 0
+    fi
+    ${lib.getExe ast-grep} scan --inline-rules "
+    id: update-version
+    language: nix
+    rule:
+      kind: binding
+      regex: '^\s*version\s*='
+    fix: 'version = \"$latestVersion\";'
+    " --update-all $(env EDITOR=echo nix edit --file . tidgi)
+    systems=$(nix eval --json -f . tidgi.meta.platforms | ${lib.getExe jq} --raw-output '.[]')
+    for system in $systems; do
+      hash=$(nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url $(nix eval --raw --file . tidgi.src.url --system "$system")))
+      ${lib.getExe' common-updater-scripts "update-source-version"} tidgi $latestVersion $hash --system=$system --ignore-same-version --ignore-same-hash
+    done
   '';
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/tiddly-gittly/TidGi-Desktop/releases/tag/v0.12.4
https://github.com/tiddly-gittly/TidGi-Desktop/compare/v0.12.1...v0.12.4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
