### PR TITLE
iredis: 1.15.1 -> 1.15.2

### DIFF
--- a/pkgs/by-name/ir/iredis/package.nix
+++ b/pkgs/by-name/ir/iredis/package.nix
@@ -7,20 +7,21 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "iredis";
-  version = "1.15.1";
+  version = "1.15.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "laixintao";
     repo = "iredis";
     tag = "v${version}";
-    hash = "sha256-ZA4q2Z3X9zhzW/TH8aRliVij8UxqDVUamhKcfVxWb/c=";
+    hash = "sha256-g/gQb9QOyfa7kyHCUZf/kLZRO5IE8389BUCYz8Sqr8o=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail 'packaging = "^23.0"' 'packaging = "*"' \
-      --replace-fail 'wcwidth = "0.1.9"' 'wcwidth = "*"'
+      --replace-fail 'wcwidth = "0.1.9"' 'wcwidth = "*"' \
+      --replace-fail 'redis = "^5.0.0"' 'redis = "*"'
   '';
 
   nativeBuildInputs = with python3.pkgs; [

--- a/pkgs/by-name/ir/iredis/package.nix
+++ b/pkgs/by-name/ir/iredis/package.nix
@@ -64,12 +64,12 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonImportsCheck = [ "iredis" ];
 
-  meta = with lib; {
+  meta = {
     description = "Terminal Client for Redis with AutoCompletion and Syntax Highlighting";
     changelog = "https://github.com/laixintao/iredis/blob/${src.tag}/CHANGELOG.md";
     homepage = "https://iredis.xbin.io/";
-    license = licenses.bsd3;
-    maintainers = [ ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ phanirithvij ];
     mainProgram = "iredis";
   };
 }


### PR DESCRIPTION
- add me as a maintainer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
