### PR TITLE
rofi-pass: replace `util-linux` with `util-linuxMinimal`

### DIFF
--- a/pkgs/tools/security/pass/rofi-pass.nix
+++ b/pkgs/tools/security/pass/rofi-pass.nix
@@ -5,7 +5,7 @@
   makeBinaryWrapper,
   unstableGitUpdater,
   coreutils,
-  util-linux,
+  util-linuxMinimal,
   gnugrep,
   libnotify,
   pwgen,
@@ -67,7 +67,7 @@ stdenv.mkDerivation {
       libnotify
       pwgen
       rofi
-      util-linux
+      util-linuxMinimal
     ]
     ++ lib.optionals (backend == "x11") [
       (pass.withExtensions (ext: [ ext.pass-otp ]))

--- a/pkgs/tools/security/pass/rofi-pass.nix
+++ b/pkgs/tools/security/pass/rofi-pass.nix
@@ -46,11 +46,15 @@ stdenv.mkDerivation {
   dontBuild = true;
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin
     cp -a rofi-pass $out/bin/rofi-pass
 
     mkdir -p $out/share/doc/rofi-pass/
     cp -a config.example $out/share/doc/rofi-pass/config.example
+
+    runHook postInstall
   '';
 
   wrapperPath = lib.makeBinPath (
@@ -78,6 +82,8 @@ stdenv.mkDerivation {
   );
 
   fixupPhase = ''
+    runHook preFixup
+
     patchShebangs $out/bin
 
     wrapProgram $out/bin/rofi-pass \
@@ -86,6 +92,8 @@ stdenv.mkDerivation {
       --set-default ROFI_PASS_CLIPBOARD_BACKEND ${
         if backend == "wayland" then "wl-clipboard" else "xclip"
       }
+
+    runHook postFixup
   '';
 
   passthru.updateScript = unstableGitUpdater { };

--- a/pkgs/tools/security/pass/rofi-pass.nix
+++ b/pkgs/tools/security/pass/rofi-pass.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  makeWrapper,
+  makeBinaryWrapper,
   unstableGitUpdater,
   coreutils,
   util-linux,
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
     hash = "sha256-1lPNj47vTPLBK7mVm+PngV8C/ZsjJ2EN4ffXGU2TlQo=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeBinaryWrapper ];
 
   dontBuild = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
