### PR TITLE
fetchurl: Add missing arg to `toPretty` invocation

### DIFF
--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -191,7 +191,7 @@ let
         outputHash = "";
       }
     else
-      throw "fetchurl requires a hash for fixed-output derivation: ${lib.generators.toPretty urls_}";
+      throw "fetchurl requires a hash for fixed-output derivation: ${lib.generators.toPretty { } urls_}";
 
   resolvedUrl =
     let


### PR DESCRIPTION
Thanks to @emilazy for the report:
https://github.com/NixOS/nixpkgs/pull/393136#issuecomment-3268711663

Fixes this crash:

```
… from call site
  at /Users/emily/Developer/nixpkgs/pkgs/build-support/fetchurl/default.nix:194:70:
   193|     else
   194|       throw "fetchurl requires a hash for fixed-output derivation: ${lib.generators.toPretty urls_}";
      |                                                                      ^
   195|

… while evaluating the value passed for the lambda argument
  at /Users/emily/Developer/nixpkgs/lib/generators.nix:524:5:
   523|   toPretty =
   524|     {
      |     ^
   525|       allowPrettyValues ? false,

error: expected a set but found a list: [ "https://cmake.org/files/v4.1/cmake-4.1.1.tar.gz" ]
```

It'll still crash, but with a nicer error message!

Follow-up to #393136.