### PR TITLE
cudaPackages: patch for issue #434096

### DIFF
--- a/pkgs/development/cuda-modules/packages/saxpy/package.nix
+++ b/pkgs/development/cuda-modules/packages/saxpy/package.nix
@@ -43,6 +43,15 @@ backendStdenv.mkDerivation {
   cmakeFlags = [
     (lib.cmakeBool "CMAKE_VERBOSE_MAKEFILE" true)
     (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" flags.cmakeCudaArchitecturesString)
+    (lib.cmakeBool "CMAKE_SKIP_INSTALL_RPATH" false)
+    (lib.cmakeBool "CMAKE_SKIP_RPATH" false)
+    (lib.cmakeBool "CMAKE_INSTALL_RPATH_USE_LINK_PATH" true)
+    (lib.cmakeFeature "CMAKE_INSTALL_RPATH" (
+      lib.makeLibraryPath [
+        (getLib libcublas)
+        cuda_cudart
+      ]
+    ))
   ];
 
   passthru.gpuCheck = saxpy.overrideAttrs (_: {

--- a/pkgs/development/cuda-modules/packages/saxpy/package.nix
+++ b/pkgs/development/cuda-modules/packages/saxpy/package.nix
@@ -43,15 +43,6 @@ backendStdenv.mkDerivation {
   cmakeFlags = [
     (lib.cmakeBool "CMAKE_VERBOSE_MAKEFILE" true)
     (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" flags.cmakeCudaArchitecturesString)
-    (lib.cmakeBool "CMAKE_SKIP_INSTALL_RPATH" false)
-    (lib.cmakeBool "CMAKE_SKIP_RPATH" false)
-    (lib.cmakeBool "CMAKE_INSTALL_RPATH_USE_LINK_PATH" true)
-    (lib.cmakeFeature "CMAKE_INSTALL_RPATH" (
-      lib.makeLibraryPath [
-        (getLib libcublas)
-        cuda_cudart
-      ]
-    ))
   ];
 
   passthru.gpuCheck = saxpy.overrideAttrs (_: {

--- a/pkgs/development/cuda-modules/packages/setupCudaHook/setup-cuda-hook.sh
+++ b/pkgs/development/cuda-modules/packages/setupCudaHook/setup-cuda-hook.sh
@@ -54,8 +54,13 @@ setupCUDAToolkit_ROOT() {
         fi
     done
 
-    appendToVar cmakeFlags "-DCUDAToolkit_INCLUDE_DIR=$CUDAToolkit_INCLUDE_DIR"
-    appendToVar cmakeFlags "-DCUDAToolkit_ROOT=$CUDAToolkit_ROOT"
+    # Use array form so semicolon-separated lists are passed safely.
+    if [[ -n "${CUDAToolkit_INCLUDE_DIR-}" ]]; then
+        cmakeFlagsArray+=("-DCUDAToolkit_INCLUDE_DIR=${CUDAToolkit_INCLUDE_DIR}")
+    fi
+    if [[ -n "${CUDAToolkit_ROOT-}" ]]; then
+        cmakeFlagsArray+=("-DCUDAToolkit_ROOT=${CUDAToolkit_ROOT}")
+    fi
 }
 preConfigureHooks+=(setupCUDAToolkit_ROOT)
 


### PR DESCRIPTION
## Summary of the Issue

This is a bug ticket associated with this issue: https://github.com/NixOS/nixpkgs/issues/434096

The bug was that running with NIX_DEBUG set to a level greater than zero (both with integer and string literals) caused RUNPATH entries to be missing from the produced binaries. In the original issue, we saw that when building saxpy:

`NIXPKGS_CONFIG=~/.config/nixpkgs/config-sm_89.nix nom build --impure .#cudaPackages_12.saxpy`

where

`
$ cat ~/.config/nixpkgs/config-sm_89.nix
{
  allowUnfree = true;
  cudaSupport = true;
  cudaCapabilities = [ "8.9" ];
}
`

we got:

`$ patchelf --print-rpath ./result/bin/saxpy 
/run/opengl-driver/lib:/nix/store/bpgbzpzv10raqcvk55xsrhb9vbg96r6g-libcublas-12.8.4.1-lib/lib:/nix/store/31wgl4db2zq67jlw6nk1rzggb36isc44-cuda_cudart-12.8.90-lib/lib:/nix/store/lmn7lwydprqibdkghw7wgcn21yhllz13-glibc-2.40-66/lib:/nix/store/fkw48vh7ivlvlmhp4j30hy2gvg00jgin-gcc-14.3.0-lib/lib`

but when we set `NIX_DEBUG=1`, we get:

```
$ patchelf --print-rpath ./result/bin/saxpy
/run/opengl-driver/lib:/nix/store/lmn7lwydprqibdkghw7wgcn21yhllz13-glibc-2.40-66/lib:/nix/store/fkw48vh7ivlvlmhp4j30hy2gvg00jgin-gcc-14.3.0-lib/lib
```

i.e. our cuda packages are dropped.

## Root Cause Analysis
  
This issue happens during CMake’s install step, not the link step. Our setup hooks is stuffing a semicolon-separated list into cmakeFlags as a plain string, and later the Nix CMake builder expands cmake $cmakeFlags without quotes. With NIX_DEBUG=1, xtrace (set -x) makes this expansion visible and the embedded `;` acts as a shell command separator, so the rest of your cmake command becomes a new shell command. That can drop or reset cache entries/flags (including your CMAKE_INSTALL_RPATH*) and you end up with CMake recomputing/overwriting the install RPATH.

The culprit is here:

```
addToSearchPathWithCustomDelimiter ";" CUDAToolkit_ROOT "$path"
addToSearchPathWithCustomDelimiter ";" CUDAToolkit_INCLUDE_DIR "$path/include"
appendToVar cmakeFlags "-DCUDAToolkit_INCLUDE_DIR=$CUDAToolkit_INCLUDE_DIR"
appendToVar cmakeFlags "-DCUDAToolkit_ROOT=$CUDAToolkit_ROOT"
```

$CUDAToolkit_ROOT / $CUDAToolkit_INCLUDE_DIR often look like "/nix/store/...;/nix/store/...". If cmakeFlags is later expanded unquoted, those `;`s split the command.

This PR patches the setup hook to use cmakeFlagsArray with guards, avoiding unquoted semicolons. The change was just to replace string appends with array-safe flags for semicolon-joined values.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
