### PR TITLE
postgresqlPackages.pgroonga: 4.0.1 -> 4.0.2

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pgroonga.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgroonga.nix
@@ -11,13 +11,13 @@
 
 postgresqlBuildExtension (finalAttrs: {
   pname = "pgroonga";
-  version = "4.0.1";
+  version = "4.0.2";
 
   src = fetchFromGitHub {
     owner = "pgroonga";
     repo = "pgroonga";
     tag = "${finalAttrs.version}";
-    hash = "sha256-a5nNtlUiFBuuqWAjIN0gU/FaoV3VpJh+/fab8R/77dw=";
+    hash = "sha256-hZy2qDI9bNFvcm7SbCMZxixPEXgPmjmeEOM4VoXKttE=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -34,11 +34,6 @@ postgresqlBuildExtension (finalAttrs: {
   ];
 
   meta = {
-    # PostgreSQL 18 support issue upstream: https://github.com/pgroonga/pgroonga/issues/708
-    # Check after next package update.
-    broken = lib.warnIf (
-      finalAttrs.version != "4.0.1"
-    ) "Is postgresql18Packages.pgroonga still broken?" (lib.versionAtLeast postgresql.version "18");
     description = "PostgreSQL extension to use Groonga as the index";
     longDescription = ''
       PGroonga is a PostgreSQL extension to use Groonga as the index.


### PR DESCRIPTION
Release Notes:
https://github.com/pgroonga/pgroonga/releases/tag/4.0.2

Even though not explicitly mentioned, this seems to fix the build for PG18.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
