### PR TITLE
mission-center: add GPU drivers to LD_LIBRARY_PATH

### DIFF
--- a/pkgs/by-name/mi/mission-center/package.nix
+++ b/pkgs/by-name/mi/mission-center/package.nix
@@ -39,6 +39,7 @@
   wayland,
 
   # magpie wrapper
+  addDriverRunpath,
   libGL,
   vulkan-loader,
 
@@ -128,6 +129,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
+    addDriverRunpath
     blueprint-compiler
     cargo
     libxml2
@@ -178,6 +180,10 @@ stdenv.mkDerivation (finalAttrs: {
           libGL
           libdrm
           vulkan-loader
+
+          # NVIDIA support requires linking libnvidia-ml.so at runtime:
+          # https://github.com/Syllo/nvtop/blob/3.2.0/src/extract_gpuinfo_nvidia.c#L274-L276
+          addDriverRunpath.driverLink
         ]
       }"
   '';


### PR DESCRIPTION
This fixes one possible cause for #342274.

Under the hood, the missioncenter-magpie executable uses nvtop to read information for and stats about GPU devices. nvtop uses `dlopen` to load vendor-specific libraries at runtime. For NVIDIA cards, this requires having the appropriate version of `libnvidia-ml.so` available under the LD_LIBRARY_PATH or RUNPATH.

Ideally, we would probably want to use `addDriverRunpath` directly to edit the `missioncenter-magpie` RUNPATH. Instead I had to wrap it with an updated LD_LIBRARY_PATH to include the same path that `addDriverRunpath` would have added, as `$out/bin/missioncenter-magpie` is actually an executable wrapper created by the `wrapGAppsHook4` hook.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
