### PR TITLE
goarista: add passthru.updateScript

### DIFF
--- a/pkgs/by-name/go/goarista/package.nix
+++ b/pkgs/by-name/go/goarista/package.nix
@@ -18,6 +18,8 @@ buildGoModule {
 
   vendorHash = "sha256-n+P3L3dT2kYuTyI2qX/nrLRgFIUsP3kkwNZmRQ8EFRs=";
 
+  passthru.updateScript = ./update.sh;
+
   checkFlags =
     let
       skippedTests = [

--- a/pkgs/by-name/go/goarista/update.sh
+++ b/pkgs/by-name/go/goarista/update.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update gnused
+
+set -eou pipefail
+
+nix-update pkgs.goarista --version branch
+
+# The last github release in 2020 was named ockafka-v0.0.5.
+# I don't want this in the version name, it's from when Arista
+# was doing per-package releases in the repo, and not just trunk
+sed -i 's/ockafka-v0\.0\.5-/0-/' pkgs/by-name/go/goarista/package.nix


### PR DESCRIPTION
## Things done
Adds update script, requires a little annoying sed over just triggering nix-update-script due to versioning name stuff I can't figure out how to override in nix-update

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
