### PR TITLE
nixos/autoUpgrade: add runGarbageCollection option

### DIFF
--- a/nixos/modules/tasks/auto-upgrade.nix
+++ b/nixos/modules/tasks/auto-upgrade.nix
@@ -184,6 +184,15 @@ in
         '';
       };
 
+      runGarbageCollection = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to automatically run `nix-gc.service` after a successful
+          system upgrade.
+        '';
+      };
+
     };
 
   };
@@ -195,6 +204,12 @@ in
         assertion = !((cfg.channel != null) && (cfg.flake != null));
         message = ''
           The options 'system.autoUpgrade.channel' and 'system.autoUpgrade.flake' cannot both be set.
+        '';
+      }
+      {
+        assertion = (cfg.runGarbageCollection -> config.nix.enable);
+        message = ''
+          The option 'system.autoUpgrade.runGarbageCollection = true' requires 'nix.enable = true'.
         '';
       }
     ];
@@ -218,6 +233,9 @@ in
 
       restartIfChanged = false;
       unitConfig.X-StopOnRemoval = false;
+      unitConfig.OnSuccess = lib.optional (
+        cfg.runGarbageCollection && config.nix.enable
+      ) "nix-gc.service";
 
       serviceConfig.Type = "oneshot";
 


### PR DESCRIPTION
fix #431363

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
