### PR TITLE
lib{windowswm,xinerama,xkbfile,xshmfence,xtst}: refactor & move to pkgs/by-name from xorg namespace

### DIFF
--- a/pkgs/by-name/li/libwindowswm/package.nix
+++ b/pkgs/by-name/li/libwindowswm/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxext,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libwindowswm";
+  version = "1.0.1";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libWindowsWM-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-JfB8+EfL6R02wg80i0uUlMRQT+ApZujN9lz1YxanDtw=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxext
+  ];
+
+  configureFlags = lib.optional (
+    stdenv.hostPlatform != stdenv.buildPlatform
+  ) "--enable-malloc0returnsnull";
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libWindowsWM \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "library for Cygwin/X rootless window management extension";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libwindowswm";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    pkgConfigModules = [ "windowswm" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxinerama/package.nix
+++ b/pkgs/by-name/li/libxinerama/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxext,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxinerama";
+  version = "1.1.5";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libXinerama-${finalAttrs.version}.tar.xz";
+    hash = "sha256-UJTR8PzBgoyxaW0NOdnoZq4yUgxU0B9hjxo8HjDCCFw=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxext
+  ];
+
+  propagatedBuildInputs = [ xorgproto ];
+
+  configureFlags = lib.optional (
+    stdenv.hostPlatform != stdenv.buildPlatform
+  ) "--enable-malloc0returnsnull";
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libXinerama \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Library for Xinerama extension to X11 Protocol";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxinerama";
+    license = with lib.licenses; [
+      mit
+      mitOpenGroup
+      # TODO: change this to a new license depending on if this
+      # https://github.com/spdx/license-list-XML/issues/2831
+      # actually creates a new license or just new markup for X11
+      x11
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [ "xinerama" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxkbfile/package.nix
+++ b/pkgs/by-name/li/libxkbfile/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxkbfile";
+  version = "1.1.3";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libxkbfile-${finalAttrs.version}.tar.xz";
+    hash = "sha256-qbY+6pl6u57mqLT7tRWDHIQfRxr4RaCd5EOygAOHS+w=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "XKB file handling routines";
+    longDescription = ''
+      libxkbfile is used by the X servers and utilities to parse the XKB configuration data files.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxkbfile";
+    license = with lib.licenses; [
+      hpnd
+      mitOpenGroup
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [ "xkbfile" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxshmfence/package.nix
+++ b/pkgs/by-name/li/libxshmfence/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxshmfence";
+  version = "1.3.3";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libxshmfence-${finalAttrs.version}.tar.xz";
+    hash = "sha256-1KTfCWq6lv6gLAKe46ROEaR+t/chPBpym+g+hew/3hA=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ xorgproto ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Shared memory 'SyncFence' synchronization primitive library";
+    longDescription = ''
+      This library offers a CPU-based synchronization primitive compatible with the X SyncFence
+      objects that can be shared between processes using file descriptor passing.
+      There are two underlying implementations:
+      - On Linux, the library uses futexes
+      - On other systems, the library uses posix mutexes and condition variables.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxshmfence";
+    license = lib.licenses.hpndSellVariant;
+    maintainers = [ ];
+    pkgConfigModules = [ "xshmfence" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxtst/package.nix
+++ b/pkgs/by-name/li/libxtst/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxext,
+  libxi,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxtst";
+  version = "1.2.5";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libXtst-${finalAttrs.version}.tar.xz";
+    hash = "sha256-tQ1MJblwCadEcGwQOcWY9NjmSRDJ/eOBmU4criNdkkI=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxext
+    libxi
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libXtst \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Library for the XTEST and RECORD X11 extensions";
+    longDescription = ''
+      The XTEST extension is a minimal set of client and server extensions required to completely
+      test the X11 server with no user intervention. This extension is not intended to support
+      general journaling and playback of user actions.
+      The RECORD extension supports the recording and reporting of all core X protocol and arbitrary
+      X extension protocol.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxtst";
+    license = with lib.licenses; [
+      mitOpenGroup
+      hpndSellVariant
+      hpndDoc
+      x11
+      hpndDocSell
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [ "xtst" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -73,6 +73,7 @@
   libxrender,
   libxres,
   libxscrnsaver,
+  libxshmfence,
   libxt,
   libxv,
   libxvmc,
@@ -147,6 +148,7 @@ self: with self; {
     libxcb
     libxcvt
     libxkbfile
+    libxshmfence
     listres
     lndir
     luit
@@ -986,38 +988,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xtst" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libxshmfence = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libxshmfence";
-      version = "1.3.3";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libxshmfence-1.3.3.tar.xz";
-        sha256 = "046y7zn8agp8kdr1lg11yyvpx90i9sjf77h25jhgx5msd84xz96l";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [ xorgproto ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xshmfence" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -64,6 +64,7 @@
   libxft,
   libxi,
   libxinerama,
+  libxkbfile,
   libxmu,
   libxp,
   libxpm,
@@ -145,6 +146,7 @@ self: with self; {
     libpciaccess
     libxcb
     libxcvt
+    libxkbfile
     listres
     lndir
     luit
@@ -984,42 +986,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xtst" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libxkbfile = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libX11,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libxkbfile";
-      version = "1.1.3";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libxkbfile-1.1.3.tar.xz";
-        sha256 = "1v2bhw1q1cj3wjfs0igq393iz10whcavbyxlm3k9xfvsk7m3xdm9";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libX11
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xkbfile" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -40,6 +40,7 @@
   libpciaccess,
   libpthread-stubs,
   libsm,
+  libwindowswm,
   libx11,
   libxau,
   libxaw,
@@ -219,6 +220,7 @@ self: with self; {
   libICE = libice;
   libpthreadstubs = libpthread-stubs;
   libSM = libsm;
+  libWindowsWM = libwindowswm;
   libX11 = libx11;
   libXau = libxau;
   libXaw = libxaw;
@@ -900,44 +902,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libWindowsWM = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libX11,
-      libXext,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libWindowsWM";
-      version = "1.0.1";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libWindowsWM-1.0.1.tar.bz2";
-        sha256 = "1p0flwb67xawyv6yhri9w17m1i4lji5qnd0gq8v1vsfb8zw7rw15";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libX11
-        libXext
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "windowswm" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -63,6 +63,7 @@
   libxfont_2,
   libxft,
   libxi,
+  libxinerama,
   libxmu,
   libxp,
   libxpm,
@@ -234,6 +235,7 @@ self: with self; {
   libXfont = libxfont_1;
   libXft = libxft;
   libXi = libxi;
+  libXinerama = libxinerama;
   libXmu = libxmu;
   libXp = libxp;
   libXpm = libxpm;
@@ -942,44 +944,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xtrap" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXinerama = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      libXext,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXinerama";
-      version = "1.1.5";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXinerama-1.1.5.tar.xz";
-        sha256 = "0p08q8q1wg0sixhizl2l1i935bk6x3ckj3bdd6qqr0n1zkqd352h";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        libXext
-        xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xinerama" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -75,6 +75,7 @@
   libxscrnsaver,
   libxshmfence,
   libxt,
+  libxtst,
   libxv,
   libxvmc,
   libxxf86dga,
@@ -249,6 +250,7 @@ self: with self; {
   libXres = libxres;
   libXScrnSaver = libxscrnsaver;
   libXt = libxt;
+  libXtst = libxtst;
   libXv = libxv;
   libXvMC = libxvmc;
   libXxf86dga = libxxf86dga;
@@ -948,46 +950,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xtrap" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXtst = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libX11,
-      libXext,
-      libXi,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXtst";
-      version = "1.2.5";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXtst-1.2.5.tar.xz";
-        sha256 = "0hljblisw72fk60y7zf9214ydn7lk32kj43cf12af2bhp4jlq3dm";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libX11
-        libXext
-        libXi
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xtst" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -86,6 +86,7 @@ $pcMap{"xscrnsaver"} = "libXScrnSaver";
 $pcMap{"xshmfence"} = "libxshmfence";
 $pcMap{"xt"} = "libXt";
 $pcMap{"xtrans"} = "xtrans";
+$pcMap{"xtst"} = "libXtst";
 $pcMap{"xv"} = "libXv";
 $pcMap{"xvmc"} = "libXvMC";
 $pcMap{"xvmc-wrapper"} = "libXvMC";
@@ -405,6 +406,7 @@ print OUT <<EOF;
   libxscrnsaver,
   libxshmfence,
   libxt,
+  libxtst,
   libxv,
   libxvmc,
   libxxf86dga,
@@ -579,6 +581,7 @@ self: with self; {
   libXres = libxres;
   libXScrnSaver = libxscrnsaver;
   libXt = libxt;
+  libXtst = libxtst;
   libXv = libxv;
   libXvMC = libxvmc;
   libXxf86dga = libxxf86dga;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -83,6 +83,7 @@ $pcMap{"xrandr"} = "libXrandr";
 $pcMap{"xrender"} = "libXrender";
 $pcMap{"xres"} = "libXres";
 $pcMap{"xscrnsaver"} = "libXScrnSaver";
+$pcMap{"xshmfence"} = "libxshmfence";
 $pcMap{"xt"} = "libXt";
 $pcMap{"xtrans"} = "xtrans";
 $pcMap{"xv"} = "libXv";
@@ -402,6 +403,7 @@ print OUT <<EOF;
   libxrender,
   libxres,
   libxscrnsaver,
+  libxshmfence,
   libxt,
   libxv,
   libxvmc,
@@ -476,6 +478,7 @@ self: with self; {
     libxcb
     libxcvt
     libxkbfile
+    libxshmfence
     listres
     lndir
     luit

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -72,6 +72,7 @@ $pcMap{"xfont"} = "libXfont";
 $pcMap{"xfont2"} = "libXfont2";
 $pcMap{"xft"} = "libXft";
 $pcMap{"xi"} = "libXi";
+$pcMap{"xinerama"} = "libXinerama";
 $pcMap{"xmu"} = "libXmu";
 $pcMap{"xmuu"} = "libXmu";
 $pcMap{"xp"} = "libXp";
@@ -390,6 +391,7 @@ print OUT <<EOF;
   libxfont_2,
   libxft,
   libxi,
+  libxinerama,
   libxmu,
   libxp,
   libxpm,
@@ -561,6 +563,7 @@ self: with self; {
   libXfont = libxfont_1;
   libXft = libxft;
   libXi = libxi;
+  libXinerama = libxinerama;
   libXmu = libxmu;
   libXp = libxp;
   libXpm = libxpm;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -73,6 +73,7 @@ $pcMap{"xfont2"} = "libXfont2";
 $pcMap{"xft"} = "libXft";
 $pcMap{"xi"} = "libXi";
 $pcMap{"xinerama"} = "libXinerama";
+$pcMap{"xkbfile"} = "libxkbfile";
 $pcMap{"xmu"} = "libXmu";
 $pcMap{"xmuu"} = "libXmu";
 $pcMap{"xp"} = "libXp";
@@ -392,6 +393,7 @@ print OUT <<EOF;
   libxft,
   libxi,
   libxinerama,
+  libxkbfile,
   libxmu,
   libxp,
   libxpm,
@@ -473,6 +475,7 @@ self: with self; {
     libpciaccess
     libxcb
     libxcvt
+    libxkbfile
     listres
     lndir
     luit

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -367,6 +367,7 @@ print OUT <<EOF;
   libpciaccess,
   libpthread-stubs,
   libsm,
+  libwindowswm,
   libx11,
   libxau,
   libxaw,
@@ -546,6 +547,7 @@ self: with self; {
   libICE = libice;
   libpthreadstubs = libpthread-stubs;
   libSM = libsm;
+  libWindowsWM = libwindowswm;
   libX11 = libx11;
   libXau = libxau;
   libXaw = libxaw;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -140,12 +140,6 @@ self: super:
 
   mkfontdir = xorg.mkfontscale;
 
-  libXtst = super.libXtst.overrideAttrs (attrs: {
-    meta = attrs.meta // {
-      pkgConfigModules = [ "xtst" ];
-    };
-  });
-
   xdpyinfo = super.xdpyinfo.overrideAttrs (attrs: {
     configureFlags = attrs.configureFlags or [ ] ++ malloc0ReturnsNullCrossFlag;
     preConfigure =

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -178,13 +178,6 @@ self: super:
     };
   });
 
-  libxshmfence = super.libxshmfence.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-    ]; # mainly to avoid propagation
-  });
-
   setxkbmap = super.setxkbmap.overrideAttrs (attrs: {
     postInstall = ''
       mkdir -p $out/share/man/man7

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -178,14 +178,6 @@ self: super:
     };
   });
 
-  libXinerama = super.libXinerama.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-    ];
-    configureFlags = attrs.configureFlags or [ ] ++ malloc0ReturnsNullCrossFlag;
-  });
-
   libxkbfile = super.libxkbfile.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -146,10 +146,6 @@ self: super:
     };
   });
 
-  libWindowsWM = super.libWindowsWM.overrideAttrs (attrs: {
-    configureFlags = attrs.configureFlags or [ ] ++ malloc0ReturnsNullCrossFlag;
-  });
-
   xdpyinfo = super.xdpyinfo.overrideAttrs (attrs: {
     configureFlags = attrs.configureFlags or [ ] ++ malloc0ReturnsNullCrossFlag;
     preConfigure =

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -178,13 +178,6 @@ self: super:
     };
   });
 
-  libxkbfile = super.libxkbfile.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-    ]; # mainly to avoid propagation
-  });
-
   libxshmfence = super.libxshmfence.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -84,7 +84,6 @@ mirror://xorg/individual/font/font-ibm-type1-1.0.4.tar.xz
 mirror://xorg/individual/font/font-jis-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz
-mirror://xorg/individual/lib/libxkbfile-1.1.3.tar.xz
 mirror://xorg/individual/lib/libxshmfence-1.3.3.tar.xz
 mirror://xorg/individual/lib/libXTrap-1.0.1.tar.bz2
 mirror://xorg/individual/lib/libXtst-1.2.5.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -84,7 +84,6 @@ mirror://xorg/individual/font/font-ibm-type1-1.0.4.tar.xz
 mirror://xorg/individual/font/font-jis-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz
-mirror://xorg/individual/lib/libXinerama-1.1.5.tar.xz
 mirror://xorg/individual/lib/libxkbfile-1.1.3.tar.xz
 mirror://xorg/individual/lib/libxshmfence-1.3.3.tar.xz
 mirror://xorg/individual/lib/libXTrap-1.0.1.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -84,7 +84,6 @@ mirror://xorg/individual/font/font-ibm-type1-1.0.4.tar.xz
 mirror://xorg/individual/font/font-jis-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz
-mirror://xorg/individual/lib/libWindowsWM-1.0.1.tar.bz2
 mirror://xorg/individual/lib/libXinerama-1.1.5.tar.xz
 mirror://xorg/individual/lib/libxkbfile-1.1.3.tar.xz
 mirror://xorg/individual/lib/libxshmfence-1.3.3.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -85,5 +85,4 @@ mirror://xorg/individual/font/font-jis-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz
 mirror://xorg/individual/lib/libXTrap-1.0.1.tar.bz2
-mirror://xorg/individual/lib/libXtst-1.2.5.tar.xz
 mirror://xorg/individual/xserver/xorg-server-21.1.18.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -84,7 +84,6 @@ mirror://xorg/individual/font/font-ibm-type1-1.0.4.tar.xz
 mirror://xorg/individual/font/font-jis-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-meltho-1.0.4.tar.xz
 mirror://xorg/individual/font/font-misc-misc-1.1.3.tar.xz
-mirror://xorg/individual/lib/libxshmfence-1.3.3.tar.xz
 mirror://xorg/individual/lib/libXTrap-1.0.1.tar.bz2
 mirror://xorg/individual/lib/libXtst-1.2.5.tar.xz
 mirror://xorg/individual/xserver/xorg-server-21.1.18.tar.xz


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Build for platform:
  - [x] x86_64-linux
  - [x] x86_64-linux static
  - [x] aarch64-multiplatform
  - [x] aarch64-multiplatform-musl
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] ran passthru.updateScript
- [x] ran nix-check-deps
- [x] ran nixpkgs-hammer
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc