### PR TITLE
nixos/windmill: Fix database setup config + target unit

### DIFF
--- a/nixos/modules/services/web-apps/windmill.nix
+++ b/nixos/modules/services/web-apps/windmill.nix
@@ -91,6 +91,16 @@ in
 
   config = lib.mkIf cfg.enable {
 
+    assertions = [
+      {
+        assertion = cfg.database.createLocally -> cfg.database.name == cfg.database.user;
+        message = ''
+          Automatically provisioning the windmill database requires both database name and database user to be equal. '${cfg.database.name}' != '${cfg.database.user}'
+          To fix this problem, assign the same value to both options services.windmill.database.{name,user}.
+        '';
+      }
+    ];
+
     services.postgresql = lib.optionalAttrs (cfg.database.createLocally) {
       enable = lib.mkDefault true;
 
@@ -101,7 +111,6 @@ in
           ensureDBOwnership = true;
         }
       ];
-
     };
 
     systemd.services =
@@ -112,7 +121,6 @@ in
           # using the same user to simplify db connection
           User = cfg.database.user;
           ExecStart = "${pkgs.windmill}/bin/windmill";
-
           Restart = "always";
         }
         // lib.optionalAttrs useUrlPath {
@@ -129,41 +137,71 @@ in
           };
       in
       {
+        windmill-initdb = lib.mkIf cfg.database.createLocally {
+          description = "Windmill database setup";
+          requires = [ "postgresql.target" ];
+          after = [ "postgresql.target" ];
+          requiredBy =
+            [ ]
+            ++ (lib.optionals config.systemd.services.windmill-server.enable [ "windmill-server.service" ])
+            ++ (lib.optionals config.systemd.services.windmill-worker.enable [ "windmill-worker.service" ])
+            ++ (lib.optionals config.systemd.services.windmill-worker-native.enable [
+              "windmill-worker-native.service"
+            ]);
+          before =
+            [ ]
+            ++ (lib.optionals config.systemd.services.windmill-server.enable [ "windmill-server.service" ])
+            ++ (lib.optionals config.systemd.services.windmill-worker.enable [ "windmill-worker.service" ])
+            ++ (lib.optionals config.systemd.services.windmill-worker-native.enable [
+              "windmill-worker-native.service"
+            ]);
 
-        # coming from https://github.com/windmill-labs/windmill/blob/main/init-db-as-superuser.sql
-        # modified to not grant privileges on all tables
-        # create role windmill_user and windmill_admin only if they don't exist
-        postgresql.postStart = lib.mkIf cfg.database.createLocally ''
-          psql -tA <<"EOF"
-          DO $$
-          BEGIN
-              IF NOT EXISTS (
-                  SELECT FROM pg_catalog.pg_roles
-                  WHERE rolname = 'windmill_user'
-              ) THEN
-                  CREATE ROLE windmill_user;
-                  GRANT ALL PRIVILEGES ON DATABASE ${cfg.database.name} TO windmill_user;
-              ELSE
-                RAISE NOTICE 'Role "windmill_user" already exists. Skipping.';
-              END IF;
-              IF NOT EXISTS (
-                  SELECT FROM pg_catalog.pg_roles
-                  WHERE rolname = 'windmill_admin'
-              ) THEN
-                CREATE ROLE windmill_admin WITH BYPASSRLS;
-                GRANT windmill_user TO windmill_admin;
-              ELSE
-                RAISE NOTICE 'Role "windmill_admin" already exists. Skipping.';
-              END IF;
-              GRANT windmill_admin TO windmill;
-          END
-          $$;
-          EOF
-        '';
+          path = [ config.services.postgresql.package ];
+          # coming from https://github.com/windmill-labs/windmill/blob/main/init-db-as-superuser.sql
+          # modified to not grant privileges on all tables
+          # create role windmill_user and windmill_admin only if they don't exist
+          script = ''
+            psql -tA <<"EOF"
+              DO $$
+              BEGIN
+                  IF NOT EXISTS (
+                      SELECT FROM pg_catalog.pg_roles
+                      WHERE rolname = 'windmill_user'
+                  ) THEN
+                      CREATE ROLE windmill_user;
+                      GRANT ALL PRIVILEGES ON DATABASE ${cfg.database.name} TO windmill_user;
+                  ELSE
+                    RAISE NOTICE 'Role "windmill_user" already exists. Skipping.';
+                  END IF;
+                  IF NOT EXISTS (
+                      SELECT FROM pg_catalog.pg_roles
+                      WHERE rolname = 'windmill_admin'
+                  ) THEN
+                    CREATE ROLE windmill_admin WITH BYPASSRLS;
+                    GRANT windmill_user TO windmill_admin;
+                  ELSE
+                    RAISE NOTICE 'Role "windmill_admin" already exists. Skipping.';
+                  END IF;
+                  GRANT windmill_admin TO ${cfg.database.user};
+              END
+              $$;
+            EOF
+          '';
+
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            # Superuser because of required permission CREATE ROLE
+            User = "postgres";
+
+            ProtectSystem = "strict";
+            ProtectHome = "read-only";
+          };
+        };
 
         windmill-server = {
           description = "Windmill server";
-          after = [ "network.target" ] ++ lib.optional cfg.database.createLocally "postgresql.target";
+          after = [ "network.target" ];
           wantedBy = [ "multi-user.target" ];
 
           serviceConfig = serviceConfig // {
@@ -181,7 +219,7 @@ in
 
         windmill-worker = {
           description = "Windmill worker";
-          after = [ "network.target" ] ++ lib.optional cfg.database.createLocally "postgresql.target";
+          after = [ "network.target" ];
           wantedBy = [ "multi-user.target" ];
 
           serviceConfig = serviceConfig // {
@@ -200,7 +238,7 @@ in
 
         windmill-worker-native = {
           description = "Windmill worker native";
-          after = [ "network.target" ] ++ lib.optional cfg.database.createLocally "postgresql.target";
+          after = [ "network.target" ];
           wantedBy = [ "multi-user.target" ];
 
           serviceConfig = serviceConfig // {

--- a/nixos/modules/services/web-apps/windmill.nix
+++ b/nixos/modules/services/web-apps/windmill.nix
@@ -113,6 +113,18 @@ in
       ];
     };
 
+    systemd.targets.windmill = {
+      description = "Windmill";
+      wantedBy = [ "multi-user.target" ];
+      requires =
+        [ ]
+        ++ (lib.optionals config.systemd.services.windmill-server.enable [ "windmill-server.service" ])
+        ++ (lib.optionals config.systemd.services.windmill-worker.enable [ "windmill-worker.service" ])
+        ++ (lib.optionals config.systemd.services.windmill-worker-native.enable [
+          "windmill-worker-native.service"
+        ]);
+    };
+
     systemd.services =
       let
         useUrlPath = (cfg.database.urlPath != null);
@@ -202,7 +214,7 @@ in
         windmill-server = {
           description = "Windmill server";
           after = [ "network.target" ];
-          wantedBy = [ "multi-user.target" ];
+          partOf = [ "windmill.target" ];
 
           serviceConfig = serviceConfig // {
             StateDirectory = "windmill";
@@ -220,7 +232,7 @@ in
         windmill-worker = {
           description = "Windmill worker";
           after = [ "network.target" ];
-          wantedBy = [ "multi-user.target" ];
+          partOf = [ "windmill.target" ];
 
           serviceConfig = serviceConfig // {
             StateDirectory = "windmill-worker";
@@ -239,7 +251,7 @@ in
         windmill-worker-native = {
           description = "Windmill worker native";
           after = [ "network.target" ];
-          wantedBy = [ "multi-user.target" ];
+          partOf = [ "windmill.target" ];
 
           serviceConfig = serviceConfig // {
             StateDirectory = "windmill-worker-native";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Backwards/forwards compatible changes;
- Update the database initialization script structure to conform new postgresql-setup unit
- Add windmill.target unit to control/order all platform services with other system units
- Add validation that database name and user must match if local provisioning is selected

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
