### PR TITLE
lomiri.*: Switch to current Mir

### DIFF
--- a/pkgs/desktops/lomiri/applications/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri/default.nix
@@ -42,7 +42,7 @@
   lomiri-thumbnailer,
   lomiri-ui-toolkit,
   maliit-keyboard,
-  mir_2_15,
+  mir,
   nixos-icons,
   pam,
   pkg-config,
@@ -71,6 +71,13 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
+    # Newer Mir dropped EDID descriptor information, will be ported to libdisplay-info eventually
+    (fetchpatch {
+      name = "0001-lomiri-DisplayConfigurationStorage-drop-use-of-descriptors.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri/-/commit/7e3001f3546e20f22aa7d0dc887a83ded1d611b7.patch";
+      hash = "sha256-ttlWYbay3/YgImNsx/eejvAE1S891yN5bJOvG4cZTQg=";
+    })
+
     # Fix broken multimedia suspend due to missing media-hub
     (fetchpatch {
       name = "2012-lomiri-dont-suspend-apps.patch";
@@ -119,8 +126,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     # Written with a different qtmir branch in mind, but different branch breaks compat with some patches
+    # Modern new needs C++20 for concept and requires
     substituteInPlace CMakeLists.txt \
-      --replace-fail 'qt5mir2server' 'qtmirserver'
+      --replace-fail 'qt5mir2server' 'qtmirserver' \
+      --replace-fail 'CMAKE_CXX_STANDARD 17' 'CMAKE_CXX_STANDARD 20'
 
     # Need to replace prefix
     substituteInPlace data/systemd-user/CMakeLists.txt \
@@ -184,7 +193,7 @@ stdenv.mkDerivation (finalAttrs: {
     lomiri-system-settings-unwrapped
     lomiri-ui-toolkit
     maliit-keyboard
-    mir_2_15
+    mir
     pam
     properties-cpp
     protobuf


### PR DESCRIPTION
WIP, hacked together on my messy trip back from NixCon. Please don't waste your time with looking at or reviewing this yet…

Not tested beyond `lomiri.qtmir` and `lomiri.lomiri` building. But they *do* build.

Debian are running ~ this on Mir 2.20. We have 2.22 already, so some extra patches were required. One is taken from an upstream MR. The other I hacked together myself, but I at least *alluded* to the made changes in the previous MR to complete the patch there.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
