### PR TITLE
nixos/syncthing: add api key option and fix `override{Folder,Device}s` handling

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -424,6 +424,8 @@ and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
 
 - `services.pds` has been renamed to `services.bluesky-pds`.
 
+- `services.syncthing` now includes an `apiKeyFile` option and the behavior of `overrideFolders`/`overrideDevices` has been fixed so that pre-existing folders or devices aren't re-created on startup anymore meaning any change to a folder or device done manually through the GUI or API does not get reset.
+
 - `services.xserver.desktopManager.deepin` and associated packages have been removed due to being unmaintained. See issue [#422090](https://github.com/NixOS/nixpkgs/issues/422090) for more details.
 
 - The new option [networking.ipips](#opt-networking.ipips) has been added to create IP within IP kind of tunnels (including 4in6, ip6ip6 and ipip).

--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -80,14 +80,31 @@ let
       umask 0077
 
       curl() {
-          # get the api key by parsing the config.xml
-          while
-              ! ${pkgs.libxml2}/bin/xmllint \
-                  --xpath 'string(configuration/gui/apikey)' \
-                  ${cfg.configDir}/config.xml \
-                  >"$RUNTIME_DIRECTORY/api_key"
-          do sleep 1; done
-          (printf "X-API-Key: "; cat "$RUNTIME_DIRECTORY/api_key") >"$RUNTIME_DIRECTORY/headers"
+          ${
+            if (cfg.apiKeyFile != null) then
+              ''
+                if [ ! -f "$RUNTIME_DIRECTORY/headers" ]
+                then
+                    (printf "X-API-Key: "; cat "${cfg.apiKeyFile}") >"$RUNTIME_DIRECTORY/headers"
+                fi
+              ''
+            else
+              ''
+                # Get the api key by parsing config.xml, we do not cache the result
+                # since apiKeyFile was not set in the (NixOS) config, and if we
+                # update the gui settings (without `apikey` set) then syncthing will
+                # generate a new api key.
+                while
+                    ! ${pkgs.libxml2}/bin/xmllint \
+                        --xpath 'string(configuration/gui/apikey)' \
+                        ${cfg.configDir}/config.xml \
+                        >"$RUNTIME_DIRECTORY/api_key"
+                do
+                    sleep 1
+                done
+                (printf "X-API-Key: "; cat "$RUNTIME_DIRECTORY/api_key") >"$RUNTIME_DIRECTORY/headers"
+              ''
+          }
           ${pkgs.curl}/bin/curl -sSLk -H "@$RUNTIME_DIRECTORY/headers" \
               --retry 1000 --retry-delay 1 --retry-all-errors \
               "$@"
@@ -728,6 +745,22 @@ in
         '';
       };
 
+      apiKeyFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          The API key used by the REST API. You must set this option if you
+          plan to use the REST API, and have anything configured under
+          `settings.gui`, since the API key will be reset every time gui
+          settings are updated when syncthing is restarted.
+
+          If this option is set it takes precedence over anything set in
+          `settings.gui.apikey`. You can use `settings.gui.apikey` instead of
+          this option if having your API key in plain text in your NixOS
+          configuration does not bother you.
+        '';
+      };
+
       systemService = mkOption {
         type = types.bool;
         default = true;
@@ -946,17 +979,26 @@ in
               ''}";
           ExecStart =
             let
-              args = lib.escapeShellArgs (
-                (lib.cli.toCommandLineGNU { } {
+              args =
+                (lib.cli.toGNUCommandLine { } {
                   "no-browser" = true;
                   "gui-address" = (if isUnixGui then "unix://" else "") + cfg.guiAddress;
                   "config" = cfg.configDir;
                   "data" = cfg.databaseDir;
                 })
-                ++ cfg.extraFlags
-              );
+                ++ (map lib.escapeShellArg cfg.extraFlags);
             in
-            "${lib.getExe cfg.package} ${args}";
+            pkgs.writeShellScript "syncthing-start" ''
+              ${optionalString (cfg.apiKeyFile != null) ''
+                if [ ! -r "${cfg.apiKeyFile}" ]; then
+                  printf >&2 "Cannot set STGUIAPIKEY: \"${cfg.apiKeyFile}\" could not be found\n"
+                  exit 1
+                fi
+                export STGUIAPIKEY="$(cat ${cfg.apiKeyFile})"
+              ''}
+              exec ${lib.getExe cfg.package} \
+                ${builtins.concatStringsSep " \\\n  " args}
+            '';
           MemoryDenyWriteExecute = true;
           NoNewPrivileges = true;
           PrivateDevices = true;

--- a/nixos/tests/syncthing/folders.nix
+++ b/nixos/tests/syncthing/folders.nix
@@ -10,7 +10,17 @@ let
   idA = genNodeId "a";
   idB = genNodeId "b";
   idC = genNodeId "c";
+  nodeIdPath = nodeId: "${nodeId}/id";
   testPassword = "it's a secret";
+  stCurl = pkgs.writeShellApplication {
+    name = "st-curl";
+    runtimeInputs = [ pkgs.curl ];
+    text = ''
+      exec curl -sSLk -H ${lib.escapeShellArg "X-API-Key: ${testPassword}"} \
+        --retry 1000 --retry-delay 1 --retry-all-errors \
+        "$@"
+    '';
+  };
 in
 {
   name = "syncthing";
@@ -21,14 +31,22 @@ in
       { config, ... }:
       {
         environment.etc.bar-encryption-password.text = testPassword;
+        environment.etc.gui-api-key.text = testPassword;
+        environment.systemPackages = [
+          stCurl
+          pkgs.jq
+        ];
         services.syncthing = {
           enable = true;
           openDefaultPorts = true;
           cert = "${idA}/cert.pem";
           key = "${idA}/key.pem";
+          apiKeyFile = "/etc/gui-api-key";
+          overrideFolders = false;
+          overrideDevices = false;
           settings = {
-            devices.b.id = lib.fileContents "${idB}/id";
-            devices.c.id = lib.fileContents "${idC}/id";
+            devices.b.id = lib.fileContents (nodeIdPath idB);
+            devices.c.id = lib.fileContents (nodeIdPath idC);
             folders.foo = {
               path = "/var/lib/syncthing/foo";
               devices = [ "b" ];
@@ -57,14 +75,21 @@ in
       { config, ... }:
       {
         environment.etc.bar-encryption-password.text = testPassword;
+        environment.etc.gui-api-key.text = testPassword;
+        environment.systemPackages = [
+          stCurl
+          pkgs.jq
+        ];
         services.syncthing = {
           enable = true;
           openDefaultPorts = true;
           cert = "${idB}/cert.pem";
           key = "${idB}/key.pem";
+          apiKeyFile = "/etc/gui-api-key";
+          overrideFolders = false;
           settings = {
-            devices.a.id = lib.fileContents "${idA}/id";
-            devices.c.id = lib.fileContents "${idC}/id";
+            devices.a.id = lib.fileContents (nodeIdPath idA);
+            devices.c.id = lib.fileContents (nodeIdPath idC);
             folders.foo = {
               path = "/var/lib/syncthing/foo";
               devices = [ "a" ];
@@ -97,9 +122,10 @@ in
         openDefaultPorts = true;
         cert = "${idC}/cert.pem";
         key = "${idC}/key.pem";
+        overrideFolders = false;
         settings = {
-          devices.a.id = lib.fileContents "${idA}/id";
-          devices.b.id = lib.fileContents "${idB}/id";
+          devices.a.id = lib.fileContents (nodeIdPath idA);
+          devices.b.id = lib.fileContents (nodeIdPath idB);
           folders.bar = {
             path = "/var/lib/syncthing/bar";
             devices = [
@@ -123,65 +149,148 @@ in
     };
   };
 
-  testScript = ''
-    start_all()
+  testScript = # python
+    ''
+      import functools
+      import json
+      import shlex
 
-    a.wait_for_unit("syncthing.service")
-    b.wait_for_unit("syncthing.service")
-    c.wait_for_unit("syncthing.service")
-    a.wait_for_open_port(22000)
-    b.wait_for_open_port(22000)
-    c.wait_for_open_port(22000)
+      start_all()
 
-    # Test foo
+      for n in (a, b, c):
+        n.wait_for_unit("syncthing.service")
+        n.wait_for_open_port(22000)
 
-    a.wait_for_file("/var/lib/syncthing/foo")
-    b.wait_for_file("/var/lib/syncthing/foo")
+      # Test foo
 
-    a.succeed("echo a2b > /var/lib/syncthing/foo/a2b")
-    b.succeed("echo b2a > /var/lib/syncthing/foo/b2a")
+      a.wait_for_file("/var/lib/syncthing/foo")
+      b.wait_for_file("/var/lib/syncthing/foo")
 
-    a.wait_for_file("/var/lib/syncthing/foo/b2a")
-    b.wait_for_file("/var/lib/syncthing/foo/a2b")
+      a.succeed("echo a2b > /var/lib/syncthing/foo/a2b")
+      b.succeed("echo b2a > /var/lib/syncthing/foo/b2a")
 
-    # Test bar
+      a.wait_for_file("/var/lib/syncthing/foo/b2a")
+      b.wait_for_file("/var/lib/syncthing/foo/a2b")
 
-    a.wait_for_file("/var/lib/syncthing/bar")
-    b.wait_for_file("/var/lib/syncthing/bar")
-    c.wait_for_file("/var/lib/syncthing/bar")
+      # Test bar
 
-    a.succeed("echo plaincontent > /var/lib/syncthing/bar/plainname")
+      a.wait_for_file("/var/lib/syncthing/bar")
+      b.wait_for_file("/var/lib/syncthing/bar")
+      c.wait_for_file("/var/lib/syncthing/bar")
 
-    # B should be able to decrypt, check that content of file matches
-    b.wait_for_file("/var/lib/syncthing/bar/plainname")
-    file_contents = b.succeed("cat /var/lib/syncthing/bar/plainname")
-    assert "plaincontent\n" == file_contents, f"Unexpected file contents: {file_contents=}"
+      a.succeed("echo plaincontent > /var/lib/syncthing/bar/plainname")
 
-    # Bar on C is untrusted, check that content is not in cleartext
-    c.fail("grep -R plaincontent /var/lib/syncthing/bar")
+      # Bar on C is untrusted, check that content is not in cleartext
+      c.fail("grep -R plaincontent /var/lib/syncthing/bar")
 
-    # Test baz
+      # Test baz
 
-    a.wait_for_file("/var/lib/syncthing/baz")
-    b.wait_for_file("/var/lib/syncthing/baz")
-    c.wait_for_file("/var/lib/syncthing/baz")
+      a.wait_for_file("/var/lib/syncthing/baz")
+      b.wait_for_file("/var/lib/syncthing/baz")
+      c.wait_for_file("/var/lib/syncthing/baz")
 
-    # A creates the file notB, C should get it, B should ignore it
-    a.succeed("echo notB > /var/lib/syncthing/baz/notB")
-    a.succeed("echo controlA > /var/lib/syncthing/baz/controlA")
-    c.wait_for_file("/var/lib/syncthing/baz/notB")
-    c.wait_for_file("/var/lib/syncthing/baz/controlA")
-    b.wait_for_file("/var/lib/syncthing/baz/controlA")
+      # A creates the file notB, C should get it, B should ignore it
+      a.succeed("echo notB > /var/lib/syncthing/baz/notB")
+      a.succeed("echo controlA > /var/lib/syncthing/baz/controlA")
+      c.wait_for_file("/var/lib/syncthing/baz/notB")
+      c.wait_for_file("/var/lib/syncthing/baz/controlA")
+      b.wait_for_file("/var/lib/syncthing/baz/controlA")
 
-    # B creates the file notC, A should get it, C should ignore it
-    b.succeed("echo notC > /var/lib/syncthing/baz/notC")
-    b.succeed("echo controlB > /var/lib/syncthing/baz/controlB")
-    a.wait_for_file("/var/lib/syncthing/baz/notC")
-    a.wait_for_file("/var/lib/syncthing/baz/controlB")
-    c.wait_for_file("/var/lib/syncthing/baz/controlB")
+      # B creates the file notC, A should get it, C should ignore it
+      b.succeed("echo notC > /var/lib/syncthing/baz/notC")
+      b.succeed("echo controlB > /var/lib/syncthing/baz/controlB")
+      a.wait_for_file("/var/lib/syncthing/baz/notC")
+      a.wait_for_file("/var/lib/syncthing/baz/controlB")
+      c.wait_for_file("/var/lib/syncthing/baz/controlB")
 
-    # Check that files have been correctly ignored
-    b.fail("cat /var/lib/syncthing/baz/notB")
-    c.fail("cat /var/lib/syncthing/baz/notC")
-  '';
+      # Check that files have been correctly ignored
+      b.fail("cat /var/lib/syncthing/baz/notB")
+      c.fail("cat /var/lib/syncthing/baz/notC")
+
+      # Through the Syncthing API:
+      #
+      # - On B: configure and share folder baz with A;
+      # - On A: configure and share folder baz with B;
+      # - On A: add device D.
+      #
+      # Then restart syncthing-init.service and
+      # make sure that those changes are persisted.
+      nodeIdA = a.succeed("cat ${nodeIdPath idA}").strip()
+      nodeIdB = a.succeed("cat ${nodeIdPath idB}").strip()
+      folder = "baz"
+
+      def share_folder_with(nodeId: str) -> str:
+        # Prepare an API request to create a new
+        # folder and share it with the given node.
+        return json.dumps({
+          "autoNormalize": False, # upstream default is True
+          "caseSensitiveFS": True, # upstream default is False
+          "copyOwnershipFromParent":False,
+          "devices": [
+            {"deviceId": nodeId},
+          ],
+          "enable":True,
+          "id": folder,
+          "label": folder,
+          "path": f"/var/lib/syncthing/{folder}",
+          "type": "sendreceive",
+          "versioning": None,
+        })
+
+      def pause_device_b(nodeId: str) -> str:
+        return json.dumps({
+          "paused": True,
+          "deviceID": nodeIdB,
+          "id": nodeIdB,
+          "name": "b",
+        })
+
+      def post(what: str, node, req: str):
+        cmd = shlex.join([
+          "st-curl",
+          "-X", "POST",
+          "-d", req,
+          f"127.0.0.1:8384/rest/config/{what}"
+        ])
+        return node.succeed(cmd)
+
+      config_folders = functools.partial(post, "folders")
+      config_devices = functools.partial(post, "devices")
+
+      def check_folder(node):
+        cmd = shlex.join(["st-curl", "127.0.0.1:8384/rest/config/folders"])
+        folders = json.loads(node.succeed(cmd))
+        def baz_only(f): return f["path"] == f"/var/lib/syncthing/{folder}"
+        # the type check coerced me to use list...
+        baz_folder = list(filter(baz_only, folders))
+        how_many = len(baz_folder)
+        assert how_many == 1, f"expected 1 {folder} folder (got {how_many})"
+        case_sensitive_fs = baz_folder[0]["caseSensitiveFS"]
+        auto_normalize = baz_folder[0]["autoNormalize"]
+        assert case_sensitive_fs is True, f"caseSensitiveFS was reset to {case_sensitive_fs}"
+        assert auto_normalize is False, f"autoNormalize was reset to {auto_normalize}"
+
+      def check_device(node):
+        cmd = shlex.join(["st-curl", "127.0.0.1:8384/rest/config/devices"])
+        devices = json.loads(node.succeed(cmd))
+        device_b = [d for d in devices if d["deviceID"] == nodeIdB]
+        how_many = len(device_b)
+        assert how_many == 1, f"expected 1 device for nodeID B (got {how_many})"
+        assert device_b[0]["paused"] == True, "syncthing-init shouldn't have unpaused B"
+
+      config_folders(a, share_folder_with(nodeIdB))
+      config_folders(b, share_folder_with(nodeIdA))
+      config_devices(a, pause_device_b(nodeIdB))
+
+      check_folder(a)
+      check_folder(b)
+      check_device(a)
+
+      a.systemctl("restart syncthing-init.service")
+      b.systemctl("restart syncthing-init.service")
+
+      check_folder(a)
+      check_folder(b)
+      check_device(a)
+    '';
 }

--- a/nixos/tests/syncthing/many-devices.nix
+++ b/nixos/tests/syncthing/many-devices.nix
@@ -124,20 +124,8 @@ let
   addDeviceToDeleteScript = pkgs.writers.writeBash "syncthing-add-device-to-delete.sh" ''
     set -euo pipefail
 
-    export RUNTIME_DIRECTORY=/tmp
-
     curl() {
-        # get the api key by parsing the config.xml
-        while
-            ! ${pkgs.libxml2}/bin/xmllint \
-                --xpath 'string(configuration/gui/apikey)' \
-                ${configPath} \
-                >"$RUNTIME_DIRECTORY/api_key"
-        do sleep 1; done
-
-        (printf "X-API-Key: "; cat "$RUNTIME_DIRECTORY/api_key") >"$RUNTIME_DIRECTORY/headers"
-
-        ${pkgs.curl}/bin/curl -sSLk -H "@$RUNTIME_DIRECTORY/headers" \
+        ${pkgs.curl}/bin/curl -sSLk -H "X-Api-Key: ${guiApiKey}" \
             --retry 1000 --retry-delay 1 --retry-all-errors \
             "$@"
     }
@@ -146,6 +134,7 @@ let
     curl -d ${lib.escapeShellArg (builtins.toJSON { id = IDsToDelete.folder; })} \
         -X POST 127.0.0.1:8384/rest/config/folders
   '';
+  guiApiKey = "very_secret_key";
 in
 {
   name = "syncthing-many-devices";
@@ -156,6 +145,7 @@ in
       enable = true;
       overrideDevices = true;
       overrideFolders = true;
+      apiKeyFile = pkgs.writeText "syncthing-api-key" guiApiKey;
       settings = settingsWithoutId // settingsWithId;
     };
   };


### PR DESCRIPTION
From the release notes:

`services.syncthing` now includes an `apiKeyFile` option and the behavior of `overrideFolders`/`overrideDevices` has been fixed so that pre-existing folders or devices aren't re-created on startup anymore meaning any change to a folder or device done manually through the GUI or API does not get reset.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

cc @jfly 

Previously: #394406 #394409.

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
