### PR TITLE
wmctrl: update src hash & meta

### DIFF
--- a/pkgs/by-name/wm/wmctrl/package.nix
+++ b/pkgs/by-name/wm/wmctrl/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [ ./64-bit-data.patch ];
 
   meta = {
-    homepage = "https://sites.google.com/site/tstyblo/wmctrl";
+    homepage = "https://web.archive.org/web/20221116231622/http://tripie.sweb.cz/utils/wmctrl/";
     description = "CLI tool to interact with EWMH/NetWM compatible X Window Managers";
     license = lib.licenses.gpl2Plus;
     platforms = with lib.platforms; all;

--- a/pkgs/by-name/wm/wmctrl/package.nix
+++ b/pkgs/by-name/wm/wmctrl/package.nix
@@ -8,15 +8,13 @@
   libXmu,
 }:
 
-stdenv.mkDerivation rec {
-
+stdenv.mkDerivation (finalAttrs: {
   pname = "wmctrl";
   version = "1.07";
 
   src = fetchurl {
-    # NOTE: 2019-04-11: There is also a semi-official mirror: http://tripie.sweb.cz/utils/wmctrl/
-    url = "https://sites.google.com/site/tstyblo/wmctrl/${pname}-${version}.tar.gz";
-    sha256 = "1afclc57b9017a73mfs9w7lbdvdipmf9q0xdk116f61gnvyix2np";
+    url = "https://web.archive.org/web/20221116231622/http://tripie.sweb.cz/utils/wmctrl/dist/wmctrl-${finalAttrs.version}.tar.gz";
+    hash = "sha256-RW/cIbA0w1UuRNDEvrljAkuKMqpdqf3996oUNSE6kx8=";
   };
 
   strictDeps = true;
@@ -38,5 +36,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.Anton-Latukha ];
     mainProgram = "wmctrl";
   };
-
-}
+})


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/442020.

Reference: https://gitlab.archlinux.org/archlinux/packaging/packages/wmctrl/-/commit/0069ae6d21a4e278093319ec7ac9bf7ac3bd3f4d

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
