### PR TITLE
python3Packages.unsloth: add CUDA tests using GPU

### DIFF
--- a/pkgs/development/python-modules/unsloth/default.nix
+++ b/pkgs/development/python-modules/unsloth/default.nix
@@ -27,7 +27,29 @@
   hf-transfer,
   diffusers,
   torchvision,
+
+  # tests
+  fetchFromGitHub,
+  cudaPackages,
+  python,
+  gcc,
 }:
+
+let
+  # Test files are absent from the PyPI package, so we fetch them separately.
+  testSrc = fetchFromGitHub {
+    owner = "unslothai";
+    repo = "unsloth";
+    rev = "cb78f0e83dc2d61fb1571b6e904eb2f064510d63";
+    hash = "sha256-0oR3m8jnjSdfjH+NslW6SsVj+0cQ4VUhKXZ38U/VBy0=";
+    # Keep only the tests directory, use the PyPI package for everything else.
+    postFetch = ''
+      mv $out/tests $TMPDIR/tests
+      rm -rf $out/*
+      mv $TMPDIR/tests $out/tests
+    '';
+  };
+in
 
 buildPythonPackage rec {
   pname = "unsloth";
@@ -84,6 +106,36 @@ buildPythonPackage rec {
   # Importing requires a GPU, else the following error is raised:
   # NotImplementedError: Unsloth: No NVIDIA GPU found? Unsloth currently only supports GPUs!
   dontUsePythonImportsCheck = true;
+
+  passthru.tests = {
+    qlora-train-and-merge =
+      # FIXME: Replace python3.pkgs with python3Packages once possible, as to unbeak splicing.
+      # Cf. https://github.com/NixOS/nixpkgs/pull/394838#issuecomment-3319287038
+      cudaPackages.writeGpuTestPython.override { python3Packages = python.pkgs; }
+        {
+          libraries = ps: [
+            ps.unsloth
+            ps.unsloth-zoo
+          ];
+          # In-derivation test would require fetching the model from hugging-face which will not be trivial.
+          gpuCheckArgs.meta.broken = true;
+        }
+        # Triton JIT requires a C compiler at runtime and imports files from the test directory.
+        ''
+          import os, sys, runpy
+
+          os.environ["CC"]  = "${lib.getExe' gcc "cc"}";
+          os.environ["CXX"] = "${lib.getExe' gcc "cxx"}";
+
+          sys.path.insert(0, "${testSrc}")
+
+          # Execute the test file from the Nix store at runtime (no eval-time IFD).
+          runpy.run_path(
+              "${testSrc}/tests/qlora/test_unsloth_qlora_train_and_merge.py",
+              run_name="__main__"
+          )
+        '';
+  };
 
   meta = {
     description = "Finetune Llama 3.3, DeepSeek-R1 & Reasoning LLMs 2x faster with 70% less memory";


### PR DESCRIPTION
This is my first attempt at testing the `unsloth` package on a GPU.

The first commit makes CUDA available and launches a test script from the upstream repository.

This uses the latest version of `unsloth`, also bumped independently in https://github.com/NixOS/nixpkgs/pull/441988

## Launching the tests

In this branch of `nixpkgs`:
```shell
nix-build -I nixpkgs=. --arg config '{ allowUnfree = true; cudaSupport = true;}' -A python312Packages.unsloth.tests.qlora-train-and-merge
```
Then launch the test script using:
```shell
./result/bin/tester-cuda
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
