### PR TITLE
[Backport release-25.05] sigil: 2.4.2 -> 2.6.2

### DIFF
--- a/pkgs/by-name/si/sigil/package.nix
+++ b/pkgs/by-name/si/sigil/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sigil";
-  version = "2.5.1";
+  version = "2.5.2";
 
   src = fetchFromGitHub {
     repo = "Sigil";
     owner = "Sigil-Ebook";
     tag = version;
-    hash = "sha256-1Z+OosEZJEHiUz+62wYuNeAyQXARh14WAtqBVjq1FZw=";
+    hash = "sha256-nMPBkAAah4qbatvtfkCJqdo6BVL0NuxFZEHhSiB4uXY=";
   };
 
   pythonPath = with python3Packages; [ lxml ];

--- a/pkgs/by-name/si/sigil/package.nix
+++ b/pkgs/by-name/si/sigil/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sigil";
-  version = "2.4.2";
+  version = "2.5.1";
 
   src = fetchFromGitHub {
     repo = "Sigil";
     owner = "Sigil-Ebook";
     tag = version;
-    hash = "sha256-/lnSNamLkPLG8tn0w8F0zFyypMUXyMhgxA2WyQFegKw=";
+    hash = "sha256-1Z+OosEZJEHiUz+62wYuNeAyQXARh14WAtqBVjq1FZw=";
   };
 
   pythonPath = with python3Packages; [ lxml ];

--- a/pkgs/by-name/si/sigil/package.nix
+++ b/pkgs/by-name/si/sigil/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sigil";
-  version = "2.6.0";
+  version = "2.6.2";
 
   src = fetchFromGitHub {
     repo = "Sigil";
     owner = "Sigil-Ebook";
     tag = version;
-    hash = "sha256-orOuY+gCh7X24jfnGgCbqRWDbtQqrlopYx9sWN2VawA=";
+    hash = "sha256-3+ODd0/kkXfAchsErLjy6FDHoyVP9VyxbINKMn3N/PM=";
   };
 
   pythonPath = with python3Packages; [ lxml ];

--- a/pkgs/by-name/si/sigil/package.nix
+++ b/pkgs/by-name/si/sigil/package.nix
@@ -57,9 +57,27 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  dontWrapQtApps = true;
+
   preFixup = ''
     qtWrapperArgs+=(--prefix PYTHONPATH : "$PYTHONPATH")
   '';
+
+  fixupPhase =
+    let
+      sigil =
+        if stdenv.hostPlatform.isDarwin then
+          "$out/Applications/Sigil.app/Contents/MacOS/Sigil"
+        else
+          "$out/bin/sigil";
+    in
+    ''
+      runHook preFixup
+
+      wrapQtApp "${sigil}"
+
+      runHook postFixup
+    '';
 
   meta = {
     description = "Free, open source, multi-platform ebook (ePub) editor";

--- a/pkgs/by-name/si/sigil/package.nix
+++ b/pkgs/by-name/si/sigil/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sigil";
-  version = "2.5.2";
+  version = "2.6.0";
 
   src = fetchFromGitHub {
     repo = "Sigil";
     owner = "Sigil-Ebook";
     tag = version;
-    hash = "sha256-nMPBkAAah4qbatvtfkCJqdo6BVL0NuxFZEHhSiB4uXY=";
+    hash = "sha256-orOuY+gCh7X24jfnGgCbqRWDbtQqrlopYx9sWN2VawA=";
   };
 
   pythonPath = with python3Packages; [ lxml ];


### PR DESCRIPTION
Manual backport to release-25.05

Requires #442531 to be merged

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md?rgh-link-date=2025-09-12T19%3A23%3A16Z#changes-acceptable-for-releases).
  - Even as a non-committer, if you find that it is not acceptable, leave a comment.