### PR TITLE
nixos/default.nix: Allow specialArgs to be passed

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -1,12 +1,15 @@
 {
   configuration ? import ./lib/from-env.nix "NIXOS_CONFIG" <nixos-config>,
   system ? builtins.currentSystem,
+  # This should only be used for special arguments that need to be evaluated when resolving module structure (like in imports).
+  # For everything else, there's _module.args.
+  specialArgs ? { },
 }:
 
 let
 
   eval = import ./lib/eval-config.nix {
-    inherit system;
+    inherit system specialArgs;
     modules = [ configuration ];
   };
 


### PR DESCRIPTION
To allow plain nixos configrations the same power as flakes, we must expose `specialArgs`, otherwise a classic pattern importing all of ones "inputs" (i.e. npins sources), and then exposing them to the module system becomes impossible due to the fact that imports must be statically resolvable so these sources cannot be passed in the existing entry point using `_module.args` if the sources themselves have modules to be imported.

This patch seems trivial and it seems overly-restrictive that flakes enjoy the equivalent under `lib.nixosSystem` but not users outside of the flakes ecosystem. I've been running this patch for a few months with no ill effects, but open to feedback on why this is a horrible idea :)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
