### PR TITLE
python3Packages.docformatter: modernize

### DIFF
--- a/pkgs/development/python-modules/docformatter/default.nix
+++ b/pkgs/development/python-modules/docformatter/default.nix
@@ -5,7 +5,6 @@
   fetchFromGitHub,
   poetry-core,
   charset-normalizer,
-  tomli,
   untokenize,
   mock,
   pytestCheckHook,
@@ -14,10 +13,7 @@
 buildPythonPackage rec {
   pname = "docformatter";
   version = "1.7.7";
-
-  disabled = pythonOlder "3.7";
-
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "PyCQA";
@@ -29,17 +25,14 @@ buildPythonPackage rec {
   patches = [ ./test-path.patch ];
 
   postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace 'charset_normalizer = "^2.0.0"' 'charset_normalizer = ">=2.0.0"'
     substituteInPlace tests/conftest.py \
       --subst-var-by docformatter $out/bin/docformatter
   '';
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ poetry-core ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     charset-normalizer
-    tomli
     untokenize
   ];
 
@@ -49,10 +42,8 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # Disable failing tests until https://github.com/PyCQA/docformatter/issues/274 is fixed upstream
-    "test_do_format_code.py"
-    "test_docformatter.py"
-    # some different issue
+    # AssertionError: assert 'utf_16' == 'latin-1'
+    # fixed by https://github.com/PyCQA/docformatter/pull/323
     "test_detect_encoding_with_undetectable_encoding"
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
