### PR TITLE
 ncompress: fix build against gcc15 

### DIFF
--- a/pkgs/by-name/nc/ncompress/package.nix
+++ b/pkgs/by-name/nc/ncompress/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation rec {
@@ -14,6 +15,26 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-Yhs3C5/kR7Ve56E84usYJprxIMAIwXVahLi1N9TIfj0=";
   };
+
+  patches = [
+    # dependencies for gcc15 patch
+    (fetchpatch {
+      url = "https://github.com/vapier/ncompress/commit/af7d29d87ddf8b2002dad41152efa94e9c825b35.patch";
+      excludes = [ "Changes" ];
+      hash = "sha256-zc+59RHVt5/aw5a4OVnOmXyFdeoshqbARG2upDujEk4=";
+    })
+    (fetchpatch {
+      url = "https://github.com/vapier/ncompress/commit/aa359df10ec29a56c12f6e5c2bcec8d8ecfa2740.patch";
+      excludes = [ "Changes" ];
+      hash = "sha256-wtZJBSfJ6QmYK+ywijQ263PnjGwD2mXcvFWvBNeODpc=";
+    })
+    # fix build against gcc15
+    # https://github.com/vapier/ncompress/pull/40
+    (fetchpatch {
+      url = "https://github.com/vapier/ncompress/pull/40/commits/90810a7f11bf157b479c23c0fe6cee0bebec15c6.patch";
+      hash = "sha256-aqIofwTxlg2lq2+ZBhG6X6MKUoafHrADZlw7Avj8anQ=";
+    })
+  ];
 
   makeFlags = [ "PREFIX=$(out)" ];
   installTargets = "install_core";

--- a/pkgs/by-name/nc/ncompress/package.nix
+++ b/pkgs/by-name/nc/ncompress/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://ncompress.sourceforge.net/";
+    homepage = "https://vapier.github.io/ncompress/";
     license = licenses.publicDomain;
     description = "Fast, simple LZW file compressor";
     platforms = platforms.unix;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
