### PR TITLE
python3Packages.flask-appbuilder: 4.8.0 -> 5.0.2

### DIFF
--- a/pkgs/development/python-modules/flask-appbuilder/default.nix
+++ b/pkgs/development/python-modules/flask-appbuilder/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   apispec,
   colorama,
   click,
@@ -18,24 +18,23 @@
   marshmallow,
   marshmallow-sqlalchemy,
   python-dateutil,
-  pythonOlder,
   prison,
   pyjwt,
-  pyyaml,
   sqlalchemy-utils,
+  wtforms,
+  werkzeug,
 }:
 
 buildPythonPackage rec {
   pname = "flask-appbuilder";
-  version = "4.8.0";
+  version = "5.0.2";
   format = "setuptools";
 
-  disabled = pythonOlder "3.7";
-
-  src = fetchPypi {
-    pname = "Flask-AppBuilder";
-    inherit version;
-    hash = "sha256-MrkDcUCNgHzHnTM3DJenPXOP7HLTTthD/YBtupNprhM=";
+  src = fetchFromGitHub {
+    owner = "dpgaspar";
+    repo = "Flask-AppBuilder";
+    tag = "v${version}";
+    hash = "sha256-Klj36981KbtOHTyl2QcFvSYYkw2qU2feen8KbS5+aXg=";
   };
 
   propagatedBuildInputs = [
@@ -57,18 +56,15 @@ buildPythonPackage rec {
     python-dateutil
     prison
     pyjwt
-    pyyaml
     sqlalchemy-utils
+    wtforms
+    werkzeug
   ]
   ++ apispec.optional-dependencies.yaml;
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "apispec[yaml]>=3.3, <6" "apispec[yaml]" \
-      --replace "Flask-SQLAlchemy>=2.4, <3" "Flask-SQLAlchemy" \
-      --replace "Flask-Babel>=1, <3" "Flask-Babel" \
-      --replace "marshmallow-sqlalchemy>=0.22.0, <0.27.0" "marshmallow-sqlalchemy" \
-      --replace "prison>=0.2.1, <1.0.0" "prison"
+      --replace-fail "prison>=0.2.1, <1.0.0" "prison"
   '';
 
   # Majority of tests require network access or mongo
@@ -82,7 +78,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/dpgaspar/Flask-AppBuilder/blob/v${version}/CHANGELOG.rst";
     license = licenses.bsd3;
     maintainers = [ ];
-    # Support for flask-sqlalchemy >= 3.0 is missing, https://github.com/dpgaspar/Flask-AppBuilder/pull/1940
-    broken = true;
   };
 }


### PR DESCRIPTION
https://github.com/dpgaspar/Flask-AppBuilder/releases/tag/v5.0.2
align dependencies with upstream setup.py
remove broken tag as now the package supports modern `flask-sqlalchemy`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
