### PR TITLE
go: set CC env variable in wrapper

### DIFF
--- a/pkgs/development/compilers/go/1.24.nix
+++ b/pkgs/development/compilers/go/1.24.nix
@@ -12,6 +12,7 @@
   testers,
   skopeo,
   buildGo124Module,
+  makeWrapper,
 }:
 
 let
@@ -39,6 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
     [ ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.libc.out ]
     ++ lib.optionals (stdenv.hostPlatform.libc == "glibc") [ stdenv.cc.libc.static ];
+
+  nativeBuildInputs = [ makeWrapper ];
 
   depsBuildTarget = lib.optional isCross targetCC;
 
@@ -137,7 +140,8 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/share/go
     cp -a bin pkg src lib misc api doc go.env VERSION $out/share/go
     mkdir -p $out/bin
-    ln -s $out/share/go/bin/* $out/bin
+    makeWrapper $out/share/go/bin/go $out/bin/go --set-default CC ${targetPackages.stdenv.cc}/bin/cc
+    ln -s $out/share/go/bin/gofmt $out/bin/gofmt
     runHook postInstall
   '';
 

--- a/pkgs/development/compilers/go/1.25.nix
+++ b/pkgs/development/compilers/go/1.25.nix
@@ -13,6 +13,7 @@
   testers,
   skopeo,
   buildGo125Module,
+  makeWrapper,
 }:
 
 let
@@ -40,6 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     [ ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.libc.out ]
     ++ lib.optionals (stdenv.hostPlatform.libc == "glibc") [ stdenv.cc.libc.static ];
+  nativeBuildInputs = [ makeWrapper ];
 
   depsTargetTargetPropagated = lib.optionals stdenv.targetPlatform.isDarwin [
     apple-sdk_12
@@ -142,7 +144,8 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/share/go
     cp -a bin pkg src lib misc api doc go.env VERSION $out/share/go
     mkdir -p $out/bin
-    ln -s $out/share/go/bin/* $out/bin
+    makeWrapper $out/share/go/bin/go $out/bin/go --set-default CC ${targetPackages.stdenv.cc}/bin/cc
+    ln -s $out/share/go/bin/gofmt $out/bin/gofmt
     runHook postInstall
   '';
 


### PR DESCRIPTION
Wraps the `go` compiler with an overrideable `CC` environment variable, pointing to `${stdenv.cc}/bin/cc`. This is useful to make the `go` compiler work outside the stdenv environment out of the box.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
