### PR TITLE
gpxsee: 13.46 -> 13.47, gpxsee-qt5: drop

### DIFF
--- a/pkgs/applications/misc/gpxsee/default.nix
+++ b/pkgs/applications/misc/gpxsee/default.nix
@@ -19,13 +19,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gpxsee";
-  version = "13.46";
+  version = "13.47";
 
   src = fetchFromGitHub {
     owner = "tumic0";
     repo = "GPXSee";
     tag = finalAttrs.version;
-    hash = "sha256-SkAEnKviUHQrej1fhpLs1bh/nAOgmRzzBzTFe4fURVc=";
+    hash = "sha256-1waE0A70MsUaGttaxHcOO2aaeRdZ9ihc7ZeqJ+azH/0=";
   };
 
   buildInputs = [

--- a/pkgs/applications/misc/gpxsee/default.nix
+++ b/pkgs/applications/misc/gpxsee/default.nix
@@ -6,17 +6,13 @@
   nix-update-script,
   qtbase,
   qttools,
-  qtlocation ? null, # qt5 only
-  qtpositioning ? null, # qt6 only
+  qtpositioning,
   qtserialport,
   qtsvg,
   wrapQtAppsHook,
   wrapGAppsHook3,
 }:
 
-let
-  isQt6 = lib.versions.major qtbase.version == "6";
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gpxsee";
   version = "13.47";
@@ -29,20 +25,11 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   buildInputs = [
+    qtbase
+    qtpositioning
     qtserialport
-  ]
-  ++ (
-    if isQt6 then
-      [
-        qtbase
-        qtpositioning
-        qtsvg
-      ]
-    else
-      [
-        qtlocation
-      ]
-  );
+    qtsvg
+  ];
 
   nativeBuildInputs = [
     qmake

--- a/pkgs/by-name/gp/gpxsee/package.nix
+++ b/pkgs/by-name/gp/gpxsee/package.nix
@@ -2,14 +2,8 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  qmake,
   nix-update-script,
-  qtbase,
-  qttools,
-  qtpositioning,
-  qtserialport,
-  qtsvg,
-  wrapQtAppsHook,
+  qt6,
   wrapGAppsHook3,
 }:
 
@@ -25,16 +19,16 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   buildInputs = [
-    qtbase
-    qtpositioning
-    qtserialport
-    qtsvg
+    qt6.qtbase
+    qt6.qtpositioning
+    qt6.qtserialport
+    qt6.qtsvg
   ];
 
   nativeBuildInputs = [
-    qmake
-    qttools
-    wrapQtAppsHook
+    qt6.qmake
+    qt6.qttools
+    qt6.wrapQtAppsHook
     wrapGAppsHook3
   ];
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1113,6 +1113,8 @@ mapAliases {
   googler = throw "'googler' has been removed, as it no longer works and is abandoned upstream"; # Added 2025-04-01
   gpicview = throw "'gpicview' has been removed due to lack of maintenance upstream and depending on gtk2. Consider using 'loupe', 'gthumb' or 'image-roll' instead"; # Added 2024-09-15
   gprbuild-boot = gnatPackages.gprbuild-boot; # Added 2024-02-25;
+  gpxsee-qt5 = throw "gpxsee-qt5 was removed, use gpxsee instead"; # added 2025-09-09
+  gpxsee-qt6 = gpxsee; # added 2025-09-09
 
   gqview = throw "'gqview' has been removed due to lack of maintenance upstream and depending on gtk2. Consider using 'gthumb' instead";
   gr-framework = throw "gr-framework has been removed, as it was broken"; # Added 2025-08-25

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11764,8 +11764,6 @@ with pkgs;
     withDoc = true;
   };
 
-  gpxsee = qt6Packages.callPackage ../applications/misc/gpxsee { };
-
   guvcview = libsForQt5.callPackage ../os-specific/linux/guvcview { };
 
   hachoir = with python3Packages; toPythonApplication hachoir;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11764,11 +11764,7 @@ with pkgs;
     withDoc = true;
   };
 
-  gpxsee-qt5 = libsForQt5.callPackage ../applications/misc/gpxsee { };
-
-  gpxsee-qt6 = qt6Packages.callPackage ../applications/misc/gpxsee { };
-
-  gpxsee = gpxsee-qt5;
+  gpxsee = qt6Packages.callPackage ../applications/misc/gpxsee { };
 
   guvcview = libsForQt5.callPackage ../os-specific/linux/guvcview { };
 


### PR DESCRIPTION
closes https://github.com/NixOS/nixpkgs/pull/441635
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
