### PR TITLE
python3Packages.mmengine: fix broken tests on Darwin

### DIFF
--- a/pkgs/development/python-modules/mmengine/default.nix
+++ b/pkgs/development/python-modules/mmengine/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
@@ -117,6 +118,18 @@ buildPythonPackage rec {
 
     # AttributeError: type object 'MagicMock' has no attribute ...
     "tests/test_fileio/test_backends/test_petrel_backend.py::TestPetrelBackend"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # RuntimeError: attempt to insert nil object from objects[1]
+    "tests/test_visualizer/test_visualizer.py::TestVisualizer::test_draw_featmap"
+    "tests/test_visualizer/test_visualizer.py::TestVisualizer::test_show"
+
+    # AssertionError: torch.bfloat16 != torch.float32
+    "tests/test_runner/test_amp.py::TestAmp::test_autocast"
+
+    # ValueError: User specified autocast device_type must be cuda or cpu, but got mps
+    "tests/test_runner/test_runner.py::TestRunner::test_test"
+    "tests/test_runner/test_runner.py::TestRunner::test_val"
   ];
 
   disabledTests = [
@@ -133,7 +146,15 @@ buildPythonPackage rec {
 
     # AssertionError: os is not <module 'os' (frozen)>
     "test_lazy_module"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Fails when max-jobs is set to use fewer processes than cores
+    # for example `AssertionError: assert 14 == 4`
+    "test_setup_multi_processes"
   ];
+
+  # torch.distributed.DistNetworkError: The server socket has failed to bind.
+  __darwinAllowLocalNetworking = true;
 
   meta = {
     description = "Library for training deep learning models based on PyTorch";


### PR DESCRIPTION
On Darwin:
1. Multiple tests fail when sandboxed with `The server socket has failed to bind`. Enabled local networking.
2. Multiple Darwin-specific failures. Disabled.
3. Test fails when `max-jobs` is set to use fewer processes than cores. Disabled.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
