### PR TITLE
python313Packages.pybind11: 2.13.6 -> 3.0.1

### DIFF
--- a/pkgs/development/python-modules/pybind11/default.nix
+++ b/pkgs/development/python-modules/pybind11/default.nix
@@ -106,7 +106,7 @@ buildPythonPackage rec {
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isMusl "fortify";
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pybind/pybind11";
     changelog = "https://github.com/pybind/pybind11/blob/${src.rev}/docs/changelog.rst";
     description = "Seamless operability between C++11 and Python";
@@ -116,8 +116,8 @@ buildPythonPackage rec {
       C++ types in Python and vice versa, mainly to create Python
       bindings of existing C++ code.
     '';
-    license = licenses.bsd3;
-    maintainers = with maintainers; [
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
       yuriaisaka
       dotlambda
     ];

--- a/pkgs/development/python-modules/pybind11/default.nix
+++ b/pkgs/development/python-modules/pybind11/default.nix
@@ -6,13 +6,14 @@
   fetchFromGitHub,
   cmake,
   ninja,
-  setuptools,
+  scikit-build-core,
+  pybind11,
   boost,
   eigen,
   python,
   catch2,
   numpy,
-  pytestCheckHook,
+  pytest,
   libxcrypt,
   makeSetupHook,
 }:
@@ -29,80 +30,79 @@ let
 in
 buildPythonPackage rec {
   pname = "pybind11";
-  version = "2.13.6";
+  version = "3.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pybind";
     repo = "pybind11";
     tag = "v${version}";
-    hash = "sha256-SNLdtrOjaC3lGHN9MAqTf51U9EzNKQLyTMNPe0GcdrU=";
+    hash = "sha256-ZiwNGsE1FOkhnWv/1ib1akhQ4FZvrXRCDnnBZoPp6r4=";
   };
 
   build-system = [
     cmake
     ninja
-    setuptools
+    pybind11.passthru.scikit-build-core-no-tests
   ];
 
-  buildInputs = lib.optionals (pythonOlder "3.9") [ libxcrypt ];
+  buildInputs = [
+    # Used only for building tests - something we do even when cross
+    # compiling.
+    catch2
+    boost
+    eigen
+  ];
+
   propagatedNativeBuildInputs = [ setupHook ];
 
-  dontUseCmakeBuildDir = true;
+  nativeCheckInputs = [
+    numpy
+    pytest
+  ];
 
-  # Don't build tests if not needed, read the doInstallCheck value at runtime
-  preConfigure = ''
-    if [ -n "$doInstallCheck" ]; then
-      cmakeFlagsArray+=("-DBUILD_TESTING=ON")
-    fi
-  '';
+  pypaBuildFlags = [
+    # Keep the build directory around to run the tests.
+    "-Cbuild-dir=build"
+  ];
 
   cmakeFlags = [
-    "-DBoost_INCLUDE_DIR=${lib.getDev boost}/include"
-    "-DCATCH_INCLUDE_DIR=${lib.getDev catch2}/include/catch2"
-    "-DEIGEN3_INCLUDE_DIR=${lib.getDev eigen}/include/eigen3"
-  ]
-  ++ lib.optionals (python.isPy3k && !stdenv.cc.isClang) [ "-DPYBIND11_CXX_STANDARD=-std=c++17" ];
+    # Always build tests, because even when cross compiling building the tests
+    # is another confirmation that everything is OK.
+    (lib.cmakeBool "BUILD_TESTING" true)
 
-  postBuild = ''
-    # build tests
-    make -j $NIX_BUILD_CORES
-  '';
+    # Override the `PYBIND11_NOPYTHON = true` in `pyproject.toml`. This
+    # is required to build the tests.
+    (lib.cmakeBool "PYBIND11_NOPYTHON" false)
+  ];
 
+  dontUseCmakeConfigure = true;
+
+  ninjaFlags = [
+    "-C"
+    "build"
+  ];
+
+  checkTarget = "check";
+
+  checkPhase = "ninjaCheckPhase";
+
+  # Make the headers and CMake/pkg-config files inside the wheel
+  # discoverable. This simulates the effect of the `pybind11[global]`
+  # installation but works better for our build.
   postInstall = ''
-    make install
-    # Symlink the CMake-installed headers to the location expected by setuptools
-    mkdir -p $out/include/${python.libPrefix}
-    ln -sf $out/include/pybind11 $out/include/${python.libPrefix}/pybind11
+    ln -s $out/${python.sitePackages}/pybind11/{include,share} $out/
   '';
 
-  nativeCheckInputs = [
-    catch2
-    numpy
-    pytestCheckHook
-  ];
-
-  disabledTestPaths = [
-    # require dependencies not available in nixpkgs
-    "tests/test_embed/test_trampoline.py"
-    "tests/test_embed/test_interpreter.py"
-    # numpy changed __repr__ output of numpy dtypes
-    "tests/test_numpy_dtypes.py"
-    # no need to test internal packaging
-    "tests/extra_python_package/test_files.py"
-    # tests that try to parse setuptools stdout
-    "tests/extra_setuptools/test_setuphelper.py"
-  ];
-
-  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
-    # expects KeyError, gets RuntimeError
-    # https://github.com/pybind/pybind11/issues/4243
-    "test_cross_module_exception_translator"
-  ];
-
-  postCheck = ''
-    make cpptest
-  '';
+  passthru = {
+    # scikit-build-core's tests depend upon pybind11, and hence introduce
+    # infinite recursion. To avoid this, we define here a scikit-build-core
+    # derivation that doesn't depend on pybind11, and use it for pybind11's
+    # build-system.
+    scikit-build-core-no-tests = scikit-build-core.overridePythonAttrs {
+      doCheck = false;
+    };
+  };
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isMusl "fortify";
 

--- a/pkgs/development/python-modules/scikit-build-core/append-cmakeFlags.sh
+++ b/pkgs/development/python-modules/scikit-build-core/append-cmakeFlags.sh
@@ -1,18 +1,9 @@
 scikitBuildFlagsHook() {
-  OLD_IFS="$IFS"
-  IFS=';'
+  concatTo flagsArray cmakeFlags cmakeFlagsArray
 
-  local args=()
-  if [[ -n "$SKBUILD_CMAKE_ARGS" ]]; then
-    read -ra existing_args <<< "$SKBUILD_CMAKE_ARGS"
-    args+=("${existing_args[@]}")
-  fi
-  args+=($cmakeFlags)
-  args+=("${cmakeFlagsArray[@]}")
-  export SKBUILD_CMAKE_ARGS="${args[*]}"
-
-  IFS="$OLD_IFS"
-  unset OLD_IFS
+  for arg in "${flagsArray[@]}"; do
+    appendToVar pypaBuildFlags "-Ccmake.args=$arg"
+  done
 }
 
 preConfigureHooks+=(scikitBuildFlagsHook)


### PR DESCRIPTION
Based on https://github.com/NixOS/nixpkgs/pull/419220, with working tests and a patch version bump, and rebased after https://github.com/NixOS/nixpkgs/pull/431558.

@doronbehar Thanks for your work on this! Hope you don’t mind me building on it here – I’ve built a fair amount of stuff with this without issues. I squashed a few of your commits together along with my fixes, as https://github.com/NixOS/nixpkgs/pull/431558 made them tricky to disentangle. Happily, it seems like all of the tests pass now, at least for me on Darwin.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
