### PR TITLE
spirv-{headers,tools}: patch for LLVM 21

### DIFF
--- a/pkgs/by-name/sp/spirv-headers/package.nix
+++ b/pkgs/by-name/sp/spirv-headers/package.nix
@@ -2,6 +2,8 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  applyPatches,
+  fetchpatch,
   cmake,
 }:
 
@@ -9,11 +11,25 @@ stdenv.mkDerivation rec {
   pname = "spirv-headers";
   version = "1.4.321.0";
 
-  src = fetchFromGitHub {
-    owner = "KhronosGroup";
-    repo = "SPIRV-Headers";
-    rev = "vulkan-sdk-${version}";
-    hash = "sha256-LRjMy9xtOErbJbMh+g2IKXfmo/hWpegZM72F8E122oY=";
+  # Several downstream derivations consume `spirv-headers.src`; apply
+  # relevant patches here rather than in the main derivation.
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "KhronosGroup";
+      repo = "SPIRV-Headers";
+      rev = "vulkan-sdk-${version}";
+      hash = "sha256-LRjMy9xtOErbJbMh+g2IKXfmo/hWpegZM72F8E122oY=";
+    };
+
+    patches = [
+      # Backport commit missing from 1.4.321.0 that is required for
+      # libclc 21 to build.
+      (fetchpatch {
+        name = "spirv-headers-add-SPV_INTEL_function_variants.patch";
+        url = "https://github.com/KhronosGroup/SPIRV-Headers/commit/9e3836d7d6023843a72ecd3fbf3f09b1b6747a9e.patch";
+        hash = "sha256-wADjOxcIXHjF735w0wUAeDbVEJR8d6UHrHS9CiOEUrA=";
+      })
+    ];
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/sp/spirv-llvm-translator/package.nix
+++ b/pkgs/by-name/sp/spirv-llvm-translator/package.nix
@@ -133,13 +133,5 @@ stdenv.mkDerivation {
     license = licenses.ncsa;
     platforms = platforms.unix;
     maintainers = with maintainers; [ gloaming ];
-
-    # For the LLVM 21 build some commits to spirv-headers
-    # are required that didn't make it into the final release of 1.4.321
-    # For example: 9e3836d Add SPV_INTEL_function_variants
-    # Once spirv-headers are released again and updated on nixpkgs,
-    # this will switch over to the nixpkgs version and should no
-    # longer be broken.
-    broken = llvmMajor == "21" && lib.versionOlder spirv-headers.version "1.4.322";
   };
 }

--- a/pkgs/by-name/sp/spirv-tools/package.nix
+++ b/pkgs/by-name/sp/spirv-tools/package.nix
@@ -2,6 +2,8 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  applyPatches,
+  fetchpatch,
   cmake,
   python3,
   spirv-headers,
@@ -11,11 +13,24 @@ stdenv.mkDerivation rec {
   pname = "spirv-tools";
   version = "1.4.321.0";
 
-  src = fetchFromGitHub {
-    owner = "KhronosGroup";
-    repo = "SPIRV-Tools";
-    rev = "vulkan-sdk-${version}";
-    hash = "sha256-yAdd/mXY8EJnE0vCu0n/aVxMH9059T/7cAdB9nP1vQQ=";
+  # Several downstream derivations consume `spirv-tools.src`; apply
+  # relevant patches here rather than in the main derivation.
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "KhronosGroup";
+      repo = "SPIRV-Tools";
+      rev = "vulkan-sdk-${version}";
+      hash = "sha256-yAdd/mXY8EJnE0vCu0n/aVxMH9059T/7cAdB9nP1vQQ=";
+    };
+
+    patches = [
+      # Fix the build with the corresponding backport in the headers.
+      (fetchpatch {
+        name = "spirv-tools-SPV_INTEL_function_variants.patch";
+        url = "https://github.com/KhronosGroup/SPIRV-Tools/commit/28a883ba4c67f58a9540fb0651c647bb02883622.patch";
+        hash = "sha256-zH8wI7Ilir0FEbJ3RzHn9b29Etn7ahMUWCFz0o7R6hE=";
+      })
+    ];
   };
 
   # The cmake options are sufficient for turning on static building, but not


### PR DESCRIPTION
It looks like Debian is already doing this, although they seem to have not yet noticed that their headers change will break the tools without additional backports.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
