### PR TITLE
browsertrix-crawler: init at 1.12.4

### DIFF
--- a/pkgs/by-name/br/browsertrix-crawler/package.nix
+++ b/pkgs/by-name/br/browsertrix-crawler/package.nix
@@ -1,0 +1,155 @@
+{
+  fetchFromGitHub,
+  fetchYarnDeps,
+  fetchurl,
+  google-chrome,
+  jq,
+  lib,
+  makeWrapper,
+  node-gyp,
+  nodejs,
+  pkg-config,
+  python3,
+  redis,
+  socat,
+  stdenv,
+  stevenblack-blocklist,
+  versionCheckHook,
+  vips,
+  x11vnc,
+  xvfb,
+  yarnBuildHook,
+  yarnConfigHook,
+  ...
+}:
+let
+  version = "1.12.4";
+
+  replayWebPage-version = "2.4.3";
+  replayWebPage-ui = fetchurl {
+    url = "https://cdn.jsdelivr.net/npm/replaywebpage@${replayWebPage-version}/ui.js";
+    hash = "sha256-Ay8T7LW11OKRbAaEkZrjU4c8QVjbpfzol1gtnhjkMuE=";
+  };
+  replayWebPage-sw = fetchurl {
+    url = "https://cdn.jsdelivr.net/npm/replaywebpage@${replayWebPage-version}/sw.js";
+    hash = "sha256-pGM9gApE2H52Kp1Lfdynwm1bXgDo0O1akS6MBwqdkPA=";
+  };
+  replayWebPage-adblock = fetchurl {
+    url = "https://cdn.jsdelivr.net/npm/replaywebpage@${replayWebPage-version}/adblock/adblock.gz";
+    hash = "sha256-mWm1egyxahV9D60AB5+XIAU8Cf1UmNw4pyKfKhmMIZg=";
+  };
+
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "browsertrix-crawler";
+  inherit version;
+  src = fetchFromGitHub {
+    owner = "webrecorder";
+    repo = "browsertrix-crawler";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eHcn9XA35GFWNv3L5bF34ltjcSSut0henjWQ1vrHLhU=";
+  };
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/yarn.lock";
+    hash = "sha256-jqXSCbFf8SGUE11Ed8JhPbGUGDUgjFyMfbH1goLq1XY=";
+  };
+
+  __structuredAttrs = true;
+
+  doCheck = true;
+
+  env.yarnBuildScript = "tsc";
+  env.PUPPETEER_SKIP_CHROMIUM_DOWNLOAD = true;
+  env.SHARP_FORCE_GLOBAL_LIBVIPS = 1;
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    nodejs
+    node-gyp
+    makeWrapper
+    pkg-config
+    python3
+    versionCheckHook
+  ];
+
+  buildInputs = [
+    vips
+  ];
+
+  patches = [
+    ./replace-default-path.patch
+  ];
+
+  preBuild = ''
+    mkdir -p $HOME/.node-gyp/${nodejs.version}
+    echo 9 > $HOME/.node-gyp/${nodejs.version}/installVersion
+    ln -sfv ${nodejs}/include $HOME/.node-gyp/${nodejs.version}
+    export npm_config_nodedir=${nodejs}
+
+    pkg-config --modversion vips-cpp
+    (cd node_modules/sharp && yarn --offline run install)
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -pv $out/{bin,lib/node_modules/browsertrix-crawler/html/rwp}
+
+    cp -rv ./* $out/lib/node_modules/browsertrix-crawler/
+
+    cp ${replayWebPage-ui} $out/lib/node_modules/browsertrix-crawler/html/rwp/ui.js
+    cp ${replayWebPage-sw} $out/lib/node_modules/browsertrix-crawler/html/rwp/sw.js
+    cp ${replayWebPage-adblock} $out/lib/node_modules/browsertrix-crawler/html/rwp/adblock.gz
+    grep '^0\.0\.0\.0 ' ${stevenblack-blocklist}/hosts \
+      | awk '{ print $2; }' \
+      | grep -v '0\.0\.0\.0\( \|$\)' \
+      | ${lib.getExe jq} --raw-input --slurp 'split("\n")' \
+        > $out/lib/node_modules/browsertrix-crawler/ad-hosts.json
+
+    makeWrapper ${lib.getExe nodejs} $out/bin/browsertrix-crawl \
+      --add-flag --experimental-global-webcrypto \
+      --add-flag $out/lib/node_modules/browsertrix-crawler/dist/main.js \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          redis
+          xvfb
+        ]
+      } \
+      --set BROWSER_BIN ${lib.getExe google-chrome} \
+      --set BROWSER_VERSION ${google-chrome.version} \
+      --set-default GEOMETRY "1360x1020x16" \
+      --set-default VNC_PASS "vncpassw0rd!" \
+      --set-default DETACHED_CHILD_PROC "1"
+
+    ln -s $out/bin/browsertrix-crawl $out/bin/browsertrix-qa
+
+    makeWrapper ${lib.getExe nodejs} $out/bin/browsertrix-create-login-profile \
+      --add-flag $out/lib/node_modules/browsertrix-crawler/dist/create-login-profile.js \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          socat
+          x11vnc
+          xvfb
+        ]
+      } \
+      --set BROWSER_BIN ${lib.getExe google-chrome} \
+      --set BROWSER_VERSION ${google-chrome.version} \
+      --set-default GEOMETRY "1360x1020x16" \
+      --set-default VNC_PASS "vncpassw0rd!" \
+      --set-default DETACHED_CHILD_PROC "1"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Browser-based crawling system";
+    homepage = "https://crawler.docs.browsertrix.com";
+    license = lib.licenses.agpl3Plus;
+    mainProgram = "browsertrix-crawl";
+    maintainers = [ lib.maintainers.skyesoss ];
+  };
+})

--- a/pkgs/by-name/br/browsertrix-crawler/replace-default-path.patch
+++ b/pkgs/by-name/br/browsertrix-crawler/replace-default-path.patch
@@ -1,0 +1,15 @@
+index 07aba7c..5cfd3ef 100755
+--- a/src/create-login-profile.ts
++++ b/src/create-login-profile.ts
+@@ -60,9 +60,9 @@ function initArgs() {
+
+       filename: {
+         describe:
+-          "The filename for the profile tarball, stored within /crawls/profiles if absolute path not provided",
++          "The filename for the profile tarball, stored within ./profiles if absolute path not provided",
+         type: "string",
+-        default: "/crawls/profiles/profile.tar.gz",
++        default: "./profiles/profile.tar.gz",
+       },
+
+       debugScreenshot: {


### PR DESCRIPTION
Browsertrix-crawler is a high-fidelity web archiving crawler. It can be used to scrape websites and create WACZ files that can be replayed later using a tool such as [replayweb.page](https://replayweb.page).
The project provides releases within an OCI container, but this derivation packages the dependencies using Nix instead.
The upstream GitHub repo can be found [here](https://github.com/webrecorder/browsertrix-crawler).

The build script is modeled after the [Dockerfile](https://github.com/webrecorder/browsertrix-crawler/blob/main/Dockerfile), including ReplayWebPage version.
The main deviation is the patch to change the default paths from `/crawls` to `.`, as the binary is not run inside a container.
Another deviation from the original Dockerfile script is the inclusion of a minor fix that I wrote [here](https://github.com/webrecorder/browsertrix-crawler/issues/881).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
