### PR TITLE
python313Packages.tkinter: fix build for python 3.10 and 3.11, enable tests

### DIFF
--- a/pkgs/development/python-modules/tkinter/default.nix
+++ b/pkgs/development/python-modules/tkinter/default.nix
@@ -73,7 +73,7 @@ buildPythonPackage {
   checkPhase = ''
     runHook preCheck
     xvfb-run -w 10 -s "-screen 0 1920x1080x24" \
-      python -m unittest test.test_tkinter
+      python -m unittest test.test_tcl test.test_tkinter test.test_ttk test.test_ttk_textonly
 
     runHook postCheck
   '';

--- a/pkgs/development/python-modules/tkinter/default.nix
+++ b/pkgs/development/python-modules/tkinter/default.nix
@@ -8,7 +8,6 @@
   tcl,
   tclPackages,
   tk,
-  tkinter,
   xvfb-run,
 }:
 
@@ -64,8 +63,6 @@ buildPythonPackage {
     ];
   };
 
-  doCheck = false;
-
   nativeCheckInputs = [ xvfb-run ];
 
   preCheck = ''
@@ -80,8 +77,6 @@ buildPythonPackage {
 
     runHook postCheck
   '';
-
-  passthru.tests.unittests = tkinter.overridePythonAttrs { doCheck = true; };
 
   pythonImportsCheck = [ "tkinter" ];
 

--- a/pkgs/development/python-modules/tkinter/fix-ttk-notebook-test.patch
+++ b/pkgs/development/python-modules/tkinter/fix-ttk-notebook-test.patch
@@ -1,0 +1,24 @@
+--- a/Lib/tkinter/test/test_ttk/test_widgets.py
++++ b/Lib/tkinter/test/test_ttk/test_widgets.py
+@@ -911,12 +911,20 @@ class ScrollbarTest(AbstractWidgetTest, unittest.TestCase):
+         return ttk.Scrollbar(self.root, **kwargs)
+ 
+ 
+-@add_standard_options(IntegerSizeTests, StandardTtkOptionsTests)
++@add_standard_options(StandardTtkOptionsTests)
+ class NotebookTest(AbstractWidgetTest, unittest.TestCase):
+     OPTIONS = (
+         'class', 'cursor', 'height', 'padding', 'style', 'takefocus', 'width',
+     )
+ 
++    def test_configure_height(self):
++        widget = self.create()
++        self.checkPixelsParam(widget, 'height', '10c', 402, -402, 0, conv=False)
++
++    def test_configure_width(self):
++        widget = self.create()
++        self.checkPixelsParam(widget, 'width', '10c', 402, -402, 0, conv=False)
++
+     def setUp(self):
+         super().setUp()
+         self.nb = self.create(padding=0)

--- a/pkgs/development/python-modules/tkinter/pyproject.toml
+++ b/pkgs/development/python-modules/tkinter/pyproject.toml
@@ -11,6 +11,5 @@ requires-python = ">=@python_version@"
 [tool.setuptools]
 packages = ["tkinter"]
 ext-modules = [
-  { name = "_tkinter", sources = ["_tkinter.c"], libraries = ["tcl9.0", "tcl9tk9.0"], include-dirs = ["@python_internal_dir@/"] }
+  { name = "_tkinter", sources = ["_tkinter.c"], libraries = ["tcl", "tk"], include-dirs = ["@python_internal_dir@/"] }
 ]
-

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18388,8 +18388,11 @@ self: super: with self; {
       null
     else
       callPackage ../development/python-modules/tkinter {
-        tcl = pkgs.tcl-9_0;
-        tk = pkgs.tk-9_0;
+        # Tcl/Tk 9.0 support in Tkinter is not quite ready yet:
+        # - https://github.com/python/cpython/issues/124111
+        # - https://github.com/python/cpython/issues/104568
+        tcl = pkgs.tcl-8_6;
+        tk = pkgs.tk-8_6;
       };
 
   tkinter-gl = callPackage ../development/python-modules/tkinter-gl { };


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/306708195/nixlog/16

Failure probably introduced by https://github.com/NixOS/nixpkgs/pull/433833

- Revert to building with Tcl 8.6 to fix Python 3.10 and 3.11 build
- The experienced build failure seems to be fixed in Python ≥3.12
  - https://github.com/python/cpython/issues/103839
  - https://github.com/python/cpython/pull/103842
- Building with Tcl 8.6 also allows us to enable tests, which are now mostly passing (so far I've only tested this on `x86_64-linux`)
- Tcl 9.0 support in Tkinter in general is not quite there yet it seems, but upstream is working on fixing tests etc.
  - https://github.com/python/cpython/issues/124111
  - https://github.com/python/cpython/issues/104568

cc @mweinelt

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
