### PR TITLE
Create SonicWall NetExtender package and NixOS Module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -114,6 +114,8 @@
 
 - [PairDrop](https://github.com/schlagmichdoch/pairdrop), a peer-to-peer file transfer web app. Available as [services.pairdrop](#opt-services.pairdrop.enable).
 
+- [SonicWall NetExtender](https://www.sonicwall.com), an enterprice VPN client. Available as [programs.netextender](#opt-programs.netextender.enable).
+
 - [SuiteNumérique Docs](https://github.com/suitenumerique/docs), a collaborative note taking, wiki and documentation web platform and alternative to Notion or Outline. Available as [services.lasuite-docs](#opt-services.lasuite-docs.enable).
 
 - [dwl](https://codeberg.org/dwl/dwl), a compact, hackable compositor for Wayland based on wlroots. Available as [programs.dwl](#opt-programs.dwl.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -271,6 +271,7 @@
   ./programs/nbd.nix
   ./programs/nekoray.nix
   ./programs/neovim.nix
+  ./programs/netextender.nix
   ./programs/nethoscope.nix
   ./programs/nexttrace.nix
   ./programs/nh.nix

--- a/nixos/modules/programs/netextender.nix
+++ b/nixos/modules/programs/netextender.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  config,
+  netextender,
+  ...
+}:
+
+let
+  cfg = config.programs.netextender;
+in
+
+{
+  options = {
+    programs.netextender = {
+      enable = lib.mkEnableOption "SonicWall NetExtender service";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ netextender ];
+
+    systemd.services.netextender = {
+      description = "SonicWall NetExtender service";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Restart = "on-failure";
+        ExecStart = "${netextender}/bin/NEService";
+        KillMode = "process";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    JacoMalan1
+  ];
+}

--- a/pkgs/by-name/ne/netextender/package.nix
+++ b/pkgs/by-name/ne/netextender/package.nix
@@ -1,0 +1,67 @@
+{
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  gtk2,
+  webkitgtk_4_1,
+  stdenv,
+  lib,
+  makeWrapper,
+  iproute2,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "netextender";
+  version = "10.3.0-21";
+
+  src = fetchurl {
+    url = "https://software.sonicwall.com/NetExtender/NetExtender-linux-amd64-${finalAttrs.version}.deb";
+    hash = "sha256-GmPEXGzQ6iT+jgwhNuTv9SzHry+84AbrrkOckPv+pc4=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    gtk2
+    webkitgtk_4_1
+  ];
+
+  autoPatchelfIgnoreMissingDeps = [
+    "libwebkit2gtk-4.0.so.37"
+    "libjavascriptcoregtk-4.0.so.18"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/{netextender,applications}
+    mkdir $out/bin
+
+    mv usr/local/netextender/locales $out/share/netextender
+    mv usr/local/netextender/{NEService,nxcli,wg,wg-quick,wireguard-go} $out/bin
+    mv usr/local/netextender/com.sonicwall.NetExtender.desktop $out/share/applications
+    mv usr/local/netextender/NetExtender_webkit2_41 $out/bin/NetExtender
+
+    sed -i "s,Icon=/usr/local/netextender/nx-icon.png,Icon=$out/share/netextender/nx-icon.png,g" $out/share/applications/com.sonicwall.NetExtender.desktop
+    sed -i "s,Exec=/usr/local/netextender/NetExtender,Exec=$out/bin/NetExtender,g" $out/share/applications/com.sonicwall.NetExtender.desktop
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/NEService --prefix PATH : "${lib.makeBinPath [ iproute2 ]}"
+  '';
+
+  meta = {
+    homepage = "https://www.sonicwall.com";
+    description = "SonicWall NetExtender Enterprise VPN Client";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    maintainers = [ lib.maintainers.JacoMalan1 ];
+    mainProgram = "NetExtender";
+  };
+})


### PR DESCRIPTION
Created a package for NetExtender.
NetExtender has a service that runs in the background to open VPN connections, so I created a module for that as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
