### PR TITLE
nix: Don't use ld.gold for powerpc64 cross

### DIFF
--- a/pkgs/tools/package-management/nix/modular/packaging/components.nix
+++ b/pkgs/tools/package-management/nix/modular/packaging/components.nix
@@ -156,6 +156,10 @@ let
       // lib.optionalAttrs (
         stdenv.isLinux
         && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")
+        && !(
+          stdenv.buildPlatform.config != stdenv.hostPlatform.config
+          && stdenv.hostPlatform.system == "powerpc64-linux"
+        )
         && !(stdenv.system == "loongarch64-linux")
         && !(stdenv.hostPlatform.useLLVM or false)
       ) { LDFLAGS = "-fuse-ld=gold"; };


### PR DESCRIPTION
I don't remember how I initially stumbled into this, because it isn't an issue with `nix`. But it *is* an issue with nix > 2.29, where the build is split up into per-component derivations.

Using the gold linker when cross-compiling for powerpc64-linux produces tons of errors like this:
```
/nix/store/y3bib7c8vpx66xypjflw783ml392105l-powerpc64-unknown-linux-gnuabielfv1-binutils-2.44/bin/powerpc64-unknown-linux-gnuabielfv1-ld.gold: error: /build/ccg9tPoL.debug.temp.o: could not decompress section .debug_str
/nix/store/y3bib7c8vpx66xypjflw783ml392105l-powerpc64-unknown-linux-gnuabielfv1-binutils-2.44/bin/powerpc64-unknown-linux-gnuabielfv1-ld.gold: error: /build/ccg9tPoL.debug.temp.o: could not decompress section .debug_line_str
/nix/store/y3bib7c8vpx66xypjflw783ml392105l-powerpc64-unknown-linux-gnuabielfv1-binutils-2.44/bin/powerpc64-unknown-linux-gnuabielfv1-ld.gold: warning: /build/ccg9tPoL.debug.temp.o: last entry in mergeable string section '.debug_line_str' not null terminated
```

This fixes i.e. `nixVersions.nixComponents_2_29.nix-util`.

(Note: [Upstream has since switched to linking with `mold`](https://github.com/NixOS/nix/commit/fadd86011f4118f8c5d27108776cc01bd06f4137), I haven't tested that.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux (native, ELFv1)
  - [x] powerpc64-linux (cross, ELFv1, `ppc64-elfv1` example)
  - [x] powerpc64-linux (cross, ELFv2, `ppc64-elfv2` example)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
