### PR TITLE
buildFHSEnvBubblewrap: unmute ldconfig

### DIFF
--- a/pkgs/build-support/build-fhsenv-bubblewrap/container-init.cc
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/container-init.cc
@@ -37,7 +37,6 @@ int main(int, const char *argv[]) {
   char *ldconfig_envp[] = {NULL};
   posix_spawn_file_actions_t action;
   posix_spawn_file_actions_init(&action);
-  posix_spawn_file_actions_addopen (&action, STDERR_FILENO, "/dev/null", O_WRONLY|O_APPEND, 0);
   if ((e = posix_spawn(&pid, ldconfig_argv[0], &action, NULL,
                        (char *const *)ldconfig_argv, ldconfig_envp))) {
     fprintf(stderr, "Failed to run ldconfig: %s\n", strerror(e));


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I've been several months without a working `steam-run-free`,
which suddenly started to fail with a terse and discouraging:
```console
$ steam-run-free date
ldconfig exited 126
```

Tonight I've finally spent two hours investigating why,
and that became much more easier to figure it out
with `ldconfig`'s error report unmuted (which this PR does):
```console
$ steam-run-free date
/bin/ldconfig: line 3: /nix/store/dgy6spispnbs3ampn70pynxmd6x3bm0k-glibc-2.40-66-bin/bin/ldconfig: cannot execute binary file: Exec format error
ldconfig exited 126
```

```console
$ file /nix/store/dgy6spispnbs3ampn70pynxmd6x3bm0k-glibc-2.40-66-bin/bin/ldconfig
/nix/store/dgy6spispnbs3ampn70pynxmd6x3bm0k-glibc-2.40-66-bin/bin/ldconfig: ELF 32-bit LSB pie executable, Intel 80386, version 1 (GNU/Linux), static-pie linked, BuildID[sha1]=884d0711d1a0c62850f052a61d58d7f0a295fe79, for GNU/Linux 3.10.0, not stripped
```

My machine is not able to execute a 32-bit ELF.
Indeed, this was a hardening I applied months ago following the advice of:
```console
$ kernel-hardening-checker -c /proc/config.gz -l /proc/cmdline | grep -i ia32
CONFIG_IA32_EMULATION                   |kconfig| is not set |   kspp   |cut_attack_surface| FAIL: "y"
ia32_emulation                          |cmdline|     0      |a13xp0p0v |cut_attack_surface| OK
```

Alas, little did I know back then that it would break `steam-run-free`
because when `multiArch = true` (which is hardcoded by `steam-run-free`)
it is assumed that all 64-bit machines can run a 32-bit `ldconfig`:
https://github.com/NixOS/nixpkgs/blob/042ccd4a882e2c11f8cd50055ac4490496ac1d14/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix#L85

It would be great to not have to make such assumption,
but in the meantime it would save time to others like me
to at least unmute `ldconfig` so that anyone hitting
an `ldconfig` has at least some clue about the problem.

## Things done
- [X] Allow `ldconfig` to output on `stderr`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc