### PR TITLE
font-bitstream-{100dpi,75dpi,type1}: refactor, move to pkgs/by-name and rename from xorg.fontbitstream*, xorg.fontbitstreamspeedo: drop

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -167,6 +167,11 @@ lib.mapAttrs mkLicense (
       fullName = "Apache License 2.0";
     };
 
+    bitstreamCharter = {
+      spdxId = "Bitstream-Charter";
+      fullName = "Bitstream Charter Font License";
+    };
+
     bitstreamVera = {
       spdxId = "Bitstream-Vera";
       fullName = "Bitstream Vera Font License";

--- a/pkgs/by-name/fo/font-bitstream-100dpi/package.nix
+++ b/pkgs/by-name/fo/font-bitstream-100dpi/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  font-util,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-bitstream-100dpi";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-bitstream-100dpi-${finalAttrs.version}.tar.xz";
+    hash = "sha256-LRzGgu/k9+vfX72Ilh2MoysnKZaHKGM96iChYnaQwac=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    bdftopcf
+    mkfontscale
+  ];
+
+  buildInputs = [ font-util ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Bitstream Charter and Terminal 100dpi pcf fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/bitstream-100dpi";
+    license = with lib.licenses; [
+      hpnd
+      # TODO: change this license or remove this comment when
+      # https://github.com/spdx/license-list-XML/issues/2824
+      # gets resolved
+      xfig
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-bitstream-100dpi/package.nix
+++ b/pkgs/by-name/fo/font-bitstream-100dpi/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ font-util ];
 
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+  configureFlags = [ "--with-fontrootdir=$(out)/share/fonts/X11" ];
 
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''

--- a/pkgs/by-name/fo/font-bitstream-75dpi/package.nix
+++ b/pkgs/by-name/fo/font-bitstream-75dpi/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  font-util,
+  bdftopcf,
+  mkfontscale,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-bitstream-75dpi";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-bitstream-75dpi-${finalAttrs.version}.tar.xz";
+    hash = "sha256-qus02HQkqcKwzw6FkHBMkMtbQsajtqDvnkZ273c7+CY=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    bdftopcf
+    mkfontscale
+  ];
+
+  buildInputs = [ font-util ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Bitstream Charter and Terminal 75dpi pcf fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/bitstream-75dpi";
+    license = with lib.licenses; [
+      hpnd
+      # TODO: change this license or remove this comment when
+      # https://github.com/spdx/license-list-XML/issues/2824
+      # gets resolved
+      xfig
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/fo/font-bitstream-75dpi/package.nix
+++ b/pkgs/by-name/fo/font-bitstream-75dpi/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ font-util ];
 
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+  configureFlags = [ "--with-fontrootdir=$(out)/share/fonts/X11" ];
 
   passthru = {
     updateScript = writeScript "update-${finalAttrs.pname}" ''

--- a/pkgs/by-name/fo/font-bitstream-type1/package.nix
+++ b/pkgs/by-name/fo/font-bitstream-type1/package.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation (finalAttrs: {
     fontforge
   ];
 
-  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-
   postBuild = ''
     # convert Postscript (Type 1) font to otf
     for i in $(find -type f -name '*.pfa' -o -name '*.pfb'); do
@@ -34,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = ''
     # install the otf fonts
-    fontDir="$out/lib/X11/fonts/misc"
+    fontDir="$out/share/fonts/X11/otf"
     install -Dm444 -t "$fontDir" *.otf
     mkfontscale "$fontDir"
   '';

--- a/pkgs/by-name/fo/font-bitstream-type1/package.nix
+++ b/pkgs/by-name/fo/font-bitstream-type1/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  mkfontscale,
+  fontforge,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-bitstream-type1";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-bitstream-type1-${finalAttrs.version}.tar.xz";
+    hash = "sha256-3i8ji0zXLbQiigumeCnXait8A54imT1mpyLuOFJIxig=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    mkfontscale
+    fontforge
+  ];
+
+  configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
+
+  postBuild = ''
+    # convert Postscript (Type 1) font to otf
+    for i in $(find -type f -name '*.pfa' -o -name '*.pfb'); do
+        name=$(basename $i | cut -d. -f1)
+        fontforge -lang=ff -c "Open(\"$i\"); Generate(\"$name.otf\")"
+    done
+  '';
+
+  postInstall = ''
+    # install the otf fonts
+    fontDir="$out/lib/X11/fonts/misc"
+    install -Dm444 -t "$fontDir" *.otf
+    mkfontscale "$fontDir"
+  '';
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Bitstream Charter PostScript Type 1 and OpenType fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/bitstream-type1";
+    license = lib.licenses.bitstreamCharter;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -17,6 +17,7 @@
   font-bh-type1,
   font-bitstream-100dpi,
   font-bitstream-75dpi,
+  font-bitstream-type1,
   font-cronyx-cyrillic,
   font-encodings,
   font-isas-misc,
@@ -201,6 +202,7 @@ self: with self; {
   fontbhtype1 = font-bh-type1;
   fontbitstream100dpi = font-bitstream-100dpi;
   fontbitstream75dpi = font-bitstream-75dpi;
+  fontbitstreamtype1 = font-bitstream-type1;
   fontcronyxcyrillic = font-cronyx-cyrillic;
   fontisasmisc = font-isas-misc;
   fontmicromisc = font-micro-misc;
@@ -381,44 +383,6 @@ self: with self; {
       nativeBuildInputs = [
         pkg-config
         bdftopcf
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontbitstreamtype1 = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-bitstream-type1";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-bitstream-type1-1.0.4.tar.xz";
-        sha256 = "0a669193ivi2lxk3v692kq1pqavaswlpi9hbi8ib8bfp9j5j6byy";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
         mkfontscale
       ];
       buildInputs = [ fontutil ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -15,6 +15,7 @@
   font-bh-lucidatypewriter-75dpi,
   font-bh-ttf,
   font-bh-type1,
+  font-bitstream-100dpi,
   font-cronyx-cyrillic,
   font-encodings,
   font-isas-misc,
@@ -197,6 +198,7 @@ self: with self; {
   fontbhlucidatypewriter75dpi = font-bh-lucidatypewriter-75dpi;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
+  fontbitstream100dpi = font-bitstream-100dpi;
   fontcronyxcyrillic = font-cronyx-cyrillic;
   fontisasmisc = font-isas-misc;
   fontmicromisc = font-micro-misc;
@@ -368,46 +370,6 @@ self: with self; {
       src = fetchurl {
         url = "mirror://xorg/individual/font/font-arabic-misc-1.0.4.tar.xz";
         sha256 = "0rrlcqbyx9y7hnhbkjir8rs6jkfqyalj1zvhr8niv2n7a8dydzs6";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontbitstream100dpi = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-bitstream-100dpi";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-bitstream-100dpi-1.0.4.tar.xz";
-        sha256 = "19y1j1v65890x8yn6a47jqljfax3ihfrd25xbzgypxz4xy1cc71d";
       };
       hardeningDisable = [
         "bindnow"

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -395,44 +395,6 @@ self: with self; {
   ) { };
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontbitstreamspeedo = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-bitstream-speedo";
-      version = "1.0.2";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-bitstream-speedo-1.0.2.tar.gz";
-        sha256 = "0wmy58cd3k7w2j4v20icnfs8z3b61qj3vqdx958z18w00h9mzsmf";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
   fontbitstreamtype1 = callPackage (
     {
       stdenv,

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -16,6 +16,7 @@
   font-bh-ttf,
   font-bh-type1,
   font-bitstream-100dpi,
+  font-bitstream-75dpi,
   font-cronyx-cyrillic,
   font-encodings,
   font-isas-misc,
@@ -199,6 +200,7 @@ self: with self; {
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
   fontbitstream100dpi = font-bitstream-100dpi;
+  fontbitstream75dpi = font-bitstream-75dpi;
   fontcronyxcyrillic = font-cronyx-cyrillic;
   fontisasmisc = font-isas-misc;
   fontmicromisc = font-micro-misc;
@@ -370,46 +372,6 @@ self: with self; {
       src = fetchurl {
         url = "mirror://xorg/individual/font/font-arabic-misc-1.0.4.tar.xz";
         sha256 = "0rrlcqbyx9y7hnhbkjir8rs6jkfqyalj1zvhr8niv2n7a8dydzs6";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        bdftopcf
-        mkfontscale
-      ];
-      buildInputs = [ fontutil ];
-      configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
-      postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontbitstream75dpi = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      fontutil,
-      bdftopcf,
-      mkfontscale,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-bitstream-75dpi";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-bitstream-75dpi-1.0.4.tar.xz";
-        sha256 = "09pq7dvyyxj6kvps1dm3qr15pjwh9iq9118fryqc5a94fkc39sxa";
       };
       hardeningDisable = [
         "bindnow"

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -340,6 +340,7 @@ print OUT <<EOF;
   font-bh-type1,
   font-bitstream-100dpi,
   font-bitstream-75dpi,
+  font-bitstream-type1,
   font-cronyx-cyrillic,
   font-encodings,
   font-isas-misc,
@@ -524,6 +525,7 @@ self: with self; {
   fontbhtype1 = font-bh-type1;
   fontbitstream100dpi = font-bitstream-100dpi;
   fontbitstream75dpi = font-bitstream-75dpi;
+  fontbitstreamtype1 = font-bitstream-type1;
   fontcronyxcyrillic = font-cronyx-cyrillic;
   fontisasmisc = font-isas-misc;
   fontmicromisc = font-micro-misc;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -338,6 +338,7 @@ print OUT <<EOF;
   font-bh-lucidatypewriter-75dpi,
   font-bh-ttf,
   font-bh-type1,
+  font-bitstream-100dpi,
   font-cronyx-cyrillic,
   font-encodings,
   font-isas-misc,
@@ -520,6 +521,7 @@ self: with self; {
   fontbhlucidatypewriter75dpi = font-bh-lucidatypewriter-75dpi;
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
+  fontbitstream100dpi = font-bitstream-100dpi;
   fontcronyxcyrillic = font-cronyx-cyrillic;
   fontisasmisc = font-isas-misc;
   fontmicromisc = font-micro-misc;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -339,6 +339,7 @@ print OUT <<EOF;
   font-bh-ttf,
   font-bh-type1,
   font-bitstream-100dpi,
+  font-bitstream-75dpi,
   font-cronyx-cyrillic,
   font-encodings,
   font-isas-misc,
@@ -522,6 +523,7 @@ self: with self; {
   fontbhttf = font-bh-ttf;
   fontbhtype1 = font-bh-type1;
   fontbitstream100dpi = font-bitstream-100dpi;
+  fontbitstream75dpi = font-bitstream-75dpi;
   fontcronyxcyrillic = font-cronyx-cyrillic;
   fontisasmisc = font-isas-misc;
   fontmicromisc = font-micro-misc;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -902,5 +902,5 @@ self: super:
 
 # deprecate some packages
 // lib.optionalAttrs config.allowAliases {
-  fontbitstreamspeedo = throw "Bitstream Speedo is an obsolete font format that hasn't been supported by Xorg since 2005";
+  fontbitstreamspeedo = throw "Bitstream Speedo is an obsolete font format that hasn't been supported by Xorg since 2005"; # added 2025-09-24
 }

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -866,27 +866,6 @@ self: super:
   });
 
   xwd = addMainProgram super.xwd { };
-
-  # convert Type1 vector fonts to OpenType fonts
-  fontbitstreamtype1 = super.fontbitstreamtype1.overrideAttrs (attrs: {
-    nativeBuildInputs = attrs.nativeBuildInputs ++ [ fontforge ];
-
-    postBuild = ''
-      # convert Postscript (Type 1) font to otf
-      for i in $(find -type f -name '*.pfa' -o -name '*.pfb'); do
-          name=$(basename $i | cut -d. -f1)
-          fontforge -lang=ff -c "Open(\"$i\"); Generate(\"$name.otf\")"
-      done
-    '';
-
-    postInstall = ''
-      # install the otf fonts
-      fontDir="$out/lib/X11/fonts/misc/"
-      install -D -m 644 -t "$fontDir" *.otf
-      mkfontscale "$fontDir"
-    '';
-  });
-
 }
 
 # mark some packages as unfree

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1,6 +1,7 @@
 {
   callPackage,
   lib,
+  config,
   stdenv,
   makeWrapper,
   fetchurl,
@@ -919,3 +920,8 @@ self: super:
   mapNamesToAttrs (setLicense lib.licenses.unfreeRedistributable) redist
   // mapNamesToAttrs (setLicense lib.licenses.unfree) unfree
 )
+
+# deprecate some packages
+// lib.optionalAttrs config.allowAliases {
+  fontbitstreamspeedo = throw "Bitstream Speedo is an obsolete font format that hasn't been supported by Xorg since 2005";
+}

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -73,7 +73,6 @@ mirror://xorg/individual/driver/xf86-video-vmware-13.4.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-wsfb-0.4.0.tar.bz2
 mirror://xorg/individual/font/font-arabic-misc-1.0.4.tar.xz
-mirror://xorg/individual/font/font-bitstream-type1-1.0.4.tar.xz
 mirror://xorg/individual/font/font-cursor-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-daewoo-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-dec-misc-1.0.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -73,7 +73,6 @@ mirror://xorg/individual/driver/xf86-video-vmware-13.4.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-wsfb-0.4.0.tar.bz2
 mirror://xorg/individual/font/font-arabic-misc-1.0.4.tar.xz
-mirror://xorg/individual/font/font-bitstream-75dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bitstream-speedo-1.0.2.tar.gz
 mirror://xorg/individual/font/font-bitstream-type1-1.0.4.tar.xz
 mirror://xorg/individual/font/font-cursor-misc-1.0.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -74,7 +74,6 @@ mirror://xorg/individual/driver/xf86-video-voodoo-1.2.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-wsfb-0.4.0.tar.bz2
 mirror://xorg/individual/font/font-arabic-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bitstream-75dpi-1.0.4.tar.xz
-mirror://xorg/individual/font/font-bitstream-100dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bitstream-speedo-1.0.2.tar.gz
 mirror://xorg/individual/font/font-bitstream-type1-1.0.4.tar.xz
 mirror://xorg/individual/font/font-cursor-misc-1.0.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -73,7 +73,6 @@ mirror://xorg/individual/driver/xf86-video-vmware-13.4.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-wsfb-0.4.0.tar.bz2
 mirror://xorg/individual/font/font-arabic-misc-1.0.4.tar.xz
-mirror://xorg/individual/font/font-bitstream-speedo-1.0.2.tar.gz
 mirror://xorg/individual/font/font-bitstream-type1-1.0.4.tar.xz
 mirror://xorg/individual/font/font-cursor-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-daewoo-misc-1.0.4.tar.xz


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Build for platform:
  - [x] x86_64-linux
  - [x] x86_64-linux static
  - [x] aarch64-multiplatform
  - [x] aarch64-multiplatform-musl
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`. (none)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] ran passthru.updateScript
- [x] ran nix-check-deps
- [x] ran nixpkgs-hammer
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc