### PR TITLE
oauth2-proxy: fix nginx variables

### DIFF
--- a/nixos/modules/services/security/oauth2-proxy-nginx.nix
+++ b/nixos/modules/services/security/oauth2-proxy-nginx.nix
@@ -97,6 +97,10 @@ in
         virtualHosts.${vhost} = {
           locations = {
             "/".extraConfig = ''
+              auth_request_set $user   $upstream_http_x_auth_request_user;
+              auth_request_set $email  $upstream_http_x_auth_request_email;
+              auth_request_set $auth_cookie $upstream_http_set_cookie;
+
               # pass information via X-User and X-Email headers to backend, requires running with --set-xauthrequest flag
               proxy_set_header X-User  $user;
               proxy_set_header X-Email $email;
@@ -141,11 +145,6 @@ in
           extraConfig = ''
             auth_request /oauth2/auth;
             error_page 401 = @redirectToAuth2ProxyLogin;
-
-            # set variables being used in locations."/".extraConfig
-            auth_request_set $user   $upstream_http_x_auth_request_user;
-            auth_request_set $email  $upstream_http_x_auth_request_email;
-            auth_request_set $auth_cookie $upstream_http_set_cookie;
           '';
         };
       }) cfg.virtualHosts)


### PR DESCRIPTION
I'm not sure why, but `auth_cookie` variable isn't properly set when located inside server section. It breaks token refreshing. Anyway it doesn't seem to have much sense to put them inside server block as they are only used in `location."/"`, and for all other custom locations they have to be configured by user.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
