### PR TITLE
balatro: add requireFile message

### DIFF
--- a/pkgs/by-name/ba/balatro/package.nix
+++ b/pkgs/by-name/ba/balatro/package.nix
@@ -18,6 +18,13 @@ stdenv.mkDerivation (finalAttrs: {
   src = requireFile {
     name = "Balatro-${finalAttrs.version}.exe";
     url = "https://store.steampowered.com/app/2379780/Balatro/";
+    message = ''
+      Balatro cannot be automatically downloaded. Please download
+      it from Steam, locate the Balatro.exe on disk, likely in
+      ~/.local/share/Steam/steamapps/common/Balatro/, then upload it
+      to your nix store with nix-store --add-fixed sha256 Balatro.exe.
+    '';
+
     # Use `nix --extra-experimental-features nix-command hash file --sri --type sha256` to get the correct hash
     hash = "sha256-DXX+FkrM8zEnNNSzesmHiN0V8Ljk+buLf5DE5Z3pP0c=";
   };


### PR DESCRIPTION
## Things Done
Adds a quick message to explain where to acquire the Balatro.exe that is required in the store.

As a note Balatro currently does not build due to a failure to build the package lovely-injector. This is being fixed by #441266 and all my testing was done with this PR applied.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc