### PR TITLE
perl: unconditionally set _GNU_SOURCE

### DIFF
--- a/pkgs/development/interpreters/perl/interpreter.nix
+++ b/pkgs/development/interpreters/perl/interpreter.nix
@@ -159,6 +159,7 @@ stdenv.mkDerivation (
         "-Dinstallstyle=lib/perl5"
         "-Dlocincpth=${libcInc}/include"
         "-Dloclibpth=${libcLib}/lib"
+        "-Accflags=-D_GNU_SOURCE"
       ]
       ++ lib.optional stdenv.hostPlatform.isStatic "-Uusedl"
       ++ lib.optionals ((builtins.match ''5\.[0-9]*[13579]\..+'' version) != null) [


### PR DESCRIPTION
Perl uses GNU extensions if they are available.  Its build system tries to detect whether the libc is one that recognizes `_GNU_SOURCE` with bad heuristics, that don't work for e.g. riscv64 musl.  Upstream is [not willing](https://github.com/Perl/perl5/issues/16807#issuecomment-544099623) to unconditionally set `_GNU_SOURCE` like programs usually do, because of an IMO misguided fear of somebody one day writing a libc that interprets `_GNU_SOURCE` to mean something different, so the only thing we can really do is set it ourselves. On libcs that don't gate GNU extensions behind `_GNU_SOURCE`, like BSDs, this should be a no-op.  This should also improve things for cross where musl builds are currently [broken](https://github.com/arsv/perl-cross/issues/158) due to perl-cross setting `_GNU_SOURCE` for the configure step but not the build step, although I haven't tested that.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] riscv64-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
