### PR TITLE
nixos/top-level: Install 'bootStage2' as 'init' in all non-initrd configs

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -148,6 +148,8 @@
 - The zookeeper project changed their logging tool to logback, therefore `services.zookeeper.logging` option has been updated to expect a logback compatible string.
 - The `dovecot` systemd service was renamed from `dovecot2` to `dovecot`. The former is now just an alias. Update any overrides on the systemd unit to the new name.
 
+- Configurations with `boot.initrd.systend.enable && !boot.initrd.enable` will have their `init` script at `$toplevel/init` instead of `$toplevel/prepare-root`. This is because it does not make sense for systemd stage 1 to affect the `init` script when stage 1 is entirely disabled (e.g. containers).
+
 - `Prosody` has been updated to major release 13 which removed some obsoleted modules and brought a couple of major and breaking changes:
   - The `http_files` module is now disabled by default because it now requires `http_files_dir` to be configured.
   - The `vcard_muc` module has been removed and got replaced by the inbuilt `muc_vcard` module.

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -12,7 +12,7 @@ let
     mkdir $out
 
     ${
-      if config.boot.initrd.systemd.enable then
+      if config.boot.initrd.enable && config.boot.initrd.systemd.enable then
         ''
           cp ${config.system.build.bootStage2} $out/prepare-root
           substituteInPlace $out/prepare-root --subst-var-by systemConfig $out

--- a/nixos/modules/virtualisation/lxc-container.nix
+++ b/nixos/modules/virtualisation/lxc-container.nix
@@ -28,9 +28,7 @@
   options = { };
 
   config =
-    let
-      initScript = if config.boot.initrd.systemd.enable then "prepare-root" else "init";
-    in
+
     {
       boot.isContainer = true;
       boot.postBootCommands = ''
@@ -79,7 +77,7 @@
 
         contents = [
           {
-            source = config.system.build.toplevel + "/${initScript}";
+            source = config.system.build.toplevel + "/init";
             target = "/sbin/init";
           }
           # Technically this is not required for lxc, but having also make this configuration work with systemd-nspawn.
@@ -104,7 +102,7 @@
 
         pseudoFiles = [
           "/sbin d 0755 0 0"
-          "/sbin/init s 0555 0 0 ${config.system.build.toplevel}/${initScript}"
+          "/sbin/init s 0555 0 0 ${config.system.build.toplevel}/init"
           "/dev d 0755 0 0"
           "/proc d 0555 0 0"
           "/sys d 0555 0 0"
@@ -113,7 +111,7 @@
 
       system.build.installBootLoader = pkgs.writeScript "install-lxc-sbin-init.sh" ''
         #!${pkgs.runtimeShell}
-        ${pkgs.coreutils}/bin/ln -fs "$1/${initScript}" /sbin/init
+        ${pkgs.coreutils}/bin/ln -fs "$1/init" /sbin/init
       '';
 
       # networkd depends on this, but systemd module disables this for containers
@@ -122,7 +120,7 @@
       systemd.packages = [ pkgs.distrobuilder.generator ];
 
       system.activationScripts.installInitScript = lib.mkForce ''
-        ln -fs $systemConfig/${initScript} /sbin/init
+        ln -fs $systemConfig/init /sbin/init
       '';
     };
 }


### PR DESCRIPTION
Eventually we'd like to change our posture on this, and somehow ensure that 'init' is always our systemd binary, but for now containers require us to do it this way.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
