### PR TITLE
roc: alpha3 -> alpha4

### DIFF
--- a/pkgs/by-name/ro/roc/package.nix
+++ b/pkgs/by-name/ro/roc/package.nix
@@ -17,7 +17,7 @@
 
 let
   llvmPackages = llvmPackages_18;
-  rocVersion = "alpha3";
+  rocVersion = "alpha4";
 in
 
 rustPlatform.buildRustPackage rec {
@@ -27,8 +27,8 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "roc-lang";
     repo = "roc";
-    rev = "9a0238e0f34c09e27e3ca89e8fc5a684a21bf456";
-    hash = "sha256-iM16DlTf+1yXBZVH7QqzhKuSkn1n/ZDosnZj3t+io0E=";
+    rev = "d73ea109cc21442da01387c1e5e911607c74692d";
+    hash = "sha256-pPnOM4hpbAkGCV47aw5eHbpOujjFtJa3v/3/D8gybO8=";
   };
 
   nativeBuildInputs = [
@@ -51,7 +51,7 @@ rustPlatform.buildRustPackage rec {
     stdenv.cc.cc.lib
   ];
 
-  cargoHash = "sha256-9cOJ79GrnrMEIhFikvCfXa2SI4O0fy50cr4Fb6p4Vho=";
+  cargoHash = "sha256-wJViSHcezoIchWe4Py9j+9U+YJUA5ja/x94UipuWO2g=";
 
   # prevents zig AccessDenied error github.com/ziglang/zig/issues/6810
   XDG_CACHE_HOME = "xdg_cache";


### PR DESCRIPTION
Roc alpha4 release notes: https://github.com/roc-lang/roc/releases/tag/alpha4-rolling

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review --eval local` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
