### PR TITLE
treewide: remove unneeded CMAKE_BUILD_TYPE

### DIFF
--- a/pkgs/by-name/ae/aeron-cpp/package.nix
+++ b/pkgs/by-name/ae/aeron-cpp/package.nix
@@ -75,7 +75,6 @@ stdenv.mkDerivation {
       cd cppbuild/Release
       cmake \
         -G "CodeBlocks - Unix Makefiles" \
-        -DCMAKE_BUILD_TYPE=Release \
         -DAERON_TESTS=OFF \
         -DAERON_SYSTEM_TESTS=OFF \
         -DAERON_BUILD_SAMPLES=OFF \

--- a/pkgs/by-name/ai/airwin2rack/package.nix
+++ b/pkgs/by-name/ai/airwin2rack/package.nix
@@ -152,8 +152,6 @@ stdenv.mkDerivation {
     (lib.cmakeFeature "RACK_SDK_DIR" "${vcvRackSdk}")
   ];
 
-  cmakeBuildType = "Release";
-
   patches = [
     ./juce-clap-juce-extensions-src-juce-cmakelists.patch
   ];

--- a/pkgs/by-name/ai/airwindows/package.nix
+++ b/pkgs/by-name/ai/airwindows/package.nix
@@ -33,10 +33,6 @@ stdenv.mkDerivation {
     cd plugins/LinuxVST
   '';
 
-  cmakeBuildType = "Release";
-
-  cmakeFlags = [ ];
-
   nativeBuildInputs = [
     cmake
   ];

--- a/pkgs/by-name/ap/apache-orc/package.nix
+++ b/pkgs/by-name/ap/apache-orc/package.nix
@@ -10,6 +10,7 @@
   snappy,
   zlib,
   zstd,
+  nix-update-script,
 }:
 
 let
@@ -71,6 +72,8 @@ stdenv.mkDerivation (finalAttrs: {
     ZLIB_ROOT = zlib.dev;
     ZSTD_ROOT = zstd.dev;
   };
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/apache/orc/releases/tag/v${finalAttrs.version}";

--- a/pkgs/by-name/ap/apache-orc/package.nix
+++ b/pkgs/by-name/ap/apache-orc/package.nix
@@ -50,7 +50,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
     (lib.cmakeBool "BUILD_JAVA" false)
     (lib.cmakeBool "STOP_BUILD_ON_WARNING" true)
     (lib.cmakeBool "INSTALL_VENDORED_LIBS" false)

--- a/pkgs/by-name/ba/badvpn/package.nix
+++ b/pkgs/by-name/ba/badvpn/package.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation rec {
     nspr
   ];
 
+  cmakeBuildType = if debug then "Debug" else "Release";
+
   preConfigure = ''
     find . -name '*.sh' -exec sed -e 's@#!/bin/sh@${stdenv.shell}@' -i '{}' ';'
     find . -name '*.sh' -exec sed -e 's@#!/bin/bash@${bash}/bin/bash@' -i '{}' ';'

--- a/pkgs/by-name/ba/badvpn/package.nix
+++ b/pkgs/by-name/ba/badvpn/package.nix
@@ -9,23 +9,25 @@
   nspr,
   bash,
   debug ? false,
+  nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "badvpn";
   version = "1.999.130";
 
   src = fetchFromGitHub {
     owner = "ambrop72";
     repo = "badvpn";
-    tag = version;
-    sha256 = "sha256-bLTDpq3ohUP+KooPvhv1/AZfdo0HwB3g9QOuE2E/pmY=";
+    tag = finalAttrs.version;
+    hash = "sha256-bLTDpq3ohUP+KooPvhv1/AZfdo0HwB3g9QOuE2E/pmY=";
   };
 
   nativeBuildInputs = [
     cmake
     pkg-config
   ];
+
   buildInputs = [
     openssl
     nss
@@ -45,10 +47,12 @@ stdenv.mkDerivation rec {
       -i CMakeLists.txt
   '';
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Set of network-related (mostly VPN-related) tools";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ raskin ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/be/bespokesynth/package.nix
+++ b/pkgs/by-name/be/bespokesynth/package.nix
@@ -65,8 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail 'cmake_host_system_information(RESULT BESPOKE_BUILD_FQDN QUERY FQDN)' 'set(BESPOKE_BUILD_FQDN "localhost")'
   '';
 
-  cmakeBuildType = "Release";
-
   cmakeFlags = [
     (lib.cmakeBool "BESPOKE_SYSTEM_PYBIND11" true)
     (lib.cmakeBool "BESPOKE_SYSTEM_JSONCPP" true)
@@ -125,7 +123,9 @@ stdenv.mkDerivation (finalAttrs: {
     if stdenv.hostPlatform.isDarwin then
       ''
         mkdir -p $out/{Applications,bin}
-        mv Source/BespokeSynth_artefacts/${finalAttrs.cmakeBuildType}/BespokeSynth.app $out/Applications/
+        mv Source/BespokeSynth_artefacts/${
+          finalAttrs.cmakeBuildType or "Release"
+        }/BespokeSynth.app $out/Applications/
         # Symlinking confuses the resource finding about the actual location of the binary
         # Resources are looked up relative to the executed file's location
         makeWrapper $out/{Applications/BespokeSynth.app/Contents/MacOS,bin}/BespokeSynth

--- a/pkgs/by-name/bo/bolt-launcher/package.nix
+++ b/pkgs/by-name/bo/bolt-launcher/package.nix
@@ -66,10 +66,7 @@ let
       jdk17
     ];
 
-    cmakeFlags = [
-      "-G Ninja"
-    ]
-    ++ lib.optionals (stdenv.hostPlatform.isAarch64) [
+    cmakeFlags = lib.optionals (stdenv.hostPlatform.isAarch64) [
       (lib.cmakeFeature "PROJECT_ARCH" "arm64")
     ];
 
@@ -159,6 +156,6 @@ buildFHSEnv {
       iedame
     ];
     platforms = lib.platforms.linux;
-    mainProgram = "${bolt.name}";
+    mainProgram = "bolt-launcher";
   };
 }

--- a/pkgs/by-name/ca/capnproto/package.nix
+++ b/pkgs/by-name/ca/capnproto/package.nix
@@ -68,14 +68,14 @@ clangStdenv.mkDerivation rec {
   # https://git.lix.systems/lix-project/lix/issues/551
   # outputs = [ "bin" "dev" "out" ];
 
+  # Take optimization flags from CXXFLAGS rather than cmake injecting them
+  cmakeBuildType = "None";
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" true)
     # merely requires setcontext/getcontext (libc), lix expects fibers to
     # be available, and we want to make sure that the build will fail if
     # it breaks
     (lib.cmakeBool "WITH_FIBERS" true)
-    # Take optimization flags from CXXFLAGS rather than cmake injecting them
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "None")
   ];
 
   env = {

--- a/pkgs/by-name/ch/chow-tape-model/package.nix
+++ b/pkgs/by-name/ch/chow-tape-model/package.nix
@@ -95,8 +95,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-DCMAKE_NM=${stdenv.cc.cc}/bin/gcc-nm"
   ];
 
-  cmakeBuildType = "Release";
-
   postPatch = ''
     cd Plugin
     substituteInPlace modules/RTNeural/CMakeLists.txt --replace-fail \
@@ -106,7 +104,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   installPhase = ''
     mkdir -p $out/lib/lv2 $out/lib/vst3 $out/lib/clap $out/bin $out/share/doc/CHOWTapeModel/
-    cd CHOWTapeModel_artefacts/${finalAttrs.cmakeBuildType}
+    cd CHOWTapeModel_artefacts/${finalAttrs.cmakeBuildType or "Release"}
     cp -r LV2/CHOWTapeModel.lv2 $out/lib/lv2
     cp -r VST3/CHOWTapeModel.vst3 $out/lib/vst3
     cp -r CLAP/CHOWTapeModel.clap $out/lib/clap

--- a/pkgs/by-name/cl/cling/package.nix
+++ b/pkgs/by-name/cl/cling/package.nix
@@ -80,6 +80,7 @@ let
 
     strictDeps = true;
 
+    cmakeBuildType = if debug then "Debug" else "Release";
     cmakeFlags = [
       "-DLLVM_EXTERNAL_PROJECTS=cling"
       "-DLLVM_EXTERNAL_CLING_SOURCE_DIR=../../cling-source"
@@ -87,12 +88,6 @@ let
       "-DLLVM_TARGETS_TO_BUILD=host;NVPTX"
       "-DLLVM_INCLUDE_TESTS=OFF"
       "-DLLVM_ENABLE_RTTI=ON"
-    ]
-    ++ lib.optionals (!debug) [
-      "-DCMAKE_BUILD_TYPE=Release"
-    ]
-    ++ lib.optionals debug [
-      "-DCMAKE_BUILD_TYPE=Debug"
     ]
     ++ lib.optionals useLLVMLibcxx [
       "-DLLVM_ENABLE_LIBCXX=ON"

--- a/pkgs/by-name/et/ete-unwrapped/package.nix
+++ b/pkgs/by-name/et/ete-unwrapped/package.nix
@@ -60,7 +60,6 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeDir = "../src";
   cmakeFlags = [
     (lib.cmakeBool "CROSS_COMPILE32" false)
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
     (lib.cmakeBool "BUILD_DEDSERVER" true)
     (lib.cmakeBool "BUILD_CLIENT" true)
     (lib.cmakeBool "BUILD_ETMAIN_MOD" true)

--- a/pkgs/by-name/et/etlegacy-unwrapped/package.nix
+++ b/pkgs/by-name/et/etlegacy-unwrapped/package.nix
@@ -66,7 +66,6 @@ stdenv.mkDerivation {
 
   cmakeFlags = [
     (lib.cmakeBool "CROSS_COMPILE32" false)
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
     (lib.cmakeBool "BUILD_SERVER" true)
     (lib.cmakeBool "BUILD_CLIENT" true)
     (lib.cmakeBool "BUNDLED_ZLIB" false)

--- a/pkgs/by-name/fc/fcitx5-mcbopomofo/package.nix
+++ b/pkgs/by-name/fc/fcitx5-mcbopomofo/package.nix
@@ -13,14 +13,14 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "fcitx5-mcbopomofo";
   version = "2.9.5";
 
   src = fetchFromGitHub {
     owner = "openvanilla";
     repo = "fcitx5-mcbopomofo";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-efpVvWchJywKyGu7I6pNRVKJhIv01iKAXFCJ+7kcMwc=";
   };
 
@@ -49,4 +49,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ shiphan ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/fc/fcitx5-mcbopomofo/package.nix
+++ b/pkgs/by-name/fc/fcitx5-mcbopomofo/package.nix
@@ -40,10 +40,6 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
-  cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
-  ];
-
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/by-name/fe/feather-tk/package.nix
+++ b/pkgs/by-name/fe/feather-tk/package.nix
@@ -62,7 +62,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
     (lib.cmakeBool "BUILD_SHARED_LIBS" enableShared)
     (lib.cmakeBool "feather_tk_UI_LIB" true)
     (lib.cmakeFeature "feather_tk_API" "GL_4_1")

--- a/pkgs/by-name/jf/jfbview/package.nix
+++ b/pkgs/by-name/jf/jfbview/package.nix
@@ -44,7 +44,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_TESTING" false)
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
     (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "/") # relative to $out
   ];
 

--- a/pkgs/by-name/li/libjson-rpc-cpp/package.nix
+++ b/pkgs/by-name/li/libjson-rpc-cpp/package.nix
@@ -65,8 +65,7 @@ stdenv.mkDerivation rec {
   # require write permission to absolute paths
   configurePhase = ''
     runHook preConfigure
-    cmake .. -DCMAKE_INSTALL_PREFIX=$(pwd)/Install \
-             -DCMAKE_BUILD_TYPE=Release
+    cmake .. -DCMAKE_INSTALL_PREFIX=$(pwd)/Install
     runHook postConfigure
   '';
 

--- a/pkgs/by-name/me/melodeon/package.nix
+++ b/pkgs/by-name/me/melodeon/package.nix
@@ -29,8 +29,6 @@ stdenv.mkDerivation (finalAttrs: {
     qt6.wrapQtAppsHook
   ];
 
-  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
-
   meta = {
     description = "QWebEngine wrapper for MaterialSkin on Lyrion Music Server (formerly Logitech Media Server)";
     mainProgram = "melodeon";

--- a/pkgs/by-name/or/orthanc-plugin-dicomweb/package.nix
+++ b/pkgs/by-name/or/orthanc-plugin-dicomweb/package.nix
@@ -86,7 +86,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DSTATIC_BUILD=OFF"
     "-DORTHANC_FRAMEWORK_SOURCE=system"
     "-DORTHANC_FRAMEWORK_ROOT=${orthanc.framework}/include/orthanc-framework"

--- a/pkgs/by-name/or/orthanc/package.nix
+++ b/pkgs/by-name/or/orthanc/package.nix
@@ -77,7 +77,6 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeFeature "DCMTK_DICTIONARY_DIR_AUTO" "${dcmtk}/share/dcmtk-${dcmtk.version}")
     (lib.cmakeFeature "DCMTK_LIBRARIES" "dcmjpls;oflog;ofstd")
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
 
     (lib.cmakeBool "BUILD_CONNECTIVITY_CHECKS" false)
     (lib.cmakeBool "UNIT_TESTS_WITH_HTTP_CONNEXIONS" false)

--- a/pkgs/by-name/pl/pluginval/package.nix
+++ b/pkgs/by-name/pl/pluginval/package.nix
@@ -16,6 +16,7 @@
   libXrandr,
   libXtst,
   ladspaH,
+  debug ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -49,9 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     ladspaH
   ];
 
-  cmakeFlags = [
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Debug")
-  ];
+  cmakeBuildType = if debug then "Debug" else "Release";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/re/renode/package.nix
+++ b/pkgs/by-name/re/renode/package.nix
@@ -142,7 +142,7 @@ buildDotnetModule rec {
       fi
 
       SOURCE="${src}/src/Infrastructure/src/Emulator/Cores"
-      CMAKE_CONF_FLAGS="-DTARGET_ARCH=$CORE -DTARGET_WORD_SIZE=$BITS -DCMAKE_BUILD_TYPE=Release -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$out/lib"
+      CMAKE_CONF_FLAGS="-DTARGET_ARCH=$CORE -DTARGET_WORD_SIZE=$BITS -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$out/lib"
       CORE_DIR=build/$CORE/$ENDIAN
       mkdir -p $CORE_DIR
       pushd $CORE_DIR

--- a/pkgs/by-name/re/retrofe/package.nix
+++ b/pkgs/by-name/re/retrofe/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation {
   configurePhase = ''
     runHook preConfigure
 
-    cmake RetroFE/Source -BRetroFE/Build -DCMAKE_BUILD_TYPE=Release \
+    cmake RetroFE/Source -BRetroFE/Build \
       -DVERSION_MAJOR=0 -DVERSION_MINOR=0 -DVERSION_BUILD=0 \
 
     runHook postConfigure

--- a/pkgs/by-name/rs/rssguard/package.nix
+++ b/pkgs/by-name/rs/rssguard/package.nix
@@ -32,9 +32,6 @@ stdenv.mkDerivation rec {
     wrapGAppsHook4
     qt6.wrapQtAppsHook
   ];
-  cmakeFlags = [
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "\"Release\"")
-  ];
 
   dontWrapGApps = true;
 

--- a/pkgs/by-name/so/socalabs-sid/package.nix
+++ b/pkgs/by-name/so/socalabs-sid/package.nix
@@ -114,8 +114,6 @@ stdenv.mkDerivation {
     --replace-fail "port = client.createPort (portName, forInput, false);" "port = client.createPort (portName, forInput, true);"
   '';
 
-  cmakeBuildType = "Release";
-
   strictDeps = true;
 
   preBuild = ''

--- a/pkgs/by-name/un/unnamed-sdvx-clone/package.nix
+++ b/pkgs/by-name/un/unnamed-sdvx-clone/package.nix
@@ -61,7 +61,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DUSE_SYSTEM_CPR=ON"
-    "-DCMAKE_BUILD_TYPE=Release"
   ];
 
   # Wrapper script because the things are hardcoded so we just

--- a/pkgs/by-name/va/vanillatd/package.nix
+++ b/pkgs/by-name/va/vanillatd/package.nix
@@ -25,7 +25,7 @@
   rsync,
 
   appName,
-  CMAKE_BUILD_TYPE ? "RelWithDebInfo", # "Choose the type of build, recommended options are: Debug Release RelWithDebInfo"
+  debug ? false,
 }:
 assert lib.assertOneOf "appName" appName [
   "vanillatd"
@@ -64,12 +64,12 @@ stdenv.mkDerivation (finalAttrs: {
     copyDesktopItems
   ];
 
+  cmakeBuildType = if debug then "Debug" else "Release";
   cmakeFlags = [
     (lib.cmakeBool "BUILD_VANILLATD" (appName == "vanillatd"))
     (lib.cmakeBool "BUILD_VANILLARA" (appName == "vanillara"))
     (lib.cmakeBool "BUILD_REMASTERTD" (appName == "remastertd"))
     (lib.cmakeBool "BUILD_REMASTERRA" (appName == "remasterra"))
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" CMAKE_BUILD_TYPE)
   ];
 
   # TODO: Fix this from the upstream

--- a/pkgs/by-name/wt/wtf/package.nix
+++ b/pkgs/by-name/wt/wtf/package.nix
@@ -26,10 +26,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   sourceRoot = "source/src";
 
-  cmakeFlags = [
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
-  ];
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/xl/xlink/package.nix
+++ b/pkgs/by-name/xl/xlink/package.nix
@@ -48,7 +48,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "XLINK_BUILD_EXAMPLES" true)
     (lib.cmakeBool "XLINK_BUILD_TESTS" true)
     (lib.cmakeBool "XLINK_LIBUSB_SYSTEM" true)
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
   ];
 
   postInstall = ''

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -457,8 +457,6 @@ stdenv.mkDerivation (
       LDFLAGS = "-Wl,--build-id=sha1";
     };
 
-    cmakeBuildType = "Release";
-
     cmakeFlags =
       let
         # These flags influence llvm-config's BuildVariables.inc in addition to the
@@ -561,7 +559,9 @@ stdenv.mkDerivation (
       mkdir -p $python/share
       mv $out/share/opt-viewer $python/share/opt-viewer
       moveToOutput "bin/llvm-config*" "$dev"
-      substituteInPlace "$dev/lib/cmake/llvm/LLVMExports-${lib.toLower finalAttrs.finalPackage.cmakeBuildType}.cmake" \
+      substituteInPlace "$dev/lib/cmake/llvm/LLVMExports-${
+        lib.toLower finalAttrs.finalPackage.cmakeBuildType or "release"
+      }.cmake" \
         --replace-fail "$out/bin/llvm-config" "$dev/bin/llvm-config"
       substituteInPlace "$dev/lib/cmake/llvm/LLVMConfig.cmake" \
         --replace-fail 'set(LLVM_BINARY_DIR "''${LLVM_INSTALL_PREFIX}")' 'set(LLVM_BINARY_DIR "'"$lib"'")'

--- a/pkgs/development/libraries/ipu6-camera-hal/default.nix
+++ b/pkgs/development/libraries/ipu6-camera-hal/default.nix
@@ -46,7 +46,6 @@ stdenv.mkDerivation {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"

--- a/pkgs/development/rocm-modules/6/composable_kernel/base.nix
+++ b/pkgs/development/rocm-modules/6/composable_kernel/base.nix
@@ -88,7 +88,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DCMAKE_MODULE_PATH=${clr}/hip/cmake"
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DCMAKE_POLICY_DEFAULT_CMP0069=NEW"
     # "-DDL_KERNELS=ON" # Not needed, slow to build
     # CK_USE_CODEGEN Required for migraphx which uses device_gemm_multiple_d.hpp

--- a/pkgs/development/rocm-modules/6/hipcc/default.nix
+++ b/pkgs/development/rocm-modules/6/hipcc/default.nix
@@ -34,9 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "/usr/bin/lsb_release" "${lsb-release}/bin/lsb_release"
   '';
 
-  cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
-  ];
   postInstall = ''
     rm -r $out/hip/bin
     ln -s $out/bin $out/hip/bin

--- a/pkgs/development/rocm-modules/6/miopen/default.nix
+++ b/pkgs/development/rocm-modules/6/miopen/default.nix
@@ -218,7 +218,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-DMIOPEN_USE_SQLITE_PERFDB=ON"
     "-DCMAKE_VERBOSE_MAKEFILE=ON"
     "-DCMAKE_MODULE_PATH=${clr}/hip/cmake"
-    "-DCMAKE_BUILD_TYPE=Release"
 
     # needs to stream to stdout so bzcat rather than bunzip2
     "-DUNZIPPER=${bzip2}/bin/bzcat"

--- a/pkgs/development/rocm-modules/6/rccl/default.nix
+++ b/pkgs/development/rocm-modules/6/rccl/default.nix
@@ -87,7 +87,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DHIP_CLANG_NUM_PARALLEL_JOBS=4"
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DROCM_PATH=${clr}"
     "-DHIP_COMPILER=${clr}/bin/amdclang++"
     "-DCMAKE_CXX_COMPILER=${clr}/bin/amdclang++"

--- a/pkgs/development/rocm-modules/6/rocmlir/default.nix
+++ b/pkgs/development/rocm-modules/6/rocmlir/default.nix
@@ -75,7 +75,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DLLVM_TARGETS_TO_BUILD=AMDGPU;${llvmNativeTarget}"
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DLLVM_USE_LINKER=lld"
     "-DLLVM_ENABLE_ZSTD=FORCE_ON"
     "-DLLVM_ENABLE_ZLIB=FORCE_ON"

--- a/pkgs/development/rocm-modules/6/rocsolver/default.nix
+++ b/pkgs/development/rocm-modules/6/rocsolver/default.nix
@@ -83,7 +83,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DHIP_CLANG_NUM_PARALLEL_JOBS=4"
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DCMAKE_VERBOSE_MAKEFILE=ON"
     # Manually define CMAKE_INSTALL_<DIR>
     # See: https://github.com/NixOS/nixpkgs/pull/197838


### PR DESCRIPTION
## Things done

#427019 

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
