### PR TITLE
openloco: 25.02 -> 25.08

### DIFF
--- a/pkgs/games/openloco/default.nix
+++ b/pkgs/games/openloco/default.nix
@@ -17,25 +17,25 @@ let
   sfl-src = fetchFromGitHub {
     owner = "slavenf";
     repo = "sfl-library";
-    tag = "1.9.0";
-    hash = "sha256-Udry/Y753l274PU6RvpPgkIr85wSCnz3mLQ0xzerUAc=";
+    tag = "1.9.2";
+    hash = "sha256-/3++CtSuZJ5Sdg8U8mJ/gT+FTatKhBx8QeYjUVQCDWA=";
   };
 
   openloco-objects = fetchurl {
-    url = "https://github.com/OpenLoco/OpenGraphics/releases/download/v0.1.1/objects.zip";
-    sha256 = "e75ad13a8e8d58458e0c54e5ce62902a073d7bb025ef8fb97cb56108ff7c57c3";
+    url = "https://github.com/OpenLoco/OpenGraphics/releases/download/v0.1.3/objects.zip";
+    sha256 = "c08937691b9d7a956305864b535c6e4537a84b81a9dc5d4c9016edff83dcceb6";
   };
 
 in
 stdenv.mkDerivation rec {
   pname = "openloco";
-  version = "25.02";
+  version = "25.08";
 
   src = fetchFromGitHub {
     owner = "OpenLoco";
     repo = "OpenLoco";
     tag = "v${version}";
-    hash = "sha256-RsiEYBNx+Lf7OyyyCShQmgtwBuxDrZkRCYCbMmZ8ZMM=";
+    hash = "sha256-f4GZxLibQM/od0tJoszaG94FkRH5vb9qwQ7OqVdt1cU=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Updated OpenLoco to the latest release as of opening this PR (25.08) and updated dependencies. Tested the result binaries a bit, the game seems to load.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
