### PR TITLE
gelasio: unstable-2022-06-09 -> unstable-2025-06-30

### DIFF
--- a/pkgs/by-name/ge/gelasio/package.nix
+++ b/pkgs/by-name/ge/gelasio/package.nix
@@ -6,13 +6,13 @@
 
 stdenvNoCC.mkDerivation {
   pname = "gelasio";
-  version = "0-unstable-2022-06-09";
+  version = "0-unstable-2025-06-30";
 
   src = fetchFromGitHub {
     owner = "SorkinType";
     repo = "Gelasio";
-    rev = "a75c6d30a35f74cdbaea1813bdbcdb64bb11d3d5";
-    hash = "sha256-ncm0lSDPPPREdxTx3dGl6OGBn4FGAjFTlQpA6oDCdMI=";
+    rev = "4d7a1d2c662582095982a3851e50d7f1e034255b";
+    hash = "sha256-GfJjpiTBayNfGULf3vqFOvQw9rqXIe8JJmF3fI9Km+Y=";
   };
 
   dontBuild = true;


### PR DESCRIPTION
Commit range: https://github.com/SorkinType/Gelasio/compare/a75c6d30a35f74cdbaea1813bdbcdb64bb11d3...4d7a1d2

Font packages are weird. It seems many font devs are happy to not version, commit WIP to main, etc.

I felt it was weird to not include latest commits, even though their messages imply some WIP for new character sets. Maybe something is better than nothing. It feels better than picking an arbitrary commit to update to.

Notably there are a number of re-importing glyphs and fixes in the changelog.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
