### PR TITLE
ovn: enable tests

### DIFF
--- a/pkgs/by-name/ov/ovn/0001-tests-Expect-musl-error-string-for-EIO-errno.patch
+++ b/pkgs/by-name/ov/ovn/0001-tests-Expect-musl-error-string-for-EIO-errno.patch
@@ -1,0 +1,31 @@
+From d4ead86b2184d1fc2748ed2b6fae8c0dceaf76c8 Mon Sep 17 00:00:00 2001
+From: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
+Date: Thu, 11 Sep 2025 23:37:28 -0400
+Subject: [PATCH ovn 1/2] tests: Expect musl error string for EIO errno.
+
+Musl uses a slightly different string representation for the error,
+which makes the test fail on cleanup because an unexpected warning is
+observed in the service log.
+
+This patch will ignore both glibc and musl error messages.
+
+Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
+---
+ tests/ovn-controller.at | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tests/ovn-controller.at b/tests/ovn-controller.at
+index 0b00906ae..bec06e527 100644
+--- a/tests/ovn-controller.at
++++ b/tests/ovn-controller.at
+@@ -846,6 +846,7 @@ OVN_CLEANUP([hv1
+ /Certificate must be configured to use SSL/d
+ /SSL_read: error/d
+ /receive error: Input/d
++/receive error: I\/O error/d
+ /connection dropped/d
+ ])
+ AT_CLEANUP
+-- 
+2.50.1
+

--- a/pkgs/by-name/ov/ovn/0002-tests-Use-localhost-when-setting-wrong-ovn-remote.patch
+++ b/pkgs/by-name/ov/ovn/0002-tests-Use-localhost-when-setting-wrong-ovn-remote.patch
@@ -1,0 +1,37 @@
+From 44d9d58461e15314edf507d0379bff991d7e9964 Mon Sep 17 00:00:00 2001
+From: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
+Date: Thu, 11 Sep 2025 23:40:51 -0400
+Subject: [PATCH ovn 2/2] tests: Use localhost when setting "wrong" ovn-remote.
+
+In some isolated environments (e.g. in nixpkgs build sandbox), the
+network namespace doesn't have any routes or interfaces but `lo`. In
+this case, an attempt to connect to 192.168.0.10 results in ENETUNREACH,
+producing an unexpected "Network unreachable" warning message in service
+log file - breaking the test cleanup checks.
+
+Since the test case doesn't seem to care if the address is available, as
+long as there is no SB database actually running at the configured
+ovn-remote port, use the localhost address instead (which is always
+present, even in the most isolated environments).
+
+Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
+---
+ tests/ovn-controller.at | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/ovn-controller.at b/tests/ovn-controller.at
+index bec06e527..a8a9a2da2 100644
+--- a/tests/ovn-controller.at
++++ b/tests/ovn-controller.at
+@@ -404,7 +404,7 @@ check_sbdb_connection () {
+ 
+ OVS_WAIT_UNTIL([check_sbdb_connection connected])
+ 
+-ovs-vsctl set open . external_ids:ovn-remote=tcp:192.168.0.10:6642
++ovs-vsctl set open . external_ids:ovn-remote=tcp:127.0.0.1:12345
+ OVS_WAIT_UNTIL([check_sbdb_connection 'not connected'])
+ 
+ # reset the remote for clean-up
+-- 
+2.50.1
+

--- a/pkgs/by-name/ov/ovn/package.nix
+++ b/pkgs/by-name/ov/ovn/package.nix
@@ -15,14 +15,14 @@
   xdp-tools,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ovn";
   version = "25.09.0";
 
   src = fetchFromGitHub {
     owner = "ovn-org";
     repo = "ovn";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-DNaf3vWb6tlzViMEI02+3st/0AiMVAomSaiGplcjkIc=";
     fetchSubmodules = true;
   };
@@ -117,15 +117,15 @@ stdenv.mkDerivation rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "Open Virtual Network";
     longDescription = ''
       OVN (Open Virtual Network) is a series of daemons that translates virtual network configuration into OpenFlow, and installs them into Open vSwitch.
     '';
-    homepage = "https://github.com/ovn-org/ovn";
-    changelog = "https://github.com/ovn-org/ovn/blob/${src.rev}/NEWS";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ adamcstephens ];
-    platforms = platforms.linux;
+    homepage = "https://www.ovn.org";
+    changelog = "https://github.com/ovn-org/ovn/blob/refs/tags/${finalAttrs.src.tag}/NEWS";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ adamcstephens ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/ov/ovn/package.nix
+++ b/pkgs/by-name/ov/ovn/package.nix
@@ -29,6 +29,15 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
   };
 
