### PR TITLE
treewide: gate command execution for `installShellCompletion` behind `buildPlatform.canExecute hostPlatform`

### DIFF
--- a/pkgs/applications/networking/cluster/kops/default.nix
+++ b/pkgs/applications/networking/cluster/kops/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -45,7 +46,7 @@ let
 
       doCheck = false;
 
-      postInstall = ''
+      postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
         installShellCompletion --cmd kops \
           --bash <($GOPATH/bin/kops completion bash) \
           --fish <($GOPATH/bin/kops completion fish) \

--- a/pkgs/applications/networking/cluster/kuma/default.nix
+++ b/pkgs/applications/networking/cluster/kuma/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   buildGoModule,
   coredns,
@@ -40,12 +41,14 @@ buildGoModule rec {
   subPackages = map (p: "app/" + p) components;
 
   postInstall =
-    lib.concatMapStringsSep "\n" (p: ''
-      installShellCompletion --cmd ${p} \
-        --bash <($out/bin/${p} completion bash) \
-        --fish <($out/bin/${p} completion fish) \
-        --zsh <($out/bin/${p} completion zsh)
-    '') components
+    lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) (
+      lib.concatMapStringsSep "\n" (p: ''
+        installShellCompletion --cmd ${p} \
+          --bash <($out/bin/${p} completion bash) \
+          --fish <($out/bin/${p} completion fish) \
+          --zsh <($out/bin/${p} completion zsh)
+      '') components
+    )
     + lib.optionalString isFull ''
       ln -sLf ${coredns}/bin/coredns $out/bin
     '';

--- a/pkgs/applications/networking/cluster/linkerd/generic.nix
+++ b/pkgs/applications/networking/cluster/linkerd/generic.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   buildGoModule,
   installShellFiles,
