### PR TITLE
thumbor: init at 7.7.7

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -176,6 +176,8 @@
 
 - [nixbit](https://github.com/pbek/nixbit), a GUI application for updating your NixOS system from a Nix Flakes Git repository. Available as [programs.nixbit](#opt-programs.nixbit.enable).
 
+- [Thumbor](https://www.thumbor.org/), an open-source photo thumbnail service. Available as [services.thumbor](#opt-services.thumbor.enable).
+
 ## Backward Incompatibilities {#sec-release-25.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1720,6 +1720,7 @@
   ./services/web-apps/strfry.nix
   ./services/web-apps/suwayomi-server.nix
   ./services/web-apps/szurubooru.nix
+  ./services/web-apps/thumbor.nix
   ./services/web-apps/trilium.nix
   ./services/web-apps/umami.nix
   ./services/web-apps/vikunja.nix

--- a/nixos/modules/services/web-apps/thumbor.nix
+++ b/nixos/modules/services/web-apps/thumbor.nix
@@ -1,0 +1,169 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.thumbor;
+
+  settingsFormat = pkgs.formats.pythonVars { };
+in
+{
+
+  options.services.thumbor = with lib; {
+    enable = mkEnableOption "thumbor";
+
+    package = mkPackageOption pkgs "thumbor" { };
+
+    port = mkOption {
+      type = types.port;
+      default = 8888;
+      description = ''
+        The port Thumbor listens to.
+      '';
+    };
+
+    listenAddress = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = ''
+        The address Thumbor listens to.
+      '';
+    };
+
+    fileDescriptor = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        The file descriptor number or path to Unix socket to listen for connections on (`port` and `listenAddress` will be ignored if this option is set).
+      '';
+    };
+
+    settings = mkOption {
+      type = settingsFormat.type;
+      default = { };
+      description = ''
+        Configuration for thumbor.
+
+        See <https://github.com/thumbor/thumbor/blob/master/thumbor/config.py> for available options.
+
+        ::: {.warning}
+        Do not put your keyfile in here! Use the `keyFile` option.
+        :::
+      '';
+      example = lib.literalExpression ''
+        let
+          format = pkgs.formats.pythonVars { };
+        in {
+          _includes = [ "os" ];
+
+          ACCESS_CONTROL_ALLOW_ORIGIN_HEADER = format.lib.mkRaw "os.environ[\"THUMBOR_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER\"]";
+        }
+      '';
+    };
+
+    keyFile = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        The path to the secret key file used to sign URLs.
+      '';
+    };
+
+    logLevel = mkOption {
+      type = types.enum [
+        "debug"
+        "info"
+        "warning"
+        "error"
+        "critical"
+        "notset"
+      ];
+      default = "warning";
+      description = ''
+        The level of messages to log.
+      '';
+    };
+
+    debug = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to enable debug mode.
+      '';
+    };
+
+    processes = mkOption {
+      type = types.ints.unsigned;
+      default = 1;
+      description = ''
+        Number of processes to start. Set to 0 to start a number of processes equal to the number of CPU cores.
+      '';
+    };
+
+    environmentFile = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        File with environment variables to pass to thumbor, in the format used
+        by Systemd EnvironmentFile (`VAR=value` entries, separated by
+        newlines). Values in this file will override any configuration set in
+        `settings`.
+      '';
+    };
+  };
+
+  meta.maintainers = [ lib.maintainers.sephi ];
+
+  config = lib.mkIf cfg.enable {
+    users.groups.thumbor = { };
+    users.users.thumbor = {
+      group = "thumbor";
+      isSystemUser = true;
+    };
+
+    systemd.services.thumbor = {
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig =
+        let
+          configFile = settingsFormat.generate "thumbor_config.py" cfg.settings;
+
+          startOptions = lib.cli.toGNUCommandLineShell { } {
+            c = configFile;
+            l = cfg.logLevel;
+            i = cfg.listenAddress;
+            p = cfg.port;
+            f = cfg.fileDescriptor;
+            k = cfg.keyFile;
+            d = cfg.debug;
+            processes = cfg.processes;
+          };
+        in
+        {
+          ExecStart = ''${lib.getExe cfg.package} --use-environment 1 ${startOptions}'';
+          EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
+          User = "thumbor";
+          Group = "thumbor";
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateTmp = true;
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelModules = true;
+          ProtectKernelLogs = true;
+          ProtectKernelTunables = true;
+          ProtectSystem = "full";
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          RemoveIPC = true;
+        };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1529,6 +1529,7 @@ in
   terminal-emulators = handleTest ./terminal-emulators.nix { };
   thanos = runTest ./thanos.nix;
   thelounge = handleTest ./thelounge.nix { };
+  thumbor = runTest ./thumbor.nix;
   tiddlywiki = runTest ./tiddlywiki.nix;
   tigervnc = handleTest ./tigervnc.nix { };
   tika = runTest ./tika.nix;

--- a/nixos/tests/thumbor.nix
+++ b/nixos/tests/thumbor.nix
@@ -1,0 +1,58 @@
+{ lib, ... }:
+{
+  name = "thumbor";
+
+  meta = {
+    maintainers = [ lib.maintainers.sephi ];
+  };
+
+  nodes.machine =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    {
+      services.thumbor = {
+        enable = true;
+      };
+
+      specialisation.withConfig.configuration = {
+        services.thumbor.settings.HEALTHCHECK_ROUTE = "/status";
+      };
+
+      specialisation.withEnvironmentVariable.configuration = {
+        services.thumbor.environmentFile = builtins.toString (
+          pkgs.writeText "thumbor_environment" ''
+            HEALTHCHECK_ROUTE="/status-test"
+          ''
+        );
+      };
+    };
+
+  testScript =
+    { nodes, ... }:
+    let
+      withConfig = "${nodes.machine.system.build.toplevel}/specialisation/withConfig";
+      withEnvironmentVariable = "${nodes.machine.system.build.toplevel}/specialisation/withEnvironmentVariable";
+    in
+    ''
+      def wait_for_thumbor():
+        machine.wait_for_unit("thumbor.service")
+
+      with subtest("healthcheck"):
+        wait_for_thumbor()
+        machine.wait_until_succeeds("curl --fail -s http://localhost:8888/healthcheck", timeout=30)
+
+      with subtest("healthcheck with configuration"):
+        machine.succeed("${withConfig}/bin/switch-to-configuration test >&2")
+        wait_for_thumbor()
+        machine.wait_until_succeeds("curl --fail -s http://localhost:8888/status", timeout=30)
+
+      with subtest("healthcheck with configuration"):
+        machine.succeed("${withEnvironmentVariable}/bin/switch-to-configuration test >&2")
+        wait_for_thumbor()
+        machine.wait_until_succeeds("curl --fail -s http://localhost:8888/status-test", timeout=30)
+    '';
+}

--- a/pkgs/by-name/th/thumbor/package.nix
+++ b/pkgs/by-name/th/thumbor/package.nix
@@ -1,0 +1,141 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+  gifsicle,
+  libjpeg,
+  ffmpeg,
+  nixosTests,
+}:
+python3.pkgs.buildPythonApplication rec {
+  pname = "thumbor";
+  version = "7.7.7";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "thumbor";
+    repo = "thumbor";
+    tag = version;
+    hash = "sha256-ZuZmI1mvfQn3hkDa5qgfEguuXmPK8t5rJH9vnR95sHY=";
+
+    # Fix fetch on Darwin. See https://github.com/thumbor/thumbor/pull/1754
+    # TODO: remove this once Thumbor version is > 7.7.7 and reenable associated tests
+    postFetch = ''
+      rm $out/tests/fixtures/images/alabama1_ap620*.jpg
+    '';
+  };
+
+  build-system = [
+    python3.pkgs.setuptools
+  ];
+
+  # Thumbor depends on `remotecv` for queued detection, however `remotecv`
+  # depends on `pyres` which has been removed from nixpkgs because it’s
+  # abandoned. The package still works fine without `remotecv` as long as
+  # queued detection is not configured.
+  dependencies = with python3.pkgs; [
+    colorama
+    derpconf
+    jpegiptc
+    libthumbor
+    piexif
+    pillow
+    pillow-avif-plugin
+    pillow-heif
+    pycurl
+    pytz
+    opencv-python-headless
+    statsd
+    thumbor-plugins-gifv
+    tornado
+    webcolors
+  ];
+
+  optional-dependencies = {
+    svg = [ python3.pkgs.cairosvg ];
+  };
+
+  pythonRelaxDeps = [
+    "pillow"
+    "pytz"
+    "setuptools"
+    "webcolors"
+  ];
+
+  buildInputs = [
+    libjpeg
+    ffmpeg
+  ];
+
+  nativeCheckInputs = [
+    python3.pkgs.pytestCheckHook
+    gifsicle
+    libjpeg
+    ffmpeg
+  ];
+
+  checkInputs = with python3.pkgs; [
+    cairosvg
+    preggy
+    pyssim
+    pytest-asyncio
+    sentry-sdk
+    redis
+  ];
+
+  preCheck = ''
+    # Cleaning up the thumbor directory is necessary to avoid errors with
+    # Python extension modules
+    find thumbor -type f -name '*.py' -delete
+  '';
+
+  disabledTestPaths = [
+    # Depends on remotecv which in turn depends on pyres, which is abandoned
+    "tests/detectors/test_queued_detector.py"
+  ];
+
+  disabledTests = [
+    # Checks existence of /bin/ls
+    "test_can_which_by_path"
+    # Error probably due to the mock object not matching the object in the Sentry SDK version in nixpkgs
+    "test_when_error_occurs_should_have_called_client"
+    # Not sure how this test is supposed to pass
+    "test_watermark_filter_detect_extension_simple"
+
+    # TODO: enable all these tests once Thumbor version is > 7.7.7
+    "test_modifying_existing_image_to_small_image"
+    "test_utf8_encoded_image_name_with_encoded_url"
+    "test_meta_with_unicode"
+    "test_image_already_generated_by_thumbor_2_times"
+    "test_can_post_from_html_form"
+    "test_can_post_image_with_charset"
+    "test_can_post_image_with_content_type"
+    "test_can_post_image_with_unknown_charset"
+    "test_can_post_image_without_filename"
+    "test_can_modify_existing_image"
+    "test_can_get_actual_id_when_stored_with_large_id"
+    "test_cant_get_truncated_id_when_stored_with_large_id"
+    "test_can_delete_existing_image"
+    "test_can_retrieve_existing_image"
+    "test_modifying_existing_image_to_heavy_image_fails"
+    "test_modifying_existing_image_to_invalid_image"
+  ];
+
+  pythonImportsCheck = [
+    "thumbor"
+  ];
+
+  passthru.tests = {
+    inherit (nixosTests) thumbor;
+  };
+
+  meta = {
+    description = "Open-source photo thumbnail service by globo.com";
+    homepage = "https://github.com/thumbor/thumbor/";
+    changelog = "https://github.com/thumbor/thumbor/blob/${src.rev}/CHANGELOG";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.sephi ];
+    mainProgram = "thumbor";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+}

