### PR TITLE
pkgs/top-level/metrics.nix: tidy, speed up, and document what's happening in this file

### DIFF
--- a/pkgs/top-level/metrics.nix
+++ b/pkgs/top-level/metrics.nix
@@ -96,4 +96,85 @@ stdenvNoCC.mkDerivation {
 
     runHook postInstall
   '';
+
+  meta = {
+    description = "Metrics tracked by Hydra about Nixpkgs";
+    homepage = "https://hydra.nixos.org/job/nixpkgs/trunk/metrics";
+    longDescription = ''
+      View the metrics for Nixpkgs evaluation over time at these URLs.
+
+      These are all produced from running `nix` with `NIX_SHOW_STATS=1`.
+      See `EvalState::printStatistics` in the Nix source code for the implementation.
+      None of these metrics are inherently meaningful on their own.
+      Exercise caution in interpreting them as "bad" or "good".
+
+      # Total repository statistics
+
+      - [Lines of code in Nixpkgs](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/loc)
+      - [Count of broken packages using `nix-env -qa`](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaCountBroken)
+      - [Count of packages using `nix-env -qa`](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaCount)
+
+      # Statistics about representative commands
+
+      These are statistics gathered by running commands against Nixpkgs.
+
+      | Name | Command |
+      |------|---------|
+      | `nix-env.qaAggressive` | `nix-env -f ${nixpkgs} -qa` |
+      | `nix-env.qaDrvAggressive` | `nix-env -f ${nixpkgs} -qa --drv-path --meta --xml` |
+      | `nix-env.qaDrv` | `nix-env -f ${nixpkgs} -qa --drv-path --meta --xml` |
+      | `nix-env.qa` | `nix-env -f ${nixpkgs} -qa` |
+      | `nixos.kde` | `nix-instantiate --dry-run ${nixpkgs}/nixos/release.nix -A closures.kde.x86_64-linux --show-trace` |
+      | `nixos.lapp` | `nix-instantiate --dry-run ${nixpkgs}/nixos/release.nix -A closures.lapp.x86_64-linux --show-trace` |
+      | `nixos.smallContainer` | `nix-instantiate --dry-run ${nixpkgs}/nixos/release.nix -A closures.smallContainer.x86_64-linux --show-trace`|
+
+      ## Allocations performed (in bytes)
+
+      This counts `envs.bytes`, `list.bytes`, `values.bytes`, and `sets.bytes` from the Nix statistics.
+
+      - [nix-env.qa.allocations](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qa.allocations)
+      - [nix-env.qaAggressive.allocations](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaAggressive.allocations)
+      - [nix-env.qaDrv.allocations](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaDrv.allocations)
+      - [nix-env.qaDrvAggressive.allocations](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaDrvAggressive.allocations)
+      - [nixos.kde.allocations](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.kde.allocations)
+      - [nixos.lapp.allocations](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.lapp.allocations)
+      - [nixos.smallContainer.allocations](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.smallContainer.allocations)
+
+      ## Maximum resident size (in number of KiB)
+
+      This counts `maxresident` KiB (`%M`) from the `time` command on Linux.
+
+      - [nix-env.qa.maxresident](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qa.maxresident)
+      - [nix-env.qaAggressive.maxresident](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaAggressive.maxresident)
+      - [nix-env.qaDrv.maxresident](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaDrv.maxresident)
+      - [nix-env.qaDrvAggressive.maxresident](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaDrvAggressive.maxresident)
+      - [nixos.kde.maxresident](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.kde.maxresident)
+      - [nixos.lapp.maxresident](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.lapp.maxresident)
+      - [nixos.smallContainer.maxresident](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.smallContainer.maxresident)
+
+      ## Time taken (in seconds)
+
+      This counts `cpuTime` as reported in the Nix statistics. On Linux, this resolves to [`getrusage(RUSAGE_SELF)`](https://man7.org/linux/man-pages/man2/getrusage.2.html).
+
+      - [nix-env.qa.time](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qa.time)
+      - [nix-env.qaAggressive.time](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaAggressive.time)
+      - [nix-env.qaDrv.time](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaDrv.time)
+      - [nix-env.qaDrvAggressive.time](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaDrvAggressive.time)
+      - [nixos.kde.time](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.kde.time)
+      - [nixos.lapp.time](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.lapp.time)
+      - [nixos.smallContainer.time](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.smallContainer.time)
+
+      ## Number of values
+
+      This counts the total number of values allocated in Nix (see `EvalState::allocValue` in the Nix source code).
+
+      - [nix-env.qa.values](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qa.values)
+      - [nix-env.qaAggressive.values](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaAggressive.values)
+      - [nix-env.qaDrv.values](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaDrv.values)
+      - [nix-env.qaDrvAggressive.values](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaDrvAggressive.values)
+      - [nixos.kde.values](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.kde.values)
+      - [nixos.lapp.values](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.lapp.values)
+      - [nixos.smallContainer.values](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.smallContainer.values)
+    '';
+  };
 }

--- a/pkgs/top-level/metrics.nix
+++ b/pkgs/top-level/metrics.nix
@@ -40,49 +40,48 @@ stdenvNoCC.mkDerivation {
       echo "running $@"
 
       case "$name" in
-        # Redirect stdout to /dev/null to avoid hitting "Output Limit
-        # Exceeded" on Hydra.
+        # Redirect stdout to /dev/null to avoid hitting "Output Limit Exceeded" on Hydra.
         nix-env.qaDrv|nix-env.qaDrvAggressive)
           NIX_SHOW_STATS=1 NIX_SHOW_STATS_PATH=stats-nix time -o stats-time "$@" >/dev/null ;;
         *)
           NIX_SHOW_STATS=1 NIX_SHOW_STATS_PATH=stats-nix time -o stats-time "$@" ;;
       esac
 
