### PR TITLE
mkosi: allow use of python3 from tools tree

### DIFF
--- a/pkgs/tools/virtualization/mkosi/0001-Use-wrapped-binaries-instead-of-Python-interpreter.patch
+++ b/pkgs/tools/virtualization/mkosi/0001-Use-wrapped-binaries-instead-of-Python-interpreter.patch
@@ -8,9 +8,9 @@ Rather than calling ukify and mkosi with sys.executable, which doesn't use the P
 Signed-off-by: Moritz Sanft <58110325+msanft@users.noreply.github.com>
 ---
  mkosi/__init__.py   | 17 +++++++----------
- mkosi/bootloader.py |  5 +----
+ mkosi/bootloader.py |  3 +--
  mkosi/run.py        |  8 ++++----
- 3 files changed, 12 insertions(+), 18 deletions(-)
+ 3 files changed, 12 insertions(+), 16 deletions(-)
 
 diff --git a/mkosi/__init__.py b/mkosi/__init__.py
 index 65cac772bf1fc9feabec5740ed89a958ba406125..c0debc09a76f36ae878bd172294eee6637b95bcb 100644
@@ -98,18 +98,16 @@ index 65cac772bf1fc9feabec5740ed89a958ba406125..c0debc09a76f36ae878bd172294eee66
          die(
              f"Found '{ukify}' with version {v} but version {version} or newer is required to {reason}.",
 diff --git a/mkosi/bootloader.py b/mkosi/bootloader.py
-index 6f112b854f72a8863dc5e7348f0154851d3dda96..8fdf2c5df7950c032bfcd36d89f7824e86ec9173 100644
+index 6f112b854f72a8863dc5e7348f0154851d3dda96..28b32b9c8fcaa7c49a7d69e7e303ccf332d47d58 100644
 --- a/mkosi/bootloader.py
 +++ b/mkosi/bootloader.py
-@@ -268,10 +268,7 @@ def find_signed_grub_image(context: Context) -> Optional[Path]:
- 
- 
+@@ -270,8 +270,7 @@ def find_signed_grub_image(context: Context) -> Optional[Path]:
  def python_binary(config: Config) -> PathString:
--    # If there's no tools tree, prefer the interpreter from MKOSI_INTERPRETER. If there is a tools
--    # tree, just use the default python3 interpreter.
+     # If there's no tools tree, prefer the interpreter from MKOSI_INTERPRETER. If there is a tools
+     # tree, just use the default python3 interpreter.
 -    exe = Path(sys.executable)
 -    return "python3" if config.tools_tree or not exe.is_relative_to("/usr") else exe
-+    return "@PYTHON_PEFILE@"
++    return "python3" if config.tools_tree else "@PYTHON_PEFILE@"
  
  
  def extract_pe_section(context: Context, binary: Path, section: str, output: Path) -> Path:


### PR DESCRIPTION
An mkosi tools tree provides all of the necessary programs for building images in a little sandbox that cannot access any of the nix store from the actual host.

maintainers: @malt3 @msanft

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
