### PR TITLE
buildGoModule: remove compatibility layer for directly specified `CGO_ENABLED`

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -38,6 +38,9 @@
 
 - `python3Packages.bjoern` has been removed, as the upstream is unmaintained and it depends on a 14-year-old version of http-parser with numerous vulnerabilities.
 
+- `buildGoModule` removes the compatibility layer of `CGO_ENABLED` not specified via `env`.
+  Specifying `CGO_ENABLED` directly now results in an error.
+
 - `buildGoModule` now warns if `<pkg>.passthru.overrideModAttrs` is lost during the overriding of its result packages.
 
 - `gentium` package now provides `Gentium-*.ttf` files, and not `GentiumPlus-*.ttf` files like before. The font identifiers `Gentium Plus*` are available in the `gentium-plus` package, and if you want to use the more recently updated package `gentium` [by sil](https://software.sil.org/gentium/), you should update your configuration files to use the `Gentium` font identifier.

--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -10,9 +10,6 @@ lib.extendMkDerivation {
   constructDrv = stdenv.mkDerivation;
   excludeDrvArgNames = [
     "overrideModAttrs"
-    # Compatibility layer to the directly-specified CGO_ENABLED.
-    # TODO(@ShamrockLee): Remove after Nixpkgs 25.05 branch-off
-    "CGO_ENABLED"
   ];
   extendDrvArgs =
     finalAttrs:
@@ -226,19 +223,7 @@ lib.extendMkDerivation {
         GO111MODULE = "on";
         GOTOOLCHAIN = "local";
 
-        CGO_ENABLED =
-          args.env.CGO_ENABLED or (
-            if args ? CGO_ENABLED then
-              # Compatibility layer to the CGO_ENABLED attribute not specified as env.CGO_ENABLED
-              # TODO(@ShamrockLee): Remove and convert to
-              # CGO_ENABLED = args.env.CGO_ENABLED or go.CGO_ENABLED
-              # after the Nixpkgs 25.05 branch-off.
-              lib.warn
-                "${finalAttrs.finalPackage.meta.position}: buildGoModule: specify CGO_ENABLED with env.CGO_ENABLED instead."
-                args.CGO_ENABLED
-            else
-              go.CGO_ENABLED
-          );
+        CGO_ENABLED = args.env.CGO_ENABLED or go.CGO_ENABLED;
       };
 
       GOFLAGS =


### PR DESCRIPTION
Subsequent clean-up for PR #359641, removing the compatibility layer and simplify the expression.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
