### PR TITLE
cargo-sbom: init at 0.10.0

### DIFF
--- a/pkgs/by-name/ca/cargo-sbom/package.nix
+++ b/pkgs/by-name/ca/cargo-sbom/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-sbom";
+  version = "0.10.0";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-2/5FCK5CCDVPemsALm6OSTfiCHGwxxp9o2R9kZ+WKP8=";
+  };
+
+  cargoHash = "sha256-99C9wFnQwQmJax89EjMU3E6xIh1eGiFiX1lF7HPdLQw=";
+
+  doCheck = true;
+
+  meta = {
+    description = "Create software bill of materials (SBOM) for Rust";
+    mainProgram = "cargo-sbom";
+    homepage = "https://github.com/psastras/sbom-rs";
+    license = with lib.licenses; [
+      mit
+    ];
+    maintainers = with lib.maintainers; [
+      shimun
+    ];
+  };
+}


### PR DESCRIPTION
Added cargo-sbom, a generator for a software bill of materials for cargo projects.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
