### PR TITLE
audit: 4.1.1-unstable-2025-08-01 -> 4.1.2, cleanup

### DIFF
--- a/nixos/modules/security/audit.nix
+++ b/nixos/modules/security/audit.nix
@@ -95,7 +95,10 @@ in
 
     environment.systemPackages = [ pkgs.audit ];
 
-    systemd.services.audit-rules = {
+    # upstream contains a audit-rules.service, which uses augenrules.
+    # That script does not handle cleanup correctly and insists on loading from /etc/audit.
+    # So, instead we have our own service for loading rules.
+    systemd.services.audit-rules-nixos = {
       description = "Load Audit Rules";
       wantedBy = [ "sysinit.target" ];
       before = [

--- a/nixos/modules/security/auditd.nix
+++ b/nixos/modules/security/auditd.nix
@@ -229,7 +229,7 @@ in
         path = lib.getExe' pkgs.audit "audisp-af_unix";
         args = [
           "0640"
-          "/var/run/audispd_events"
+          "/run/audit/audispd_events"
           "string"
         ];
         format = "binary";

--- a/nixos/modules/services/security/opensnitch.nix
+++ b/nixos/modules/services/security/opensnitch.nix
@@ -167,6 +167,15 @@ in
               '';
             };
 
+            Audit.AudispSocketPath = lib.mkOption {
+              type = lib.types.path;
+              default = "/run/audit/audispd_events";
+              description = ''
+                Configure audit socket path. Used when
+                `settings.ProcMonitorMethod` is set to `audit`.
+              '';
+            };
+
             Rules.Path = lib.mkOption {
               type = lib.types.path;
               default = "/var/lib/opensnitch/rules";

--- a/nixos/tests/audit.nix
+++ b/nixos/tests/audit.nix
@@ -40,7 +40,7 @@
       t.assertIn("backlog_limit 512", audit_status)
 
     with subtest("unix socket plugin activated"):
-      machine.succeed("stat /var/run/audispd_events")
+      machine.succeed("stat /run/audit/audispd_events")
 
     with subtest("Custom rule produces audit traces"):
       machine.succeed("hello")

--- a/nixos/tests/audit.nix
+++ b/nixos/tests/audit.nix
@@ -31,7 +31,7 @@
   };
 
   testScript = ''
-    machine.wait_for_unit("audit-rules.service")
+    machine.wait_for_unit("audit-rules-nixos.service")
     machine.wait_for_unit("auditd.service")
 
     with subtest("Audit subsystem gets enabled"):
@@ -46,8 +46,8 @@
       machine.succeed("hello")
       print(machine.succeed("ausearch -k nixos-test -sc exit_group"))
 
-    with subtest("Stopping audit-rules.service disables the audit subsystem"):
-      machine.succeed("systemctl stop audit-rules.service")
+    with subtest("Stopping audit-rules-nixos.service disables the audit subsystem"):
+      machine.succeed("systemctl stop audit-rules-nixos.service")
       t.assertIn("enabled 0", machine.succeed("auditctl -s"))
   '';
 

--- a/pkgs/by-name/au/audit/package.nix
+++ b/pkgs/by-name/au/audit/package.nix
@@ -41,10 +41,6 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs auparse/test/auparse_test.py
   '';
 
-  # https://github.com/linux-audit/audit-userspace/issues/474
-  # building databuf_test fails otherwise, as that uses hidden symbols only available in the static builds
-  dontDisableStatic = true;
-
   outputs = [
     "bin"
     "lib"

--- a/pkgs/by-name/au/audit/package.nix
+++ b/pkgs/by-name/au/audit/package.nix
@@ -9,7 +9,6 @@
   linuxHeaders,
   python3,
   swig,
-  pkgsCross,
   libcap_ng,
   installShellFiles,
 
@@ -17,9 +16,13 @@
   # configure script tries executing python to gather info instead of relying on
   # python3-config exclusively
   enablePython ? stdenv.hostPlatform == stdenv.buildPlatform,
+
+  # passthru
   nix-update-script,
   testers,
   nixosTests,
+  pkgsStatic ? { }, # CI has allowVariants = false, in which case pkgsMusl would not be passed. So, instead add a default here.
+  pkgsMusl ? { },
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "audit";
@@ -108,7 +111,8 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = nix-update-script { };
     tests = {
-      musl = pkgsCross.musl64.audit;
+      musl = pkgsMusl.audit or null;
+      static = pkgsStatic.audit or null;
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       audit = nixosTests.audit;
     };

--- a/pkgs/by-name/au/audit/package.nix
+++ b/pkgs/by-name/au/audit/package.nix
@@ -36,6 +36,9 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace bindings/swig/src/auditswig.i \
       --replace-fail "/usr/include/linux/audit.h" \
                      "${linuxHeaders}/include/linux/audit.h"
+  ''
+  + lib.optionalString (enablePython && finalAttrs.finalPackage.doCheck) ''
+    patchShebangs auparse/test/auparse_test.py
   '';
 
   # https://github.com/linux-audit/audit-userspace/issues/474
@@ -97,6 +100,8 @@ stdenv.mkDerivation (finalAttrs: {
     bash
     bashNonInteractive
   ];
+
+  doCheck = true;
 
   postInstall = ''
     installShellCompletion --bash init.d/audit.bash_completion

--- a/pkgs/by-name/au/audit/package.nix
+++ b/pkgs/by-name/au/audit/package.nix
@@ -11,6 +11,10 @@
   swig,
   libcap_ng,
   installShellFiles,
+  makeWrapper,
+  gawk,
+  gnugrep,
+  coreutils,
 
   enablePython ? !stdenv.hostPlatform.isStatic,
 
@@ -58,6 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     autoreconfHook
     installShellFiles
+    makeWrapper
   ]
   ++ lib.optionals enablePython [
     python3Packages.python # for python3-config
@@ -107,6 +112,20 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = ''
     installShellCompletion --bash init.d/audit.bash_completion
+  '';
+
+  postFixup = ''
+    substituteInPlace $bin/bin/augenrules \
+      --replace-fail "/sbin/auditctl" "$bin/bin/auditctl" \
+      --replace-fail "/bin/ls" "ls"
+    wrapProgram $bin/bin/augenrules \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          gawk
+          gnugrep
+          coreutils
+        ]
+      }
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/au/audit/package.nix
+++ b/pkgs/by-name/au/audit/package.nix
@@ -23,13 +23,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "audit";
-  version = "4.1.1-unstable-2025-08-01";
+  version = "4.1.2-unstable-2025-09-06"; # fixes to non-static builds right after 4.1.2 release
 
   src = fetchFromGitHub {
     owner = "linux-audit";
     repo = "audit-userspace";
-    rev = "bee5984843d0b38992a369825a87a65fb54b18fc"; # musl fixes, --disable-legacy-actions and --runstatedir support
-    hash = "sha256-l3JHWEHz2xGrYxEvfCUD29W8xm5llUnXwX5hLymRG74=";
+    rev = "cb13fe75ee2c36d5c525ed9de22aae10dbc8caf4";
+    hash = "sha256-NX0TWA+LtcZgbM9aQfokWv2rGNAAb3ksGqAH8URAkYM=";
   };
 
   postPatch = ''
@@ -116,7 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://people.redhat.com/sgrubb/audit/";
     description = "Audit Library";
-    changelog = "https://github.com/linux-audit/audit-userspace/releases/tag/v4.1.1";
+    changelog = "https://github.com/linux-audit/audit-userspace/releases/tag/v4.1.2";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ grimmauld ];
     pkgConfigModules = [

--- a/pkgs/by-name/op/opensnitch/package.nix
+++ b/pkgs/by-name/op/opensnitch/package.nix
@@ -1,6 +1,7 @@
 {
   buildGoModule,
   fetchFromGitHub,
+  fetchpatch,
   protobuf,
   go-protobuf,
   pkg-config,
@@ -42,6 +43,20 @@ buildGoModule (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-XAR7yZjAzbMxIVGSV82agpAGwlejkILGgDI6iRicZuQ=";
   };
+
+  patches = [
+    (fetchpatch {
+      # https://github.com/evilsocket/opensnitch/pull/1418
+      # allow configuring the audit socket path
+      url = "https://github.com/evilsocket/opensnitch/commit/f9358a464f204068359bf5174e6ff43288f12c7e.patch?full_index=1";
+      hash = "sha256-s9CM1CyGpfJZXEtihXCM7nfPhBY8XuwubynTotqtf3E=";
+    })
+    (fetchpatch {
+      # add missing colon in test definition
+      url = "https://github.com/evilsocket/opensnitch/commit/4b38ca1260295d2e0f8c4a7313529f83dcca4554.patch?full_index=1";
+      hash = "sha256-/z3iFRpcv75FyarVnpK8/PTU2fcFHS+SNbHn7M5Etk8=";
+    })
+  ];
 
   postPatch = ''
     # Allow configuring Version at build time

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1136,6 +1136,12 @@ self: super: with self; {
 
   audiotools = callPackage ../development/python-modules/audiotools { };
 
+  audit = toPythonModule (
+    pkgs.audit.override {
+      python3Packages = self;
+    }
+  );
+
   auditok = callPackage ../development/python-modules/auditok { };
 
   auditwheel = callPackage ../development/python-modules/auditwheel {


### PR DESCRIPTION
- Release Notes for 4.1.2: https://github.com/linux-audit/audit-userspace/releases/tag/v4.1.2
- the default audisp socket path was changed, so the default in nix was adjusted accordingly. This allows removing the dependency on `systemd-tmpfiles-setup.service`
- adjusted the audit test to look for the new socket path
- adjusted opensnitch to use the new socket path
- set `doCheck = true` (required patching a `#! /usr/bin/env` shebang)
- disabled static build by default (was enabled to allow tests of audit internals to build, but these will now automatically be disabled if static is disabled, thanks to a patch upstream)
- enabled python bindings on cross, disabled them on static (makes little sense, wouldn't be importable)
- added audit to the python package set so it can be imported on all python3 versions
- cleaned up passthru tests
- added `pythonImportsCheckHook`


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
