### PR TITLE
ida-free: 9.1 -> 9.2

### DIFF
--- a/pkgs/by-name/id/ida-free/package.nix
+++ b/pkgs/by-name/id/ida-free/package.nix
@@ -12,7 +12,6 @@
   libGL,
   libkrb5,
   libsecret,
-  libsForQt5,
   libunwind,
   libxkbcommon,
   makeWrapper,
@@ -21,21 +20,19 @@
   xorg,
   zlib,
 }:
-
 stdenv.mkDerivation (finalAttrs: rec {
   pname = "ida-free";
-  version = "9.1";
+  version = "9.2";
 
   src = requireFile {
     name = "ida-free-pc_${lib.replaceStrings [ "." ] [ "" ] version}_x64linux.run";
-    url = "https://my.hex-rays.com/dashboard/download-center/${version}/ida-free";
-    hash = "sha256-DIkxr9yD6yvziO8XHi0jt80189bXueRxmSFyq2LM0cg=";
+    url = "https://my.hex-rays.com/dashboard/download-center/installers/release/${version}/ida-free";
+    hash = "sha256-CQm9phkqLXhht4UQxooKmhmiGuW3lV8RIJuDrm52aNw=";
   };
 
   nativeBuildInputs = [
     makeWrapper
     autoPatchelfHook
-    libsForQt5.wrapQtAppsHook
   ];
 
   # We just get a runfile in $src, so no need to unpack it.
@@ -53,7 +50,6 @@ stdenv.mkDerivation (finalAttrs: rec {
     libGL
     libkrb5
     libsecret
-    libsForQt5.qtbase
     libunwind
     libxkbcommon
     openssl
@@ -70,11 +66,18 @@ stdenv.mkDerivation (finalAttrs: rec {
     xorg.xcbutilkeysyms
     xorg.xcbutilrenderutil
     xorg.xcbutilwm
+    xorg.xcbutilcursor
     zlib
   ];
   buildInputs = runtimeDependencies;
 
-  dontWrapQtApps = true;
+  # IDA comes with its own Qt6, some dependencies are missing in the installer.
+  autoPatchelfIgnoreMissingDeps = [
+    "libQt6Network.so.6"
+    "libQt6EglFSDeviceIntegration.so.6"
+    "libQt6WaylandEglClientHwIntegration.so.6"
+    "libQt6WlShellIntegration.so.6"
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -101,11 +104,9 @@ stdenv.mkDerivation (finalAttrs: rec {
     # Some libraries come with the installer.
     addAutoPatchelfSearchPath $IDADIR
 
-    for bb in ida assistant; do
-      wrapProgram $IDADIR/$bb \
-        --prefix QT_PLUGIN_PATH : $IDADIR/plugins/platforms
-      ln -s $IDADIR/$bb $out/bin/$bb
-    done
+    # Wrap the ida executable to set QT_PLUGIN_PATH
+    wrapProgram $IDADIR/ida --prefix QT_PLUGIN_PATH : $IDADIR/plugins/platforms
+    ln -s $IDADIR/ida $out/bin/ida
 
     # runtimeDependencies don't get added to non-executables, and openssl is needed
     #  for cloud decompilation


### PR DESCRIPTION
IDA Release notes: https://docs.hex-rays.com/release-notes/9_2

IDA switched from using Qt5 to Qt6, even with `qt6.wrapQtAppsHook` instead, as soon as `qt6.qtbase` was added to the `runtimeDependencies` (among other Qt6 dependencies) IDA wouldn't launch due to the inconsistencies.

Previous (broken) PR: #441821 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
