### PR TITLE
maintainers: remove benwbooth

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3198,12 +3198,6 @@
     githubId = 442623;
     name = "Ben Pye";
   };
-  benwbooth = {
-    email = "benwboooth@gmail.com";
-    github = "benwbooth";
-    githubId = 75972;
-    name = "Ben Booth";
-  };
   benwis = {
     name = "Ben Wishovich";
     email = "ben@benw.is";

--- a/pkgs/by-name/jb/jbrowse/package.nix
+++ b/pkgs/by-name/jb/jbrowse/package.nix
@@ -36,7 +36,7 @@ appimageTools.wrapType2 {
     mainProgram = "jbrowse-desktop";
     homepage = "https://jbrowse.org/jb2/";
     license = licenses.asl20;
-    maintainers = with maintainers; [ benwbooth ];
+    maintainers = with maintainers; [ ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/by-name/jx/jxplorer/package.nix
+++ b/pkgs/by-name/jx/jxplorer/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     description = "Java Ldap Browser";
     homepage = "https://sourceforge.net/projects/jxplorer/";
     license = lib.licenses.asl11;
-    maintainers = with maintainers; [ benwbooth ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
     mainProgram = "jxplorer";
   };


### PR DESCRIPTION
Inactive on nixpkgs in 2025 despite the 10 pull requests that requested their review.

Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/tree/99b4fe0118ad739cbd4f9d60d76c020317908135/maintainers#losing-maintainer-status)

@benwbooth: if you'd like to stay involved, please respond within a week and join the NixOS org (following the instructions in the "Tools for maintainers" section of maintainers/README.md).
