### PR TITLE
siril: 1.2.6 -> 1.4.0

### DIFF
--- a/pkgs/by-name/si/siril/package.nix
+++ b/pkgs/by-name/si/siril/package.nix
@@ -9,9 +9,11 @@
   git,
   criterion,
   gtk3,
+  gtksourceview4,
   libconfig,
   gnuplot,
   opencv,
+  python3,
   json-glib,
   fftwFloat,
   cfitsio,
@@ -23,24 +25,28 @@
   libraw,
   libtiff,
   libpng,
+  libgit2,
   libjpeg,
+  libjxl,
   libheif,
+  libxisf,
   ffms,
   wrapGAppsHook3,
   curl,
+  yyjson,
   versionCheckHook,
   nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "siril";
-  version = "1.2.6";
+  version = "1.4.0";
 
   src = fetchFromGitLab {
     owner = "free-astro";
     repo = "siril";
     tag = finalAttrs.version;
-    hash = "sha256-pSJp4Oj8x4pKuwPSaSyGbyGfpnanoWBxAdXtzGTP7uA=";
+    hash = "sha256-qE1K3/o7ubrIEWldRgus1quSVehJqjFxhsKb1HQPNLA=";
   };
 
   nativeBuildInputs = [
@@ -59,6 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
     gsl
     exiv2
     gnuplot
+    gtksourceview4
     opencv
     fftwFloat
     librtprocess
@@ -67,30 +74,27 @@ stdenv.mkDerivation (finalAttrs: {
     libraw
     libtiff
     libpng
+    libgit2
     libjpeg
+    libjxl
     libheif
+    libxisf
     ffms
     ffmpeg
     json-glib
     curl
+    yyjson
   ];
 
+  propagatedBuildInputs = [ python3 ];
+
   # Necessary because project uses default build dir for flatpaks/snaps
-  dontUseMesonConfigure = true;
-  dontUseCmakeConfigure = true;
-
-  # Meson fails to find libcurl unless the option is specifically enabled
-  configureScript = ''
-    ${meson}/bin/meson setup -Denable-libcurl=yes --buildtype release nixbld .
-  '';
-
-  postConfigure = ''
-    cd nixbld
-  '';
+  mesonBuildDir = "nixbld";
 
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
+
   versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
@@ -107,5 +111,6 @@ stdenv.mkDerivation (finalAttrs: {
       returntoreality
     ];
     platforms = lib.platforms.linux;
+    mainProgram = "siril";
   };
 })


### PR DESCRIPTION
Update to new siril 1.4.0.

Resolves #403409 

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
