### PR TITLE
maintainers: remove artuuge

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2203,12 +2203,6 @@
     githubId = 4679721;
     name = "Artur Cygan";
   };
-  artuuge = {
-    email = "artuuge@gmail.com";
-    github = "artuuge";
-    githubId = 10285250;
-    name = "Artur E. Ruuge";
-  };
   arunoruto = {
     email = "mirza.arnaut45@gmail.com";
     github = "arunoruto";

--- a/pkgs/by-name/ar/argtable/package.nix
+++ b/pkgs/by-name/ar/argtable/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
       are essential but tedious to implement for a robust CLI program.
     '';
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ artuuge ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/cl/clblas/package.nix
+++ b/pkgs/by-name/cl/clblas/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
       This package contains a library of BLAS functions on top of OpenCL.
     '';
     license = licenses.asl20;
-    maintainers = with maintainers; [ artuuge ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 

--- a/pkgs/by-name/ep/epson-escpr/package.nix
+++ b/pkgs/by-name/ep/epson-escpr/package.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation {
           nssmdns4 = true;
         };'';
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ artuuge ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/li/libcpuid/package.nix
+++ b/pkgs/by-name/li/libcpuid/package.nix
@@ -26,7 +26,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd2;
     maintainers = with maintainers; [
       orivej
-      artuuge
     ];
     platforms = platforms.x86;
   };

--- a/pkgs/development/python-modules/pycuda/default.nix
+++ b/pkgs/development/python-modules/pycuda/default.nix
@@ -76,6 +76,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/inducer/pycuda/";
     description = "CUDA integration for Python";
     license = licenses.mit;
-    maintainers = with maintainers; [ artuuge ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pytools/default.nix
+++ b/pkgs/development/python-modules/pytools/default.nix
@@ -50,6 +50,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/inducer/pytools/";
     changelog = "https://github.com/inducer/pytools/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ artuuge ];
+    maintainers = with lib.maintainers; [ ];
   };
 }


### PR DESCRIPTION
Totally inactive on GitHub since 2023, despite many PRs in which they were tagged.

Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/tree/99b4fe0118ad739cbd4f9d60d76c020317908135/maintainers#losing-maintainer-status)

@artuuge: if you'd like to stay involved, please respond within a week and join the NixOS org (following the instructions in the "Tools for maintainers" section of maintainers/README.md).
