### PR TITLE
maintainers: add `adhityaravi`, `bepri` and `dstathis`

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -641,6 +641,12 @@
     githubId = 8026586;
     name = "Adrien Faure";
   };
+  adhityaravi = {
+    email = "adhitya.ravi@canonical.com";
+    github = "adhityaravi";
+    githubId = 34714491;
+    name = "Adhitya Ravi";
+  };
   adisbladis = {
     email = "adisbladis@gmail.com";
     matrix = "@adis:blad.is";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3197,6 +3197,12 @@
     github = "benwis";
     githubId = 6953353;
   };
+  bepri = {
+    email = "imani.pelton@canonical.com";
+    github = "bepri";
+    githubId = 17732342;
+    name = "Imani Pelton";
+  };
   berberman = {
     email = "berberman@yandex.com";
     matrix = "@berberman:mozilla.org";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6977,6 +6977,12 @@
     github = "dsluijk";
     githubId = 8537327;
   };
+  dstathis = {
+    email = "dylan.stephano-shachter@canonical.com";
+    github = "dstathis";
+    githubId = 2110777;
+    name = "Dylan Stephano-Shachter";
+  };
   dstengele = {
     name = "Dennis Stengele";
     email = "dennis@stengele.me";

--- a/pkgs/by-name/ch/charmcraft/package.nix
+++ b/pkgs/by-name/ch/charmcraft/package.nix
@@ -132,7 +132,11 @@ python.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/canonical/charmcraft";
     changelog = "https://github.com/canonical/charmcraft/releases/tag/${version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/ro/rockcraft/package.nix
+++ b/pkgs/by-name/ro/rockcraft/package.nix
@@ -78,7 +78,11 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/canonical/rockcraft";
     changelog = "https://github.com/canonical/rockcraft/releases/tag/${version}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/sn/snapcraft/package.nix
+++ b/pkgs/by-name/sn/snapcraft/package.nix
@@ -203,7 +203,11 @@ python312Packages.buildPythonApplication rec {
     homepage = "https://github.com/canonical/snapcraft";
     changelog = "https://github.com/canonical/snapcraft/releases/tag/${version}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/catkin-pkg/default.nix
+++ b/pkgs/development/python-modules/catkin-pkg/default.nix
@@ -42,6 +42,10 @@ buildPythonPackage rec {
     description = "Library for retrieving information about catkin packages";
     homepage = "http://wiki.ros.org/catkin_pkg";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
   };
 }

--- a/pkgs/development/python-modules/craft-application/default.nix
+++ b/pkgs/development/python-modules/craft-application/default.nix
@@ -154,7 +154,11 @@ buildPythonPackage rec {
     homepage = "https://github.com/canonical/craft-application";
     changelog = "https://github.com/canonical/craft-application/blob/${src.tag}/docs/reference/changelog.rst";
     license = lib.licenses.lgpl3Only;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/craft-archives/default.nix
+++ b/pkgs/development/python-modules/craft-archives/default.nix
@@ -67,7 +67,11 @@ buildPythonPackage rec {
     homepage = "https://github.com/canonical/craft-archives";
     changelog = "https://github.com/canonical/craft-archives/releases/tag/${version}";
     license = lib.licenses.lgpl3Only;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/craft-cli/default.nix
+++ b/pkgs/development/python-modules/craft-cli/default.nix
@@ -59,7 +59,11 @@ buildPythonPackage rec {
     homepage = "https://github.com/canonical/craft-cli";
     changelog = "https://github.com/canonical/craft-cli/releases/tag/${version}";
     license = lib.licenses.lgpl3Only;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/craft-grammar/default.nix
+++ b/pkgs/development/python-modules/craft-grammar/default.nix
@@ -51,7 +51,11 @@ buildPythonPackage rec {
     homepage = "https://github.com/canonical/craft-grammar";
     changelog = "https://github.com/canonical/craft-grammar/releases/tag/${version}";
     license = lib.licenses.lgpl3Only;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/craft-parts/default.nix
+++ b/pkgs/development/python-modules/craft-parts/default.nix
@@ -126,7 +126,11 @@ buildPythonPackage rec {
     homepage = "https://github.com/canonical/craft-parts";
     changelog = "https://github.com/canonical/craft-parts/releases/tag/${src.tag}";
     license = lib.licenses.lgpl3Only;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/craft-platforms/default.nix
+++ b/pkgs/development/python-modules/craft-platforms/default.nix
@@ -60,7 +60,11 @@ buildPythonPackage rec {
     homepage = "https://github.com/canonical/craft-platforms";
     changelog = "https://github.com/canonical/craft-platforms/releases/tag/${version}";
     license = lib.licenses.lgpl3Only;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/craft-providers/default.nix
+++ b/pkgs/development/python-modules/craft-providers/default.nix
@@ -101,7 +101,11 @@ buildPythonPackage rec {
     homepage = "https://github.com/canonical/craft-providers";
     changelog = "https://github.com/canonical/craft-providers/releases/tag/${src.tag}";
     license = lib.licenses.lgpl3Only;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/craft-store/default.nix
+++ b/pkgs/development/python-modules/craft-store/default.nix
@@ -81,7 +81,11 @@ buildPythonPackage rec {
     homepage = "https://github.com/canonical/craft-store";
     changelog = "https://github.com/canonical/craft-store/releases/tag/${version}";
     license = lib.licenses.lgpl3Only;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/logassert/default.nix
+++ b/pkgs/development/python-modules/logassert/default.nix
@@ -36,7 +36,11 @@ buildPythonPackage rec {
     homepage = "https://github.com/facundobatista/logassert";
     changelog = "https://github.com/facundobatista/logassert/releases/tag/${src.tag}";
     license = lib.licenses.lgpl3Only;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/macaroonbakery/default.nix
+++ b/pkgs/development/python-modules/macaroonbakery/default.nix
@@ -62,7 +62,11 @@ buildPythonPackage rec {
     homepage = "https://github.com/go-macaroon-bakery/py-macaroon-bakery";
     changelog = "https://github.com/go-macaroon-bakery/py-macaroon-bakery/releases/tag/${version}";
     license = lib.licenses.lgpl3Only;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/pydantic-yaml/default.nix
+++ b/pkgs/development/python-modules/pydantic-yaml/default.nix
@@ -48,6 +48,10 @@ buildPythonPackage rec {
     homepage = "https://github.com/NowanIlfideme/pydantic-yaml";
     changelog = "https://github.com/NowanIlfideme/pydantic-yaml/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
   };
 }

--- a/pkgs/development/python-modules/python-apt/default.nix
+++ b/pkgs/development/python-modules/python-apt/default.nix
@@ -35,7 +35,11 @@ buildPythonPackage rec {
     description = "Python bindings for APT";
     homepage = "https://launchpad.net/python-apt";
     license = lib.licenses.gpl2;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/snap-helpers/default.nix
+++ b/pkgs/development/python-modules/snap-helpers/default.nix
@@ -40,7 +40,11 @@ buildPythonPackage rec {
     homepage = "https://github.com/albertodonato/snap-helpers";
     changelog = "https://github.com/albertodonato/snap-helpers/releases/tag/${version}";
     license = lib.licenses.lgpl3Only;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/spdx-lookup/default.nix
+++ b/pkgs/development/python-modules/spdx-lookup/default.nix
@@ -35,6 +35,10 @@ buildPythonPackage rec {
     homepage = "https://github.com/bbqsrc/spdx-lookup-python";
     changelog = "https://github.com/bbqsrc/spdx-lookup-python/releases/tag/v${version}";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
   };
 }

--- a/pkgs/development/python-modules/spdx/default.nix
+++ b/pkgs/development/python-modules/spdx/default.nix
@@ -32,6 +32,10 @@ buildPythonPackage rec {
     homepage = "https://github.com/bbqsrc/spdx-python";
     changelog = "https://github.com/bbqsrc/spdx-python/releases/tag/v${version}";
     license = lib.licenses.cc0;
-    maintainers = with lib.maintainers; [ jnsgruk ];
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
   };
 }


### PR DESCRIPTION
## Things done

I have been maintaining the suite of Canonical `*craft` tools for a couple of years, and have now identified a team of three people who are willing to share the maintenance of these packages going forward, one of whom is a developer on the upstream team.

This PR removes me as a maintainer, adds @dstathis, @bepri and @adhityaravi as new maintainers, and adds them to the relevant packages.

I intend on assisting this new team going forward as they learn the ropes.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
