### PR TITLE
grub2_ieee1275: init at 2.12

### DIFF
--- a/pkgs/tools/misc/grub/default.nix
+++ b/pkgs/tools/misc/grub/default.nix
@@ -26,6 +26,7 @@
   runtimeShell,
   zfs ? null,
   efiSupport ? false,
+  ieee1275Support ? false,
   zfsSupport ? false,
   xenSupport ? false,
   xenPvhSupport ? false,
@@ -61,6 +62,11 @@ let
     riscv64-linux.target = "riscv64";
   };
 
+  ieee1275SystemsBuild = {
+    x86_64-linux.target = "i386";
+    powerpc64-linux.target = "powerpc";
+  };
+
   xenSystemsBuild = {
     i686-linux.target = "i386";
     x86_64-linux.target = "x86_64";
@@ -90,8 +96,16 @@ let
 in
 
 assert zfsSupport -> zfs != null;
-assert !(efiSupport && (xenSupport || xenPvhSupport));
-assert !(xenSupport && xenPvhSupport);
+assert lib.asserts.assertMsg (
+  lib.lists.length (
+    lib.lists.filter (x: x) [
+      efiSupport
+      ieee1275Support
+      xenSupport
+      xenPvhSupport
+    ]
+  ) <= 1 # (0 == pc)
+) "Only <= 1 of grub2's platform-related *Support options may be enabled at the same time";
 
 stdenv.mkDerivation rec {
   pname = "grub";
@@ -618,6 +632,10 @@ stdenv.mkDerivation rec {
     "--target=${efiSystemsBuild.${stdenv.hostPlatform.system}.target}"
     "--program-prefix="
   ]
+  ++ lib.optionals ieee1275Support [
+    "--with-platform=ieee1275"
+    "--target=${ieee1275SystemsBuild.${stdenv.hostPlatform.system}.target}"
+  ]
   ++ lib.optionals xenSupport [
     "--with-platform=xen"
     "--target=${xenSystemsBuild.${stdenv.hostPlatform.system}.target}"
@@ -631,6 +649,8 @@ stdenv.mkDerivation rec {
   grubTarget =
     if efiSupport then
       "${efiSystemsInstall.${stdenv.hostPlatform.system}.target}-efi"
+    else if ieee1275Support then
+      "${ieee1275SystemsBuild.${stdenv.hostPlatform.system}.target}-ieee1275"
     else
       lib.optionalString inPCSystems "${pcSystems.${stdenv.hostPlatform.system}.target}-pc";
 
@@ -674,6 +694,8 @@ stdenv.mkDerivation rec {
     platforms =
       if efiSupport then
         lib.attrNames efiSystemsBuild
+      else if ieee1275Support then
+        lib.attrNames ieee1275SystemsBuild
       else if xenSupport then
         lib.attrNames xenSystemsBuild
       else if xenPvhSupport then

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2894,6 +2894,10 @@ with pkgs;
     efiSupport = true;
   };
 
+  grub2_ieee1275 = grub2.override {
+    ieee1275Support = true;
+  };
+
   grub2_light = grub2.override {
     zfsSupport = false;
   };


### PR DESCRIPTION
[Open Firmware](https://en.wikipedia.org/wiki/Open_Firmware) / IEEE-1275 is the boot standard used on *mostly old hardware from the [AIM alliance](https://en.wikipedia.org/wiki/AIM_alliance)*, which evolved out of Sun's boot system. So the supported systems include SPARC systems, Apple PowerMacs, older IBM POWER systems (they switched to OPAL and petitboot with POWER8, not sure what was used between that and the OpenFirmware-using RS/6000 machines). <sup><sub>*There were apparently also some x86 and ARM machines using this? Maybe?*</sub></sup>

GRUB is one of two boot loaders used in the Linux world, the other being [Yaboot](https://en.wikipedia.org/wiki/Yaboot). Since we already have GRUB packaged and configurable, I'm hoping that it's the less painful option for my hardware.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] powerpc64-linux (cross, `ppc64-elfv1` example)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
