### PR TITLE
linux_xanmod: customize update commit body

### DIFF
--- a/pkgs/os-specific/linux/kernel/update-xanmod.sh
+++ b/pkgs/os-specific/linux/kernel/update-xanmod.sh
@@ -47,7 +47,7 @@ while IFS= read -r url; do
     fi
 done < <(echo "$RELEASE_URLS" | jq -r)
 
-echo "Updating Xanmod \"$VARIANT\" from $OLD_VERSION to $NEW_VERSION ($SUFFIX)"
+>&2 echo "Updating Xanmod \"$VARIANT\" from $OLD_VERSION to $NEW_VERSION ($SUFFIX)"
 
 URL="https://gitlab.com/api/v4/projects/xanmod%2Flinux/repository/archive.tar.gz?sha=$NEW_VERSION-$SUFFIX"
 HASH="$(nix-prefetch fetchzip --quiet --url "$URL")"
@@ -87,3 +87,12 @@ update_variant() {
 }
 
 update_variant "$FILE_PATH" "$VARIANT" "$NEW_VERSION" "$HASH" "$SUFFIX"
+
+# Customize commit
+# https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#supported-features
+COMMIT_BODY="
+- Changelog: https://dl.xanmod.org/changelog/${NEW_VERSION%.*}/ChangeLog-$NEW_VERSION-xanmod1.gz
+- Diff: https://gitlab.com/xanmod/linux/-/compare/$OLD_VERSION-xanmod1..$NEW_VERSION-xanmod1?from_project_id=51590166
+"
+
+jq -n --arg commitBody "$COMMIT_BODY" '[$ARGS.named]'

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -74,10 +74,16 @@ let
           RCU_EXP_KTHREAD = yes;
         };
 
-        extraPassthru.updateScript = [
-          ./update-xanmod.sh
-          variant
-        ];
+        extraPassthru.updateScript = {
+          command = [
+            ./update-xanmod.sh
+            variant
+          ];
+          supportedFeatures = [
+            "commit"
+          ];
+        };
+
         inherit isLTS;
 
         extraMeta = {


### PR DESCRIPTION
I'm not sure if the update bot picks this up, but I think this would be useful by itself.

Tested the script with both variants, which produces the following commit messages:

```shellSession
nix-shell maintainers/scripts/update.nix --argstr package linux_xanmod --argstr commit true
```

```md
linux_xanmod: 6.12.46 -> 6.12.47

- Changelog: https://dl.xanmod.org/changelog/6.12/ChangeLog-6.12.47-xanmod1.gz
- Diff: https://gitlab.com/xanmod/linux/-/compare/6.12.46-xanmod1..6.12.47-xanmod1?from_project_id=51590166
```

```shellSession
nix-shell maintainers/scripts/update.nix --argstr package linux_xanmod_latest --argstr commit true
```

```md
linux_xanmod_latest: 6.16.6 -> 6.16.7

- Changelog: https://dl.xanmod.org/changelog/6.16/ChangeLog-6.16.7-xanmod1.gz
- Diff: https://gitlab.com/xanmod/linux/-/compare/6.16.6-xanmod1..6.16.7-xanmod1?from_project_id=51590166
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