-      cat stats-nix; echo; cat stats-time; echo
+      # Show the Nix statistics and the `time` statistics.
+      cat stats-nix
+      echo
+      cat stats-time
+      echo
 
-      x=$(jq '.cpuTime' < stats-nix)
-      [[ -n $x ]] || exit 1
-      echo "$name.time $x s" >> $out/nix-support/hydra-metrics
+      cpuTime="$(jq '.cpuTime' < stats-nix)"
+      [[ -n $cpuTime ]] || exit 1
+      echo "$name.time $cpuTime s" >> $out/nix-support/hydra-metrics
 
-      x=$(sed -e 's/.* \([0-9]\+\)maxresident.*/\1/ ; t ; d' < stats-time)
-      [[ -n $x ]] || exit 1
-      echo "$name.maxresident $x KiB" >> $out/nix-support/hydra-metrics
+      maxresident="$(sed -e 's/.* \([0-9]\+\)maxresident.*/\1/ ; t ; d' < stats-time)"
+      [[ -n $maxresident ]] || exit 1
+      echo "$name.maxresident $maxresident KiB" >> $out/nix-support/hydra-metrics
 
-      # nix-2.2 also outputs .symbols.bytes but that wasn't summed originally
-      # https://github.com/NixOS/nix/pull/2392/files#diff-8e6ba8c21672fc1a5f6f606e1e101c74L1762
-      x=$(jq '[.envs,.list,.values,.sets] | map(.bytes) | add' < stats-nix)
-      [[ -n $x ]] || exit 1
-      echo "$name.allocations $x B" >> $out/nix-support/hydra-metrics
+      # Nix also outputs `.symbols.bytes` but since that wasn't summed originally, we don't count it here.
+      allocations="$(jq '[.envs,.list,.values,.sets] | map(.bytes) | add' < stats-nix)"
+      [[ -n $allocations ]] || exit 1
+      echo "$name.allocations $allocations B" >> $out/nix-support/hydra-metrics
 
-      x=$(jq '.values.number' < stats-nix)
-      [[ -n $x ]] || exit 1
-      echo "$name.values $x" >> $out/nix-support/hydra-metrics
+      values="$(jq '.values.number' < stats-nix)"
+      [[ -n $values ]] || exit 1
+      echo "$name.values $values" >> $out/nix-support/hydra-metrics
     }
 
-    run nixos.smallContainer nix-instantiate --dry-run ${nixpkgs}/nixos/release.nix \
-      -A closures.smallContainer.x86_64-linux --show-trace
-    run nixos.kde nix-instantiate --dry-run ${nixpkgs}/nixos/release.nix \
-      -A closures.kde.x86_64-linux --show-trace
-    run nixos.lapp nix-instantiate --dry-run ${nixpkgs}/nixos/release.nix \
-      -A closures.lapp.x86_64-linux --show-trace
+    run nixos.smallContainer nix-instantiate --dry-run ${nixpkgs}/nixos/release.nix -A closures.smallContainer.x86_64-linux --show-trace
+    run nixos.kde nix-instantiate --dry-run ${nixpkgs}/nixos/release.nix -A closures.kde.x86_64-linux --show-trace
+    run nixos.lapp nix-instantiate --dry-run ${nixpkgs}/nixos/release.nix -A closures.lapp.x86_64-linux --show-trace
     run nix-env.qa nix-env -f ${nixpkgs} -qa
     run nix-env.qaDrv nix-env -f ${nixpkgs} -qa --drv-path --meta --xml
 
     # It's slightly unclear which of the set to track: qaCount, qaCountDrv, qaCountBroken.
