### PR TITLE
miniaudio: 0.11.22 -> 0.11.23, switch to cmake; sfml: unvendor miniaudio

### DIFF
--- a/pkgs/by-name/mi/miniaudio/package.nix
+++ b/pkgs/by-name/mi/miniaudio/package.nix
@@ -6,13 +6,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "miniaudio";
-  version = "0.11.22";
+  version = "0.11.23";
 
   src = fetchFromGitHub {
     owner = "mackron";
     repo = "miniaudio";
-    rev = finalAttrs.version;
-    hash = "sha256-o/7sfBcrhyXEakccOAogQqm8dO4Szj1QSpaIHg6OSt4=";
+    tag = finalAttrs.version;
+    hash = "sha256-ZrfKw5a3AtIER2btCKWhuvygasNaHNf9EURf1Kv96Vc=";
   };
 
   postInstall = ''

--- a/pkgs/by-name/mi/miniaudio/package.nix
+++ b/pkgs/by-name/mi/miniaudio/package.nix
@@ -3,6 +3,21 @@
   stdenv,
   fetchFromGitHub,
   testers,
+
+  cmake,
+  ninja,
+
+  alsa-lib,
+  libjack2,
+  libpulseaudio,
+  libvorbis,
+  opusfile,
+  sndio,
+
+  alsaSupport ? true,
+  pulseSupport ? true,
+  jackSupport ? true,
+  sndioSupport ? true,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "miniaudio";
@@ -15,26 +30,39 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-ZrfKw5a3AtIER2btCKWhuvygasNaHNf9EURf1Kv96Vc=";
   };
 
-  postInstall = ''
-    mkdir -p $out/include
-    mkdir -p $out/lib/pkgconfig
+  outputs = [
+    "out"
+    "dev"
+  ];
 
-    cp $src/miniaudio.h $out/include
-    ln -s $out/include/miniaudio.h $out
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
 
-    cp -r $src/extras $out/
+  buildInputs = [
+    libvorbis
+    opusfile
+  ]
+  ++ lib.optional pulseSupport libpulseaudio
+  ++ lib.optional jackSupport libjack2
+  ++ lib.optional alsaSupport alsa-lib
+  ++ lib.optional sndioSupport sndio;
 
-    cat <<EOF >$out/lib/pkgconfig/miniaudio.pc
-    prefix=$out
-    includedir=$out/include
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "MINIAUDIO_NO_RUNTIME_LINKING" true)
+    (lib.cmakeBool "MINIAUDIO_BUILD_TESTS" true)
+    (lib.cmakeBool "MINIAUDIO_BUILD_EXAMPLES" true)
 
-    Name: miniaudio
-    Description: An audio playback and capture library in a single source file.
-    Version: $version
-    Cflags: -I$out/include
-    Libs: -lm -lpthread -latomic
-    EOF
-  '';
+    (lib.cmakeBool "MINIAUDIO_ENABLE_ONLY_SPECIFIC_BACKENDS" true)
+    (lib.cmakeBool "MINIAUDIO_ENABLE_PULSEAUDIO" pulseSupport)
+    (lib.cmakeBool "MINIAUDIO_ENABLE_JACK" jackSupport)
+    (lib.cmakeBool "MINIAUDIO_ENABLE_SNDIO" alsaSupport)
+    (lib.cmakeBool "MINIAUDIO_ENABLE_ALSA" sndioSupport)
+  ];
+
+  doCheck = true;
 
   passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
 
@@ -48,6 +76,6 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     maintainers = [ maintainers.jansol ];
     pkgConfigModules = [ "miniaudio" ];
-    platforms = platforms.all;
+    platforms = platforms.linux;
   };
 })

--- a/pkgs/by-name/sf/sfml/package.nix
+++ b/pkgs/by-name/sf/sfml/package.nix
@@ -6,6 +6,7 @@
 
   # nativeBuildInputs
   cmake,
+  pkg-config,
 
   # buildInputs
   flac,
@@ -13,6 +14,7 @@
   glew,
   libjpeg,
   libvorbis,
+  miniaudio,
   udev,
   libXi,
   libX11,
@@ -20,12 +22,6 @@
   libXrandr,
   libXrender,
   xcbutilimage,
-
-  # miniaudio
-  alsa-lib,
-  libjack2,
-  libpulseaudio,
-  sndio,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -45,15 +41,22 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/SFML/SFML/commit/a87763becbc4672b38f1021418ed94caa0f6540a.patch?full_index=1";
       hash = "sha256-tJmXTdhwtWq6XfUPBzw47yTrc6EzwmSiVj9n6jQwHig=";
     })
