### PR TITLE
RON Types

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -844,6 +844,14 @@ checkConfigError 'A definition for option .* is not of type .RON enum, one of "R
 checkConfigError 'A definition for option .* is not of type .RON enum, one of "Point", "Line".*' config.invalidWithValues ./ronEnum.nix
 checkConfigError 'A definition for option .* is not of type .RON enum, one of "Red", "Green", "Blue".*' config.invalidNotRonEnum ./ronEnum.nix
 
+# types.ronTupleEnumOf
+checkConfigOutput '{"_type":"ron-enum","values":\[10,20\],"variant":"Point"}' config.validPoint ./ronTupleEnumOf.nix
+checkConfigOutput '{"_type":"ron-enum","values":\[0,100\],"variant":"Line"}' config.validLine ./ronTupleEnumOf.nix
+checkConfigError 'A definition for option .* is not of type .RON tuple enum with 2 signed integer values, one of "Point", "Line".*' config.invalidWrongVariant ./ronTupleEnumOf.nix
+checkConfigError 'A definition for option .* is not of type .RON tuple enum with 2 signed integer values, one of "Point", "Line".*' config.invalidWrongSize ./ronTupleEnumOf.nix
+checkConfigError 'A definition for option .* is not of type .signed integer.*' config.invalidWrongType ./ronTupleEnumOf.nix
+checkConfigError 'A definition for option .* is not of type .RON tuple enum with 2 signed integer values, one of "Point", "Line".*' config.invalidNotRonEnum ./ronTupleEnumOf.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -837,6 +837,13 @@ checkConfigError 'A definition for option .* is not of type .RON character.*' co
 checkConfigError 'A definition for option .* is not of type .RON character.*' config.invalidTooLong ./ronChar.nix
 checkConfigError 'A definition for option .* is not of type .RON character.*' config.invalidEmpty ./ronChar.nix
 
+# types.ronEnum
+checkConfigOutput '{"_type":"ron-enum","variant":"Red"}' config.validRed ./ronEnum.nix
+checkConfigOutput '{"_type":"ron-enum","variant":"Green"}' config.validGreen ./ronEnum.nix
+checkConfigError 'A definition for option .* is not of type .RON enum, one of "Red", "Green", "Blue".*' config.invalidVariant ./ronEnum.nix
+checkConfigError 'A definition for option .* is not of type .RON enum, one of "Point", "Line".*' config.invalidWithValues ./ronEnum.nix
+checkConfigError 'A definition for option .* is not of type .RON enum, one of "Red", "Green", "Blue".*' config.invalidNotRonEnum ./ronEnum.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -844,6 +844,13 @@ checkConfigError 'A definition for option .* is not of type .RON enum, one of "R
 checkConfigError 'A definition for option .* is not of type .RON enum, one of "Point", "Line".*' config.invalidWithValues ./ronEnum.nix
 checkConfigError 'A definition for option .* is not of type .RON enum, one of "Red", "Green", "Blue".*' config.invalidNotRonEnum ./ronEnum.nix
 
+# types.ronNamedStructOf
+checkConfigOutput '{"_type":"ron-named-struct","name":"Point","value":{"x":10,"y":20}}' config.validPoint ./ronNamedStructOf.nix
+checkConfigOutput '{"_type":"ron-named-struct","name":"Person","value":{"age":"30","name":"Alice"}}' config.validPerson ./ronNamedStructOf.nix
+checkConfigError 'A definition for option .* is not of type .RON named struct of signed integer.*' config.invalidNotRonNamedStruct ./ronNamedStructOf.nix
+checkConfigError 'A definition for option .* is not of type .signed integer.*' config.invalidWrongType ./ronNamedStructOf.nix
+checkConfigError 'The option .* has conflicting struct names' config.invalidMixedNames ./ronNamedStructOf.nix
+
 # types.ronOptionalOf
 checkConfigOutput '{"_type":"ron-optional","value":null}' config.validNone ./ronOptionalOf.nix
 checkConfigOutput '{"_type":"ron-optional","value":42}' config.validSome ./ronOptionalOf.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -825,6 +825,12 @@ checkConfigError 'Please use.*lib.types.addCheck.*instead' config.adhocFail.foo 
 checkConfigError 'A definition for option .* is not of type .*' config.addCheckFail.bar.baz ./v2-check-coherence.nix
 checkConfigOutput '^true$' config.result ./v2-check-coherence.nix
 
