### PR TITLE
grafana-image-renderer: 3.12.7 -> 4.0.14

### DIFF
--- a/pkgs/by-name/gr/grafana-image-renderer/package.json
+++ b/pkgs/by-name/gr/grafana-image-renderer/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/grafana/grafana-image-renderer.git"
   },
   "scripts": {
-    "eslint": "eslint . --ext .ts",
+    "eslint": "eslint .",
     "typecheck": "tsc --noEmit",
     "prettier:check": "prettier --list-different \"**/*.ts\"",
     "prettier:write": "prettier --list-different \"**/*.ts\" --write",
@@ -45,32 +45,43 @@
     "lodash": "^4.17.21",
     "minimist": "^1.2.6",
     "morgan": "^1.9.0",
-    "multer": "^2.0.0",
+    "multer": "^2.0.2",
     "on-finished": "^2.3.0",
     "poolpeteer": "^0.24.0",
     "prom-client": "^14.1.0",
     "puppeteer": "^22.8.2",
     "puppeteer-cluster": "^0.24.0",
     "rate-limiter-flexible": "^7.0.0",
+    "tar-fs": "^3.0.9",
     "unique-filename": "^2.0.1",
     "winston": "^3.8.2"
   },
   "devDependencies": {
-    "@grafana/eslint-config": "^6.0.0",
-    "@types/dompurify": "^3.2.0",
+    "@eslint/js": "^9.31.0",
+    "@grafana/eslint-config": "^8.1.0",
+    "@grafana/sign-plugin": "^3.1.3",
+    "@stylistic/eslint-plugin-ts": "^4.4.1",
+    "@types/content-disposition": "^0.5.9",
     "@types/express": "^4.17.14",
     "@types/jest": "^29.5.12",
     "@types/jsdom": "20.0.0",
+    "@types/lodash": "^4.17.20",
+    "@types/minimist": "^1.2.5",
+    "@types/morgan": "^1.9.10",
     "@types/multer": "^1.4.7",
     "@types/node": "^20.17.27",
     "@types/pixelmatch": "^5.2.6",
     "@types/supertest": "^2.0.15",
-    "@typescript-eslint/eslint-plugin": "5.37.0",
-    "@typescript-eslint/parser": "5.37.0",
+    "@typescript-eslint/eslint-plugin": "^8.37.0",
+    "@typescript-eslint/parser": "^8.37.0",
     "@yao-pkg/pkg": "^6.3.0",
     "axios": "1.8.2",
     "cross-env": "7.0.3",
-    "eslint": "8.23.1",
+    "eslint": "^9.31.0",
+    "eslint-config-prettier": "^10.1.5",
+    "eslint-plugin-jsdoc": "^51.4.1",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "fast-png": "^6.2.0",
     "jest": "^29.7.0",
     "jsonwebtoken": "^9.0.2",
@@ -80,11 +91,8 @@
     "ts-jest": "^29.1.1",
     "ts-node": "10.9.1",
     "tsc-watch": "5.0.3",
-    "typescript": "4.8.3"
-  },
-  "resolutions": {
-    "@types/express": "^4.17.14",
-    "xml2js": "^0.6.2"
+    "typescript": "^5.8.3",
+    "typescript-eslint": "^8.37.0"
   },
   "lint-staged": {
     "*.ts": [
@@ -96,6 +104,6 @@
   },
   "bin": "build/app.js",
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   }
 }

--- a/pkgs/by-name/gr/grafana-image-renderer/package.nix
+++ b/pkgs/by-name/gr/grafana-image-renderer/package.nix
@@ -14,18 +14,18 @@
 
 mkYarnPackage rec {
   pname = "grafana-image-renderer";
-  version = "3.12.7";
+  version = "4.0.14";
 
   src = fetchFromGitHub {
     owner = "grafana";
     repo = "grafana-image-renderer";
     rev = "v${version}";
-    hash = "sha256-X7aBUvyktqRHUGvIBBoqAHCUHbddU0ltyd3AhRW+PaA=";
+    hash = "sha256-CoQTOzQ7h31B3U0yvJYsgC3uaSyjNNLpD+8uMN+naiQ=";
   };
 
   offlineCache = fetchYarnDeps {
     yarnLock = src + "/yarn.lock";
-    hash = "sha256-lV+4r+5E55J4H1zl05SimxIhGVD/PvEkIr3j1yhZS4o=";
+    hash = "sha256-xZrIoQlPeyGTbFRUQ0M8Tc6YpzsC5IACW0bbZ+HnsOQ=";
   };
 
   packageJSON = ./package.json;


### PR DESCRIPTION
ChangeLog: https://github.com/grafana/grafana-image-renderer/blob/v4.0.14/CHANGELOG.md

Code-wise, there's nothing particularly interesting. This is mostly done for the dependency updates.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