-    num=$(nix-env -f ${nixpkgs} -qa | wc -l)
+    num="$(nix-env -f ${nixpkgs} -qa | wc -l)"
     echo "nix-env.qaCount $num" >> $out/nix-support/hydra-metrics
-    qaCountDrv=$(nix-env -f ${nixpkgs} -qa --drv-path | wc -l)
-    num=$((num - $qaCountDrv))
+    qaCountDrv="$(nix-env -f ${nixpkgs} -qa --drv-path | wc -l)"
+    num="$((num - $qaCountDrv))"
     echo "nix-env.qaCountBroken $num" >> $out/nix-support/hydra-metrics
 
     # TODO: this has been ignored for some time
@@ -91,7 +90,7 @@ stdenvNoCC.mkDerivation {
     run nix-env.qaAggressive nix-env -f ${nixpkgs} -qa
     run nix-env.qaDrvAggressive nix-env -f ${nixpkgs} -qa --drv-path --meta --xml
 
-    lines=$(find ${nixpkgs} -name "*.nix" -type f | xargs cat | wc -l)
+    lines="$(find ${nixpkgs} -name "*.nix" -type f | xargs cat | wc -l)"
     echo "loc $lines" >> $out/nix-support/hydra-metrics
 
     runHook postInstall

--- a/pkgs/top-level/metrics.nix
+++ b/pkgs/top-level/metrics.nix
@@ -97,7 +97,7 @@ stdenvNoCC.mkDerivation {
     numBroken="$((num - $qaCountDrv))"
     echo "nix-env.qaCountBroken $numBroken" >> hydra-metrics
 
-    lines="$(find "$nixpkgs" -name "*.nix" -type f | xargs cat | wc -l)"
+    lines="$(find "$nixpkgs" -name "*.nix" -type f -print0 | xargs -0 cat | wc -l)"
     echo "loc $lines" >> hydra-metrics
 
     runHook postBuild

--- a/pkgs/top-level/metrics.nix
+++ b/pkgs/top-level/metrics.nix
@@ -47,7 +47,7 @@ stdenvNoCC.mkDerivation {
 
       case "$name" in
         # Redirect stdout to /dev/null to avoid hitting "Output Limit Exceeded" on Hydra.
-        nix-env.qaDrv|nix-env.qaDrvAggressive)
+        nix-env.qaDrv)
           NIX_SHOW_STATS=1 NIX_SHOW_STATS_PATH=stats-nix time -o stats-time "$@" >/dev/null ;;
         *)
           NIX_SHOW_STATS=1 NIX_SHOW_STATS_PATH=stats-nix time -o stats-time "$@" ;;
