### PR TITLE
toml11: 3.7.1 -> 4.4.0 

### DIFF
--- a/pkgs/by-name/ca/cabinpkg/package.nix
+++ b/pkgs/by-name/ca/cabinpkg/package.nix
@@ -6,19 +6,10 @@
   libgit2,
   curl,
   fmt,
+  toml11_4,
   nlohmann_json,
   pkg-config,
 }:
-
-let
-  toml11 = fetchFromGitHub rec {
-    owner = "ToruNiina";
-    repo = "toml11";
-    version = "4.2.0";
-    tag = "v${version}";
-    sha256 = "sha256-NUuEgTpq86rDcsQnpG0IsSmgLT0cXhd1y32gT57QPAw=";
-  };
-in
 stdenv.mkDerivation rec {
   pname = "cabinpkg";
   version = "0.11.1";
@@ -40,6 +31,7 @@ stdenv.mkDerivation rec {
     libgit2
     fmt
     tbb_2021
+    toml11_4
     nlohmann_json
     curl
   ];
@@ -49,11 +41,6 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile \
        --replace-fail "git clone https://github.com/ToruNiina/toml11.git \$@" ":" \
        --replace-fail "git -C \$@ reset --hard v4.2.0" ":"
-  '';
-
-  preBuild = ''
-    mkdir -p build/DEPS/
-    cp -rf ${toml11} build/DEPS/toml11
   '';
 
   makeFlags = [

--- a/pkgs/by-name/to/toml11_4/package.nix
+++ b/pkgs/by-name/to/toml11_4/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "toml11";
+  version = "4.4.0";
+
+  src = fetchFromGitHub {
+    owner = "ToruNiina";
+    repo = "toml11";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-NnM+I43UVcd72Y9h+ysAAc7s5gZ78mjVwIMReTJ7G5M=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeFlags = [ "-DTOML11_BUILD_TOML_TESTS=ON" ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/ToruNiina/toml11";
+    description = "TOML for Modern C++";
+    longDescription = ''
+      toml11 is a C++11 (or later) header-only toml parser/encoder depending
+      only on C++ standard library.
+
+      - It complies with the latest TOML language specification.
+      - It passes all the standard TOML language test cases.
+      - It supports new features merged into the upcoming TOML version (v1.1.0).
+      - It provides clear error messages, including the location of the error.
+      - It parses and retains comments, associating them with corresponding values.
+      - It maintains formatting information such as hex integers and considers these during serialization.
+      - It provides exception-less parse function.
+      - It supports complex type conversions from TOML values.
+      - It allows customization of the types stored in toml::value.
+      - It provides some extensions not present in the TOML language standard.
+    '';
+    license = licenses.mit;
+    maintainers = with lib.maintainers; [ cobalt ];
+    platforms = platforms.unix ++ platforms.windows;
+  };
+})


### PR DESCRIPTION
Major bump, see https://github.com/ToruNiina/toml11/releases/tag/v4.4.0 for the current release notes. This also enables the upstream unit tests.

---

see #430607, #442668 and #434186 for related comments

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
