### PR TITLE
audiomatch: init at 0.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14345,6 +14345,12 @@
     githubId = 4701504;
     name = "James Robinson";
   };
+  leha44581 = {
+    email = "leha55481@gmail.com";
+    github = "Leha44581";
+    githubId = 70238465;
+    name = "Leha";
+  };
   leifhelm = {
     email = "jakob.leifhelm@gmail.com";
     github = "leifhelm";

--- a/pkgs/by-name/au/audiomatch/package.nix
+++ b/pkgs/by-name/au/audiomatch/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  chromaprint,
+  fetchFromGitHub,
+  python3Packages,
+}:
+python3Packages.buildPythonPackage rec {
+  version = "0.2.2";
+  pname = "audiomatch";
+  pyproject = true;
+  src = fetchFromGitHub {
+    owner = "unmade";
+    repo = "audiomatch";
+    tag = version;
+    hash = "sha256-I7gTP2lwg4EDNmI+tVmI721/nEDShb7q21tD9tRbskY=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+     --replace-fail 'poetry>=0.12,<1.0' "poetry-core" \
+     --replace-fail 'poetry.masonry.api' 'poetry.core.masonry.api'
+
+    substituteInPlace src/audiomatch/fingerprints.py \
+     --replace-fail 'fpcalc' '${lib.getExe chromaprint}'
+  '';
+
+  build-system = [
+    python3Packages.poetry-core
+    python3Packages.distutils
+  ];
+
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+  ];
+
+  meta = {
+    homepage = "https://github.com/unmade/audiomatch";
+    description = "A small command-line tool to find similar audio files";
+    changelog = "https://github.com/unmade/audiomatch/releases/tag/${version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    mainProgram = "audiomatch";
+    maintainers = with lib.maintainers; [ leha44581 ];
+  };
+}


### PR DESCRIPTION
<!-- Added the audiomatch package, i couldn't find a different solution to find similar (not identical) audio files
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
--> A small command-line tool to find similar audio files https://github.com/unmade/audiomatch

Package co-authored-by: Notarin Steele <424c414e4b@gmail.com>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
