### PR TITLE
ungoogled-chromium: 140.0.7339.80-1 -> 140.0.7339.127-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -798,7 +798,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "140.0.7339.80",
+    "version": "140.0.7339.127",
     "deps": {
       "depot_tools": {
         "rev": "7d1e2bdb9168718566caba63a170a67cdab2356b",
@@ -810,16 +810,16 @@
         "hash": "sha256-Z7bTto8BHnJzjvmKmcVAZ0/BrXimcAETV6YGKNTorQw="
       },
       "ungoogled-patches": {
-        "rev": "140.0.7339.80-1",
-        "hash": "sha256-jBRBph+rhSK6tmrSpCDN39VbSmvHnTquy1HBUQ6QFFY="
+        "rev": "140.0.7339.127-1",
+        "hash": "sha256-mhMudxJU2arMcmECS9+3ne9X66zyKq5WGc8PSx9RfLc="
       },
       "npmHash": "sha256-R2gOpfPOUAmnsnUTIvzDPHuHNzL/b2fwlyyfTrywEcI="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "670b6f192f4668d2ac2c06bd77ec3e4eeda7d648",
-        "hash": "sha256-tAiE11g/zymsOOjb64ZIA0GCGDV+6X5qlXUiU9vED/c=",
+        "rev": "9412745860d8c3dfed9cf38f5daa943b163f8c69",
+        "hash": "sha256-rAyS5AhWHL9+6N4+2PFYKPJjzErj8LfIm5ptcsTTV8E=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -889,8 +889,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "cbc4153da8d5796b0fbb3cf288e97bee19436191",
-        "hash": "sha256-lexJRf3EZexLgSuk8ziA+OUW+jTYlkXUPKHU/E6aUcY="
+        "rev": "a8c8a6febe630c6239a5e207530e9fac651ae373",
+        "hash": "sha256-GxWTdzSf7/9WIqrECdAEkibXve/ZpKpxJcNS+KnfNc0="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -1049,8 +1049,8 @@
       },
       "src/third_party/devtools-frontend/src": {
         "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
-        "rev": "ab96665ae2cfcc054e0243461cfcb56bb016f71a",
-        "hash": "sha256-8G9OCH5xapLf83bXrKwygCrzwF8C9H2NfnIrDbL+uCc="
+        "rev": "5dbb6f71a9bd613c0403242c7c021652fbf155fd",
+        "hash": "sha256-tA+6iKBfJVrlT+1UH55vqa5JCONweZeD/zWfNHHD+Kw="
       },
       "src/third_party/dom_distiller_js/dist": {
         "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",
@@ -1559,8 +1559,8 @@
       },
       "src/third_party/webrtc": {
         "url": "https://webrtc.googlesource.com/src.git",
-        "rev": "847fe7905954f3ae883de2936415ff567aa9039b",
-        "hash": "sha256-kcK1kJdPCkXbEFuS+b6wKUBaKLXmkAEwVKp4/YWDv8s="
+        "rev": "36ea4535a500ac137dbf1f577ce40dc1aaa774ef",
+        "hash": "sha256-/3V/V0IrhOKcMAgs/C1qraqq+1pfopW8HKvGRmqLE0Q="
       },
       "src/third_party/wuffs/src": {
         "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git",


### PR DESCRIPTION
https://chromereleases.googleblog.com/2025/09/stable-channel-update-for-desktop_9.html

This update includes 2 security fixes.

CVEs:
CVE-2025-10200 CVE-2025-10201

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test