### PR TITLE
lib.makeAlias: init with by-name support

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -394,6 +394,7 @@ let
         makeOverridable
         callPackageWith
         callPackagesWith
+        makeAlias
         extendDerivation
         hydraJob
         makeScope

--- a/pkgs/by-name/do/docker-sync/package.nix
+++ b/pkgs/by-name/do/docker-sync/package.nix
@@ -1,0 +1,5 @@
+{
+  type = "alias";
+  release = "25.11";
+  reason = "broken and unmaintained";
+}

--- a/pkgs/by-name/fo/follow/package.nix
+++ b/pkgs/by-name/fo/follow/package.nix
@@ -1,0 +1,5 @@
+{
+  type = "alias";
+  release = "25.05";
+  package = "folo";
+}

--- a/pkgs/by-name/fo/follow/package.nix
+++ b/pkgs/by-name/fo/follow/package.nix
@@ -1,5 +1,5 @@
 {
   type = "alias";
-  release = "25.05";
-  package = "folo";
+  release = "25.11";
+  reason = "renamed to folo";
 }

--- a/pkgs/by-name/op/open-timeline-io/package.nix
+++ b/pkgs/by-name/op/open-timeline-io/package.nix
@@ -1,0 +1,5 @@
+{
+  type = "alias";
+  release = "25.11";
+  package = "opentimelineio";
+}

--- a/pkgs/by-name/po/postcss-cli/package.nix
+++ b/pkgs/by-name/po/postcss-cli/package.nix
@@ -1,5 +1,0 @@
-{
-  type = "alias";
-  release = "25.05";
-  reason = "broken";
-}

