### PR TITLE
lazyjj: cleanup, 0.5.0 -> 0.6.0

### DIFF
--- a/pkgs/by-name/la/lazyjj/package.nix
+++ b/pkgs/by-name/la/lazyjj/package.nix
@@ -49,6 +49,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/Cretezy/lazyjj/releases/tag/v${finalAttrs.version}";
     mainProgram = "lazyjj";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ colemickens ];
+    maintainers = with lib.maintainers; [
+      colemickens
+      GaetanLepage
+    ];
   };
 })

--- a/pkgs/by-name/la/lazyjj/package.nix
+++ b/pkgs/by-name/la/lazyjj/package.nix
@@ -1,41 +1,46 @@
 {
   lib,
+  rustPlatform,
   fetchFromGitHub,
   makeWrapper,
   jujutsu,
-  rustPlatform,
-  testers,
-  lazyjj,
+  versionCheckHook,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "lazyjj";
   version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "Cretezy";
     repo = "lazyjj";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Pz2q+uyr8r5G5Zs5mC/nvHdK6hTpiLBzjgUmvd5dwZw=";
   };
 
   cargoHash = "sha256-70xKyzRFMyAKhSwEsdNBK2afs0UpVoTvIXuQJgeqYY8=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  nativeCheckInputs = [
+    jujutsu
+  ];
 
   postInstall = ''
     wrapProgram $out/bin/lazyjj \
       --prefix PATH : ${lib.makeBinPath [ jujutsu ]}
   '';
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
 
-  nativeCheckInputs = [ jujutsu ];
-
-  passthru.tests.version = testers.testVersion { package = lazyjj; };
-
-  meta = with lib; {
+  meta = {
     description = "TUI for Jujutsu/jj";
     homepage = "https://github.com/Cretezy/lazyjj";
+    changelog = "https://github.com/Cretezy/lazyjj/releases/tag/v${finalAttrs.version}";
     mainProgram = "lazyjj";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ colemickens ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ colemickens ];
   };
-}
+})

--- a/pkgs/by-name/la/lazyjj/package.nix
+++ b/pkgs/by-name/la/lazyjj/package.nix
@@ -8,16 +8,23 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "lazyjj";
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "Cretezy";
     repo = "lazyjj";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Pz2q+uyr8r5G5Zs5mC/nvHdK6hTpiLBzjgUmvd5dwZw=";
+    hash = "sha256-BmME+LpYv3Ynpbo/k9pA5qcNmv7XLPXasPvHW4QalwY=";
   };
 
-  cargoHash = "sha256-70xKyzRFMyAKhSwEsdNBK2afs0UpVoTvIXuQJgeqYY8=";
+  postPatch = ''
+    substituteInPlace Cargo.toml \
+      --replace-fail \
+        'version = "0.5.0"' \
+        'version = "0.6.0"'
+  '';
+
+  cargoHash = "sha256-bQNLhQAUw2JgThC+RiNC5ap8D6a4JgflV2whXKu7QF8=";
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -34,6 +41,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     versionCheckHook
   ];
   versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   meta = {
     description = "TUI for Jujutsu/jj";


### PR DESCRIPTION
## Things done

- **lazyjj: cleanup**
- **lazyjj: 0.5.0 -> 0.6.0**

Fixes #441205.

cc @colemickens

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
