### PR TITLE
nixos/k3s: use improved error reporting and assertions

### DIFF
--- a/nixos/tests/k3s/auto-deploy-charts.nix
+++ b/nixos/tests/k3s/auto-deploy-charts.nix
@@ -135,7 +135,7 @@ import ../make-test-python.nix (
         machine.succeed("test -e /var/lib/rancher/k3s/server/manifests/advanced.yaml")
         # check that the timeout is set correctly, select only the first doc in advanced.yaml
         advancedManifest = json.loads(machine.succeed("yq -o json 'select(di == 0)' /var/lib/rancher/k3s/server/manifests/advanced.yaml"))
-        assert advancedManifest["spec"]["timeout"] == "69s", f"unexpected value for spec.timeout: {advancedManifest["spec"]["timeout"]}"
+        t.assertEqual(advancedManifest["spec"]["timeout"], "69s", "unexpected value for spec.timeout")
         # wait for test jobs to complete
         machine.wait_until_succeeds("kubectl wait --for=condition=complete job/hello", timeout=180)
         machine.wait_until_succeeds("kubectl wait --for=condition=complete job/values-file", timeout=180)
@@ -145,9 +145,9 @@ import ../make-test-python.nix (
         values_file_output = machine.succeed("kubectl logs -l batch.kubernetes.io/job-name=values-file")
         advanced_output = machine.succeed("kubectl -n test logs -l batch.kubernetes.io/job-name=advanced")
         # strip the output to remove trailing whitespaces
-        assert hello_output.rstrip() == "Hello, world!", f"unexpected output of hello job: {hello_output}"
-        assert values_file_output.rstrip() == "Hello, file!", f"unexpected output of values file job: {values_file_output}"
-        assert advanced_output.rstrip() == "advanced hello", f"unexpected output of advanced job: {advanced_output}"
+        t.assertEqual(hello_output.rstrip(), "Hello, world!", "unexpected output of hello job")
+        t.assertEqual(values_file_output.rstrip(), "Hello, file!", "unexpected output of values file job")
+        t.assertEqual(advanced_output.rstrip(), "advanced hello", "unexpected output of advanced job")
         # wait for bundled traefik deployment
         machine.wait_until_succeeds("kubectl -n kube-system rollout status deployment traefik", timeout=180)
       '';

--- a/nixos/tests/k3s/auto-deploy.nix
+++ b/nixos/tests/k3s/auto-deploy.nix
@@ -99,26 +99,25 @@ import ../make-test-python.nix (
         };
       };
 
-    testScript = ''
-      start_all()
+    testScript = # python
+      ''
+        start_all()
 
-      machine.wait_for_unit("k3s")
-      # check existence of the manifest files
-      machine.fail("ls /var/lib/rancher/k3s/server/manifests/absent.yaml")
-      machine.succeed("ls /var/lib/rancher/k3s/server/manifests/foo-namespace.yaml")
-      machine.succeed("ls /var/lib/rancher/k3s/server/manifests/hello.yaml")
+        machine.wait_for_unit("k3s")
+        # check existence of the manifest files
+        machine.fail("ls /var/lib/rancher/k3s/server/manifests/absent.yaml")
+        machine.succeed("ls /var/lib/rancher/k3s/server/manifests/foo-namespace.yaml")
+        machine.succeed("ls /var/lib/rancher/k3s/server/manifests/hello.yaml")
 
-      # check if container images got imported
-      machine.wait_until_succeeds("crictl img | grep 'test\.local/pause'")
-      machine.wait_until_succeeds("crictl img | grep 'test\.local/hello'")
+        # check if container images got imported
+        machine.wait_until_succeeds("crictl img | grep 'test\.local/pause'")
+        machine.wait_until_succeeds("crictl img | grep 'test\.local/hello'")
 
-      # check if resources of manifests got created
-      machine.wait_until_succeeds("kubectl get ns foo")
-      machine.wait_until_succeeds("kubectl wait --for=condition=complete job/hello")
-      machine.fail("kubectl get ns absent")
-
-      machine.shutdown()
-    '';
+        # check if resources of manifests got created
+        machine.wait_until_succeeds("kubectl get ns foo")
+        machine.wait_until_succeeds("kubectl wait --for=condition=complete job/hello")
+        machine.fail("kubectl get ns absent")
+      '';
 
     meta.maintainers = lib.teams.k3s.members;
   }

