### PR TITLE
python3Packages.kaitaistruct: 0.10 -> 0.11

### DIFF
--- a/pkgs/development/python-modules/kaitaistruct/01-add-kaitai-compress.patch
+++ b/pkgs/development/python-modules/kaitaistruct/01-add-kaitai-compress.patch
@@ -1,0 +1,11 @@
+diff --git a/setup.cfg b/setup.cfg
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -30,6 +30,7 @@ classifiers =
+ [options]
+ zip_safe = True
+ include_package_data = True
++packages = kaitai/compress
+ py_modules = kaitaistruct
+ python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+ install_requires =

--- a/pkgs/development/python-modules/kaitaistruct/default.nix
+++ b/pkgs/development/python-modules/kaitaistruct/default.nix
@@ -18,17 +18,18 @@ let
 in
 buildPythonPackage rec {
   pname = "kaitaistruct";
-  version = "0.10";
+  version = "0.11";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-oETe4pFz1q+6zye8rDna+JtlTdQYz6AJq4LZF4qa5So=";
+    hash = "sha256-BT7nZCiOeLjlOs90jpczJorL1Xm42CpCexgFRTYl10s=";
   };
+
+  patches = [ ./01-add-kaitai-compress.patch ];
 
   preBuild = ''
     ln -s ${kaitai_compress}/python/kaitai kaitai
-    sed '32ipackages = kaitai/compress' -i setup.cfg
   '';
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/mitmproxy/default.nix
+++ b/pkgs/development/python-modules/mitmproxy/default.nix
@@ -52,6 +52,7 @@ buildPythonPackage rec {
     "cryptography"
     "flask"
     "h2"
+    "kaitaistruct"
     "passlib"
     "pyopenssl"
     "tornado"


### PR DESCRIPTION
- Release: https://github.com/kaitai-io/kaitai_struct_python_runtime/releases/tag/v0.11

- Changes: https://github.com/kaitai-io/kaitai_struct_python_runtime/compare/0.10...v0.11

- Resolves: https://github.com/NixOS/nixpkgs/issues/442639

- Notes:
'mitmproxy' locks this package to v0.10.
To keep the package working, added 'kaitaistruct' to 'relaxedPythonDeps'.
The 'mitmproxy' tests still pass with this change.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
