### PR TITLE
hypr-dynamic-cursors: 0-unstable-2025-07-19 -> 0-unstable-2025-09-01

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hypr-dynamic-cursors.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hypr-dynamic-cursors.nix
@@ -8,13 +8,13 @@
 
 mkHyprlandPlugin hyprland {
   pluginName = "hypr-dynamic-cursors";
-  version = "0-unstable-2025-07-19";
+  version = "0-unstable-2025-09-01";
 
   src = fetchFromGitHub {
     owner = "VirtCode";
     repo = "hypr-dynamic-cursors";
-    rev = "d6eb0b798c9b07f7f866647c8eb1d75a930501be";
-    hash = "sha256-Yd5oSg1gS/mwobd5YFrLC3I4bar/cSGNGuIvxF3UeHE=";
+    rev = "0e11ed12dbd4d0c62b362dda2559c2e374814d56";
+    hash = "sha256-2JQ/KxMEVDjauaFU62T0udjKXKSiCyKO5frjVf4b4A8=";
   };
 
   dontUseCmakeConfigure = true;


### PR DESCRIPTION
## Summary

- Update hypr-dynamic-cursors plugin to latest commit (0e11ed12dbd4d0c62b362dda2559c2e374814d56) from 2025-09-01
- Fixes breaking API changes related to DRM in latest hyprland.