### PR TITLE
nixos/murmur: Hard-code log directory to /var/log/murmur

### DIFF
--- a/nixos/modules/services/networking/murmur.nix
+++ b/nixos/modules/services/networking/murmur.nix
@@ -7,7 +7,7 @@
 
 let
   cfg = config.services.murmur;
-  forking = cfg.logFile != null;
+  forking = cfg.logToFile;
   configFile = pkgs.writeText "murmurd.ini" ''
     database=${cfg.stateDir}/murmur.sqlite
     dbDriver=QSQLITE
@@ -16,7 +16,7 @@ let
     autobanTimeframe=${toString cfg.autobanTimeframe}
     autobanTime=${toString cfg.autobanTime}
 
-    logfile=${lib.optionalString (cfg.logFile != null) cfg.logFile}
+    logfile=${lib.optionalString cfg.logToFile "/var/log/murmur/murmurd.log"}
     ${lib.optionalString forking "pidfile=/run/murmur/murmurd.pid"}
 
     welcometext="${cfg.welcometext}"
@@ -51,6 +51,15 @@ let
   '';
 in
 {
+
+  imports = [
+    (lib.mkRemovedOptionModule [
+      "services"
+      "murmur"
+      "logfile"
+    ] "This option has been superseded by services.murmur.logToFile")
+  ];
+
   options = {
     services.murmur = {
       enable = lib.mkEnableOption "Mumble server";
@@ -108,12 +117,7 @@ in
         description = "The amount of time an IP ban lasts (in seconds).";
       };
 
-      logFile = lib.mkOption {
-        type = lib.types.nullOr lib.types.path;
-        default = null;
-        example = "/var/log/murmur/murmurd.log";
-        description = "Path to the log file for Murmur daemon. Empty means log to journald.";
-      };
+      logToFile = lib.mkEnableOption "logging to a file instead of journald, which is stored in /var/log/murmur";
 
       welcometext = lib.mkOption {
         type = lib.types.str;
@@ -329,6 +333,8 @@ in
         EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
         ExecStart = "${cfg.package}/bin/mumble-server -ini /run/murmur/murmurd.ini";
         Restart = "always";
+        LogsDirectory = lib.mkIf cfg.logToFile "murmur";
+        LogsDirectoryMode = "0750";
         RuntimeDirectory = "murmur";
         RuntimeDirectoryMode = "0700";
         User = cfg.user;
@@ -403,8 +409,8 @@ in
         r /run/murmur/murmurd.ini,
         r ${configFile},
     ''
-    + lib.optionalString (cfg.logFile != null) ''
-      rw ${cfg.logFile},
+    + lib.optionalString cfg.logToFile ''
+      rw /var/log/murmur/murmurd.log,
     ''
     + lib.optionalString (cfg.sslCert != "") ''
       r ${cfg.sslCert},


### PR DESCRIPTION
The Murmur NixOS module allows logging to a file instead of journald. At the moment any arbitrary directory may be specified by using the `logfile` option, but nothing ensures that the directory exists or proper permissions are configured.

Since there is not much reason to specify a custom directory for log files anyway, just use `/var/log/murmur` by using the systemd way. This replaces the option `logfile` with the boolean option `logToFile` as well.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
