### PR TITLE
runc: fix cross-compilation

### DIFF
--- a/pkgs/by-name/ru/runc/package.nix
+++ b/pkgs/by-name/ru/runc/package.nix
@@ -14,14 +14,14 @@
   nixosTests,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "runc";
   version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "opencontainers";
     repo = "runc";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-B7x1J2ijM+/RWzPTldBNhvrGa/8de6Unl47lOS/KxXs=";
   };
 
@@ -53,7 +53,7 @@ buildGoModule rec {
   buildPhase = ''
     runHook preBuild
     patchShebangs .
-    make ${toString makeFlags} runc man
+    make ${toString finalAttrs.makeFlags} runc man
     runHook postBuild
   '';
 
@@ -77,4 +77,4 @@ buildGoModule rec {
     platforms = platforms.linux;
     mainProgram = "runc";
   };
-}
+})

--- a/pkgs/by-name/ru/runc/package.nix
+++ b/pkgs/by-name/ru/runc/package.nix
@@ -10,7 +10,7 @@
   libseccomp,
   libselinux,
   stdenv,
-  makeWrapper,
+  makeBinaryWrapper,
   nixosTests,
 }:
 
@@ -34,7 +34,7 @@ buildGoModule (finalAttrs: {
   nativeBuildInputs = [
     go-md2man
     installShellFiles
-    makeWrapper
+    makeBinaryWrapper
     pkg-config
     which
   ];

--- a/pkgs/by-name/ru/runc/package.nix
+++ b/pkgs/by-name/ru/runc/package.nix
@@ -9,7 +9,7 @@
   libapparmor,
   libseccomp,
   libselinux,
-  runtimeShell,
+  stdenv,
   makeWrapper,
   nixosTests,
 }:
@@ -47,7 +47,7 @@ buildGoModule rec {
 
   makeFlags = [
     "BUILDTAGS+=seccomp"
-    "SHELL=${runtimeShell}"
+    "SHELL=${stdenv.shell}"
   ];
 
   buildPhase = ''


### PR DESCRIPTION
Should fix #442275

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage442275

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