+# types.ronChar
+checkConfigOutput '{"_type":"ron-char","value":"a"}' config.validChar ./ronChar.nix
+checkConfigOutput '{"_type":"ron-char","value":"z"}' config.anotherValidChar ./ronChar.nix
+checkConfigError 'A definition for option .* is not of type .RON character.*' config.invalidNotRonChar ./ronChar.nix
+checkConfigError 'A definition for option .* is not of type .RON character.*' config.invalidTooLong ./ronChar.nix
+checkConfigError 'A definition for option .* is not of type .RON character.*' config.invalidEmpty ./ronChar.nix
 
 cat <<EOF
 ====== module tests ======

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -825,6 +825,11 @@ checkConfigError 'Please use.*lib.types.addCheck.*instead' config.adhocFail.foo 
 checkConfigError 'A definition for option .* is not of type .*' config.addCheckFail.bar.baz ./v2-check-coherence.nix
 checkConfigOutput '^true$' config.result ./v2-check-coherence.nix
 
+# types.rawRon
+checkConfigOutput '{"_type":"ron-raw","value":"raw_value"}' config.validRaw ./rawRon.nix
+checkConfigOutput '{"_type":"ron-raw","value":"MyEnum::Variant\(1\)"}' config.anotherValidRaw ./rawRon.nix
+checkConfigError 'A definition for option .* is not of type .raw RON value.*' config.invalidNotRonRaw ./rawRon.nix
+
 # types.ronChar
 checkConfigOutput '{"_type":"ron-char","value":"a"}' config.validChar ./ronChar.nix
 checkConfigOutput '{"_type":"ron-char","value":"z"}' config.anotherValidChar ./ronChar.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -859,6 +859,13 @@ checkConfigError 'A definition for option .* is not of type .RON tuple enum with
 checkConfigError 'A definition for option .* is not of type .signed integer.*' config.invalidWrongType ./ronTupleEnumOf.nix
 checkConfigError 'A definition for option .* is not of type .RON tuple enum with 2 signed integer values, one of "Point", "Line".*' config.invalidNotRonEnum ./ronTupleEnumOf.nix
 
+# types.ronTupleOf
+checkConfigOutput '{"_type":"ron-tuple","values":\[1,2,3\]}' config.validTuple ./ronTupleOf.nix
+checkConfigOutput '{"_type":"ron-tuple","values":\[10,20\]}' config.anotherValidTuple ./ronTupleOf.nix
+checkConfigError 'A definition for option .* is not of type .RON tuple of 3 signed integer.*' config.invalidNotRonTuple ./ronTupleOf.nix
+checkConfigError 'A definition for option .* is not of type .RON tuple of 3 signed integer.*' config.invalidWrongSize ./ronTupleOf.nix
+checkConfigError 'A definition for option .* is not of type .signed integer.*' config.invalidWrongType ./ronTupleOf.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -844,6 +844,13 @@ checkConfigError 'A definition for option .* is not of type .RON enum, one of "R
 checkConfigError 'A definition for option .* is not of type .RON enum, one of "Point", "Line".*' config.invalidWithValues ./ronEnum.nix
 checkConfigError 'A definition for option .* is not of type .RON enum, one of "Red", "Green", "Blue".*' config.invalidNotRonEnum ./ronEnum.nix
 
+# types.ronOptionalOf
+checkConfigOutput '{"_type":"ron-optional","value":null}' config.validNone ./ronOptionalOf.nix
+checkConfigOutput '{"_type":"ron-optional","value":42}' config.validSome ./ronOptionalOf.nix
+checkConfigError 'A definition for option .* is not of type .RON optional of signed integer.*' config.invalidNotRonOptional ./ronOptionalOf.nix
+checkConfigError 'A definition for option .* is not of type .RON optional of signed integer.*' config.invalidWrongType ./ronOptionalOf.nix
+checkConfigError 'The option .* is defined both None and Some' config.invalidMixed ./ronOptionalOf.nix
+
 # types.ronTupleEnumOf
 checkConfigOutput '{"_type":"ron-enum","values":\[10,20\],"variant":"Point"}' config.validPoint ./ronTupleEnumOf.nix
 checkConfigOutput '{"_type":"ron-enum","values":\[0,100\],"variant":"Line"}' config.validLine ./ronTupleEnumOf.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -844,6 +844,13 @@ checkConfigError 'A definition for option .* is not of type .RON enum, one of "R
 checkConfigError 'A definition for option .* is not of type .RON enum, one of "Point", "Line".*' config.invalidWithValues ./ronEnum.nix
 checkConfigError 'A definition for option .* is not of type .RON enum, one of "Red", "Green", "Blue".*' config.invalidNotRonEnum ./ronEnum.nix
 
