### PR TITLE
mkosi: update patch to address all calls to ukify

### DIFF
--- a/pkgs/tools/virtualization/mkosi/0001-Use-wrapped-binaries-instead-of-Python-interpreter.patch
+++ b/pkgs/tools/virtualization/mkosi/0001-Use-wrapped-binaries-instead-of-Python-interpreter.patch
@@ -7,15 +7,24 @@ Rather than calling ukify and mkosi with sys.executable, which doesn't use the P
 
 Signed-off-by: Moritz Sanft <58110325+msanft@users.noreply.github.com>
 ---
- mkosi/__init__.py   | 11 +++++------
+ mkosi/__init__.py   | 17 +++++++----------
  mkosi/bootloader.py |  5 +----
  mkosi/run.py        |  8 ++++----
- 3 files changed, 10 insertions(+), 14 deletions(-)
+ 3 files changed, 12 insertions(+), 18 deletions(-)
 
 diff --git a/mkosi/__init__.py b/mkosi/__init__.py
-index 65cac772bf1fc9feabec5740ed89a958ba406125..12b29061c819d50559132aa6c3b6f24a12945bb9 100644
+index 65cac772bf1fc9feabec5740ed89a958ba406125..c0debc09a76f36ae878bd172294eee6637b95bcb 100644
 --- a/mkosi/__init__.py
 +++ b/mkosi/__init__.py
+@@ -570,7 +570,7 @@ def finalize_host_scripts(
+         if context.config.find_binary(binary):
+             scripts[binary] = (binary, "--root", "/buildroot")
+     if ukify := context.config.find_binary("ukify"):
+-        scripts["ukify"] = (python_binary(context.config), ukify)
++        scripts["ukify"] = (ukify,)
+     return finalize_scripts(context.config, scripts | dict(helpers))
+ 
+ 
 @@ -702,7 +702,7 @@ def script_maybe_chroot_sandbox(
  
      helpers = {
@@ -51,7 +60,23 @@ index 65cac772bf1fc9feabec5740ed89a958ba406125..12b29061c819d50559132aa6c3b6f24a
          die("Could not find ukify")
  
      json_out = False
-@@ -1887,7 +1886,7 @@ def want_uki(context: Context) -> bool:
+@@ -1759,7 +1758,6 @@ def build_uki(
+         # TODO: bump version to 258 once it is released
+         if (
+             systemd_tool_version(
+-                python_binary(context.config),
+                 ukify,
+                 sandbox=context.sandbox,
+             )
+@@ -1819,7 +1817,6 @@ def build_uki(
+         # new .ucode section support?
+         if (
+             systemd_tool_version(
+-                python_binary(context.config),
+                 ukify,
+                 sandbox=context.sandbox,
+             )
+@@ -1887,7 +1884,7 @@ def want_uki(context: Context) -> bool:
          or (
              context.config.unified_kernel_images == ConfigFeature.auto
              and systemd_stub_binary(context).exists()
@@ -60,15 +85,18 @@ index 65cac772bf1fc9feabec5740ed89a958ba406125..12b29061c819d50559132aa6c3b6f24a
          )
      )
  
-@@ -2769,7 +2768,7 @@ def check_ukify(
+@@ -2769,9 +2766,9 @@ def check_ukify(
      reason: str,
      hint: Optional[str] = None,
  ) -> None:
 -    ukify = check_tool(config, "ukify", "/usr/lib/systemd/ukify", reason=reason, hint=hint)
 +    ukify = check_tool(config, "ukify", "@UKIFY@", reason=reason, hint=hint)
  
-     v = systemd_tool_version(python_binary(config), ukify, sandbox=config.sandbox)
+-    v = systemd_tool_version(python_binary(config), ukify, sandbox=config.sandbox)
++    v = systemd_tool_version(ukify, sandbox=config.sandbox)
      if v < version:
+         die(
+             f"Found '{ukify}' with version {v} but version {version} or newer is required to {reason}.",
 diff --git a/mkosi/bootloader.py b/mkosi/bootloader.py
 index 6f112b854f72a8863dc5e7348f0154851d3dda96..8fdf2c5df7950c032bfcd36d89f7824e86ec9173 100644
 --- a/mkosi/bootloader.py


### PR DESCRIPTION
Since ukify is wrapped as an ELF binary, it can't be used by a python interpreter and some instances of fixing that were missing.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
