### PR TITLE
{go_1_24,go_1_25}: Disable CGO for powerpc64-linux target

### DIFF
--- a/pkgs/development/compilers/go/1.24.nix
+++ b/pkgs/development/compilers/go/1.24.nix
@@ -80,7 +80,19 @@ stdenv.mkDerivation (finalAttrs: {
 
   GO386 = "softfloat"; # from Arch: don't assume sse2 on i686
   # Wasi does not support CGO
-  CGO_ENABLED = if stdenv.targetPlatform.isWasi then 0 else 1;
+  # ppc64/linux CGO is incomplete/borked, and will likely not receive any further improvements
+  # https://github.com/golang/go/issues/8912
+  # https://github.com/golang/go/issues/13192
+  CGO_ENABLED =
+    if
+      (
+        stdenv.targetPlatform.isWasi
+        || (stdenv.targetPlatform.isPower64 && stdenv.targetPlatform.isBigEndian)
+      )
+    then
+      0
+    else
+      1;
 
   GOROOT_BOOTSTRAP = "${goBootstrap}/share/go";
 

--- a/pkgs/development/compilers/go/1.25.nix
+++ b/pkgs/development/compilers/go/1.25.nix
@@ -85,7 +85,19 @@ stdenv.mkDerivation (finalAttrs: {
 
   GO386 = "softfloat"; # from Arch: don't assume sse2 on i686
   # Wasi does not support CGO
-  CGO_ENABLED = if stdenv.targetPlatform.isWasi then 0 else 1;
+  # ppc64/linux CGO is incomplete/borked, and will likely not receive any further improvements
+  # https://github.com/golang/go/issues/8912
+  # https://github.com/golang/go/issues/13192
+  CGO_ENABLED =
+    if
+      (
+        stdenv.targetPlatform.isWasi
+        || (stdenv.targetPlatform.isPower64 && stdenv.targetPlatform.isBigEndian)
+      )
+    then
+      0
+    else
+      1;
 
   GOROOT_BOOTSTRAP = "${goBootstrap}/share/go";
 


### PR DESCRIPTION
While cross-compiling `libcap` to the `ppc64-elfv1` example for https://github.com/NixOS/nixpkgs/pull/442608, I stumbled into this error:

```
/nix/store/gp3h46w93a424jvnp78niym40sp5j6j5-go-1.25.0/share/go/pkg/tool/linux_amd64/link: external linking not supported for linux/ppc64
```

Based on the following upstream issues / comments on them, and issues in other repos like openwrt that reference them, let's just disable CGO for that platform.

- https://github.com/golang/go/issues/8912
- https://github.com/golang/go/issues/13192

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
