### PR TITLE
imake: add support for riscv and loongarch

### DIFF
--- a/pkgs/by-name/im/imake/package.nix
+++ b/pkgs/by-name/im/imake/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   tradcpp,
   xorg-cf-files,
   pkg-config,
@@ -37,6 +38,16 @@ stdenv.mkDerivation (finalAttrs: {
     # ELF interpreter path. (Which arguably, is a bug in its own.)
     # (copied from the commit message on 0100b270694ecab8aaa13fa5f3d30639b50d7777)
     ./cc-wrapper-uberhack.patch
+    # Add support for RISC-V
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/xorg/util/imake/-/commit/a37ee515742f58359b4248742fa06d504f2dce1b.patch";
+      hash = "sha256-2aoXBm1JmNjS5vqGKEyX/qYUVJ8kYIzh/eq3WKU3uQ4=";
+    })
+    # Add support for LoongArch
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/xorg/util/imake/-/commit/b4d568b7aa2db5525f63b1bc9486dc5e2ed36bd0.patch";
+      hash = "sha256-m35H3v5IFslqx5QaszPFAJ+g2HfDYyxbX+h+7/8/59M=";
+    })
   ];
 
   strictDeps = true;


### PR DESCRIPTION
https://gitlab.freedesktop.org/xorg/util/imake/-/commits/master?ref_type=HEADS

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] loongarch64-linux
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