--- a/pkgs/development/python-modules/jpegiptc/default.nix
+++ b/pkgs/development/python-modules/jpegiptc/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  setuptools,
+  buildPythonPackage,
+}:
+buildPythonPackage rec {
+  pname = "jpegiptc";
+  version = "1.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "gdegoulet";
+    repo = "JpegIPTC";
+    tag = "v${version}";
+    hash = "sha256-5yWDDF0JFGY3JxvvyHj7bLGjwo/tJM2ZqN0AmSQdZjs=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  # tests do not use pytest but some self written scripts
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "JpegIPTC"
+  ];
+
+  meta = {
+    description = "Extract APP13 (iptc data) from image and raw copy APP13 to another image";
+    homepage = "https://github.com/gdegoulet/JpegIPTC";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.sephi ];
+  };
+}

--- a/pkgs/development/python-modules/thumbor-plugins-gifv/default.nix
+++ b/pkgs/development/python-modules/thumbor-plugins-gifv/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  setuptools,
+  buildPythonPackage,
+  webcolors,
+}:
+buildPythonPackage rec {
+  pname = "thumbor-plugins-gifv";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "thumbor";
+    repo = "thumbor-plugins";
+    tag = "thumbor-plugins-gifv-v${version}";
+    hash = "sha256-P1EhAUTIyjAY5nXYoB7F67QqQHlxdz7JzRoPcRFN8f0=";
+  };
+
+  sourceRoot = "${src.name}/thumbor_plugins/optimizers/gifv";
+
+  pyproject = true;
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [ webcolors ];
+
+  pythonRelaxDeps = [ "webcolors" ];
+
+  meta = {
+    description = "Gifv plugin for Thumbor";
+    homepage = "https://github.com/thumbor/thumbor-plugins/tree/master/thumbor_plugins/optimizers/gifv";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.sephi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7529,6 +7529,8 @@ self: super: with self; {
 
   joserfc = callPackage ../development/python-modules/joserfc { };
 
+  jpegiptc = callPackage ../development/python-modules/jpegiptc { };
+
   jplephem = callPackage ../development/python-modules/jplephem { };
 
   jproperties = callPackage ../development/python-modules/jproperties { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18476,6 +18476,8 @@ self: super: with self; {
 
   thttp = callPackage ../development/python-modules/thttp { };
 
+  thumbor-plugins-gifv = callPackage ../development/python-modules/thumbor-plugins-gifv { };
+
   tianshou = callPackage ../development/python-modules/tianshou { };
 
   tidalapi = callPackage ../development/python-modules/tidalapi { };


### PR DESCRIPTION
thumbor is an open-source photo thumbnail service.

https://github.com/thumbor/thumbor

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
