### PR TITLE
nixos/stage-1: make "testing patched programs" build output more useful

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -206,6 +206,7 @@ let
         if [ -z "${toString (pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform)}" ]; then
         # Make sure that the patchelf'ed binaries still work.
         echo "testing patched programs..."
+        set -x
         $out/bin/ash -c 'echo hello world' | grep "hello world"
         $out/bin/mount -V 2>&1 | grep -q "mount from util-linux"
         $out/bin/blkid -V 2>&1 | grep -q 'libblkid'
@@ -218,6 +219,7 @@ let
         ''}
 
         ${config.boot.initrd.extraUtilsCommandsTest}
+        set +x
         fi
       ''; # */
 


### PR DESCRIPTION
Most of the commands executed during the "testing patched programs" phase of the extra-utils build don't produce any output whatsoever.  Therefore, if something goes wrong in that phase, the build log is uninformative.  Mitigate this by adding a `set -x` immediately after the "testing patched programs" message is printed, causing the shell to print an execution trace.  This way we'll at least know _which command_ failed.

I wrote this PR to help me troubleshoot issue #441269. It does not _fix_ that issue, but I believe it is a desirable change in its own right, regardless of the eventual outcome of that issue.  If this PR is accepted I would request that it also be merged to ~at least the 25.05 release branches.~ whichever release branches are still receiving bugfixes at the time it lands.
