### PR TITLE
diagrams-builder: disable cairo backend (incompatible with Stackage LTS) 

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -3289,6 +3289,17 @@ with haskellLib;
   # 2025-04-23: missing test data
   llvm-pretty-bc-parser = dontCheck super.llvm-pretty-bc-parser;
 
+  # diagrams-builder wants diagrams-cairo < 1.5 for its cairo executable,
+  # but Stackage LTS 24 contains diagrams-cairo >= 1.5.
+  # As such it is difficult to provide (2025-09-13)
+  # ATTN: This needs to match ../../tools/graphics/diagrams-builder/default.nix:/backends
+  # TODO: can we reinstate this by manually passing an older version?
+  diagrams-builder = disableCabalFlag "cairo" (
+    super.diagrams-builder.override {
+      diagrams-cairo = null;
+    }
+  );
+
   # 2025-04-23: Allow bytestring >= 0.12
   # https://github.com/mrkkrp/wave/issues/48
   wave = doJailbreak super.wave;

--- a/pkgs/tools/graphics/diagrams-builder/default.nix
+++ b/pkgs/tools/graphics/diagrams-builder/default.nix
@@ -1,11 +1,11 @@
 /*
-  If user need access to more haskell package for building his
-  diagrams, he simply has to pass these package through the
-  extra packages function as follow in `config.nix`:
+  If a user needs access to more haskell packages for building their
+  diagrams, they simply have to pass these packages through the
+  extraPackages function, as follows:
 
   ~~~
   diagrams-builder.override {
-    extraPackages = self : [myHaskellPackage];
+    extraPackages = self: [ self.myHaskellPackage ];
   }
   ­~~~
 */

--- a/pkgs/tools/graphics/diagrams-builder/default.nix
+++ b/pkgs/tools/graphics/diagrams-builder/default.nix
@@ -50,7 +50,8 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "diagrams-builder";
+  pname = "diagrams-builder";
+  inherit (diagrams-builder) version;
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/tools/graphics/diagrams-builder/default.nix
+++ b/pkgs/tools/graphics/diagrams-builder/default.nix
@@ -25,18 +25,26 @@ let
   wrappedGhc = ghcWithPackages (self: [ diagrams-builder ] ++ extraPackages self);
   ghc = lib.getExe' wrappedGhc "ghc";
 
-  exeWrapper = backend: ''
-    makeWrapper \
-    "${diagrams-builder}/bin/diagrams-builder-${backend}" "$out/bin/diagrams-builder-${backend}" \
-      --set NIX_GHC ${ghc} \
-      --set NIX_GHC_LIBDIR "$(${ghc} --print-libdir)"
-  '';
+  exeWrapper =
+    backend:
+    let
+      exe = "${diagrams-builder}/bin/diagrams-builder-${backend}";
+    in
+    ''
+      test ! -x "${exe}" || \
+      makeWrapper "${exe}" \
+      "$out/bin/diagrams-builder-${backend}" \
+        --set NIX_GHC ${ghc} \
+        --set NIX_GHC_LIBDIR "$(${ghc} --print-libdir)"
+    '';
 
-  backends = [
+  # Needs to match executable, suffix, not flag name
+  allBackends = [
     "svg"
     "ps"
-    # See ../../../development/haskell-modules/configuration-common.nix:/diagrams-builder.=
-    # "cairo"
+    "cairo"
+    "rasterific"
+    "pgf"
   ];
 
 in
@@ -46,7 +54,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  buildCommand = lib.concatStringsSep "\n" (map exeWrapper backends);
+  buildCommand = lib.concatStringsSep "\n" (map exeWrapper allBackends);
 
   # Will be faster to build the wrapper locally then to fetch it from a binary cache.
   preferLocalBuild = true;

--- a/pkgs/tools/graphics/diagrams-builder/default.nix
+++ b/pkgs/tools/graphics/diagrams-builder/default.nix
@@ -34,8 +34,9 @@ let
 
   backends = [
     "svg"
-    "cairo"
     "ps"
+    # See ../../../development/haskell-modules/configuration-common.nix:/diagrams-builder.=
+    # "cairo"
   ];
 
 in


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
