### PR TITLE
tests.cross.sanity: fix eval

### DIFF
--- a/pkgs/test/cross/default.nix
+++ b/pkgs/test/cross/default.nix
@@ -195,7 +195,7 @@ let
     pkgs.pkgsCross.mips64el-linux-gnuabi64.stdenv
     pkgs.pkgsCross.mips64el-linux-gnuabin32.stdenv
     pkgs.pkgsCross.mingwW64.stdenv
-    # Uses the expression that is used by the most cross-compil_ed_ GHCs
+    # Uses the expression that is used by the most cross-compiled GHCs
     pkgs.pkgsCross.riscv64.haskell.compiler.native-bignum.ghc948
 
   ]
@@ -206,7 +206,7 @@ let
     pkgs.pkgsMusl.pkgsCross.gnu64.hello
 
     # Two web browsers -- exercises almost the entire packageset
-    pkgs.pkgsCross.aarch64-multiplatform.qutebrowser-qt5
+    pkgs.pkgsCross.aarch64-multiplatform.qutebrowser
     pkgs.pkgsCross.aarch64-multiplatform.firefox
 
     # Uses pkgsCross.riscv64-embedded; see https://github.com/NixOS/nixpkgs/issues/267859


### PR DESCRIPTION
Previously, it failed to eval due to parts of the `qutebrowser` being marked as insecure. `qt5` is not long for the world.

I'm still building `tests.cross.sanity` but now it evals.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
