### PR TITLE
treewide: drop things the c3d2 is no longer using

### DIFF
--- a/pkgs/applications/audio/codecserver/default.nix
+++ b/pkgs/applications/audio/codecserver/default.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation rec {
     description = "Modular audio codec server";
     license = licenses.gpl3Only;
     platforms = platforms.unix;
-    teams = [ teams.c3d2 ];
     mainProgram = "codecserver";
   };
 }

--- a/pkgs/by-name/cs/csdr/package.nix
+++ b/pkgs/by-name/cs/csdr/package.nix
@@ -48,6 +48,5 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Only;
     platforms = platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
-    teams = [ teams.c3d2 ];
   };
 }

--- a/pkgs/by-name/di/digiham/package.nix
+++ b/pkgs/by-name/di/digiham/package.nix
@@ -46,6 +46,5 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Tools for decoding digital ham communication";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.unix;
-    teams = [ lib.teams.c3d2 ];
   };
 })

--- a/pkgs/by-name/dr/drone-runner-ssh/package.nix
+++ b/pkgs/by-name/dr/drone-runner-ssh/package.nix
@@ -21,7 +21,6 @@ buildGoModule {
     description = "Experimental Drone runner that executes a pipeline on a remote machine";
     homepage = "https://github.com/drone-runners/drone-runner-ssh";
     license = licenses.unfreeRedistributable;
-    teams = [ teams.c3d2 ];
     mainProgram = "drone-runner-ssh";
   };
 }

--- a/pkgs/by-name/m1/m17-cxx-demod/package.nix
+++ b/pkgs/by-name/m1/m17-cxx-demod/package.nix
@@ -44,7 +44,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/mobilinkd/m17-cxx-demod";
     license = licenses.gpl3Only;
     platforms = platforms.unix;
-    teams = [ teams.c3d2 ];
     # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/op/openipmi/package.nix
+++ b/pkgs/by-name/op/openipmi/package.nix
@@ -42,6 +42,5 @@ stdenv.mkDerivation rec {
     ];
     platforms = platforms.linux;
     maintainers = with maintainers; [ arezvov ];
-    teams = [ teams.c3d2 ];
   };
 }

--- a/pkgs/by-name/wa/wander/package.nix
+++ b/pkgs/by-name/wa/wander/package.nix
@@ -36,7 +36,6 @@ buildGoModule rec {
     description = "Terminal app/TUI for HashiCorp Nomad";
     license = licenses.mit;
     homepage = "https://github.com/robinovitch61/wander";
-    teams = [ teams.c3d2 ];
     mainProgram = "wander";
   };
 }

--- a/pkgs/development/python-modules/napalm/default.nix
+++ b/pkgs/development/python-modules/napalm/default.nix
@@ -91,6 +91,5 @@ buildPythonPackage rec {
     description = "Network Automation and Programmability Abstraction Layer with Multivendor support";
     homepage = "https://github.com/napalm-automation/napalm";
     license = licenses.asl20;
-    teams = [ teams.c3d2 ];
   };
 }

--- a/pkgs/development/python-modules/pycsdr/default.nix
+++ b/pkgs/development/python-modules/pycsdr/default.nix
@@ -27,6 +27,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/jketterl/pycsdr";
     description = "Bindings for the csdr library";
     license = lib.licenses.gpl3Only;
-    teams = [ lib.teams.c3d2 ];
   };
 }

--- a/pkgs/development/python-modules/pydigiham/default.nix
+++ b/pkgs/development/python-modules/pydigiham/default.nix
@@ -38,6 +38,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/jketterl/pydigiham";
     description = "Bindings for the csdr library";
     license = lib.licenses.gpl3Only;
-    teams = [ lib.teams.c3d2 ];
   };
 }


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
