### PR TITLE
treewide: adopt astronomy packages maintained by hjones2199

### DIFF
--- a/pkgs/applications/science/astronomy/celestia/default.nix
+++ b/pkgs/applications/science/astronomy/celestia/default.nix
@@ -70,7 +70,10 @@ stdenv.mkDerivation rec {
     mainProgram = "celestia";
     changelog = "https://github.com/CelestiaProject/Celestia/releases/tag/${version}";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ hjones2199 ];
+    maintainers = with lib.maintainers; [
+      hjones2199
+      returntoreality
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/cf/cfitsio/package.nix
+++ b/pkgs/by-name/cf/cfitsio/package.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/docs/changes.txt";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
+      returntoreality
       xbreak
       hjones2199
     ];

--- a/pkgs/by-name/li/libnova/package.nix
+++ b/pkgs/by-name/li/libnova/package.nix
@@ -25,7 +25,10 @@ stdenv.mkDerivation rec {
     mainProgram = "libnovaconfig";
     homepage = "http://libnova.sf.net";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ hjones2199 ];
+    maintainers = with maintainers; [
+      hjones2199
+      returntoreality
+    ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/li/librtprocess/package.nix
+++ b/pkgs/by-name/li/librtprocess/package.nix
@@ -25,7 +25,10 @@ stdenv.mkDerivation rec {
     description = "Highly optimized library for processing RAW images";
     homepage = "https://github.com/CarVac/librtprocess";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ hjones2199 ];
+    maintainers = with maintainers; [
+      hjones2199
+      returntoreality
+    ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/ph/phd2/package.nix
+++ b/pkgs/by-name/ph/phd2/package.nix
@@ -55,7 +55,10 @@ stdenv.mkDerivation rec {
     description = "Telescope auto-guidance application";
     changelog = "https://github.com/OpenPHDGuiding/phd2/releases/tag/v${version}";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ hjones2199 ];
+    maintainers = with lib.maintainers; [
+      hjones2199
+      returntoreality
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/si/siril/package.nix
+++ b/pkgs/by-name/si/siril/package.nix
@@ -103,7 +103,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Astrophotographic image processing tool";
     license = lib.licenses.gpl3Plus;
     changelog = "https://gitlab.com/free-astro/siril/-/blob/HEAD/ChangeLog";
-    maintainers = with lib.maintainers; [ hjones2199 ];
+    maintainers = with lib.maintainers; [
+      hjones2199
+      returntoreality
+    ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/wc/wcslib/package.nix
+++ b/pkgs/by-name/wc/wcslib/package.nix
@@ -40,7 +40,10 @@ stdenv.mkDerivation rec {
       and their conversion to image coordinate systems. This is the
       standard library for this purpose in astronomy.
     '';
-    maintainers = with lib.maintainers; [ hjones2199 ];
+    maintainers = with lib.maintainers; [
+      hjones2199
+      returntoreality
+    ];
     license = lib.licenses.lgpl3Plus;
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
I added myself to the maintainers of several astronomy packages maintained by @hjones2199 to adopt them as this maintainer has not been active in the last years

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
