### PR TITLE
gst_all_1.gst-plugins-rs: fix build on exotic platforms

### DIFF
--- a/pkgs/development/libraries/gstreamer/rs/default.nix
+++ b/pkgs/development/libraries/gstreamer/rs/default.nix
@@ -13,6 +13,7 @@
   cargo-c,
   lld,
   nasm,
+  cmake,
   gstreamer,
   gst-plugins-base,
   gst-plugins-bad,
@@ -198,6 +199,12 @@ stdenv.mkDerivation (finalAttrs: {
     cargo
     cargo-c
     nasm
+  ]
+  # aws-lc-rs has no pregenerated bindings for exotic platforms
+  # https://aws.github.io/aws-lc-rs/platform_support.html
+  ++ lib.optionals (!(stdenv.hostPlatform.isx86 || stdenv.hostPlatform.isAarch64)) [
+    cmake
+    rustPlatform.bindgenHook
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     lld


### PR DESCRIPTION
On platforms other than x86 or AArch64, `aws-lc-sys` requires cmake (see https://aws.github.io/aws-lc-rs/platform_support.html), otherwise 

```shell
...
   Compiling native-tls v0.2.14
   Compiling hyper v1.6.0
   Compiling derive_builder_macro v0.20.2
   Compiling p256 v0.11.1
error: failed to run custom build command for `aws-lc-sys v0.30.0`

Caused by:
  process didn't exit successfully: `/build/source/build/target/release/build/aws-lc-sys-98283dc11caf341a/build-script-main` (exit status: 101)
  --- stdout
  ...
  cargo:rerun-if-env-changed=CMAKE

  --- stderr
  Missing dependency: cmake

  thread 'main' panicked at /build/gst-plugins-rs-0.14.1-vendor/aws-lc-sys-0.30.0/builder/main.rs:463:40:
  called `Result::unwrap()` on an `Err` value: "Required build dependency is missing. Halting build."
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
