### PR TITLE
workflows/{merge_group,pr}: fail status check explicitly

### DIFF
--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -29,7 +29,7 @@ jobs:
   # This job's only purpose is to create the target for the "Required Status Checks" branch ruleset.
   # It "needs" all the jobs that should block the Merge Queue.
   unlock:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && always()
     # Modify this list to add or remove jobs from required status checks.
     needs:
       - lint
@@ -38,6 +38,8 @@ jobs:
       statuses: write
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
         with:
           script: |
             const { serverUrl, repo, runId, payload } = context
@@ -50,6 +52,6 @@ jobs:
               // Do NOT change the name of this, otherwise the rule will not catch it anymore.
               // This would prevent all PRs from merging.
               context: 'no PR failures',
-              state: 'success',
+              state: JSON.parse(process.env.RESULTS).every(result => result == 'success') ? 'success' : 'error',
               target_url,
             })

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -127,7 +127,7 @@ jobs:
   # This job's only purpose is to create the target for the "Required Status Checks" branch ruleset.
   # It "needs" all the jobs that should block merging a PR.
   unlock:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && always()
     # Modify this list to add or remove jobs from required status checks.
     needs:
       - check
@@ -139,6 +139,8 @@ jobs:
       statuses: write
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
         with:
           script: |
             const { serverUrl, repo, runId, payload } = context
@@ -151,6 +153,6 @@ jobs:
               // Do NOT change the name of this, otherwise the rule will not catch it anymore.
               // This would prevent all PRs from merging.
               context: 'no PR failures',
-              state: 'success',
+              state: JSON.parse(process.env.RESULTS).every(status => status == 'success') ? 'success' : 'error',
               target_url,
             })


### PR DESCRIPTION
When the merge queue fails, the workflow currently does not post a negative result - and GitHub Actions waits for the status check to time out, which takes 60 minutes.

This, of course, is a waste of time and resources. By explicitly failing the status check, we boot the PR out of the merge queue immediately.

Happend in #441864

## Things done

- [x] Tested in my fork (the PR workflow parts)
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
