### PR TITLE
tidal-hifi: 5.20.0 -> 5.20.1

### DIFF
--- a/pkgs/by-name/ti/tidal-hifi/electron.nix
+++ b/pkgs/by-name/ti/tidal-hifi/electron.nix
@@ -8,11 +8,11 @@ let
     https://github.com/Mastermindzh/tidal-hifi/blob/master/build/electron-builder.base.yml
      for the expected version
   */
-  version = "35.1.1";
+  version = "37.2.5";
 in
 (fetchzip {
   url = "https://github.com/castlabs/electron-releases/releases/download/v${version}+wvcus/electron-v${version}+wvcus-linux-x64.zip";
-  hash = "sha256-AkPKeG7MrCBlk41qXZxFPRukUPRcIUanq6fJPx5d3RU=";
+  hash = "sha256-mRbweXYfsWxu7I+pqtBjgA0n+ad2iFawVbDUBT5+LZo=";
   stripRoot = false;
 
 }).overrideAttrs

--- a/pkgs/by-name/ti/tidal-hifi/package.nix
+++ b/pkgs/by-name/ti/tidal-hifi/package.nix
@@ -47,7 +47,7 @@
 }:
 
 let
-  version = "5.20.0";
+  version = "5.20.1";
 
   electronLibPath = lib.makeLibraryPath [
     alsa-lib
@@ -95,7 +95,7 @@ buildNpmPackage (self: {
     owner = "Mastermindzh";
     repo = "tidal-hifi";
     tag = version;
-    hash = "sha256-PENNkmCiCFcaHNCBfwVitYfqKN0ZR0QHwE3WQHp0tGI=";
+    hash = "sha256-uiRvbxUztLwNSB1BHa9rGrPl2akt21VqxEV4pBgNwPo=";
   };
 
   nativeBuildInputs = [
@@ -104,7 +104,7 @@ buildNpmPackage (self: {
     copyDesktopItems
   ];
 
-  npmDepsHash = "sha256-4J5wGq/zpEK+xKtVg2zf7lIDHo9d4KW5fDY05siaFC4=";
+  npmDepsHash = "sha256-BsHlATxdZ/5QFr2HAGSeKo+aR7udfD6X8h/qyJnBrr0=";
   forceGitDeps = true;
   makeCacheWritable = true;
 


### PR DESCRIPTION
supersides #436982

Diff: https://github.com/Mastermindzh/tidal-hifi/compare/5.20.0...5.20.1

Changelog: https://github.com/Mastermindzh/tidal-hifi/releases/tag/5.20.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
