### PR TITLE
toml11_4: init

### DIFF
--- a/pkgs/by-name/to/toml11_4/package.nix
+++ b/pkgs/by-name/to/toml11_4/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "toml11";
+  version = "4.4.0";
+
+  src = fetchFromGitHub {
+    owner = "ToruNiina";
+    repo = "toml11";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-NnM+I43UVcd72Y9h+ysAAc7s5gZ78mjVwIMReTJ7G5M=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeFlags = [ "-DTOML11_BUILD_TOML_TESTS=ON" ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/ToruNiina/toml11";
+    description = "TOML for Modern C++";
+    longDescription = ''
+      toml11 is a C++11 (or later) header-only toml parser/encoder depending
+      only on C++ standard library.
+
+      - It complies with the latest TOML language specification.
+      - It passes all the standard TOML language test cases.
+      - It supports new features merged into the upcoming TOML version (v1.1.0).
+      - It provides clear error messages, including the location of the error.
+      - It parses and retains comments, associating them with corresponding values.
+      - It maintains formatting information such as hex integers and considers these during serialization.
+      - It provides exception-less parse function.
+      - It supports complex type conversions from TOML values.
+      - It allows customization of the types stored in toml::value.
+      - It provides some extensions not present in the TOML language standard.
+    '';
+    license = licenses.mit;
+    maintainers = with lib.maintainers; [ cobalt ];
+    platforms = platforms.unix ++ platforms.windows;
+  };
+})


### PR DESCRIPTION
Init of toml11 with major version 4. This is a seperate package to keep toml11 (with version 3.x) for other dependent packages, like nix and lix.

The code is effectively the `toml11` package however I have also made a minor adjustment to build & run the included unit tests.

It should be noted that the main reason for not replacing `toml11`, with `toml11_3` and taking over with this derivation, is to avoid the mass rebuild from `nix.
I can't test those rebuilds locally and would like to avoid it unless necessary.

Successor of #430607

---

I noticed that `cabinpkg` contains an inlined build of toml11 4.2.0, it is likely possible to replace this with the `toml11_4` from this PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
