### PR TITLE
abduco: fix version, use hash and configureFlags

### DIFF
--- a/pkgs/by-name/ab/abduco/package.nix
+++ b/pkgs/by-name/ab/abduco/package.nix
@@ -9,10 +9,11 @@
 
 let
   rev = "8c32909a159aaa9484c82b71f05b7a73321eb491";
+  defaultUserConfig = writeText "config.def.h" conf;
 in
 stdenv.mkDerivation {
   pname = "abduco";
-  version = "unstable-2020-04-30";
+  version = "0.6.0-unstable-2020-04-30";
 
   src = fetchzip {
     urls = [
@@ -22,17 +23,18 @@ stdenv.mkDerivation {
     hash = "sha256-o7SPK/G31cW/rrLwV3UJOTq6EBHl6AEE/GdeKGlHdyg=";
   };
 
-  preBuild = lib.optionalString (conf != null) "cp ${writeText "config.def.h" conf} config.def.h";
+  configureFlags = lib.optionals stdenv.hostPlatform.isDarwin [ "-D_DARWIN_C_SOURCE" ];
+
+  preBuild = lib.optionalString (conf != null) "cp ${defaultUserConfig} config.def.h";
 
   installFlags = [ "install-completion" ];
-  CFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-D_DARWIN_C_SOURCE";
 
   patches = [
     # https://github.com/martanne/abduco/pull/22
     (fetchpatch {
       name = "use-XDG-directory-scheme-by-default";
       url = "https://github.com/martanne/abduco/commit/0e9a00312ac9777edcb169122144762e3611287b.patch";
-      sha256 = "sha256-4NkIflbRkUpS5XTM/fxBaELpvlZ4S5lecRa8jk0XC9g=";
+      hash = "sha256-4NkIflbRkUpS5XTM/fxBaELpvlZ4S5lecRa8jk0XC9g=";
     })
 
     # “fix bug where attaching to dead session won't give underlying exit code”
@@ -40,7 +42,7 @@ stdenv.mkDerivation {
     (fetchpatch {
       name = "exit-code-when-attaching-to-dead-session";
       url = "https://github.com/martanne/abduco/commit/972ca8ab949ee342569dbd66b47cc4a17b28247b.patch";
-      sha256 = "sha256-8hios0iKYDOmt6Bi5NNM9elTflGudnG2xgPF1pSkHI0=";
+      hash = "sha256-8hios0iKYDOmt6Bi5NNM9elTflGudnG2xgPF1pSkHI0=";
     })
 
     # “report pixel sizes to child processes that use ioctl(0, TIOCGWINSZ, ...)”
@@ -49,7 +51,7 @@ stdenv.mkDerivation {
     (fetchpatch {
       name = "report-pixel-sizes-to-child-processes";
       url = "https://github.com/martanne/abduco/commit/a1e222308119b3251f00b42e1ddff74a385d4249.patch";
-      sha256 = "sha256-eiF0A4IqJrrvXxjBYtltuVNpxQDv/iQPO+K7Y8hWBGg=";
+      hash = "sha256-eiF0A4IqJrrvXxjBYtltuVNpxQDv/iQPO+K7Y8hWBGg=";
     })
   ];
 


### PR DESCRIPTION
I noticed this version being "off" relative to the [version guidance](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#versioning).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
