### PR TITLE
brush-splat: init at 0.2.0

### DIFF
--- a/pkgs/by-name/br/brush-splat/package.nix
+++ b/pkgs/by-name/br/brush-splat/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  bzip2,
+  libxkbcommon,
+  sqlite,
+  vulkan-loader,
+  zstd,
+  stdenv,
+  wayland,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "brush-splat";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "ArthurBrussee";
+    repo = "brush";
+    tag = finalAttrs.version;
+    hash = "sha256-IvsHYCM/M2hHozzKwovgXpcW1b7MSEGneU62y1k8U9U=";
+  };
+
+  cargoHash = "sha256-7cJj5L8ggkBP9SDaYMtY9xIAHVAhi8cTD/0pncUaHbI=";
+
+  # Force linking to libEGL, which is always dlopen()ed, and to
+  # libwayland-client & libxkbcommon, which is dlopen()ed based on the
+  # winit backend.
+  NIX_LDFLAGS = [
+    "--no-as-needed"
+    "-lvulkan"
+    "-lwayland-client"
+    "-lxkbcommon"
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    bzip2
+    libxkbcommon
+    sqlite
+    vulkan-loader
+    zstd
+  ]
+  ++ lib.optionals stdenv.isLinux [
+    wayland
+  ];
+
+  env = {
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+  };
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "3D Reconstruction for all";
+    homepage = "https://github.com/ArthurBrussee/brush";
+    changelog = "https://github.com/ArthurBrussee/brush/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ matthewcroughan ];
+    mainProgram = "brush_app";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

There was already a package named `brush` so I named this `brush-splat`. This is a toolkit for viewing and training a network of gaussian splats, so long as you have a dataset (directory of images) augmented by SfM (Structure-from-Motion) tools. We have a few tools in Nixpkgs right now that can produce a dataset for this application to consume, but they seem to be broken at runtime or build time. In particular I tried `colmap` which doesn't build due to its `freeimage` dependency being full of CVEs, and `python3Packages.opensfm` which seems to fail when it runs, so I'm on the lookout for better SfM tools.

<img width="1379" height="1219" alt="image" src="https://github.com/user-attachments/assets/9e2ae37d-0447-4ae6-a85a-afbc780b2705" />

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