--- a/pkgs/by-name/po/postcss-cli/package.nix
+++ b/pkgs/by-name/po/postcss-cli/package.nix
@@ -1,0 +1,5 @@
+{
+  type = "alias";
+  release = "25.05";
+  reason = "broken";
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -771,7 +771,6 @@ mapAliases {
   docker_27 = throw "'docker_27' has been removed because it has been unmaintained since May 2025. Use docker_28 or newer instead."; # Added 2025-06-15
   docker-compose_1 = throw "'docker-compose_1' has been removed because it has been unmaintained since May 2021. Use docker-compose instead."; # Added 2024-07-29
   docker-distribution = distribution; # Added 2023-12-26
-  docker-sync = throw "'docker-sync' has been removed because it was broken and unmaintained"; # Added 2025-08-26
   dolphin-emu-beta = dolphin-emu; # Added 2023-02-11
   dolphinEmu = throw "'dolphinEmu' has been renamed to/replaced by 'dolphin-emu'"; # Converted to throw 2024-10-17
   dolphinEmuMaster = throw "'dolphinEmuMaster' has been renamed to/replaced by 'dolphin-emu-beta'"; # Converted to throw 2024-10-17
@@ -926,7 +925,6 @@ mapAliases {
   fmt_8 = throw "fmt_8 has been removed as it is obsolete and was no longer used in the tree"; # Added 2024-11-12
   fntsample = throw "fntsample has been removed as it is unmaintained upstream"; # Added 2025-04-21
   foldingathome = throw "'foldingathome' has been renamed to/replaced by 'fahclient'"; # Converted to throw 2024-10-17
-  follow = lib.warnOnInstantiate "follow has been renamed to folo" folo; # Added 2025-05-18
   forgejo-actions-runner = forgejo-runner; # Added 2024-04-04
   fornalder = throw "'fornalder' has been removed as it is unmaintained upstream"; # Added 2025-01-25
   foundationdb71 = throw "foundationdb71 has been removed; please upgrade to foundationdb73"; # Added 2024-12-28
@@ -1839,7 +1837,6 @@ mapAliases {
   openssl_3_0 = openssl_3; # Added 2022-06-27
   opensycl = lib.warnOnInstantiate "'opensycl' has been renamed to 'adaptivecpp'" adaptivecpp; # Added 2024-12-04
   opensyclWithRocm = lib.warnOnInstantiate "'opensyclWithRocm' has been renamed to 'adaptivecppWithRocm'" adaptivecppWithRocm; # Added 2024-12-04
-  open-timeline-io = lib.warnOnInstantiate "'open-timeline-io' has been renamed to 'opentimelineio'" opentimelineio; # Added 2025-08-10
   opentofu-ls = lib.warnOnInstantiate "'opentofu-ls' has been renamed to 'tofu-ls'" tofu-ls; # Added 2025-06-10
   openvdb_11 = throw "'openvdb_11' has been removed in favor of the latest version'"; # Added 2025-05-03
   opera = throw "'opera' has been removed due to lack of maintenance in nixpkgs"; # Added 2025-05-19
@@ -1958,7 +1955,6 @@ mapAliases {
   pgroonga = throw "'pgroonga' has been removed. Use 'postgresqlPackages.pgroonga' instead."; # Added 2025-07-19
   pgtap = throw "'pgtap' has been removed. Use 'postgresqlPackages.pgtap' instead."; # Added 2025-07-19
   plv8 = throw "'plv8' has been removed. Use 'postgresqlPackages.plv8' instead."; # Added 2025-07-19
-  postcss-cli = throw "postcss-cli has been removed because it was broken"; # added 2025-03-24
   postgis = throw "'postgis' has been removed. Use 'postgresqlPackages.postgis' instead."; # Added 2025-07-19
   tegaki-zinnia-japanese = throw "'tegaki-zinnia-japanese' has been removed due to lack of maintenance"; # Added 2025-09-10
   tet = throw "'tet' has been removed for lack of maintenance"; # Added 2025-10-12

--- a/pkgs/top-level/by-name-overlay.nix
+++ b/pkgs/top-level/by-name-overlay.nix
@@ -51,6 +51,8 @@ in
 # and ideally https://github.com/NixOS/nix/pull/8895
 self: super:
 {
+  _isAlias = name: packages.${name}.type or null == "alias";
+
   # This attribute is necessary to allow CI to ensure that all packages defined in `pkgs/by-name`
   # don't have an overriding definition in `all-packages.nix` with an empty (`{ }`) second `callPackage` argument.
   # It achieves that with an overlay that modifies both `callPackage` and this attribute to signal whether `callPackage` is used

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -290,31 +290,116 @@ in
 
         linux_hardened = hardenedKernelFor packageAliases.linux_default.kernel { };
       }
-      // lib.optionalAttrs config.allowAliases {
-        linux_4_19 = throw "linux 4.19 was removed because it will reach its end of life within 24.11";
-        linux_6_9 = throw "linux 6.9 was removed because it has reached its end of life upstream";
-        linux_6_10 = throw "linux 6.10 was removed because it has reached its end of life upstream";
-        linux_6_11 = throw "linux 6.11 was removed because it has reached its end of life upstream";
-        linux_6_13 = throw "linux 6.13 was removed because it has reached its end of life upstream";
-        linux_6_14 = throw "linux 6.14 was removed because it has reached its end of life upstream";
-        linux_6_15 = throw "linux 6.15 was removed because it has reached its end of life upstream";
+      // (
+        let
+          aliases = {
+            linux_4_19 = {
+              type = "alias";
+              release = "25.11";
+              reason = "it will reach its end of life within 24.11";
+            };
+            linux_6_9 = {
+              type = "alias";
+              release = "25.11";
+              reason = "it has reached its end of life upstream";
+            };
+            linux_6_10 = {
+              type = "alias";
+              release = "25.11";
+              reason = "it has reached its end of life upstream";
+            };
+            linux_6_11 = {
+              type = "alias";
+              release = "25.11";
+              reason = "it has reached its end of life upstream";
+            };
+            linux_6_13 = {
+              type = "alias";
+              release = "25.11";
+              reason = "it has reached its end of life upstream";
+            };
+            linux_6_14 = {
+              type = "alias";
+              release = "25.11";
+              reason = "it has reached its end of life upstream";
+            };
+            linux_6_15 = {
+              type = "alias";
+              release = "25.11";
+              reason = "it has reached its end of life upstream";
+            };
 
-        linux_5_10_hardened = throw "linux_hardened on nixpkgs only contains latest stable and latest LTS";
-        linux_5_15_hardened = throw "linux_hardened on nixpkgs only contains latest stable and latest LTS";
-        linux_6_1_hardened = throw "linux_hardened on nixpkgs only contains latest stable and latest LTS";
-        linux_6_6_hardened = throw "linux_hardened on nixpkgs only contains latest stable and latest LTS";
+            linux_5_10_hardened = {
+              type = "alias";
+              release = "25.11";
+              reason = "linux_hardened on nixpkgs only contains latest stable and latest LTS";
+            };
+            linux_5_15_hardened = {
+              type = "alias";
+              release = "25.11";
+              reason = "linux_hardened on nixpkgs only contains latest stable and latest LTS";
+            };
+            linux_6_1_hardened = {
+              type = "alias";
+              release = "25.11";
+              reason = "linux_hardened on nixpkgs only contains latest stable and latest LTS";
+            };
+            linux_6_6_hardened = {
+              type = "alias";
+              release = "25.11";
+              reason = "linux_hardened on nixpkgs only contains latest stable and latest LTS";
+            };
 
-        linux_4_19_hardened = throw "linux 4.19 was removed because it will reach its end of life within 24.11";
-        linux_5_4_hardened = throw "linux_5_4_hardened was removed because it was broken";
-        linux_6_9_hardened = throw "linux 6.9 was removed because it has reached its end of life upstream";
-        linux_6_10_hardened = throw "linux 6.10 was removed because it has reached its end of life upstream";
-        linux_6_11_hardened = throw "linux 6.11 was removed because it has reached its end of life upstream";
-        linux_6_13_hardened = throw "linux 6.13 was removed because it has reached its end of life upstream";
-        linux_6_14_hardened = throw "linux 6.14 was removed because it has reached its end of life upstream";
-        linux_6_15_hardened = throw "linux 6.15 was removed because it has reached its end of life upstream";
+            linux_4_19_hardened = {
+              type = "alias";
+              release = "25.11";
+              reason = "linux 4.19 was removed because it will reach its end of life within 24.11";
+            };
+            linux_5_4_hardened = {
+              type = "alias";
+              release = "25.11";
+              reason = "linux_5_4_hardened was removed because it was broken";
+            };
+            linux_6_9_hardened = {
+              type = "alias";
+              release = "25.11";
+              reason = "linux 6.9 was removed because it has reached its end of life upstream";
+            };
+            linux_6_10_hardened = {
+              type = "alias";
+              release = "25.11";
+              reason = "linux 6.10 was removed because it has reached its end of life upstream";
+            };
+            linux_6_11_hardened = {
+              type = "alias";
+              release = "25.11";
+              reason = "linux 6.11 was removed because it has reached its end of life upstream";
+            };
+            linux_6_13_hardened = {
+              type = "alias";
+              release = "25.11";
+              reason = "linux 6.13 was removed because it has reached its end of life upstream";
+            };
+            linux_6_14_hardened = {
+              type = "alias";
+              release = "25.11";
+              reason = "linux 6.14 was removed because it has reached its end of life upstream";
+            };
+            linux_6_15_hardened = {
+              type = "alias";
+              release = "25.11";
+              reason = "linux 6.15 was removed because it has reached its end of life upstream";
+            };
 
-        linux_ham = throw "linux_ham has been removed in favour of the standard kernel packages";
-      }
+            linux_ham = {
+              type = "alias";
+              release = "25.11";
+              reason = "in favour of the standard kernel packages";
+            };
+          };
+        in
+        (lib.mapAttrs (lib.makeAlias kernels) aliases) // { _isAlias = name: aliases ? ${name}; }
+      )
     )
   );
   /*


### PR DESCRIPTION
WIP for "structured aliases in by-name".

Features:
- Aliases are managed via `by-name/`.
- Aliases are release-bound, not date-bound.
- Conversion to throw / removal is forced via CI.
- Throwing aliases can be filtered out with `x.type != "error"` or `lib.isDerivation x`
- `callPackage` prevents alias arguments.
- `lib.meta.availableOn ... pkgs.<alias>` fails, too, if somebody works around the `callPackage` limitation.
- Should support non-by-name package sets (not tested, yet)

The first commit converts some aliases - two of these fail CI immediately, The last two commits fix that.

TODO:
- [ ] Improve the API / custom messages / default messages etc.
- [ ] Documentation
- [ ] Script for conversion / removal of aliases
- [x] Implement example for non-by-name package set
- [x] Performance testing / optimization

The design of "by-name returns an attrset" is extensible. I'm thinking we could represent package sets in by-name in the future with something like `type = "scope"` or so - working towards unified APIs / tools / design of package sets.

Supersedes #441492. More discussion in #441108.

WDYT, @emilazy?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
