### PR TITLE
dbus-broker: fix test-sockopt on kernel 6.16+

### DIFF
--- a/pkgs/by-name/db/dbus-broker/package.nix
+++ b/pkgs/by-name/db/dbus-broker/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   docutils,
   meson,
   ninja,
@@ -120,6 +121,11 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./paths.patch
     ./disable-test.patch
+    (fetchpatch {
+      name = "backport-test-sockopt-6.16-fix.patch";
+      url = "https://github.com/bus1/dbus-broker/commit/fd5c6e191bffcf5b3e6c9abb8b0b03479accc04b.patch";
+      hash = "sha256-+QgZzm/qRnVSr0wDNw9Np3LRreRKl6CQXJextLPy6fc=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Fixes #439331

backports https://github.com/bus1/dbus-broker/pull/409 to resolve:
- test_peerpidfd_client: Assertion `false && "r == SOCKOPT_E_REAPED"' failed.
- wait_and_verify: Assertion `false && "WIFEXITED(status)"' failed.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. `nix-build . -A nixosTests.switchTest`
  -  ~~[Package tests] at `passthru.tests`.~~
  -  ~~Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~~
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - ~~Package update: when the change is major or breaking.~~
- NixOS Release Notes
  - ~~Module addition: when adding a new NixOS module.~~
  - ~~Module update: when the change is significant.~~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
