### PR TITLE
vscode-extensions.rooveterinaryinc.roo-cline: 3.28.16 -> 3.33.1

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/rooveterinaryinc.roo-cline/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/rooveterinaryinc.roo-cline/default.nix
@@ -8,8 +8,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     publisher = "RooVeterinaryInc";
     name = "roo-cline";
-    version = "3.28.16";
-    hash = "sha256-Ot7Rrb9tbnXEsVGpJXULq+8o3UhPA2rwtawSbop7wHg=";
+    version = "3.32.1";
+    hash = "sha256-pEWWvePC30X0RuAwLsgoWwYqigkocjMjQNIiGDC80Fk=";
   };
 
   passthru.updateScript = vscode-extension-update-script { };

--- a/pkgs/applications/editors/vscode/extensions/rooveterinaryinc.roo-cline/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/rooveterinaryinc.roo-cline/default.nix
@@ -8,8 +8,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     publisher = "RooVeterinaryInc";
     name = "roo-cline";
-    version = "3.32.1";
-    hash = "sha256-pEWWvePC30X0RuAwLsgoWwYqigkocjMjQNIiGDC80Fk=";
+    version = "3.33.1";
+    hash = "sha256-F9iQKh+OITlxNbFQf/IVoyeTkmo7S17nv6jq5GT7xCQ=";
   };
 
   passthru.updateScript = vscode-extension-update-script { };


### PR DESCRIPTION
Roo Code version bump to 3.32.1

Release notes from https://github.com/RooCodeInc/Roo-Code/releases