--- a/nixos/tests/k3s/containerd-config.nix
+++ b/nixos/tests/k3s/containerd-config.nix
@@ -40,18 +40,19 @@ import ../make-test-python.nix (
         };
       };
 
-    testScript = ''
-      start_all()
-      machine.wait_for_unit("k3s")
-      # wait until the node is ready
-      machine.wait_until_succeeds(r"""kubectl get node ${nodeName} -ojson | jq -e '.status.conditions[] | select(.type == "Ready") | .status == "True"'""")
-      # test whether the config template file contains the magic comment
-      out=machine.succeed("cat /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl")
-      assert "MAGIC COMMENT" in out, "the containerd config template does not contain the magic comment"
-      # test whether the config file contains the magic comment
-      out=machine.succeed("cat /var/lib/rancher/k3s/agent/etc/containerd/config.toml")
-      assert "MAGIC COMMENT" in out, "the containerd config does not contain the magic comment"
-    '';
+    testScript = # python
+      ''
+        start_all()
+        machine.wait_for_unit("k3s")
+        # wait until the node is ready
+        machine.wait_until_succeeds(r"""kubectl get node ${nodeName} -ojson | jq -e '.status.conditions[] | select(.type == "Ready") | .status == "True"'""")
+        # test whether the config template file contains the magic comment
+        out=machine.succeed("cat /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl")
+        t.assertIn("MAGIC COMMENT", out, "the containerd config template does not contain the magic comment")
+        # test whether the config file contains the magic comment
+        out=machine.succeed("cat /var/lib/rancher/k3s/agent/etc/containerd/config.toml")
+        t.assertIn("MAGIC COMMENT", out, "the containerd config does not contain the magic comment")
+      '';
 
     meta.maintainers = lib.teams.k3s.members;
   }

--- a/nixos/tests/k3s/etcd.nix
+++ b/nixos/tests/k3s/etcd.nix
@@ -82,46 +82,43 @@ import ../make-test-python.nix (
         };
     };
 
-    testScript = ''
-      with subtest("should start etcd"):
-          etcd.start()
-          etcd.wait_for_unit("etcd.service")
+    testScript = # python
+      ''
+        with subtest("should start etcd"):
+            etcd.start()
+            etcd.wait_for_unit("etcd.service")
 
-      with subtest("should wait for etcdctl endpoint status to succeed"):
-          etcd.wait_until_succeeds("etcdctl endpoint status")
+        with subtest("should wait for etcdctl endpoint status to succeed"):
+            etcd.wait_until_succeeds("etcdctl endpoint status")
 
-      with subtest("should wait for etcdctl endpoint health to succeed"):
-          etcd.wait_until_succeeds("etcdctl endpoint health")
+        with subtest("should wait for etcdctl endpoint health to succeed"):
+            etcd.wait_until_succeeds("etcdctl endpoint health")
 
-      with subtest("should start k3s"):
-          k3s.start()
-          k3s.wait_for_unit("k3s")
+        with subtest("should start k3s"):
+            k3s.start()
+            k3s.wait_for_unit("k3s")
 
-      with subtest("should test if kubectl works"):
-          k3s.wait_until_succeeds("k3s kubectl get node")
+        with subtest("should test if kubectl works"):
+            k3s.wait_until_succeeds("k3s kubectl get node")
 
-      with subtest("should wait for service account to show up; takes a sec"):
-          k3s.wait_until_succeeds("k3s kubectl get serviceaccount default")
+        with subtest("should wait for service account to show up; takes a sec"):
+            k3s.wait_until_succeeds("k3s kubectl get serviceaccount default")
 
-      with subtest("should create a sample secret object"):
-          k3s.succeed("k3s kubectl create secret generic nixossecret --from-literal thesecret=abacadabra")
+        with subtest("should create a sample secret object"):
+            k3s.succeed("k3s kubectl create secret generic nixossecret --from-literal thesecret=abacadabra")
 
