### PR TITLE
pluginval: init at 1.0.4

### DIFF
--- a/pkgs/by-name/pl/pluginval/package.nix
+++ b/pkgs/by-name/pl/pluginval/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  alsa-lib,
+  fontconfig,
+  freetype,
+  libX11,
+  libXcomposite,
+  libXcursor,
+  libXdmcp,
+  libXext,
+  libXinerama,
+  libXrandr,
+  libXtst,
+  ladspaH,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pluginval";
+  version = "1.0.4";
+  src = fetchFromGitHub {
+    owner = "Tracktion";
+    repo = "pluginval";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-j4Lb3pcw0931o63OvTTaIm2UzvYDIjmnaCXGvKB4gwM=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    fontconfig
+    freetype
+    libX11
+    libXcomposite
+    libXcursor
+    libXdmcp
+    libXext
+    libXinerama
+    libXrandr
+    libXtst
+    ladspaH
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Debug")
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 pluginval_artefacts/Debug/pluginval $out/bin/pluginval
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Cross-platform plugin validator and tester for AU/VST2/VST3 plugins";
+    homepage = "https://github.com/Tracktion/pluginval";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ magnetophon ];
+    platforms = lib.platforms.linux;
+    mainProgram = "pluginval";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds pluginval, a cross platform plugin testing and validation tool.
https://github.com/Tracktion/pluginval


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
