### PR TITLE
yopass: init at 14.2.0

### DIFF
--- a/pkgs/by-name/yo/yopass/package.nix
+++ b/pkgs/by-name/yo/yopass/package.nix
@@ -1,0 +1,51 @@
+{
+  buildGoModule,
+  callPackage,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  lib,
+}:
+let
+  version = "12.4.0";
+  src = fetchFromGitHub {
+    owner = "jhaals";
+    repo = "yopass";
+    tag = version;
+    hash = "sha256-rpPwMALKgU1N982icphtVeQhYouMyAYD0LMyZxv0+9M=";
+  };
+
+  website = callPackage ./website.nix { inherit src version; };
+in
+buildGoModule (finalAttrs: {
+  inherit version src;
+  pname = "yopass";
+
+  vendorHash = "sha256-7jOaw60hzZwtJkntagz+H4IjFUqrUcCNL1rkWDqQRuU=";
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  subPackages = [
+    "cmd/yopass"
+    "cmd/yopass-server"
+  ];
+
+  checkFlags = [
+    # Disable tests that require network access
+    "-skip=TestSecretNotFoundError"
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/yopass-server \
+      --add-flags "--asset-path ${website}"
+  '';
+
+  meta = {
+    description = "Secure sharing of secrets, passwords and files";
+    homepage = "https://github.com/jhaals/yopass";
+    changelog = "https://github.com/jhaals/yopass/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ivarmedi ];
+    mainProgram = "yopass";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/yo/yopass/package.nix
+++ b/pkgs/by-name/yo/yopass/package.nix
@@ -1,0 +1,51 @@
+{
+  buildGoModule,
+  callPackage,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  lib,
+}:
+let
+  version = "14.2.0";
+  src = fetchFromGitHub {
+    owner = "jhaals";
+    repo = "yopass";
+    tag = version;
+    hash = "sha256-cctouzn2HGV08Ytns2ZzvbnIj88/GRnUio2vHzeS3nA=";
+  };
+
+  website = callPackage ./website.nix { inherit src version; };
+in
+buildGoModule (finalAttrs: {
+  inherit version src;
+  pname = "yopass";
+
+  vendorHash = "sha256-U+P6Ioj1hXWtlUtCbG8gD9ORugkJMbqWeXSC1pPmMig=";
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  subPackages = [
+    "cmd/yopass"
+    "cmd/yopass-server"
+  ];
+
+  checkFlags = [
+    # Disable tests that require network access
+    "-skip=TestSecretNotFoundError"
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/yopass-server \
+      --add-flags "--asset-path ${website}"
+  '';
+
+  meta = {
+    description = "Secure sharing of secrets, passwords and files";
+    homepage = "https://github.com/jhaals/yopass";
+    changelog = "https://github.com/jhaals/yopass/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ivarmedi ];
+    mainProgram = "yopass";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/yo/yopass/website.nix
+++ b/pkgs/by-name/yo/yopass/website.nix
@@ -1,0 +1,35 @@
+{
+  fetchYarnDeps,
+  nodejs-slim,
+  src,
+  stdenv,
+  version,
+  yarnBuildHook,
+  yarnConfigHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "yopass-website";
+  inherit version;
+
+  src = src + "/website";
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/yarn.lock";
+    hash = "sha256-zREUxn5ouN7Mp5V70CdPLgctXtWlvo3VhCPdEe1lmXo=";
+  };
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    nodejs-slim
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mv dist $out
+
+    runHook postInstall
+  '';
+})

--- a/pkgs/by-name/yo/yopass/website.nix
+++ b/pkgs/by-name/yo/yopass/website.nix
@@ -1,0 +1,35 @@
+{
+  fetchYarnDeps,
+  nodejs-slim,
+  src,
+  stdenv,
+  version,
+  yarnBuildHook,
+  yarnConfigHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "yopass-website";
+  inherit version;
+
+  src = src + "/website";
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/yarn.lock";
+    hash = "sha256-uNtQCAu2LtE8O7AjGaXnlKsHxc5nX2AxEb+3awyNBOA=";
+  };
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    nodejs-slim
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mv dist $out
+
+    runHook postInstall
+  '';
+})


### PR DESCRIPTION
yopass: init at 14.2.0
https://github.com/jhaals/yopass

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc