### PR TITLE
tapview: 1.1 -> 1.15

### DIFF
--- a/pkgs/by-name/ta/tapview/package.nix
+++ b/pkgs/by-name/ta/tapview/package.nix
@@ -5,30 +5,27 @@
   stdenv,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tapview";
-  version = "1.1";
+  version = "1.15";
 
   nativeBuildInputs = [ asciidoctor ];
 
   src = fetchFromGitLab {
     owner = "esr";
     repo = "tapview";
-    rev = version;
-    hash = "sha256-inrxICNglZU/tup+YnHaDiVss32K2OXht/7f8lOZI4g=";
+    tag = finalAttrs.version;
+    hash = "sha256-6v+CxNjj3gPE3wmhit6e5OuhkjVACFv/4QAbFDCySGc=";
   };
-
-  # Remove unnecessary `echo` checks: `/bin/echo` fails, and `echo -n` works as expected.
-  patches = [ ./dont_check_echo.patch ];
 
   makeFlags = [ "prefix=$(out)" ];
 
-  meta = with lib; {
+  meta = {
     description = "Minimalist pure consumer for TAP (Test Anything Protocol)";
     mainProgram = "tapview";
     homepage = "https://gitlab.com/esr/tapview";
-    license = licenses.bsd2;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ pamplemousse ];
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ pamplemousse ];
   };
-}
+})


### PR DESCRIPTION
https://gitlab.com/esr/tapview/-/tags/1.15

https://gitlab.com/esr/tapview/-/blob/master/NEWS.adoc

Diff: https://gitlab.com/esr/tapview/-/compare/1.1...1.15


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