+# types.ronMapOf
+checkConfigOutput '{"_type":"ron-map","attrs":\[{"key":"a","value":1},{"key":"b","value":2}\]}' config.validStringIntMap ./ronMapOf.nix
+checkConfigOutput '{"_type":"ron-map","attrs":\[{"key":1,"value":"one"},{"key":2,"value":"two"}\]}' config.validIntStrMap ./ronMapOf.nix
+checkConfigError 'A definition for option .* is not of type .RON map of string to signed integer.*' config.invalidNotRonMap ./ronMapOf.nix
+checkConfigError 'A definition for option .* is not of type .signed integer.*' config.invalidWrongKeyType ./ronMapOf.nix
+checkConfigError 'A definition for option .* is not of type .signed integer.*' config.invalidWrongValueType ./ronMapOf.nix
+
 # types.ronNamedStructOf
 checkConfigOutput '{"_type":"ron-named-struct","name":"Point","value":{"x":10,"y":20}}' config.validPoint ./ronNamedStructOf.nix
 checkConfigOutput '{"_type":"ron-named-struct","name":"Person","value":{"age":"30","name":"Alice"}}' config.validPerson ./ronNamedStructOf.nix

--- a/lib/tests/modules/rawRon.nix
+++ b/lib/tests/modules/rawRon.nix
@@ -1,0 +1,29 @@
+{ lib, ... }:
+let
+  # Mock mkRaw since lib.ron doesn't exist in this branch yet
+  mkRaw = value: {
+    _type = "ron-raw";
+    inherit value;
+  };
+in
+{
+  options = {
+    validRaw = lib.mkOption {
+      type = lib.types.rawRon;
+    };
+
+    anotherValidRaw = lib.mkOption {
+      type = lib.types.rawRon;
+    };
+
+    invalidNotRonRaw = lib.mkOption {
+      type = lib.types.rawRon;
+    };
+  };
+
+  config = {
+    validRaw = mkRaw "raw_value";
+    anotherValidRaw = mkRaw "MyEnum::Variant(1)";
+    invalidNotRonRaw = "plain_string";
+  };
+}

--- a/lib/tests/modules/ronChar.nix
+++ b/lib/tests/modules/ronChar.nix
@@ -1,0 +1,39 @@
+{ lib, ... }:
+let
+  # Mock mkChar since lib.ron doesn't exist in this branch yet
+  mkChar = value: {
+    _type = "ron-char";
+    inherit value;
+  };
+in
+{
+  options = {
+    validChar = lib.mkOption {
+      type = lib.types.ronChar;
+    };
+
+    anotherValidChar = lib.mkOption {
+      type = lib.types.ronChar;
+    };
+
+    invalidNotRonChar = lib.mkOption {
+      type = lib.types.ronChar;
+    };
+
+    invalidTooLong = lib.mkOption {
+      type = lib.types.ronChar;
+    };
+
+    invalidEmpty = lib.mkOption {
+      type = lib.types.ronChar;
+    };
+  };
+
+  config = {
+    validChar = mkChar "a";
+    anotherValidChar = mkChar "z";
+    invalidNotRonChar = "a";
+    invalidTooLong = mkChar "ab";
+    invalidEmpty = mkChar "";
+  };
+}

--- a/lib/tests/modules/ronEnum.nix
+++ b/lib/tests/modules/ronEnum.nix
@@ -1,0 +1,70 @@
+{ lib, ... }:
+let
+  # Mock mkEnum since lib.ron doesn't exist in this branch yet
+  mkEnum =
+    {
+      variant,
+      values ? [ ],
+    }:
+    {
+      _type = "ron-enum";
+      inherit variant;
+    }
+    // lib.optionalAttrs (values != [ ]) { inherit values; };
+in
+{
+  options = {
+    validRed = lib.mkOption {
+      type = lib.types.ronEnum [
+        "Red"
+        "Green"
+        "Blue"
+      ];
+    };
+
+    validGreen = lib.mkOption {
+      type = lib.types.ronEnum [
+        "Red"
+        "Green"
+        "Blue"
+      ];
+    };
+
+    invalidVariant = lib.mkOption {
+      type = lib.types.ronEnum [
+        "Red"
+        "Green"
+        "Blue"
+      ];
+    };
+
+    invalidWithValues = lib.mkOption {
+      type = lib.types.ronEnum [
+        "Point"
+        "Line"
+      ];
+    };
+
+    invalidNotRonEnum = lib.mkOption {
+      type = lib.types.ronEnum [
+        "Red"
+        "Green"
+        "Blue"
+      ];
+    };
+  };
+
+  config = {
+    validRed = mkEnum { variant = "Red"; };
+    validGreen = mkEnum { variant = "Green"; };
+    invalidVariant = mkEnum { variant = "Yellow"; };
+    invalidWithValues = mkEnum {
+      variant = "Point";
+      values = [
+        10
+        20
+      ];
+    };
+    invalidNotRonEnum = "Red";
+  };
+}

