### PR TITLE
python3Packages.kafka-python: re-init at 2.3.2

### DIFF
--- a/pkgs/development/python-modules/kafka-python/default.nix
+++ b/pkgs/development/python-modules/kafka-python/default.nix
@@ -1,0 +1,84 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  pythonAtLeast,
+
+  # build system
+  setuptools,
+
+  # optional dependencies
+  crc32c,
+  lz4,
+  pyperf,
+  python-snappy,
+  zstandard,
+
+  # test dependencies
+  pytestCheckHook,
+  pytest-mock,
+  pytest-timeout,
+  xxhash,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "kafka-python";
+  version = "2.3.2";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  disabled = pythonAtLeast "3.14";
+
+  src = fetchFromGitHub {
+    owner = "dpkp";
+    repo = "kafka-python";
+    tag = finalAttrs.version;
+    hash = "sha256-FC5ntcRy2iF2sqYVxWg11EcGA5ncpuUuQHOkBG0paog=";
+  };
+
+  build-system = [ setuptools ];
+
+  optional-dependencies = {
+    benchmarks = [ pyperf ];
+    crc32c = [ crc32c ];
+    lz4 = [ lz4 ];
+    snappy = [ python-snappy ];
+    zstd = [ zstandard ];
+  };
+
+  pythonImportsCheck = [
+    "kafka"
+    "kafka.admin"
+    "kafka.benchmarks"
+    "kafka.cli"
+    "kafka.consumer"
+    "kafka.coordinator"
+    "kafka.metrics"
+    "kafka.partitioner"
+    "kafka.producer"
+    "kafka.protocol"
+    "kafka.record"
+    "kafka.sasl"
+    "kafka.serializer"
+    "kafka.vendor"
+  ];
+
+  nativeCheckInputs = [
+    pytest-mock
+    pytest-timeout
+    pytestCheckHook
+    xxhash
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
+
+  meta = {
+    changelog = "https://github.com/dpkp/kafka-python/blob/${finalAttrs.src.tag}/CHANGES.md";
+    description = "Pure Python client for Apache Kafka";
+    homepage = "https://github.com/dpkp/kafka-python";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
+  };
+})

--- a/pkgs/development/python-modules/pytest-kafka/default.nix
+++ b/pkgs/development/python-modules/pytest-kafka/default.nix
@@ -1,9 +1,13 @@
 {
-  lib,
   buildPythonPackage,
   fetchFromGitLab,
+  lib,
+
+  # build system
   setuptools,
-  kafka-python-ng,
+
+  # dependencies
+  kafka-python,
   port-for,
   pytest,
 }:
@@ -23,7 +27,7 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   dependencies = [
-    kafka-python-ng
+    kafka-python
     port-for
     pytest
   ];

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -298,7 +298,6 @@ mapAliases {
   jupyter_core = throw "'jupyter_core' has been renamed to/replaced by 'jupyter-core'"; # Converted to throw 2025-10-29
   jupyter_server = throw "'jupyter_server' has been renamed to/replaced by 'jupyter-server'"; # Converted to throw 2025-10-29
   jupyterlab_server = throw "'jupyterlab_server' has been renamed to/replaced by 'jupyterlab-server'"; # Converted to throw 2025-10-29
-  kafka-python = throw "'kafka-python' has been renamed to/replaced by 'kafka-python-ng'"; # Converted to throw 2025-10-29
   Kajiki = throw "'Kajiki' has been renamed to/replaced by 'kajiki'"; # Converted to throw 2025-10-29
   keepkey-agent = throw "keepkey-agent has been removed because upstream dropped KeepKey support"; # Added 2026-03-11
   keepkey_agent = throw "keepkey-agent has been removed because upstream dropped KeepKey support"; # Added 2026-03-11

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8342,6 +8342,8 @@ self: super: with self; {
 
   kaa-metadata = callPackage ../development/python-modules/kaa-metadata { };
 
+  kafka-python = callPackage ../development/python-modules/kafka-python { };
+
   kafka-python-ng = callPackage ../development/python-modules/kafka-python-ng { };
 
   kaggle = callPackage ../development/python-modules/kaggle { };


### PR DESCRIPTION
Adds `kafka-python` back in (it was removed in #328348 as unused)

I'm not sure if it's okay to just remove the python alias set up that points to `kafka-python-ng` (fwiw the upstream repo for it is archived). Please let me know if I should be doing something differently in order to remove it

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
