### PR TITLE
scrutiny: remove jnsgruk from maintainers

### DIFF
--- a/nixos/modules/services/monitoring/scrutiny.nix
+++ b/nixos/modules/services/monitoring/scrutiny.nix
@@ -274,5 +274,5 @@ in
     })
   ];
 
-  meta.maintainers = [ maintainers.jnsgruk ];
+  meta.maintainers = [ ];
 }

--- a/nixos/tests/homepage-dashboard.nix
+++ b/nixos/tests/homepage-dashboard.nix
@@ -1,7 +1,7 @@
 { lib, ... }:
 {
   name = "homepage-dashboard";
-  meta.maintainers = with lib.maintainers; [ jnsgruk ];
+  meta.maintainers = with lib.maintainers; [ ];
 
   nodes.machine = _: {
     services.homepage-dashboard = {

--- a/nixos/tests/multipass.nix
+++ b/nixos/tests/multipass.nix
@@ -12,7 +12,7 @@ in
 {
   name = "multipass";
 
-  meta.maintainers = [ lib.maintainers.jnsgruk ];
+  meta.maintainers = [ ];
 
   nodes.machine =
     { lib, ... }:

--- a/nixos/tests/scrutiny.nix
+++ b/nixos/tests/scrutiny.nix
@@ -2,7 +2,7 @@
 
 {
   name = "scrutiny";
-  meta.maintainers = with lib.maintainers; [ jnsgruk ];
+  meta.maintainers = with lib.maintainers; [ ];
 
   nodes = {
     machine =

--- a/pkgs/by-name/ho/homepage-dashboard/package.nix
+++ b/pkgs/by-name/ho/homepage-dashboard/package.nix
@@ -111,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "homepage";
     homepage = "https://gethomepage.dev";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/ic/icloudpd/package.nix
+++ b/pkgs/by-name/ic/icloudpd/package.nix
@@ -86,7 +86,6 @@ python3Packages.buildPythonApplication rec {
     mainProgram = "icloudpd";
     maintainers = with maintainers; [
       anpin
-      jnsgruk
     ];
   };
 }

--- a/pkgs/by-name/mu/multipass/package.nix
+++ b/pkgs/by-name/mu/multipass/package.nix
@@ -22,7 +22,7 @@ let
   commonMeta = {
     homepage = "https://multipass.run";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [ ];
     platforms = [ "x86_64-linux" ];
   };
 

--- a/pkgs/by-name/sc/scrutiny-collector/package.nix
+++ b/pkgs/by-name/sc/scrutiny-collector/package.nix
@@ -49,7 +49,7 @@ buildGoModule rec {
     description = "Hard disk metrics collector for Scrutiny";
     homepage = "https://github.com/AnalogJ/scrutiny";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "scrutiny-collector-metrics";
   };
 }

--- a/pkgs/by-name/sc/scrutiny/package.nix
+++ b/pkgs/by-name/sc/scrutiny/package.nix
@@ -67,7 +67,7 @@ buildGoModule rec {
     homepage = "https://github.com/AnalogJ/scrutiny";
     changelog = "https://github.com/AnalogJ/scrutiny/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "scrutiny";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -127,7 +127,7 @@ in
       description = "Soothing pastel theme for Tmux";
       license = licenses.mit;
       platforms = platforms.unix;
-      maintainers = with maintainers; [ jnsgruk ];
+      maintainers = with maintainers; [ ];
     };
   };
 

--- a/pkgs/servers/home-assistant/custom-components/solis-sensor/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/solis-sensor/package.nix
@@ -29,6 +29,6 @@ buildHomeAssistantComponent rec {
     changelog = "https://github.com/hultenvp/solis-sensor/releases/tag/v${version}";
     homepage = "https://github.com/hultenvp/solis-sensor";
     license = licenses.asl20;
-    maintainers = with maintainers; [ jnsgruk ];
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
## Things done

Removing myself from a few packages and modules. New role is seeing me spend much, much less time on NixOS, so many of these are becoming harder for me to test/maintain. I'm not using any of these packages any more.

I'm working on a backup plan for Multipass, but need to do a bit of coaching before they're ready.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
