### PR TITLE
sphinx-sitemap: fix build; sphinx-last-updated-by-git: init at 0.3.8-unstable-2025-08-26

### DIFF
--- a/pkgs/development/python-modules/sphinx-last-updated-by-git/default.nix
+++ b/pkgs/development/python-modules/sphinx-last-updated-by-git/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  sphinx,
+  gitpython,
+  gitMinimal,
+  pytestCheckHook,
+  sphinx-pytest,
+  pytest-cov-stub,
+}:
+buildPythonPackage rec {
+  pname = "sphinx-last-updated-by-git";
+  version = "0.3.8-unstable-2025-08-26";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mgeier";
+    repo = "sphinx-last-updated-by-git";
+    rev = "07ac1a98af2a927e773a65c6524ce83067c977b8";
+    hash = "sha256-2TGFR11Ejh/9zpVC/TEdmMNaBt38wE5yeJeYixZSVUE=";
+    fetchSubmodules = true;
+    leaveDotGit = true;
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    sphinx
+    gitpython
+  ];
+
+  postPatch = ''
+    # we cant just substitute by matching `'git'` due to collisons
+    substituteInPlace src/sphinx_last_updated_by_git.py \
+      --replace-fail "'git', 'ls-tree'" " '${lib.getExe gitMinimal}', 'ls-tree'" \
+      --replace-fail "'git', 'log'" "'${lib.getExe gitMinimal}', 'log'" \
+      --replace-fail "'git', 'rev-parse'" "'${lib.getExe gitMinimal}', 'rev-parse'" \
+  '';
+
+  propagatedBuildInputs = [ gitMinimal ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    sphinx-pytest
+    pytest-cov-stub
+  ];
+
+  disabledTests = [
+    "test_no_git" # we hardcoded the git path
+
+    "test_repo_shallow"
+    "test_repo_shallow_without_warning"
+  ];
+
+  meta = {
+    changelog = "https://github.com/mgeier/sphinx-last-updated-by-git/blob/${version}/NEWS.rst";
+    description = "Get the last updated time for each Sphinx page from Git";
+    homepage = "https://github.com/mgeier/sphinx-last-updated-by-git";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ sigmanificient ];
+  };
+}

--- a/pkgs/development/python-modules/sphinx-sitemap/default.nix
+++ b/pkgs/development/python-modules/sphinx-sitemap/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   setuptools,
   sphinx,
+  sphinx-last-updated-by-git,
   sphinx-pytest,
   defusedxml,
   pytestCheckHook,
@@ -23,9 +24,12 @@ buildPythonPackage rec {
     hash = "sha256-b8eo77Ab9w8JR6mLqXcIWeTkuJFTHjJBk440fksBbyw=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [ sphinx ];
+  dependencies = [
+    sphinx
+    sphinx-last-updated-by-git
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17239,6 +17239,10 @@ self: super: with self; {
 
   sphinx-jupyterbook-latex = callPackage ../development/python-modules/sphinx-jupyterbook-latex { };
 
+  sphinx-last-updated-by-git =
+    callPackage ../development/python-modules/sphinx-last-updated-by-git
+      { };
+
   sphinx-lv2-theme = callPackage ../development/python-modules/sphinx-lv2-theme { };
 
   sphinx-markdown-builder = callPackage ../development/python-modules/sphinx-markdown-builder { };


### PR DESCRIPTION
- Tested with https://github.com/Sigmanificient/csfml-handbook

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
