### PR TITLE
[25.05] dokuwiki: apply xss fix

### DIFF
--- a/pkgs/by-name/do/dokuwiki/package.nix
+++ b/pkgs/by-name/do/dokuwiki/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   writeText,
   nixosTests,
+  fetchpatch,
   dokuwiki,
 }:
 
@@ -17,6 +18,17 @@ stdenv.mkDerivation rec {
     rev = "release-${version}";
     sha256 = "sha256-jrxsVBStvRxHCAOGVUkqtzE75wRBiVR+KxSCNuI2vnk=";
   };
+
+  patches = [
+    (fetchpatch {
+      # Backported from dokuwiki 2025-05-14b release
+      # Since the exact same (vulnerable) code is also present in 2024-02-06b, but there is no
+      # updated 2024-02-06* available.
+      name = "backport-xss-fix-in-search.patch";
+      url = "https://github.com/dokuwiki-translate/dokuwiki/commit/03fdedf74fd0e882fc06c06cd90a2bb608fe374b.patch";
+      hash = "sha256-h6qscrZ0VNguelWyrAxQVze9H2Y5oXH2tCEpEdRqr2I=";
+    })
+  ];
 
   preload = writeText "preload.php" ''
     <?php


### PR DESCRIPTION
## Things done

Backported fix for https://github.com/dokuwiki/dokuwiki/issues/4512
(Unauthenticated Reflected Cross Site Scripting) since the 2024-02-06 release didn't receive it.

I believe 2024-02-06b to be vulnerable since the affected code has not been touched since 7(?) years prior to this fix.

Only applying a patch since 2025-05-14 brings breaking changes; since the fix is small and can easily be applied, I don't see a reason to bring breaking updates.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
