### PR TITLE
rofi-nerdy: fix plugin output path

### DIFF
--- a/pkgs/by-name/ro/rofi-nerdy/package.nix
+++ b/pkgs/by-name/ro/rofi-nerdy/package.nix
@@ -28,6 +28,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     pango
   ];
 
+  postInstall = ''
+    mkdir -p $out/lib/rofi
+    mv $out/lib/librofi_nerdy.so $out/lib/rofi/nerdy.so
+  '';
+
   meta = {
     description = "Nerd font icon selector plugin for rofi";
     homepage = "https://github.com/Rolv-Apneseth/rofi-nerdy";


### PR DESCRIPTION
The plugin was being installed to` $out/lib/librofi_nerdy.so` instead of the expected `$out/lib/rofi/nerdy.so`. This caused the plugin to not be discoverable by rofi's plugin system and prevented it from working with Home Manager's `programs.rofi.plugins` option.

To be honest, it worked for me when I tested the package before. This is probably because I was using an older cached version or something like that...

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