+
+    # Not upstreamble in the near future, see https://github.com/SFML/SFML/pull/3555
+    ./unvendor-miniaudio.patch
   ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
   buildInputs = [
     flac
     freetype
     glew
     libjpeg
     libvorbis
+    miniaudio
   ]
   ++ lib.optional stdenv.hostPlatform.isLinux udev
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
@@ -65,25 +68,12 @@ stdenv.mkDerivation (finalAttrs: {
     xcbutilimage
   ];
 
-  # We rely on RUNPATH
-  dontPatchELF = true;
-
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
     (lib.cmakeBool "SFML_INSTALL_PKGCONFIG_FILES" true)
     (lib.cmakeFeature "SFML_MISC_INSTALL_PREFIX" "share/SFML")
     (lib.cmakeBool "SFML_BUILD_FRAMEWORKS" false)
     (lib.cmakeBool "SFML_USE_SYSTEM_DEPS" true)
-
-    # FIXME: Unvendor miniaudio and move these deps there
-    (lib.cmakeFeature "CMAKE_INSTALL_RPATH" (
-      lib.makeLibraryPath [
-        alsa-lib
-        libjack2
-        libpulseaudio
-        sndio
-      ]
-    ))
   ];
 
   meta = {

--- a/pkgs/by-name/sf/sfml/unvendor-miniaudio.patch
+++ b/pkgs/by-name/sf/sfml/unvendor-miniaudio.patch
@@ -1,0 +1,35 @@
+diff --git a/src/SFML/Audio/CMakeLists.txt b/src/SFML/Audio/CMakeLists.txt
+index 7567205c..ecbb4ea1 100644
+--- a/src/SFML/Audio/CMakeLists.txt
++++ b/src/SFML/Audio/CMakeLists.txt
+@@ -10,7 +10,6 @@ set(SRC
+     ${INCROOT}/Export.hpp
+     ${SRCROOT}/Listener.cpp
+     ${INCROOT}/Listener.hpp
+-    ${SRCROOT}/Miniaudio.cpp
+     ${SRCROOT}/MiniaudioUtils.hpp
+     ${SRCROOT}/MiniaudioUtils.cpp
+     ${SRCROOT}/Music.cpp
+@@ -169,8 +168,10 @@ sfml_add_library(Audio
+ # avoids warnings in vorbisfile.h
+ target_compile_definitions(sfml-audio PRIVATE OV_EXCLUDE_STATIC_CALLBACKS FLAC__NO_DLL)
+ 
+-# disable miniaudio features we do not use
+-target_compile_definitions(sfml-audio PRIVATE MA_NO_MP3 MA_NO_FLAC MA_NO_ENCODING MA_NO_RESOURCE_MANAGER MA_NO_GENERATION)
++find_package(PkgConfig REQUIRED)
++pkg_check_modules(miniaudio REQUIRED IMPORTED_TARGET miniaudio)
++target_link_libraries(sfml-audio PRIVATE PkgConfig::miniaudio)
++target_include_directories(sfml-audio SYSTEM PRIVATE "${miniaudio_INCLUDE_DIRS}/miniaudio")
+ 
+ # use standard fixed-width integer types
+ target_compile_definitions(sfml-audio PRIVATE MA_USE_STDINT)
+@@ -186,9 +187,6 @@ if(SFML_OS_IOS)
+     target_link_libraries(sfml-audio PRIVATE "-framework Foundation" "-framework CoreFoundation" "-framework CoreAudio" "-framework AudioToolbox" "-framework AVFoundation")
+ endif()
+ 
+-# miniaudio sources
+-target_include_directories(sfml-audio SYSTEM PRIVATE "${PROJECT_SOURCE_DIR}/extlibs/headers/miniaudio")
+-
+ # minimp3 sources
+ target_include_directories(sfml-audio SYSTEM PRIVATE "${PROJECT_SOURCE_DIR}/extlibs/headers/minimp3")
+ 

--- a/pkgs/development/python-modules/miniaudio/default.nix
+++ b/pkgs/development/python-modules/miniaudio/default.nix
@@ -3,22 +3,10 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
-  miniaudio,
   cffi,
   pytestCheckHook,
 }:
 
-let
-  # TODO: recheck after 1.59
-  miniaudio' = miniaudio.overrideAttrs (oldAttrs: rec {
-    version = "0.11.16"; # cffi breakage with 0.11.17
-    src = fetchFromGitHub {
-      inherit (oldAttrs.src) owner repo;
-      rev = "refs/tags/${version}";
-      hash = "sha256-POe/dYPJ25RKNGIhaLoqxm9JJ08MrTyHVN4NmaGOdwM=";
-    };
-  });
-in
 buildPythonPackage rec {
   pname = "miniaudio";
   version = "1.61";
@@ -31,14 +19,7 @@ buildPythonPackage rec {
     hash = "sha256-H3o2IWGuMqLrJTzQ7w636Ito6f57WBtMXpXXzrZ7UD8=";
   };
 
-  postPatch = ''
-    rm -r miniaudio
-    ln -s ${miniaudio'} miniaudio
-    substituteInPlace build_ffi_module.py \
-      --replace-fail "miniaudio/stb_vorbis.c" "miniaudio/extras/stb_vorbis.c";
-    substituteInPlace miniaudio.c \
-      --replace-fail "miniaudio/stb_vorbis.c" "miniaudio/extras/stb_vorbis.c";
-  '';
+  # TODO: Properly unvendor miniaudio c library
 
   build-system = [ setuptools ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9329,9 +9329,7 @@ self: super: with self; {
 
   minexr = callPackage ../development/python-modules/minexr { };
 
-  miniaudio = callPackage ../development/python-modules/miniaudio {
-    inherit (pkgs) miniaudio;
-  };
+  miniaudio = callPackage ../development/python-modules/miniaudio { };
 
   minichain = callPackage ../development/python-modules/minichain { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
