### PR TITLE
calibre: 8.7.0 -> 8.10.0

### DIFF
--- a/pkgs/by-name/ca/calibre/package.nix
+++ b/pkgs/by-name/ca/calibre/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   cmake,
+  espeak-ng,
   fetchpatch,
   ffmpeg,
   fontconfig,
@@ -18,6 +19,7 @@
   libusb1,
   libwebp,
   nix-update-script,
+  onnxruntime,
   optipng,
   piper-tts,
   pkg-config,
@@ -36,11 +38,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "calibre";
-  version = "8.7.0";
+  version = "8.10.0";
 
   src = fetchurl {
     url = "https://download.calibre-ebook.com/${finalAttrs.version}/calibre-${finalAttrs.version}.tar.xz";
-    hash = "sha256-LP5Yfjdz2GB/6LvvvNd7XPuBYSTKyJ5JE1PeuPL6kyQ=";
+    hash = "sha256-ByDUoF9C5FE8ZlQ/zP4H43b9+zUIsgah5/FO5mtXsMU=";
   };
 
   patches = [
@@ -79,6 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    espeak-ng
     ffmpeg
     fontconfig
     hunspell
@@ -91,7 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
     libstemmer
     libuchardet
     libusb1
-    piper-tts
+    onnxruntime
     podofo_0_10
     poppler-utils
     qt6.qtbase
@@ -145,6 +148,7 @@ stdenv.mkDerivation (finalAttrs: {
           ]
       ++ lib.optional unrarSupport unrardll
     ))
+    piper-tts
     xdg-utils
   ]
   ++ lib.optional speechSupport speechd-minimal;


### PR DESCRIPTION
Couple of bugfixes and minor features. The build now has dependencies on `espeak-ng` and `onnxruntime`. I needed to use a recent dev version of `espeak-ng` because `calibre` uses functions, like `espeak_TextToPhonemesWithTerminator`, that are not in nixpkgs' `1.51` version of `espeak-ng` (nor in [the upcoming 1.52](https://github.com/NixOS/nixpkgs/pull/439761), as far as I can tell).

https://calibre-ebook.com/whats-new

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
