### PR TITLE
thinkfan: 1.3.1 -> 2.0.0

### DIFF
--- a/pkgs/by-name/th/thinkfan/package.nix
+++ b/pkgs/by-name/th/thinkfan/package.nix
@@ -12,14 +12,14 @@
   libatasmart,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "thinkfan";
   version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "vmatare";
     repo = "thinkfan";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-QqDWPOXy8E+TY5t0fFRAS8BGA7ZH90xecv5UsFfDssk=";
   };
 
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = [
-    "-DCMAKE_INSTALL_DOCDIR=share/doc/${pname}"
+    "-DCMAKE_INSTALL_DOCDIR=share/doc/thinkfan"
     "-DUSE_NVML=OFF"
     # force install unit files
     "-DSYSTEMD_FOUND=ON"
@@ -70,4 +70,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     mainProgram = "thinkfan";
   };
-}
+})

--- a/pkgs/by-name/th/thinkfan/package.nix
+++ b/pkgs/by-name/th/thinkfan/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  lm_sensors,
   yaml-cpp,
   pkg-config,
   procps,
@@ -13,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "thinkfan";
-  version = "1.3.1";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "vmatare";
     repo = "thinkfan";
-    rev = version;
-    sha256 = "sha256-aREZv+t4QhtfLKOMrneLiRxgnu0fzB8UV8dvr1dnhx4=";
+    tag = version;
+    hash = "sha256-QqDWPOXy8E+TY5t0fFRAS8BGA7ZH90xecv5UsFfDssk=";
   };
 
   postPatch = ''
@@ -48,7 +49,11 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
 
-  buildInputs = [ yaml-cpp ] ++ lib.optional smartSupport libatasmart;
+  buildInputs = [
+    lm_sensors
+    yaml-cpp
+  ]
+  ++ lib.optional smartSupport libatasmart;
 
   meta = {
     description = "Simple, lightweight fan control program";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/vmatare/thinkfan/releases/tag/2.0.0
https://github.com/vmatare/thinkfan/compare/1.3.1...2.0.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
