### PR TITLE
catppuccin-sddm: fix custom background substitution

### DIFF
--- a/pkgs/by-name/ca/catppuccin-sddm/package.nix
+++ b/pkgs/by-name/ca/catppuccin-sddm/package.nix
@@ -11,6 +11,7 @@
   font ? "Noto Sans",
   fontSize ? "9",
   background ? null,
+  disableBackground ? false,
   loginBackground ? false,
   userIcon ? false,
   clockEnabled ? true,
@@ -65,6 +66,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     ${lib.optionalString (background != null) ''
       substituteInPlace $configFile \
         --replace-fail 'Background="backgrounds/wall.png"' 'Background="${background}"'
+    ''}
+
+    ${lib.optionalString disableBackground ''
+      substituteInPlace $configFile \
+        --replace-fail 'CustomBackground="true"' 'CustomBackground="false"'
     ''}
 
     ${lib.optionalString loginBackground ''

--- a/pkgs/by-name/ca/catppuccin-sddm/package.nix
+++ b/pkgs/by-name/ca/catppuccin-sddm/package.nix
@@ -64,8 +64,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     ${lib.optionalString (background != null) ''
       substituteInPlace $configFile \
-        --replace-fail 'Background="backgrounds/wall.png"' 'Background="${background}"' \
-        --replace-fail 'CustomBackground="false"' 'CustomBackground="true"'
+        --replace-fail 'Background="backgrounds/wall.png"' 'Background="${background}"'
     ''}
 
     ${lib.optionalString loginBackground ''


### PR DESCRIPTION
- Upstream changed the default `CustomBackground` configuration option to `true` instead of `false`. Therefore, when `background` is not null the configuration is correct and a substitution is no longer required.

- When `background` is `null`, the configuration remains correct as the default upstream behaviour is to use a default background.

- See: catppuccin/sddm@f5418099#diff-e121ebe3

- Resolves: https://github.com/NixOS/nixpkgs/issues/442758

- Tested with a custom background and the derivation successfully builds and substitutes the custom background path.

- Added a new option `disableBackground` that defaults to `false`. When it is set to `true` it will stop the default transparent overlay background from being loaded.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
