### PR TITLE
python3Packages.pyliblo3: add patch to fix cython compilation failure

### DIFF
--- a/pkgs/development/python-modules/pyliblo3/default.nix
+++ b/pkgs/development/python-modules/pyliblo3/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   setuptools,
   python,
   liblo,
@@ -19,6 +20,15 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-QfwZXkUT4U2Gfbv3rk0F/bze9hwJGn7H8t0X1SWqIuc=";
   };
+
+  patches = [
+    # https://github.com/NixOS/nixpkgs/issues/437077
+    (fetchpatch2 {
+      name = "fix-compilation-for-cython-3.1.2";
+      url = "https://github.com/gesellkammer/pyliblo3/commit/baa249acf91bcb851aa4e30e53e88728fe0fb0c9.patch?full_index=1";
+      hash = "sha256-fMKBVIZLBq62khhX40tpaM47nuHB0eqiURIul/4LMig=";
+    })
+  ];
 
   build-system = [
     setuptools


### PR DESCRIPTION
Fixes #437077
Updating cython from 3.0.12 to 3.1.2 broke pyliblo compilations. This patch has already been upstreamed but no official release has been made yet.
Once an official release is made the patch can be removed.

@nyabinary this version of the PR is to vendor the patch rather than pointing to an unstable version. I'd rather do this because the release cycle of pyliblo3 is very inconsistent and it could potentially be a while before the next release is made. (We'd need to wait for 0.16.5 since 0.16.4 never had a tagged git release). 

If you would really prefer an unstable version (activity seems to have calmed down again after fixing this bug) I could make a different PR doing that.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
