### PR TITLE
python313Packages.aiohttp-client-cache: fix broken tests in 0.13.0

### DIFF
--- a/pkgs/development/python-modules/aiohttp-client-cache/default.nix
+++ b/pkgs/development/python-modules/aiohttp-client-cache/default.nix
@@ -12,6 +12,7 @@
   itsdangerous,
   motor,
   poetry-core,
+  pytest-asyncio,
   pytest-aiohttp,
   pytestCheckHook,
   redis,
@@ -62,18 +63,19 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     faker
+    pytest-asyncio
     pytest-aiohttp
     pytestCheckHook
   ]
   ++ lib.flatten (builtins.attrValues optional-dependencies);
 
+  pytestFlags = [ "--asyncio-mode=auto" ];
+
   pythonImportsCheck = [ "aiohttp_client_cache" ];
 
   disabledTestPaths = [
     # Tests require running instances of the services
-    "test/integration/test_dynamodb.py"
-    "test/integration/test_redis.py"
-    "test/integration/test_sqlite.py"
+    "test/integration/*"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
- The async tests need an explicit asyncio_mode=auto flag to run.
- We ignore all the tests in test/integration/* to cover all the current and future tests that require an instance of the service to be running.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
