### PR TITLE
jocalsend: 1.6.18033 -> 1.61803398

### DIFF
--- a/pkgs/by-name/jo/jocalsend/package.nix
+++ b/pkgs/by-name/jo/jocalsend/package.nix
@@ -8,17 +8,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "jocalsend";
-  version = "1.6.18033";
+  version = "1.61803398";
 
   src = fetchFromGitea {
     domain = "git.kittencollective.com";
     owner = "nebkor";
     repo = "joecalsend";
     tag = finalAttrs.version;
-    hash = "sha256-q2fzi0NKfkjCwV7FD0PqXSHtJWQtvdvKx4WmhnZpKvg=";
+    hash = "sha256-7Gl+G4BN3CgF0c/AEhI1OvRhveqGeFNmGRI3XRf6rAo=";
   };
 
-  cargoHash = "sha256-u9Ev/Qr/WN6OOaMXPesA3nmV3efKJA3/2YWm8S60PjU=";
+  cargoHash = "sha256-prT1wO3ctnTfMHfICFcihB739lN/QXPH3AamIR6dM9A=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Update jocalsend to v1.61803398

@nebkor is it meant to be 1.61803398 and not 1.6.1803398?
[Changelog (empty)](https://git.kittencollective.com/nebkor/joecalsend/releases/tag/1.61803398)
Diff: [https://git.kittencollective.com/nebkor/joecalsend/compare/1.6.18033...1.61803398](https://git.kittencollective.com/nebkor/joecalsend/compare/1.6.18033...1.61803398)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
