### PR TITLE
newlib: fix i386 libgloss support

### DIFF
--- a/pkgs/by-name/ne/newlib/0002-newlib-Fix-i386-libgloss-support.patch
+++ b/pkgs/by-name/ne/newlib/0002-newlib-Fix-i386-libgloss-support.patch
@@ -1,0 +1,74 @@
+# From: ROUSSARIE Killian <oss@xtrm.me>
+# Date: Sat, 13 Sep 2025 00:34:07 +0200
+# Subject: [PATCH] Fix i386 support in libgloss
+
+diff --git a/libgloss/i386/cygmon-gmon.c b/libgloss/i386/cygmon-gmon.c
+index 3c15b70..6f5f1b7 100644
+--- a/libgloss/i386/cygmon-gmon.c
++++ b/libgloss/i386/cygmon-gmon.c
+@@ -85,7 +85,7 @@ static int	s_scale;
+ 
+ extern int errno;
+ 
+-int
++void
+ monstartup(lowpc, highpc)
+      char	*lowpc;
+      char	*highpc;
+@@ -187,7 +187,7 @@ _mcleanup()
+ 	  rawarc.raw_frompc = (unsigned long) frompc;
+ 	  rawarc.raw_selfpc = (unsigned long) tos[toindex].selfpc;
+ 	  rawarc.raw_count = tos[toindex].count;
+-	  profil_write (2, &rawarc, sizeof (rawarc));
++	  profil_write (2, (char*) &rawarc, sizeof (rawarc));
+ 	}
+     }
+   profil_write (3, 0, 0);
+@@ -195,7 +195,7 @@ _mcleanup()
+ 
+ static char already_setup = 0;
+ 
+-_mcount()
++void _mcount()
+ {
+   register char			*selfpc;
+   register unsigned short	*frompcindex;
+@@ -217,8 +217,8 @@ _mcount()
+ 
+   if (! already_setup) 
+     {
+-      extern _etext();
+-      extern _ftext();
++      extern void *_etext;
++      extern void *_ftext;
+       already_setup = 1;
+       monstartup(_ftext, _etext);
+       atexit(_mcleanup);
+@@ -337,7 +337,7 @@ overflow:
+  *	profiling is what mcount checks to see if
+  *	all the data structures are ready.
+  */
+-moncontrol(mode)
++void moncontrol(mode)
+     int mode;
+ {
+   if (mode)
+diff --git a/libgloss/i386/cygmon-gmon.h b/libgloss/i386/cygmon-gmon.h
+index f35ae33..b2380cb 100644
+--- a/libgloss/i386/cygmon-gmon.h
++++ b/libgloss/i386/cygmon-gmon.h
+@@ -1,6 +1,14 @@
+ #ifndef GMON_CYGMON_H
+ #define GMON_CYGMON_H
+ 
++#include <stdlib.h>
++#include <unistd.h>
++
++int profil(unsigned short *buf, size_t bufsiz, size_t offset, unsigned int scale);
++void profil_write (int type, char *buffer, int len);
++void moncontrol(int mode);
++void bzero(void *s, size_t n);
++
+ struct phdr 
+ {
+   char    *lpc;

--- a/pkgs/by-name/ne/newlib/package.nix
+++ b/pkgs/by-name/ne/newlib/package.nix
@@ -26,6 +26,8 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
       url = "https://sourceware.org/git/?p=newlib-cygwin.git;a=patch;h=8a8fb570d7c5310a03a34b3dd6f9f8bb35ee9f40";
       hash = "sha256-hWS/X0jf/ZFXIR39NvNDVhkR8F81k9UWpsqDhZFxO5o=";
     })
+    ./0002-newlib-Fix-i386-libgloss-support.patch
+
   ]
   ++ lib.optionals nanoizeNewlib [
     # https://bugs.gentoo.org/723756


### PR DESCRIPTION
This PR adds a patch to fix compilation with gcc-14.

I've tested this by building locally:
- `newlib`
- `pkgsCross.i686-embedded.newlib`
- `pkgsCross.i686-embedded.buildPackages.binutils`
- `pkgsCross.i686-embedded.stdenv` (via [this](https://codeberg.org/27/kfs/src/commit/3b35de78fe434f51c7adec5521684edba2c14917//shell.nix#L7) devshell)

Fixes #424403, fixes #404741 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
