### PR TITLE
python3Packages.pyiceberg: 0.9.1 -> 0.10.0

### DIFF
--- a/pkgs/development/python-modules/pyiceberg-core/default.nix
+++ b/pkgs/development/python-modules/pyiceberg-core/default.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+
+  # tests
+  datafusion,
+  pyarrow,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pyiceberg-core";
+  version = "0.6.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "apache";
+    repo = "iceberg-rust";
+    tag = "v${version}";
+    hash = "sha256-vRSZnMkZptGkLZBN1RRu0YGRQCOgJioBIghXnvU9UXc=";
+  };
+
+  sourceRoot = "${src.name}/bindings/python";
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit
+      pname
+      version
+      src
+      sourceRoot
+      ;
+    hash = "sha256-QfNVqyZ/O3vZAf689Fg5qPY6jcN4G1zo2eS2AEcdIL4=";
+  };
+
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  pythonImportsCheck = [ "pyiceberg_core" ];
+
+  nativeCheckInputs = [
+    pyarrow
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # Circular dependency on pyiceberg
+    "tests/test_datafusion_table_provider.py"
+  ];
+
+  meta = {
+    description = "Iceberg-rust powered core for pyiceberg";
+    homepage = "https://github.com/apache/iceberg-rust/tree/main/bindings/python";
+    changelog = "https://github.com/apache/iceberg-rust/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/development/python-modules/pyiceberg/default.nix
+++ b/pkgs/development/python-modules/pyiceberg/default.nix
@@ -13,9 +13,11 @@
   cachetools,
   click,
   fsspec,
+  google-auth,
   mmh3,
   pydantic,
   pyparsing,
+  pyroaring,
   ray,
   requests,
   rich,
@@ -26,14 +28,20 @@
 
   # optional-dependencies
   adlfs,
-  # getdaft,
+  google-cloud-bigquery,
+  # bodo,
+  # daft,
   duckdb,
   pyarrow,
+  pyiceberg-core,
   boto3,
+  huggingface-hub,
   gcsfs,
-  mypy-boto3-glue,
   thrift,
+  kerberos,
+  # thrift-sasl,
   pandas,
+  # pyiceberg-core,
   s3fs,
   python-snappy,
   psycopg2-binary,
@@ -56,14 +64,14 @@
 
 buildPythonPackage rec {
   pname = "iceberg-python";
-  version = "0.9.1";
+  version = "0.10.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "apache";
     repo = "iceberg-python";
     tag = "pyiceberg-${version}";
-    hash = "sha256-OUj8z/UOIcK0S4tf6Id52YHweNDfYnX6P4nChXrOxqY=";
+    hash = "sha256-uR8nmKVjYjiArcNaf/Af2kGh14p59VV9g2mKPKmiJnc=";
   };
 
   patches = [
@@ -92,9 +100,11 @@ buildPythonPackage rec {
     cachetools
     click
     fsspec
+    google-auth
     mmh3
     pydantic
     pyparsing
+    pyroaring
     ray
     requests
     rich
@@ -108,8 +118,14 @@ buildPythonPackage rec {
     adlfs = [
       adlfs
     ];
+    bigquery = [
+      google-cloud-bigquery
+    ];
+    bodo = [
+      # bodo
+    ];
     daft = [
-      # getdaft
+      # daft
     ];
     duckdb = [
       duckdb
@@ -118,15 +134,22 @@ buildPythonPackage rec {
     dynamodb = [
       boto3
     ];
+    hf = [
+      huggingface-hub
+    ];
     gcsfs = [
       gcsfs
     ];
     glue = [
       boto3
-      mypy-boto3-glue
     ];
     hive = [
       thrift
+    ];
+    hive-kerberos = [
+      kerberos
+      thrift
+      # thrift-sasl
     ];
     pandas = [
       pandas
@@ -134,6 +157,7 @@ buildPythonPackage rec {
     ];
     pyarrow = [
       pyarrow
+      pyiceberg-core
     ];
     ray = [
       pandas
@@ -171,19 +195,19 @@ buildPythonPackage rec {
     datafusion
     fastavro
     moto
-    mypy-boto3-glue
-    pandas
-    pyarrow
     pyspark
     pytest-lazy-fixture
     pytest-mock
     pytest-timeout
     pytestCheckHook
     requests-mock
-    s3fs
-    sqlalchemy
-    thrift
   ]
+  ++ optional-dependencies.bigquery
+  ++ optional-dependencies.hive
+  ++ optional-dependencies.pandas
+  ++ optional-dependencies.pyarrow
+  ++ optional-dependencies.s3fs
+  ++ optional-dependencies.sql-sqlite
   ++ moto.optional-dependencies.server;
 
   pytestFlags = [
@@ -200,14 +224,19 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
+    # KeyError: 'authorization'
+    "test_token_200"
+    "test_token_200_without_optional_fields"
+    "test_token_with_default_scope"
+    "test_token_with_optional_oauth_params"
+    "test_token_with_custom_scope"
+
+    # AttributeError: 'SessionContext' object has no attribute 'register_table_provider'
+    "test_datafusion_register_pyiceberg_tabl"
+
     # ModuleNotFoundError: No module named 'puresasl'
     "test_create_hive_client_with_kerberos"
     "test_create_hive_client_with_kerberos_using_context_manager"
-
-    # Require unpackaged pyiceberg_core
-    "test_bucket_pyarrow_transforms"
-    "test_transform_consistency_with_pyarrow_transform"
-    "test_truncate_pyarrow_transforms"
 
     # botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL
     "test_checking_if_a_file_exists"
@@ -227,6 +256,7 @@ buildPythonPackage rec {
     "test_fsspec_pickle_roundtrip_gcs"
 
     # Timeout (network access)
+    "test_config_200"
     "test_fsspec_converting_an_outputfile_to_an_inputfile_adls"
     "test_fsspec_new_abfss_output_file_adls"
     "test_fsspec_new_input_file_adls"
@@ -234,12 +264,24 @@ buildPythonPackage rec {
     "test_partitioned_write"
     "test_token_200_w_oauth2_server_uri"
 
+    # azure.core.exceptions.ServiceRequestError (network access)
+    "test_converting_an_outputfile_to_an_inputfile_adls"
+    "test_file_tell_adls"
+    "test_getting_length_of_file_adls"
+    "test_new_input_file_adls"
+    "test_new_output_file_adls"
+    "test_raise_on_opening_file_not_found_adls"
+    "test_read_specified_bytes_for_file_adls"
+    "test_write_and_read_file_adls"
+
     # Hangs forever (from tests/io/test_pyarrow.py)
     "test_getting_length_of_file_gcs"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # ImportError: The pyarrow installation is not built with support for 'GcsFileSystem'
     "test_converting_an_outputfile_to_an_inputfile_gcs"
+    "test_create_table_with_database_location"
+    "test_drop_table_with_database_location"
     "test_new_input_file_gcs"
     "test_new_output_file_gc"
 
@@ -247,6 +289,8 @@ buildPythonPackage rec {
     # '/tmp/iceberg/warehouse/default.db/test_projection_partitions/metadata/00000-6c1c61a1-495f-45d3-903d-a2643431be91.metadata.json'
     "test_identity_transform_column_projection"
     "test_identity_transform_columns_projection"
+    "test_in_memory_catalog_context_manager"
+    "test_inspect_partition_for_nested_field"
   ]
   ++ lib.optionals (pythonAtLeast "3.13") [
     # AssertionError:

--- a/pkgs/development/python-modules/pyroaring/default.nix
+++ b/pkgs/development/python-modules/pyroaring/default.nix
@@ -20,6 +20,11 @@ buildPythonPackage rec {
     hash = "sha256-g+xpQ2DuVn8b0DiIOY69QOH6iwOYHG4bltX1zbDemdI=";
   };
 
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "cython>=3.0.2,<3.1.0" "cython"
+  '';
+
   build-system = [
     cython
     setuptools

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13162,6 +13162,8 @@ self: super: with self; {
 
   pyiceberg = callPackage ../development/python-modules/pyiceberg { };
 
+  pyiceberg-core = callPackage ../development/python-modules/pyiceberg-core { };
+
   pyicloud = callPackage ../development/python-modules/pyicloud { };
 
   pyicu = callPackage ../development/python-modules/pyicu { };


### PR DESCRIPTION
## Things done

- **python3Packages.pyroaring: relax cython**
- **python3Packages.pyiceberg-core: init at 0.6.0**
- **python3Packages.pyiceberg: 0.9.1 -> 0.10.0**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
