### PR TITLE
homepage-dashboard: add unixtools.ping to PATH

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19674,6 +19674,12 @@
     githubId = 821972;
     name = "Parth Mehrotra";
   };
+  parthiv-krishna = {
+    email = "nixpkgs@parthiv.cc";
+    github = "parthiv-krishna";
+    githubId = 20658472;
+    name = "Parthiv Krishna";
+  };
   pascalj = {
     email = "nix@pascalj.de";
     github = "pascalj";

--- a/nixos/tests/homepage-dashboard.nix
+++ b/nixos/tests/homepage-dashboard.nix
@@ -21,10 +21,23 @@
           ];
         }
       ];
+      services = [
+        {
+          Machines = [
+            {
+              Localhost = {
+                ping = "127.0.0.1";
+              };
+            }
+          ];
+        }
+      ];
     };
   };
 
   testScript = ''
+    import json
+
     # Ensure the services are started on managed machine
     machine.wait_for_unit("homepage-dashboard.service")
     machine.wait_for_open_port(8082)
@@ -40,5 +53,9 @@
     # Ensure that we see the custom bookmarks on the page
     page = machine.succeed("curl --fail http://127.0.0.1:8082/api/bookmarks")
     assert "nixpkgs" in page, "Custom bookmarks not found"
+
+    # Ensure that the ping command works
+    response = machine.succeed("curl --fail \"http://localhost:8082/api/ping?groupName=Machines&serviceName=Localhost\"")
+    assert json.loads(response)["alive"] is True, "Ping to localhost failed"
   '';
 }

--- a/nixos/tests/homepage-dashboard.nix
+++ b/nixos/tests/homepage-dashboard.nix
@@ -1,7 +1,7 @@
 { lib, ... }:
 {
   name = "homepage-dashboard";
-  meta.maintainers = with lib.maintainers; [ ];
+  meta.maintainers = with lib.maintainers; [ parthiv-krishna ];
 
   nodes.machine = _: {
     services.homepage-dashboard = {

--- a/pkgs/by-name/ho/homepage-dashboard/package.nix
+++ b/pkgs/by-name/ho/homepage-dashboard/package.nix
@@ -6,6 +6,7 @@
   pnpm_10,
   python3,
   stdenv,
+  unixtools,
   cctools,
   lib,
   nixosTests,
@@ -89,7 +90,8 @@ stdenv.mkDerivation (finalAttrs: {
       --set-default PORT 3000 \
       --set-default HOMEPAGE_CONFIG_DIR /var/lib/homepage-dashboard \
       --set-default NIXPKGS_HOMEPAGE_CACHE_DIR /var/cache/homepage-dashboard \
-      --add-flags "$out/share/homepage/server.js"
+      --add-flags "$out/share/homepage/server.js" \
+      --set PATH "${lib.makeBinPath [ unixtools.ping ]}"
 
     ${if enableLocalIcons then installLocalIcons else ""}
 

--- a/pkgs/by-name/ho/homepage-dashboard/package.nix
+++ b/pkgs/by-name/ho/homepage-dashboard/package.nix
@@ -111,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "homepage";
     homepage = "https://gethomepage.dev";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ parthiv-krishna ];
     platforms = lib.platforms.all;
   };
 })


### PR DESCRIPTION
This PR adds `unixtools.ping` to the path for the `homepage-dashboard` NixOS package. Homepage added a [`ping` property for services](https://gethomepage.dev/configs/services/#ping) to monitor the status of external hosts. This requires access to `ping`; otherwise, hosts always appear down (see issue #442569). 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
