### PR TITLE
ci/eval: fix local full eval

### DIFF
--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -13,7 +13,12 @@
   byName ? false,
 }:
 let
-  combined = builtins.storePath combinedDir;
+  # Usually we expect a derivation, but when evaluating in multiple separate steps, we pass
+  # nix store paths around. These need to be turned into (fake) derivations again to track
+  # dependencies properly.
+  # We use two steps for evaluation, because we compare results from two different checkouts.
+  # CI additionalls spreads evaluation across multiple workers.
+  combined = if lib.isDerivation combinedDir then combinedDir else lib.toDerivation combinedDir;
 
   /*
     Derivation that computes which packages are affected (added, changed or removed) between two revisions of nixpkgs.

--- a/ci/eval/diff.nix
+++ b/ci/eval/diff.nix
@@ -11,8 +11,13 @@
 }:
 
 let
-  before = builtins.storePath beforeDir;
-  after = builtins.storePath afterDir;
+  # Usually we expect a derivation, but when evaluating in multiple separate steps, we pass
+  # nix store paths around. These need to be turned into (fake) derivations again to track
+  # dependencies properly.
+  # We use two steps for evaluation, because we compare results from two different checkouts.
+  # CI additionalls spreads evaluation across multiple workers.
+  before = if lib.isDerivation beforeDir then beforeDir else lib.toDerivation beforeDir;
+  after = if lib.isDerivation afterDir then afterDir else lib.toDerivation afterDir;
 
   /*
     Computes the key difference between two attrs


### PR DESCRIPTION
The change to use `builtins.storePath` was good - for when the store path *is* already part of the nix store. In all my tests so far, that was already the case, because I was iterating on the solution and the Eval results stayed the same.

But when this is run on a entirely new commit, these the values for `afterDir` and `combinedDir` are *not* in the store, yet. As part of running `eval.full` on a new commit they will be created. `eval.full` is linked up, so that the values passed around there will actually be derivations, which might not be realized, yet.

Checking whether the input is a path or not fixes this for both cases.

Follow up to #441746, again.

## Things done

- [x] Tested locally.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
