### PR TITLE
gftp: 2.9.1b-> 2.9.1b-unstable-2025-05-12

### DIFF
--- a/pkgs/by-name/gf/gftp/package.nix
+++ b/pkgs/by-name/gf/gftp/package.nix
@@ -2,12 +2,10 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  autoconf,
-  automake,
+  meson,
+  ninja,
   gettext,
   gtk2,
-  intltool,
-  libtool,
   ncurses,
   openssl,
   pkg-config,
@@ -18,21 +16,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gftp";
-  version = "2.9.1b";
+  version = "2.9.1b-unstable-2025-05-12";
 
   src = fetchFromGitHub {
     owner = "masneyb";
     repo = "gftp";
-    tag = finalAttrs.version;
-    hash = "sha256-0zdv2oYl24BXh61IGCWby/2CCkzNjLpDrAFc0J89Pw4=";
+    rev = "48114635f7b7b1f9a5eda985021ea53b10a7a030";
+    hash = "sha256-unTsd2xX8Y71ItE3gYHoxUPgViK/xhZdx0IQYvDPaEc=";
   };
 
   nativeBuildInputs = [
-    autoconf
-    automake
+    meson
+    ninja
     gettext
-    intltool
-    libtool
     pkg-config
   ];
 
@@ -43,22 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     readline
   ];
 
-  # https://github.com/masneyb/gftp/issues/178
-  postPatch = ''
-    substituteInPlace lib/gftp.h \
-      --replace-fail "size_t remote_addr_len" "socklen_t remote_addr_len"
-  '';
-
-  preConfigure = ''
-    ./autogen.sh
-  '';
-
   hardeningDisable = [ "format" ];
-
-  doInstallCheck = true;
-  nativeInstallCheckInputs = [ versionCheckHook ];
-
-  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/masneyb/gftp";
@@ -66,5 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     maintainers = [ lib.maintainers.haylin ];
     platforms = lib.platforms.unix;
+    mainProgram = "gftp";
   };
 })


### PR DESCRIPTION
## Things done
Fix build by bumping to unstable release

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
