### PR TITLE
nixos/victoriametrics: Add ability to pass basicAuthPasswordFile

### DIFF
--- a/nixos/modules/services/databases/victoriametrics.nix
+++ b/nixos/modules/services/databases/victoriametrics.nix
@@ -73,6 +73,22 @@ in
       '';
     };
 
+    basicAuthUsername = lib.mkOption {
+      default = null;
+      type = lib.types.nullOr lib.types.str;
+      description = ''
+        Basic Auth username used to protect VictoriaMetrics instance by authorization
+      '';
+    };
+
+    basicAuthPasswordFile = lib.mkOption {
+      default = null;
+      type = lib.types.nullOr lib.types.path;
+      description = ''
+        File that contains the Basic Auth password used to protect VictoriaMetrics instance by authorization
+      '';
+    };
+
     prometheusConfig = lib.mkOption {
       type = lib.types.submodule { freeformType = settingsFormat.type; };
       default = { };
@@ -118,8 +134,6 @@ in
       default = [ ];
       example = literalExpression ''
         [
-          "-httpAuth.username=username"
-          "-httpAuth.password=file:///abs/path/to/file"
           "-loggerLevel=WARN"
         ]
       '';
@@ -143,6 +157,16 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+
+    assertions = [
+      {
+        assertion =
+          (cfg.basicAuthUsername == null && cfg.basicAuthPasswordFile == null)
+          || (cfg.basicAuthUsername != null && cfg.basicAuthPasswordFile != null);
+        message = "Both basicAuthUsername and basicAuthPasswordFile must be set together to enable basicAuth functionality, or neither should be set.";
+      }
+    ];
+
     systemd.services.victoriametrics = {
       description = "VictoriaMetrics time series database";
       wantedBy = [ "multi-user.target" ];
@@ -153,9 +177,17 @@ in
         ExecStart = lib.escapeShellArgs (
           startCLIList
           ++ lib.optionals (cfg.prometheusConfig != { }) [ "-promscrape.config=${prometheusConfigYml}" ]
+          ++ lib.optional (cfg.basicAuthUsername != null) "-httpAuth.username=${cfg.basicAuthUsername}"
+          ++ lib.optional (
+            cfg.basicAuthPasswordFile != null
+          ) "-httpAuth.password=file://%d/basic_auth_password"
         );
 
         DynamicUser = true;
+        LoadCredential = lib.optionals (cfg.basicAuthPasswordFile != null) [
+          "basic_auth_password:${cfg.basicAuthPasswordFile}"
+        ];
+
         RestartSec = 1;
         Restart = "on-failure";
         RuntimeDirectory = "victoriametrics";

--- a/nixos/tests/victoriametrics/remote-write.nix
+++ b/nixos/tests/victoriametrics/remote-write.nix
@@ -22,10 +22,8 @@ in
         networking.firewall.allowedTCPPorts = [ 8428 ];
         services.victoriametrics = {
           enable = true;
-          extraOptions = [
-            "-httpAuth.username=${username}"
-            "-httpAuth.password=file://${toString passwordFile}"
-          ];
+          basicAuthUsername = username;
+          basicAuthPasswordFile = toString passwordFile;
         };
       };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR is a resubmitted version of https://github.com/NixOS/nixpkgs/pull/370996/  with the fixed comments.
Sadly it has gone stale by the author and there is no response on the original pr.

I am using that since a very long time (on my fork) and also submitted a similar change for victorialogs that has been merged.

I omitted the release notes, as i personally think the change does not need to go to release notes (please let me know if you think otherwise).






## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
