### PR TITLE
various: Stop using shortenPerlShebang

### DIFF
--- a/pkgs/by-name/bi/biber-ms/package.nix
+++ b/pkgs/by-name/bi/biber-ms/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   perlPackages,
-  shortenPerlShebang,
   texlive,
 }:
 
@@ -78,7 +77,6 @@ perlPackages.buildPerlModule {
     XMLWriter
     autovivification
   ];
-  nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
 
   preConfigure = ''
     cp '${multiscriptBltxml}' t/tdata/multiscript.bltxml
@@ -86,9 +84,6 @@ perlPackages.buildPerlModule {
 
   postInstall = ''
     mv "$out"/bin/biber{,-ms}
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    shortenPerlShebang "$out"/bin/biber-ms
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/bi/biber/package.nix
+++ b/pkgs/by-name/bi/biber/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   perlPackages,
-  shortenPerlShebang,
   texlive,
 }:
 
@@ -59,11 +58,6 @@ perlPackages.buildPerlModule {
     TestDifferences
     PerlIOutf8_strict
   ];
-  nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
-
-  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    shortenPerlShebang $out/bin/biber
-  '';
 
   meta = with lib; {
     description = "Backend for BibLaTeX";

--- a/pkgs/by-name/co/convos/package.nix
+++ b/pkgs/by-name/co/convos/package.nix
@@ -5,7 +5,6 @@
   perl,
   perlPackages,
   makeWrapper,
-  shortenPerlShebang,
   openssl,
   nixosTests,
 }:
@@ -21,10 +20,7 @@ perlPackages.buildPerlPackage rec {
     sha256 = "sha256-dBvXo8y4OMKcb0imgnnzoklnPN3YePHDvy5rIBOkTfs=";
   };
 
