### PR TITLE
bluej: 5.2.0 -> 5.5.0, add weirdrock as maintainer, remove chvp

### DIFF
--- a/pkgs/by-name/bl/bluej/package.nix
+++ b/pkgs/by-name/bl/bluej/package.nix
@@ -102,7 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
       classpathException20
     ];
     mainProgram = "bluej";
-    maintainers = with lib.maintainers; [ chvp ];
+    maintainers = with lib.maintainers; [ weirdrock ];
     platforms = lib.platforms.linux;
   };
 

--- a/pkgs/by-name/bl/bluej/package.nix
+++ b/pkgs/by-name/bl/bluej/package.nix
@@ -2,58 +2,96 @@
   lib,
   stdenv,
   fetchurl,
-  openjdk17,
-  openjfx17,
+  makeDesktopItem,
+  copyDesktopItems,
+  unzip,
+  openjdk21,
+  openjfx21,
   glib,
-  dpkg,
+  gsettings-desktop-schemas,
+  gtk3,
   wrapGAppsHook3,
+  imagemagick,
+  nix-update-script,
 }:
 let
-  openjdk = openjdk17.override {
+  openjdk = openjdk21.override {
     enableJavaFX = true;
-    openjfx_jdk = openjfx17.override { withWebKit = true; };
+    openjfx_jdk = openjfx21.override { withWebKit = true; };
   };
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "bluej";
-  version = "5.2.0";
+  version = "5.5.0";
 
   src = fetchurl {
-    # We use the deb here. First instinct might be to go for the "generic" JAR
-    # download, but that is actually a graphical installer that is much harder
-    # to unpack than the deb.
-    url = "https://www.bluej.org/download/files/BlueJ-linux-${
-      builtins.replaceStrings [ "." ] [ "" ] version
-    }.deb";
-    sha256 = "sha256-sOT86opMa9ytxJlfURIsD06HiP+j+oz3lQ0DqmLV1wE=";
+    url = "https://github.com/k-pet-group/BlueJ-Greenfoot/releases/download/BLUEJ-RELEASE-${finalAttrs.version}/BlueJ-generic-${finalAttrs.version}.jar";
+    sha256 = "sha256-UClhTH/9oFfhjYsScBvmD4cKZUJwuAsiyRTiVkPAV0o=";
   };
 
+  unpackPhase = ''
+    runHook preUnpack
+
+    unzip -d jar ${finalAttrs.src}
+    unzip -d dist jar/bluej-dist.jar
+
+    runHook postUnpack
+  '';
+
+  sourceRoot = "dist";
+
   nativeBuildInputs = [
-    dpkg
     wrapGAppsHook3
+    copyDesktopItems
+    imagemagick
+    unzip
   ];
-  buildInputs = [ glib ];
+  buildInputs = [
+    glib
+    gtk3
+  ];
 
   dontWrapGApps = true;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "BlueJ";
+      desktopName = "BlueJ";
+      exec = "BlueJ";
+      icon = "bluej";
+      comment = "A simple powerful Java IDE";
+      categories = [
+        "Application"
+        "Development"
+      ];
+    })
+  ];
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out
-    cp -r usr/* $out
+    mkdir -p $out/lib
 
-    rm -r $out/share/bluej/jdk
-    rm -r $out/share/bluej/javafx
-    rm -r $out/share/bluej/javafx-*.jar
+    cp -r ./lib $out/lib/bluej
+
+    mkdir -p $out/share/icons/hicolor/{16x16,32x32,48x48,64x64,128x128,256x256}/apps
+
+    for dimension in 16x16 32x32 48x48 64x64 128x128 256x256; do
+      magick convert ./icons/bluej-icon-512-embossed.png -geometry $dimension\
+        $out/share/icons/hicolor/$dimension/apps/bluej.png
+    done
 
     makeWrapper ${openjdk}/bin/java $out/bin/bluej \
       "''${gappsWrapperArgs[@]}" \
-      --add-flags "-Dawt.useSystemAAFontSettings=gasp -Xmx512M \
+      --suffix XDG_DATA_DIRS : ${gtk3}/share/gsettings-schemas/${gtk3.name}/ \
+      --add-flags "-Dawt.useSystemAAFontSettings=on \
                    --add-opens javafx.graphics/com.sun.glass.ui=ALL-UNNAMED \
-                   -cp $out/share/bluej/boot.jar bluej.Boot"
+                   -cp $out/lib/bluej/boot.jar bluej.Boot"
 
     runHook postInstall
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Simple integrated development environment for Java";
@@ -68,4 +106,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
   };
 
-}
+})


### PR DESCRIPTION
Closes #439382
Closes #396968
I'll try to keep this up to date as long as I have to use it :slightly_smiling_face: 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
