### PR TITLE
nixos/limine: fix install script when using Xen with EFI (#441473)

### DIFF
--- a/nixos/modules/system/boot/loader/limine/limine-install.py
+++ b/nixos/modules/system/boot/loader/limine/limine-install.py
@@ -97,13 +97,23 @@ def is_encrypted(device: str) -> bool:
 def is_fs_type_supported(fs_type: str) -> bool:
     return fs_type.startswith('vfat')
 
+
+def get_dest_file(path: str) -> str:
+    package_id = os.path.basename(os.path.dirname(path))
+    suffix = os.path.basename(path)
+    return f'{package_id}-{suffix}'
+
+
+def get_dest_path(path: str, target: str) -> str:
+    dest_file = get_dest_file(path)
+    return os.path.join(str(limine_install_dir), target, dest_file)
+
+
 def get_copied_path_uri(path: str, target: str) -> str:
     result = ''
 
-    package_id = os.path.basename(os.path.dirname(path))
-    suffix = os.path.basename(path)
-    dest_file = f'{package_id}-{suffix}'
-    dest_path = os.path.join(str(limine_install_dir), target, dest_file)
+    dest_file = get_dest_file(path)
+    dest_path = get_dest_path(path, target)
 
     if not os.path.exists(dest_path):
         copy_file(path, dest_path)


### PR DESCRIPTION
This MR fixes a bug introduced in #393287 due to refactors and rebases over the lifetime of the PR, which impacted the Limine build script's ability to successfully enable Xen with Limine when using EFI.

## Things done

I've added and updated the missing functions to be:
 - Present, rather than missing
 - Consistent with refactors of the script made since the Xen support was first written

I've also tested the following configurations:
 - Xen enabled, Limine enabled, BIOS support enabled: builds correctly, BIOS files and Xen multiboot present for that generation
 - Xen enabled, Limine enabled, EFI support enabled: builds correctly, EFI files and Xen .efi binary present for that generation
 - Xen disabled, Limine enabled, BIOS support enabled: builds correctly, no xen files present in /boot for that generation
 - Xen enabled, Limine enabled, EFI support enabled: builds correctly, no xen files present in /boot for that generation

So everything seems to be building and copying correctly with these changes in all 4 major configuration cases.

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