-  nativeBuildInputs = [
-    makeWrapper
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [ shortenPerlShebang ];
+  nativeBuildInputs = [ makeWrapper ];
 
   buildInputs = with perlPackages; [
     CryptPassphrase
@@ -107,9 +103,6 @@ perlPackages.buildPerlPackage rec {
     ln -s $AUTO_SHARE_PATH/public/assets $out/assets
     cp -vR templates $out/templates
     cp Makefile.PL $out/Makefile.PL
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    shortenPerlShebang $out/bin/convos
   ''
   + ''
     wrapProgram $out/bin/convos --set MOJO_HOME $out

--- a/pkgs/by-name/fe/feedgnuplot/package.nix
+++ b/pkgs/by-name/fe/feedgnuplot/package.nix
@@ -8,7 +8,6 @@
   perl,
   perlPackages,
   stdenv,
-  shortenPerlShebang,
   installShellFiles,
 }:
 
@@ -34,8 +33,7 @@ perlPackages.buildPerlPackage rec {
   nativeBuildInputs = [
     makeWrapper
     installShellFiles
-  ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
+  ];
 
   buildInputs = [
     gnuplot
@@ -57,18 +55,14 @@ perlPackages.buildPerlPackage rec {
   # Tests require gnuplot 4.6.4 and are completely skipped with gnuplot 5.
   doCheck = false;
 
-  postInstall =
-    lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang $out/bin/feedgnuplot
-    ''
-    + ''
-      wrapProgram $out/bin/feedgnuplot \
-          --prefix "PATH" ":" "$PATH" \
-          --prefix "PERL5LIB" ":" "$PERL5LIB"
+  postInstall = ''
+    wrapProgram $out/bin/feedgnuplot \
+        --prefix "PATH" ":" "$PATH" \
+        --prefix "PERL5LIB" ":" "$PERL5LIB"
 
-      installShellCompletion --bash --name feedgnuplot.bash completions/bash/feedgnuplot
-      installShellCompletion --zsh completions/zsh/_feedgnuplot
-    '';
+    installShellCompletion --bash --name feedgnuplot.bash completions/bash/feedgnuplot
+    installShellCompletion --zsh completions/zsh/_feedgnuplot
+  '';
 
   meta = with lib; {
     description = "General purpose pipe-oriented plotting tool";

--- a/pkgs/by-name/ge/get_iplayer/package.nix
+++ b/pkgs/by-name/ge/get_iplayer/package.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   makeWrapper,
   stdenv,
-  shortenPerlShebang,
   perl,
   atomicparsley,
   ffmpeg,
@@ -23,7 +22,7 @@ perlPackages.buildPerlPackage rec {
     hash = "sha256-O/mVtbudrYw0jKeSckZlgonFDiWxfeiVc8gdcy4iNBw=";
   };
 
-  nativeBuildInputs = [ makeWrapper ] ++ lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
+  nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ perl ];
   propagatedBuildInputs = with perlPackages; [
     LWP
@@ -52,10 +51,6 @@ perlPackages.buildPerlPackage rec {
     install -Dm444 get_iplayer.1 -t $out/share/man/man1
 
     runHook postInstall
-  '';
-
-  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    shortenPerlShebang $out/bin/.get_iplayer-wrapped
   '';
 
   passthru.tests.version = testers.testVersion {

--- a/pkgs/by-name/oc/ocsinventory-agent/package.nix
+++ b/pkgs/by-name/oc/ocsinventory-agent/package.nix
@@ -5,7 +5,6 @@
   fetchFromGitHub,
   fetchpatch,
   makeWrapper,
-  shortenPerlShebang,
   coreutils,
   dmidecode,
   findutils,
@@ -43,7 +42,7 @@ perlPackages.buildPerlPackage rec {
     })
   ];
 
-  nativeBuildInputs = [ makeWrapper ] ++ lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
+  nativeBuildInputs = [ makeWrapper ];
 
   buildInputs =
     with perlPackages;
@@ -94,10 +93,7 @@ perlPackages.buildPerlPackage rec {
         util-linux # last, lsblk, mount
       ];
     in
-    lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang $out/bin/ocsinventory-agent
     ''
-    + ''
       wrapProgram $out/bin/ocsinventory-agent --prefix PATH : ${lib.makeBinPath runtimeDependencies}
     '';
 

--- a/pkgs/by-name/pg/pgformatter/package.nix
+++ b/pkgs/by-name/pg/pgformatter/package.nix
@@ -1,9 +1,7 @@
 {
   lib,
-  stdenv,
   perlPackages,
   fetchFromGitHub,
-  shortenPerlShebang,
 }:
 
 perlPackages.buildPerlPackage rec {
@@ -31,11 +29,6 @@ perlPackages.buildPerlPackage rec {
     substituteInPlace Makefile.PL \
       --replace "'DESTDIR'      => \$DESTDIR," "'DESTDIR'      => '$out/'," \
       --replace "'INSTALLDIRS'  => \$INSTALLDIRS," "'INSTALLDIRS'  => \$INSTALLDIRS, 'INSTALLVENDORLIB' => 'bin/lib', 'INSTALLVENDORBIN' => 'bin', 'INSTALLVENDORSCRIPT' => 'bin', 'INSTALLVENDORMAN1DIR' => 'share/man/man1', 'INSTALLVENDORMAN3DIR' => 'share/man/man3',"
-  '';
-
-  nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
-  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    shortenPerlShebang $out/bin/pg_format
   '';
 
   doCheck = false;

--- a/pkgs/by-name/pg/pgtop/package.nix
+++ b/pkgs/by-name/pg/pgtop/package.nix
@@ -1,9 +1,7 @@
 {
   lib,
-  stdenv,
   perlPackages,
   fetchFromGitHub,
-  shortenPerlShebang,
 }:
 
 perlPackages.buildPerlPackage rec {
@@ -26,11 +24,6 @@ perlPackages.buildPerlPackage rec {
     JSON
     LWP
   ];
-
-  nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
-  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    shortenPerlShebang $out/bin/pgtop
-  '';
 
   meta = {
     description = "PostgreSQL clone of `mytop', which in turn is a `top' clone for MySQL";

--- a/pkgs/by-name/sh/shelldap/package.nix
+++ b/pkgs/by-name/sh/shelldap/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   perlPackages,
-  shortenPerlShebang,
 }:
 
 perlPackages.buildPerlPackage rec {
@@ -29,8 +28,6 @@ perlPackages.buildPerlPackage rec {
     YAMLSyck
   ];
 
-  nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
-
   prePatch = ''
     touch Makefile.PL
   '';
@@ -39,10 +36,6 @@ perlPackages.buildPerlPackage rec {
     runHook preInstall
     install -Dm555 -t $out/bin shelldap
     runHook postInstall
-  '';
-
-  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    shortenPerlShebang $out/bin/shelldap
   '';
 
   # no make target 'test', not tests provided by source

--- a/pkgs/by-name/wa/wakeonlan/package.nix
+++ b/pkgs/by-name/wa/wakeonlan/package.nix
@@ -1,10 +1,8 @@
 {
   lib,
-  stdenv,
   perlPackages,
   fetchFromGitHub,
   installShellFiles,
-  shortenPerlShebang,
 }:
 
 perlPackages.buildPerlPackage rec {
@@ -22,8 +20,7 @@ perlPackages.buildPerlPackage rec {
 
   nativeBuildInputs = [
     installShellFiles
-  ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
+  ];
 
   nativeCheckInputs = [
     perlPackages.TestPerlCritic
@@ -38,9 +35,6 @@ perlPackages.buildPerlPackage rec {
   installPhase = ''
     install -Dt $out/bin wakeonlan
     installManPage blib/man1/wakeonlan.1
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    shortenPerlShebang $out/bin/wakeonlan
   '';
 
   meta = with lib; {

--- a/pkgs/development/perl-modules/ImageExifTool/default.nix
+++ b/pkgs/development/perl-modules/ImageExifTool/default.nix
@@ -4,8 +4,6 @@
   fetchurl,
   gitUpdater,
   lib,
-  shortenPerlShebang,
-  stdenv,
   testers,
 }:
 
@@ -18,14 +16,8 @@ buildPerlPackage rec {
     hash = "sha256-HNVVFEhGooKYeDvr86tFIjUnPHg1hBCBPj1Ok8ZTsfo=";
   };
 
-  nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
-
   postPatch = ''
     patchShebangs exiftool
-  '';
-
-  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    shortenPerlShebang $out/bin/exiftool
   '';
 
   passthru = {

--- a/pkgs/development/perl-modules/Percona-Toolkit/default.nix
+++ b/pkgs/development/perl-modules/Percona-Toolkit/default.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   buildPerlPackage,
-  shortenPerlShebang,
   DBDmysql,
   DBI,
   IOSocketSSL,
@@ -42,7 +41,6 @@ buildPerlPackage {
 
   nativeBuildInputs = [
     git
-    shortenPerlShebang
   ];
 
   buildInputs = [
@@ -62,10 +60,6 @@ buildPerlPackage {
 
   preBuild = ''
     export HOME=$TMPDIR
-  '';
-
-  postInstall = ''
-    shortenPerlShebang $(grep -l "/bin/env perl" $out/bin/*)
   '';
 
   meta = {

--- a/pkgs/development/perl-modules/WWW-YoutubeViewer/default.nix
+++ b/pkgs/development/perl-modules/WWW-YoutubeViewer/default.nix
@@ -3,7 +3,6 @@
   lib,
   fetchFromGitHub,
   buildPerlPackage,
-  shortenPerlShebang,
   LWP,
   LWPProtocolHttps,
   DataDump,
@@ -22,16 +21,12 @@ buildPerlPackage rec {
     sha256 = "9Z4fv2B0AnwtYsp7h9phnRMmHtBOMObIJvK8DmKQRxs=";
   };
 
-  nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
   propagatedBuildInputs = [
     LWP
     LWPProtocolHttps
     DataDump
     JSON
   ];
-  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    shortenPerlShebang $out/bin/youtube-viewer
-  '';
 
   passthru.updateScript = gitUpdater { };
 

--- a/pkgs/development/perl-modules/strip-nondeterminism/default.nix
+++ b/pkgs/development/perl-modules/strip-nondeterminism/default.nix
@@ -7,7 +7,6 @@
   ArchiveZip,
   ArchiveCpio,
   SubOverride,
-  shortenPerlShebang,
   gitUpdater,
 }:
 
@@ -29,7 +28,6 @@ buildPerlPackage rec {
   };
 
   strictDeps = true;
-  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ shortenPerlShebang ];
   buildInputs = [
     ArchiveZip
     ArchiveCpio
@@ -49,9 +47,6 @@ buildPerlPackage rec {
     # we don’t need the debhelper script
     rm $out/bin/dh_strip_nondeterminism
     rm $out/share/man/man1/dh_strip_nondeterminism.1
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    shortenPerlShebang $out/bin/strip-nondeterminism
   '';
 
   installCheckPhase = ''
@@ -60,8 +55,6 @@ buildPerlPackage rec {
     runHook postInstallCheck
   '';
 
-  # running shortenPerlShebang in postBuild results in non-functioning binary 'exec format error'
-  doCheck = !stdenv.hostPlatform.isDarwin;
   doInstallCheck = true;
 
   passthru = {

--- a/pkgs/development/tools/misc/sqitch/default.nix
+++ b/pkgs/development/tools/misc/sqitch/default.nix
@@ -3,7 +3,6 @@
   lib,
   perlPackages,
   makeWrapper,
-  shortenPerlShebang,
   mysqlSupport ? false,
   postgresqlSupport ? false,
   sqliteSupport ? false,
@@ -25,7 +24,7 @@ stdenv.mkDerivation {
   pname = "sqitch";
   version = sqitch.version;
 
-  nativeBuildInputs = [ makeWrapper ] ++ lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
+  nativeBuildInputs = [ makeWrapper ];
 
   src = sqitch;
   dontBuild = true;
@@ -39,9 +38,6 @@ stdenv.mkDerivation {
         ln -s ${sqitch}/$d $out/$d
       fi
     done
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    shortenPerlShebang $out/bin/sqitch
   '';
   dontStrip = true;
   postFixup = ''

--- a/pkgs/tools/misc/pgbadger/default.nix
+++ b/pkgs/tools/misc/pgbadger/default.nix
@@ -7,8 +7,6 @@
   nix-update-script,
   pgbadger,
   PodMarkdown,
-  shortenPerlShebang,
-  stdenv,
   testers,
   TextCSV_XS,
   which,
@@ -29,13 +27,6 @@ buildPerlPackage rec {
     patchShebangs ./pgbadger
   '';
 
-  # pgbadger has too many `-Idir` flags on its shebang line on Darwin,
-  # causing the build to fail when trying to generate the documentation.
-  # Rewrite the -I flags in `use lib` form.
-  preBuild = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    shortenPerlShebang ./pgbadger
-  '';
-
   outputs = [ "out" ];
 
   PERL_MM_OPT = "INSTALL_BASE=${placeholder "out"}";
@@ -45,8 +36,6 @@ buildPerlPackage rec {
     PodMarkdown
     TextCSV_XS
   ];
-
-  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ shortenPerlShebang ];
 
   nativeCheckInputs = [
     bzip2

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -43,7 +43,6 @@
   woff2,
   xxHash,
   makeWrapper,
-  shortenPerlShebang,
   useFixedHashes,
   asymptote,
   biber-ms,

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20,7 +20,6 @@
   fetchFromGitHub,
   fetchFromGitLab,
   perl,
-  shortenPerlShebang,
   nixosTests,
 }:
 
@@ -126,11 +125,7 @@ with self;
       "man"
     ];
 
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
     propagatedBuildInputs = [ FileNext ];
-    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang $out/bin/ack
-    '';
 
     # tests fails on nixos and hydra because of different purity issues
     doCheck = false;
@@ -1192,10 +1187,6 @@ with self;
         --replace-fail http://cpanmetadb.plackperl.org https://cpanmetadb.plackperl.org
     '';
     propagatedBuildInputs = [ IOSocketSSL ];
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
-    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang $out/bin/cpanm
-    '';
     meta = {
       description = "Get, unpack, build and install modules from CPAN";
       homepage = "https://github.com/miyagawa/cpanminus";
@@ -1233,10 +1224,6 @@ with self;
       ParallelPipes
       locallib
     ];
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
-    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang $out/bin/cpm
-    '';
     meta = {
       description = "Fast CPAN module installer";
       homepage = "https://github.com/skaji/cpm";
@@ -1284,7 +1271,6 @@ with self;
       TextLayout
     ]
     ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ Wx ];
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
 
     # Delete tests that fail when version env var is set, see
     # https://github.com/ChordPro/chordpro/issues/293
@@ -1293,7 +1279,6 @@ with self;
     '';
 
     postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang $out/bin/chordpro
       rm $out/bin/wxchordpro # Wx not supported on darwin
     '';
     meta = {
@@ -6628,14 +6613,10 @@ with self;
       url = "mirror://cpan/authors/id/R/RJ/RJBS/CPAN-Mini-1.111017.tar.gz";
       hash = "sha256-8gQpO+JqyEGsyHBEoYjbD1kegIgTFseiiK7A7s4wYVU=";
     };
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
     propagatedBuildInputs = [
       FileHomeDir
       LWPProtocolHttps
     ];
-    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang $out/bin/minicpan
-    '';
 
     meta = {
       description = "Create a minimal mirror of CPAN";
@@ -7100,7 +7081,6 @@ with self;
       url = "mirror://cpan/authors/id/B/BA/BARTB/Crypt-HSXKPasswd-v3.6.tar.gz";
       hash = "sha256-lZ3MX58BG/ALha0i31ZrerK/XqHTYrDeD7WuKfvEWLM=";
     };
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
     propagatedBuildInputs = [
       Clone
       DateTime
@@ -7115,9 +7095,6 @@ with self;
       TextUnidecode
       TypeTiny
     ];
-    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang $out/bin/hsxkpasswd
-    '';
 
     meta = {
       description = "Secure memorable password generator";
@@ -7569,10 +7546,6 @@ with self;
       LWP
     ];
 
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
-    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang $out/bin/pgplet
-    '';
     doCheck = false; # test fails with 'No random source available!'
 
     meta = {
@@ -10600,10 +10573,6 @@ with self;
       CaptureTiny
       TestDifferences
     ];
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
-    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang $out/bin/*
-    '';
     meta = {
       description = "Powerful fast feature-rich Perl source code profiler";
       homepage = "https://code.google.com/p/perl-devel-nytprof";
@@ -11004,10 +10973,6 @@ with self;
       TermUI
       YAMLTiny
     ];
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
-    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang $out/bin/dzil
-    '';
     doCheck = false;
     meta = {
       description = "Distribution builder; installer not included";
@@ -11865,12 +11830,8 @@ with self;
       Throwable
       TryTiny
     ];
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
     postPatch = ''
       patchShebangs --build util
-    '';
-    preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang util/sendmail
     '';
     meta = {
       description = "Library for sending email";
@@ -14781,10 +14742,6 @@ with self;
       url = "mirror://cpan/authors/id/T/TO/TORBIAK/App-Git-Autofixup-0.004007.tar.gz";
       hash = "sha256-2pe/dnKAlbO27nHaGfC/GUMBsvRd9HietU23Tt0hCjs=";
     };
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
-    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang $out/bin/git-autofixup
-    '';
     meta = {
       description = "Create fixup commits for topic branches";
       license = with lib.licenses; [ artistic2 ];
@@ -15563,15 +15520,11 @@ with self;
       TermSk
       namespaceclean
     ];
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
     patches = [
       ../development/perl-modules/Hailo-fix-test-gld.patch
     ];
     postPatch = ''
       patchShebangs bin
-    '';
-    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang $out/bin/hailo
     '';
     meta = {
       description = "Pluggable Markov engine analogous to MegaHAL";
@@ -17287,10 +17240,6 @@ with self;
     };
     buildInputs = [ CanaryStability ];
     propagatedBuildInputs = [ commonsense ];
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
-    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang $out/bin/treescan
-    '';
     meta = {
       description = "Asynchronous/Advanced Input/Output";
       license = with lib.licenses; [
@@ -18430,8 +18379,7 @@ with self;
     ];
     nativeBuildInputs = [
       pkgs.makeWrapper
-    ]
-    ++ lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
+    ];
     makeMakerFlags = [
       "TEXMF=\${tex}"
       "NOMKTEXLSR"
@@ -18439,11 +18387,6 @@ with self;
     # shebangs need to be patched before executables are copied to $out
     preBuild = ''
       patchShebangs bin/
-    ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      for file in bin/*; do
-        shortenPerlShebang "$file"
-      done
     '';
     postInstall = ''
       for file in latexmlc latexmlmath latexmlpost ; do
@@ -27700,7 +27643,6 @@ with self;
       hash = "sha256-5c2V3j5DvOcHdRdidLqkBfMm/IdA3wBUu4FpdcyNNJs=";
     };
     buildInputs = [ TestDeep ];
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
     propagatedBuildInputs = [
       BKeywords
       ConfigTiny
@@ -27718,9 +27660,6 @@ with self;
       Readonly
       StringFormat
     ];
-    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang $out/bin/perlcritic
-    '';
     preCheck = ''
       # Remove tests with hardcoded line numbers.
       rm t/20_policy_require_tidy_code.t
@@ -28440,10 +28379,6 @@ with self;
       PodMarkdown
       URI
     ];
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
-    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang $out/bin/pls
-    '';
     preCheck = ''
       # Remove tests with hardcoded line numbers.
       rm t/02document-new.t
@@ -29675,10 +29610,6 @@ with self;
       url = "mirror://cpan/authors/id/S/SY/SYP/App-rainbarf-1.4.tar.gz";
       hash = "sha256-TxOa01+q8t4GI9wLsd2J+lpDHlSL/sh97hlM8OJcyX0=";
     };
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
-    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang $out/bin/rainbarf
-    '';
     meta = {
       description = "CPU/RAM/battery stats chart bar for tmux (and GNU screen)";
       homepage = "https://github.com/creaktive/rainbarf";
@@ -31153,13 +31084,6 @@ with self;
       patchShebangs script
     '';
 
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
-    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      for file in $out/bin/*; do
-        shortenPerlShebang $file
-      done
-    '';
-
     meta = {
       description = "SQL DDL transformations and more";
       license = with lib.licenses; [
@@ -31247,7 +31171,6 @@ with self;
       TestRequires
       TestTCP
     ];
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
     propagatedBuildInputs = [
       DataDump
       HTTPParserXS
@@ -31256,9 +31179,6 @@ with self;
       NetServerSSPrefork
       IOSocketINET6
     ];
-    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang $out/bin/starman
-    '';
 
     doCheck = false; # binds to various TCP ports
     meta = {
@@ -36098,15 +36018,11 @@ with self;
       url = "mirror://cpan/authors/id/B/BO/BOBTFISH/Text-Markdown-1.000031.tar.gz";
       hash = "sha256-wZHG1ezrjLdcBWUZI2BmLSAtcWutB6IzxLMppChNxxs=";
     };
-    nativeBuildInputs = [ shortenPerlShebang ];
     nativeCheckInputs = [
       ListMoreUtils
       TestDifferences
       TestException
     ];
-    postInstall = ''
-      shortenPerlShebang $out/bin/Markdown.pl
-    '';
     meta = {
       description = "Convert Markdown syntax to (X)HTML";
       license = with lib.licenses; [ bsd3 ];
@@ -38420,11 +38336,7 @@ with self;
       url = "mirror://cpan/authors/id/S/SI/SIXTEASE/XML-Entities-1.0002.tar.gz";
       hash = "sha256-wyqk8wlXPXZIqy5Bb2K2sgZS8q2c/T7sgv1REB/nMQ0=";
     };
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
     propagatedBuildInputs = [ LWP ];
-    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang $out/bin/download-entities.pl
-    '';
     meta = {
       description = "Mapping of XML entities to Unicode";
       license = with lib.licenses; [
@@ -38510,14 +38422,10 @@ with self;
       url = "mirror://cpan/authors/id/G/GR/GRANTM/XML-Filter-Sort-1.01.tar.gz";
       hash = "sha256-UQWF85pJFszV+o1UXpYXnJHq9vx8l6QBp1aOhBFi+l8=";
     };
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin shortenPerlShebang;
     propagatedBuildInputs = [
       XMLSAX
       XMLSAXWriter
     ];
-    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      shortenPerlShebang $out/bin/xmlsort
-    '';
     meta = {
       description = "SAX filter for sorting elements in XML";
       license = with lib.licenses; [


### PR DESCRIPTION
shortenPerlShebang was made obsolete. This change usage of it from nixpkgs. The stub itself is left for external users.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
I built a couple of packages to see whether they still produced working executables. The changes mainly affect darwin. And while I am on Linux, this change reduces the differences between these systems.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Yes, of `convos`, `biber` and `gnufeedplot`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
