### PR TITLE
pythonPackages.rds2py: init at 0.7.3

### DIFF
--- a/pkgs/development/python-modules/rds2py/default.nix
+++ b/pkgs/development/python-modules/rds2py/default.nix
@@ -1,0 +1,123 @@
+{
+  lib,
+  buildPythonPackage,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  zlib,
+  pybind11,
+  pytestCheckHook,
+  pytest-cov-stub,
+  pkg-config,
+  setuptools,
+  setuptools-scm,
+  biocutils,
+  biocframe,
+  pandas,
+  scipy,
+}:
+
+buildPythonPackage rec {
+  pname = "rds2py";
+  version = "0.7.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "BiocPy";
+    repo = "rds2py";
+    tag = version;
+    hash = "sha256-GbRpkt+K2HXuAT7KtI4h1SnZ4RtSo5hrea2L92VZj/o=";
+  };
+
+  rds2cpp-src = fetchFromGitHub {
+    owner = "LTLA";
+    repo = "rds2cpp";
+    rev = "v1.1.0";
+    hash = "sha256-q7C/oORmhgXlqnZnslhyrxBc3RRF2gdgGuQU4TimxtI=";
+  };
+
+  byteme-src = fetchFromGitHub {
+    owner = "LTLA";
+    repo = "byteme";
+    rev = "v1.2.2";
+    hash = "sha256-rM/pSMGlaMWE69lYORaa8SQYGQyzhdyQnXImmAesxFA=";
+  };
+
+  # Upstream uses CMake's FetchContent to download rds2cpp and byteme into
+  # build/_deps at configure time. We pre-fetch both repos and copy them
+  # into build/_deps manually. This way the build tree matches what upstream expects.
+  prePatch = ''
+    mkdir -p build/_deps
+    cp -r ${rds2cpp-src} build/_deps/rds2cpp-src
+    cp -r ${byteme-src} build/_deps/byteme-src
+    chmod -R u+w build/_deps
+  '';
+
+  # Patch upstream CMakeLists.txt files to use our vendored sources instead of
+  # calling FetchContent. We point add_subdirectory() to the copies staged in
+  # build/_deps above. We also patch rds2cpp's own extern/CMakeLists.txt to
+  # disable its nested FetchContent call for byteme, since we already provide it.
+  postPatch = ''
+    substituteInPlace lib/CMakeLists.txt \
+      --replace-fail \
+        "FetchContent_MakeAvailable(byteme)" \
+        "add_subdirectory(\''${CMAKE_BINARY_DIR}/../_deps/byteme-src \''${CMAKE_CURRENT_BINARY_DIR}/byteme)" \
+      --replace-fail \
+        "FetchContent_MakeAvailable(rds2cpp)" \
+        "add_subdirectory(\''${CMAKE_BINARY_DIR}/../_deps/rds2cpp-src \''${CMAKE_CURRENT_BINARY_DIR}/rds2cpp)"
+
+    substituteInPlace build/_deps/rds2cpp-src/extern/CMakeLists.txt \
+      --replace-fail "FetchContent_MakeAvailable(byteme)" "# FetchContent_MakeAvailable(byteme) -- Patched by Nix"
+  '';
+
+  # We use the MORE_CMAKE_OPTIONS environment variable, which is a hook provided
+  # by the upstream setup.py, to pass our zlib flags to the CMake configure step.
+  preConfigure = ''
+    export MORE_CMAKE_OPTIONS="-DZLIB_INCLUDE_DIR=${lib.getDev zlib}/include -DZLIB_LIBRARY=${lib.getLib zlib}/lib/libz.so"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    pybind11
+    zlib
+  ];
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    biocutils
+  ];
+
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+    biocframe
+    pandas
+    scipy
+  ];
+
+  disabledTestPaths = [
+    # Requires packages not in Nixpkgs
+    "tests/test_delayedmatrices.py"
+    "tests/test_granges.py"
+    "tests/test_mae.py"
+    "tests/test_sce.py"
+    "tests/test_se.py"
+  ];
+
+  # setuptools drives the build, so disable cmake configure hook
+  dontUseCmakeConfigure = true;
+
+  pythonImportsCheck = [ "rds2py" ];
+
+  meta = {
+    description = "Read RDS files, in Python";
+    homepage = "https://github.com/BiocPy/rds2py";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ b-rodrigues ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15704,6 +15704,8 @@ self: super: with self; {
     };
   };
 
+  rds2py = callPackage ../development/python-modules/rds2py { };
+
   re-assert = callPackage ../development/python-modules/re-assert { };
 
   reactionmenu = callPackage ../development/python-modules/reactionmenu { };


### PR DESCRIPTION
This adds `rds2py`, a Python library from the BiocPy project for reading R’s RDS file format via fast C++ backends.  

- Upstream fetches `rds2cpp` and `byteme` with CMake’s `FetchContent`. The CMakeLists are patched to use them, and `rds2cpp`’s own `extern/CMakeLists.txt` is adjusted to disable its nested fetch of `byteme`.  
- Because setuptools drives the build (and `dontUseCmakeConfigure = true`), the usual `cmakeFlags` mechanism doesn’t apply. A wrapper script around `cmake` injects `ZLIB_*` paths only at configure time, leaving the build step untouched.  
- Most of the upstream test suite runs with `pandas` and `scipy`. A handful of tests requiring BiocPy/Bioconductor packages not yet in Nixpkgs (`BiocFrames`, `SummarizedExperiment`, etc.) are disabled via `disabledTestPaths`.  

All enabled tests pass.

FYI, I packaged this with the help of Gemini and Chatgpt.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
