### PR TITLE
lib/modules: add suggestions to invalid option name errors

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -314,8 +314,10 @@ let
                     (addErrorContext "while evaluating a definition from `${firstDef.file}'" (showDefs [ firstDef ]));
 
                 prefix' = init (prefix ++ firstDef.prefix);
-                adj = attrNames (attrByPath prefix' { } options);
-                adj' = if prefix' == [ ] then remove "_module" adj else adj;
+                # In submodules, prefix is absolute, but options and most variables are relative to the submodule prefix.
+                lookupPath = init firstDef.prefix;
+                adj = attrNames (attrByPath lookupPath { } options);
+                adj' = if lookupPath == [ ] then remove "_module" adj else adj;
                 invalidOptName = last firstDef.prefix;
                 # For small option sets, check all; for large sets, only check distance ≤ 2
                 suggestions =

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -741,6 +741,10 @@ checkConfigError 'attribute .*bar.* not found' config.sub.conditionalImportAsNix
 checkConfigError 'attribute .*foo.* not found' config.sub.conditionalImportAsDarwin.foo ./specialArgs-class.nix
 checkConfigOutput '"foo"' config.sub.conditionalImportAsDarwin.bar ./specialArgs-class.nix
 
+# Option name suggestions
+checkConfigError 'Did you mean .set\.enable.\?' config.set ./error-typo-nested.nix
+checkConfigError 'Did you mean .set.\?' config ./error-typo-outside-with-nested.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -746,6 +746,8 @@ checkConfigError 'Did you mean .set\.enable.\?' config.set ./error-typo-nested.n
 checkConfigError 'Did you mean .set.\?' config ./error-typo-outside-with-nested.nix
 checkConfigError 'Did you mean .bar., .baz. or .foo.\?' config ./error-typo-multiple-suggestions.nix
 checkConfigError 'Did you mean .enable., .ebe. or .enabled.\?' config ./error-typo-large-attrset.nix
+checkConfigError 'Did you mean .services\.myservice\.port. or .services\.myservice\.enable.\?' config.services.myservice ./error-typo-submodule.nix
+checkConfigError 'Did you mean .services\.nginx\.virtualHosts\."example\.com"\.ssl\.certificate. or .services\.nginx\.virtualHosts\."example\.com"\.ssl\.certificateKey.\?' config.services.nginx.virtualHosts.\"example.com\" ./error-typo-deeply-nested.nix
 
 cat <<EOF
 ====== module tests ======

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -744,6 +744,8 @@ checkConfigOutput '"foo"' config.sub.conditionalImportAsDarwin.bar ./specialArgs
 # Option name suggestions
 checkConfigError 'Did you mean .set\.enable.\?' config.set ./error-typo-nested.nix
 checkConfigError 'Did you mean .set.\?' config ./error-typo-outside-with-nested.nix
+checkConfigError 'Did you mean .bar., .baz. or .foo.\?' config ./error-typo-multiple-suggestions.nix
+checkConfigError 'Did you mean .enable., .ebe. or .enabled.\?' config ./error-typo-large-attrset.nix
 
 cat <<EOF
 ====== module tests ======

--- a/lib/tests/modules/error-typo-deeply-nested.nix
+++ b/lib/tests/modules/error-typo-deeply-nested.nix
@@ -1,0 +1,42 @@
+{ lib, ... }:
+
+{
+  options.services = {
+    nginx = {
+      enable = lib.mkOption {
+        default = false;
+        type = lib.types.bool;
+      };
+      virtualHosts = lib.mkOption {
+        type = lib.types.attrsOf (
+          lib.types.submodule {
+            options = {
+              enableSSL = lib.mkOption {
+                default = false;
+                type = lib.types.bool;
+              };
+              ssl = {
+                certificate = lib.mkOption {
+                  default = "";
+                  type = lib.types.str;
+                };
+                certificateKey = lib.mkOption {
+                  default = "";
+                  type = lib.types.str;
+                };
+              };
+            };
+          }
+        );
+        default = { };
+      };
+    };
+  };
+
+  config = {
+    services.nginx.virtualHosts."example.com" = {
+      # Typo: "certficate" instead of "certificate" (nested within submodule)
+      ssl.certficate = "/path/to/cert";
+    };
+  };
+}

--- a/lib/tests/modules/error-typo-large-attrset.nix
+++ b/lib/tests/modules/error-typo-large-attrset.nix
@@ -1,0 +1,56 @@
+{ lib, ... }:
+
+let
+  inherit (lib) mkOption concatMapAttrs;
+
+  ten = {
+    a = null;
+    b = null;
+    c = null;
+    d = null;
+    e = null;
+    f = null;
+    g = null;
+    h = null;
+    i = null;
+    j = null;
+  };
+
+  # Generate 1000 options (10 * 10 * 10)
+  generatedOptions = concatMapAttrs (
+    k1: _:
+    concatMapAttrs (
+      k2: _:
+      concatMapAttrs (k3: _: {
+        "${k1}${k2}${k3}" = mkOption {
+          type = lib.types.bool;
+          default = false;
+        };
+      }) ten
+    ) ten
+  ) ten;
+
+  # Add some sensible options that are close to our typo
+  sensibleOptions = {
+    enable = mkOption {
+      type = lib.types.bool;
+      default = false;
+    };
+    enabled = mkOption {
+      type = lib.types.bool;
+      default = false;
+    };
+    disable = mkOption {
+      type = lib.types.bool;
+      default = false;
+    };
+  };
+in
+{
+  options = generatedOptions // sensibleOptions;
+
+  config = {
+    # Typo: "enble" is distance 1 from "enable"
+    enble = true;
+  };
+}

--- a/lib/tests/modules/error-typo-multiple-suggestions.nix
+++ b/lib/tests/modules/error-typo-multiple-suggestions.nix
@@ -1,0 +1,22 @@
+{ lib, ... }:
+
+{
+  options.foo = lib.mkOption {
+    default = false;
+    type = lib.types.bool;
+  };
+
+  options.bar = lib.mkOption {
+    default = false;
+    type = lib.types.bool;
+  };
+
+  options.baz = lib.mkOption {
+    default = false;
+    type = lib.types.bool;
+  };
+
+  config = {
+    far = true;
+  };
+}

--- a/lib/tests/modules/error-typo-nested.nix
+++ b/lib/tests/modules/error-typo-nested.nix
@@ -1,0 +1,18 @@
+{ lib, ... }:
+
+{
+  options.set = {
+    enable = lib.mkOption {
+      default = false;
+      example = true;
+      type = lib.types.bool;
+      description = ''
+        Some descriptive text
+      '';
+    };
+  };
+
+  config = {
+    set.ena = true;
+  };
+}

--- a/lib/tests/modules/error-typo-outside-with-nested.nix
+++ b/lib/tests/modules/error-typo-outside-with-nested.nix
@@ -1,0 +1,18 @@
+{ lib, ... }:
+
+{
+  options.set = {
+    enable = lib.mkOption {
+      default = false;
+      example = true;
+      type = lib.types.bool;
+      description = ''
+        Some descriptive text
+      '';
+    };
+  };
+
+  config = {
+    sea.enable = true;
+  };
+}

--- a/lib/tests/modules/error-typo-submodule.nix
+++ b/lib/tests/modules/error-typo-submodule.nix
@@ -1,0 +1,28 @@
+{ lib, ... }:
+
+{
+  options.services = lib.mkOption {
+    type = lib.types.attrsOf (
+      lib.types.submodule {
+        options = {
+          enable = lib.mkOption {
+            default = false;
+            type = lib.types.bool;
+          };
+          port = lib.mkOption {
+            default = 8080;
+            type = lib.types.int;
+          };
+        };
+      }
+    );
+    default = { };
+  };
+
+  config = {
+    services.myservice = {
+      # Typo: "prot" instead of "port"
+      prot = 9000;
+    };
+  };
+}


### PR DESCRIPTION
This change introduces the suggesting of possible valid option names for a given invalid option, based on the keys of said invalid option's parent attrset. That is, `foo.bar.baz` will only be suggested keys from `foo.bar`, while `(config).baz` will only be suggested keys from the toplevel.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
