### PR TITLE
vimPlugins: fix hard depenency on pickers

### DIFF
--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2641,14 +2641,10 @@ assertNoAdditions {
   };
 
   nvim-tinygit = super.nvim-tinygit.overrideAttrs {
-    dependencies = with self; [
-      telescope-nvim
-    ];
-
     checkInputs = [
       gitMinimal
-      # transitive dependency (telescope-nvim) not properly propagated to the test environment
-      self.plenary-nvim
+      # interactive staging support
+      self.telescope-nvim
     ];
   };
 

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1628,11 +1628,13 @@ assertNoAdditions {
   };
 
   leetcode-nvim = super.leetcode-nvim.overrideAttrs {
-    checkInputs = [ self.snacks-nvim ];
+    checkInputs = with self; [
+      snacks-nvim
+      telescope-nvim
+    ];
     dependencies = with self; [
       nui-nvim
       plenary-nvim
-      telescope-nvim
     ];
 
     doInstallCheck = true;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -3607,9 +3607,6 @@ assertNoAdditions {
   };
 
   uv-nvim = super.uv-nvim.overrideAttrs {
-    dependencies = with self; [
-      telescope-nvim
-    ];
     runtimeDeps = [ uv ];
   };
 

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1107,11 +1107,11 @@ assertNoAdditions {
   easy-dotnet-nvim = super.easy-dotnet-nvim.overrideAttrs {
     dependencies = with self; [
       plenary-nvim
-      telescope-nvim
     ];
     checkInputs = with self; [
-      # Pickers, can use telescope or fzf-lua
+      # Pickers, can use telescope, fzf-lua, or snacks
       fzf-lua
+      telescope-nvim
     ];
   };
 

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -4010,9 +4010,12 @@ assertNoAdditions {
   };
 
   vs-tasks-nvim = super.vs-tasks-nvim.overrideAttrs {
-    dependencies = with self; [
-      plenary-nvim
-      telescope-nvim
+    checkInputs = [
+      # Optional telescope integration
+      self.telescope-nvim
+    ];
+    dependencies = [
+      self.plenary-nvim
     ];
   };
 

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2187,11 +2187,14 @@ assertNoAdditions {
   };
 
   neotest-playwright = super.neotest-playwright.overrideAttrs {
+    checkInputs = with self; [
+      # Optional picker integration
+      telescope-nvim
+    ];
     dependencies = with self; [
       neotest
       nvim-nio
       plenary-nvim
-      telescope-nvim
     ];
     # Unit test assert
     nvimSkipModules = "neotest-playwright-assertions";

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -143,13 +143,13 @@ in
 assertNoAdditions {
   advanced-git-search-nvim = super.advanced-git-search-nvim.overrideAttrs {
     checkInputs = with self; [
+      fzf-lua
       snacks-nvim
+      telescope-nvim
     ];
     dependencies = with self; [
-      telescope-nvim
       vim-fugitive
       vim-rhubarb
-      fzf-lua
       plenary-nvim
     ];
   };


### PR DESCRIPTION
Inspired by recent effort to get rid of telescope now that i've switched to fzf-lua/snacks. Noticed it still getting pulled in by a few plugins that I wouldn't have expected the dependency. Went through our list of overrides and removed it from ones that support different pickers. 

Plugin offers configuration to choose which picker you'd like, don't need to pollute environment with extra deps.

advanced-git-search-nvim
https://github.com/aaronhallaert/advanced-git-search.nvim/blob/ec0dabe38857bc7ba2097677e80155a572e0dfbe/lua/advanced_git_search/global_picker.lua#L5

easy-dotnet: 
>Although not required by the plugin, it is highly recommended to install one of:
>
>    [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
>    [fzf-lua](https://github.com/ibhagwan/fzf-lua)
>    [snacks.nvim](https://github.com/folke/snacks.nvim)

leetcode-nvim
> picker
> 
> Supported picker providers are:
> 
>     [snacks-picker](https://github.com/folke/snacks.nvim)
>     [fzf-lua](https://github.com/ibhagwan/fzf-lua)
>     [telescope](https://github.com/nvim-telescope/telescope.nvim)
> 
> If provider is nil, [leetcode.nvim](https://github.com/kawre/leetcode.nvim) will try to resolve the first available one in the order above.

neotest-playwright
https://github.com/thenbe/neotest-playwright/blob/6266945039dac27a354de33d2f2a66e75485d5e9/src/pickers.lua#L4

uv-nvim
Uses logic to check which picker is installed. 
>- Integration with UI pickers (like Telescope and Snacks.nvim)

vs-tasks-nvim
> 
> Picker Support
> 
> VS Tasks supports multiple picker backends:
> Telescope (Default)
> 
>     Full-featured picker with preview
>     Requires nvim-telescope/telescope.nvim
>     Load extension: require("telescope").load_extension("vstask")
> 
> snacks.nvim
> 
>     Modern picker with excellent UX
>     Requires folke/snacks.nvim
>     Configure with picker = "snacks" in setup
> 
> Note doesn't support dynamic updating of preview as job runs
> Custom Picker
> 
> You can also provide your own picker implementation that follows the picker interface defined in lua/vstask/picker.lua.
> Configuration
> 
>     Configure picker backend (telescope, snacks, or custom)
>     Configure toggle term use
>     Configure terminal behavior
>     Cache json conf sets whether the config will be ran every time. If the cache is removed, this will also remove cache features such as remembering last ran command





<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
