### PR TITLE
xrandr-invert-colors: fix build and use current best practices.

### DIFF
--- a/pkgs/by-name/xr/xrandr-invert-colors/package.nix
+++ b/pkgs/by-name/xr/xrandr-invert-colors/package.nix
@@ -3,33 +3,37 @@
   stdenv,
   fetchFromGitHub,
   libXrandr,
+  libxcb,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "xrandr-invert-colors";
   version = "0.02";
 
   src = fetchFromGitHub {
     owner = "zoltanp";
     repo = "xrandr-invert-colors";
-    rev = "v${version}";
-    sha256 = "sha256-MIbHNJFDQsvjPUbperTKKbHY5GSgItvRyV5OsfpzYT4=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MIbHNJFDQsvjPUbperTKKbHY5GSgItvRyV5OsfpzYT4=";
   };
 
-  buildInputs = [ libXrandr ];
+  buildInputs = [
+    libXrandr
+    libxcb
+  ];
 
   installPhase = ''
-    mkdir -p $out/bin
-    mv xrandr-invert-colors.bin xrandr-invert-colors
-    install xrandr-invert-colors $out/bin
+    runHook preInstall
+    install -Dm755 xrandr-invert-colors.bin $out/bin/xrandr-invert-colors
+    runHook postInstall
   '';
 
-  meta = with lib; {
-    description = "Inverts the colors of your screen";
+  meta = {
+    description = "Invert colors on all screens, using XRandR";
     license = lib.licenses.gpl3Plus;
     homepage = "https://github.com/zoltanp/xrandr-invert-colors";
     maintainers = [ lib.maintainers.magnetophon ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "xrandr-invert-colors";
   };
-}
+})


### PR DESCRIPTION
This didn't build anymore, complaining that it was missing xcb.
Also updated to use current best practices, as mentioned by @Prince213 in https://github.com/NixOS/nixpkgs/pull/442616


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
