### PR TITLE
tcpreplay: Fix build after splitting libpcap to multiple outputs

### DIFF
--- a/pkgs/by-name/tc/tcpreplay/package.nix
+++ b/pkgs/by-name/tc/tcpreplay/package.nix
@@ -17,6 +17,13 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libpcap ];
 
+  # Allow having different prefix for header files (default output
+  # "out") and libraries ("lib" output)
+  postPatch = ''
+    substituteInPlace configure \
+      --replace-fail 'ls ''${testdir}/$dir/libpcap' 'ls ${lib.getLib libpcap}/$dir/libpcap'
+  '';
+
   configureFlags = [
     "--disable-local-libopts"
     "--disable-libopts-install"


### PR DESCRIPTION
This fixes recent [build failure](https://hydra.nixos.org/build/307008719).

Configure file of tcpreplay expects that libpcap header files and libraries share the same prefix. Since commit [1] (#429972) this is no longer true so we have to patch the configure script.

[1]: https://github.com/NixOS/nixpkgs/pull/429972/commits/da89a2d075f2279a09585c1b217b8f7382817339

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
