### PR TITLE
nextpnr: 0.8 -> 0.9

### DIFF
--- a/pkgs/by-name/ne/nextpnr/package.nix
+++ b/pkgs/by-name/ne/nextpnr/package.nix
@@ -23,20 +23,13 @@ let
   };
 
   pname = "nextpnr";
-  version = "0.8";
-
-  prjxray_src = fetchFromGitHub {
-    owner = "f4pga";
-    repo = "prjxray";
-    rev = "faf9c774a340e39cf6802d009996ed6016e63521";
-    hash = "sha256-BEv7vJoOHWHZoc9EXbesfwFFClkuiSpVwHUrj4ahUcA=";
-  };
+  version = "0.9";
 
   prjbeyond_src = fetchFromGitHub {
     owner = "YosysHQ-GmbH";
     repo = "prjbeyond-db";
-    rev = "06d3b424dd0e52d678087c891c022544238fb9e3";
-    hash = "sha256-nmyFFUO+/J2lb+lPATEjdYq0d21P1fN3N94JXR8brZ0=";
+    rev = "f49f66be674d9857c657930353b867ba94bcbdd7";
+    hash = "sha256-B/VmKgMu6f2Y8umE+NgGD5W0FYBIfDcMVwgHocFzreA=";
   };
 in
 
@@ -47,7 +40,7 @@ stdenv.mkDerivation rec {
     owner = "YosysHQ";
     repo = "nextpnr";
     tag = "${pname}-${version}";
-    hash = "sha256-lconcmLACxWxC41fTIkUaGbfp79G98YdHA4mRJ9Qo1w=";
+    hash = "sha256-rpg99k7rSNU4p5D0iXipLgNNOA2j0PdDsz8JTxyYNPM=";
     fetchSubmodules = true;
   };
 
@@ -80,9 +73,12 @@ stdenv.mkDerivation rec {
       "-DTRELLIS_LIBDIR=${trellis}/lib/trellis"
       "-DGOWIN_BBA_EXECUTABLE=${python3Packages.apycula}/bin/gowin_bba"
       "-DUSE_OPENMP=ON"
-      "-DHIMBAECHEL_UARCH=all"
+
+      # gatemate excluded due to non-reproducible build https://github.com/YosysHQ/prjpeppercorn/issues/9
+      # xilinx excluded due to needing vivado https://github.com/f4pga/prjxray?tab=readme-ov-file#step-1
+      "-DHIMBAECHEL_UARCH=example;gowin;ng-ultra"
+
       "-DHIMBAECHEL_GOWIN_DEVICES=all"
-      "-DHIMBAECHEL_PRJXRAY_DB=${prjxray_src}"
       "-DHIMBAECHEL_PRJBEYOND_DB=${prjbeyond_src}"
     ]
     ++ (lib.optional enableGui "-DBUILD_GUI=ON");

--- a/pkgs/development/python-modules/apycula/default.nix
+++ b/pkgs/development/python-modules/apycula/default.nix
@@ -9,15 +9,14 @@
 
 buildPythonPackage rec {
   pname = "apycula";
-  version = "0.21";
+  version = "0.25";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
-    inherit version;
-    pname = "Apycula";
-    hash = "sha256-rh+1U1bqyrX3Mv1HUl22ykUHx5Zaq59suc7ZVAOi0mo=";
+    inherit pname version;
+    hash = "sha256-CLrceuZbmGygZtPM0ETVvsBosjY3FlQDo0sJh2I1uF0=";
   };
 
   build-system = [ setuptools-scm ];


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/439087 and closes #437337

Things of note:
* nextpnr v0.9 adds support for the [gatemate](https://www.colognechip.com/programmable-logic/gatemate/) microarchitecture in himbaechel, however [prjpeppercorn does not currently allow for reproducible builds](https://github.com/YosysHQ/prjpeppercorn/issues/9), this is why it's excluded from the build.
* I removed `prjxray` along with `xilinx` from the target architectures, because it [cannot be built without vivado](https://github.com/f4pga/prjxray?tab=readme-ov-file#step-1) and further bootstrapping steps are needed for prjxray which haven't been done so far. The previous version made it appear like `xilinx` was being built, but the [default target device list was empty](https://github.com/YosysHQ/nextpnr/commit/1d4b0eeac429766f7feaa96f346867e96c078817#diff-ebeefe6dac2acc74d86b5b5f1704577c84163858ae10cd57333a2673cc69c593L31-L32), so [no actual devices were available](https://hydra.nixos.org/build/305372633/nixlog/1) (search for `Enabled Himbaechel-Xilinx devices: `).
* apycula update 0.21 -> 0.25

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc