### PR TITLE
{cc-wrapper,bintools-wrapper}: drop pie hardening flag

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -1190,7 +1190,8 @@
     "index.html#sec-purity-in-nixpkgs"
   ],
   "sec-hardening-in-nixpkgs": [
-    "index.html#sec-hardening-in-nixpkgs"
+    "index.html#sec-hardening-in-nixpkgs",
+    "index.html#pie"
   ],
   "sec-hardening-flags-enabled-by-default": [
     "index.html#sec-hardening-flags-enabled-by-default"
@@ -1224,9 +1225,6 @@
   ],
   "sec-hardening-flags-disabled-by-default": [
     "index.html#sec-hardening-flags-disabled-by-default"
-  ],
-  "pie": [
-    "index.html#pie"
   ],
   "shadowstack": [
     "index.html#shadowstack"

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -88,6 +88,8 @@
 
 - `forgejo` main program has been renamed to `bin/forgejo` from the previous `bin/gitea`.
 
+- the "pie" hardening flag has been removed. compilers are expected to enable PIE by default, as has been common practice since 2016 outside of nixpkgs. If a package needs "pie" disabled pass `-no-pie` in `CFLAGS`. It is unlikely this will be necessary in many cases; due to the prevalance of default PIE toolchains most packages incompatible with PIE already pass no-pie.
+
 - `cudaPackages.cudatoolkit-legacy-runfile` has been removed.
 
 - `conduwuit` was removed due to upstream ceasing development and deleting their repository. For existing data, a migration to `matrix-conduit`, `matrix-continuwuity` or `matrix-tuwunel` may be possible.

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1631,19 +1631,6 @@ The following flags are disabled by default and should be enabled with `hardenin
 
 This flag adds the `-fno-strict-aliasing` compiler option, which prevents the compiler from assuming code has been written strictly following the standard in regards to pointer aliasing and therefore performing optimizations that may be unsafe for code that has not followed these rules.
 
-#### `pie` {#pie}
-
-This flag is disabled by default for normal `glibc` based NixOS package builds, but enabled by default for
-
-  - `musl`-based package builds, except on Aarch64 and Aarch32, where there are issues.
-
-  - Statically-linked for OpenBSD builds, where it appears to be required to get a working binary.
-
-Adds the `-fPIE` compiler and `-pie` linker options. Position Independent Executables are needed to take advantage of Address Space Layout Randomization, supported by modern kernel versions. While ASLR can already be enforced for data areas in the stack and heap (brk and mmap), the code areas must be compiled as position-independent. Shared libraries already do this with the `pic` flag, so they gain ASLR automatically, but binary .text regions need to be build with `pie` to gain ASLR. When this happens, ROP attacks are much harder since there are no static locations to bounce off of during a memory corruption attack.
-
-Static libraries need to be compiled with `-fPIE` so that executables can link them in with the `-pie` linker option.
-If the libraries lack `-fPIE`, you will get the error `recompile with -fPIE`.
-
 #### `strictflexarrays1` {#strictflexarrays1}
 
 This flag adds the `-fstrict-flex-arrays=1` compiler option, which reduces the cases the compiler treats as "flexible arrays" to those declared with length `[1]`, `[0]` or (the correct) `[]`. This increases the coverage of fortify checks, because such arrays declared as the trailing element of a structure can normally not have their intended length determined by the compiler.

--- a/pkgs/build-support/bintools-wrapper/add-hardening.sh
+++ b/pkgs/build-support/bintools-wrapper/add-hardening.sh
@@ -15,7 +15,7 @@ for flag in @hardening_unsupported_flags@; do
 done
 
 if (( "${NIX_DEBUG:-0}" >= 1 )); then
-  declare -a allHardeningFlags=(pie relro bindnow)
+  declare -a allHardeningFlags=(relro bindnow)
   declare -A hardeningDisableMap=()
 
   # Determine which flags were effectively disabled so we can report below.
@@ -36,16 +36,6 @@ fi
 
 for flag in "${!hardeningEnableMap[@]}"; do
   case $flag in
-    pie)
-      if [[ ! (" ${params[*]} " =~ " -shared " \
-            || " ${params[*]} " =~ " -static " \
-            || " ${params[*]} " =~ " -r " \
-            || " ${params[*]} " =~ " -Ur " \
-            || " ${params[*]} " =~ " -i ") ]]; then
-        if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling LDFlags -pie >&2; fi
-        hardeningLDFlags+=('-pie')
-      fi
-      ;;
     relro)
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling relro >&2; fi
       hardeningLDFlags+=('-z' 'relro')

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -55,24 +55,7 @@
     "stackprotector"
     "strictoverflow"
     "zerocallusedregs"
-  ]
-  ++ lib.optional (
-    with stdenvNoCC;
-    lib.any (x: x) [
-      # OpenBSD static linking requires PIE
-      (with targetPlatform; isOpenBSD && isStatic)
-      (lib.all (x: x) [
-        # Musl-based platforms will keep "pie", other platforms will not.
-        # If you change this, make sure to update section `{#sec-hardening-in-nixpkgs}`
-        # in the nixpkgs manual to inform users about the defaults.
-        (targetPlatform.libc == "musl")
-        # Except when:
-        #    - static aarch64, where compilation works, but produces segfaulting dynamically linked binaries.
-        #    - static armv7l, where compilation fails.
-        (!(targetPlatform.isAarch && targetPlatform.isStatic))
-      ])
-    ]
-  ) "pie",
+  ],
 }:
 
 assert propagateDoc -> bintools ? man;

--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -52,7 +52,7 @@ fi
 
 
 if (( "${NIX_DEBUG:-0}" >= 1 )); then