[Release v3.33.1](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.33.1) [Latest](https://github.com/RooCodeInc/Roo-Code/releases/latest)
[3.33.1] - 2025-11-18

3.33.1 Release - Native Tool Protocol Fixes

    Add native tool calling support to OpenAI-compatible (PR https://github.com/RooCodeInc/Roo-Code/pull/9369 by @mrubens)
    Fix: Resolve native tool protocol race condition causing 400 errors (PR https://github.com/RooCodeInc/Roo-Code/pull/9363 by @daniel-lxs)
    Fix: Update tools to return structured JSON for native protocol (PR https://github.com/RooCodeInc/Roo-Code/pull/9373 by @daniel-lxs)
    Fix: Include nativeArgs in tool repetition detection (PR https://github.com/RooCodeInc/Roo-Code/pull/9377 by @daniel-lxs)
    Fix: Ensure no XML parsing when protocol is native (PR https://github.com/RooCodeInc/Roo-Code/pull/9371 by @daniel-lxs)
    Fix: Gemini maxOutputTokens and reasoning config (PR https://github.com/RooCodeInc/Roo-Code/pull/9375 by @hannesrudolph)
    Fix: Gemini thought signature validation and token counting errors (PR https://github.com/RooCodeInc/Roo-Code/pull/9380 by @hannesrudolph)
    Fix: Exclude XML tool examples from MODES section when native protocol enabled (PR https://github.com/RooCodeInc/Roo-Code/pull/9367 by @daniel-lxs)
    Retry eval tasks if API instability detected (PR https://github.com/RooCodeInc/Roo-Code/pull/9365 by @cte)
    Add toolProtocol property to PostHog tool usage telemetry (PR https://github.com/RooCodeInc/Roo-Code/pull/9374 by @app/roomote)

[Release v3.33.0](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.33.0)
[3.33.0] - 2025-11-18

v3.33.0 Release - Twin Kangaroos and the Gemini Constellation

    Add Gemini 3 Pro Preview model (PR https://github.com/RooCodeInc/Roo-Code/pull/9357 by @hannesrudolph)
    Improve Google Gemini defaults with better temperature and cost reporting (PR https://github.com/RooCodeInc/Roo-Code/pull/9327 by @hannesrudolph)
    Enable native tool calling for openai-native provider (PR https://github.com/RooCodeInc/Roo-Code/pull/9348 by @hannesrudolph)
    Add git status information to environment details (PR https://github.com/RooCodeInc/Roo-Code/pull/9310 by @daniel-lxs)
    Add tool protocol selector to advanced settings (PR https://github.com/RooCodeInc/Roo-Code/pull/9324 by @daniel-lxs)
    Implement dynamic tool protocol resolution with proper precedence hierarchy (PR https://github.com/RooCodeInc/Roo-Code/pull/9286 by @daniel-lxs)
    Move Import/Export functionality to Modes view toolbar and cleanup Mode Edit view (PR https://github.com/RooCodeInc/Roo-Code/pull/9077 by @hannesrudolph)
    Update cloud agent CTA to point to setup page (PR https://github.com/RooCodeInc/Roo-Code/pull/9338 by @app/roomote)
    Fix: Prevent duplicate tool_result blocks in native tool protocol (PR https://github.com/RooCodeInc/Roo-Code/pull/9248 by @daniel-lxs)
    Fix: Format tool responses properly for native protocol (PR https://github.com/RooCodeInc/Roo-Code/pull/9270 by @daniel-lxs)
    Fix: Centralize toolProtocol configuration checks (PR https://github.com/RooCodeInc/Roo-Code/pull/9279 by @daniel-lxs)
    Fix: Preserve tool blocks for native protocol in conversation history (PR https://github.com/RooCodeInc/Roo-Code/pull/9319 by @daniel-lxs)
    Fix: Prevent infinite loop when task_done succeeds (PR https://github.com/RooCodeInc/Roo-Code/pull/9325 by @daniel-lxs)
    Fix: Sync parser state with profile/model changes (PR https://github.com/RooCodeInc/Roo-Code/pull/9355 by @daniel-lxs)
    Fix: Pass tool protocol parameter to lineCountTruncationError (PR https://github.com/RooCodeInc/Roo-Code/pull/9358 by @daniel-lxs)
    Use VSCode theme color for outline button borders (PR https://github.com/RooCodeInc/Roo-Code/pull/9336 by @app/roomote)
    Replace broken badgen.net badges with shields.io (PR https://github.com/RooCodeInc/Roo-Code/pull/9318 by @app/roomote)
    Add max git status files setting to evals (PR https://github.com/RooCodeInc/Roo-Code/pull/9322 by @mrubens)
    Roo Code Cloud Provider pricing page and changes elsewhere (PR https://github.com/RooCodeInc/Roo-Code/pull/9195 by @brunobergher)

[Release v3.32.1](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.32.1)
[3.32.1] - 2025-11-14

    Fix: Add abort controller for request cancellation in OpenAI native protocol (PR https://github.com/RooCodeInc/Roo-Code/pull/9276 by @daniel-lxs)
    Fix: Resolve duplicate tool blocks causing 'tool has already been used' error in native protocol mode (PR https://github.com/RooCodeInc/Roo-Code/pull/9275 by @daniel-lxs)
    Fix: Prevent duplicate tool_result blocks in native protocol mode for read_file (PR https://github.com/RooCodeInc/Roo-Code/pull/9272 by @daniel-lxs)
    Fix: Correct OpenAI Native handling of encrypted reasoning blocks to prevent errors during condensing (PR https://github.com/RooCodeInc/Roo-Code/pull/9263 by @hannesrudolph)
    Fix: Disable XML parser for native tool protocol to prevent parsing conflicts (PR https://github.com/RooCodeInc/Roo-Code/pull/9277 by @daniel-lxs)

[Release v3.32.0](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.32.0)
[3.32.0] - 2025-11-14

    Feature: Add GPT-5.1 models to OpenAI provider (PR https://github.com/RooCodeInc/Roo-Code/pull/9252 by @hannesrudolph)
    Feature: Support for OpenAI Responses 24 hour prompt caching (PR https://github.com/RooCodeInc/Roo-Code/pull/9259 by @hannesrudolph)
    Fix: Repair the share button in the UI (PR https://github.com/RooCodeInc/Roo-Code/pull/9253 by @hannesrudolph)
    Docs: Include PR numbers in the release guide to improve traceability (PR https://github.com/RooCodeInc/Roo-Code/pull/9236 by @hannesrudolph)

[Release v3.31.3](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.31.3)
[3.31.3] - 2025-11-13

    Fix: OpenAI Native encrypted_content handling and remove gpt-5-chat-latest verbosity flag (https://github.com/RooCodeInc/Roo-Code/issues/9225 by @politsin, PR by @hannesrudolph)
    Fix: Roo Code Cloud provider Anthropic input token normalization to avoid double-counting (thanks @hannesrudolph!)
    Refactor: Rename sliding-window to context-management and truncateConversationIfNeeded to manageContext (thanks @hannesrudolph!)

[Release v3.31.2](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.31.2)
[3.31.2] - 2025-11-12

    Fix: Apply updated API profile settings when provider/model unchanged (https://github.com/RooCodeInc/Roo-Code/issues/9208 by @hannesrudolph, PR by @hannesrudolph)
    Migrate conversation continuity to plugin-side encrypted reasoning items using Responses API for improved reliability (thanks @hannesrudolph!)
    Fix: Include mcpServers in getState() for auto-approval (https://github.com/RooCodeInc/Roo-Code/issues/9190 by @bozoweed, PR by @daniel-lxs)
    Batch settings updates from the webview to the extension host for improved performance (thanks @cte!)
    Fix: Replace rate-limited badges with badgen.net to improve README reliability (thanks @daniel-lxs!)

[Release v3.31.1](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.31.1)
[3.31.1] - 2025-11-11

    Fix: Prevent command_output ask from blocking in cloud/headless environments (thanks @daniel-lxs!)
    Add IPC command for sending messages to the current task (thanks @mrubens!)
    Fix: Model switch re-applies selected profile, ensuring task configuration stays in sync (https://github.com/RooCodeInc/Roo-Code/issues/9179 by @hannesrudolph, PR by @hannesrudolph)
    Move auto-approval logic from ChatView to Task for better architecture (thanks @cte!)
    Add custom Button component with variant system (thanks @brunobergher!)

[Release v3.31.0](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.31.0)
[3.31.0] - 2025-11-07

    Improvements to to-do lists and task headers (thanks @brunobergher!)
    Fix: Prevent crash when streaming chunks have null choices array (thanks @daniel-lxs!)
    Fix: Prevent context condensing on settings save when provider/model unchanged (https://github.com/RooCodeInc/Roo-Code/issues/4430 by @hannesrudolph, PR by @daniel-lxs)
    Fix: Respect custom OpenRouter URL for all API operations (https://github.com/RooCodeInc/Roo-Code/issues/8947 by @sstraus, PR by @roomote)
    Add comprehensive error logging to Roo Cloud provider (thanks @daniel-lxs!)
    UX: Less caffeinated kangaroo (thanks @brunobergher!)

[Release v3.30.3](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.30.3)
[3.30.3] - 2025-11-06

    Feat: Add kimi-k2-thinking model to Moonshot provider (thanks @daniel-lxs!)
    Fix: Auto-retry on empty assistant response to prevent task failures (https://github.com/RooCodeInc/Roo-Code/issues/9076 by @Akillatech, PR by @daniel-lxs)
    Fix: Use system role for OpenAI Compatible provider when streaming is disabled (https://github.com/RooCodeInc/Roo-Code/issues/8215 by @whitfin, PR by @roomote)
    Fix: Prevent notification sound on attempt_completion with queued messages (https://github.com/RooCodeInc/Roo-Code/issues/8537 by @hannesrudolph, PR by @roomote)
    Feat: Auto-switch to imported mode with architect fallback for better mode detection (https://github.com/RooCodeInc/Roo-Code/issues/8239 by @hannesrudolph, PR by @daniel-lxs)
    Feat: Add MiniMax-M2-Stable model and enable prompt caching (https://github.com/RooCodeInc/Roo-Code/issues/9070 by @nokaka, PR by @roomote)
    Feat: Improve diff appearance in main chat view (thanks @hannesrudolph!)
    UX: Home screen visuals (thanks @brunobergher!)
    Docs: Clarify that setting 0 disables Error & Repetition Limit (thanks @roomote!)
    Chore: Update dependency @changesets/cli to v2.29.7 (thanks @renovate!)

[Release v3.30.2](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.30.2)
[3.30.2] - 2025-11-05

    Fix: eliminate UI flicker during task cancellation (thanks @daniel-lxs!)
    Add Global Inference support for Bedrock models (https://github.com/RooCodeInc/Roo-Code/issues/8750 by @ronyblum, PR by @hannesrudolph)
    Add Qwen3 embedding models (0.6B and 4B) to OpenRouter support (https://github.com/RooCodeInc/Roo-Code/issues/9058 by @dmarkey, PR by @app/roomote)
    Fix: resolve incorrect commit location when GIT_DIR set in Dev Containers (https://github.com/RooCodeInc/Roo-Code/issues/4567 by @nonsleepr, PR by @heyseth)
    Fix: keep pinned models fixed at top of scrollable list (https://github.com/RooCodeInc/Roo-Code/issues/8812 by @XiaoYingYo, PR by @app/roomote)
    Fix: update Opus 4.1 max tokens from 8K to 32K (https://github.com/RooCodeInc/Roo-Code/issues/9045 by @kaveh-deriv, PR by @app/roomote)
    Set Claude Sonnet 4.5 as default for key providers (thanks @hannesrudolph!)
    Fix: dynamic provider model validation to prevent cross-contamination (https://github.com/RooCodeInc/Roo-Code/issues/9047 by @NotADev137, PR by @daniel-lxs)
    Fix: Bedrock user agent to report full SDK details (https://github.com/RooCodeInc/Roo-Code/issues/9031 by @ajjuaire, PR by @ajjuaire)
    Add file path tooltips with centralized PathTooltip component (https://github.com/RooCodeInc/Roo-Code/issues/8278 by @da2ce7, PR by @daniel-lxs)
    Add conditional test running to pre-push hook (thanks @daniel-lxs!)
    Update Cerebras integration (thanks @sebastiand-cerebras!)

[Release v3.30.1](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.30.1) [Latest](https://github.com/RooCodeInc/Roo-Code/releases/latest)
[3.30.1] - 2025-11-04

    Fix: Correct OpenRouter Mistral model embedding dimension from 3072 to 1536 (thanks @daniel-lxs!)
    Revert: Previous UI flicker fix that caused issues with task resumption (thanks @mrubens!)

[Release v3.30.0](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.30.0)
[3.30.0] - 2025-11-03

    Feat: Add OpenRouter embedding provider support (https://github.com/RooCodeInc/Roo-Code/issues/8972 by @dmarkey, PR by @dmarkey)
    Feat: Add GLM-4.6 model to Fireworks provider (https://github.com/RooCodeInc/Roo-Code/issues/8752 by @mmealman, PR by @app/roomote)
    Feat: Add MiniMax M2 model to Fireworks provider (https://github.com/RooCodeInc/Roo-Code/issues/8961 by @dmarkey, PR by @app/roomote)
    Feat: Add preserveReasoning flag to include reasoning in API history (thanks @daniel-lxs!)
    Fix: Prevent message loss during queue drain race condition (https://github.com/RooCodeInc/Roo-Code/issues/8536 by @hannesrudolph, PR by @daniel-lxs)
    Fix: Capture the reasoning content in base-openai-compatible for GLM 4.6 (thanks @mrubens!)
    Fix: Create new Requesty profile during OAuth (thanks @Thibault00!)
    Fix: Prevent UI flicker and enable resumption after task cancellation (thanks @daniel-lxs!)
    Fix: Cleanup terminal settings tab and change default terminal to inline (thanks @hannesrudolph!)

[Release v3.29.5](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.29.5)
[3.29.5] - 2025-11-01

    Fix: Resolve Qdrant codebase_search error by adding keyword index for type field (https://github.com/RooCodeInc/Roo-Code/issues/8963 by @rossdonald, PR by @app/roomote)
    Fix cost and token tracking between provider styles to ensure accurate usage metrics (thanks @mrubens!)

[Release v3.29.4](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.29.4)
[3.29.4] - 2025-10-30

    Feat: Add Minimax Provider (thanks @Maosghoul!)
    Fix: prevent infinite loop when canceling during auto-retry (https://github.com/RooCodeInc/Roo-Code/issues/8901 by @mini2s, PR by @app/roomote)
    Fix: Enhanced codebase index recovery and reuse ('Start Indexing' button now reuses existing Qdrant index) (https://github.com/RooCodeInc/Roo-Code/issues/8129 by @jaroslaw-weber, PR by @heyseth)
    Fix: make code index initialization non-blocking at activation (https://github.com/RooCodeInc/Roo-Code/issues/8777 by @cjlawson02, PR by @daniel-lxs)
    Fix: remove search_and_replace tool from codebase (https://github.com/RooCodeInc/Roo-Code/issues/8891 by @hannesrudolph, PR by @app/roomote)
    Fix: custom modes under custom path not showing (https://github.com/RooCodeInc/Roo-Code/issues/8122 by @hannesrudolph, PR by @elianiva)
    Fix: prevent MCP server restart when toggling tool permissions (https://github.com/RooCodeInc/Roo-Code/issues/8231 by @hannesrudolph, PR by @heyseth)
    Fix: truncate type definition to match max read line (https://github.com/RooCodeInc/Roo-Code/issues/8149 by @chenxluo, PR by @elianiva)
    Fix: auto-sync enableReasoningEffort with reasoning dropdown selection (thanks @daniel-lxs!)
    Fix: Gate auth-driven Roo model refresh to active provider only (thanks @daniel-lxs!)
    Prevent a noisy cloud agent exception (thanks @cte!)
    Feat: improve @ file search for large projects (https://github.com/RooCodeInc/Roo-Code/issues/5721 by @Naituw, PR by @daniel-lxs)
    Feat: add zai-glm-4.6 model to Cerebras and set gpt-oss-120b as default (thanks @kevint-cerebras!)
    Feat: rename MCP Errors tab to Logs for mixed-level messages (https://github.com/RooCodeInc/Roo-Code/issues/8893 by @hannesrudolph, PR by @app/roomote)
    docs(vscode-lm): clarify VS Code LM API integration warning (thanks @hannesrudolph!)

[Release v3.29.3](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.29.3)
[3.29.3] - 2025-10-28

    Update Gemini models with latest 09-2025 versions including Gemini 2.5 Pro and Flash (https://github.com/RooCodeInc/Roo-Code/issues/8485 by @cleacos, PR by @roomote)
    Add reasoning support for Z.ai GLM binary thinking mode (https://github.com/RooCodeInc/Roo-Code/issues/8465 by @BeWater799, PR by @daniel-lxs)
    Enable reasoning in Roo provider (thanks @mrubens!)
    Add settings to configure time and cost display in system prompt (https://github.com/RooCodeInc/Roo-Code/issues/8450 by @jaxnb, PR by @roomote)
    Fix: Use max_output_tokens when available in LiteLLM fetcher (https://github.com/RooCodeInc/Roo-Code/issues/8454 by @fabb, PR by @roomote)
    Fix: Process queued messages after context condensing completes (https://github.com/RooCodeInc/Roo-Code/issues/8477 by @JosXa, PR by @roomote)
    Fix: Use monotonic clock for rate limiting to prevent timing issues (https://github.com/RooCodeInc/Roo-Code/issues/7770 by @intermarkec, PR by @chrarnoldus)
    Fix: Resolve checkpoint menu popover overflow (thanks @daniel-lxs!)
    Fix: LiteLLM test failures after merge (thanks @daniel-lxs!)
    Improve UX: Focus textbox and add newlines after adding to context (thanks @mrubens!)

[Release v3.29.2](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.29.2)
[3.29.2] - 2025-10-27

    Add support for LongCat-Flash-Thinking-FP8 models in Chutes AI provider (https://github.com/RooCodeInc/Roo-Code/issues/8425 by @leakless21, PR by @roomote)
    Fix: Remove specific Claude model version from settings descriptions to avoid outdated references (https://github.com/RooCodeInc/Roo-Code/issues/8435 by @rwydaegh, PR by @roomote)
    Fix: Correct caching logic in Roo provider to improve performance (thanks @mrubens!)
    Fix: Ensure free models don't display pricing information in the UI (thanks @mrubens!)

[Release v3.29.1](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.29.1)

3.29.1 Release - Window Cleaning

    Fix: Clean up max output token calculations to prevent context window overruns (https://github.com/RooCodeInc/Roo-Code/issues/8821 by @enerage, PR by @roomote)
    Fix: Change Add to Context keybinding to avoid Redo conflict (https://github.com/RooCodeInc/Roo-Code/issues/8652 by @swythan, PR by @roomote)
    Fix provider model loading race conditions (thanks @mrubens!)

[Release v3.29.0](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.29.0)
[3.29.0] - 2025-10-24

    Add token-budget based file reading with intelligent preview to avoid context overruns (thanks @daniel-lxs!)
    Enable browser-use tool for all image-capable models (https://github.com/RooCodeInc/Roo-Code/issues/8116 by @hannesrudolph, PR by @app/roomote!)
    Add dynamic model loading for Roo Code Cloud provider (thanks @app/roomote!)
    Fix: Respect nested .gitignore files in search_files (https://github.com/RooCodeInc/Roo-Code/issues/7921 by @hannesrudolph, PR by @daniel-lxs)
    Fix: Preserve trailing newlines in stripLineNumbers for apply_diff (https://github.com/RooCodeInc/Roo-Code/issues/8020 by @liyi3c, PR by @app/roomote)
    Fix: Exclude max tokens field for models that don't support it in export (https://github.com/RooCodeInc/Roo-Code/issues/7944 by @hannesrudolph, PR by @elianiva)
    Retry API requests on stream failures instead of aborting task (thanks @daniel-lxs!)
    Improve auto-approve button responsiveness (thanks @daniel-lxs!)
    Add checkpoint initialization timeout settings and fix checkpoint timeout warnings (https://github.com/RooCodeInc/Roo-Code/issues/7843 by @NaccOll, PR by @NaccOll)
    Always show checkpoint restore options regardless of change detection (thanks @daniel-lxs!)
    Improve checkpoint menu translations (thanks @daniel-lxs!)
    Add GLM-4.6-turbo model to chutes ai provider (thanks @mohammad154!)
    Add Claude Haiku 4.5 to prompt caching models (thanks @hannesrudolph!)
    Expand Z.ai model coverage with GLM-4.5-X, AirX, Flash (thanks @hannesrudolph!)
    Update Mistral Medium model name (https://github.com/RooCodeInc/Roo-Code/issues/8362 by @ThomsenDrake, PR by @ThomsenDrake)
    Remove GPT-5 instructions/reasoning_summary from UI message metadata to prevent ui_messages.json bloat (thanks @hannesrudolph!)
    Normalize docs-extractor audience tags; remove admin/stakeholder; strip tool invocations (thanks @hannesrudolph!)
    Update X/Twitter username from roo_code to roocode (thanks @app/roomote!)
    Update Configuring Profiles video link (thanks @app/roomote!)
    Fix link text for Roomote Control in README (thanks @laz-001!)
    Remove verbose error for cloud agents (thanks @cte!)
    Try 5s status mutation timeout (thanks @cte!)

[Release v3.28.18](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.28.18)
[3.28.18] - 2025-10-17

    Fix: Remove request content from UI messages to improve performance and reduce clutter (https://github.com/RooCodeInc/Roo-Code/issues/5601 by @MuriloFP, https://github.com/RooCodeInc/Roo-Code/issues/8594 by @multivac2x, https://github.com/RooCodeInc/Roo-Code/issues/8690 by @hannesrudolph, PR by @mrubens)
    Fix: Prevent file editing issues when git diff views are open (thanks @hassoncs!)
    Fix: Add userAgent to Bedrock client for version tracking (https://github.com/RooCodeInc/Roo-Code/issues/8660 by @ajjuaire, PR by @app/roomote)
    Feat: Z AI now uses only two coding endpoints for better performance (https://github.com/RooCodeInc/Roo-Code/issues/8687 by @hannesrudolph)
    Feat: Update image generation model selection for improved quality (thanks @chrarnoldus!)

[Release v3.28.17](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.28.17)
[3.28.17] - 2025-10-15

    Add support for Claude Haiku 4.5 model (thanks @daniel-lxs!)
    Fix: Update zh-TW run command title translation (thanks @PeterDaveHello!)

[Release v3.29.0](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.29.0) 
[3.29.0] - 2025-10-24

    Add token-budget based file reading with intelligent preview to avoid context overruns (thanks @daniel-lxs!)
    Enable browser-use tool for all image-capable models (https://github.com/RooCodeInc/Roo-Code/issues/8116 by @hannesrudolph, PR by @app/roomote!)
    Add dynamic model loading for Roo Code Cloud provider (thanks @app/roomote!)
    Fix: Respect nested .gitignore files in search_files (https://github.com/RooCodeInc/Roo-Code/issues/7921 by @hannesrudolph, PR by @daniel-lxs)
    Fix: Preserve trailing newlines in stripLineNumbers for apply_diff (https://github.com/RooCodeInc/Roo-Code/issues/8020 by @liyi3c, PR by @app/roomote)
    Fix: Exclude max tokens field for models that don't support it in export (https://github.com/RooCodeInc/Roo-Code/issues/7944 by @hannesrudolph, PR by @elianiva)
    Retry API requests on stream failures instead of aborting task (thanks @daniel-lxs!)
    Improve auto-approve button responsiveness (thanks @daniel-lxs!)
    Add checkpoint initialization timeout settings and fix checkpoint timeout warnings (https://github.com/RooCodeInc/Roo-Code/issues/7843 by @NaccOll, PR by @NaccOll)
    Always show checkpoint restore options regardless of change detection (thanks @daniel-lxs!)
    Improve checkpoint menu translations (thanks @daniel-lxs!)
    Add GLM-4.6-turbo model to chutes ai provider (thanks @mohammad154!)
    Add Claude Haiku 4.5 to prompt caching models (thanks @hannesrudolph!)
    Expand Z.ai model coverage with GLM-4.5-X, AirX, Flash (thanks @hannesrudolph!)
    Update Mistral Medium model name (https://github.com/RooCodeInc/Roo-Code/issues/8362 by @ThomsenDrake, PR by @ThomsenDrake)
    Remove GPT-5 instructions/reasoning_summary from UI message metadata to prevent ui_messages.json bloat (thanks @hannesrudolph!)
    Normalize docs-extractor audience tags; remove admin/stakeholder; strip tool invocations (thanks @hannesrudolph!)
    Update X/Twitter username from roo_code to roocode (thanks @app/roomote!)
    Update Configuring Profiles video link (thanks @app/roomote!)
    Fix link text for Roomote Control in README (thanks @laz-001!)
    Remove verbose error for cloud agents (thanks @cte!)
    Try 5s status mutation timeout (thanks @cte!)


[Release v3.28.18](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.28.18)
[3.28.18] - 2025-10-17

    Fix: Remove request content from UI messages to improve performance and reduce clutter (https://github.com/RooCodeInc/Roo-Code/issues/5601 by @MuriloFP, https://github.com/RooCodeInc/Roo-Code/issues/8594 by @multivac2x, https://github.com/RooCodeInc/Roo-Code/issues/8690 by @hannesrudolph, PR by @mrubens)
    Fix: Prevent file editing issues when git diff views are open (thanks @hassoncs!)
    Fix: Add userAgent to Bedrock client for version tracking (https://github.com/RooCodeInc/Roo-Code/issues/8660 by @ajjuaire, PR by @app/roomote)
    Feat: Z AI now uses only two coding endpoints for better performance (https://github.com/RooCodeInc/Roo-Code/issues/8687 by @hannesrudolph)
    Feat: Update image generation model selection for improved quality (thanks @chrarnoldus!)


[Release v3.28.17](https://github.com/RooCodeInc/Roo-Code/releases/tag/v3.28.17)
[3.28.17] - 2025-10-15

    Add support for Claude Haiku 4.5 model (thanks @daniel-lxs!)
    Fix: Update zh-TW run command title translation (thanks @PeterDaveHello!)

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
