### PR TITLE
kiro: 0.2.13 -> 0.2.38

### DIFF
--- a/pkgs/by-name/ki/kiro/package.nix
+++ b/pkgs/by-name/ki/kiro/package.nix
@@ -15,12 +15,12 @@ in
   inherit useVSCodeRipgrep;
   commandLineArgs = extraCommandLineArgs;
 
-  version = "0.2.13";
+  version = "0.2.38";
   pname = "kiro";
 
   # You can find the current VSCode version in the About dialog:
   # workbench.action.showAboutDialog (Help: About)
-  vscodeVersion = "1.94.0";
+  vscodeVersion = "1.100.3";
 
   executableName = "kiro";
   longName = "Kiro";

--- a/pkgs/by-name/ki/kiro/sources.json
+++ b/pkgs/by-name/ki/kiro/sources.json
@@ -1,14 +1,14 @@
 {
   "x86_64-linux": {
-    "url": "https://prod.download.desktop.kiro.dev/releases/202508150626--distro-linux-x64-tar-gz/202508150626-distro-linux-x64.tar.gz",
-    "hash": "sha256-ORgN7gOyHGkO/ewqy62H0oNweZz7ViUAuEtXM1WgYIE="
+    "url": "https://prod.download.desktop.kiro.dev/releases/202509032213--distro-linux-x64-tar-gz/202509032213-distro-linux-x64.tar.gz",
+    "hash": "sha256-nqOtD7Ef7dLYHzAM2jTybV/paUPjPYBJpa2AM0lnyIE="
   },
   "x86_64-darwin": {
-    "url": "https://prod.download.desktop.kiro.dev/releases/202508150626-Kiro-dmg-darwin-x64.dmg",
-    "hash": "sha256-8lIiMfDxp8VuRG/tiuojtOksc6oGT0+ZPpSAriRmKYU="
+    "url": "https://prod.download.desktop.kiro.dev/releases/202509032213-Kiro-dmg-darwin-x64.dmg",
+    "hash": "sha256-IdLKALVT5yj6oTJnOnqAqMzN29ZzI2XFMm61YwwaT/Q="
   },
   "aarch64-darwin": {
-    "url": "https://prod.download.desktop.kiro.dev/releases/202508150626-Kiro-dmg-darwin-arm64.dmg",
-    "hash": "sha256-2WGLIspDErwa1CZmSTTFa4aNCi6T/8x3vDNalNsm4xQ="
+    "url": "https://prod.download.desktop.kiro.dev/releases/202509032213-Kiro-dmg-darwin-arm64.dmg",
+    "hash": "sha256-bqBNm0O6jZS5R+xyuxRys1Sgw3e6QiyHDJ3BKC8UzIo="
   }
 }


### PR DESCRIPTION
👋 **Kiro v0.2.38** is Here! 🚀

Thank you for your feedback and bug reports here and on GitHub — they directly help us improve Kiro. We've released a new version 0.2.38 with editor performance improvements and bug fixes. Update your IDE now to get these latest improvements!

**Performance & Reliability**

- **Code OSS v1.100.3 Upgrade**: Updated to Code OSS v1.100.3 that adds improved stability and performance improvements
- **Faster Response Times**: Optimized request handling makes interactions more efficient and improves performance
- **Improved Session Management**: Enhanced backend processing reduces interruptions and allows for longer continuous work sessions

**Enhanced User Experience**

- **Enhanced Tool Call Recovery**: When tool invocations result in repeated failures, Kiro now prompts for your intervention instead of continuing indefinitely, protecting your usage limits and preventing loops
- **Enhanced Security Patterns**: Expanded detection of dangerous shell commands with improved pattern recognition. Risky commands require manual review unless you explicitly trust them. [Learn more about security patterns](https://kiro.dev/docs/chat/terminal/#dangerous-patterns).

**Bug Fixes**

- **Git Repository Initialization**: Fixed issue that prevented Git setup for new projects without existing repositories
- **Model Selection Persistence**: Fixed chat model selection not being saved when restarting Kiro IDE

Want to know what's new in each release? We've got you covered! Check our announcements here or visit our [changelog page](https://kiro.dev/changelog/). Keep the feedback coming!

Until next time, 
Happy coding!

---

Above message is the announcement from Kiro's official discord.
Although a passthru.updateScript is already defined, this PR is done manually due to the internal Code OSS version update, which is not handled by the script.
Supersedes #441490 
Closes #441490 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
