### PR TITLE
hadoop: 3.4.1 -> 3.4.2, use jdk21

### DIFF
--- a/nixos/tests/hadoop/hadoop.nix
+++ b/nixos/tests/hadoop/hadoop.nix
@@ -238,7 +238,7 @@ import ../make-test-python.nix (
       nn2.wait_for_open_port(9870)
       nn2.wait_for_open_port(8022)
       nn2.wait_for_open_port(8020)
-      nn1.succeed("systemd-cat netstat -tulpne")
+      nn1.succeed("systemd-cat ss -tulpne")
 
       # Start failover controllers
       nn1.succeed("systemctl start hdfs-zkfc")

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -6,6 +6,7 @@
   autoPatchelfHook,
   jdk8_headless,
   jdk11_headless,
+  jdk21_headless,
   bash,
   coreutils,
   which,
@@ -39,11 +40,15 @@ let
       tests,
     }:
     stdenv.mkDerivation (finalAttrs: {
-      inherit pname jdk;
+      inherit pname;
+      jdk = platformAttrs.${stdenv.system}.jdk or jdk;
       version = platformAttrs.${stdenv.system}.version or (throw "Unsupported system: ${stdenv.system}");
       src = fetchurl {
         url =
           "mirror://apache/hadoop/common/hadoop-${finalAttrs.version}/hadoop-${finalAttrs.version}"
+          +
+            lib.optionalString (lib.hasAttr "variant" platformAttrs.${stdenv.system})
+              "-${platformAttrs.${stdenv.system}.variant}"
           + lib.optionalString stdenv.hostPlatform.isAarch64 "-aarch64"
           + ".tar.gz";
         inherit (platformAttrs.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}"))
@@ -170,19 +175,21 @@ in
     pname = "hadoop";
     platformAttrs = rec {
       x86_64-linux = {
-        version = "3.4.1";
-        hash = "sha256-mtVIeDOZbf5VFOdW9DkQKckFKf0i6NAC/T3QwUwEukY=";
-        srcHash = "sha256-lE9uSohy6GWXprFEYbEin2ITqTms2h6EWXe4nEd3U4Y=";
+        version = "3.4.2";
+        hash = "sha256-YySoP+EeUXiQQ2/G2AvIKVBu0lLL4kZXUrkSIJAN+4M=";
+        srcHash = "sha256-AkZjpHk57S3pYiZambxgRHR7PD51HSI4H1HHW9ICah4=";
+        variant = "lean";
       };
       x86_64-darwin = x86_64-linux;
-      aarch64-linux = x86_64-linux // {
+      aarch64-linux = {
         version = "3.4.0";
         hash = "sha256-QWxzKtNyw/AzcHMv0v7kj91pw1HO7VAN9MHO84caFk8=";
         srcHash = "sha256-viDF3LdRCZHqFycOYfN7nUQBPHiMCIjmu7jgIAaaK9E=";
+        jdk = jdk11_headless;
       };
       aarch64-darwin = aarch64-linux;
     };
-    jdk = jdk11_headless;
+    jdk = jdk21_headless;
     # TODO: Package and add Intel Storage Acceleration Library
     tests = nixosTests.hadoop;
   };


### PR DESCRIPTION
- Update hadoop to 3.4.2
- Switch from jdk11 to jdk21
- Add support for lean variant builds
- Replace netstat with ss in tests


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
