### PR TITLE
[Backport release-25.05] nixos/nextcloud: remove X-XSS-Protection

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -1531,7 +1531,6 @@ in
           index index.php index.html /index.php$request_uri;
           ${optionalString (cfg.nginx.recommendedHttpHeaders) ''
             add_header X-Content-Type-Options nosniff;
-            add_header X-XSS-Protection "1; mode=block";
             add_header X-Robots-Tag "noindex, nofollow";
             add_header X-Permitted-Cross-Domain-Policies none;
             add_header X-Frame-Options sameorigin;


### PR DESCRIPTION
Manual backport of #438799 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
