### PR TITLE
tree-sitter-grammars.tree-sitter-yaml: switch to maintained fork

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-yaml.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-yaml.json
@@ -1,13 +1,14 @@
 {
-  "url": "https://github.com/ikatyang/tree-sitter-yaml",
-  "rev": "0e36bed171768908f331ff7dff9d956bae016efb",
-  "date": "2021-05-11T12:47:24+08:00",
-  "path": "/nix/store/7d7m4zs4ydnwbn3xnfm3pvpy7gvkrmg8-tree-sitter-yaml",
-  "sha256": "0wyvjh62zdp5bhd2y8k7k7x4wz952l55i1c8d94rhffsbbf9763f",
-  "hash": "sha256-bpiT3FraOZhJaoiFWAoVJX1O+plnIi8aXOW2LwyU23M=",
+  "url": "https://github.com/tree-sitter-grammars/tree-sitter-yaml",
+  "rev": "9632edc32eb86966a482fcb3c9a7f4bb78ae0ddb",
+  "date": "2025-05-22T16:31:05+03:00",
+  "path": "/nix/store/rz2zq4cpjgkcnl9b3y0wckcz91a4b7lz-tree-sitter-yaml",
+  "sha256": "0j03miv56d0sh9cnnrxjxwzwjiypw9pqxpx698f9zjc80mlzyqk7",
+  "hash": "sha256-Z2L/aQWIyZ8cSqbfjm/i10fJP++yZ2tZgho0U3asA0g=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "fetchTags": false,
-  "leaveDotGit": false
+  "leaveDotGit": false,
+  "rootDir": ""
 }

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -209,7 +209,7 @@ let
       repo = "tree-sitter-viml";
     };
     "tree-sitter-yaml" = {
-      orga = "ikatyang";
+      orga = "tree-sitter-grammars";
       repo = "tree-sitter-yaml";
     };
     "tree-sitter-zig" = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR changes the tree-sitter-yaml grammar to a maintained fork, the one currently in use was last updated 4 years ago and has bugs that are resolved in the fork.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
