### PR TITLE
grub: Fix build by updating hash of patch

### DIFF
--- a/pkgs/tools/misc/grub/default.nix
+++ b/pkgs/tools/misc/grub/default.nix
@@ -219,7 +219,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "23_prerequisite_1_key_protector_add_key_protectors_framework.patch";
       url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=5d260302da672258444b01239803c8f4d753e3f3";
-      hash = "sha256-9WnFN6xMiv+1XMhNHgVEegkhwzp9KpRZI6MIZY/Ih3Q=";
+      hash = "sha256-5aFHzc5qXBNLEc6yzI17AH6J7EYogcXdLxk//1QgumY=";
     })
     (fetchpatch {
       name = "23_prerequisite_2_disk_cryptodisk_allow_user_to_retry_failed_passphrase.patch";


### PR DESCRIPTION
After [mirrors were added for git.savannah.gnu.org](https://lists.gnu.org/archive/html/savannah-users/2025-05/msg00002.html) the fetched patch has a small difference in its formatting so the hash has changed. I fetched this from all three mirrors and I'm getting the same exact patch, so this is not mirror specific.

The diff between the new and old version is:
```
diff /nix/store/c8fmjixgr2i38841xd26z63pmwn5dpg0-23_prerequisite_1_key_protector_add_key_protectors_framework.patch /nix/store/6mi6z9hglcazqdfj1n1fvy4ypkkhvqsy-23_prerequisite_1_key_protector_add_key_protectors_framework.patch
13c13,14
< @@ -1283,6 +1283,11 @@
---
> @@ -1282,6 +1282,11 @@
>    common = disk/raid6_recover.c;
16c17
<  module = {
---
> +module = {
21c22
< +module = {
---
>  module = {
24d24
<  };
```

PS. This might have changed before the mirrors were added, but I noticed this now.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
