### PR TITLE
doctest: 2.4.11 -> 2.4.12

### DIFF
--- a/pkgs/by-name/do/doctest/package.nix
+++ b/pkgs/by-name/do/doctest/package.nix
@@ -8,27 +8,40 @@
 
 stdenv.mkDerivation rec {
   pname = "doctest";
-  version = "2.4.11";
+  version = "2.4.12";
 
   src = fetchFromGitHub {
     owner = "doctest";
     repo = "doctest";
-    rev = "v${version}";
-    sha256 = "sha256-hotO6QVpPn8unYTaQHFgi40A3oLUd++I3aTe293e4Aw=";
+    tag = "v${version}";
+    hash = "sha256-Fxs1EWydhqN9whx+Cn4fnZ4fhCEQvFgL5e9TUiXlnq8=";
   };
 
   patches = [
-    # Suppress unsafe buffer usage warnings with clang 16, which are treated as errors due to `-Werror`.
-    # https://github.com//doctest/doctest/pull/768
+    # Fix the build with Clang.
     (fetchpatch {
-      url = "https://github.com/doctest/doctest/commit/9336c9bd86e3fc2e0c36456cad8be3b4e8829a22.patch";
-      hash = "sha256-ZFCVk5qvgfixRm7ZFr7hyNCSEvrT6nB01G/CBshq53o=";
+      name = "doctest-disable-warnings.patch";
+      url = "https://github.com/doctest/doctest/commit/c8d9ed2398d45aa5425d913bd930f580560df30d.patch";
+      excludes = [ ".github/workflows/main.yml" ];
+      hash = "sha256-kOBy0om6MPM2vLXZjNLXiezZqVgNr/viBI7mXrOZts8=";
     })
   ];
 
   nativeBuildInputs = [ cmake ];
 
   doCheck = true;
+
+  # Fix the build with LLVM 21 / GCC 15.
+  #
+  # See:
+  #
+  # * <https://github.com/doctest/doctest/issues/928>
+  # * <https://github.com/doctest/doctest/pull/929>
+  # * <https://github.com/doctest/doctest/issues/950>
+  env.NIX_CFLAGS_COMPILE = lib.concatStringsSep " " [
+    "-Wno-error=nrvo"
+    "-Wno-error=missing-noreturn"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/doctest/doctest";


### PR DESCRIPTION
Fixes the build with CMake 4. I also replaced a closed pull request to disable warnings with a merged one, and then disabled some more for LLVM 21 / GCC 15…

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
