### PR TITLE
folo: 0.6.3 -> 1.10.0; add nix-update-script

### DIFF
--- a/pkgs/by-name/fo/folo/package.nix
+++ b/pkgs/by-name/fo/folo/package.nix
@@ -12,7 +12,7 @@
   pnpmConfigHook,
   stdenv,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "folo";
 
   version = "1.10.0";
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "RSSNext";
     repo = "Folo";
-    tag = "desktop/v${version}";
+    tag = "desktop/v${finalAttrs.version}";
     hash = "sha256-+k09Psuf6Bvjoc9Z1O0u2v44IIsaSQF1QbjJM6cWlUw=";
   };
 
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   ];
 
   pnpmDeps = fetchPnpmDeps {
-    inherit
+    inherit (finalAttrs)
       pname
       version
       src
@@ -43,6 +43,9 @@ stdenv.mkDerivation rec {
     fetcherVersion = 3;
     hash = "sha256-dF0nnBBpJaFq6MYCZVMMt4D85EWDv8zsGEbVnyhP0kE=";
   };
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
@@ -89,7 +92,7 @@ stdenv.mkDerivation rec {
     mimeTypes = [ "x-scheme-handler/follow" ];
   };
 
-  icon = src + "/apps/desktop/resources/icon.png";
+  icon = finalAttrs.src + "/apps/desktop/resources/icon.png";
 
   buildPhase = ''
     runHook preBuild
@@ -121,12 +124,12 @@ stdenv.mkDerivation rec {
       --add-flags $out/share/follow/apps/desktop \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
 
-    install -m 444 -D "${desktopItem}/share/applications/"* \
+    install -m 444 -D "${finalAttrs.desktopItem}/share/applications/"* \
         -t $out/share/applications/
 
     for size in 16 24 32 48 64 128 256 512; do
       mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
-      convert -background none -resize "$size"x"$size" ${icon} $out/share/icons/hicolor/"$size"x"$size"/apps/follow.png
+      convert -background none -resize "$size"x"$size" ${finalAttrs.icon} $out/share/icons/hicolor/"$size"x"$size"/apps/follow.png
     done
 
     runHook postInstall
@@ -142,7 +145,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Next generation information browser";
     homepage = "https://github.com/RSSNext/Folo";
-    changelog = "https://github.com/RSSNext/Folo/releases/tag/${src.tag}";
+    changelog = "https://github.com/RSSNext/Folo/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       amadejkastelic
@@ -151,4 +154,4 @@ stdenv.mkDerivation rec {
     platforms = [ "x86_64-linux" ];
     mainProgram = "follow";
   };
-}
+})

--- a/pkgs/by-name/fo/folo/package.nix
+++ b/pkgs/by-name/fo/folo/package.nix
@@ -7,7 +7,7 @@
   makeDesktopItem,
   makeWrapper,
   nodejs,
-  pnpm_10_29_2,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   stdenv,
@@ -15,19 +15,19 @@
 stdenv.mkDerivation rec {
   pname = "folo";
 
-  version = "0.6.3";
+  version = "1.10.0";
 
   src = fetchFromGitHub {
     owner = "RSSNext";
     repo = "Folo";
-    tag = "v${version}";
-    hash = "sha256-huVk5KcsepDwtdWMm9pvn31GE1felbH1pR3mGqlSWRs=";
+    tag = "desktop/v${version}";
+    hash = "sha256-+k09Psuf6Bvjoc9Z1O0u2v44IIsaSQF1QbjJM6cWlUw=";
   };
 
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_10_29_2
+    pnpm_11
     makeWrapper
     imagemagick
   ];
@@ -37,10 +37,11 @@ stdenv.mkDerivation rec {
       pname
       version
       src
+      pnpmInstallFlags
       ;
-    pnpm = pnpm_10_29_2;
+    pnpm = pnpm_11;
     fetcherVersion = 3;
-    hash = "sha256-EP7bpbJUcKmHm7KMlKc0Fz2u0niQ3jC7YN/9pp7vucE=";
+    hash = "sha256-dF0nnBBpJaFq6MYCZVMMt4D85EWDv8zsGEbVnyhP0kE=";
   };
 
   env = {
@@ -68,6 +69,16 @@ stdenv.mkDerivation rec {
 
   dontCheckForBrokenSymlinks = true;
 
+  # Several build scripts import transitive dependencies directly (e.g.
+  # ast-kit from unplugin-ast).
+  pnpmInstallFlags = [ "--shamefully-hoist" ];
+
+  postPatch = ''
+    # pnpm 11 verifies node_modules before every `pnpm run` which conflicts
+    # with --shamefully-hoist
+    echo 'verifyDepsBeforeRun: false' >> pnpm-workspace.yaml
+  '';
+
   desktopItem = makeDesktopItem {
     name = "folo";
     desktopName = "Folo";
@@ -87,13 +98,13 @@ stdenv.mkDerivation rec {
 
     # Build desktop app.
     cd apps/desktop
-    pnpm --offline --no-inline-css build:electron-vite
+    pnpm run build:electron-vite
     cd ../..
 
     # Remove dev dependencies.
     CI=true pnpm --ignore-scripts prune --prod
     # Clean up broken symlinks left behind by `pnpm prune`
-    find node_modules/.bin -xtype l -delete
+    [ -d node_modules/.bin ] && find node_modules/.bin -xtype l -delete
 
     runHook postBuild
   '';

--- a/pkgs/by-name/fo/folo/package.nix
+++ b/pkgs/by-name/fo/folo/package.nix
@@ -1,6 +1,7 @@
 {
   electron,
   fetchFromGitHub,
+  nix-update-script,
   imagemagick,
   lib,
   makeDesktopItem,
@@ -119,6 +120,13 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^desktop/v([0-9]+\\.[0-9]+\\.[0-9]+)$"
+    ];
+  };
 
   meta = {
     description = "Next generation information browser";

--- a/pkgs/by-name/fo/folo/package.nix
+++ b/pkgs/by-name/fo/folo/package.nix
@@ -144,7 +144,10 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/RSSNext/Folo";
     changelog = "https://github.com/RSSNext/Folo/releases/tag/${src.tag}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ iosmanthus ];
+    maintainers = with lib.maintainers; [
+      amadejkastelic
+      iosmanthus
+    ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "follow";
   };


### PR DESCRIPTION
Changelog: https://github.com/RSSNext/Folo/releases/tag/desktop%2Fv1.10.0
Diff: https://github.com/RSSNext/Folo/compare/v0.6.3..desktop%2Fv1.10.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
