### PR TITLE
python313Packages.pymitsubishi: 0.1.8 -> 0.3.0

### DIFF
--- a/pkgs/development/python-modules/pymitsubishi/default.nix
+++ b/pkgs/development/python-modules/pymitsubishi/default.nix
@@ -5,19 +5,20 @@
   setuptools,
   requests,
   pycryptodome,
+  pytest-cov-stub,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "pymitsubishi";
-  version = "0.1.8";
+  version = "0.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pymitsubishi";
     repo = "pymitsubishi";
     tag = "v${version}";
-    hash = "sha256-hawPxP8WqpHUikmbcSFIjSeSTNyWu1zYtgT/TCPbOro=";
+    hash = "sha256-cfLKFvhzLN9dM0cMogCL93LVfRd8jDFo9x+nnEWInSc=";
   };
 
   build-system = [ setuptools ];
@@ -27,12 +28,15 @@ buildPythonPackage rec {
     pycryptodome
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "pymitsubishi" ];
 
   meta = {
-    description = "A Python library for controlling and monitoring Mitsubishi MAC-577IF-2E air conditioners";
+    description = "Library for controlling and monitoring Mitsubishi MAC-577IF-2E air conditioners";
     homepage = "https://github.com/pymitsubishi/pymitsubishi";
     changelog = "https://github.com/pymitsubishi/pymitsubishi/releases/tag/${src.tag}";
     license = lib.licenses.mit;

--- a/pkgs/servers/home-assistant/custom-components/mitsubishi/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/mitsubishi/package.nix
@@ -11,13 +11,13 @@
 buildHomeAssistantComponent rec {
   owner = "pymitsubishi";
   domain = "mitsubishi";
-  version = "0.1.8";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "pymitsubishi";
     repo = "homeassistant-mitsubishi";
     tag = "v${version}";
-    hash = "sha256-qxYdE70APMO+ydv+lQzJY3gRYr/y5p0zJSgPt/k1cys=";
+    hash = "sha256-V8fT/w7a/uUN4yKJ+jB6UUQDP6dif80MvlqV9n4KENc=";
   };
 
   dependencies = [


### PR DESCRIPTION
Changelog: https://github.com/pymitsubishi/pymitsubishi/releases/tag/v0.3.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