@@ -51,6 +52,8 @@ buildGoModule rec {
 
   postInstall = ''
     mv $out/bin/cli $out/bin/linkerd
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd linkerd \
       --bash <($out/bin/linkerd completion bash) \
       --zsh <($out/bin/linkerd completion zsh) \

--- a/pkgs/by-name/_1/_1password-cli/package.nix
+++ b/pkgs/by-name/_1/_1password-cli/package.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     HOME=$TMPDIR
     installShellCompletion --cmd ${mainProgram} \
       --bash <($out/bin/${mainProgram} completion bash) \

--- a/pkgs/by-name/ab/abbreviate/package.nix
+++ b/pkgs/by-name/ab/abbreviate/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -27,7 +28,7 @@ buildGoModule rec {
     "-w"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd abbreviate \
       --bash <($out/bin/abbreviate completion bash) \
       --fish <($out/bin/abbreviate completion fish) \

--- a/pkgs/by-name/al/algolia-cli/package.nix
+++ b/pkgs/by-name/al/algolia-cli/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -30,7 +31,7 @@ buildGoModule {
     "-X github.com/algolia/cli/pkg/version.Version=${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd algolia \
       --bash <($out/bin/algolia completion bash) \
       --fish <($out/bin/algolia completion fish) \

--- a/pkgs/by-name/an/angrr/package.nix
+++ b/pkgs/by-name/an/angrr/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
   installShellFiles,
@@ -22,7 +23,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-lo9JpsHkvyrEqFnIiGlU2o4rREeQeqWpe9WMwisvw+4=";
 
   nativeBuildInputs = [ installShellFiles ];
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd angrr \
       --bash <($out/bin/angrr completion bash) \
       --fish <($out/bin/angrr completion fish) \

--- a/pkgs/by-name/ar/arkade/package.nix
+++ b/pkgs/by-name/ar/arkade/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -42,7 +43,7 @@ buildGoModule rec {
     "-X github.com/alexellis/arkade/pkg.Version=${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd arkade \
       --bash <($out/bin/arkade completion bash) \
       --zsh <($out/bin/arkade completion zsh) \

--- a/pkgs/by-name/as/astartectl/package.nix
+++ b/pkgs/by-name/as/astartectl/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -19,7 +20,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd astartectl \
       --bash <($out/bin/astartectl completion bash) \
       --fish <($out/bin/astartectl completion fish) \

--- a/pkgs/by-name/at/atlas/package.nix
+++ b/pkgs/by-name/at/atlas/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -32,7 +33,7 @@ buildGoModule (finalAttrs: {
 
   subPackages = [ "." ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd atlas \
       --bash <($out/bin/atlas completion bash) \
       --fish <($out/bin/atlas completion fish) \

--- a/pkgs/by-name/au/autorestic/package.nix
+++ b/pkgs/by-name/au/autorestic/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   installShellFiles,
   buildGoModule,
@@ -20,7 +21,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd autorestic \
          --bash <($out/bin/autorestic completion bash) \
          --fish <($out/bin/autorestic completion fish) \

--- a/pkgs/by-name/ba/badrobot/package.nix
+++ b/pkgs/by-name/ba/badrobot/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -25,7 +26,7 @@ buildGoModule rec {
     "-X github.com/controlplaneio/badrobot/cmd.version=v${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd badrobot \
       --bash <($out/bin/badrobot completion bash) \
       --fish <($out/bin/badrobot completion fish) \

--- a/pkgs/by-name/bl/bleep/package.nix
+++ b/pkgs/by-name/bl/bleep/package.nix
@@ -53,7 +53,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     lib.optionalString stdenvNoCC.hostPlatform.isLinux ''
       autoPatchelf $out
     ''
-    + ''
+    + lib.optionalString (stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform) ''
       export PATH=$PATH:$out/bin
       installShellCompletion --cmd bleep \
         --bash <(bleep install-tab-completions-bash --stdout) \

--- a/pkgs/by-name/bo/bom/package.nix
+++ b/pkgs/by-name/bo/bom/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -43,7 +44,7 @@ buildGoModule rec {
     ldflags+=" -X sigs.k8s.io/release-utils/version.buildDate=$(cat SOURCE_DATE_EPOCH)"
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd bom \
       --bash <($out/bin/bom completion bash) \
       --fish <($out/bin/bom completion fish) \

--- a/pkgs/by-name/bo/borgmatic/package.nix
+++ b/pkgs/by-name/bo/borgmatic/package.nix
@@ -56,21 +56,22 @@ python3Packages.buildPythonApplication rec {
     apprise = [ python3Packages.apprise ];
   };
 
-  postInstall = ''
-    installShellCompletion --cmd borgmatic \
-      --bash <($out/bin/borgmatic --bash-completion)
-  ''
-  + lib.optionalString enableSystemd ''
-    mkdir -p $out/lib/systemd/system
-    cp sample/systemd/borgmatic.timer $out/lib/systemd/system/
-    # there is another "sleep", so choose the one with the space after it
-    # due to https://github.com/borgmatic-collective/borgmatic/commit/2e9f70d49647d47fb4ca05f428c592b0e4319544
-    substitute sample/systemd/borgmatic.service \
-               $out/lib/systemd/system/borgmatic.service \
-               --replace /root/.local/bin/borgmatic $out/bin/borgmatic \
-               --replace systemd-inhibit ${systemd}/bin/systemd-inhibit \
-               --replace "sleep " "${coreutils}/bin/sleep "
-  '';
+  postInstall =
+    lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd borgmatic \
+        --bash <($out/bin/borgmatic --bash-completion)
+    ''
+    + lib.optionalString enableSystemd ''
+      mkdir -p $out/lib/systemd/system
+      cp sample/systemd/borgmatic.timer $out/lib/systemd/system/
+      # there is another "sleep", so choose the one with the space after it
+      # due to https://github.com/borgmatic-collective/borgmatic/commit/2e9f70d49647d47fb4ca05f428c592b0e4319544
+      substitute sample/systemd/borgmatic.service \
+                 $out/lib/systemd/system/borgmatic.service \
+                 --replace /root/.local/bin/borgmatic $out/bin/borgmatic \
+                 --replace systemd-inhibit ${systemd}/bin/systemd-inhibit \
+                 --replace "sleep " "${coreutils}/bin/sleep "
+    '';
 
   passthru.tests = {
     version = testers.testVersion { package = borgmatic; };

--- a/pkgs/by-name/bu/buildpack/package.nix
+++ b/pkgs/by-name/bu/buildpack/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -31,7 +32,7 @@ buildGoModule {
     "-X github.com/buildpacks/pack.Version=${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd pack \
       --zsh $(PACK_HOME=$PWD $out/bin/pack completion --shell zsh) \
       --bash $(PACK_HOME=$PWD $out/bin/pack completion --shell bash) \

--- a/pkgs/by-name/ca/catppuccin-catwalk/package.nix
+++ b/pkgs/by-name/ca/catppuccin-catwalk/package.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage {
   ];
   buildInputs = [ libwebp ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd catwalk \
       --bash <("$out/bin/catwalk" completion bash) \
       --zsh <("$out/bin/catwalk" completion zsh) \

--- a/pkgs/by-name/ch/chain-bench/package.nix
+++ b/pkgs/by-name/ch/chain-bench/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -25,7 +26,7 @@ buildGoModule rec {
     "-X main.version=v${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd chain-bench \
       --bash <($out/bin/chain-bench completion bash) \
       --fish <($out/bin/chain-bench completion fish) \

--- a/pkgs/by-name/ch/changelogger/package.nix
+++ b/pkgs/by-name/ch/changelogger/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -27,7 +28,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd changelogger \
       --bash <($out/bin/changelogger completion bash) \
       --fish <($out/bin/changelogger completion fish) \

--- a/pkgs/by-name/ch/changie/package.nix
+++ b/pkgs/by-name/ch/changie/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -28,7 +29,7 @@ buildGoModule rec {
     "-X=main.version=${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd changie \
       --bash <($out/bin/changie completion bash) \
       --fish <($out/bin/changie completion fish) \

--- a/pkgs/by-name/ci/cilium-cli/package.nix
+++ b/pkgs/by-name/ci/cilium-cli/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   cilium-cli,
   fetchFromGitHub,
@@ -34,7 +35,7 @@ buildGoModule rec {
   # 2022/06/25 10:36:22 Unable to start gops: mkdir /homeless-shelter: permission denied
   HOME = "$TMPDIR";
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd cilium \
       --bash <($out/bin/cilium completion bash) \
       --fish <($out/bin/cilium completion fish) \

--- a/pkgs/by-name/ci/cirrus-cli/package.nix
+++ b/pkgs/by-name/ci/cirrus-cli/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   buildGoModule,
   installShellFiles,
@@ -24,7 +25,7 @@ buildGoModule rec {
   ];
 
   nativeBuildInputs = [ installShellFiles ];
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd cirrus \
       --bash <($out/bin/cirrus completion bash) \
       --zsh <($out/bin/cirrus completion zsh) \

--- a/pkgs/by-name/ci/civo/package.nix
+++ b/pkgs/by-name/ci/civo/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -36,6 +37,8 @@ buildGoModule rec {
 
   postInstall = ''
     mv $out/bin/cli $out/bin/civo
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd civo \
       --bash <($out/bin/civo completion bash) \
       --fish <($out/bin/civo completion fish) \

--- a/pkgs/by-name/cl/cliam/package.nix
+++ b/pkgs/by-name/cl/cliam/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -33,7 +34,7 @@ buildGoModule rec {
     mv $GOPATH/bin/{cli,cliam}
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd cliam \
       --bash <($out/bin/cliam completion bash) \
       --fish <($out/bin/cliam completion fish) \

--- a/pkgs/by-name/cl/clive/package.nix
+++ b/pkgs/by-name/cl/clive/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   ttyd,
   buildGoModule,
   fetchFromGitHub,
@@ -33,6 +34,8 @@ buildGoModule rec {
 
   postInstall = ''
     wrapProgram $out/bin/clive --prefix PATH : ${ttyd}/bin
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd clive \
       --bash <($out/bin/clive completion bash) \
       --fish <($out/bin/clive completion fish) \

--- a/pkgs/by-name/cl/clusterctl/package.nix
+++ b/pkgs/by-name/cl/clusterctl/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -34,7 +35,7 @@ buildGoModule rec {
       "-X ${t}.gitVersion=v${version}"
     ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     # errors attempting to write config to read-only $HOME
     export HOME=$TMPDIR
 

--- a/pkgs/by-name/co/cobra-cli/package.nix
+++ b/pkgs/by-name/co/cobra-cli/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   makeWrapper,
@@ -39,7 +40,7 @@ buildGoModule rec {
       --prefix PATH : ${go}/bin
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd cobra-cli \
       --bash <($out/bin/cobra-cli completion bash) \
       --fish <($out/bin/cobra-cli completion fish) \

--- a/pkgs/by-name/co/copilot-cli/package.nix
+++ b/pkgs/by-name/co/copilot-cli/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -32,7 +33,7 @@ buildGoModule rec {
 
   subPackages = [ "./cmd/copilot" ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd copilot \
       --bash <($out/bin/copilot completion bash) \
       --fish <($out/bin/copilot completion fish) \

--- a/pkgs/by-name/ct/ctlptl/package.nix
+++ b/pkgs/by-name/ct/ctlptl/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -28,7 +29,7 @@ buildGoModule rec {
     "-X main.version=${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd ctlptl \
       --bash <($out/bin/ctlptl completion bash) \
       --fish <($out/bin/ctlptl completion fish) \

--- a/pkgs/by-name/da/datree/package.nix
+++ b/pkgs/by-name/da/datree/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -30,7 +31,7 @@ buildGoModule rec {
 
   tags = [ "main" ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion \
       --cmd datree \
       --bash <($out/bin/datree completion bash) \

--- a/pkgs/by-name/de/deck/package.nix
+++ b/pkgs/by-name/de/deck/package.nix
@@ -1,5 +1,6 @@
 {
   buildGoModule,
+  stdenv,
   lib,
   installShellFiles,
   fetchFromGitHub,
@@ -29,7 +30,7 @@ buildGoModule rec {
   proxyVendor = true; # darwin/linux hash mismatch
   vendorHash = "sha256-nKKCz7T6HLCBwQjPV/kpzgtR8yNiZS/Ta0H1DlKaLk8=";
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd deck \
       --bash <($out/bin/deck completion bash) \
       --fish <($out/bin/deck completion fish) \

--- a/pkgs/by-name/dn/dnscontrol/package.nix
+++ b/pkgs/by-name/dn/dnscontrol/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGo125Module,
   fetchFromGitHub,
   installShellFiles,
@@ -30,7 +31,7 @@ buildGo125Module rec {
     "-X=github.com/StackExchange/dnscontrol/v4/pkg/version.version=${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd dnscontrol \
       --bash <($out/bin/dnscontrol shell-completion bash) \
       --zsh <($out/bin/dnscontrol shell-completion zsh)

--- a/pkgs/by-name/dr/driftctl/package.nix
+++ b/pkgs/by-name/dr/driftctl/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -28,7 +29,7 @@ buildGoModule rec {
     "-X github.com/snyk/driftctl/build.enableUsageReporting=false"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd driftctl \
       --bash <($out/bin/driftctl completion bash) \
       --fish <($out/bin/driftctl completion fish) \

--- a/pkgs/by-name/dy/dyff/package.nix
+++ b/pkgs/by-name/dy/dyff/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -38,7 +39,7 @@ buildGoModule rec {
     "-X=github.com/homeport/dyff/internal/cmd.version=${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd dyff \
       --bash <($out/bin/dyff completion bash) \
       --fish <($out/bin/dyff completion fish) \

--- a/pkgs/by-name/ek/eksctl/package.nix
+++ b/pkgs/by-name/ek/eksctl/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -36,7 +37,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd eksctl \
       --bash <($out/bin/eksctl completion bash) \
       --fish <($out/bin/eksctl completion fish) \

--- a/pkgs/by-name/en/enc/package.nix
+++ b/pkgs/by-name/en/enc/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   git,
@@ -31,7 +32,7 @@ buildGoModule rec {
 
   nativeCheckInputs = [ git ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd enc \
       --bash <($out/bin/enc completion bash) \
       --fish <($out/bin/enc completion fish) \

--- a/pkgs/by-name/en/ent-go/package.nix
+++ b/pkgs/by-name/en/ent-go/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -36,7 +37,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd ent \
       --bash <($out/bin/ent completion bash) \
       --fish <($out/bin/ent completion fish) \

--- a/pkgs/by-name/ex/expenses/package.nix
+++ b/pkgs/by-name/ex/expenses/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   sqlite,
@@ -32,7 +33,7 @@ buildGoModule rec {
     "-X github.com/manojkarthick/expenses/cmd.Version=${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd expenses \
       --bash <($out/bin/expenses completion bash) \
       --zsh <($out/bin/expenses completion zsh) \

--- a/pkgs/by-name/fa/fastly/package.nix
+++ b/pkgs/by-name/fa/fastly/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchurl,
   fetchFromGitHub,
   installShellFiles,
@@ -68,7 +69,7 @@ buildGoModule rec {
       --set FASTLY_VICEROY_USE_PATH 1
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     export HOME="$(mktemp -d)"
     installShellCompletion --cmd fastly \
       --bash <($out/bin/fastly --completion-script-bash) \

--- a/pkgs/by-name/fe/fetchit/package.nix
+++ b/pkgs/by-name/fe/fetchit/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -58,7 +59,7 @@ buildGoModule rec {
   # There are no tests for cmd/fetchit.
   doCheck = false;
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     for i in bash fish zsh; do
       installShellCompletion --cmd fetchit \
         --$i <($out/bin/fetchit completion $i)

--- a/pkgs/by-name/fi/fioctl/package.nix
+++ b/pkgs/by-name/fi/fioctl/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -28,7 +29,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd fioctl \
       --bash <($out/bin/fioctl completion bash) \
       --fish <($out/bin/fioctl completion fish) \

--- a/pkgs/by-name/fl/flyctl/package.nix
+++ b/pkgs/by-name/fl/flyctl/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   testers,
@@ -53,7 +54,7 @@ buildGoModule rec {
     runHook postCheck
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd flyctl \
       --bash <($out/bin/flyctl completion bash) \
       --fish <($out/bin/flyctl completion fish) \

--- a/pkgs/by-name/fu/func/package.nix
+++ b/pkgs/by-name/fu/func/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -31,7 +32,7 @@ buildGoModule (finalAttrs: {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd func \
       --bash <($out/bin/func completion bash) \
       --zsh <($out/bin/func completion zsh)

--- a/pkgs/by-name/fx/fx/package.nix
+++ b/pkgs/by-name/fx/fx/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -22,7 +23,7 @@ buildGoModule (finalAttrs: {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd fx \
       --bash <($out/bin/fx --comp bash) \
       --fish <($out/bin/fx --comp fish) \

--- a/pkgs/by-name/ga/gambit-chess/package.nix
+++ b/pkgs/by-name/ga/gambit-chess/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -31,7 +32,7 @@ buildGoModule rec {
     "-X=main.CommitSHA=${src.rev}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd gambit \
       --bash <($out/bin/gambit completion bash) \
       --fish <($out/bin/gambit completion fish) \

--- a/pkgs/by-name/ga/gatekeeper/package.nix
+++ b/pkgs/by-name/ga/gatekeeper/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -28,7 +29,7 @@ buildGoModule rec {
 
   subPackages = [ "cmd/gator" ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd gator \
       --bash <($out/bin/gator completion bash) \
       --fish <($out/bin/gator completion fish) \

--- a/pkgs/by-name/gh/ghorg/package.nix
+++ b/pkgs/by-name/gh/ghorg/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -28,7 +29,7 @@ buildGoModule rec {
   ];
 
   nativeBuildInputs = [ installShellFiles ];
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd ghorg \
       --bash <($out/bin/ghorg completion bash) \
       --fish <($out/bin/ghorg completion fish) \

--- a/pkgs/by-name/gh/ghq/package.nix
+++ b/pkgs/by-name/gh/ghq/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -29,7 +30,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion \
       --bash $src/misc/bash/_ghq \
       --fish $src/misc/fish/ghq.fish \

--- a/pkgs/by-name/gl/glasskube/package.nix
+++ b/pkgs/by-name/gl/glasskube/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   buildNpmPackage,
   fetchFromGitHub,
@@ -67,7 +68,7 @@ buildGoModule rec {
     cp -r ${web-bundle}/bundle internal/web/root/static/bundle
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     # Completions
     installShellCompletion --cmd glasskube \
       --bash <($out/bin/glasskube completion bash) \

--- a/pkgs/by-name/gl/glooctl/package.nix
+++ b/pkgs/by-name/gl/glooctl/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -35,6 +36,8 @@ buildGoModule rec {
 
   postInstall = ''
     mv $out/bin/cmd $out/bin/glooctl
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd glooctl \
       --bash <($out/bin/glooctl completion bash) \
       --zsh <($out/bin/glooctl completion zsh)

--- a/pkgs/by-name/gm/gmailctl/package.nix
+++ b/pkgs/by-name/gm/gmailctl/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -22,7 +23,7 @@ buildGoModule rec {
     installShellFiles
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd gmailctl \
       --bash <($out/bin/gmailctl completion bash) \
       --fish <($out/bin/gmailctl completion fish) \

--- a/pkgs/by-name/go/go-containerregistry/package.nix
+++ b/pkgs/by-name/go/go-containerregistry/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -52,7 +53,7 @@ buildGoModule rec {
         ln -s ''$${bin}/bin/${bin} $out/bin/
       '') bins
     )
-    + ''
+    + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
       for cmd in crane gcrane; do
         installShellCompletion --cmd "$cmd" \
           --bash <($GOPATH/bin/$cmd completion bash) \

--- a/pkgs/by-name/go/go-licenses/package.nix
+++ b/pkgs/by-name/go/go-licenses/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   go,
@@ -36,7 +37,7 @@ buildGoModule rec {
 
   allowGoReference = true;
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd go-licenses \
       --bash <("$out/bin/go-licenses" completion bash) \
       --fish <("$out/bin/go-licenses" completion fish) \

--- a/pkgs/by-name/go/gosmee/package.nix
+++ b/pkgs/by-name/go/gosmee/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -23,7 +24,7 @@ buildGoModule rec {
     printf ${version} > gosmee/templates/version
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd gosmee \
       --bash <($out/bin/gosmee completion bash) \
       --fish <($out/bin/gosmee completion fish) \

--- a/pkgs/by-name/go/goverview/package.nix
+++ b/pkgs/by-name/go/goverview/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -25,7 +26,7 @@ buildGoModule rec {
   nativeBuildInputs = [
     installShellFiles
   ];
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd goverview \
       --bash <($out/bin/goverview completion bash) \
       --fish <($out/bin/goverview completion fish) \

--- a/pkgs/by-name/gr/grafana-alloy/package.nix
+++ b/pkgs/by-name/gr/grafana-alloy/package.nix
@@ -112,7 +112,7 @@ buildGoModule rec {
       $out/bin/alloy
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd alloy \
       --bash <($out/bin/alloy completion bash) \
       --fish <($out/bin/alloy completion fish) \

--- a/pkgs/by-name/gr/graphite-cli/package.nix
+++ b/pkgs/by-name/gr/graphite-cli/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildNpmPackage,
   fetchurl,
   git,
@@ -28,7 +29,7 @@ buildNpmPackage rec {
 
   dontNpmBuild = true;
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd gt \
       --bash <($out/bin/gt completion) \
       --fish <(GT_PAGER= $out/bin/gt fish) \

--- a/pkgs/by-name/gr/grype/package.nix
+++ b/pkgs/by-name/gr/grype/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   git,
@@ -111,7 +112,7 @@ buildGoModule (finalAttrs: {
     rm grype/db/v5/namespace/cpe/namespace_test.go
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd grype \
       --bash <($out/bin/grype completion bash) \
       --fish <($out/bin/grype completion fish) \

--- a/pkgs/by-name/gt/gtrash/package.nix
+++ b/pkgs/by-name/gt/gtrash/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -33,7 +34,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd gtrash \
       --bash <($out/bin/gtrash completion bash) \
       --fish <($out/bin/gtrash completion fish) \

--- a/pkgs/by-name/he/helm-ls/package.nix
+++ b/pkgs/by-name/he/helm-ls/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -28,7 +29,7 @@ buildGoModule rec {
     "-X main.Version=${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     mv $out/bin/helm-ls $out/bin/helm_ls
     installShellCompletion --cmd helm_ls \
       --bash <($out/bin/helm_ls completion bash) \

--- a/pkgs/by-name/he/helmfile/package.nix
+++ b/pkgs/by-name/he/helmfile/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGo125Module,
   fetchFromGitHub,
   installShellFiles,
@@ -39,7 +40,7 @@ buildGo125Module rec {
       wrapProgram $out/bin/helmfile \
         --set HELM_PLUGINS "${pluginsDir}"
     ''
-    + ''
+    + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
       installShellCompletion --cmd helmfile \
         --bash <($out/bin/helmfile completion bash) \
         --fish <($out/bin/helmfile completion fish) \

--- a/pkgs/by-name/hl/hl-log-viewer/package.nix
+++ b/pkgs/by-name/hl/hl-log-viewer/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   installShellFiles,
   fetchFromGitHub,
@@ -21,7 +22,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd hl \
       --bash <($out/bin/hl --shell-completions bash) \
       --fish <($out/bin/hl --shell-completions fish) \

--- a/pkgs/by-name/ho/hostctl/package.nix
+++ b/pkgs/by-name/ho/hostctl/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -28,7 +29,7 @@ buildGoModule rec {
     "-X github.com/guumaster/hostctl/cmd/hostctl/actions.version=${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd hostctl \
       --bash <($out/bin/hostctl completion bash) \
       --zsh <($out/bin/hostctl completion zsh)

--- a/pkgs/by-name/hu/humioctl/package.nix
+++ b/pkgs/by-name/hu/humioctl/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   installShellFiles,
   lib,
+  stdenv,
 }:
 
 buildGoModule rec {
@@ -26,7 +27,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd humioctl \
       --bash <($out/bin/humioctl completion bash) \
       --zsh <($out/bin/humioctl completion zsh)

--- a/pkgs/by-name/hy/hyprkeys/package.nix
+++ b/pkgs/by-name/hy/hyprkeys/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -28,7 +29,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-JFvC9V0xS8SZSdLsOtpyTrFzXjYAOaPQaJHdcnJzK3s=";
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd hyprkeys \
       --bash <($out/bin/hyprkeys completion bash) \
       --fish <($out/bin/hyprkeys completion fish) \

--- a/pkgs/by-name/hy/hyprland-workspaces-tui/package.nix
+++ b/pkgs/by-name/hy/hyprland-workspaces-tui/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
   makeWrapper,
@@ -27,7 +28,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ hyprland-workspaces ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd hyprland-workspaces-tui \
       --bash <($out/bin/hyprland-workspaces-tui --completions bash) \
       --zsh <($out/bin/hyprland-workspaces-tui --completions zsh) \

--- a/pkgs/by-name/in/infracost/package.nix
+++ b/pkgs/by-name/in/infracost/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -43,7 +44,7 @@ buildGoModule rec {
     "-short"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     export INFRACOST_SKIP_UPDATE_CHECK=true
     installShellCompletion --cmd infracost \
       --bash <($out/bin/infracost completion --shell bash) \

--- a/pkgs/by-name/ip/ipam/package.nix
+++ b/pkgs/by-name/ip/ipam/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitea,
   installShellFiles,
@@ -28,7 +29,7 @@ buildGoModule rec {
     "-w"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd ipam \
       --bash <($out/bin/ipam completion bash) \
       --fish <($out/bin/ipam completion fish) \

--- a/pkgs/by-name/k3/k3d/package.nix
+++ b/pkgs/by-name/k3/k3d/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -52,7 +53,7 @@ buildGoModule rec {
       --replace-fail "TestGetK3sVersion" "SkipGetK3sVersion"
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd k3d \
       --bash <($out/bin/k3d completion bash) \
       --fish <($out/bin/k3d completion fish) \

--- a/pkgs/by-name/k8/k8s-manifest-sigstore/package.nix
+++ b/pkgs/by-name/k8/k8s-manifest-sigstore/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -39,7 +40,7 @@ buildGoModule rec {
       "-X ${prefix}.GitVersion=v${version}"
     ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd kubectl-sigstore \
       --bash <($out/bin/kubectl-sigstore completion bash) \
       --fish <($out/bin/kubectl-sigstore completion fish) \

--- a/pkgs/by-name/ka/karmor/package.nix
+++ b/pkgs/by-name/ka/karmor/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -34,6 +35,8 @@ buildGoModule rec {
 
   postInstall = ''
     mv $out/bin/{kubearmor-client,karmor}
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd karmor \
       --bash <($out/bin/karmor completion bash) \
       --fish <($out/bin/karmor completion fish) \

--- a/pkgs/by-name/kd/kdigger/package.nix
+++ b/pkgs/by-name/kd/kdigger/package.nix
@@ -42,7 +42,7 @@ buildGoModule rec {
     ldflags+=" -X github.com/quarkslab/kdigger/commands.GITCOMMIT=$(cat COMMIT)"
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd kdigger \
       --bash <($out/bin/kdigger completion bash) \
       --fish <($out/bin/kdigger completion fish) \

--- a/pkgs/by-name/ki/kind/package.nix
+++ b/pkgs/by-name/ki/kind/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -37,7 +38,7 @@ buildGoModule rec {
     "-w"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd kind \
       --bash <($out/bin/kind completion bash) \
       --fish <($out/bin/kind completion fish) \

--- a/pkgs/by-name/kn/kn/package.nix
+++ b/pkgs/by-name/kn/kn/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   getent,
@@ -27,7 +28,7 @@ buildGoModule (finalAttrs: {
 
   ldflags = [ "-X knative.dev/client/pkg/commands/version.Version=v${finalAttrs.version}" ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd kn \
       --bash <($out/bin/kn completion bash) \
       --zsh <($out/bin/kn completion zsh)

--- a/pkgs/by-name/ko/ko/package.nix
+++ b/pkgs/by-name/ko/ko/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   gitMinimal,
@@ -55,7 +56,7 @@ buildGoModule rec {
     unset GOOS GOARCH GOARM
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd ko \
       --bash <($out/bin/ko completion bash) \
       --fish <($out/bin/ko completion fish) \

--- a/pkgs/by-name/ko/konstraint/package.nix
+++ b/pkgs/by-name/ko/konstraint/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -28,7 +29,7 @@ buildGoModule rec {
     "-X github.com/plexsystems/konstraint/internal/commands.version=${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd konstraint \
       --bash <($out/bin/konstraint completion bash) \
       --fish <($out/bin/konstraint completion fish) \

--- a/pkgs/by-name/ku/kube-linter/package.nix
+++ b/pkgs/by-name/ku/kube-linter/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -32,7 +33,7 @@ buildGoModule rec {
 
   checkFlags = [ "-skip=TestCreateContextsWithIgnorePaths" ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd kube-linter \
       --bash <($out/bin/kube-linter completion bash) \
       --fish <($out/bin/kube-linter completion fish) \

--- a/pkgs/by-name/ku/kubecfg/package.nix
+++ b/pkgs/by-name/ku/kubecfg/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -26,7 +27,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd kubecfg \
       --bash <($out/bin/kubecfg completion --shell=bash) \
       --zsh  <($out/bin/kubecfg completion --shell=zsh)

--- a/pkgs/by-name/ku/kubeone/package.nix
+++ b/pkgs/by-name/ku/kubeone/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -31,7 +32,7 @@ buildGoModule rec {
     installShellFiles
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd kubeone \
       --bash <($out/bin/kubeone completion bash) \
       --zsh <($out/bin/kubeone completion zsh)

--- a/pkgs/by-name/ku/kubernetes-polaris/package.nix
+++ b/pkgs/by-name/ku/kubernetes-polaris/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -27,7 +28,7 @@ buildGoModule rec {
     "-X main.Commit=${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd polaris \
       --bash <($out/bin/polaris completion bash) \
       --fish <($out/bin/polaris completion fish) \

--- a/pkgs/by-name/ku/kubescape/package.nix
+++ b/pkgs/by-name/ku/kubescape/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   git,
@@ -57,7 +58,7 @@ buildGoModule rec {
       --replace-fail "TestSetContextMetadata" "SkipSetContextMetadata"
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd kubescape \
       --bash <($out/bin/kubescape completion bash) \
       --fish <($out/bin/kubescape completion fish) \

--- a/pkgs/by-name/ku/kubesec/package.nix
+++ b/pkgs/by-name/ku/kubesec/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -29,7 +30,7 @@ buildGoModule rec {
   # Tests wants to download the kubernetes schema for use with kubeval
   doCheck = false;
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd kubesec \
       --bash <($out/bin/kubesec completion bash) \
       --fish <($out/bin/kubesec completion fish) \

--- a/pkgs/by-name/ku/kubevirt/package.nix
+++ b/pkgs/by-name/ku/kubevirt/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   installShellFiles,
   lib,
+  stdenv,
   testers,
   kubevirt,
 }:
@@ -32,7 +33,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd virtctl \
       --bash <($out/bin/virtctl completion bash) \
       --fish <($out/bin/virtctl completion fish) \

--- a/pkgs/by-name/ky/kyverno/package.nix
+++ b/pkgs/by-name/ky/kyverno/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -35,6 +36,8 @@ buildGoModule rec {
     # we have no integration between krew and kubectl
     # so better rename binary to kyverno and use as a standalone
     mv $out/bin/kubectl-kyverno $out/bin/kyverno
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd kyverno \
       --bash <($out/bin/kyverno completion bash) \
       --zsh <($out/bin/kyverno completion zsh) \

--- a/pkgs/by-name/le/leetgo/package.nix
+++ b/pkgs/by-name/le/leetgo/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -28,7 +29,7 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd leetgo \
       --bash <($out/bin/leetgo completion bash) \
       --fish <($out/bin/leetgo completion fish) \

--- a/pkgs/by-name/le/lefthook/package.nix
+++ b/pkgs/by-name/le/lefthook/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -30,7 +31,7 @@ buildGoModule {
 
   doCheck = false;
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd lefthook \
       --bash <($out/bin/lefthook completion bash) \
       --fish <($out/bin/lefthook completion fish) \

--- a/pkgs/by-name/li/libgen-cli/package.nix
+++ b/pkgs/by-name/li/libgen-cli/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -29,7 +30,7 @@ buildGoModule rec {
     "-w"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd libgen-cli \
       --bash <($out/bin/libgen-cli completion bash) \
       --fish <($out/bin/libgen-cli completion fish) \

--- a/pkgs/by-name/li/litmusctl/package.nix
+++ b/pkgs/by-name/li/litmusctl/package.nix
@@ -4,6 +4,7 @@
   installShellFiles,
   kubectl,
   lib,
+  stdenv,
 }:
 
 buildGoModule rec {
@@ -27,7 +28,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-7FYOQ89aUFPX+5NCPYKg+YGCXstQ6j9DK4V2mCgklu0=";
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd litmusctl \
       --bash <($out/bin/litmusctl completion bash) \
       --fish <($out/bin/litmusctl completion fish) \

--- a/pkgs/by-name/ma/madonctl/package.nix
+++ b/pkgs/by-name/ma/madonctl/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -27,7 +28,7 @@ buildGoModule rec {
     "-w"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd madonctl \
       --bash <($out/bin/madonctl completion bash) \
       --zsh <($out/bin/madonctl completion zsh)

--- a/pkgs/by-name/me/melange/package.nix
+++ b/pkgs/by-name/me/melange/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -45,7 +46,7 @@ buildGoModule rec {
     ldflags+=" -X sigs.k8s.io/release-utils/version.buildDate=$(cat SOURCE_DATE_EPOCH)"
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd melange \
       --bash <($out/bin/melange completion bash) \
       --fish <($out/bin/melange completion fish) \

--- a/pkgs/by-name/me/metal-cli/package.nix
+++ b/pkgs/by-name/me/metal-cli/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -29,7 +30,7 @@ buildGoModule (finalAttrs: {
     installShellFiles
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd metal \
       --bash <($out/bin/metal completion bash) \
       --fish <($out/bin/metal completion fish) \

--- a/pkgs/by-name/ni/nimbo/package.nix
+++ b/pkgs/by-name/ni/nimbo/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   python3,
   fetchFromGitHub,
   installShellFiles,
@@ -51,7 +52,7 @@ python3.pkgs.buildPythonApplication rec {
     (lib.makeBinPath [ awscli ])
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd nimbo \
       --zsh <(_NIMBO_COMPLETE=source_zsh $out/bin/nimbo) \
       --bash <(_NIMBO_COMPLETE=source_bash $out/bin/nimbo) \

--- a/pkgs/by-name/ni/nixci/package.nix
+++ b/pkgs/by-name/ni/nixci/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     openssl
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd nixci \
       --bash <($out/bin/nixci completion bash) \
       --fish <($out/bin/nixci completion fish) \

--- a/pkgs/by-name/no/notation/package.nix
+++ b/pkgs/by-name/no/notation/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -33,7 +34,7 @@ buildGoModule (finalAttrs: {
     "-X github.com/notaryproject/notation/internal/version.BuildMetadata="
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd notation \
       --bash <($out/bin/notation completion bash) \
       --fish <($out/bin/notation completion fish) \

--- a/pkgs/by-name/no/novops/package.nix
+++ b/pkgs/by-name/no/novops/package.nix
@@ -40,7 +40,7 @@ rustPlatform.buildRustPackage rec {
     "--lib"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd novops \
       --bash <($out/bin/novops completion bash) \
       --fish <($out/bin/novops completion fish) \

--- a/pkgs/by-name/nv/nvs/package.nix
+++ b/pkgs/by-name/nv/nvs/package.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -29,7 +30,7 @@ buildGoModule (finalAttrs: {
     installShellFiles
     writableTmpDirAsHomeHook
   ];
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd nvs \
       --bash <($out/bin/nvs completion bash) \
       --fish <($out/bin/nvs completion fish) \

--- a/pkgs/by-name/oc/ocm/package.nix
+++ b/pkgs/by-name/oc/ocm/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -38,7 +39,7 @@ buildGoModule rec {
     "-skip=^TestCLI$"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd ocm \
       --bash <($out/bin/ocm completion bash) \
       --fish <($out/bin/ocm completion fish) \

--- a/pkgs/by-name/ok/okteto/package.nix
+++ b/pkgs/by-name/ok/okteto/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -65,7 +66,7 @@ buildGoModule (finalAttrs: {
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd okteto \
       --bash <($out/bin/okteto completion bash) \
       --fish <($out/bin/okteto completion fish) \

--- a/pkgs/by-name/om/omnictl/package.nix
+++ b/pkgs/by-name/om/omnictl/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -29,7 +30,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd omnictl \
       --bash <($out/bin/omnictl completion bash) \
       --fish <($out/bin/omnictl completion fish) \

--- a/pkgs/by-name/op/open-policy-agent/package.nix
+++ b/pkgs/by-name/op/open-policy-agent/package.nix
@@ -91,7 +91,7 @@ buildGoModule (finalAttrs: {
       rm v1/server/server_bench_test.go
     '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd opa \
       --bash <($out/bin/opa completion bash) \
       --fish <($out/bin/opa completion fish) \

--- a/pkgs/by-name/op/openapi-python-client/package.nix
+++ b/pkgs/by-name/op/openapi-python-client/package.nix
@@ -52,7 +52,7 @@ python3Packages.buildPythonApplication rec {
   # just a simple wrapper to locate the binary. We'll remove the upper bound
   pythonRelaxDeps = [ "ruff" ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     # see: https://github.com/fastapi/typer/blob/5889cf82f4ed925f92e6b0750bf1b1ed9ee672f3/typer/completion.py#L54
     # otherwise shellingham throws exception on darwin
     export _TYPER_COMPLETE_TEST_DISABLE_SHELL_DETECTION=1

--- a/pkgs/by-name/op/opensearch-cli/package.nix
+++ b/pkgs/by-name/op/opensearch-cli/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -19,7 +20,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     export HOME="$(mktemp -d)"
     installShellCompletion --cmd opensearch-cli \
       --bash <($out/bin/opensearch-cli completion bash) \

--- a/pkgs/by-name/op/optinix/package.nix
+++ b/pkgs/by-name/op/optinix/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitLab,
   buildGoModule,
   installShellFiles,
@@ -20,7 +21,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd optinix \
       --bash <($out/bin/optinix completion bash) \
       --fish <($out/bin/optinix completion fish) \

--- a/pkgs/by-name/or/oras/package.nix
+++ b/pkgs/by-name/or/oras/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -33,7 +34,7 @@ buildGoModule (finalAttrs: {
     "-X oras.land/oras/internal/version.GitTreeState=clean"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd oras \
       --bash <($out/bin/oras completion bash) \
       --fish <($out/bin/oras completion fish) \

--- a/pkgs/by-name/or/orchard/package.nix
+++ b/pkgs/by-name/or/orchard/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   buildGoModule,
   installShellFiles,
@@ -41,7 +42,7 @@ buildGoModule rec {
 
   subPackages = [ "cmd/orchard" ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     export HOME="$(mktemp -d)"
     installShellCompletion --cmd orchard \
       --bash <($out/bin/orchard completion bash) \

--- a/pkgs/by-name/or/ory/package.nix
+++ b/pkgs/by-name/or/ory/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -32,6 +33,8 @@ buildGoModule rec {
 
   postInstall = ''
     mv $out/bin/cli $out/bin/ory
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd ory \
       --bash <($out/bin/ory completion bash) \
       --fish <($out/bin/ory completion fish) \

--- a/pkgs/by-name/pa/packwiz/package.nix
+++ b/pkgs/by-name/pa/packwiz/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -24,7 +25,7 @@ buildGoModule {
     installShellFiles
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd packwiz \
       --bash <($out/bin/packwiz completion bash) \
       --fish <($out/bin/packwiz completion fish) \

--- a/pkgs/by-name/pi/pinniped/package.nix
+++ b/pkgs/by-name/pi/pinniped/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   buildGoModule,
   installShellFiles,
@@ -27,7 +28,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd pinniped \
       --bash <($out/bin/pinniped completion bash) \
       --fish <($out/bin/pinniped completion fish) \

--- a/pkgs/by-name/pi/pipenv/package.nix
+++ b/pkgs/by-name/pi/pipenv/package.nix
@@ -100,7 +100,7 @@ buildPythonApplication rec {
     '';
   };
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd pipenv \
       --bash <(_PIPENV_COMPLETE=bash_source $out/bin/pipenv) \
       --zsh <(_PIPENV_COMPLETE=zsh_source $out/bin/pipenv) \

--- a/pkgs/by-name/po/poetry/unwrapped.nix
+++ b/pkgs/by-name/po/poetry/unwrapped.nix
@@ -97,7 +97,7 @@ buildPythonPackage rec {
   ++ pbs-installer.optional-dependencies.download
   ++ pbs-installer.optional-dependencies.install;
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd poetry \
       --bash <($out/bin/poetry completions bash) \
       --fish <($out/bin/poetry completions fish) \

--- a/pkgs/by-name/po/pop/package.nix
+++ b/pkgs/by-name/po/pop/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   installShellFiles,
   fetchFromGitHub,
@@ -30,7 +31,7 @@ buildGoModule rec {
     "-X=main.Version=${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     $out/bin/pop man > pop.1
     installManPage pop.1
     installShellCompletion --cmd pop \

--- a/pkgs/by-name/po/popeye/package.nix
+++ b/pkgs/by-name/po/popeye/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -27,7 +28,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd popeye \
       --bash <($out/bin/popeye completion bash) \
       --fish <($out/bin/popeye completion fish) \

--- a/pkgs/by-name/po/portablemc/package.nix
+++ b/pkgs/by-name/po/portablemc/package.nix
@@ -72,7 +72,7 @@ python3Packages.buildPythonApplication rec {
 
   # Note: Tests use networking, so we don't run them
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd portablemc \
         --bash <($out/bin/portablemc show completion bash) \
         --zsh <($out/bin/portablemc show completion zsh)

--- a/pkgs/by-name/pu/pulsarctl/package.nix
+++ b/pkgs/by-name/pu/pulsarctl/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -50,7 +51,7 @@ buildGoModule rec {
 
   doCheck = false;
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd pulsarctl \
       --bash <($out/bin/pulsarctl completion bash) \
       --fish <($out/bin/pulsarctl completion fish) \

--- a/pkgs/by-name/pv/pv-migrate/package.nix
+++ b/pkgs/by-name/pv/pv-migrate/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -32,7 +33,7 @@ buildGoModule rec {
     installShellFiles
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd pv-migrate \
       --bash <($out/bin/pv-migrate completion bash) \
       --fish <($out/bin/pv-migrate completion fish) \

--- a/pkgs/by-name/py/pytr/package.nix
+++ b/pkgs/by-name/py/pytr/package.nix
@@ -2,6 +2,7 @@
   fetchFromGitHub,
   installShellFiles,
   lib,
+  stdenv,
   python3Packages,
   versionCheckHook,
 }:
@@ -38,7 +39,7 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd pytr \
       --bash <($out/bin/pytr completion bash) \
       --zsh <($out/bin/pytr completion zsh)

--- a/pkgs/by-name/qc/qc/package.nix
+++ b/pkgs/by-name/qc/qc/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -33,7 +34,7 @@ buildGoModule rec {
     installShellFiles
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     export HOME=$(mktemp -d)
     installShellCompletion --cmd qc \
       --bash <($out/bin/qc completion bash) \

--- a/pkgs/by-name/qo/qovery-cli/package.nix
+++ b/pkgs/by-name/qo/qovery-cli/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -22,7 +23,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd ${pname} \
       --bash <($out/bin/${pname} completion bash) \
       --fish <($out/bin/${pname} completion fish) \

--- a/pkgs/by-name/ra/radioboat/package.nix
+++ b/pkgs/by-name/ra/radioboat/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   buildGoModule,
   mpv,
@@ -38,7 +39,7 @@ buildGoModule rec {
     wrapProgram $out/bin/radioboat --prefix PATH ":" "${lib.makeBinPath [ mpv ]}";
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd radioboat \
       --bash <($out/bin/radioboat completion bash) \
       --fish <($out/bin/radioboat completion fish) \

--- a/pkgs/by-name/re/readability-cli/package.nix
+++ b/pkgs/by-name/re/readability-cli/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildNpmPackage,
   fetchFromGitLab,
   installShellFiles,
@@ -35,6 +36,8 @@ buildNpmPackage (finalAttrs: {
 
   postInstall = ''
     installManPage readability-cli.1
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd readable \
       --bash <(SHELL=bash $out/bin/readable --completion) \
       --zsh <(SHELL=zsh $out/bin/readable --completion)

--- a/pkgs/by-name/re/repro-get/package.nix
+++ b/pkgs/by-name/re/repro-get/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -35,7 +36,7 @@ buildGoModule rec {
     "-X github.com/reproducible-containers/${pname}/pkg/version.Version=v${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd repro-get \
       --bash <($out/bin/repro-get completion bash) \
       --fish <($out/bin/repro-get completion fish) \

--- a/pkgs/by-name/ro/roadrunner/package.nix
+++ b/pkgs/by-name/ro/roadrunner/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -28,7 +29,7 @@ buildGoModule rec {
     "-X=github.com/roadrunner-server/roadrunner/v2023/internal/meta.buildTime=1970-01-01T00:00:00Z"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd rr \
       --bash <($out/bin/rr completion bash) \
       --zsh <($out/bin/rr completion zsh) \

--- a/pkgs/by-name/ro/rosa/package.nix
+++ b/pkgs/by-name/ro/rosa/package.nix
@@ -43,7 +43,7 @@ buildGoModule rec {
     [ "-skip=^${lib.concatStringsSep "$|^" skippedTests}$" ];
 
   nativeBuildInputs = [ installShellFiles ];
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd rosa \
       --bash <($out/bin/rosa completion bash) \
       --fish <($out/bin/rosa completion fish) \

--- a/pkgs/by-name/ro/roxctl/package.nix
+++ b/pkgs/by-name/ro/roxctl/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -30,7 +31,7 @@ buildGoModule rec {
     "-X github.com/stackrox/rox/pkg/version/internal.MainVersion=${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd roxctl \
       --bash <($out/bin/roxctl completion bash) \
       --fish <($out/bin/roxctl completion fish) \

--- a/pkgs/by-name/sc/scorecard/package.nix
+++ b/pkgs/by-name/sc/scorecard/package.nix
@@ -73,7 +73,7 @@ buildGoModule rec {
     "-skip TestCollectDockerfilePinning/Non-pinned_dockerfile|TestMixedPinning"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd scorecard \
       --bash <($out/bin/scorecard completion bash) \
       --fish <($out/bin/scorecard completion fish) \

--- a/pkgs/by-name/sh/shiori/package.nix
+++ b/pkgs/by-name/sh/shiori/package.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
   ];
 
   nativeBuildInputs = [ installShellFiles ];
-  postInstall = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd shiori \
       --bash <($out/bin/shiori completion bash) \
       --fish <($out/bin/shiori completion fish) \

--- a/pkgs/by-name/sh/shopware-cli/package.nix
+++ b/pkgs/by-name/sh/shopware-cli/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -29,7 +30,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-Ckn6+DzHPX+UG5YxYqvkdaio/elRQssbDSR+zAfxzdE=";
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd shopware-cli \
       --bash <($out/bin/shopware-cli completion bash) \
       --zsh <($out/bin/shopware-cli completion zsh) \

--- a/pkgs/by-name/sp/spicedb-zed/package.nix
+++ b/pkgs/by-name/sp/spicedb-zed/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -26,7 +27,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd zed \
       --bash <($out/bin/zed completion bash) \
       --fish <($out/bin/zed completion fish) \

--- a/pkgs/by-name/sp/spicedb/package.nix
+++ b/pkgs/by-name/sp/spicedb/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -26,7 +27,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd spicedb \
       --bash <($out/bin/spicedb completion bash) \
       --fish <($out/bin/spicedb completion fish) \

--- a/pkgs/by-name/sq/sq/package.nix
+++ b/pkgs/by-name/sq/sq/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -33,7 +34,7 @@ buildGoModule rec {
     "-X=github.com/neilotoole/sq/cli/buildinfo.Version=v${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd sq \
       --bash <($out/bin/sq completion bash) \
       --fish <($out/bin/sq completion fish) \

--- a/pkgs/by-name/sr/srgn/package.nix
+++ b/pkgs/by-name/sr/srgn/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   installShellFiles,
   lib,
+  stdenv,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "srgn";
@@ -19,7 +20,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     for shell in bash zsh fish; do
       installShellCompletion --cmd srgn "--$shell" <("$out/bin/srgn" --completions "$shell")
     done

--- a/pkgs/by-name/st/starboard/package.nix
+++ b/pkgs/by-name/st/starboard/package.nix
@@ -63,7 +63,7 @@ buildGoModule (finalAttrs: {
     }
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd starboard \
       --bash <($out/bin/starboard completion bash) \
       --fish <($out/bin/starboard completion fish) \

--- a/pkgs/by-name/st/stripe-cli/package.nix
+++ b/pkgs/by-name/st/stripe-cli/package.nix
@@ -54,7 +54,7 @@ buildGoModule rec {
         rm pkg/plugins/plugin_test.go
       '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd stripe \
       --bash <($out/bin/stripe completion --write-to-stdout --shell bash) \
       --zsh <($out/bin/stripe completion --write-to-stdout --shell zsh)

--- a/pkgs/by-name/st/sttr/package.nix
+++ b/pkgs/by-name/st/sttr/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -26,7 +27,7 @@ buildGoModule rec {
     "-X=main.version=${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd sttr \
       --bash <($out/bin/sttr completion bash) \
       --fish <($out/bin/sttr completion fish) \

--- a/pkgs/by-name/su/subtitlr/package.nix
+++ b/pkgs/by-name/su/subtitlr/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -27,7 +28,7 @@ buildGoModule rec {
     installShellFiles
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd Subtitlr \
       --bash <($out/bin/Subtitlr completion bash) \
       --fish <($out/bin/Subtitlr completion fish) \

--- a/pkgs/by-name/sy/syft/package.nix
+++ b/pkgs/by-name/sy/syft/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -56,7 +57,7 @@ buildGoModule rec {
   # tests require a running docker instance
   doCheck = false;
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd syft \
       --bash <($out/bin/syft completion bash) \
       --fish <($out/bin/syft completion fish) \

--- a/pkgs/by-name/ta/talosctl/package.nix
+++ b/pkgs/by-name/ta/talosctl/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -30,7 +31,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd talosctl \
       --bash <($out/bin/talosctl completion bash) \
       --fish <($out/bin/talosctl completion fish) \

--- a/pkgs/by-name/te/temporal-cli/package.nix
+++ b/pkgs/by-name/te/temporal-cli/package.nix
@@ -47,7 +47,7 @@ buildGoModule (finalAttrs: {
     export HOME="$(mktemp -d)"
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd temporal \
       --bash <($out/bin/temporal completion bash) \
       --fish <($out/bin/temporal completion fish) \

--- a/pkgs/by-name/te/terraform-backend-git/package.nix
+++ b/pkgs/by-name/te/terraform-backend-git/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -28,7 +29,7 @@ buildGoModule rec {
     "-X=github.com/plumber-cd/terraform-backend-git/cmd.Version=${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd terraform-backend-git \
       --bash <($out/bin/terraform-backend-git completion bash) \
       --fish <($out/bin/terraform-backend-git completion fish) \

--- a/pkgs/by-name/th/threatest/package.nix
+++ b/pkgs/by-name/th/threatest/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -23,7 +24,7 @@ buildGoModule rec {
     installShellFiles
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd threatest \
       --bash <($out/bin/threatest completion bash) \
       --fish <($out/bin/threatest completion fish) \

--- a/pkgs/by-name/ti/timoni/package.nix
+++ b/pkgs/by-name/ti/timoni/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -31,7 +32,7 @@ buildGoModule (finalAttrs: {
     "-X main.VERSION=${finalAttrs.version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd timoni \
     --bash <($out/bin/timoni completion bash) \
     --fish <($out/bin/timoni completion fish) \

--- a/pkgs/by-name/tr/trash-cli/package.nix
+++ b/pkgs/by-name/tr/trash-cli/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   installShellFiles,
   nix-update-script,
@@ -65,7 +66,7 @@ python3Packages.buildPythonApplication rec {
 
   pythonImportsCheck = [ "trashcli" ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     for bin in trash-empty trash-list trash-restore trash-put trash; do
       installShellCompletion --cmd "$bin" \
         --bash <("$out/bin/$bin" --print-completion bash) \

--- a/pkgs/by-name/tr/tray-tui/package.nix
+++ b/pkgs/by-name/tr/tray-tui/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
   installShellFiles,
@@ -22,7 +23,7 @@ rustPlatform.buildRustPackage rec {
     installShellFiles
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd tray-tui \
       --bash <($out/bin/tray-tui --completions bash) \
       --zsh <($out/bin/tray-tui --completions zsh) \

--- a/pkgs/by-name/ty/tyson/package.nix
+++ b/pkgs/by-name/ty/tyson/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -27,7 +28,7 @@ buildGoModule rec {
     "-w"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd tyson \
       --bash <($out/bin/tyson completion bash) \
       --fish <($out/bin/tyson completion fish) \

--- a/pkgs/by-name/up/updatecli/package.nix
+++ b/pkgs/by-name/up/updatecli/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   go,
   buildGoModule,
   fetchFromGitHub,
@@ -45,7 +46,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd updatecli \
       --bash <($out/bin/updatecli completion bash) \
       --fish <($out/bin/updatecli completion fish) \

--- a/pkgs/by-name/up/uplosi/package.nix
+++ b/pkgs/by-name/up/uplosi/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   buildGoModule,
   installShellFiles,
@@ -27,7 +28,7 @@ buildGoModule (finalAttrs: {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd uplosi \
       --bash <($out/bin/uplosi completion bash) \
       --fish <($out/bin/uplosi completion fish) \

--- a/pkgs/by-name/us/usage/package.nix
+++ b/pkgs/by-name/us/usage/package.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd usage \
       --bash <($out/bin/usage --completions bash) \
       --fish <($out/bin/usage --completions fish) \

--- a/pkgs/by-name/ve/vexctl/package.nix
+++ b/pkgs/by-name/ve/vexctl/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -44,7 +45,7 @@ buildGoModule rec {
     ldflags+=" -X sigs.k8s.io/release-utils/version.buildDate=$(cat SOURCE_DATE_EPOCH)"
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd vexctl \
       --bash <($out/bin/vexctl completion bash) \
       --fish <($out/bin/vexctl completion fish) \

--- a/pkgs/by-name/vh/vhs/package.nix
+++ b/pkgs/by-name/vh/vhs/package.nix
@@ -44,6 +44,8 @@ buildGoModule rec {
         ]
       )
     }
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     $out/bin/vhs man > vhs.1
     installManPage vhs.1
     installShellCompletion --cmd vhs \

--- a/pkgs/by-name/wa/wal-g/package.nix
+++ b/pkgs/by-name/wa/wal-g/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   brotli,
@@ -43,6 +44,8 @@ buildGoModule rec {
 
   postInstall = ''
     mv $out/bin/pg $out/bin/wal-g
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd wal-g \
       --bash <($out/bin/wal-g completion bash) \
       --zsh <($out/bin/wal-g completion zsh)

--- a/pkgs/by-name/wa/wander/package.nix
+++ b/pkgs/by-name/wa/wander/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -25,7 +26,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd wander \
       --fish <($out/bin/wander completion fish) \
       --bash <($out/bin/wander completion bash) \

--- a/pkgs/by-name/we/werf/package.nix
+++ b/pkgs/by-name/we/werf/package.nix
@@ -83,7 +83,7 @@ buildGoModule (finalAttrs: {
 
   versionCheckProgramArg = "version";
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     for shell in bash fish zsh; do
       installShellCompletion \
         --cmd werf \

--- a/pkgs/by-name/wi/witness/package.nix
+++ b/pkgs/by-name/wi/witness/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -39,7 +40,7 @@ buildGoModule rec {
     unset subPackages
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd witness \
       --bash <($out/bin/witness completion bash) \
       --fish <($out/bin/witness completion fish) \

--- a/pkgs/by-name/ya/yanic/package.nix
+++ b/pkgs/by-name/ya/yanic/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -26,7 +27,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd yanic \
       --bash <($out/bin/yanic completion bash) \
       --fish <($out/bin/yanic completion fish) \

--- a/pkgs/by-name/yt/ytt/package.nix
+++ b/pkgs/by-name/yt/ytt/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -27,7 +28,7 @@ buildGoModule rec {
     "-X carvel.dev/ytt/pkg/version.Version=${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd ytt \
       --bash <($out/bin/ytt completion bash) \
       --fish <($out/bin/ytt completion fish) \

--- a/pkgs/by-name/zi/zitadel-tools/package.nix
+++ b/pkgs/by-name/zi/zitadel-tools/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -26,7 +27,7 @@ buildGoModule rec {
     "-X main.version=${version}"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     local INSTALL="$out/bin/zitadel-tools"
     installShellCompletion --cmd zitadel-tools \
       --bash <($out/bin/zitadel-tools completion bash) \

--- a/pkgs/by-name/zs/zs/package.nix
+++ b/pkgs/by-name/zs/zs/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitea,
   buildGoModule,
   installShellFiles,
@@ -28,7 +29,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd zs \
       --bash <($out/bin/zs completion bash) \
       --fish <($out/bin/zs completion fish) \

--- a/pkgs/development/python-modules/keyring/default.nix
+++ b/pkgs/development/python-modules/keyring/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
   ]
   ++ lib.optionals (pythonOlder "3.12") [ importlib-metadata ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd keyring \
       --bash <($out/bin/keyring --print-completion bash) \
       --zsh <($out/bin/keyring --print-completion zsh)

--- a/pkgs/development/python-modules/pynitrokey/default.nix
+++ b/pkgs/development/python-modules/pynitrokey/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchPypi,
   installShellFiles,
@@ -72,7 +73,7 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "pynitrokey" ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd ${mainProgram} \
       --bash <(_NITROPY_COMPLETE=bash_source $out/bin/${mainProgram}) \
       --zsh <(_NITROPY_COMPLETE=zsh_source $out/bin/${mainProgram}) \

--- a/pkgs/development/tools/kustomize/4.nix
+++ b/pkgs/development/tools/kustomize/4.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -35,7 +36,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd kustomize \
       --bash <($out/bin/kustomize completion bash) \
       --fish <($out/bin/kustomize completion fish) \

--- a/pkgs/development/tools/kustomize/default.nix
+++ b/pkgs/development/tools/kustomize/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -35,7 +36,7 @@ buildGoModule (finalAttrs: {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd kustomize \
       --bash <($out/bin/kustomize completion bash) \
       --fish <($out/bin/kustomize completion fish) \

--- a/pkgs/servers/headscale/default.nix
+++ b/pkgs/servers/headscale/default.nix
@@ -43,7 +43,7 @@ buildGoModule rec {
     export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols:/etc/services=${iana-etc}/etc/services
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd headscale \
       --bash <($out/bin/headscale completion bash) \
       --fish <($out/bin/headscale completion fish) \

--- a/pkgs/tools/admin/pulumi-bin/default.nix
+++ b/pkgs/tools/admin/pulumi-bin/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   + lib.optionalString stdenv.hostPlatform.isLinux ''
     wrapProgram $out/bin/pulumi --set LD_LIBRARY_PATH "${lib.getLib stdenv.cc.cc}/lib"
   ''
-  + ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd pulumi \
       --bash <($out/bin/pulumi completion bash) \
       --fish <($out/bin/pulumi completion fish) \

--- a/pkgs/tools/security/rekor/default.nix
+++ b/pkgs/tools/security/rekor/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -52,7 +53,7 @@ let
         ldflags+=" -X sigs.k8s.io/release-utils/version.buildDate=$(cat SOURCE_DATE_EPOCH)"
       '';
 
-      postInstall = ''
+      postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
         installShellCompletion --cmd ${pname} \
           --bash <($out/bin/${pname} completion bash) \
           --fish <($out/bin/${pname} completion fish) \

--- a/pkgs/tools/virtualization/linode-cli/default.nix
+++ b/pkgs/tools/virtualization/linode-cli/default.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   buildPythonApplication,
   colorclass,
   fetchPypi,
@@ -71,7 +72,7 @@ buildPythonApplication rec {
     $out/bin/linode-cli --skip-config --version | grep ${version} > /dev/null
   '';
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     for shell in bash fish; do
       installShellCompletion --cmd linode-cli \
         --$shell <($out/bin/linode-cli --skip-config completion $shell)


### PR DESCRIPTION
This treewide conditions execution of the built applications for the purpose of generating shell completions behind `stdenv.buildPlatform.canExecute stdenv.hostPlatform`, which helps cross. This is a common issue I spot during review, let's prevent copy-paste errors by fixing it treewide.

Candidates were located with:

```shell
rg 'installShellCompletion' -l -tnix | xargs grep -F 'stdenv.buildPlatform.canExecute stdenv.hostPlatform' -L
```

Then I migrated the obvious cases which would not require a rebuild, as a means of testing.
This diff was not scripted. Should be zero rebuilds.

<details>
<summary>
Alternatives
</summary>

Alternatively I could have use this pattern:

```nix
postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
let
    emulator = stdenv.hostPlatform.emulator buildPackages;
in
''
    installShellCompletion --cmd foobar \
    --bash <(${emulator} $out/bin/foobar completion bash) \
    --fish <(${emulator} $out/bin/foobar completion fish) \
    --zsh <(${emulator} $out/bin/foobar completion zsh)
''
);
```

but that would cause rebuilds and will also require testing.

---

An other alternative is to use the binary from the corresponding package in `buildPackages`.
This however would also cause rebuilds and will also require testing.

</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
