### PR TITLE
nixosTestRunner: cache store path length to avoid useless calls

### DIFF
--- a/pkgs/applications/virtualization/qemu/force-uid0-on-9p.patch
+++ b/pkgs/applications/virtualization/qemu/force-uid0-on-9p.patch
@@ -9,7 +9,7 @@ index 45e9a1f9b0..494ee00c66 100644
 +static int is_in_store_path(const char *path)
 +{
 +    static char *store_path = NULL;
-+    int store_path_len = -1;
++    static ssize_t store_path_len = -1;
 +
 +    if (store_path_len == -1) {
 +        if ((store_path = getenv("NIX_STORE")) != NULL)
@@ -19,7 +19,7 @@ index 45e9a1f9b0..494ee00c66 100644
 +    }
 +
 +    if (store_path_len > 0)
-+        return strncmp(path, store_path, strlen(store_path)) == 0;
++        return strncmp(path, store_path, store_path_len) == 0;
 +    return 0;
 +}
 +


### PR DESCRIPTION
The modified patch applies to `qemu` when running nixos tests. The patch was incorrectly using `static` and causing 2 calls to `strlen(store_path)` plus one to `get_env` on each execution. With this PR, a single call to each should now be executed on the first call, and values be cached for subsequent calls.

It should result in a tiny performance improvement when running tests :)

I ran a few nixosTests (including the ones around qemu) for some services to check that nothing was broken.

I wasn't entirely sure how to name the PR, despite reading the contributing guidelines. I hope I got things right!

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
