### PR TITLE
nixos/ifstate: fixed initrd usage with cryptsetup 

### DIFF
--- a/nixos/modules/services/networking/ifstate.nix
+++ b/nixos/modules/services/networking/ifstate.nix
@@ -291,9 +291,6 @@ in
               # Otherwise systemd starts ifstate again, after the encryption password was entered by the user
               # and we are able to implement the cleanup using ExecStop rather than a separate unit.
               RemainAfterExit = true;
-              # When using network namespaces pyroute2 expects this directory to exists.
-              # @liske is currently investigating whether this should be considered a bug in pyroute2.
-              ExecStartPre = "${lib.getExe' pkgs.coreutils "mkdir"} /var/run";
               ExecStart = "${lib.getExe initrdCfg.package} --config ${
                 config.environment.etc."ifstate/ifstate.initrd.yaml".source
               } apply";

--- a/nixos/modules/services/networking/ifstate.nix
+++ b/nixos/modules/services/networking/ifstate.nix
@@ -176,6 +176,11 @@ in
           "network.target"
         ];
 
+        unitConfig = {
+          # Avoid default dependencies like "basic.target", which prevents ifstate from starting before luks is unlocked.
+          DefaultDependencies = "no";
+        };
+
         # mount is always available on nixos, avoid adding additional store paths to the closure
         path = [ "/run/wrappers" ];
 
@@ -290,6 +295,11 @@ in
             wants = [
               "network.target"
             ];
+
+            unitConfig = {
+              # Avoid default dependencies like "basic.target", which prevents ifstate from starting before luks is unlocked.
+              DefaultDependencies = "no";
+            };
 
             # mount is always available on nixos, avoid adding additional store paths to the closure
             # https://github.com/NixOS/nixpkgs/blob/2b8e2457ebe576ebf41ddfa8452b5b07a8d493ad/nixos/modules/system/boot/systemd/initrd.nix#L550-L551

--- a/nixos/modules/services/networking/ifstate.nix
+++ b/nixos/modules/services/networking/ifstate.nix
@@ -254,6 +254,17 @@ in
             )
           ];
 
+          # https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/system/boot/networkd.nix#L3444
+          additionalUpstreamUnits = [
+            "network-online.target"
+            "network-pre.target"
+            "network.target"
+            "nss-lookup.target"
+            "nss-user-lookup.target"
+            "remote-fs-pre.target"
+            "remote-fs.target"
+          ];
+
           services.ifstate-initrd = {
             description = "IfState initrd";
 


### PR DESCRIPTION


- fixed ifstate initrd when using luks encryption (already worked with zfs encryption)
- fixed usage of network namespaces in initrd (taken from https://github.com/NixOS/nixpkgs/pull/439681 )
- deduplicated systemd dependencies for initrd and non-initrd unit

Resolves #440577

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
