### PR TITLE
uhttpd: init at 0-unstable-2025-12-24

### DIFF
--- a/pkgs/by-name/uh/uhttpd/package.nix
+++ b/pkgs/by-name/uh/uhttpd/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  cmake,
+  pkg-config,
+  lua5_1,
+  json_c,
+  libubox-wolfssl,
+  ubus,
+  libxcrypt,
+  unstableGitUpdater,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "uhttpd";
+  version = "0-unstable-2025-12-24";
+
+  src = fetchgit {
+    url = "https://git.openwrt.org/project/uhttpd.git";
+    rev = "506e24987b97fbc866005bfb71316bd63601a1ef";
+    hash = "sha256-x5hbbEcyxWhCjjqiHvAxvI1eHewqRlXuAGqXNw+c4sA=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    lua5_1
+    json_c
+    libubox-wolfssl
+    ubus
+    libxcrypt
+  ];
+
+  cmakeFlags = [
+    "-DUCODE_SUPPORT=off"
+    "-DTLS_SUPPORT=on"
+    "-DLUA_SUPPORT=on"
+  ];
+
+  NIX_LDFLAGS = "-lcrypt";
+
+  postInstall = ''
+    wrapProgram $out/bin/uhttpd \
+      --prefix LD_LIBRARY_PATH : $out/lib/uhttpd
+  '';
+
+  passthru.updateScript = unstableGitUpdater {
+    branch = "master";
+    hardcodeZeroVersion = true;
+  };
+
+  meta = {
+    description = "Tiny HTTP server from OpenWrt project";
+    homepage = "https://openwrt.org/docs/guide-user/services/webserver/uhttpd";
+    license = lib.licenses.isc;
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.haylin ];
+    mainProgram = "uhttpd";
+  };
+})


### PR DESCRIPTION
## Things done
I might throw together a nixos module and test so that in future updates lua and tls support can be validated per update easier

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
