### PR TITLE
lib.makeOverridable: propagate .override

### DIFF
--- a/pkgs/by-name/_1/_1password-gui/package.nix
+++ b/pkgs/by-name/_1/_1password-gui/package.nix
@@ -4,8 +4,6 @@
   channel ? "stable",
   fetchurl,
   lib,
-  # This is only relevant for Linux, so we need to pass it through
-  polkitPolicyOwners ? [ ],
 }:
 
 let
@@ -63,6 +61,5 @@ else
       version
       src
       meta
-      polkitPolicyOwners
       ;
   }

--- a/pkgs/by-name/gl/glib/package.nix
+++ b/pkgs/by-name/gl/glib/package.nix
@@ -37,9 +37,7 @@
   libsysprof-capture,
   mesonEmulatorHook,
   withIntrospection ?
-    stdenv.hostPlatform.emulatorAvailable buildPackages
-    && lib.meta.availableOn stdenv.hostPlatform gobject-introspection
-    && stdenv.hostPlatform.isLittleEndian == stdenv.buildPlatform.isLittleEndian,
+    false,
 }:
 
 assert stdenv.hostPlatform.isLinux -> util-linuxMinimal != null;


### PR DESCRIPTION
Just a draft to resolve https://github.com/NixOS/nixpkgs/pull/441492#issuecomment-3272169845:

> Standard `by-name` caveat, though: you actually need to do `{ mkRenameAlias, ... }@args: (mkRenameAlias "25.11" "renamed-package").override args` for renames, which sucks.

With this PR, you can do:

```
nix repl . --arg config { allowUnfree = true; }

nix-repl> _1password-gui-beta.override { channel = "stable"; lib = { inherit (lib) maintainers licenses sourceTypes; }; polkitPolicyOwners = [ "foo" ]; }
«derivation /nix/store/kgxk8mpa1wszjzdab9gf4yvjaidxkcpc-1password-8.11.8.drv»
```

where:
- `channel = stable` is passed to https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/_1/_1password-gui-beta/package.nix
- `lib` is only passed to https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/_1/_1password-gui/package.nix, but not `./linux.nix` - otherwise it would error because stuff in lib is failing.
- `polkitPolicyOwners` is passed to https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/_1/_1password-gui/linux.nix

The idea is that outer `.override`s "consume" arguments and pass on what is left.

In theory, this should not be a breaking change, because arguments that the outer function can't consume would currently throw an error. Unless... people are using `... }@args` stuff. I hit some of that in https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/gobject-introspection/wrapper.nix#L27-L33 - and just temporarily worked around that for now.

I'd like to discuss the idea first - is this something that we *want* to have? Is this something that we *can actually do* given the breaking change potential for this specific `@args` use-case?

Even if we have breaking changes.. we surely have a lot more packages just flat out doing it wrong, which we would fix that way. `_1password-gui` is just the first thing that I hit, I'm sure.

WDYT @emilazy?

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
