### PR TITLE
grott: init at 2.8.3

### DIFF
--- a/pkgs/by-name/gr/grott/package.nix
+++ b/pkgs/by-name/gr/grott/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+let
+  version = "2.8.3";
+  versionSuffix = "-master";
+in
+python3Packages.buildPythonApplication {
+  pname = "grott";
+  version = "${version}${versionSuffix}";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "johanmeijer";
+    repo = "grott";
+    rev = "fb52e2d4ff3065f60db45a7c2c82f2ad7e9f8463";
+    hash = "sha256-q521T9KZz/QhbSOyNAFsftUZeMLaW/pjmGCJgk2j0Rs=";
+  };
+
+  build-system = [
+    python3Packages.setuptools
+  ];
+
+  postPatch = ''
+    cat > pyproject.toml <<'EOF'
+      [build-system]
+      requires = ["setuptools"]
+      build-backend = "setuptools.build_meta"
+
+      [project]
+      name = "grott"
+      version = "${version}"
+      dependencies = [
+          "paho-mqtt",
+          "requests",
+      ]
+
+      [project.scripts]
+      grott = "grott.__main__:main"
+
+      [tool.setuptools.packages.find]
+      where = ["."]
+
+      [tool.setuptools]
+      py-modules = [
+          "grott",
+          "grottconf",
+          "grottdata",
+          "grottproxy",
+          "grottserver",
+          "grottsniffer",
+      ]
+    EOF
+
+    find .
+    echo
+    echo pyproject.toml:
+    cat pyproject.toml
+    # exit 1
+  '';
+
+  pythonPath = with python3Packages; [
+    paho-mqtt
+    requests
+    # libscrc # optional; not packaged in nixpkgs yet
+  ];
+
+  pythonImportsCheck = [
+    "grott"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Growatt inverter monitor";
+    homepage = "https://github.com/johanmeijer/grott";
+    license = lib.licenses.unfree; # see https://github.com/johanmeijer/grott/issues/512
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.nh2 ];
+  };
+}

--- a/pkgs/by-name/gr/grott/package.nix
+++ b/pkgs/by-name/gr/grott/package.nix
@@ -6,7 +6,7 @@
 }:
 let
   version = "2.8.3";
-  versionSuffix = "-master";
+  versionSuffix = "-unstable-2025-05-27";
 in
 python3Packages.buildPythonApplication {
   pname = "grott";


### PR DESCRIPTION
For the license, see https://github.com/johanmeijer/grott/issues/512

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
