### PR TITLE
ieda: 0-unstable-2025-06-30 -> 0.1.0-unstable-2025-09-10

### DIFF
--- a/pkgs/by-name/ie/ieda/fix-cmake-require.patch
+++ b/pkgs/by-name/ie/ieda/fix-cmake-require.patch
@@ -1,0 +1,96 @@
+diff --git a/src/operation/iPNP/CMakeLists.txt b/src/operation/iPNP/CMakeLists.txt
+index b8f308a6e..4749d5024 100644
+--- a/src/operation/iPNP/CMakeLists.txt
++++ b/src/operation/iPNP/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.0)
++cmake_minimum_required(VERSION 3.5)
+ set (CMAKE_CXX_STANDARD 20)
+ 
+ add_subdirectory(api)
+diff --git a/src/third_party/pybind11/CMakeLists.txt b/src/third_party/pybind11/CMakeLists.txt
+index 0d9320388..5b5967713 100644
+--- a/src/third_party/pybind11/CMakeLists.txt
++++ b/src/third_party/pybind11/CMakeLists.txt
+@@ -5,7 +5,7 @@
+ # All rights reserved. Use of this source code is governed by a
+ # BSD-style license that can be found in the LICENSE file.
+ 
+-cmake_minimum_required(VERSION 3.4)
++cmake_minimum_required(VERSION 3.5)
+ 
+ # The `cmake_minimum_required(VERSION 3.4...3.22)` syntax does not work with
+ # some versions of VS that have a patched CMake 3.11. This forces us to emulate
+diff --git a/src/third_party/pybind11/tests/CMakeLists.txt b/src/third_party/pybind11/tests/CMakeLists.txt
+index 9beb268ed..417cd04d0 100644
+--- a/src/third_party/pybind11/tests/CMakeLists.txt
++++ b/src/third_party/pybind11/tests/CMakeLists.txt
+@@ -5,7 +5,7 @@
+ # All rights reserved. Use of this source code is governed by a
+ # BSD-style license that can be found in the LICENSE file.
+ 
+-cmake_minimum_required(VERSION 3.4)
++cmake_minimum_required(VERSION 3.5)
+ 
+ # The `cmake_minimum_required(VERSION 3.4...3.18)` syntax does not work with
+ # some versions of VS that have a patched CMake 3.11. This forces us to emulate
+diff --git a/src/third_party/pybind11/tests/test_cmake_build/installed_embed/CMakeLists.txt b/src/third_party/pybind11/tests/test_cmake_build/installed_embed/CMakeLists.txt
+index f7d693998..2847142a4 100644
+--- a/src/third_party/pybind11/tests/test_cmake_build/installed_embed/CMakeLists.txt
++++ b/src/third_party/pybind11/tests/test_cmake_build/installed_embed/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.4)
++cmake_minimum_required(VERSION 3.5)
+ 
+ # The `cmake_minimum_required(VERSION 3.4...3.18)` syntax does not work with
+ # some versions of VS that have a patched CMake 3.11. This forces us to emulate
+diff --git a/src/third_party/pybind11/tests/test_cmake_build/installed_function/CMakeLists.txt b/src/third_party/pybind11/tests/test_cmake_build/installed_function/CMakeLists.txt
+index d7ca4db55..74322f598 100644
+--- a/src/third_party/pybind11/tests/test_cmake_build/installed_function/CMakeLists.txt
++++ b/src/third_party/pybind11/tests/test_cmake_build/installed_function/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.4)
++cmake_minimum_required(VERSION 3.5)
+ project(test_installed_module CXX)
+ 
+ # The `cmake_minimum_required(VERSION 3.4...3.18)` syntax does not work with
+diff --git a/src/third_party/pybind11/tests/test_cmake_build/installed_target/CMakeLists.txt b/src/third_party/pybind11/tests/test_cmake_build/installed_target/CMakeLists.txt
+index bc5e101f1..2d21a21de 100644
+--- a/src/third_party/pybind11/tests/test_cmake_build/installed_target/CMakeLists.txt
++++ b/src/third_party/pybind11/tests/test_cmake_build/installed_target/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.4)
++cmake_minimum_required(VERSION 3.5)
+ 
+ # The `cmake_minimum_required(VERSION 3.4...3.18)` syntax does not work with
+ # some versions of VS that have a patched CMake 3.11. This forces us to emulate
+diff --git a/src/third_party/pybind11/tests/test_cmake_build/subdirectory_embed/CMakeLists.txt b/src/third_party/pybind11/tests/test_cmake_build/subdirectory_embed/CMakeLists.txt
+index 58cdd7cfd..f9835f31e 100644
+--- a/src/third_party/pybind11/tests/test_cmake_build/subdirectory_embed/CMakeLists.txt
++++ b/src/third_party/pybind11/tests/test_cmake_build/subdirectory_embed/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.4)
++cmake_minimum_required(VERSION 3.5)
+ 
+ # The `cmake_minimum_required(VERSION 3.4...3.18)` syntax does not work with
+ # some versions of VS that have a patched CMake 3.11. This forces us to emulate
+diff --git a/src/third_party/pybind11/tests/test_cmake_build/subdirectory_function/CMakeLists.txt b/src/third_party/pybind11/tests/test_cmake_build/subdirectory_function/CMakeLists.txt
+index 01557c439..6d96cc3b3 100644
+--- a/src/third_party/pybind11/tests/test_cmake_build/subdirectory_function/CMakeLists.txt
++++ b/src/third_party/pybind11/tests/test_cmake_build/subdirectory_function/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.4)
++cmake_minimum_required(VERSION 3.5)
+ 
+ # The `cmake_minimum_required(VERSION 3.4...3.18)` syntax does not work with
+ # some versions of VS that have a patched CMake 3.11. This forces us to emulate
+diff --git a/src/third_party/pybind11/tests/test_cmake_build/subdirectory_target/CMakeLists.txt b/src/third_party/pybind11/tests/test_cmake_build/subdirectory_target/CMakeLists.txt
+index ba82fdee2..6f8e04429 100644
+--- a/src/third_party/pybind11/tests/test_cmake_build/subdirectory_target/CMakeLists.txt
++++ b/src/third_party/pybind11/tests/test_cmake_build/subdirectory_target/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.4)
++cmake_minimum_required(VERSION 3.5)
+ 
+ # The `cmake_minimum_required(VERSION 3.4...3.18)` syntax does not work with
+ # some versions of VS that have a patched CMake 3.11. This forces us to emulate


### PR DESCRIPTION
- iEDA released v0.1.0 at 2025-07-02: https://gitee.com/oscc-project/iEDA/releases/tag/v0.1.0
- Remove postPatch to patches and update patches
- Add pkg-config, curl and tbb_2021 as dependencies

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
