### PR TITLE
goarista: 0-unstable-2025-03-24 -> 0-unstable-2025-09-01

### DIFF
--- a/pkgs/by-name/go/goarista/package.nix
+++ b/pkgs/by-name/go/goarista/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule {
   pname = "goarista";
-  version = "0-unstable-2025-03-24";
+  version = "0-unstable-2025-09-01";
 
   src = fetchFromGitHub {
     owner = "aristanetworks";
     repo = "goarista";
-    rev = "2af7f36a2220911d96d9d5cf8dee641a7c01eb07";
-    hash = "sha256-M/gZVn4ioaxRwbqlee3yeRfWIjaG6mFq2Z+XL5mGjoA=";
+    rev = "4c0e3d6d22a8b50c5a7e107011bbd843ea3a1f76";
+    hash = "sha256-S1RKLcLhy8gPQlbJM4txOCqNWVHQOlJq2zY4Rdhfdls=";
   };
 
-  vendorHash = "sha256-5vdVHTQOXsYc8EdEGEAXk2ZX/6o88gHxBzfwETcwXvA=";
+  vendorHash = "sha256-n+P3L3dT2kYuTyI2qX/nrLRgFIUsP3kkwNZmRQ8EFRs=";
 
   checkFlags =
     let


### PR DESCRIPTION
## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc