### PR TITLE
orbstack: init at 2.0.3-19876

### DIFF
--- a/pkgs/by-name/or/orbstack/package.nix
+++ b/pkgs/by-name/or/orbstack/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  _7zz,
+}:
+let
+  inherit (stdenvNoCC.hostPlatform) system;
+  version = "2.0.3-19876";
+  sourceData = {
+    aarch64-darwin = {
+      arch = "arm64";
+      hash = "sha256-3Ppc0zWEgR/nTS7R9uAkUYYgYu5q2TWmfd3evT+Z8g4=";
+    };
+    x86_64-darwin = {
+      arch = "amd64";
+      hash = "sha256-+JpyynFKmDjHLetvvEpQ0qw4crAVmx0ucWm+bvtZ2Fg=";
+    };
+  };
+  sources = lib.mapAttrs (
+    system:
+    { arch, hash }:
+    fetchurl {
+      url = "https://cdn-updates.orbstack.dev/${arch}/OrbStack_v${
+        lib.replaceString "-" "_" version
+      }_${arch}.dmg";
+      inherit hash;
+    }
+  ) sourceData;
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "orbstack";
+  inherit version;
+
+  src = finalAttrs.passthru.sources.${system} or (throw "unsupported system ${system}");
+
+  # -snld prevents "ERROR: Dangerous symbolic link path was ignored"
+  # -xr'!*:com.apple.*' prevents macOS extended attributes (e.g. macl or
+  # quarantine) being turned into real files when extracting an APFS .dmg
+  # (e.g. Info.plist:com.apple.macl or Info.plist:com.apple.quarantine).
+  # These bogus files corrupt the .app bundle and prevent it from launching.
+  unpackCmd = "7zz x -snld -xr'!*:com.apple.*' $curSrc";
+
+  nativeBuildInputs = [ _7zz ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications"
+    cp -R OrbStack.app "$out/Applications"
+
+    mkdir -p "$out/bin"
+    for binary in "$out"/Applications/OrbStack.app/Contents/MacOS/{bin,xbin}/*; do
+      ln -s "$binary" "$out/bin/$(basename "$binary")"
+    done
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit sources;
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    changelog = "https://docs.orbstack.dev/release-notes#${
+      builtins.replaceStrings [ "." ] [ "-" ] version
+    }";
+    description = "Fast, light, and easy way to run Docker containers and Linux machines";
+    homepage = "https://orbstack.dev/";
+    license = lib.licenses.unfree;
+    mainProgram = "orb";
+    maintainers = with lib.maintainers; [ deejayem ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/or/orbstack/update.sh
+++ b/pkgs/by-name/or/orbstack/update.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p coreutils curl gawk gnugrep gnused common-updater-scripts
+#shellcheck shell=bash
+
+set -eu -o pipefail
+
+update_arch() {
+  local arch="$1"
+  local system="$2"
+
+  local source_url
+  source_url="$(curl -L -I "https://orbstack.dev/download/stable/latest/$arch" | grep -i "location:" | awk '{print $2}' | tr -d '\r')"
+
+  local version
+  version="$(echo "$source_url" | grep -o '\([0-9]\+\.\)\{2\}[0-9]\+_[0-9]\+' | sed 's/_/-/')"
+
+  local hash
+  hash=$(nix --extra-experimental-features nix-command hash convert --to sri --hash-algo sha256 "$(nix-prefetch-url --type sha256 "$source_url")")
+
+  update-source-version orbstack "$version" "$hash" --system="$system" --source-key="sources.$system" --ignore-same-version
+}
+
+update_arch "arm64" "aarch64-darwin"
+update_arch "amd64" "x86_64-darwin"


### PR DESCRIPTION
Add orbstack (https://orbstack.dev), a fast, lightweight, and efficient alternative to Docker Desktop for macOS. It provides support for running containers and Linux VMs seamlessly on macOS, with features focused on speed and low resource usage.

This is based on the work previously done in https://github.com/NixOS/nixpkgs/pull/427676, but with a couple of tweaks. 

The original version deleted files that were being incorrectly created from extended attributes, but I am preventing them from being created. And rather than having two separate URLs for the two different architectures, I extracted that information, along with the hashes into an attribute set, and then use that data to call fetchurl with. This is roughly the approach used in the brew formula. I'm happy to undo that change if others think the original was better.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