-      with subtest("should check if secret is correct"):
-          k3s.wait_until_succeeds("[[ $(kubectl get secrets nixossecret -o json | jq -r .data.thesecret | base64 -d) == abacadabra ]]")
+        with subtest("should check if secret is correct"):
+            k3s.wait_until_succeeds("[[ $(kubectl get secrets nixossecret -o json | jq -r .data.thesecret | base64 -d) == abacadabra ]]")
 
-      with subtest("should have a secret in database"):
-          etcd.wait_until_succeeds("[[ $(etcdctl get /registry/secrets/default/nixossecret | head -c1 | wc -c) -ne 0 ]]")
+        with subtest("should have a secret in database"):
+            etcd.wait_until_succeeds("[[ $(etcdctl get /registry/secrets/default/nixossecret | head -c1 | wc -c) -ne 0 ]]")
 
-      with subtest("should delete the secret"):
-          k3s.succeed("k3s kubectl delete secret nixossecret")
+        with subtest("should delete the secret"):
+            k3s.succeed("k3s kubectl delete secret nixossecret")
 
-      with subtest("should not have a secret in database"):
-          etcd.wait_until_fails("[[ $(etcdctl get /registry/secrets/default/nixossecret | head -c1 | wc -c) -ne 0 ]]")
-
-      with subtest("should shutdown k3s and etcd"):
-          k3s.shutdown()
-          etcd.shutdown()
-    '';
+        with subtest("should not have a secret in database"):
+            etcd.wait_until_fails("[[ $(etcdctl get /registry/secrets/default/nixossecret | head -c1 | wc -c) -ne 0 ]]")
+      '';
 
     meta.maintainers = etcd.meta.maintainers ++ lib.teams.k3s.members;
   }

--- a/nixos/tests/k3s/multi-node.nix
+++ b/nixos/tests/k3s/multi-node.nix
@@ -192,7 +192,7 @@ import ../make-test-python.nix (
             # Verify the pods can talk to each other
             for pod in pods:
                 resp = server.succeed(f"k3s kubectl exec {pod} -- socat TCP:{pod_ip}:8000 -")
-                assert resp.strip() == "server"
+                t.assertEqual(resp.strip(), "server")
       '';
 
     meta.maintainers = lib.teams.k3s.members;

--- a/nixos/tests/k3s/single-node.nix
+++ b/nixos/tests/k3s/single-node.nix
@@ -76,40 +76,39 @@ import ../make-test-python.nix (
         };
       };
 
-    testScript = ''
-      start_all()
+    testScript = # python
+      ''
+        start_all()
 
-      machine.wait_for_unit("k3s")
-      machine.succeed("kubectl cluster-info")
-      machine.fail("sudo -u noprivs kubectl cluster-info")
-      machine.succeed("k3s check-config")
-      machine.succeed(
-          "${pauseImage} | ctr image import -"
-      )
+        machine.wait_for_unit("k3s")
+        machine.succeed("kubectl cluster-info")
+        machine.fail("sudo -u noprivs kubectl cluster-info")
+        machine.succeed("k3s check-config")
+        machine.succeed(
+            "${pauseImage} | ctr image import -"
+        )
 
-      # Also wait for our service account to show up; it takes a sec
-      machine.wait_until_succeeds("kubectl get serviceaccount default")
-      machine.succeed("kubectl apply -f ${testPodYaml}")
-      machine.succeed("kubectl wait --for 'condition=Ready' pod/test")
-      machine.succeed("kubectl delete -f ${testPodYaml}")
+        # Also wait for our service account to show up; it takes a sec
+        machine.wait_until_succeeds("kubectl get serviceaccount default")
+        machine.succeed("kubectl apply -f ${testPodYaml}")
+        machine.succeed("kubectl wait --for 'condition=Ready' pod/test")
+        machine.succeed("kubectl delete -f ${testPodYaml}")
 