@@ -90,12 +90,6 @@ stdenvNoCC.mkDerivation {
     num="$((num - $qaCountDrv))"
     echo "nix-env.qaCountBroken $num" >> $out/nix-support/hydra-metrics
 
-    # TODO: this has been ignored for some time
-    # GC Warning: Bad initial heap size 128k - ignoring it.
-    #export GC_INITIAL_HEAP_SIZE=128k
-    run nix-env.qaAggressive nix-env -f "$nixpkgs" -qa
-    run nix-env.qaDrvAggressive nix-env -f "$nixpkgs" -qa --drv-path --meta --xml
-
     lines="$(find "$nixpkgs" -name "*.nix" -type f | xargs cat | wc -l)"
     echo "loc $lines" >> $out/nix-support/hydra-metrics
 
@@ -125,8 +119,6 @@ stdenvNoCC.mkDerivation {
 
       | Name | Command |
       |------|---------|
-      | `nix-env.qaAggressive` | `nix-env -f ${nixpkgs} -qa` |
-      | `nix-env.qaDrvAggressive` | `nix-env -f ${nixpkgs} -qa --drv-path --meta --xml` |
       | `nix-env.qaDrv` | `nix-env -f ${nixpkgs} -qa --drv-path --meta --xml` |
       | `nix-env.qa` | `nix-env -f ${nixpkgs} -qa` |
       | `nixos.kde` | `nix-instantiate --dry-run ${nixpkgs}/nixos/release.nix -A closures.kde.x86_64-linux --show-trace` |
@@ -138,9 +130,7 @@ stdenvNoCC.mkDerivation {
       This counts `envs.bytes`, `list.bytes`, `values.bytes`, and `sets.bytes` from the Nix statistics.
 
       - [nix-env.qa.allocations](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qa.allocations)
-      - [nix-env.qaAggressive.allocations](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaAggressive.allocations)
       - [nix-env.qaDrv.allocations](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaDrv.allocations)
-      - [nix-env.qaDrvAggressive.allocations](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaDrvAggressive.allocations)
       - [nixos.kde.allocations](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.kde.allocations)
       - [nixos.lapp.allocations](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.lapp.allocations)
       - [nixos.smallContainer.allocations](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.smallContainer.allocations)
@@ -150,9 +140,7 @@ stdenvNoCC.mkDerivation {
       This counts `maxresident` KiB (`%M`) from the `time` command on Linux.
 
       - [nix-env.qa.maxresident](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qa.maxresident)
-      - [nix-env.qaAggressive.maxresident](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaAggressive.maxresident)
       - [nix-env.qaDrv.maxresident](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaDrv.maxresident)
-      - [nix-env.qaDrvAggressive.maxresident](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaDrvAggressive.maxresident)
       - [nixos.kde.maxresident](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.kde.maxresident)
       - [nixos.lapp.maxresident](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.lapp.maxresident)
       - [nixos.smallContainer.maxresident](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.smallContainer.maxresident)
@@ -162,9 +150,7 @@ stdenvNoCC.mkDerivation {
       This counts `cpuTime` as reported in the Nix statistics. On Linux, this resolves to [`getrusage(RUSAGE_SELF)`](https://man7.org/linux/man-pages/man2/getrusage.2.html).
 
       - [nix-env.qa.time](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qa.time)
-      - [nix-env.qaAggressive.time](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaAggressive.time)
       - [nix-env.qaDrv.time](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaDrv.time)
-      - [nix-env.qaDrvAggressive.time](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaDrvAggressive.time)
       - [nixos.kde.time](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.kde.time)
       - [nixos.lapp.time](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.lapp.time)
       - [nixos.smallContainer.time](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.smallContainer.time)
@@ -174,9 +160,7 @@ stdenvNoCC.mkDerivation {
       This counts the total number of values allocated in Nix (see `EvalState::allocValue` in the Nix source code).
 
       - [nix-env.qa.values](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qa.values)
-      - [nix-env.qaAggressive.values](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaAggressive.values)
       - [nix-env.qaDrv.values](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaDrv.values)
-      - [nix-env.qaDrvAggressive.values](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nix-env.qaDrvAggressive.values)
       - [nixos.kde.values](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.kde.values)
       - [nixos.lapp.values](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.lapp.values)
       - [nixos.smallContainer.values](https://hydra.nixos.org/job/nixpkgs/trunk/metrics/metric/nixos.smallContainer.values)

--- a/pkgs/top-level/metrics.nix
+++ b/pkgs/top-level/metrics.nix
@@ -84,9 +84,9 @@ stdenvNoCC.mkDerivation {
       echo "$name.values $values" >> $out/nix-support/hydra-metrics
     }
 
-    run nixos.smallContainer nix-instantiate --option eval-system "$evalSystem" --dry-run "$release" -A closures.smallContainer.x86_64-linux --show-trace
-    run nixos.kde nix-instantiate --option eval-system "$evalSystem" --dry-run "$release" -A closures.kde.x86_64-linux --show-trace
-    run nixos.lapp nix-instantiate --option eval-system "$evalSystem" --dry-run "$release" -A closures.lapp.x86_64-linux --show-trace
+    run nixos.smallContainer nix-instantiate --option eval-system "$evalSystem" --dry-run "$release" -A closures.smallContainer.x86_64-linux --show-trace --no-gc-warning
+    run nixos.kde nix-instantiate --option eval-system "$evalSystem" --dry-run "$release" -A closures.kde.x86_64-linux --show-trace --no-gc-warning
+    run nixos.lapp nix-instantiate --option eval-system "$evalSystem" --dry-run "$release" -A closures.lapp.x86_64-linux --show-trace --no-gc-warning
     run nix-env.qa nix-env --option eval-system "$evalSystem" -f "$nixpkgs" -qa
     run nix-env.qaDrv nix-env --option eval-system "$evalSystem" -f "$nixpkgs" -qa --drv-path --meta --json
 

--- a/pkgs/top-level/metrics.nix
+++ b/pkgs/top-level/metrics.nix
@@ -86,7 +86,7 @@ stdenvNoCC.mkDerivation {
     run nixos.kde nix-instantiate --option eval-system "$evalSystem" --dry-run "$release" -A closures.kde.x86_64-linux --show-trace
     run nixos.lapp nix-instantiate --option eval-system "$evalSystem" --dry-run "$release" -A closures.lapp.x86_64-linux --show-trace
     run nix-env.qa nix-env --option eval-system "$evalSystem" -f "$nixpkgs" -qa
-    run nix-env.qaDrv nix-env --option eval-system "$evalSystem" -f "$nixpkgs" -qa --drv-path --meta --xml
+    run nix-env.qaDrv nix-env --option eval-system "$evalSystem" -f "$nixpkgs" -qa --drv-path --meta --json
 
     # It's slightly unclear which of the set to track: qaCount, qaCountDrv, qaCountBroken.
     num="$(nix-env --option eval-system "$evalSystem" -f "$nixpkgs" -qa | wc -l)"
@@ -124,7 +124,7 @@ stdenvNoCC.mkDerivation {
 
       | Name | Command |
       |------|---------|
-      | `nix-env.qaDrv` | `nix-env -f ${nixpkgs} -qa --drv-path --meta --xml` |
+      | `nix-env.qaDrv` | `nix-env -f ${nixpkgs} -qa --drv-path --meta --json` |
       | `nix-env.qa` | `nix-env -f ${nixpkgs} -qa` |
       | `nixos.kde` | `nix-instantiate --dry-run ${nixpkgs}/nixos/release.nix -A closures.kde.x86_64-linux --show-trace` |
       | `nixos.lapp` | `nix-instantiate --dry-run ${nixpkgs}/nixos/release.nix -A closures.lapp.x86_64-linux --show-trace` |

--- a/pkgs/top-level/metrics.nix
+++ b/pkgs/top-level/metrics.nix
@@ -18,7 +18,7 @@ stdenvNoCC.mkDerivation {
   ];
 
   nativeBuildInputs = map lib.getBin [
-    pkgs.nix
+    pkgs.nixVersions.latest
     pkgs.time
     pkgs.jq
   ];

--- a/pkgs/top-level/metrics.nix
+++ b/pkgs/top-level/metrics.nix
@@ -56,9 +56,11 @@ stdenvNoCC.mkDerivation {
       esac
 
       # Show the Nix statistics and the `time` statistics.
-      cat "$nix_stats"
+      echo "Nix statistics for $@"
+      jq . "$nix_stats"
       echo
-      cat "$time_stats"
+      echo "Time statistics for $@"
+      jq . "$time_stats"
       echo
 
       cpuTime="$(jq '.cpuTime' < "$nix_stats")"

--- a/pkgs/top-level/metrics.nix
+++ b/pkgs/top-level/metrics.nix
@@ -201,4 +201,11 @@ stdenvNoCC.mkDerivation {
     exit_status = "%x";
     command = "%C";
   };
+
+  # Don't allow aliases anywhere in Nixpkgs for the metrics.
+  env.NIXPKGS_CONFIG = builtins.toFile "nixpkgs-config.nix" ''
+    {
+      allowAliases = false;
+    }
+  '';
 }

--- a/pkgs/top-level/metrics.nix
+++ b/pkgs/top-level/metrics.nix
@@ -2,6 +2,7 @@
 
 let
   inherit (pkgs) lib stdenvNoCC;
+  evalSystem = "x86_64-linux";
 in
 
 stdenvNoCC.mkDerivation {
@@ -9,7 +10,7 @@ stdenvNoCC.mkDerivation {
 
   # Use structured attrs to pass in relevant information.
   __structuredAttrs = true;
-  inherit nixpkgs;
+  inherit evalSystem nixpkgs;
 
   nativeBuildInputs = map lib.getBin [
     pkgs.nix
@@ -81,16 +82,16 @@ stdenvNoCC.mkDerivation {
       echo "$name.values $values" >> $out/nix-support/hydra-metrics
     }
 
-    run nixos.smallContainer nix-instantiate --dry-run "$release" -A closures.smallContainer.x86_64-linux --show-trace
-    run nixos.kde nix-instantiate --dry-run "$release" -A closures.kde.x86_64-linux --show-trace
-    run nixos.lapp nix-instantiate --dry-run "$release" -A closures.lapp.x86_64-linux --show-trace
-    run nix-env.qa nix-env -f "$nixpkgs" -qa
-    run nix-env.qaDrv nix-env -f "$nixpkgs" -qa --drv-path --meta --xml
+    run nixos.smallContainer nix-instantiate --option eval-system "$evalSystem" --dry-run "$release" -A closures.smallContainer.x86_64-linux --show-trace
+    run nixos.kde nix-instantiate --option eval-system "$evalSystem" --dry-run "$release" -A closures.kde.x86_64-linux --show-trace
+    run nixos.lapp nix-instantiate --option eval-system "$evalSystem" --dry-run "$release" -A closures.lapp.x86_64-linux --show-trace
+    run nix-env.qa nix-env --option eval-system "$evalSystem" -f "$nixpkgs" -qa
+    run nix-env.qaDrv nix-env --option eval-system "$evalSystem" -f "$nixpkgs" -qa --drv-path --meta --xml
 
     # It's slightly unclear which of the set to track: qaCount, qaCountDrv, qaCountBroken.
-    num="$(nix-env -f "$nixpkgs" -qa | wc -l)"
+    num="$(nix-env --option eval-system "$evalSystem" -f "$nixpkgs" -qa | wc -l)"
     echo "nix-env.qaCount $num" >> $out/nix-support/hydra-metrics
-    qaCountDrv="$(nix-env -f "$nixpkgs" -qa --drv-path | wc -l)"
+    qaCountDrv="$(nix-env --option eval-system "$evalSystem" -f "$nixpkgs" -qa --drv-path | wc -l)"
     num="$((num - $qaCountDrv))"
     echo "nix-env.qaCountBroken $num" >> $out/nix-support/hydra-metrics
 


### PR DESCRIPTION
I took a sick day detour into Nix performance statistics that are tracked on Hydra.

Best reviewed commit by commit.

I validated this was correct by taking a baseline reading before changing anything, then diffing with the end result after all these commits.

Before: 16m41s
After: ~6m37s~ ~5m20s~ 1m59s

That's greater than 8x speedup!

To test it out, run:

```
nix-build pkgs/top-level/release.nix -A metrics
```

- f87776bd7c3cc67de6155ed8c9fd32ebda4bfdb0 Changed to use `stdenvNoCC.mkDerivation` instead of `runCommand`.
- c3f0ef37ebf21bfea5c17a7ef7d53afc39f711bc Added metadata explaining the purpose of `metrics.nix`.
- a34bbb6b9cd5f511fb5d5cff7d2ceb12d927cffb Tidied up variable usage and improved quoting; allowed for unbroken lines.
- 29db1d32be1964eefd223a974f733f261f32ec55 Utilized `__structuredAttrs` in the code.
- b2331161b3aeb84a9a0be008cb1547cb3d34cb56 Removed aggressive variants as they had become identical to non-aggressive variants since Jan 13, 2019.
- 94f1da567e4717c81fc28195a6eb301e720303b6 Configured the `time` command to output JSON and named the JSON files with the `.json` extension.
- b9519e2c0af72fe953c48cfa8e941d558219cfa2 Logged statistics using `jq` with a header included.
- e35ab56228ac9027e54c3eae9267fab48aaccd95 Implemented the `eval-system` parameter for targeting a specific system.
- 146c6b9aadc712723370be6ecee8d28fc8f60331 Switched from XML to JSON for output, ensuring the testing remains the same.
- dfd90bf4c07b6eb3d101190c2ad2369c92ea52d5 Reduced the number of calls to `nix-env -qa` to just once, saving the output for later use with `jq`.
- 251dff3a3e2a057cb7c3f8e46e15e1d95211c012 Added functionality to save raw files and compress the output.
- 4973d53405faece1e5394cc9616fca610641d117 Updated to use the latest Nix version, aligning with CI practices.
- 8ac12754cecbfffadeb97178a32584f9342df04b Disabled aliases during evaluation to prevent numerous warnings, in line with `ci/eval`.
- fda7cefcdbd5e50052dfd3bf9b97ae5cc32d8cf9 Passed `--no-gc-warning` to suppress garbage collection warning messages.
- 32c68bb46e8d51f5833830750af8bbb078299949 Reorganized the script to use the configure, build, and install phases following code review feedback.
- 79feab6cff53917a2fd40be55547faf68ea0eee5 Used the `-print0` option in `find` to handle file names with spaces efficiently.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test