### PR TITLE
qwen-code: 0.0.6 -> 0.0.11

### DIFF
--- a/pkgs/by-name/qw/qwen-code/add-missing-resolved-integrity-fields.patch
+++ b/pkgs/by-name/qw/qwen-code/add-missing-resolved-integrity-fields.patch
@@ -1,0 +1,70 @@
+From 0735b59eba183574e080d2912347d58e6e3d158e Mon Sep 17 00:00:00 2001
+From: Sergey Volkov <taranarmo@gmail.com>
+Date: Fri, 12 Sep 2025 20:06:24 +0200
+Subject: [PATCH] Add missing resolved and integrity fields to several packages
+
+---
+ package-lock.json | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/package-lock.json b/package-lock.json
+index 146686dc..9ad9009f 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -12574,6 +12574,8 @@
+     },
+     "packages/cli/node_modules/@testing-library/dom": {
+       "version": "10.4.0",
++      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
++      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+       "dev": true,
+       "license": "MIT",
+       "peer": true,
+@@ -12609,6 +12611,8 @@
+     },
+     "packages/cli/node_modules/@testing-library/react": {
+       "version": "16.3.0",
++      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
++      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+       "dev": true,
+       "license": "MIT",
+       "dependencies": {
+@@ -12660,6 +12664,8 @@
+     },
+     "packages/cli/node_modules/aria-query": {
+       "version": "5.3.0",
++      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
++      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+       "dev": true,
+       "license": "Apache-2.0",
+       "peer": true,
+@@ -12669,6 +12675,8 @@
+     },
+     "packages/cli/node_modules/emoji-regex": {
+       "version": "10.4.0",
++      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
++      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+       "license": "MIT"
+     },
+     "packages/cli/node_modules/react-is": {
+@@ -12681,6 +12689,8 @@
+     },
+     "packages/cli/node_modules/string-width": {
+       "version": "7.2.0",
++      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
++      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+       "license": "MIT",
+       "dependencies": {
+         "emoji-regex": "^10.3.0",
+@@ -12815,6 +12825,8 @@
+     },
+     "packages/core/node_modules/ignore": {
+       "version": "7.0.5",
++      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
++      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+       "license": "MIT",
+       "engines": {
+         "node": ">= 4"
+-- 
+2.51.0
+

--- a/pkgs/by-name/qw/qwen-code/package.nix
+++ b/pkgs/by-name/qw/qwen-code/package.nix
@@ -2,25 +2,56 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
-  fetchNpmDeps,
   nix-update-script,
+  jq,
 }:
 
 buildNpmPackage (finalAttrs: {
   pname = "qwen-code";
-  version = "0.0.6";
+  version = "0.0.11";
 
   src = fetchFromGitHub {
     owner = "QwenLM";
     repo = "qwen-code";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-s4+1hqdlJh5jOy6uZz608n5DzuBR+v/s+7D85oFwQIY=";
+    hash = "sha256-5qKSWbc0NPpgvt36T/gRSgm1+o2Pbdw3tgfcGba6YSs=";
   };
 
-  npmDeps = fetchNpmDeps {
-    inherit (finalAttrs) src;
-    hash = "sha256-cGO66hQxgpoxphtt/BPPDIBuAG8yQseCdzUdAO2mkr4=";
-  };
+  patches = [
+    # similar to upstream gemini-cli some node deps are missing resolved and integrity fields
+    # upstream the problem is solved in master and in v0.4+, eventually the fix should arrive to qwen
+    ./add-missing-resolved-integrity-fields.patch
+  ];
+
+  npmDepsHash = "sha256-XvJO3ylm/ER5neSubci2w9OCTmqobmmXLbKmdQAqArY=";
+
+  nativeBuildInputs = [
+    jq
+  ];
+
+  postPatch = ''
+    # patches below remove node-pty dependency which causes build fail on Darwin
+    # should be conditional on platform but since package-lock.json is patched it changes its hash
+    # though seems like this dependency is not really required by the package
+    ${jq}/bin/jq '
+      del(.packages."node_modules/node-pty") |
+      del(.packages."node_modules/@lydell/node-pty") |
+      del(.packages."node_modules/@lydell/node-pty-darwin-arm64") |
+      del(.packages."node_modules/@lydell/node-pty-darwin-x64") |
+      del(.packages."node_modules/@lydell/node-pty-linux-arm64") |
+      del(.packages."node_modules/@lydell/node-pty-linux-x64") |
+      del(.packages."node_modules/@lydell/node-pty-win32-arm64") |
+      del(.packages."node_modules/@lydell/node-pty-win32-x64") |
+      walk(
+        if type == "object" and has("dependencies") then
+          .dependencies |= with_entries(select(.key | contains("node-pty") | not))
+        elif type == "object" and has("optionalDependencies") then
+          .optionalDependencies |= with_entries(select(.key | contains("node-pty") | not))
+        else .
+        end
+      )
+    ' package-lock.json > package-lock.json.tmp && mv package-lock.json.tmp package-lock.json
+  '';
 
   buildPhase = ''
     runHook preBuild
@@ -34,10 +65,10 @@ buildNpmPackage (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin
-    cp -r bundle/* $out/
-    patchShebangs $out
-    ln -s $out/gemini.js $out/bin/qwen
+    mkdir -p $out/bin $out/share/qwen-code
+    cp -r bundle/* $out/share/qwen-code/
+    patchShebangs $out/share/qwen-code
+    ln -s $out/share/qwen-code/gemini.js $out/bin/qwen
 
     runHook postInstall
   '';


### PR DESCRIPTION
https://github.com/QwenLM/qwen-code/releases/tag/v0.0.11
had to construct a patch similar to https://github.com/google-gemini/gemini-cli/pull/5336

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
