### PR TITLE
pkgs.formats.vimAtoms: init

### DIFF
--- a/nixos/doc/manual/development/settings-options.section.md
+++ b/nixos/doc/manual/development/settings-options.section.md
@@ -343,6 +343,16 @@ have a predefined type and string generator already declared under
     and returning a set with TOML-specific attributes `type` and
     `generate` as specified [below](#pkgs-formats-result).
 
+`pkgs.formats.vim` { }
+
+:   A function taking an empty attribute set (for future extensibility)
+    and returning a set with Vim-specific attributes `type` and
+    `generate` as specified [below](#pkgs-formats-result).
+
+    `mkRaw vimCode`
+
+    :   Outputs the given string as raw Vim code
+
 `pkgs.formats.xml` { format ? "badgerfish", withHeader ? true}
 
 :   A function taking an attribute set with values

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -921,6 +921,52 @@ runBuildTests {
     '';
   };
 
+  vimAtoms = shouldPass rec {
+    format = formats.vim { };
+    input = {
+      attrs.foo = "woot";
+      false = false;
+      float = 3.141001;
+      int = 10;
+      list = [
+        null
+        null
+      ];
+      mixed = [
+        {
+          smallerFloats = [
+            0.133642
+            3.140000
+          ];
+        }
+        input.attrs
+      ];
+      null = null;
+      path = /etc/noop;
+      raw = format.lib.mkRaw "{arg1, arg2 -> arg1 - arg2}";
+      storePath = /nix/store/noop.drv;
+      str = "foo";
+      true = true;
+    };
+    expected =
+      "{"
+      + lib.concatStringsSep "," [
+        ''"attrs":{"foo":"woot"}''
+        ''"false":v:false''
+        ''"float":3.141001''
+        ''"int":10''
+        ''"list":[v:null,v:null]''
+        ''"mixed":[{"smallerFloats":[0.133642,3.140000]},{"foo":"woot"}]''
+        ''"null":v:null''
+        ''"path":"/etc/noop"''
+        ''"raw":{arg1, arg2 -> arg1 - arg2}''
+        ''"storePath":"/nix/store/noop.drv"''
+        ''"str":"foo"''
+        ''"true":v:true''
+      ]
+      + "}";
+  };
+
   badgerfishToXmlGenerate = shouldPass {
     format = formats.xml { };
     input = {


### PR DESCRIPTION
The output of `generate` does not prefixed `let ${name} =` because there are other places formatted results could be injected within Vim scripts.

... Plus the verity of prefixed options of `let` alone makes ideas of maintaining such things not spark joy; check `:help let` for details.

This means, until I'm told a better way, users will need to use `.text` from `.generate` result to access formatted output, ex;

```nix
nix-repl> git-nixpkgs = import ./default.nix { }
nix-repl> f = git-nixpkgs.pkgs.formats.vim { }
nix-repl> x = f.generate "test" { foo.bar = "woot"; }
nix-repl> :p x.text
#> {"foo":{"bar":"woot"}}
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Tests in [pkgs/pkgs-lib/tests/formats.nix]
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