--- a/lib/tests/modules/ronMapOf.nix
+++ b/lib/tests/modules/ronMapOf.nix
@@ -1,0 +1,78 @@
+{ lib, ... }:
+let
+  # Mock mkMap since lib.ron doesn't exist in this branch yet
+  mkMap = attrs: {
+    _type = "ron-map";
+    inherit attrs;
+  };
+in
+{
+  options = {
+    validStringIntMap = lib.mkOption {
+      type = lib.types.ronMapOf lib.types.str lib.types.int;
+      # Force evaluation for testing
+      apply = v: builtins.deepSeq v v;
+    };
+
+    validIntStrMap = lib.mkOption {
+      type = lib.types.ronMapOf lib.types.int lib.types.str;
+      # Force evaluation for testing
+      apply = v: builtins.deepSeq v v;
+    };
+
+    invalidNotRonMap = lib.mkOption {
+      type = lib.types.ronMapOf lib.types.str lib.types.int;
+    };
+
+    invalidWrongKeyType = lib.mkOption {
+      type = lib.types.ronMapOf lib.types.int lib.types.str;
+      # Force evaluation for testing
+      apply = v: builtins.deepSeq v v;
+    };
+
+    invalidWrongValueType = lib.mkOption {
+      type = lib.types.ronMapOf lib.types.str lib.types.int;
+      # Force evaluation for testing
+      apply = v: builtins.deepSeq v v;
+    };
+  };
+
+  config = {
+    validStringIntMap = mkMap [
+      {
+        key = "a";
+        value = 1;
+      }
+      {
+        key = "b";
+        value = 2;
+      }
+    ];
+    validIntStrMap = mkMap [
+      {
+        key = 1;
+        value = "one";
+      }
+      {
+        key = 2;
+        value = "two";
+      }
+    ];
+    invalidNotRonMap = {
+      a = 1;
+      b = 2;
+    };
+    invalidWrongKeyType = mkMap [
+      {
+        key = "not an int";
+        value = "value";
+      }
+    ];
+    invalidWrongValueType = mkMap [
+      {
+        key = "key";
+        value = "not an int";
+      }
+    ];
+  };
+}

--- a/lib/tests/modules/ronNamedStructOf.nix
+++ b/lib/tests/modules/ronNamedStructOf.nix
@@ -1,0 +1,81 @@
+{ lib, ... }:
+let
+  # Mock mkNamedStruct since lib.ron doesn't exist in this branch yet
+  mkNamedStruct =
+    { name, value }:
+    {
+      _type = "ron-named-struct";
+      inherit name value;
+    };
+in
+{
+  options = {
+    validPoint = lib.mkOption {
+      type = lib.types.ronNamedStructOf lib.types.int;
+      # Force evaluation for testing
+      apply = v: builtins.deepSeq v v;
+    };
+
+    validPerson = lib.mkOption {
+      type = lib.types.ronNamedStructOf lib.types.str;
+      # Force evaluation for testing
+      apply = v: builtins.deepSeq v v;
+    };
+
+    invalidNotRonNamedStruct = lib.mkOption {
+      type = lib.types.ronNamedStructOf lib.types.int;
+    };
+
+    invalidWrongType = lib.mkOption {
+      type = lib.types.ronNamedStructOf lib.types.int;
+      # Force evaluation for testing
+      apply = v: builtins.deepSeq v v;
+    };
+
+    invalidMixedNames = lib.mkOption {
+      type = lib.types.ronNamedStructOf lib.types.int;
+    };
+  };
+
+  config = {
+    validPoint = mkNamedStruct {
+      name = "Point";
+      value = {
+        x = 10;
+        y = 20;
+      };
+    };
+    validPerson = mkNamedStruct {
+      name = "Person";
+      value = {
+        name = "Alice";
+        age = "30";
+      };
+    };
+    invalidNotRonNamedStruct = {
+      x = 10;
+      y = 20;
+    };
+    invalidWrongType = mkNamedStruct {
+      name = "Point";
+      value = {
+        x = "not an int";
+        y = 20;
+      };
+    };
+    invalidMixedNames = lib.mkMerge [
+      (mkNamedStruct {
+        name = "Point";
+        value = {
+          x = 10;
+        };
+      })
+      (mkNamedStruct {
+        name = "Line";
+        value = {
+          x = 20;
+        };
+      })
+    ];
+  };
+}

