### PR TITLE
perlPackages.NetSSLeay: patch for split OpenSSL outputs

### DIFF
--- a/pkgs/development/perl-modules/Net-SSLeay-paths.patch
+++ b/pkgs/development/perl-modules/Net-SSLeay-paths.patch
@@ -1,0 +1,22 @@
+diff --git a/Makefile.PL b/Makefile.PL
+index dc058ff657..dff4cdd7c5 100644
+--- a/Makefile.PL
++++ b/Makefile.PL
+@@ -139,7 +139,7 @@
+ }
+ 
+ sub ssleay {
+-    my $prefix = find_openssl_prefix();
++    my $prefix = '@bin@';
+     my $exec   = find_openssl_exec($prefix);
+     unless (defined $exec && -x $exec) {
+         print <<EOM;
+@@ -198,6 +198,8 @@
+     my ($prefix) = @_;
+ 
+     my $opts = {
++        inc_path   => '@include@/include',
++        lib_paths  => ['@lib@/lib'],
+         lib_links  => [],
+         cccdlflags => '',
+     };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -19,6 +19,7 @@
   fetchDebianPatch,
   fetchFromGitHub,
   fetchFromGitLab,
+  replaceVars,
   perl,
   shortenPerlShebang,
   nixosTests,
@@ -26175,18 +26176,18 @@ with self;
       url = "mirror://cpan/authors/id/C/CH/CHRISN/Net-SSLeay-1.92.tar.gz";
       hash = "sha256-R8LyswDy5xYtcdaZ9jPdajWwYloAy9qMUKwBFEqTlqk=";
     };
+    patches = [
+      (replaceVars ../development/perl-modules/Net-SSLeay-paths.patch {
+        bin = lib.getBin buildPackages.openssl;
+        lib = lib.getLib pkgs.openssl;
+        include = lib.getInclude pkgs.openssl;
+      })
+    ];
     buildInputs = [
       pkgs.openssl
       pkgs.zlib
     ];
     doCheck = false; # Test performs network access.
-    preConfigure = ''
-      mkdir openssl
-      ln -s ${lib.getLib pkgs.openssl}/lib openssl
-      ln -s ${pkgs.openssl.bin}/bin openssl
-      ln -s ${pkgs.openssl.dev}/include openssl
-      export OPENSSL_PREFIX=$(realpath openssl)
-    '';
     meta = {
       description = "Perl bindings for OpenSSL and LibreSSL";
       license = with lib.licenses; [ artistic2 ];


### PR DESCRIPTION
The wrapper directory currently used was ending up in the run path of the built library, at least on macOS, leaking the build directory.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
