### PR TITLE
[Backport release-25.05] ghidra-extensions.findcrypt: 3.0.5 -> 3.1.2

### DIFF
--- a/pkgs/tools/security/ghidra/extensions/findcrypt/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/findcrypt/default.nix
@@ -4,7 +4,7 @@
   buildGhidraExtension,
 }:
 let
-  version = "3.0.5";
+  version = "3.1.2";
 in
 buildGhidraExtension {
   pname = "findcrypt";
@@ -14,7 +14,7 @@ buildGhidraExtension {
     owner = "antoniovazquezblanco";
     repo = "GhidraFindcrypt";
     rev = "v${version}";
-    hash = "sha256-gWVYy+PWpNXlcgD83jap4IFRv66qdhloOwvpQVU2TcI=";
+    hash = "sha256-KP6Wx2U8O/37yEAcV3abKg/uWraHJJOIfb7kvcfejHA=";
   };
 
   meta = {


### PR DESCRIPTION
Manual backport of #438919 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
