### PR TITLE
spotdl: 4.2.11 -> 4.4.2

### DIFF
--- a/pkgs/by-name/sp/spotdl/package.nix
+++ b/pkgs/by-name/sp/spotdl/package.nix
@@ -1,28 +1,29 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
   ffmpeg,
+  writableTmpDirAsHomeHook,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "spotdl";
-  version = "4.2.11";
+  version = "4.4.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "spotDL";
     repo = "spotify-downloader";
     tag = "v${version}";
-    hash = "sha256-9PlqnpUlV5b8g+lctGjVL1Xgf25SS5xqkDaa1bSlxpk=";
+    hash = "sha256-guQ8fIA20wtCkB5CkU7zg/INE+g8/fvQfIs5TNteQGo=";
   };
 
-  build-system = with python3.pkgs; [ poetry-core ];
+  build-system = with python3Packages; [ hatchling ];
 
   pythonRelaxDeps = true;
 
   dependencies =
-    with python3.pkgs;
+    with python3Packages;
     [
       beautifulsoup4
       fastapi
@@ -45,17 +46,14 @@ python3.pkgs.buildPythonApplication rec {
     ]
     ++ python-slugify.optional-dependencies.unidecode;
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
     pyfakefs
     pytest-mock
     pytest-subprocess
     pytest-vcr
     pytestCheckHook
+    writableTmpDirAsHomeHook
   ];
-
-  preCheck = ''
-    export HOME=$TMPDIR
-  '';
 
   disabledTestPaths = [
     # Tests require networking
@@ -91,7 +89,7 @@ python3.pkgs.buildPythonApplication rec {
   meta = {
     description = "Download your Spotify playlists and songs along with album art and metadata";
     homepage = "https://github.com/spotDL/spotify-downloader";
-    changelog = "https://github.com/spotDL/spotify-downloader/releases/tag/v${version}";
+    changelog = "https://github.com/spotDL/spotify-downloader/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dotlambda ];
     mainProgram = "spotdl";


### PR DESCRIPTION
Diff: https://github.com/spotDL/spotify-downloader/compare/v4.2.11...v4.4.2

Changelog: https://github.com/spotDL/spotify-downloader/releases/tag/v4.4.2

replaces https://github.com/NixOS/nixpkgs/pull/431653
cc @kilisei @freerig 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
