### PR TITLE
pypy: fix installPhase

### DIFF
--- a/pkgs/development/interpreters/python/pypy/default.nix
+++ b/pkgs/development/interpreters/python/pypy/default.nix
@@ -181,7 +181,9 @@ stdenv.mkDerivation rec {
     ${pythonForPypy.interpreter} rpython/bin/rpython \
       --make-jobs="$NIX_BUILD_CORES" \
       -O${optimizationLevel} \
-      --batch pypy/goal/targetpypystandalone.py
+      --batch \
+      pypy/goal/targetpypystandalone.py \
+      ${lib.optionalString ((toString optimizationLevel) == "1") "--withoutmod-cpyext"}
 
     runHook postBuild
   '';

--- a/pkgs/development/interpreters/python/pypy/default.nix
+++ b/pkgs/development/interpreters/python/pypy/default.nix
@@ -7,6 +7,7 @@
   zlib,
   bzip2,
   pkg-config,
+  lndir,
   libffi,
   sqlite,
   openssl,
@@ -80,7 +81,10 @@ stdenv.mkDerivation rec {
     inherit hash;
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    lndir
+  ];
   buildInputs = [
     bzip2
     openssl
@@ -185,16 +189,17 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/{bin,include,lib,${executable}-c}
+    mkdir -p $out/{bin,lib/${libPrefix}}
 
-    cp -R {include,lib_pypy,lib-python,${executable}-c} $out/${executable}-c
-    cp lib${executable}-c${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib/
-    ln -s $out/${executable}-c/${executable}-c $out/bin/${executable}
+    cp -R {include,lib_pypy,lib-python} $out
+    install -Dm755 lib${executable}-c${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib/
+    install -Dm755 ${executable}-c $out/bin/${executable}
     ${lib.optionalString isPy39OrNewer "ln -s $out/bin/${executable} $out/bin/pypy3"}
 
     # other packages expect to find stuff according to libPrefix
-    ln -s $out/${executable}-c/include $out/include/${libPrefix}
-    ln -s $out/${executable}-c/lib-python/${if isPy3k then "3" else pythonVersion} $out/lib/${libPrefix}
+    ln -s $out/include $out/include/${libPrefix}
+    lndir $out/lib-python/${if isPy3k then "3" else pythonVersion} $out/lib/${libPrefix}
+    lndir $out/lib_pypy $out/lib/${libPrefix}
 
     # Include a sitecustomize.py file
     cp ${../sitecustomize.py} $out/${
@@ -207,11 +212,6 @@ stdenv.mkDerivation rec {
   preFixup =
     lib.optionalString (stdenv.hostPlatform.isDarwin) ''
       install_name_tool -change @rpath/lib${executable}-c.dylib $out/lib/lib${executable}-c.dylib $out/bin/${executable}
-    ''
-    + lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) ''
-      mkdir -p $out/${executable}-c/pypy/bin
-      mv $out/bin/${executable} $out/${executable}-c/pypy/bin/${executable}
-      ln -s $out/${executable}-c/pypy/bin/${executable} $out/bin/${executable}
     ''
     # _testcapi is compiled dynamically, into the store.
     # This would fail if we don't do it here.


### PR DESCRIPTION
part of ~~https://github.com/NixOS/nixpkgs/pull/442206~~ https://github.com/NixOS/nixpkgs/pull/442540

prerequset for wrapping python executable with `--inherit-argv0` in python-env, otherwise issue https://github.com/NixOS/nixpkgs/issues/301498 will happen.

IMO, pypy{2,3} is very different from pypy{2,3}_prebuilt in tree structure, this pr make it more consistent with prebuilt binary.

tested work on aarch64-darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