--- a/lib/tests/modules/ronOptionalOf.nix
+++ b/lib/tests/modules/ronOptionalOf.nix
@@ -1,0 +1,44 @@
+{ lib, ... }:
+let
+  # Mock mkOptional since lib.ron doesn't exist in this branch yet
+  mkOptional = value: {
+    _type = "ron-optional";
+    inherit value;
+  };
+in
+{
+  options = {
+    validNone = lib.mkOption {
+      type = lib.types.ronOptionalOf lib.types.int;
+    };
+
+    validSome = lib.mkOption {
+      type = lib.types.ronOptionalOf lib.types.int;
+      # Force evaluation for testing
+      apply = v: builtins.deepSeq v v;
+    };
+
+    invalidNotRonOptional = lib.mkOption {
+      type = lib.types.ronOptionalOf lib.types.int;
+    };
+
+    invalidWrongType = lib.mkOption {
+      type = lib.types.ronOptionalOf lib.types.int;
+    };
+
+    invalidMixed = lib.mkOption {
+      type = lib.types.ronOptionalOf lib.types.int;
+    };
+  };
+
+  config = {
+    validNone = mkOptional null;
+    validSome = mkOptional 42;
+    invalidNotRonOptional = 42;
+    invalidWrongType = mkOptional "not an int";
+    invalidMixed = lib.mkMerge [
+      (mkOptional null)
+      (mkOptional 10)
+    ];
+  };
+}

--- a/lib/tests/modules/ronTupleEnumOf.nix
+++ b/lib/tests/modules/ronTupleEnumOf.nix
@@ -1,0 +1,86 @@
+{ lib, ... }:
+let
+  # Mock mkEnum since lib.ron doesn't exist in this branch yet
+  mkEnum =
+    {
+      variant,
+      values ? [ ],
+    }:
+    {
+      _type = "ron-enum";
+      inherit variant;
+    }
+    // lib.optionalAttrs (values != [ ]) { inherit values; };
+in
+{
+  options = {
+    validPoint = lib.mkOption {
+      type = lib.types.ronTupleEnumOf lib.types.int [ "Point" "Line" ] 2;
+      # Force evaluation for testing
+      apply = v: builtins.deepSeq v v;
+    };
+
+    validLine = lib.mkOption {
+      type = lib.types.ronTupleEnumOf lib.types.int [ "Point" "Line" ] 2;
+      # Force evaluation for testing
+      apply = v: builtins.deepSeq v v;
+    };
+
+    invalidWrongVariant = lib.mkOption {
+      type = lib.types.ronTupleEnumOf lib.types.int [ "Point" "Line" ] 2;
+    };
+
+    invalidWrongSize = lib.mkOption {
+      type = lib.types.ronTupleEnumOf lib.types.int [ "Point" "Line" ] 2;
+    };
+
+    invalidWrongType = lib.mkOption {
+      type = lib.types.ronTupleEnumOf lib.types.int [ "Point" "Line" ] 2;
+      # Force evaluation for testing
+      apply = v: builtins.deepSeq v v;
+    };
+
+    invalidNotRonEnum = lib.mkOption {
+      type = lib.types.ronTupleEnumOf lib.types.int [ "Point" "Line" ] 2;
+    };
+  };
+
+  config = {
+    validPoint = mkEnum {
+      variant = "Point";
+      values = [
+        10
+        20
+      ];
+    };
+    validLine = mkEnum {
+      variant = "Line";
+      values = [
+        0
+        100
+      ];
+    };
+    invalidWrongVariant = mkEnum {
+      variant = "Circle";
+      values = [
+        5
+        5
+      ];
+    };
+    invalidWrongSize = mkEnum {
+      variant = "Point";
+      values = [ 10 ];
+    };
+    invalidWrongType = mkEnum {
+      variant = "Point";
+      values = [
+        "a"
+        "b"
+      ];
+    };
+    invalidNotRonEnum = [
+      10
+      20
+    ];
+  };
+}

