### PR TITLE
treewide: prefer `types.ints` over `addCheck` expressions

### DIFF
--- a/nixos/modules/services/mail/postgrey.nix
+++ b/nixos/modules/services/mail/postgrey.nix
@@ -10,9 +10,6 @@ let
 
   cfg = config.services.postgrey;
 
-  natural = with types; addCheck int (x: x >= 0);
-  natural' = with types; addCheck int (x: x > 0);
-
   socket =
     with types;
     addCheck (either (submodule unixSocket) (submodule inetSocket)) (x: x ? path || x ? port);
@@ -127,17 +124,17 @@ in
         description = "Prepend header to greylisted mails; use %%t for seconds delayed due to greylisting, %%v for the version of postgrey, %%d for the date, and %%h for the host";
       };
       delay = mkOption {
-        type = natural;
+        type = ints.unsigned;
         default = 300;
         description = "Greylist for N seconds";
       };
       maxAge = mkOption {
-        type = natural;
+        type = ints.unsigned;
         default = 35;
         description = "Delete entries from whitelist if they haven't been seen for N days";
       };
       retryWindow = mkOption {
-        type = either str natural;
+        type = either str ints.unsigned;
         default = 2;
         example = "12h";
         description = "Allow N days for the first retry. Use string with appended 'h' to specify time in hours";
@@ -148,12 +145,12 @@ in
         description = "Strip the last N bits from IP addresses, determined by IPv4CIDR and IPv6CIDR";
       };
       IPv4CIDR = mkOption {
-        type = natural;
+        type = ints.unsigned;
         default = 24;
         description = "Strip N bits from IPv4 addresses if lookupBySubnet is true";
       };
       IPv6CIDR = mkOption {
-        type = natural;
+        type = ints.unsigned;
         default = 64;
         description = "Strip N bits from IPv6 addresses if lookupBySubnet is true";
       };
@@ -163,7 +160,7 @@ in
         description = "Store data using one-way hash functions (SHA1)";
       };
       autoWhitelist = mkOption {
-        type = nullOr natural';
+        type = nullOr ints.positive;
         default = 5;
         description = "Whitelist clients after successful delivery of N messages";
       };

--- a/nixos/modules/services/networking/monero.nix
+++ b/nixos/modules/services/networking/monero.nix
@@ -107,7 +107,7 @@ in
       };
 
       mining.threads = lib.mkOption {
-        type = lib.types.addCheck lib.types.int (x: x >= 0);
+        type = lib.types.ints.unsigned;
         default = 0;
         description = ''
           Number of threads used for mining.
@@ -174,7 +174,7 @@ in
       };
 
       limits.threads = lib.mkOption {
-        type = lib.types.addCheck lib.types.int (x: x >= 0);
+        type = lib.types.ints.unsigned;
         default = 0;
         description = ''
           Maximum number of threads used for a parallel job.
@@ -183,7 +183,7 @@ in
       };
 
       limits.syncSize = lib.mkOption {
-        type = lib.types.addCheck lib.types.int (x: x >= 0);
+        type = lib.types.ints.unsigned;
         default = 0;
         description = ''
           Maximum number of blocks to sync at once.

--- a/nixos/modules/services/networking/tayga.nix
+++ b/nixos/modules/services/networking/tayga.nix
@@ -42,7 +42,7 @@ let
         };
 
         prefixLength = mkOption {
-          type = types.addCheck types.int (n: n >= 0 && n <= (if v == 4 then 32 else 128));
+          type = types.ints.between 0 (if v == 4 then 32 else 128);
           description = ''
             Subnet mask of the interface, specified as the number of
             bits in the prefix ("${if v == 4 then "24" else "64"}").

--- a/nixos/modules/services/networking/tinc.nix
+++ b/nixos/modules/services/networking/tinc.nix
@@ -72,7 +72,7 @@ let
       };
 
       prefixLength = mkOption {
-        type = with types; nullOr (addCheck int (n: n >= 0 && n <= 128));
+        type = with types; nullOr (ints.between 0 128);
         default = null;
         description = ''
           The prefix length of the subnet.
@@ -227,7 +227,7 @@ in
 
                   debugLevel = mkOption {
                     default = 0;
-                    type = types.addCheck types.int (l: l >= 0 && l <= 5);
+                    type = types.ints.between 0 5;
                     description = ''
                       The amount of debugging information to add to the log. 0 means little
                       logging while 5 is the most logging. {command}`man tincd` for

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -82,7 +82,7 @@ let
         };
 
         prefixLength = mkOption {
-          type = types.addCheck types.int (n: n >= 0 && n <= (if v == 4 then 32 else 128));
+          type = types.ints.between 0 (if v == 4 then 32 else 128);
           description = ''
             Subnet mask of the interface, specified as the number of
             bits in the prefix (`${if v == 4 then "24" else "64"}`).
@@ -99,7 +99,7 @@ let
       };
 
       prefixLength = mkOption {
-        type = types.addCheck types.int (n: n >= 0 && n <= (if v == 4 then 32 else 128));
+        type = types.ints.between 0 (if v == 4 then 32 else 128);
         description = ''
           Subnet mask of the network, specified as the number of
           bits in the prefix (`${if v == 4 then "24" else "64"}`).


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`types.ints` are doing the `addCheck` behind the scenes, but they also bring better type descriptions for the manual, and the nix expressions might be easier to read.

Tested with `nix build .#htmlDocs.nixosManual.x86_64-linux`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
