### PR TITLE
python313Packages.datalad-next: 1.5.0 -> 0.unstable-2025-07-04

### DIFF
--- a/pkgs/development/python-modules/datalad-next/default.nix
+++ b/pkgs/development/python-modules/datalad-next/default.nix
@@ -13,34 +13,32 @@
   psutil,
   pytestCheckHook,
   pythonAtLeast,
-  setuptools,
+  hatchling,
+  hatch-vcs,
   unzip,
-  versioneer,
   webdavclient3,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "datalad-next";
-  version = "1.5.0";
+  version = "1.5.0-unstable-2025-07-04";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "datalad";
     repo = "datalad-next";
-    tag = version;
-    hash = "sha256-fqP6nG2ncDRg48kvlsmPjNBOzfQp9+7wTcGvsYVrRzA=";
+    rev = "2d2b1526c1e396964dd3ffdbb37597adefe7682d";
+    hash = "sha256-47cRxaxOGzR6hDfiW2hS3MNHp2aP9rxtWNxV+33PPfs=";
   };
-
-  postPatch = ''
-    # Remove vendorized versioneer.py
-    rm versioneer.py
-  '';
 
   nativeBuildInputs = [ git ];
 
+  # our version does not comply with PEP440
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = "1.5.0.dev0";
+
   build-system = [
-    setuptools
-    versioneer
+    hatchling
+    hatch-vcs
   ];
 
   dependencies = [
@@ -97,6 +95,8 @@ buildPythonPackage rec {
     "test_compressed_file_stay_compressed"
     "test_ls_file_collection_tarfile"
     "test_iter_tar"
+    "test_delete_method"
+    "test_delete_timeout"
   ]
   ++ lib.optionals (pythonAtLeast "3.13") [
     # RuntimeError


### PR DESCRIPTION
fixes build error with setuptools

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