--- a/lib/tests/modules/ronTupleOf.nix
+++ b/lib/tests/modules/ronTupleOf.nix
@@ -1,0 +1,62 @@
+{ lib, ... }:
+let
+  # Mock mkTuple since lib.ron doesn't exist in this branch yet
+  mkTuple = values: {
+    _type = "ron-tuple";
+    inherit values;
+  };
+in
+{
+  options = {
+    validTuple = lib.mkOption {
+      type = lib.types.ronTupleOf lib.types.int 3;
+      # Force evaluation for testing
+      apply = v: builtins.deepSeq v v;
+    };
+
+    anotherValidTuple = lib.mkOption {
+      type = lib.types.ronTupleOf lib.types.int 2;
+      # Force evaluation for testing
+      apply = v: builtins.deepSeq v v;
+    };
+
+    invalidNotRonTuple = lib.mkOption {
+      type = lib.types.ronTupleOf lib.types.int 3;
+    };
+
+    invalidWrongSize = lib.mkOption {
+      type = lib.types.ronTupleOf lib.types.int 3;
+    };
+
+    invalidWrongType = lib.mkOption {
+      type = lib.types.ronTupleOf lib.types.int 2;
+      # Force evaluation for testing
+      apply = v: builtins.deepSeq v v;
+    };
+  };
+
+  config = {
+    validTuple = mkTuple [
+      1
+      2
+      3
+    ];
+    anotherValidTuple = mkTuple [
+      10
+      20
+    ];
+    invalidNotRonTuple = [
+      1
+      2
+      3
+    ];
+    invalidWrongSize = mkTuple [
+      1
+      2
+    ];
+    invalidWrongType = mkTuple [
+      "a"
+      "b"
+    ];
+  };
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1036,6 +1036,31 @@ let
         merge = mergeEqualOption;
       };
 
+      ronEnum =
+        variants:
+        let
+          inherit (lib.lists) unique;
+          show = v: ''"${v}"'';
+        in
+        mkOptionType rec {
+          name = "ronEnum";
+          description =
+            if variants == [ ] then
+              "impossible (empty RON enum)"
+            else if builtins.length variants == 1 then
+              "RON enum variant ${show (builtins.head variants)} (singular enum)"
+            else
+              "RON enum, one of ${concatMapStringsSep ", " show variants}";
+          descriptionClass = if builtins.length variants < 2 then "noun" else "conjunction";
+          check = x: isType "ron-enum" x && isString x.variant && !(x ? values) && elem x.variant variants;
+          merge = mergeEqualOption;
+          functor = defaultFunctor name // {
+            payload = { inherit variants; };
+            type = payload: types.ronEnum payload.variants;
+            binOp = a: b: { variants = unique (a.variants ++ b.variants); };
+          };
+        };
+
       uniq = unique { message = ""; };
 
       unique =

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1020,6 +1020,14 @@ let
         merge = mergeEqualOption;
       };
 
+      rawRon = mkOptionType {
+        name = "rawRon";
+        description = "raw RON value";
+        descriptionClass = "noun";
+        check = x: isType "ron-raw" x && isString x.value;
+        merge = mergeEqualOption;
+      };
+
       ronChar = mkOptionType {
         name = "ronChar";
         description = "RON character";

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1020,6 +1020,14 @@ let
         merge = mergeEqualOption;
       };
 
+      ronChar = mkOptionType {
+        name = "ronChar";
+        description = "RON character";
+        descriptionClass = "noun";
+        check = x: isType "ron-char" x && isString x.value && builtins.stringLength x.value == 1;
+        merge = mergeEqualOption;
+      };
+
       uniq = unique { message = ""; };
 
       unique =

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -261,6 +261,14 @@ merging is handled.
     to create values of this type. Similar to `types.enum` but for RON enum values.
     Multiple definitions cannot be merged.
 
