### PR TITLE
spotify/darwin: add warning to check timestamp

### DIFF
--- a/pkgs/by-name/sp/spotify/darwin.nix
+++ b/pkgs/by-name/sp/spotify/darwin.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation {
   version = "1.2.72.438";
 
   src =
+    # WARNING: This Wayback Machine URL redirects to the closest timestamp.
+    # Future maintainers must manually check the timestamp exists and exactly matches at:
+    # https://web.archive.org/web/*/https://download.scdn.co/SpotifyARM64.dmg
+    # https://web.archive.org/web/*/https://download.scdn.co/Spotify.dmg
     if stdenv.hostPlatform.isAarch64 then
       (fetchurl {
         url = "https://web.archive.org/web/20250912003756/https://download.scdn.co/SpotifyARM64.dmg";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

As of commit ca77296380960cd497a765102eeb1356eb80fed0 (the current `nixpkgs-unstable`), the `spotify` package fails to build on `aarch64-darwin`:

```
$ NIXPKGS_ALLOW_UNFREE=1 nix-build -A spotify
these 2 derivations will be built:
  /nix/store/f26qfna4wqrkjsxssnrhmsjs2mppkcnl-SpotifyARM64.dmg.drv
  /nix/store/birs8x86bbsg696zmx73cx300fk5kzh0-spotify-1.2.70.409.drv
building '/nix/store/f26qfna4wqrkjsxssnrhmsjs2mppkcnl-SpotifyARM64.dmg.drv'...

trying https://web.archive.org/web/20250826093914/https://download.scdn.co/SpotifyARM64.dmg
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
100  136M  100  136M    0     0  1004k      0  0:02:19  0:02:19 --:--:--  844k
error: hash mismatch in fixed-output derivation '/nix/store/f26qfna4wqrkjsxssnrhmsjs2mppkcnl-SpotifyARM64.dmg.drv':
         specified: sha256-bs+rSMfIFG0FyHGDUtuk6tSbd5l6r6qUNH20hQQjZC0=
            got:    sha256-fTyACxbyIgg7EwIgnNvNerJGUwAVLP2bg0TMnOegWeQ=
error: 1 dependencies of derivation '/nix/store/birs8x86bbsg696zmx73cx300fk5kzh0-spotify-1.2.70.409.drv' failed to build
```

I double-checked this hash by instead downloading https://web.archive.org/web/20250826093914/https://download.scdn.co/SpotifyARM64.dmg in Firefox and running this command on it:

```sh
nix hash file SpotifyARM64.dmg
```

I also tried the same for the x86 `Spotify.dmg`, and for that one, `nix hash file` _does_ agree with the `hash` added by #437067. So it seems that only the ARM one is wrong; not sure exactly how that happened.

@joaosreis @iedame @bengsparks

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
