### PR TITLE
prettier: Use `wrapProgram` for plugins

### DIFF
--- a/pkgs/by-name/pr/prettier/package.nix
+++ b/pkgs/by-name/pr/prettier/package.nix
@@ -1,3 +1,17 @@
+/**
+  # Example
+
+  Prettier with plugins and Vim Home Manager configuration
+
+  ```nix
+  pkgs.prettier.override {
+    plugins = with pkgs.nodePackages; [
+      prettier-plugin-toml
+      # ...
+    ];
+  }
+  ```
+*/
 {
   fetchFromGitHub,
   lib,
@@ -6,7 +20,109 @@
   stdenv,
   versionCheckHook,
   yarn-berry,
+  plugins ? [ ],
 }:
+let
+  /**
+    # Example
+
+    ```nix
+    exportRelativePathOf (builtins.fromJSON "./package.json")
+    =>
+    lib/node_modules/prettier-plugin-toml/./lib/index.cjs
+    ```
+
+    # Type
+
+    ```
+    exportRelativePathOf :: AttrSet => String
+    ```
+
+    # Arguments
+
+    packageJsonAttrs
+    : Attribute set with shape similar to `package.json` file
+  */
+  ## Blame NodeJS
+  exportRelativePathOf =
+    let
+      nodeExportAttrAddresses = [
+        [ "main" ]
+        [
+          "exports"
+          "."
+          "default"
+        ]
+        [
+          "exports"
+          "."
+        ]
+        [
+          "exports"
+          "default"
+        ]
+        [ "exports" ]
+      ];
+
+      recAttrByPath =
+        addresses: default: attrs:
+        if builtins.length addresses == 0 then
+          default
+        else
+          let
+            addressNext = builtins.head addresses;
+            addressesRemaning = lib.lists.drop 1 addresses;
+          in
+          lib.attrByPath addressNext (recAttrByPath addressesRemaning default attrs) attrs;
+    in
+    packageJsonAttrs:
+    recAttrByPath nodeExportAttrAddresses (builtins.head (
+      lib.attrByPath [ "prettier" "plugins" ] [ "null" ] packageJsonAttrs
+    )) packageJsonAttrs;
+
+  /**
+    # Example
+
+    ```nix
+    nodeEntryPointOf pkgs.nodePackages.prettier-plugin-toml
+    =>
+    /nix/store/<NAR_HASH>-prettier-plugin-toml-<VERSION>/lib/node_modules/prettier-plugin-toml/./lib/index.cjs
+    ```
+
+    # Type
+
+    ```
+    nodeEntryPointOf :: AttrSet => String
+    ```
+
+    # Arguments
+
+    plugin
+    : Attribute set with `.packageName` and `.outPath` defined
+  */
+  nodeEntryPointOf =
+    plugin:
+    let
+      pluginDir = "${plugin.outPath}/lib/node_modules/${plugin.packageName}";
+
+      packageJsonAttrs = builtins.fromJSON (builtins.readFile "${pluginDir}/package.json");
+
+      exportPath = exportRelativePathOf packageJsonAttrs;
+
+      pathAbsoluteNaive = "${pluginDir}/${exportPath}";
+      pathAbsoluteFallback = "${pluginDir}/${exportPath}.js";
+    in
+    if builtins.pathExists pathAbsoluteNaive then
+      pathAbsoluteNaive
+    else if builtins.pathExists pathAbsoluteFallback then
+      pathAbsoluteFallback
+    else
+      lib.warn ''
+        ${plugin.packageName}: error context, tried finding entry point under;
+        pathAbsoluteNaive -> ${pathAbsoluteNaive}
+        pathAbsoluteFallback -> ${pathAbsoluteFallback}
+      '' throw ''${plugin.packageName}: does not provide parse-able entry point'';
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "prettier";
   version = "3.6.2";
@@ -41,7 +157,13 @@ stdenv.mkDerivation (finalAttrs: {
 
     makeBinaryWrapper "${lib.getExe nodejs}" "$out/bin/prettier" \
       --add-flags "$out/bin/prettier.cjs"
-
+  ''
+  + lib.optionalString (builtins.length plugins > 0) ''
+    wrapProgram $out/bin/prettier --add-flags "${
+      builtins.concatStringsSep " " (lib.map (plugin: "--plugin=${nodeEntryPointOf plugin}") plugins)
+    }";
+  ''
+  + ''
     runHook postInstall
   '';
 
@@ -57,6 +179,9 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://prettier.io/";
     license = lib.licenses.mit;
     mainProgram = "prettier";
-    maintainers = with lib.maintainers; [ l0b0 ];
+    maintainers = with lib.maintainers; [
+      l0b0
+      S0AndS0
+    ];
   };
 })


### PR DESCRIPTION
These changes _should_ be backwards compatible while allowing users to opt-in to declaring list of Prettier `plugins` via `.override`

Doc-comments hopefully'll provide sufficient details about what the added features/functions are intended to do.

High-level summary;

- Add `plugins` package level argument
- Add `exportRelativePathOf` and `nodeEntryPointOf` internal functions
- Inject `wrapProgram` into `installPhase`
- Majority of [plugins](https://prettier.io/docs/plugins/) tested work well with Vim

Limitations;

- [Cannot find `<plugin>` imported from `noop.js`](https://github.com/nix-utilities/prettier-with-plugins/issues/1) shows though we can add `--plugin=<path>` to CLI via `wrapProgram` there are upstream limitations due to how they do `import`/`require` path discovery
- Likely there are other, _imaginative_, ways for plugin authors to declare the main export/entry-point that is not currently covered by `nodeExportAttrAddresses`...  also that list's order is kinda brittle
- There likely is a limit to the number of `--plugin=<path>` that can be injected, while still allowing users to define other parameters, but unlikely it is that limit will be reached


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
