### PR TITLE
powersupply: 0.9.0 -> 0.10.1

### DIFF
--- a/pkgs/by-name/po/powersupply/package.nix
+++ b/pkgs/by-name/po/powersupply/package.nix
@@ -4,57 +4,57 @@
   fetchFromGitLab,
   desktop-file-utils,
   gobject-introspection,
-  gtk3,
-  libhandy,
+  gtk4,
+  libadwaita,
   meson,
   ninja,
   pkg-config,
-  wrapGAppsHook3,
+  wrapGAppsHook4,
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "powersupply";
-  version = "0.9.0";
+  version = "0.10.1";
 
   format = "other";
 
   src = fetchFromGitLab {
-    owner = "martijnbraam";
+    domain = "gitlab.postmarketos.org";
+    owner = "postmarketOS";
     repo = "powersupply";
     rev = version;
-    hash = "sha256-3NXoOqveMlMezYe4C78F3764KeAy5Sz3M714PO3h/eI=";
+    hash = "sha256-sPdtrm2WQYjPu+1bb0ltBiqS9t8FFvbgRdGe1PEthy0=";
   };
+
+  postPatch = ''
+    substituteInPlace build-aux/meson/postinstall.py \
+      --replace 'gtk-update-icon-cache' 'gtk4-update-icon-cache'
+  '';
 
   nativeBuildInputs = [
     desktop-file-utils
-    gtk3
-    gobject-introspection
+    gtk4 # for gtk4-update-icon-cache
+    gobject-introspection # Without this, launching the app on aarch64-linux results in ValueError: Namespace Gtk not available
     meson
     ninja
     pkg-config
-    wrapGAppsHook3
+    wrapGAppsHook4
   ];
 
   buildInputs = [
-    gtk3
-    libhandy
+    gtk4
+    libadwaita
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  dependencies = with python3.pkgs; [
     pygobject3
   ];
-
-  dontWrapGApps = true;
-
-  preFixup = ''
-    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
-  '';
 
   strictDeps = true;
 
   meta = with lib; {
     description = "Graphical app to display power status of mobile Linux platforms";
-    homepage = "https://gitlab.com/MartijnBraam/powersupply";
+    homepage = "https://gitlab.postmarketos.org/postmarketOS/powersupply";
     license = licenses.mit;
     mainProgram = "powersupply";
     platforms = platforms.linux;


### PR DESCRIPTION
This fork seems more maintained and is also used by Alpine Linux and the AUR.

https://gitlab.postmarketos.org/postmarketOS/powersupply/-/tags/0.10.0
https://gitlab.postmarketos.org/postmarketOS/powersupply/-/tags/0.10.1

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
