### PR TITLE
teams: add friedow to apm

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -64,6 +64,7 @@ with lib.maintainers;
     # Edits to this list should only be done by an already existing member.
     members = [
       DutchGerman
+      friedow
     ];
   };
 


### PR DESCRIPTION
Adds [friedow](https://github.com/friedow/) to the apm team.