+`types.ronTupleEnumOf` *`elemType`* *`variants`* *`size`*
+
+:   A RON (Rusty Object Notation) tuple enum where all tuple values are of *`elemType`* type.
+    This type accepts attribute sets with `_type = "ron-enum"`, a `variant` field containing
+    one of the allowed variant names from *`variants`*, and a `values` field containing exactly
+    *`size`* elements. Multiple definitions cannot be merged. Use `lib.ron.mkEnum` to create
+    values of this type, e.g. `types.ronTupleEnumOf int [ "Point" "Line" ] 2`.
+
 ## Submodule types {#sec-option-types-submodule}
 
 Submodules are detailed in [Submodule](#section-option-types-submodule).

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -261,6 +261,14 @@ merging is handled.
     to create values of this type. Similar to `types.enum` but for RON enum values.
     Multiple definitions cannot be merged.
 
+`types.ronOptionalOf` *`elemType`*
+
+:   RON optional of *`elemType`* type. This type accepts attribute sets with `_type = "ron-optional"`
+    and a `value` field that is either `null` (representing `None`) or a value of type *`elemType`*
+    (representing `Some`). If all definitions are `None`, the merged value is `None`. If any
+    definitions are `Some`, they must all be `Some` and their values are merged through *`elemType`*.
+    Use `lib.ron.mkOptional` to create values of this type, e.g. `types.ronOptionalOf int`.
+
 `types.ronTupleEnumOf` *`elemType`* *`variants`* *`size`*
 
 :   A RON (Rusty Object Notation) tuple enum where all tuple values are of *`elemType`* type.

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -253,6 +253,14 @@ merging is handled.
     with `_type = "ron-char"` and a `value` field containing a single character string.
     Use `lib.ron.mkChar` to create values of this type. Multiple definitions cannot be merged.
 
+`types.ronEnum` *`variants`*
+
+:   A RON (Rusty Object Notation) enum value restricted to simple variants (without associated data).
+    This type accepts attribute sets with `_type = "ron-enum"`, a `variant` field containing one
+    of the allowed variant names from *`variants`*, and no `values` field. Use `lib.ron.mkEnum`
+    to create values of this type. Similar to `types.enum` but for RON enum values.
+    Multiple definitions cannot be merged.
+
 ## Submodule types {#sec-option-types-submodule}
 
 Submodules are detailed in [Submodule](#section-option-types-submodule).

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -239,6 +239,14 @@ merging is handled.
 :   A string wrapped using `lib.mkLuaInline`. Allows embedding lua expressions
     inline within generated lua. Multiple definitions cannot be merged.
 
+`types.rawRon`
+
+:   A RON (Rusty Object Notation) raw value. This type accepts attribute sets
+    with `_type = "ron-raw"` and a `value` field containing a string that will be
+    injected directly as raw RON syntax. Use `lib.ron.mkRaw` to create values of
+    this type. Useful for injecting complex RON expressions or features not natively
+    supported by the RON builder. Multiple definitions cannot be merged.
+
 `types.ronChar`
 
 :   A RON (Rusty Object Notation) character value. This type accepts attribute sets

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -261,6 +261,14 @@ merging is handled.
     to create values of this type. Similar to `types.enum` but for RON enum values.
     Multiple definitions cannot be merged.
 
+`types.ronNamedStructOf` *`elemType`*
+
+:   A RON named struct where all fields are of *`elemType`* type. This type accepts attribute sets with
+    `_type = "ron-named-struct"`, a `name` field containing the struct type name, and a `value`
+    field containing an attribute set. Multiple definitions with the same name are merged by joining
+    their field attribute sets. Use `lib.ron.mkNamedStruct` to create values of this type, e.g.
+    `types.ronNamedStructOf int`.
+
 `types.ronOptionalOf` *`elemType`*
 
 :   RON optional of *`elemType`* type. This type accepts attribute sets with `_type = "ron-optional"`

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -261,6 +261,13 @@ merging is handled.
     to create values of this type. Similar to `types.enum` but for RON enum values.
     Multiple definitions cannot be merged.
 
+`types.ronMapOf` *`keyType`* *`valueType`*
+
+:   A RON map of *`keyType`* to *`valueType`*. This type accepts attribute sets with `_type = "ron-map"`
+    and an `attrs` field containing a list of key-value pairs, where each pair is an attribute set with
+    `key` and `value` fields. Multiple definitions are concatenated. Use `lib.ron.mkMap` to create values
+    of this type, e.g. `types.ronMapOf str int`.
+
 `types.ronNamedStructOf` *`elemType`*
 
 :   A RON named struct where all fields are of *`elemType`* type. This type accepts attribute sets with

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -277,6 +277,13 @@ merging is handled.
     *`size`* elements. Multiple definitions cannot be merged. Use `lib.ron.mkEnum` to create
     values of this type, e.g. `types.ronTupleEnumOf int [ "Point" "Line" ] 2`.
 
+`types.ronTupleOf` *`elemType`* *`size`*
+
+:   A RON tuple where all *`size`* values are of *`elemType`* type. This type accepts attribute sets
+    with `_type = "ron-tuple"` and a `values` field containing exactly *`size`* elements. Multiple
+    definitions cannot be merged. Use `lib.ron.mkTuple` to create values of this type, e.g.
+    `types.ronTupleOf int 3`.
+
 ## Submodule types {#sec-option-types-submodule}
 
 Submodules are detailed in [Submodule](#section-option-types-submodule).

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -239,6 +239,12 @@ merging is handled.
 :   A string wrapped using `lib.mkLuaInline`. Allows embedding lua expressions
     inline within generated lua. Multiple definitions cannot be merged.
 
+`types.ronChar`
+
+:   A RON (Rusty Object Notation) character value. This type accepts attribute sets
+    with `_type = "ron-char"` and a `value` field containing a single character string.
+    Use `lib.ron.mkChar` to create values of this type. Multiple definitions cannot be merged.
+
 ## Submodule types {#sec-option-types-submodule}
 
 Submodules are detailed in [Submodule](#section-option-types-submodule).

--- a/pkgs/build-support/writers/data.nix
+++ b/pkgs/build-support/writers/data.nix
@@ -1,7 +1,6 @@
 {
   lib,
   pkgs,
-  formats,
   runCommand,
 }:
 let
@@ -74,6 +73,17 @@ in
     ```
   */
   writeJSON = (pkgs.formats.json { }).generate;
+
+  /**
+    Writes the content to a RON file.
+
+    # Example
+
+    ```nix
+    writeRON "data.ron" { hello = "world"; }
+    ```
+  */
+  writeRON = (pkgs.formats.ron { }).generate;
 
   /**
     Writes the content to a TOML file.

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -1084,4 +1084,64 @@ optionalAttrs allowAliases aliases
 
       generate = name: value: pkgs.writeText name (lib.generators.toPlist { inherit escape; } value);
     };
+
+  ron =
+    { }:
+    {
+      type =
+        let
+          inherit (lib.types)
+            rawRon
+            ronChar
+            ronEnum
+            ronMapOf
+            ronNamedStructOf
+            ronOptionalOf
+            ronTupleEnumOf
+            ronTupleOf
+            ;
+
+          valueType = oneOf [
+            bool
+            int
+            float
+            str
+            path
+            rawRon
+            ronChar
+            (attrsOf valueType)
+            (listOf valueType)
+            (ronOptionalOf valueType)
+            (ronMapOf valueType valueType)
+            (ronNamedStructOf valueType)
+            # Override check to accept any tuple
+            (
+              (ronTupleOf valueType 0)
+              // {
+                check = x: lib.types.isType "ron-tuple" x && isList x.values;
+              }
+            )
+            # Override check to accept any enum variant
+            (
+              (ronEnum [ ])
+              // {
+                check = x: lib.types.isType "ron-enum" x && isString x.variant && !(x ? values);
+              }
+            )
+            # Override check to accept any tuple enum
+            (
+              (ronTupleEnumOf valueType [ ] 0)
+              // {
+                check = x: lib.types.isType "ron-enum" x && isString x.variant && x ? values && isList x.values;
+              }
+            )
+          ]
+          // {
+            description = "RON value";
+          };
+        in
+        valueType;
+
+      generate = name: value: pkgs.writeText name (lib.ron.toRON { } value);
+    };
 }

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -1080,4 +1080,96 @@ runBuildTests {
       </dict>
       </plist>'';
   };
+
+  ronAtoms = shouldPass (
+    let
+      format = formats.ron { };
+    in
+    {
+      inherit format;
+      input = {
+        false = false;
+        true = true;
+        int = 10;
+        float = 3.141;
+        str = "foo";
+        attrs.foo = lib.ron.mkOptional null;
+        list = [
+          1
+          2
+          3
+        ];
+        char = lib.ron.mkChar "a";
+        optional_some = lib.ron.mkOptional 42;
+        optional_none = lib.ron.mkOptional null;
+        enum_simple = lib.ron.mkEnum { variant = "Red"; };
+        enum_tuple = lib.ron.mkEnum {
+          variant = "Point";
+          values = [
+            10
+            20
+          ];
+        };
+        tuple = lib.ron.mkTuple [
+          1
+          "hello"
+          true
+        ];
+        named_struct = lib.ron.mkNamedStruct {
+          name = "Point";
+          value = {
+            x = 10;
+            y = 20;
+          };
+        };
+        map = lib.ron.mkMap [
+          {
+            key = "a";
+            value = 1;
+          }
+          {
+            key = "b";
+            value = 2;
+          }
+        ];
+        raw = lib.ron.mkRaw "CustomValue";
+      };
+      expected = ''
+        (
+            attrs: (
+                foo: None,
+            ),
+            char: 'a',
+            enum_simple: Red,
+            enum_tuple: Point(10, 20),
+            false: false,
+            float: 3.141,
+            int: 10,
+            list: [
+                1,
+                2,
+                3,
+            ],
+            map: {
+                "a": 1,
+                "b": 2,
+            },
+            named_struct: Point(
+                x: 10,
+                y: 20,
+            ),
+            optional_none: None,
+            optional_some: Some(42),
+            raw: CustomValue,
+            str: "foo",
+            true: true,
+            tuple: (
+                1,
+                "hello",
+                true,
+            ),
+        )
+      '';
+    }
+  );
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Follow-up to #440544, adds RON types and RON format

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
