### PR TITLE
maintainers: remove yuuyins

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28592,14 +28592,6 @@
     githubId = 37774475;
     name = "Yusuf Duran";
   };
-  yuu = {
-    email = "yuunix@grrlz.net";
-    matrix = "@yuu:matrix.org";
-    github = "yuuyins";
-    githubId = 86538850;
-    name = "Yuu Yin";
-    keys = [ { fingerprint = "9F19 3AE8 AA25 647F FC31  46B5 416F 303B 43C2 0AC3"; } ];
-  };
   yvan-sraka = {
     email = "yvan@sraka.xyz";
     github = "yvan-sraka";

--- a/pkgs/by-name/br/brmodelo/package.nix
+++ b/pkgs/by-name/br/brmodelo/package.nix
@@ -127,6 +127,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/chcandido/brModelo";
     license = licenses.gpl3;
     mainProgram = "brmodelo";
-    maintainers = with maintainers; [ yuu ];
+    maintainers = with maintainers; [ ];
   };
 })

--- a/pkgs/by-name/jf/jflap/package.nix
+++ b/pkgs/by-name/jf/jflap/package.nix
@@ -67,7 +67,6 @@ stdenvNoCC.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     maintainers = with maintainers; [
       grnnja
-      yuu
     ];
     platforms = jre8.meta.platforms;
   };

--- a/pkgs/by-name/md/mdbook-epub/package.nix
+++ b/pkgs/by-name/md/mdbook-epub/package.nix
@@ -29,7 +29,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://michael-f-bryan.github.io/mdbook-epub";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [
-      yuu
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ni/nix-tour/package.nix
+++ b/pkgs/by-name/ni/nix-tour/package.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = with maintainers; [
       qknight
-      yuu
     ];
     mainProgram = "nix-tour";
   };

--- a/pkgs/by-name/st/stargate-libcds/package.nix
+++ b/pkgs/by-name/st/stargate-libcds/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "C data structure library";
     homepage = "https://github.com/stargateaudio/libcds";
-    maintainers = with maintainers; [ yuu ];
+    maintainers = with maintainers; [ ];
     license = licenses.lgpl3Only;
   };
 }

--- a/pkgs/by-name/st/strictdoc/package.nix
+++ b/pkgs/by-name/st/strictdoc/package.nix
@@ -76,7 +76,7 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/strictdoc-project/strictdoc";
     changelog = "https://github.com/strictdoc-project/strictdoc/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ yuu ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "strictdoc";
   };
 }

--- a/pkgs/by-name/sv/svgcleaner/package.nix
+++ b/pkgs/by-name/sv/svgcleaner/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/RazrFalcon/SVGCleaner";
     changelog = "https://github.com/RazrFalcon/svgcleaner/releases";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ yuu ];
+    maintainers = with maintainers; [ ];
     mainProgram = "svgcleaner";
   };
 }

--- a/pkgs/by-name/zi/zix/package.nix
+++ b/pkgs/by-name/zi/zix/package.nix
@@ -37,6 +37,6 @@ stdenv.mkDerivation rec {
     changelog = "https://gitlab.com/drobilla/zix/-/blob/${src.rev}/NEWS";
     license = licenses.isc;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ yuu ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/zr/zrythm/package.nix
+++ b/pkgs/by-name/zr/zrythm/package.nix
@@ -208,7 +208,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       tshaynik
       magnetophon
-      yuu
       astavie
       PowerUser64
     ];

--- a/pkgs/development/libraries/libsbsms/common.nix
+++ b/pkgs/development/libraries/libsbsms/common.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
   meta = {
     inherit homepage;
     description = "Subband sinusoidal modeling library for time stretching and pitch scaling audio";
-    maintainers = with lib.maintainers; [ yuu ];
+    maintainers = with lib.maintainers; [ ];
     license = lib.licenses.gpl2;
     platforms = lib.platforms.all;
   };

--- a/pkgs/development/python-modules/datauri/default.nix
+++ b/pkgs/development/python-modules/datauri/default.nix
@@ -43,6 +43,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/fcurella/python-datauri";
     changelog = "https://github.com/fcurella/python-datauri/releases/tag/${src.tag}";
     license = licenses.unlicense;
-    maintainers = with maintainers; [ yuu ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/django-debug-toolbar/default.nix
+++ b/pkgs/development/python-modules/django-debug-toolbar/default.nix
@@ -70,6 +70,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/jazzband/django-debug-toolbar";
     changelog = "https://django-debug-toolbar.readthedocs.io/en/latest/changes.html";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ yuu ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pymarshal/default.nix
+++ b/pkgs/development/python-modules/pymarshal/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python data serialization library";
     homepage = "https://github.com/stargateaudio/pymarshal";
-    maintainers = with lib.maintainers; [ yuu ];
+    maintainers = with lib.maintainers; [ ];
     license = lib.licenses.bsd2;
   };
 }

--- a/pkgs/development/python-modules/reqif/default.nix
+++ b/pkgs/development/python-modules/reqif/default.nix
@@ -49,6 +49,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/strictdoc-project/reqif";
     changelog = "https://github.com/strictdoc-project/reqif/releases/tag/${src.tag}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ yuu ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/textx/default.nix
+++ b/pkgs/development/python-modules/textx/default.nix
@@ -62,7 +62,7 @@ let
       mainProgram = "textx";
       homepage = "https://github.com/textx/textx/";
       license = licenses.mit;
-      maintainers = with maintainers; [ yuu ];
+      maintainers = with maintainers; [ ];
     };
   };
 

--- a/pkgs/development/python-modules/wavefile/default.nix
+++ b/pkgs/development/python-modules/wavefile/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     description = "Pythonic libsndfile wrapper to read and write audio files";
     homepage = "https://github.com/vokimon/python-wavefile";
     changelog = "https://github.com/vokimon/python-wavefile#version-history";
-    maintainers = with maintainers; [ yuu ];
+    maintainers = with maintainers; [ ];
     license = licenses.gpl3Plus;
   };
 }


### PR DESCRIPTION
Totally inactive on GitHub since 2023, despite many PRs requesting their review.

Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/tree/99b4fe0118ad739cbd4f9d60d76c020317908135/maintainers#losing-maintainer-status)

@yuuyins: if you'd like to stay involved, please respond within a week and join the NixOS org (following the instructions in the "Tools for maintainers" section of maintainers/README.md).
