### PR TITLE
wa-crypt-tools: init at 0.1.0

### DIFF
--- a/pkgs/by-name/wa/wa-crypt-tools/package.nix
+++ b/pkgs/by-name/wa/wa-crypt-tools/package.nix
@@ -1,0 +1,41 @@
+{
+  python3Packages,
+  lib,
+  versionCheckHook,
+  fetchPypi,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "wa-crypt-tools";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "wa_crypt_tools";
+    inherit version;
+    hash = "sha256-E/k2lKxlBxUDnfbeELHBi3sML3T+BQJ3zPHh4hGviJ4=";
+  };
+
+  build-system = [
+    python3Packages.setuptools-scm
+  ];
+
+  dependencies = [
+    python3Packages.javaobj-py3
+    python3Packages.pycryptodomex
+    python3Packages.protobuf5
+  ];
+
+  # The program does not provide a --version flag.
+  dontVersionCheck = true;
+
+  pythonRelaxDeps = [ "protobuf" ];
+
+  meta = {
+    description = "Manage WhatsApp .crypt12, .crypt14 and .crypt15 files";
+    mainProgram = "wadecrypt";
+    homepage = "https://github.com/ElDavoo/wa-crypt-tools";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ kmein ];
+  };
+}


### PR DESCRIPTION


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
