### PR TITLE
maintainers: drop hjones2199

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10300,12 +10300,6 @@
     github = "hitsmaxft";
     githubId = 352727;
   };
-  hjones2199 = {
-    email = "hjones2199@gmail.com";
-    github = "hjones2199";
-    githubId = 5525217;
-    name = "Hunter Jones";
-  };
   hkjn = {
     email = "me@hkjn.me";
     name = "Henrik Jonsson";

--- a/pkgs/applications/science/astronomy/celestia/default.nix
+++ b/pkgs/applications/science/astronomy/celestia/default.nix
@@ -71,7 +71,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/CelestiaProject/Celestia/releases/tag/${version}";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
-      hjones2199
       returntoreality
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/cf/cfitsio/package.nix
+++ b/pkgs/by-name/cf/cfitsio/package.nix
@@ -63,7 +63,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       returntoreality
       xbreak
-      hjones2199
     ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/ks/kstars/package.nix
+++ b/pkgs/by-name/ks/kstars/package.nix
@@ -89,7 +89,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = platforms.linux;
     maintainers = with maintainers; [
       timput
-      hjones2199
       returntoreality
     ];
   };

--- a/pkgs/by-name/li/libnova/package.nix
+++ b/pkgs/by-name/li/libnova/package.nix
@@ -26,7 +26,6 @@ stdenv.mkDerivation rec {
     homepage = "http://libnova.sf.net";
     license = licenses.gpl2;
     maintainers = with maintainers; [
-      hjones2199
       returntoreality
     ];
     platforms = platforms.unix;

--- a/pkgs/by-name/li/librtprocess/package.nix
+++ b/pkgs/by-name/li/librtprocess/package.nix
@@ -26,7 +26,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/CarVac/librtprocess";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [
-      hjones2199
       returntoreality
     ];
     platforms = platforms.unix;

--- a/pkgs/by-name/ph/phd2/package.nix
+++ b/pkgs/by-name/ph/phd2/package.nix
@@ -56,7 +56,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/OpenPHDGuiding/phd2/releases/tag/v${version}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
-      hjones2199
       returntoreality
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/si/siril/package.nix
+++ b/pkgs/by-name/si/siril/package.nix
@@ -104,7 +104,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     changelog = "https://gitlab.com/free-astro/siril/-/blob/HEAD/ChangeLog";
     maintainers = with lib.maintainers; [
-      hjones2199
       returntoreality
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/st/stellarsolver/package.nix
+++ b/pkgs/by-name/st/stellarsolver/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Astrometric plate solving library";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [
-      hjones2199
       returntoreality
     ];
     platforms = platforms.unix;

--- a/pkgs/by-name/wc/wcslib/package.nix
+++ b/pkgs/by-name/wc/wcslib/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation rec {
       standard library for this purpose in astronomy.
     '';
     maintainers = with lib.maintainers; [
-      hjones2199
       returntoreality
     ];
     license = lib.licenses.lgpl3Plus;

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -252,7 +252,6 @@ stdenv.mkDerivation {
     # will succeed, but packages depending on boost-context will fail with
     # a very cryptic error message.
     badPlatforms = [ lib.systems.inspect.patterns.isMips64n32 ];
-    maintainers = with maintainers; [ hjones2199 ];
     broken =
       enableNumpy && lib.versionOlder version "1.86" && lib.versionAtLeast python.pkgs.numpy.version "2";
   };

--- a/pkgs/development/libraries/science/astronomy/indilib/default.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/default.nix
@@ -87,7 +87,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/indilib/indi/releases/tag/v${finalAttrs.version}";
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [
-      hjones2199
       sheepforce
       returntoreality
     ];

--- a/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
@@ -116,7 +116,6 @@ let
             changelog = "https://github.com/indilib/indi-3rdparty/releases/tag/v${version}";
             license = licenses.lgpl2Plus;
             maintainers = with maintainers; [
-              hjones2199
               sheepforce
               returntoreality
             ];


### PR DESCRIPTION
Inactive since 2023.

Dropping according to maintainer guidelines: https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status

@hjones2199 if you'd like to stay a maintainer, please respond within a week.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
