### PR TITLE
nixos/home-assistant: add themes support

### DIFF
--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -71,7 +71,7 @@ let
   # Filter null values from the configuration, so that we can still advertise
   # optional options in the config attribute.
   filteredConfig = converge (filterAttrsRecursive (_: v: !elem v [ null ])) (
-    recursiveUpdate customLovelaceModulesResources (cfg.config or { })
+    recursiveUpdate (customLovelaceModulesResources // themesConfig) (cfg.config or { })
   );
   configFile = renderYAMLFile "configuration.yaml" filteredConfig;
 
@@ -143,13 +143,28 @@ let
     paths = cfg.customLovelaceModules;
   };
 
-  # Create parts of the lovelace config that reference lovelave modules as resources
+  # Create parts of the lovelace config that reference lovelace modules as resources
   customLovelaceModulesResources = {
     lovelace.resources = map (card: {
       url = "/local/nixos-lovelace-modules/${card.entrypoint or (card.pname + ".js")}?${card.version}";
       type = "module";
     }) cfg.customLovelaceModules;
   };
+
+  # Create a directory that holds all lovelace themes
+  themesDir = pkgs.buildEnv {
+    name = "home-assistant-themes";
+    paths = cfg.themes;
+  };
+
+  # Auto-inject frontend.themes include directive when themes are used.
+  themesConfig =
+    if cfg.themes != [ ] then
+      {
+        frontend.themes = "!include_dir_merge_named ${themesDir}/themes";
+      }
+    else
+      { };
 
   componentsUsingBluetooth = [
     # Components that require the AF_BLUETOOTH address family
@@ -440,6 +455,33 @@ in
         ::: {.note}
         When non-empty, `lovelace.resource_mode` is automatically set to `"yaml"`
         so that resources are loaded from the YAML configuration.
+        :::
+      '';
+    };
+
+    themes = mkOption {
+      type = types.listOf (
+        types.addCheck types.package (p: p.isHomeAssistantTheme or false)
+        // {
+          name = "home-assistant-theme";
+          description = "package that is a Home Assistant theme";
+        }
+      );
+      default = [ ];
+      example = literalExpression ''
+        with pkgs.home-assistant-themes; [
+          material-you-theme
+        ];
+      '';
+      description = ''
+        List of themes to load.
+
+        Available themes can be found below `pkgs.home-assistant-themes`.
+
+        ::: {.note}
+        When `themes` is set, the module takes authoritative control
+        over the `frontend.themes` setting in
+        {option}`services.home-assistant.config`.
         :::
       '';
     };
@@ -797,6 +839,10 @@ in
         assertion = !(cfg.lovelaceConfig != null && cfg.lovelaceConfigFile != null);
         message = "Only one of `lovelaceConfig` or `lovelaceConfigFile` can be configured at the same time.";
       }
+      {
+        assertion = cfg.themes != [ ] -> !(hasAttrByPath [ "frontend" "themes" ] (cfg.config or { }));
+        message = "`services.home-assistant.themes` and `services.home-assistant.config.frontend.themes` cannot both be set. When `themes` is non-empty the module sets `frontend.themes` authoritatively.";
+      }
     ];
 
     networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.config.http.server_port ];
@@ -880,6 +926,7 @@ in
               ln -fns "''${paths[@]}" "${cfg.configDir}/custom_components/"
             done
           '';
+
           removeBlueprints = ''
             # remove blueprints symlinked in from below the /nix/store
             readarray -d "" blueprints < <(find "${cfg.configDir}/blueprints" -maxdepth 2 -type l -print0)

--- a/nixos/tests/home-assistant.nix
+++ b/nixos/tests/home-assistant.nix
@@ -71,6 +71,11 @@ in
           mini-graph-card
         ];
 
+        # test loading themes
+        themes = with pkgs.home-assistant-themes; [
+          material-you-theme
+        ];
+
         config = {
           homeassistant = {
             name = "Home";
@@ -249,6 +254,11 @@ in
       with subtest("Check that lovelace modules are referenced and fetchable"):
           hass.succeed("grep -q 'mini-graph-card-bundle.js' '${configDir}/configuration.yaml'")
           hass.succeed("curl --fail http://localhost:8123/local/nixos-lovelace-modules/mini-graph-card-bundle.js")
+
+      with subtest("Check that themes are referenced and installed"):
+          hass.succeed("grep -q '!include_dir_merge_named.*themes' '${configDir}/configuration.yaml'")
+          themes_dir = hass.succeed("sed -n 's/.*!include_dir_merge_named \\(.*\\)/\\1/p' '${configDir}/configuration.yaml'").strip()
+          hass.succeed(f"test -f {themes_dir}/material_you.yaml")
 
       with subtest("Check that optional dependencies are in the PYTHONPATH"):
           env = get_unit_property("Environment")

--- a/pkgs/servers/home-assistant/themes/README.md
+++ b/pkgs/servers/home-assistant/themes/README.md
@@ -1,0 +1,13 @@
+# Packaging guidelines
+
+## isHomeAssistantTheme
+
+The nixos module checks for `passthru.isHomeAssistantTheme` on every
+package passed to `services.home-assistant.themes`, and rejects packages
+that don't have it set. Mark a theme package like this:
+
+```nix
+{ passthru.isHomeAssistantTheme = true; }
+```
+
+Themes are expected to install their `.yaml` files into `$out/themes/`.

--- a/pkgs/servers/home-assistant/themes/material-you-theme/package.nix
+++ b/pkgs/servers/home-assistant/themes/material-you-theme/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage rec {
+  pname = "material-you-theme";
+  version = "5.0.1";
+
+  src = fetchFromGitHub {
+    owner = "Nerwyn";
+    repo = "material-you-theme";
+    tag = version;
+    hash = "sha256-xJXhvKwp/l08/ZWi3OcGPmCdsUiMjBDwrKz5OIpD2t8=";
+  };
+
+  npmDepsHash = "sha256-g133Je2Md4nKLZucSeM6TVEdaCsR2Ja1Aj2kf7JQk6w=";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dt $out/themes themes/material_you.yaml
+    runHook postInstall
+  '';
+
+  passthru.isHomeAssistantTheme = true;
+
+  meta = {
+    description = "Material Design 3 Theme for Home Assistant";
+    homepage = "https://github.com/Nerwyn/material-you-theme";
+    changelog = "https://github.com/Nerwyn/material-you-theme/releases/tag/${src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jpinz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7931,6 +7931,13 @@ with pkgs;
     )
   );
 
+  home-assistant-themes = lib.recurseIntoAttrs (
+    lib.packagesFromDirectoryRecursive {
+      inherit callPackage;
+      directory = ../servers/home-assistant/themes;
+    }
+  );
+
   home-assistant-cli = callPackage ../servers/home-assistant/cli.nix { };
 
   _surrealdbPackage = ../by-name/su/surrealdb/package.nix;


### PR DESCRIPTION
## Things done

- Add custom-themes support to home-assistant.
- Add [material-you-theme](https://github.com/Nerwyn/material-you-theme)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
