### PR TITLE
x{11perf,calc,compmgr,eyes}: refactor and move to pkgs/by-name from xorg namespace

### DIFF
--- a/pkgs/by-name/x1/x11perf/package.nix
+++ b/pkgs/by-name/x1/x11perf/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxext,
+  libxft,
+  libxmu,
+  libxrender,
+  freetype,
+  fontconfig,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "x11perf";
+  version = "1.7.0";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/test/x11perf-${finalAttrs.version}.tar.xz";
+    hash = "sha256-JPgNhLDpYXGpmJMv8Adpj9F3bamXXtQuUdV7nPypGCg=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxext
+    libxft
+    libxmu
+    libxrender
+    freetype
+    fontconfig
+  ];
+
+  postInstall = ''
+    substituteInPlace $out/bin/x11perfcomp \
+      --replace-fail "/bin/cat" "cat"
+  '';
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/test/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "X11 server performance test program";
+    homepage = "https://gitlab.freedesktop.org/xorg/test/x11perf";
+    license = lib.licenses.hpnd;
+    mainProgram = "x11perf";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xc/xcalc/package.nix
+++ b/pkgs/by-name/xc/xcalc/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  wrapWithXFileSearchPathHook,
+  libx11,
+  libxaw,
+  libxt,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xcalc";
+  version = "1.1.2";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xcalc-${finalAttrs.version}.tar.xz";
+    hash = "sha256-hXjfoUV+lCifbW7WFGcUMH2Kc6G1TS9CrxMhtiX8HNQ=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapWithXFileSearchPathHook
+  ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxaw
+    libxt
+  ];
+
+  installFlags = [ "appdefaultdir=$(out)/share/X11/app-defaults" ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Scientific calculator X11 client that can emulate a TI-30 or an HP-10C";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xcalc";
+    license = with lib.licenses; [
+      x11
+      hpndSellVariant
+    ];
+    mainProgram = "xcalc";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xc/xcompmgr/package.nix
+++ b/pkgs/by-name/xc/xcompmgr/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxrender,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xcompmgr";
+  version = "1.1.10";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xcompmgr-${finalAttrs.version}.tar.xz";
+    hash = "sha256-eCT3CcTyJDLq6nVC7JM4Tl3Uj2/LhcEv+C1yFCOwuY8=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libxcomposite
+    libxdamage
+    libxext
+    libxfixes
+    libxrender
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Sample X11 compositing manager";
+    longDescription = ''
+      xcompmgr is a sample compositing manager for X servers supporting the XFIXES, DAMAGE, RENDER
+      and COMPOSITE extensions. It enables basic eye-candy effects.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xcompmgr";
+    license = lib.licenses.hpndSellVariant;
+    mainProgram = "xcompmgr";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xe/xeyes/package.nix
+++ b/pkgs/by-name/xe/xeyes/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxcb,
+  libxext,
+  libxi,
+  libxmu,
+  libxrender,
+  libxt,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xeyes";
+  version = "1.3.1";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xeyes-${finalAttrs.version}.tar.xz";
+    hash = "sha256-VgjXa3sarF7X8i8ba1rXTvmMhpMiDzK0uH3M7kqVbqo=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxcb
+    libxext
+    libxi
+    libxmu
+    libxrender
+    libxt
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "A \"follow the mouse\" X demo, using the X SHAPE extension";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xeyes";
+    license = lib.licenses.x11;
+    mainProgram = "xeyes";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -95,6 +95,7 @@
   xcalc,
   xcb-proto,
   xcmsdb,
+  xcompmgr,
   xconsole,
   xcursorgen,
   xcursor-themes,
@@ -161,6 +162,7 @@ self: with self; {
     xbitmaps
     xcalc
     xcmsdb
+    xcompmgr
     xconsole
     xcursorgen
     xdriinfo
@@ -1260,50 +1262,6 @@ self: with self; {
         xorgproto
         libXrender
         libXt
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xcompmgr = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libXcomposite,
-      libXdamage,
-      libXext,
-      libXfixes,
-      xorgproto,
-      libXrender,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xcompmgr";
-      version = "1.1.10";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xcompmgr-1.1.10.tar.xz";
-        sha256 = "13xrn0ii8widz0pw31fbdy7x8paf729yqhkmxbm3497jqh4zf93q";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libXcomposite
-        libXdamage
-        libXext
-        libXfixes
-        xorgproto
-        libXrender
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -92,6 +92,7 @@
   xauth,
   xbacklight,
   xbitmaps,
+  xcalc,
   xcb-proto,
   xcmsdb,
   xconsole,
@@ -158,6 +159,7 @@ self: with self; {
     xauth
     xbacklight
     xbitmaps
+    xcalc
     xcmsdb
     xconsole
     xcursorgen
@@ -1206,50 +1208,6 @@ self: with self; {
         libX11
         libxkbfile
         libXrandr
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xcalc = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libXaw,
-      xorgproto,
-      libXt,
-      wrapWithXFileSearchPathHook,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xcalc";
-      version = "1.1.2";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xcalc-1.1.2.tar.xz";
-        sha256 = "1m0wzhjvc88kmx12ykdml5rqlz9h2iki9mkfdngji53y8nhxyy45";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        wrapWithXFileSearchPathHook
-      ];
-      buildInputs = [
-        libX11
-        libXaw
-        xorgproto
-        libXt
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -101,6 +101,7 @@
   xcursor-themes,
   xdriinfo,
   xev,
+  xeyes,
   xfontsel,
   xfsinfo,
   xgamma,
@@ -167,6 +168,7 @@ self: with self; {
     xcursorgen
     xdriinfo
     xev
+    xeyes
     xfontsel
     xfsinfo
     xgamma
@@ -1380,54 +1382,6 @@ self: with self; {
         libXxf86dga
         libXxf86misc
         libXxf86vm
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xeyes = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libxcb,
-      libXext,
-      libXi,
-      libXmu,
-      xorgproto,
-      libXrender,
-      libXt,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xeyes";
-      version = "1.3.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xeyes-1.3.0.tar.xz";
-        sha256 = "08rhfp5xlmdbyxkvxhgjxdn6vwzrbrjyd7jkk8b7wi1kpw0ccl09";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        libxcb
-        libXext
-        libXi
-        libXmu
-        xorgproto
-        libXrender
-        libXt
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -88,6 +88,7 @@
   transset,
   util-macros,
   viewres,
+  x11perf,
   xauth,
   xbacklight,
   xbitmaps,
@@ -153,6 +154,7 @@ self: with self; {
     smproxy
     transset
     viewres
+    x11perf
     xauth
     xbacklight
     xbitmaps
@@ -1204,50 +1206,6 @@ self: with self; {
         libX11
         libxkbfile
         libXrandr
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  x11perf = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libXext,
-      libXft,
-      libXmu,
-      xorgproto,
-      libXrender,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "x11perf";
-      version = "1.6.1";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/x11perf-1.6.1.tar.bz2";
-        sha256 = "0d3wh6z6znwhfdiv0zaggfj0xgish98xa10yy76b9517zj7hnzhw";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        libXext
-        libXft
-        libXmu
-        xorgproto
-        libXrender
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -422,6 +422,7 @@ print OUT <<EOF;
   xcalc,
   xcb-proto,
   xcmsdb,
+  xcompmgr,
   xconsole,
   xcursorgen,
   xcursor-themes,
@@ -488,6 +489,7 @@ self: with self; {
     xbitmaps
     xcalc
     xcmsdb
+    xcompmgr
     xconsole
     xcursorgen
     xdriinfo

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -415,6 +415,7 @@ print OUT <<EOF;
   transset,
   util-macros,
   viewres,
+  x11perf,
   xauth,
   xbacklight,
   xbitmaps,
@@ -480,6 +481,7 @@ self: with self; {
     smproxy
     transset
     viewres
+    x11perf
     xauth
     xbacklight
     xbitmaps

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -428,6 +428,7 @@ print OUT <<EOF;
   xcursor-themes,
   xdriinfo,
   xev,
+  xeyes,
   xfontsel,
   xfsinfo,
   xgamma,
@@ -494,6 +495,7 @@ self: with self; {
     xcursorgen
     xdriinfo
     xev
+    xeyes
     xfontsel
     xfsinfo
     xgamma

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -419,6 +419,7 @@ print OUT <<EOF;
   xauth,
   xbacklight,
   xbitmaps,
+  xcalc,
   xcb-proto,
   xcmsdb,
   xconsole,
@@ -485,6 +486,7 @@ self: with self; {
     xauth
     xbacklight
     xbitmaps
+    xcalc
     xcmsdb
     xconsole
     xcursorgen

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -411,8 +411,6 @@ self: super:
     };
   });
 
-  xeyes = addMainProgram super.xeyes { };
-
   xkbcomp = super.xkbcomp.overrideAttrs (attrs: {
     configureFlags = [ "--with-xkb-config-root=${xorg.xkeyboardconfig}/share/X11/xkb" ];
     meta = attrs.meta // {

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -720,7 +720,6 @@ self: super:
   });
 
   xclock = addMainProgram super.xclock { };
-  xcompmgr = addMainProgram super.xcompmgr { };
 
   xinit =
     (super.xinit.override {

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -217,16 +217,6 @@ self: super:
 
   oclock = addMainProgram super.oclock { };
 
-  x11perf = super.x11perf.overrideAttrs (attrs: {
-    buildInputs = attrs.buildInputs ++ [
-      freetype
-      fontconfig
-    ];
-    meta = attrs.meta // {
-      mainProgram = "x11perf";
-    };
-  });
-
   xcalc = addMainProgram super.xcalc { };
 
   xf86inputevdev = super.xf86inputevdev.overrideAttrs (attrs: {

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -217,8 +217,6 @@ self: super:
 
   oclock = addMainProgram super.oclock { };
 
-  xcalc = addMainProgram super.xcalc { };
-
   xf86inputevdev = super.xf86inputevdev.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -4,7 +4,6 @@ mirror://xorg/individual/app/fonttosfnt-1.2.4.tar.xz
 mirror://xorg/individual/app/iceauth-1.0.10.tar.xz
 mirror://xorg/individual/app/oclock-1.0.6.tar.xz
 mirror://xorg/individual/app/setxkbmap-1.3.4.tar.xz
-mirror://xorg/individual/app/x11perf-1.6.1.tar.bz2
 mirror://xorg/individual/app/xcalc-1.1.2.tar.xz
 mirror://xorg/individual/app/xclock-1.1.1.tar.xz
 mirror://xorg/individual/app/xcompmgr-1.1.10.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -4,7 +4,6 @@ mirror://xorg/individual/app/fonttosfnt-1.2.4.tar.xz
 mirror://xorg/individual/app/iceauth-1.0.10.tar.xz
 mirror://xorg/individual/app/oclock-1.0.6.tar.xz
 mirror://xorg/individual/app/setxkbmap-1.3.4.tar.xz
-mirror://xorg/individual/app/xcalc-1.1.2.tar.xz
 mirror://xorg/individual/app/xclock-1.1.1.tar.xz
 mirror://xorg/individual/app/xcompmgr-1.1.10.tar.xz
 mirror://xorg/individual/app/xdm-1.1.17.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -7,7 +7,6 @@ mirror://xorg/individual/app/setxkbmap-1.3.4.tar.xz
 mirror://xorg/individual/app/xclock-1.1.1.tar.xz
 mirror://xorg/individual/app/xdm-1.1.17.tar.xz
 mirror://xorg/individual/app/xdpyinfo-1.3.4.tar.xz
-mirror://xorg/individual/app/xeyes-1.3.0.tar.xz
 mirror://xorg/individual/app/xfd-1.1.4.tar.xz
 mirror://xorg/individual/app/xfs-1.2.2.tar.xz
 mirror://xorg/individual/app/xinit-1.4.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -5,7 +5,6 @@ mirror://xorg/individual/app/iceauth-1.0.10.tar.xz
 mirror://xorg/individual/app/oclock-1.0.6.tar.xz
 mirror://xorg/individual/app/setxkbmap-1.3.4.tar.xz
 mirror://xorg/individual/app/xclock-1.1.1.tar.xz
-mirror://xorg/individual/app/xcompmgr-1.1.10.tar.xz
 mirror://xorg/individual/app/xdm-1.1.17.tar.xz
 mirror://xorg/individual/app/xdpyinfo-1.3.4.tar.xz
 mirror://xorg/individual/app/xeyes-1.3.0.tar.xz

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13357,8 +13357,6 @@ with pkgs;
 
   xca = qt6Packages.callPackage ../applications/misc/xca { };
 
-  inherit (xorg) xcompmgr;
-
   xdg-desktop-portal = callPackage ../development/libraries/xdg-desktop-portal { };
 
   xdg-desktop-portal-hyprland =


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Build for platform:
  - [x] x86_64-linux
  - [x] x86_64-linux static
  - [x] aarch64-multiplatform
  - [x] aarch64-multiplatform-musl
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.`
  - as far as possible inside wayland
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] ran passthru.updateScript
- [x] ran nix-check-deps
- [x] ran nixpkgs-hammer
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc