### PR TITLE
nixos/chromadb: deprecate logPath option

### DIFF
--- a/nixos/modules/services/databases/chromadb.nix
+++ b/nixos/modules/services/databases/chromadb.nix
@@ -19,6 +19,12 @@ in
 
   meta.maintainers = with lib.maintainers; [ ];
 
+  imports = [
+    (lib.mkRemovedOptionModule [ "services" "chromadb" "logFile" ] ''
+      ChromaDB has removed the --log-path parameter that logFile relied on.
+    '')
+  ];
+
   options = {
     services.chromadb = {
       enable = mkEnableOption "ChromaDB, an open-source AI application database.";
@@ -44,14 +50,6 @@ in
         default = 8000;
         description = ''
           Defined the port number to listen.
-        '';
-      };
-
-      logFile = mkOption {
-        type = types.path;
-        default = "/var/log/chromadb/chromadb.log";
-        description = ''
-          Specifies the location of file for logging output.
         '';
       };
 
@@ -81,7 +79,7 @@ in
         StateDirectory = "chromadb";
         WorkingDirectory = "/var/lib/chromadb";
         LogsDirectory = "chromadb";
-        ExecStart = "${lib.getExe cfg.package} run --path ${cfg.dbpath} --host ${cfg.host} --port ${toString cfg.port} --log-path ${cfg.logFile}";
+        ExecStart = "${lib.getExe cfg.package} run --path ${cfg.dbpath} --host ${cfg.host} --port ${toString cfg.port}";
         Restart = "on-failure";
         ProtectHome = true;
         ProtectSystem = "strict";


### PR DESCRIPTION
## Things done

The module and nixos test are currently broken because the logPath option is always set by default and it passes a parameter to the CLI that no longer exists. Lets just remove logPath all together as the parameter it relied on got removed. In it's current state the module does not work and fails with this error looping.
```
machine # [  193.939160] chroma[2148]: error: unexpected argument '--log-path' found
machine # [  193.940345] chroma[2148]:   tip: to pass '--log-path' as a value, use '-- --log-path'
machine # [  193.941772] chroma[2148]: Usage: chroma run <CONFIG_PATH|--path <PATH>|--host <HOST>|--port <PORT>>
machine # [  193.943135] chroma[2148]: For more information, try '--help'.
```

It's been failing for a while https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.chromadb.x86_64-linux

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
