### PR TITLE
capnproto: add patch to fix powerpc-linux build

### DIFF
--- a/pkgs/by-name/ca/capnproto/fix-libatomic.patch
+++ b/pkgs/by-name/ca/capnproto/fix-libatomic.patch
@@ -1,0 +1,35 @@
+From dfbbc505817bd0c3e01af5865196629c2a2a2b5e Mon Sep 17 00:00:00 2001
+From: Marie Ramlow <me@nycode.dev>
+Date: Wed, 10 Sep 2025 20:12:39 +0200
+Subject: [PATCH] Check if libatomic is needed
+
+---
+ c++/src/kj/CMakeLists.txt | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/c++/src/kj/CMakeLists.txt b/c++/src/kj/CMakeLists.txt
+index 7114ddb80e..8ce355b8b0 100644
+--- a/c++/src/kj/CMakeLists.txt
++++ b/c++/src/kj/CMakeLists.txt
+@@ -84,6 +84,21 @@ target_compile_features(kj PUBLIC cxx_std_20)
+ if(UNIX AND NOT ANDROID)
+   target_link_libraries(kj PUBLIC pthread)
+ endif()
++
++include(CheckCXXSourceCompiles)
++check_cxx_source_compiles("#include <atomic>
++int main() {
++  std::atomic<uint8_t> w1;
++  std::atomic<uint16_t> w2;
++  std::atomic<uint32_t> w4;
++  std::atomic<uint64_t> w8;
++  return ++w1 + ++w2 + ++w4 + ++w8;
++}" CAPNP_BUILDS_WITHOUT_LIBATOMIC)
++
++if(NOT CAPNP_BUILDS_WITHOUT_LIBATOMIC)
++  target_link_libraries(kj PUBLIC atomic)
++endif()
++
+ #make sure the lite flag propagates to all users (internal + external) of this library
+ target_compile_definitions(kj PUBLIC ${CAPNP_LITE_FLAG})
+ #make sure external consumers don't need to manually set the include dirs

--- a/pkgs/by-name/ca/capnproto/package.nix
+++ b/pkgs/by-name/ca/capnproto/package.nix
@@ -46,6 +46,8 @@ clangStdenv.mkDerivation rec {
   patches = [
     # https://github.com/capnproto/capnproto/pull/2377
     ./fix-libucontext.patch
+    # https://github.com/capnproto/capnproto/pull/2410
+    ./fix-libatomic.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] powerpc-linux: `pkgsCross.ppc32.capnproto`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
