### PR TITLE
openblas: add patch to disable buggy SME SGEMM kernel

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -194,6 +194,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-foP2OXUL6ttgYvCxLsxUiVdkPoTvGiHomdNudbSUmSE=";
   };
 
+  patches = [
+    # Remove this once https://github.com/OpenMathLib/OpenBLAS/issues/5414 is
+    # resolved.
+    ./disable-sme-sgemm-kernel.patch
+  ];
+
   postPatch = ''
     # cc1: error: invalid feature modifier 'sve2' in '-march=armv8.5-a+sve+sve2+bf16'
     substituteInPlace Makefile.arm64 --replace "+sve2+bf16" ""

--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -275,6 +275,9 @@ stdenv.mkDerivation rec {
     })
   );
 
+  # The default "all" target unconditionally builds the "tests" target.
+  buildFlags = lib.optionals (!doCheck) [ "shared" ];
+
   doCheck = true;
   checkTarget = "tests";
 

--- a/pkgs/development/libraries/science/math/openblas/disable-sme-sgemm-kernel.patch
+++ b/pkgs/development/libraries/science/math/openblas/disable-sme-sgemm-kernel.patch
@@ -1,0 +1,13 @@
+diff --git a/interface/gemm.c b/interface/gemm.c
+index c5182c266..7056422e1 100644
+--- a/interface/gemm.c
++++ b/interface/gemm.c
+@@ -436,7 +436,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_TRANSPOSE TransA, enum CBLAS_TRANS
+ #endif
+ #if defined(ARCH_ARM64) && (defined(USE_SGEMM_KERNEL_DIRECT)||defined(DYNAMIC_ARCH))
+ #if defined(DYNAMIC_ARCH)
+- if (support_sme1())
++ if (false)
+ #endif
+   if (beta == 0 && alpha == 1.0 && order == CblasRowMajor && TransA == CblasNoTrans && TransB == CblasNoTrans) {
+ 	SGEMM_DIRECT(m, n, k, a, lda, b, ldb, c, ldc);


### PR DESCRIPTION
All work done by @al3xtjames to address https://github.com/OpenMathLib/OpenBLAS/issues/5414; this is a pure cherry‐pick.

@al3xtjames It seems we keep running into the same issues :) I hope you don’t mind me putting this PR up for this fix – it was blocking my `staging` work and your workaround seems like good to me.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
