### PR TITLE
pychess: 1.0.5 -> 1.0.6

### DIFF
--- a/pkgs/by-name/py/pychess/package.nix
+++ b/pkgs/by-name/py/pychess/package.nix
@@ -7,20 +7,20 @@
   wrapGAppsHook3,
   gtk3,
   gst_all_1,
-  gtksourceview,
   writableTmpDirAsHomeHook,
+  gtksourceview4,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "pychess";
-  version = "1.0.5";
+  version = "1.0.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pychess";
     repo = "pychess";
-    rev = "${version}";
-    hash = "sha256-hxc+vYvCeiM0+oOu1peI9qkZg5PeIsDMCiydJQAuzOk=";
+    rev = version;
+    hash = "sha256-1FJgwdZTyyZBswXFnUowSXlEXzL86C4uK2qDdseqzLs=";
   };
 
   nativeBuildInputs = [
@@ -33,7 +33,7 @@ python3Packages.buildPythonApplication rec {
   buildInputs = [
     gtk3
     gst_all_1.gst-plugins-base
-    gtksourceview
+    gtksourceview4
   ];
 
   build-system = with python3Packages; [ setuptools ];
@@ -44,7 +44,6 @@ python3Packages.buildPythonApplication rec {
     sqlalchemy
     pexpect
     psutil
-    standard-telnetlib
     websockets
     ptyprocess
   ];


### PR DESCRIPTION
- bumped gtksourceview4 after update in upstream
- removed standard-telnetlib as not required by upstream anymore

This is a follow-up to #442080 and was thanks to pychess/pychess#2382 being handled quickly by the upstream maintainers.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