-      # regression test for #176445
-      machine.fail("journalctl -o cat -u k3s.service | grep 'ipset utility not found'")
+        # regression test for #176445
+        machine.fail("journalctl -o cat -u k3s.service | grep 'ipset utility not found'")
 
-      with subtest("Run k3s-killall"):
-          # Call the killall script with a clean path to assert that
-          # all required commands are wrapped
-          output = machine.succeed("PATH= ${k3s}/bin/k3s-killall.sh 2>&1 | tee /dev/stderr")
-          assert "command not found" not in output, "killall script contains unknown command"
+        with subtest("Run k3s-killall"):
+            # Call the killall script with a clean path to assert that
+            # all required commands are wrapped
+            output = machine.succeed("PATH= ${k3s}/bin/k3s-killall.sh 2>&1 | tee /dev/stderr")
+            t.assertNotIn("command not found", output, "killall script contains unknown command")
 
-          # Check that killall cleaned up properly
-          machine.fail("systemctl is-active k3s.service")
-          machine.fail("systemctl list-units | grep containerd")
-          machine.fail("ip link show | awk -F': ' '{print $2}' | grep -e flannel -e cni0")
-          machine.fail("ip netns show | grep cni-")
-
-      machine.shutdown()
-    '';
+            # Check that killall cleaned up properly
+            machine.fail("systemctl is-active k3s.service")
+            machine.fail("systemctl list-units | grep containerd")
+            machine.fail("ip link show | awk -F': ' '{print $2}' | grep -e flannel -e cni0")
+            machine.fail("ip netns show | grep cni-")
+      '';
 
     meta.maintainers = lib.teams.k3s.members;
   }

--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -201,13 +201,9 @@ let
     sed --quiet '/# --- run the install process --/q;p' ${k3sRepo}/install.sh > install.sh
 
     # Let killall expect "containerd-shim" in the Nix store
-    to_replace="/data/\[\^/\]\*/bin/containerd-shim"
-    replacement="/nix/store/.*k3s-containerd.*/bin/containerd-shim"
-    changes=$(sed -i "s|$to_replace|$replacement| w /dev/stdout" install.sh)
-    if [ -z "$changes" ]; then
-      echo "failed to replace \"$to_replace\" in k3s installer script (install.sh)"
-      exit 1
-    fi
+    substituteInPlace install.sh \
+      --replace-fail '/data/[^/]*/bin/containerd-shim' \
+        '/nix/store/.*k3s-containerd.*/bin/containerd-shim'
 
     remove_matching_line() {
       line_to_delete=$(grep -n "$1" install.sh | cut -d : -f 1 || true)

--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -449,12 +449,15 @@ buildGoModule (finalAttrs: {
   versionCheckProgramArg = "--version";
 
   passthru = {
-    inherit airgap-images;
-    k3sCNIPlugins = k3sCNIPlugins;
-    k3sContainerd = k3sContainerd;
-    k3sRepo = k3sRepo;
-    k3sRoot = k3sRoot;
-    k3sBundle = k3sBundle;
+    inherit
+      airgap-images
+      k3sCNIPlugins
+      k3sContainerd
+      k3sRepo
+      k3sRoot
+      k3sBundle
+      updateScript
+      ;
     tests =
       let
         mkTests =
@@ -465,7 +468,6 @@ buildGoModule (finalAttrs: {
           lib.mapAttrs (name: value: nixosTests.k3s.${name}.${k3s_version}) nixosTests.k3s;
       in
       mkTests k3sVersion;
-    updateScript = updateScript;
     imagesList = throw "k3s.imagesList was removed";
     airgapImages = throw "k3s.airgapImages was renamed to k3s.airgap-images";
     airgapImagesAmd64 = throw "k3s.airgapImagesAmd64 was renamed to k3s.airgap-images-amd64-tar-zst";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->



## Things done

- use `substituteInPlace` instead of custom `sed` for killall script
- use inherit for passthru attributes
- use improved error reporting and assertions (introduced in https://github.com/NixOS/nixpkgs/pull/390996)
- mark all test scripts as python
- remove `shutdown()`s at the end of tests 

@NixOS/k3s 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
