### PR TITLE
lib.options.optionAttrSetToDocList: add `visible = "transparent"`

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -113,7 +113,10 @@ rec {
       : Optional boolean indicating whether the option is for NixOS developers only.
 
       `visible`
-      : Optional boolean indicating whether the option shows up in the manual. Default: true. Use false to hide the option and any sub-options from submodules. Use "shallow" to hide only sub-options.
+      : Optional boolean indicating whether the option shows up in the manual.
+        Use false to hide the option and any sub-options from submodules.
+        Use "shallow" to hide only sub-options.
+        Default: true.
 
       `readOnly`
       : Optional boolean indicating whether the option can be set only once.

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -116,6 +116,7 @@ rec {
       : Optional, whether the option and/or sub-options show up in the manual.
         Use false to hide the option and any sub-options from submodules.
         Use "shallow" to hide only sub-options.
+        Use "transparent" to hide this option, but not its sub-options.
         Default: true.
 
       `readOnly`
@@ -575,13 +576,14 @@ rec {
       opt:
       let
         name = showOption opt.loc;
+        visible = opt.visible or true;
         docOption = {
           loc = opt.loc;
           inherit name;
           description = opt.description or null;
           declarations = filter (x: x != unknownModule) opt.declarations;
           internal = opt.internal or false;
-          visible = if (opt ? visible && opt.visible == "shallow") then true else opt.visible or true;
+          visible = if isBool visible then visible else visible == "shallow";
           readOnly = opt.readOnly or false;
           type = opt.type.description or "unspecified";
         }
@@ -604,7 +606,7 @@ rec {
             ss = opt.type.getSubOptions opt.loc;
           in
           if ss != { } then optionAttrSetToDocList' opt.loc ss else [ ];
-        subOptionsVisible = docOption.visible && opt.visible or null != "shallow";
+        subOptionsVisible = if isBool visible then visible else visible == "transparent";
       in
       # To find infinite recursion in NixOS option docs:
       # builtins.trace opt.loc

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -113,7 +113,7 @@ rec {
       : Optional boolean indicating whether the option is for NixOS developers only.
 
       `visible`
-      : Optional boolean indicating whether the option shows up in the manual.
+      : Optional, whether the option and/or sub-options show up in the manual.
         Use false to hide the option and any sub-options from submodules.
         Use "shallow" to hide only sub-options.
         Default: true.

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -3232,6 +3232,10 @@ runTests {
                 type = lib.types.submodule submodule;
                 visible = "shallow";
               };
+              transparent = lib.mkOption {
+                type = lib.types.submodule submodule;
+                visible = "transparent";
+              };
               "true" = lib.mkOption {
                 type = lib.types.submodule submodule;
                 visible = true;
@@ -3265,6 +3269,18 @@ runTests {
       ];
     expected = {
       shallow = {
+        visible = true;
+        internal = false;
+      };
+      transparent = {
+        visible = false;
+        internal = false;
+      };
+      "transparent.foo" = {
+        visible = true;
+        internal = false;
+      };
+      "transparent.<name>.bar" = {
         visible = true;
         internal = false;
       };

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -3210,6 +3210,95 @@ runTests {
     ];
   };
 
+  testDocOptionVisiblity = {
+    expr =
+      let
+        submodule =
+          { lib, ... }:
+          {
+            freeformType = lib.types.attrsOf (
+              lib.types.submodule {
+                options.bar = lib.mkOption { };
+              }
+            );
+            options.foo = lib.mkOption { };
+          };
+
+        module =
+          { lib, ... }:
+          {
+            options = {
+              shallow = lib.mkOption {
+                type = lib.types.submodule submodule;
+                visible = "shallow";
+              };
+              "true" = lib.mkOption {
+                type = lib.types.submodule submodule;
+                visible = true;
+              };
+              "false" = lib.mkOption {
+                type = lib.types.submodule submodule;
+                visible = false;
+              };
+              "internal" = lib.mkOption {
+                type = lib.types.submodule submodule;
+                internal = true;
+              };
+            };
+          };
+
+        options =
+          (evalModules {
+            modules = [ module ];
+          }).options;
+      in
+      pipe options [
+        optionAttrSetToDocList
+        (filter (opt: !(builtins.elem "_module" opt.loc)))
+        (map (
+          opt:
+          nameValuePair opt.name {
+            inherit (opt) visible internal;
+          }
+        ))
+        listToAttrs
+      ];
+    expected = {
+      shallow = {
+        visible = true;
+        internal = false;
+      };
+      "true" = {
+        visible = true;
+        internal = false;
+      };
+      "true.foo" = {
+        visible = true;
+        internal = false;
+      };
+      "true.<name>.bar" = {
+        visible = true;
+        internal = false;
+      };
+      "false" = {
+        visible = false;
+        internal = false;
+      };
+      "internal" = {
+        visible = true;
+        internal = true;
+      };
+      "internal.foo" = {
+        visible = true;
+        internal = false;
+      };
+      "internal.<name>.bar" = {
+        visible = true;
+        internal = false;
+      };
+    };
+  };
+
   testAttrsWithName = {
     expr =
       let


### PR DESCRIPTION
It came up in [a](https://github.com/nix-community/nixvim/pull/3670#issuecomment-3273219347) [discussion](https://github.com/nix-community/nixvim/pull/3670#discussion_r2336614883) that there is a way to mark an option as invisible, or an option's sub-options, but not a way to mark an option as invisible _without_ hiding its sub-options.

Technically, you can mark an option as `internal`, and this will have a similar effect. That's because, currently, `optionAttrSetToDocList` will not check `internal` when deciding whether to recurse into sub-options. However that feels like an implementation detail that I'm uncomfortable relying on. According to their docs, `visible` and `internal` have subtly different semantics, too; so I'm uncomfortable using them interchangeably.

This PR expands the test suite to explicitly test how `optionAttrSetToDocList` handles `visible` and `internal`, then adds a new `visible = "transparent"` value. This new value is used to indicate that the option is not visible, but its sub-options are.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
    - [x] `nix-build lib/tests/release.nix`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