-  declare -a allHardeningFlags=(fortify fortify3 shadowstack stackprotector stackclashprotection nostrictaliasing pacret strictflexarrays1 strictflexarrays3 pie pic strictoverflow glibcxxassertions format trivialautovarinit zerocallusedregs)
+  declare -a allHardeningFlags=(fortify fortify3 shadowstack stackprotector stackclashprotection nostrictaliasing pacret strictflexarrays1 strictflexarrays3 pic strictoverflow glibcxxassertions format trivialautovarinit zerocallusedregs)
   declare -A hardeningDisableMap=()
 
   # Determine which flags were effectively disabled so we can report below.
@@ -126,15 +126,6 @@ for flag in "${!hardeningEnableMap[@]}"; do
     nostrictaliasing)
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling nostrictaliasing >&2; fi
       hardeningCFlagsBefore+=('-fno-strict-aliasing')
-      ;;
-    pie)
-      # NB: we do not use `+=` here, because PIE flags must occur before any PIC flags
-      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling CFlags -fPIE >&2; fi
-      hardeningCFlagsBefore=('-fPIE' "${hardeningCFlagsBefore[@]}")
-      if [[ ! (" ${params[*]} " =~ " -shared " || " ${params[*]} " =~ " -static ") ]]; then
-        if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling LDFlags -pie >&2; fi
-        hardeningCFlagsBefore=('-pie' "${hardeningCFlagsBefore[@]}")
-      fi
       ;;
     pic)
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling pic >&2; fi

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -225,14 +225,7 @@ let
 
   canExecuteHostOnBuild = buildPlatform.canExecute hostPlatform;
   defaultHardeningFlags =
-    (if stdenvHasCC then stdenv.cc else { }).defaultHardeningFlags or
-    # fallback safe-ish set of flags
-    (
-      if isOpenBSD && isStatic then
-        knownHardeningFlags # Need pie, in fact
-      else
-        remove "pie" knownHardeningFlags
-    );
+    (if stdenvHasCC then stdenv.cc else { }).defaultHardeningFlags or knownHardeningFlags;
   stdenvHostSuffix = optionalString (hostPlatform != buildPlatform) "-${hostPlatform.config}";
   stdenvStaticMarker = optionalString isStatic "-static";
   userHook = config.stdenv.userHook or null;

--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -116,6 +116,16 @@ stdenv.mkDerivation {
       ''
     }
 
+    ${
+      # Check whether fuse-ld=gold works on our GNU toolchain
+      # Regression test for https://github.com/NixOS/nixpkgs/issues/49071
+      lib.optionalString stdenv.cc.isGNU ''
+        echo "checking whether compiler builds valid C binaries... " >&2
+        CFLAGS="-fuse-ld=gold" ${CC} -o cc-check ${./cc-main.c}
+        ${emulator} ./cc-check
+      ''
+    }
+
     echo "checking whether compiler uses NIX_CFLAGS_COMPILE... " >&2
     mkdir -p foo/include
     cp ${./foo.c} foo/include/foo.h

--- a/pkgs/test/cc-wrapper/hardening.nix
+++ b/pkgs/test/cc-wrapper/hardening.nix
@@ -455,25 +455,10 @@ nameDrvAfterAttrName (
       )
     );
 
-    pieExplicitEnabled = brokenIf stdenv.hostPlatform.isStatic (
-      checkTestBin
-        (f2exampleWithStdEnv stdenv {
-          hardeningEnable = [ "pie" ];
-        })
-        {
-          ignorePie = false;
-        }
-    );
-
-    pieExplicitEnabledStructuredAttrs = brokenIf stdenv.hostPlatform.isStatic (
-      checkTestBin
-        (f2exampleWithStdEnv stdenv {
-          hardeningEnable = [ "pie" ];
-          __structuredAttrs = true;
-        })
-        {
-          ignorePie = false;
-        }
+    pieAlwaysEnabled = brokenIf stdenv.hostPlatform.isStatic (
+      checkTestBin (f2exampleWithStdEnv stdenv { }) {
+        ignorePie = false;
+      }
     );
 
     relROExplicitEnabled =
@@ -660,17 +645,6 @@ nameDrvAfterAttrName (
           };
         }
       )
-    );
-
-    pieExplicitDisabled = brokenIf (stdenv.hostPlatform.isMusl && stdenv.cc.isClang) (
-      checkTestBin
-        (f2exampleWithStdEnv stdenv {
-          hardeningDisable = [ "pie" ];
-        })
-        {
-          ignorePie = false;
-          expectFailure = true;
-        }
     );
 
     # can't force-disable ("partial"?) relro
@@ -1100,13 +1074,6 @@ nameDrvAfterAttrName (
         ignoreFortify = false;
         expectFailure = true;
       };
-
-      allExplicitDisabledPie = brokenIf (stdenv.hostPlatform.isMusl && stdenv.cc.isClang) (
-        checkTestBin tb {
-          ignorePie = false;
-          expectFailure = true;
-        }
-      );
 
       # can't force-disable ("partial"?) relro
       allExplicitDisabledRelRO = brokenIf true (


### PR DESCRIPTION
Followup to #439314 (gcc: build with --enable-default-pie configure option). Now that the "pie" hardening flag is unnecessary for both our GCC and LLVM stdenvs, drop the flag.

- [x] Drop "pie" hardening flag from wrappers
- [x] make sure we aren't regressing 6d531f354155043518a59161f42f24f5918e76ab by adding a cc-wrapper test for fuse-ld=gold.
  - Test added, still works fine for pkgsMusl and pkgs
- [x] update {#sec-hardening-in-nixpkgs}
- [x] release note

Should be merged first:

- #442965

To be done in a followup:

- treewide "pie" hardeningDisable/hardeningEnable drops
- evaluation warning if "pie" flag is used

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
