### PR TITLE
virtualisation/qemu-vm: add support for nix storePaths to virtualisation.diskImage

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -136,6 +136,18 @@ let
 
     NIX_DISK_IMAGE=$(readlink -f "''${NIX_DISK_IMAGE:-${toString config.virtualisation.diskImage}}") || test -z "$NIX_DISK_IMAGE"
 
+    # If the disk image is in the Nix store (read-only), create a writable qcow2 copy in $TMPDIR
+    if [[ "$NIX_DISK_IMAGE" == ${builtins.storeDir}/* ]]; then
+        # Create a directory for storing temporary data of the running VM if not already created
+        if [ -z "$TMPDIR" ] || [ -z "$USE_TMPDIR" ]; then
+            TMPDIR=$(mktemp -d nix-vm.XXXXXXXXXX --tmpdir)
+        fi
+        TMP_DISK_IMAGE="$TMPDIR/root-disk.qcow2"
+        echo "Detected Nix store disk image, creating writable qcow2 copy at $TMP_DISK_IMAGE"
+        ${qemu}/bin/qemu-img create -f qcow2 -b "$NIX_DISK_IMAGE" -F raw "$TMP_DISK_IMAGE"
+        NIX_DISK_IMAGE="$TMP_DISK_IMAGE"
+    fi
+
     if test -n "$NIX_DISK_IMAGE" && ! test -e "$NIX_DISK_IMAGE"; then
         echo "Disk image do not exist, creating the virtualisation disk image..."
 

--- a/nixos/tests/appliance-repart-image-verity-store.nix
+++ b/nixos/tests/appliance-repart-image-verity-store.nix
@@ -67,6 +67,7 @@
         directBoot.enable = false;
         mountHostNixStore = false;
         useEFIBoot = true;
+        diskImage = "${config.system.build.finalImage}/${config.image.repart.imageFile}";
       };
 
       boot = {
@@ -86,28 +87,8 @@
     };
 
   testScript =
-    { nodes, ... }: # python
+    # python
     ''
-      import os
-      import subprocess
-      import tempfile
-
-      tmp_disk_image = tempfile.NamedTemporaryFile()
-
-      subprocess.run([
-        "${nodes.machine.virtualisation.qemu.package}/bin/qemu-img",
-        "create",
-        "-f",
-        "qcow2",
-        "-b",
-        "${nodes.machine.system.build.finalImage}/${nodes.machine.image.repart.imageFile}",
-        "-F",
-        "raw",
-        tmp_disk_image.name,
-      ])
-
-      os.environ['NIX_DISK_IMAGE'] = tmp_disk_image.name
-
       machine.wait_for_unit("default.target")
 
       with subtest("Running with volatile root"):

--- a/nixos/tests/appliance-repart-image.nix
+++ b/nixos/tests/appliance-repart-image.nix
@@ -92,32 +92,14 @@ in
           };
         };
       };
+
+      # Use the store image path directly; qemu-vm.nix will handle making it writable
+      virtualisation.diskImage = "${config.system.build.image}/${config.image.repart.imageFile}";
     };
 
   testScript =
     { nodes, ... }:
     ''
-      import os
-      import subprocess
-      import tempfile
-
-      tmp_disk_image = tempfile.NamedTemporaryFile()
-
-      subprocess.run([
-        "${nodes.machine.virtualisation.qemu.package}/bin/qemu-img",
-        "create",
-        "-f",
-        "qcow2",
-        "-b",
-        "${nodes.machine.system.build.image}/${nodes.machine.image.repart.imageFile}",
-        "-F",
-        "raw",
-        tmp_disk_image.name,
-      ])
-
-      # Set NIX_DISK_IMAGE so that the qemu script finds the right disk image.
-      os.environ['NIX_DISK_IMAGE'] = tmp_disk_image.name
-
       os_release = machine.succeed("cat /etc/os-release")
       assert 'IMAGE_ID="${imageId}"' in os_release
       assert 'IMAGE_VERSION="${imageVersion}"' in os_release


### PR DESCRIPTION
This way don't need to do the weird python dance.

I still gotta convert the rest of the NixOS tests. I honestly feel like the need of `NIX_DISK_IMAGE` is very limited but we probably can't remove it for backward-compatibility reasons

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