+  patches = [
+    # Fix test failure with musl libc.
+    # https://patchwork.ozlabs.org/project/ovn/patch/20250912035054.50593-1-ihar.hrachyshka@gmail.com/
+    ./0001-tests-Expect-musl-error-string-for-EIO-errno.patch
+    # Fix sandbox test failure.
+    # https://patchwork.ozlabs.org/project/ovn/patch/20250912035054.50593-2-ihar.hrachyshka@gmail.com/
+    ./0002-tests-Use-localhost-when-setting-wrong-ovn-remote.patch
+  ];
+
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
@@ -45,16 +54,6 @@ stdenv.mkDerivation (finalAttrs: {
     libbpf
     xdp-tools
   ];
-
-  postPatch = ''
-    # One test assumes that the test environment has a network route to
-    # 192.168.0.10 and fails in sandbox. Replace it with localhost.
-    #
-    # The test case checks behavior when the configured ovn-remote is down, so
-    # we can pick any "free" port here.
-    substituteInPlace tests/ovn-controller.at \
-      --replace-fail 192.168.0.10:6642 127.0.0.1:9999
-  '';
 
   # need to build the ovs submodule first
   preConfigure = ''

--- a/pkgs/by-name/ov/ovn/package.nix
+++ b/pkgs/by-name/ov/ovn/package.nix
@@ -102,6 +102,10 @@ stdenv.mkDerivation rec {
     sed -i '/chown -R $INSTALL_USER:$INSTALL_GROUP $ovn_etcdir/d' $out/share/ovn/scripts/ovn-ctl
   '';
 
+  env = {
+    SKIP_UNSTABLE = "yes";
+  };
+
   # https://docs.ovn.org/en/latest/topics/testing.html
   preCheck = ''
     export TESTSUITEFLAGS="-j$NIX_BUILD_CORES"

--- a/pkgs/by-name/ov/ovn/package.nix
+++ b/pkgs/by-name/ov/ovn/package.nix
@@ -14,7 +14,9 @@
   unbound,
   xdp-tools,
 }:
-
+let
+  withOpensslConfigureFlag = "--with-openssl=${lib.getLib openssl.dev}";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "ovn";
   version = "25.09.0";
@@ -58,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
   preConfigure = ''
     pushd ovs
     ./boot.sh
-    ./configure --with-dbdir=/var/lib/openvswitch
+    ./configure --with-dbdir=/var/lib/openvswitch ${lib.optionalString stdenv.hostPlatform.isStatic withOpensslConfigureFlag}
     make -j $NIX_BUILD_CORES
     popd
   '';
@@ -70,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--sbindir=$(out)/bin"
     "--enable-ssl"
   ]
-  ++ lib.optional stdenv.hostPlatform.isStatic "--with-openssl=${lib.getLib openssl.dev}";
+  ++ lib.optional stdenv.hostPlatform.isStatic withOpensslConfigureFlag;
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/ov/ovn/package.nix
+++ b/pkgs/by-name/ov/ovn/package.nix
@@ -125,7 +125,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.ovn.org";
     changelog = "https://github.com/ovn-org/ovn/blob/refs/tags/${finalAttrs.src.tag}/NEWS";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ adamcstephens ];
+    maintainers = with lib.maintainers; [
+      adamcstephens
+      booxter
+    ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ov/ovn/package.nix
+++ b/pkgs/by-name/ov/ovn/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
-  gnused,
   libbpf,
   libcap_ng,
   nix-update-script,
@@ -78,7 +77,6 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   nativeCheckInputs = [
-    gnused
     procps
   ];
 

--- a/pkgs/by-name/ov/ovn/package.nix
+++ b/pkgs/by-name/ov/ovn/package.nix
@@ -77,6 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   nativeCheckInputs = [
+    openssl # used to generate certificates used for test services
     procps
   ];
 

--- a/pkgs/by-name/ov/ovn/package.nix
+++ b/pkgs/by-name/ov/ovn/package.nix
@@ -45,6 +45,16 @@ stdenv.mkDerivation rec {
     xdp-tools
   ];
 
+  postPatch = ''
+    # One test assumes that the test environment has a network route to
+    # 192.168.0.10 and fails in sandbox. Replace it with localhost.
+    #
+    # The test case checks behavior when the configured ovn-remote is down, so
+    # we can pick any "free" port here.
+    substituteInPlace tests/ovn-controller.at \
+      --replace-fail 192.168.0.10:6642 127.0.0.1:9999
+  '';
+
   # need to build the ovs submodule first
   preConfigure = ''
     pushd ovs

--- a/pkgs/by-name/ov/ovn/package.nix
+++ b/pkgs/by-name/ov/ovn/package.nix
@@ -65,8 +65,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  # disable tests due to networking issues and because individual tests can't be skipped easily
-  doCheck = false;
+  doCheck = true;
 
   nativeCheckInputs = [
     gnused


### PR DESCRIPTION
```
pkgsStatic.ovn: fix test failure; replace postPatch with a real patch
pkgsStatic.ovn: build ovs lib with ssl support
pkgsStatic.ovn: add openssl to check deps
ovn: add booxter as maintainer
ovn: modernize
ovn: remove explicit gnused check dependency
ovn: skip unstable tests
ovn: fix test failure due to network sandbox
ovn: enable tests
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
