### PR TITLE
qt6.qttools: add desktop files for GUI tools

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qttools/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qttools/default.nix
@@ -7,6 +7,7 @@
   qtdeclarative,
   cups,
   llvmPackages,
+  fetchpatch,
   # clang-based c++ parser for qdoc and lupdate
   withClang ? false,
 }:
@@ -22,12 +23,20 @@ qtModule {
     qtdeclarative
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ cups ];
-  cmakeFlags = lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+  cmakeFlags = [
+    "-DQT_INSTALL_XDG_DESKTOP_ENTRIES=ON"
+  ]
+  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
     "-DQt6LinguistTools_DIR=${pkgsBuildBuild.qt6.qttools}/lib/cmake/Qt6LinguistTools"
     "-DQt6ToolsTools_DIR=${pkgsBuildBuild.qt6.qttools}/lib/cmake/Qt6ToolsTools"
   ];
   patches = [
     ./paths.patch
+    (fetchpatch {
+      name = "add-desktop-files.patch";
+      url = "https://code.qt.io/cgit/qt/qttools.git/patch/?id=9cbd235f7e9dd5baea2f55a6fe1c29a7abd7255b";
+      hash = "sha256-Plu9Wx7pPxTa0jkNG96gBYb1T0L9VQC5xBoHsVj/NC4=";
+    })
   ];
   env.NIX_CFLAGS_COMPILE = toString [
     "-DNIX_OUTPUT_OUT=\"${placeholder "out"}\""


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fix #441135

I cherry-picked the upstream patch that adds the desktop files to the build

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
