### PR TITLE
mctc-lib: fix openmp cores in checkPhase

### DIFF
--- a/pkgs/by-name/cp/cp2k/package.nix
+++ b/pkgs/by-name/cp/cp2k/package.nix
@@ -70,7 +70,7 @@ let
   grimmeCmake = lib.makeScope newScope (self: {
     mctc-lib = mctc-lib.override {
       buildType = "cmake";
-      inherit (self) jonquil toml-f;
+      inherit (self) jonquil;
     };
 
     toml-f = toml-f.override {

--- a/pkgs/by-name/df/dftd4/package.nix
+++ b/pkgs/by-name/df/dftd4/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  fetchpatch,
   gfortran,
   buildType ? "meson",
   cmake,

--- a/pkgs/by-name/mc/mctc-lib/package.nix
+++ b/pkgs/by-name/mc/mctc-lib/package.nix
@@ -9,7 +9,6 @@
   cmake,
   pkg-config,
   python3,
-  toml-f,
   jonquil,
 }:
 

--- a/pkgs/by-name/mc/mctc-lib/package.nix
+++ b/pkgs/by-name/mc/mctc-lib/package.nix
@@ -61,6 +61,10 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  preCheck = ''
+    export OMP_NUM_THREADS=2
+  '';
+
   postPatch = ''
     patchShebangs --build config/install-mod.py
   '';

--- a/pkgs/by-name/si/sirius/package.nix
+++ b/pkgs/by-name/si/sirius/package.nix
@@ -51,7 +51,7 @@ assert builtins.elem gpuBackend [
 ];
 assert enablePython -> pythonPackages != null;
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "SIRIUS";
   version = "7.8.0-unstable-2025-07-23";
 

--- a/pkgs/development/libraries/science/chemistry/tblite/python.nix
+++ b/pkgs/development/libraries/science/chemistry/tblite/python.nix
@@ -1,5 +1,4 @@
 {
-  lib,
   buildPythonPackage,
   meson,
   ninja,


### PR DESCRIPTION
The tests chokes itself on machines with a high core count.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
