### PR TITLE
portmaster: init at 2.2.1; nixos/portmaster: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28542,6 +28542,11 @@
     githubId = 36118348;
     keys = [ { fingerprint = "69C9 876B 5797 1B2E 11C5  7C39 80A1 F76F C9F9 54AE"; } ];
   };
+  WitteShadovv = {
+    name = "WitteShadovv";
+    github = "WitteShadovv";
+    githubId = 26429638;
+  };
   wizardlink = {
     name = "wizardlink";
     email = "contact@thewizard.link";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30609,6 +30609,12 @@
     githubId = 36118348;
     keys = [ { fingerprint = "69C9 876B 5797 1B2E 11C5  7C39 80A1 F76F C9F9 54AE"; } ];
   };
+  WitteShadovv = {
+    name = "WitteShadovv";
+    email = "contact@witteshadovv.dev";
+    github = "WitteShadovv";
+    githubId = 26429638;
+  };
   wiyba = {
     name = "Dmitry Shmakov";
     email = "contact@wiyba.org";

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1,4 +1,10 @@
 {
+  "module-services-portmaster": [
+    "index.html#module-services-portmaster"
+  ],
+  "module-services-portmaster-declarative-configuration": [
+    "index.html#module-services-portmaster-declarative-configuration"
+  ],
   "module-hardware-facter": [
     "index.html#module-hardware-facter"
   ],

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -22,6 +22,10 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- [Portmaster](https://safing.io/portmaster/), a privacy-focused application
+  firewall, is available through
+  [services.portmaster](#opt-services.portmaster.enable).
+
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 
 - [Moonlight Qt](https://moonlight-stream.org/), a client for playing your PC games on almost any device. Available as [programs.moonlight-qt](#opt-programs.moonlight-qt.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1332,6 +1332,7 @@
   ./services/networking/pihole-ftl.nix
   ./services/networking/pixiecore.nix
   ./services/networking/pleroma.nix
+  ./services/networking/portmaster.nix
   ./services/networking/powerdns.nix
   ./services/networking/pppd.nix
   ./services/networking/pptpd.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1374,6 +1374,7 @@
   ./services/networking/pihole-ftl.nix
   ./services/networking/pixiecore.nix
   ./services/networking/pleroma.nix
+  ./services/networking/portmaster.nix
   ./services/networking/porxie.nix
   ./services/networking/powerdns.nix
   ./services/networking/pppd.nix

--- a/nixos/modules/services/networking/portmaster.md
+++ b/nixos/modules/services/networking/portmaster.md
@@ -1,0 +1,114 @@
+# Portmaster {#module-services-portmaster}
+
+[Portmaster](https://safing.io/portmaster/) is an application firewall that monitors and controls network connections
+per application. A minimal configuration is:
+
+```nix
+{
+  services.portmaster.enable = true;
+}
+```
+
+The desktop client is installed in the system environment when the service is enabled and starts in the background with
+graphical sessions. It is authenticated through the package's immutable binary directory. Set
+`services.portmaster.settings.devmode = true` only when unrestricted browser or debugging access to
+`http://127.0.0.1:817` is required.
+
+Portmaster's binary self-updater is disabled because Nix owns the installed files. Intelligence data updates remain
+enabled and are stored under {option}`services.portmaster.stateDir`.
+Changing `stateDir` does not automatically move Portmaster's existing state or remove module-managed files from its old
+location.
+
+## Declarative configuration {#module-services-portmaster-declarative-configuration}
+
+Global settings can be set with {option}`services.portmaster.settings`. Later inputs override earlier inputs in this
+order: `settings`, {option}`services.portmaster.settingsFile`, then {option}`services.portmaster.secretsFile`. Use the
+last option for values that must not be copied to the Nix store.
+
+When any of these options or {option}`services.portmaster.profiles` is used, the module owns Portmaster's runtime
+`config.json`. Put all desired global settings in these options; global changes made only through the UI are replaced at
+the next service start.
+
+Declarative application profiles can combine multiple packages with manually specified fingerprints. A prefix can be
+added to their display names so that module-managed profiles are easy to recognize in Portmaster:
+
+```nix
+{ pkgs, ... }:
+{
+  services.portmaster = {
+    enable = true;
+    profilePrefix = "[NixOS] ";
+
+    profiles = {
+      Firefox = {
+        packages = [ pkgs.firefox ];
+        settings.filter.defaultAction = "permit";
+      };
+
+      Development = {
+        packages = [
+          {
+            package = pkgs.go;
+            directory = "share/go/bin";
+          }
+          pkgs.cargo
+        ];
+        settings.filter.endpoints = [ "+ .golang.org" ];
+      };
+
+      Vesktop = {
+        fingerprints = [
+          {
+            type = "env";
+            key = "CHROME_DESKTOP";
+            operation = "equals";
+            value = "vesktop.desktop";
+          }
+        ];
+      };
+    };
+  };
+}
+```
+
+Package identities use a regular expression that ignores the Nix store hash and package version and matches both the
+normal executable and Nix-generated `.program-wrapped` executables. A package can be written directly or as an attribute
+set with `package`, `type`, `storeNameRegex`, `directory`, `name`, `wrapped`, `strictHead`, and `strictLast` fields.
+`storeNameRegex` is a regular expression fragment, while `directory` and `name` are matched literally.
+
+Some packages start the real executable outside {file}`bin`. Specify those layouts explicitly, for example:
+
+```nix
+{ pkgs, ... }:
+{
+  services.portmaster.profiles = {
+    Brave.packages = [
+      {
+        package = pkgs.brave;
+        directory = "opt/brave.com/brave";
+      }
+    ];
+
+    LibreWolf.packages = [
+      {
+        package = pkgs.librewolf;
+        directory = "lib/librewolf";
+      }
+    ];
+  };
+}
+```
+
+The `packages` and `fingerprints` lists are merged, and at least one of them must be non-empty. Use manual fingerprints
+when package paths alone are not enough to identify an application.
+
+Package-name matching is a convenience, not a security boundary against local Nix users: someone who can add arbitrary
+store paths can create a derivation with the same name. Use manually chosen fingerprints when that threat is relevant.
+
+Portmaster fingerprints are alternatives: a process matches when any fingerprint matches. Broad regular expressions
+can therefore match unintended applications. Removing a profile declaration does not remove a profile already imported
+into Portmaster.
+
+Changing fingerprints changes Portmaster's derived profile ID. Portmaster 2.2.1 and later can migrate existing profiles
+whose fingerprints are edited, but declarative imports with a new identity can still leave the previous imported profile
+behind. Stable package identities avoid that churn.

--- a/nixos/modules/services/networking/portmaster.nix
+++ b/nixos/modules/services/networking/portmaster.nix
@@ -1,0 +1,232 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.portmaster;
+  settingsFormat = pkgs.formats.json { };
+in
+{
+  options.services.portmaster = {
+    enable = lib.mkEnableOption "Portmaster application firewall";
+
+    package = lib.mkPackageOption pkgs "portmaster" { };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+        options = {
+          devmode = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = ''
+              Enable development mode. This makes the Portmaster UI available at 127.0.0.1:817.
+            '';
+          };
+        };
+      };
+      default = { };
+      description = ''
+        Configuration for Portmaster. Options set here will be passed to portmaster-core.
+      '';
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        Extra command-line arguments to pass to portmaster-core.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    boot.kernelModules = [ "netfilter_queue" ];
+
+    systemd.tmpfiles.settings."10-portmaster" = {
+      "/var/lib/portmaster".d = {
+        mode = "0755";
+        user = "root";
+        group = "root";
+      };
+      "/var/lib/portmaster/logs".d = {
+        mode = "0755";
+        user = "root";
+        group = "root";
+      };
+      "/var/lib/portmaster/download_binaries".d = {
+        mode = "0755";
+        user = "root";
+        group = "root";
+      };
+      "/var/lib/portmaster/updates".d = {
+        mode = "0755";
+        user = "root";
+        group = "root";
+      };
+      "/var/lib/portmaster/databases".d = {
+        mode = "0755";
+        user = "root";
+        group = "root";
+      };
+      "/var/lib/portmaster/databases/icons".d = {
+        mode = "0755";
+        user = "root";
+        group = "root";
+      };
+      "/var/lib/portmaster/config".d = {
+        mode = "0755";
+        user = "root";
+        group = "root";
+      };
+      "/var/lib/portmaster/intel".d = {
+        mode = "0755";
+        user = "root";
+        group = "root";
+      };
+      "/var/lib/portmaster/runtime".d = {
+        mode = "0755";
+        user = "root";
+        group = "root";
+      };
+      "/usr/lib/portmaster".d = {
+        mode = "0755";
+        user = "root";
+        group = "root";
+      };
+      "/var/lib/portmaster/runtime/portmaster-core"."L+" = {
+        argument = "${cfg.package}/lib/portmaster/portmaster-core";
+      };
+      "/var/lib/portmaster/runtime/portmaster"."L+" = {
+        argument = "${cfg.package}/lib/portmaster/portmaster";
+      };
+      "/var/lib/portmaster/runtime/portmaster.zip"."L+" = {
+        argument = "${cfg.package}/lib/portmaster/portmaster.zip";
+      };
+      "/var/lib/portmaster/runtime/assets.zip"."L+" = {
+        argument = "${cfg.package}/lib/portmaster/assets.zip";
+      };
+      # Portmaster hardcoded expectation - portmaster.zip needs to be accessible from /usr/lib/portmaster/
+      "/usr/lib/portmaster/portmaster.zip"."L+" = {
+        argument = "${cfg.package}/lib/portmaster/portmaster.zip";
+      };
+    };
+
+    systemd.services.portmaster = {
+      description = "Portmaster by Safing";
+      documentation = [
+        "https://safing.io"
+        "https://docs.safing.io"
+      ];
+      before = [
+        "nss-lookup.target"
+        "network.target"
+        "shutdown.target"
+      ];
+      after = [
+        "systemd-networkd.service"
+        "systemd-tmpfiles-setup.service"
+      ];
+      conflicts = [
+        "shutdown.target"
+        "firewalld.service"
+      ];
+      wants = [ "nss-lookup.target" ];
+      wantedBy = [ "multi-user.target" ];
+      requires = [ "systemd-tmpfiles-setup.service" ];
+
+      postStop = ''
+        /var/lib/portmaster/runtime/portmaster-core recover-iptables
+      '';
+
+      serviceConfig =
+        let
+          baseArgs = [
+            "/var/lib/portmaster/runtime/portmaster-core"
+            "--data-dir=/var/lib/portmaster/runtime"
+            "--log-dir=/var/lib/portmaster/logs"
+          ];
+          devmodeArgs = lib.optional cfg.settings.devmode "--devmode";
+          allArgs = baseArgs ++ devmodeArgs ++ cfg.extraArgs;
+        in
+        {
+          Type = "simple";
+          ExecStart = lib.concatStringsSep " " allArgs;
+          Restart = "on-failure";
+          RestartSec = "10";
+          RestartPreventExitStatus = "24";
+          User = "root";
+          Group = "root";
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          MemoryLow = "2G";
+          NoNewPrivileges = true;
+          PrivateTmp = true;
+          PIDFile = "/var/lib/portmaster/core-lock.pid";
+          StateDirectory = "portmaster";
+          WorkingDirectory = "/var/lib/portmaster";
+          ProtectSystem = true;
+          ReadWritePaths = [ "/var/lib/portmaster" ];
+          ProtectHome = "read-only";
+          ProtectKernelTunables = true;
+          ProtectKernelLogs = true;
+          ProtectControlGroups = true;
+          PrivateDevices = true;
+          RestrictNamespaces = true;
+          AmbientCapabilities = [
+            "cap_chown"
+            "cap_kill"
+            "cap_net_admin"
+            "cap_net_bind_service"
+            "cap_net_broadcast"
+            "cap_net_raw"
+            "cap_sys_module"
+            "cap_sys_ptrace"
+            "cap_dac_override"
+            "cap_fowner"
+            "cap_fsetid"
+            "cap_sys_resource"
+            "cap_bpf"
+            "cap_perfmon"
+          ];
+          CapabilityBoundingSet = [
+            "cap_chown"
+            "cap_kill"
+            "cap_net_admin"
+            "cap_net_bind_service"
+            "cap_net_broadcast"
+            "cap_net_raw"
+            "cap_sys_module"
+            "cap_sys_ptrace"
+            "cap_dac_override"
+            "cap_fowner"
+            "cap_fsetid"
+            "cap_sys_resource"
+            "cap_bpf"
+            "cap_perfmon"
+          ];
+          RestrictAddressFamilies = [
+            "AF_UNIX"
+            "AF_NETLINK"
+            "AF_INET"
+            "AF_INET6"
+          ];
+          Environment = [
+            "LOGLEVEL=info"
+            "PORTMASTER_DATA_DIR=/var/lib/portmaster"
+            "PORTMASTER_RUNTIME_DIR=/var/lib/portmaster/runtime"
+          ];
+        };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    WitteShadovv
+    nyabinary
+  ];
+}

--- a/nixos/modules/services/networking/portmaster.nix
+++ b/nixos/modules/services/networking/portmaster.nix
@@ -1,0 +1,920 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+
+let
+  inherit (lib)
+    boolToString
+    concatMapStringsSep
+    concatStringsSep
+    escapeRegex
+    escapeShellArg
+    genAttrs
+    getExe
+    getExe'
+    getName
+    literalExpression
+    mapAttrs
+    mapAttrsToList
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    optional
+    optionalAttrs
+    optionals
+    types
+    ;
+  inherit (lib.strings) sanitizeDerivationName;
+
+  cfg = config.services.portmaster;
+  settingsFormat = pkgs.formats.json { };
+
+  nonEmptyStringType = types.addCheck types.str (value: value != "");
+  relativeDirectoryType = types.addCheck types.str (
+    value:
+    value == ""
+    || (
+      !(lib.hasPrefix "/" value)
+      && !(lib.hasSuffix "/" value)
+      && builtins.all (
+        component:
+        !builtins.elem component [
+          ""
+          "."
+          ".."
+        ]
+      ) (lib.splitString "/" value)
+    )
+  );
+
+  fingerprintType = types.submodule {
+    options = {
+      type = mkOption {
+        type = types.enum [
+          "path"
+          "cmdline"
+          "env"
+          "tag"
+        ];
+        description = "Portmaster fingerprint type.";
+      };
+      key = mkOption {
+        type = types.nullOr nonEmptyStringType;
+        default = null;
+        description = ''
+          Environment variable or metadata tag key. Required for `env` and
+          `tag` fingerprints, and invalid for `path` and `cmdline` fingerprints.
+        '';
+      };
+      operation = mkOption {
+        type = types.enum [
+          "equals"
+          "prefix"
+          "regex"
+        ];
+        description = "Operation used to compare the fingerprint value.";
+      };
+      value = mkOption {
+        type = nonEmptyStringType;
+        description = "The value to match against.";
+      };
+    };
+  };
+
+  packageMatchType = types.submodule (
+    { config, ... }:
+    {
+      options = {
+        package = mkOption {
+          type = types.package;
+          description = "Package from which to derive a Portmaster fingerprint.";
+        };
+
+        type = mkOption {
+          type = types.enum [
+            "path"
+            "cmdline"
+          ];
+          default = "path";
+          description = "Fingerprint type used for the generated package regular expression.";
+        };
+
+        storeNameRegex = mkOption {
+          type = types.nullOr nonEmptyStringType;
+          default = null;
+          example = "python3[0-9.]*-umu-launcher-unwrapped-[0-9.]+";
+          description = ''
+            Regular expression matching the package output name after the Nix
+            store hash. `null` matches the package's `pname` with an optional
+            version suffix.
+          '';
+        };
+
+        directory = mkOption {
+          type = relativeDirectoryType;
+          default = "bin";
+          example = "share/go/bin";
+          description = ''
+            Relative directory below the package output that contains the
+            executable. An empty string selects the output root.
+          '';
+        };
+
+        name = mkOption {
+          type = types.nullOr nonEmptyStringType;
+          default = config.package.meta.mainProgram or (config.package.pname or (getName config.package));
+          defaultText = literalExpression "package.meta.mainProgram or package.pname";
+          example = "nmap";
+          description = ''
+            Executable name. Set this to `null` and disable `strictLast` to
+            match every path below `directory`.
+          '';
+        };
+
+        wrapped = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Also match Nix wrapper names such as `.program-wrapped`.";
+        };
+
+        strictHead = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Anchor the generated regular expression at the beginning.";
+        };
+
+        strictLast = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Anchor the generated regular expression at the end.";
+        };
+      };
+    }
+  );
+
+  profilePackageType = types.coercedTo types.package (package: { inherit package; }) packageMatchType;
+
+  normalizeFingerprint =
+    fingerprint:
+    {
+      inherit (fingerprint) type operation;
+      # Keep string context so manually specified package paths remain in the
+      # system closure.
+      value = toString fingerprint.value;
+    }
+    // optionalAttrs ((fingerprint.key or null) != null) {
+      inherit (fingerprint) key;
+    };
+
+  fingerprintIdentityKey =
+    fingerprint: builtins.unsafeDiscardStringContext (builtins.toJSON fingerprint);
+
+  normalizeFingerprints =
+    fingerprints:
+    mapAttrsToList (
+      _: fingerprintsWithSameIdentity:
+      let
+        fingerprint = builtins.head fingerprintsWithSameIdentity;
+      in
+      fingerprint
+      // {
+        value = builtins.foldl' (
+          value: duplicate: lib.addContextFrom duplicate.value value
+        ) fingerprint.value (builtins.tail fingerprintsWithSameIdentity);
+      }
+    ) (builtins.groupBy fingerprintIdentityKey (map normalizeFingerprint fingerprints));
+
+  mkPackageRegex =
+    packageMatch:
+    let
+      packageName = packageMatch.package.pname or (getName packageMatch.package);
+      storeNameRegex =
+        if packageMatch.storeNameRegex == null then
+          "${escapeRegex packageName}(-[^/]+)?"
+        else
+          packageMatch.storeNameRegex;
+      inherit (packageMatch) name;
+    in
+    concatStringsSep "" [
+      (lib.optionalString packageMatch.strictHead "^")
+      (escapeRegex builtins.storeDir)
+      "/[a-z0-9]{32}-"
+      storeNameRegex
+      (lib.optionalString (packageMatch.directory != "") "/${escapeRegex packageMatch.directory}")
+      "/"
+      (
+        if name == null then
+          ""
+        else if packageMatch.wrapped then
+          "(${escapeRegex name}|\\.${escapeRegex name}-wrapped)"
+        else
+          escapeRegex name
+      )
+      (lib.optionalString packageMatch.strictLast "$")
+    ];
+
+  mkPackageFingerprint = packageMatch: {
+    inherit (packageMatch) type;
+    operation = "regex";
+    value = mkPackageRegex packageMatch;
+  };
+
+  fingerprintError =
+    fingerprint:
+    if
+      builtins.elem fingerprint.type [
+        "env"
+        "tag"
+      ]
+      && (fingerprint.key or null) == null
+    then
+      "`${fingerprint.type}` fingerprints require `key`"
+    else if
+      builtins.elem fingerprint.type [
+        "path"
+        "cmdline"
+      ]
+      && (fingerprint.key or null) != null
+    then
+      "`${fingerprint.type}` fingerprints must not set `key`"
+    else
+      null;
+
+  stateDir = toString cfg.stateDir;
+  logsDir = "${stateDir}/logs";
+  configDir = "${stateDir}/config";
+  packageLibDir = "${cfg.package}/lib/portmaster";
+
+  runtimeConfigPath = "${stateDir}/config.json";
+  runtimeConfigManagedMarkerPath = "${stateDir}/.config.json.nix-managed";
+  profilesApiKeyPath = "${configDir}/nix-managed-profiles-api-key";
+
+  profilesApiBaseUrl = "http://127.0.0.1:817/api/v1";
+  profilesPingUrl = "${profilesApiBaseUrl}/ping";
+  profilesImportUrl = "${profilesApiBaseUrl}/sync/profile/import?allowReplace";
+
+  configSettings = builtins.removeAttrs cfg.settings [ "devmode" ];
+  hasExternalConfigInputs = cfg.settingsFile != null || cfg.secretsFile != null;
+  profilesEnabled = cfg.profiles != { };
+  shouldGenerateManagedConfig = configSettings != { } || hasExternalConfigInputs || profilesEnabled;
+
+  managedConfigSettings =
+    optionalAttrs (shouldGenerateManagedConfig && !builtins.hasAttr "core/devMode" cfg.settings) {
+      "core/devMode" = cfg.settings.devmode;
+    }
+    // configSettings;
+  generatedManagedConfigFile = settingsFormat.generate "portmaster-config.json" managedConfigSettings;
+  managedConfigMergeInputs =
+    optionals shouldGenerateManagedConfig [ generatedManagedConfigFile ]
+    ++ optional (cfg.settingsFile != null) cfg.settingsFile
+    ++ optional (cfg.secretsFile != null) cfg.secretsFile;
+  managesConfig = managedConfigMergeInputs != [ ];
+
+  portmasterCapabilities = [
+    "cap_chown"
+    "cap_kill"
+    "cap_net_admin"
+    "cap_net_bind_service"
+    "cap_net_broadcast"
+    "cap_net_raw"
+    "cap_sys_module"
+    "cap_sys_ptrace"
+    "cap_dac_override"
+    "cap_fowner"
+    "cap_fsetid"
+    "cap_sys_resource"
+    "cap_bpf"
+    "cap_perfmon"
+  ];
+
+  tmpfileDir = {
+    mode = "0755";
+    user = "root";
+    group = "root";
+  };
+
+  tmpfileDirectories = [
+    stateDir
+    logsDir
+    configDir
+  ];
+
+  mkProfileResolution =
+    logicalName: profileCfg:
+    let
+      rawFingerprints = map mkPackageFingerprint profileCfg.packages ++ profileCfg.fingerprints;
+      fingerprints = normalizeFingerprints rawFingerprints;
+      packageErrors = builtins.filter (error: error != null) (
+        map (
+          packageMatch:
+          if packageMatch.name == null && packageMatch.strictLast then
+            "`strictLast` must be false when a package match has no executable `name`"
+          else
+            null
+        ) profileCfg.packages
+      );
+      fingerprintErrors = builtins.filter (error: error != null) (map fingerprintError fingerprints);
+      error =
+        if rawFingerprints == [ ] then
+          "one of `packages` or `fingerprints` must be non-empty"
+        else if packageErrors != [ ] then
+          builtins.head packageErrors
+        else if fingerprintErrors != [ ] then
+          builtins.head fingerprintErrors
+        else
+          null;
+    in
+    {
+      inherit logicalName error fingerprints;
+      inherit (profileCfg) settings;
+      name = cfg.profilePrefix + profileCfg.name;
+    };
+
+  profileResolutions = mapAttrs mkProfileResolution cfg.profiles;
+  profileErrors = builtins.filter (error: error != null) (
+    mapAttrsToList (
+      logicalName: resolution:
+      if resolution.error != null then "`${logicalName}`: ${resolution.error}" else null
+    ) profileResolutions
+  );
+
+  mkProfilePayload = profileCfg: {
+    type = "profile";
+    source = "local";
+    inherit (profileCfg) name;
+    inherit (profileCfg) fingerprints;
+    config = profileCfg.settings;
+  };
+
+  profileIdentityEntries = builtins.filter (entry: entry != null) (
+    mapAttrsToList (
+      logicalName: resolution:
+      if resolution.error == null then
+        {
+          inherit logicalName;
+          normalizedFingerprints = resolution.fingerprints;
+          identityKey = fingerprintIdentityKey resolution.fingerprints;
+        }
+      else
+        null
+    ) profileResolutions
+  );
+
+  profileIdentityCollisions = builtins.filter (group: builtins.length group > 1) (
+    builtins.attrValues (builtins.groupBy (entry: entry.identityKey) profileIdentityEntries)
+  );
+
+  formatProfileIdentityCollision =
+    group:
+    let
+      profileNames = map (entry: "`${entry.logicalName}`") group;
+      inherit ((builtins.head group)) normalizedFingerprints;
+    in
+    "profiles ${concatStringsSep ", " profileNames} normalize to the same fingerprints: ${builtins.toJSON normalizedFingerprints}";
+
+  profileExports = mapAttrsToList (logicalName: resolution: {
+    inherit logicalName;
+    path = settingsFormat.generate "portmaster-profile-${sanitizeDerivationName logicalName}.json" (
+      mkProfilePayload resolution
+    );
+  }) profileResolutions;
+
+  mergeConfig = pkgs.writeShellScript "portmaster-merge-config" ''
+    set -euo pipefail
+
+    umask 077
+    key_tmp=
+    cleanup() {
+      ${getExe' pkgs.coreutils "rm"} -f \
+        ${escapeShellArg runtimeConfigPath}.tmp \
+        "''${key_tmp:-}"
+    }
+    trap cleanup EXIT
+
+    inputs=(
+    ${concatMapStringsSep "\n" (input: "  ${escapeShellArg (toString input)}") managedConfigMergeInputs}
+    )
+
+    ${lib.optionalString profilesEnabled ''
+      if [ ! -s ${escapeShellArg profilesApiKeyPath} ]; then
+        key_tmp="$(${getExe' pkgs.coreutils "mktemp"} ${escapeShellArg "${configDir}/.nix-managed-profiles-api-key.XXXXXX"})"
+        ${getExe' pkgs.coreutils "od"} -An -tx1 -N32 /dev/urandom | ${getExe' pkgs.coreutils "tr"} -d ' \n' > "$key_tmp"
+        if [ "$(${getExe' pkgs.coreutils "wc"} -c < "$key_tmp")" -ne 64 ]; then
+          printf >&2 '%s\n' "Failed to generate Portmaster managed profiles API key"
+          exit 1
+        fi
+        ${getExe' pkgs.coreutils "install"} -m 0600 -o root -g root "$key_tmp" ${escapeShellArg profilesApiKeyPath}
+        ${getExe' pkgs.coreutils "rm"} -f "$key_tmp"
+        key_tmp=
+      fi
+
+      managed_api_key="$(${getExe' pkgs.coreutils "tr"} -d '\r\n' < ${escapeShellArg profilesApiKeyPath})"
+      if [[ ! "$managed_api_key" =~ ^[0-9a-f]{64}$ ]]; then
+        printf >&2 '%s\n' "Portmaster managed profiles API key must contain exactly 64 lowercase hexadecimal characters"
+        exit 1
+      fi
+      unset managed_api_key
+
+      ${getExe' pkgs.coreutils "chown"} root:root ${escapeShellArg profilesApiKeyPath}
+      ${getExe' pkgs.coreutils "chmod"} 0600 ${escapeShellArg profilesApiKeyPath}
+    ''}
+
+    if [ "''${#inputs[@]}" -eq 0 ]; then
+      exit 0
+    fi
+
+    for input in "''${inputs[@]}"; do
+      if ! ${getExe pkgs.jq} -e '
+        if type == "object" then
+          if has("core/apiKeys") and (."core/apiKeys" | type != "array") then
+            error("core/apiKeys must be an array")
+          else
+            true
+          end
+        else
+          error("top-level JSON value must be an object")
+        end
+      ' "$input" > /dev/null; then
+        printf >&2 'Invalid Portmaster config input: %s\n' "$input"
+        exit 1
+      fi
+    done
+
+    jq_merge_args=(-s)
+    ${lib.optionalString profilesEnabled ''
+      jq_merge_args+=(--rawfile profilesApiKey ${escapeShellArg profilesApiKeyPath})
+    ''}
+
+    ${getExe pkgs.jq} "''${jq_merge_args[@]}" '
+      reduce .[] as $item ({}; . * $item)
+      ${lib.optionalString profilesEnabled ''
+          | if has("core/apiKeys") and (."core/apiKeys" | type != "array") then
+              error("core/apiKeys must be an array")
+            else
+              .
+            end
+        | (."core/apiKeys" // []) as $apiKeys
+        | (($profilesApiKey | gsub("[\\r\\n]"; "")) + "?read=admin&write=admin") as $managedApiKey
+          | ."core/apiKeys" = (
+              $apiKeys + (if ($apiKeys | index($managedApiKey)) then [] else [ $managedApiKey ] end)
+            )
+      ''}
+    ' "''${inputs[@]}" > ${escapeShellArg runtimeConfigPath}.tmp
+    ${getExe' pkgs.coreutils "install"} -m 0600 ${escapeShellArg runtimeConfigPath}.tmp ${escapeShellArg runtimeConfigPath}
+    : > ${escapeShellArg runtimeConfigManagedMarkerPath}
+    ${getExe' pkgs.coreutils "chmod"} 0600 ${escapeShellArg runtimeConfigManagedMarkerPath}
+  '';
+in
+{
+  options.services.portmaster = {
+    enable = mkEnableOption "Portmaster application firewall";
+
+    package = mkPackageOption pkgs "portmaster" { };
+
+    stateDir = mkOption {
+      type = types.externalPath;
+      default = "/var/lib/portmaster";
+      example = "/persist/portmaster";
+      description = "Directory used for Portmaster's mutable state, configuration, and logs.";
+    };
+
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = settingsFormat.type;
+        options.devmode = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Enable development mode, which relaxes local API authentication
+            for debugging and browser access to 127.0.0.1:817. The packaged
+            desktop client does not require this option.
+          '';
+        };
+      };
+      default = { };
+      example = {
+        "core/log/level" = "warning";
+      };
+      description = ''
+        Global Portmaster settings for runtime {file}`config.json`.
+        Per-application profiles are managed by {option}`profiles`.
+
+        Merge order is recursive and later inputs win: this option,
+        {option}`settingsFile`, then {option}`secretsFile`.
+
+        When declarative configuration is active, the module owns runtime
+        {file}`config.json`; global changes made only through the UI are not
+        preserved across service starts.
+
+        Do not put secrets here; values are stored in the Nix store. Use
+        {option}`secretsFile` instead.
+
+        Upstream currently documents the available keys in
+        [basic_config.go](https://github.com/safing/portmaster/blob/v2.2.1/base/config/basic_config.go#L10-L96).
+      '';
+    };
+
+    settingsFile = mkOption {
+      type = types.nullOr types.externalPath;
+      default = null;
+      example = "/run/secrets/portmaster-settings.json";
+      description = ''
+        Additional global settings JSON file merged after {option}`settings`.
+        Overlapping keys override values from that option.
+      '';
+    };
+
+    secretsFile = mkOption {
+      type = types.nullOr types.externalPath;
+      default = null;
+      example = "/run/secrets/portmaster-secrets.json";
+      description = ''
+        Sensitive global settings JSON file merged last into runtime
+        {file}`config.json`, keeping secret values out of the Nix store.
+      '';
+    };
+
+    profilePrefix = mkOption {
+      type = types.str;
+      default = "";
+      example = "[NixOS] ";
+      description = "Prefix added to the display name of every declarative profile.";
+    };
+
+    profiles = mkOption {
+      type = types.attrsOf (
+        types.submodule (
+          { name, ... }:
+          {
+            options = {
+              name = mkOption {
+                type = nonEmptyStringType;
+                default = name;
+                description = "Human-readable Portmaster profile name.";
+              };
+
+              packages = mkOption {
+                type = types.listOf profilePackageType;
+                default = [ ];
+                example = literalExpression ''
+                  [
+                    pkgs.firefox
+                    {
+                      package = pkgs.go;
+                      directory = "share/go/bin";
+                    }
+                  ]
+                '';
+                description = ''
+                  Packages from which to derive Portmaster fingerprints.
+
+                  A package can be specified directly for the default matching
+                  behavior, or as an attribute set to customize its generated
+                  fingerprint. Package-derived regular expressions do not include
+                  a specific store hash or package version and also match
+                  Nix-generated `.program-wrapped` executables by default.
+                '';
+              };
+
+              fingerprints = mkOption {
+                type = types.listOf fingerprintType;
+                default = [ ];
+                example = [
+                  {
+                    type = "env";
+                    key = "CHROME_DESKTOP";
+                    operation = "equals";
+                    value = "vesktop.desktop";
+                  }
+                ];
+                description = ''
+                  Additional Portmaster fingerprints for this profile. These are
+                  merged with fingerprints generated from `packages`.
+
+                  Portmaster fingerprints are ORed, not ANDed, so broad
+                  fingerprints can match unrelated applications.
+                '';
+              };
+
+              settings = mkOption {
+                type = types.submodule {
+                  freeformType = settingsFormat.type;
+                  options = { };
+                };
+                default = { };
+                example = {
+                  filter.defaultAction = "permit";
+                };
+                description = ''
+                  Per-application Portmaster settings for this profile, using the
+                  upstream nested per-app configuration shape such as
+                  `history.enable`, `filter.defaultAction`, or `spn.use`.
+                  Global-only settings are rejected by Portmaster during sync.
+
+                  Do not put secrets here; generated profile payloads are stored in
+                  the Nix store.
+                '';
+              };
+            };
+          }
+        )
+      );
+      default = { };
+      example = literalExpression ''
+        {
+          Firefox = {
+            packages = [ pkgs.firefox ];
+            settings.filter.defaultAction = "permit";
+          };
+        }
+      '';
+      description = ''
+        Declarative per-application profiles keyed by logical name.
+
+        Profiles are imported through Portmaster's profile import API with
+        `allowReplace`. Package-derived regular expressions remain stable across
+        package updates. At least one entry in `packages` or `fingerprints` is
+        required. Changing a profile's normalized
+        fingerprints creates a different Portmaster identity and can leave the
+        previous imported profile behind. Removing a declaration does not delete
+        a previously imported profile.
+      '';
+    };
+
+    extraArgs = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "--print-stack-on-exit" ];
+      description = ''
+        Extra command-line arguments to pass to portmaster-core.
+        Do not include secrets because these arguments are visible in the
+        generated systemd unit and process list.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = optional profilesEnabled {
+      assertion = profileErrors == [ ] && profileIdentityCollisions == [ ];
+      message = ''
+        services.portmaster.profiles must be valid and have unique normalized fingerprints; ${
+          concatStringsSep "; " (
+            profileErrors ++ map formatProfileIdentityCollision profileIdentityCollisions
+          )
+        }
+      '';
+    };
+
+    system.activationScripts.portmaster-cleanup = ''
+      if ${boolToString (!managesConfig)}; then
+        if [ -e ${escapeShellArg runtimeConfigManagedMarkerPath} ]; then
+          ${getExe' pkgs.coreutils "rm"} -f ${escapeShellArg runtimeConfigPath} ${escapeShellArg runtimeConfigManagedMarkerPath}
+        fi
+      fi
+
+      if ${boolToString (!profilesEnabled)}; then
+        ${getExe' pkgs.coreutils "rm"} -f ${escapeShellArg profilesApiKeyPath}
+      fi
+    '';
+
+    environment.systemPackages = [ cfg.package ];
+
+    boot.kernelModules = [ "nfnetlink_queue" ];
+
+    systemd = {
+      tmpfiles.settings."10-portmaster" = genAttrs tmpfileDirectories (_: {
+        d = tmpfileDir;
+      });
+
+      services.portmaster = {
+        description = "Portmaster by Safing";
+        documentation = [
+          "https://safing.io"
+          "https://docs.safing.io"
+        ];
+        before = [
+          "nss-lookup.target"
+          "network.target"
+          "shutdown.target"
+        ];
+        after = [
+          "systemd-networkd.service"
+          "systemd-tmpfiles-setup.service"
+        ];
+        conflicts = [
+          "shutdown.target"
+          "firewalld.service"
+        ];
+        wants = [ "nss-lookup.target" ];
+        wantedBy = [ "multi-user.target" ];
+        requires = [ "systemd-tmpfiles-setup.service" ];
+
+        preStart = lib.optionalString managesConfig ''
+          ${mergeConfig}
+        '';
+
+        serviceConfig =
+          let
+            baseArgs = [
+              (getExe' cfg.package "portmaster-core")
+              "--bin-dir=${packageLibDir}"
+              "--data-dir=${stateDir}"
+              "--log-dir=${logsDir}"
+            ];
+            devmodeArgs = optional (!managesConfig && cfg.settings.devmode) "--devmode";
+          in
+          {
+            Type = "simple";
+            ExecStart = utils.escapeSystemdExecArgs (baseArgs ++ devmodeArgs ++ cfg.extraArgs);
+            ExecStopPost = "-${getExe' cfg.package "portmaster-core"} recover-iptables";
+            Restart = "on-failure";
+            RestartSec = "10";
+            RestartPreventExitStatus = "24";
+            User = "root";
+            Group = "root";
+            LockPersonality = true;
+            MemoryDenyWriteExecute = true;
+            MemoryLow = "2G";
+            NoNewPrivileges = true;
+            PrivateTmp = true;
+            PIDFile = "${stateDir}/core-lock.pid";
+            WorkingDirectory = stateDir;
+            ProtectSystem = true;
+            ReadOnlyPaths = [ builtins.storeDir ];
+            ReadWritePaths = [ stateDir ];
+            ProtectHome = "read-only";
+            ProtectKernelTunables = true;
+            ProtectKernelLogs = true;
+            ProtectControlGroups = true;
+            PrivateDevices = true;
+            RestrictNamespaces = true;
+            AmbientCapabilities = portmasterCapabilities;
+            CapabilityBoundingSet = portmasterCapabilities;
+            RestrictAddressFamilies = [
+              "AF_UNIX"
+              "AF_NETLINK"
+              "AF_INET"
+              "AF_INET6"
+            ];
+            Environment = [ "LOGLEVEL=info" ];
+          };
+      };
+
+      services.portmaster-managed-profiles = mkIf profilesEnabled {
+        description = "Sync declarative Portmaster managed profiles";
+        wantedBy = [ "portmaster.service" ];
+        after = [ "portmaster.service" ];
+        partOf = [ "portmaster.service" ];
+
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          LoadCredential = [ "managed-profiles-api-key:${profilesApiKeyPath}" ];
+          AmbientCapabilities = [ ];
+          CapabilityBoundingSet = [ ];
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateTmp = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectKernelLogs = true;
+          ProtectKernelTunables = true;
+          ProtectSystem = "strict";
+          RestrictAddressFamilies = [
+            "AF_UNIX"
+            "AF_INET"
+            "AF_INET6"
+          ];
+          RestrictNamespaces = true;
+          RestrictSUIDSGID = true;
+          SystemCallArchitectures = "native";
+          UMask = "0077";
+        };
+
+        script = ''
+          set -euo pipefail
+
+          curl_config="$(${getExe' pkgs.coreutils "mktemp"} --tmpdir portmaster-managed-profiles-curl.XXXXXX)"
+          response_file="$(${getExe' pkgs.coreutils "mktemp"} --tmpdir portmaster-managed-profiles-response.XXXXXX)"
+          cleanup() {
+            ${getExe' pkgs.coreutils "rm"} -f "$curl_config" "$response_file"
+          }
+          trap cleanup EXIT
+          ${getExe' pkgs.coreutils "chmod"} 0600 "$curl_config" "$response_file"
+
+          managed_api_key="$(${getExe' pkgs.coreutils "tr"} -d '\r\n' < "$CREDENTIALS_DIRECTORY/managed-profiles-api-key")"
+          if [[ ! "$managed_api_key" =~ ^[0-9a-f]{64}$ ]]; then
+            printf >&2 '%s\n' "Portmaster managed profiles API key credential is invalid"
+            exit 1
+          fi
+
+          printf 'header = "Authorization: Bearer %s"\n' "$managed_api_key" > "$curl_config"
+          unset managed_api_key
+
+          ready=0
+          for _ in $(${getExe' pkgs.coreutils "seq"} 1 60); do
+            if ${getExe pkgs.curl} --silent --fail --noproxy '*' --max-time 2 ${escapeShellArg profilesPingUrl} > /dev/null; then
+              ready=1
+              break
+            fi
+            ${getExe' pkgs.coreutils "sleep"} 1
+          done
+
+          if [ "$ready" -ne 1 ]; then
+            printf >&2 '%s\n' "Portmaster API at ${profilesPingUrl} did not become ready in time"
+            exit 1
+          fi
+
+          import_profile() {
+            local logical_name="$1"
+            local profile="$2"
+
+            if ! ${getExe pkgs.jq} -e '
+              .type == "profile"
+              and (.source == "local")
+              and (.name | type == "string" and length > 0)
+              and (.config | type == "object")
+              and (.fingerprints | type == "array")
+              and (.fingerprints | length > 0)
+              and (has("id") | not)
+              and all(
+                .fingerprints[];
+                (.type == "path" or .type == "cmdline" or .type == "env" or .type == "tag")
+                and (.operation == "equals" or .operation == "prefix" or .operation == "regex")
+                and (.value | type == "string" and length > 0)
+                and (
+                  if (.type == "env" or .type == "tag") then
+                    (.key | type == "string" and length > 0)
+                  else
+                    (has("key") | not)
+                  end
+                )
+              )
+            ' "$profile" > /dev/null
+            then
+              printf >&2 'Invalid generated Portmaster profile `%s` (%s)\n' "$logical_name" "$profile"
+              exit 1
+            fi
+
+            : > "$response_file"
+            if ${getExe pkgs.curl} \
+              --config "$curl_config" \
+              --silent \
+              --show-error \
+              --fail-with-body \
+              --noproxy '*' \
+              --max-time 30 \
+              --header "Content-Type: application/json" \
+              --data-binary @"$profile" \
+              --output "$response_file" \
+              ${escapeShellArg profilesImportUrl}
+            then
+              :
+            else
+              curl_status=$?
+              printf >&2 'Failed to import Portmaster profile `%s` from %s (curl exit %s)\n' \
+                "$logical_name" "$profile" "$curl_status"
+              if [ -s "$response_file" ]; then
+                printf >&2 '%s\n' 'Portmaster response:'
+                ${getExe' pkgs.coreutils "cat"} "$response_file" >&2
+                printf >&2 '\n'
+              fi
+              exit "$curl_status"
+            fi
+
+            if ! ${getExe pkgs.jq} -e '
+              (.restartRequired | type == "boolean")
+              and (.replacesExisting | type == "boolean")
+            ' "$response_file" > /dev/null
+            then
+              printf >&2 'Portmaster returned an invalid response while importing profile `%s` from %s:\n' \
+                "$logical_name" "$profile"
+              ${getExe' pkgs.coreutils "cat"} "$response_file" >&2
+              printf >&2 '\n'
+              exit 1
+            fi
+          }
+
+          ${concatMapStringsSep "\n" (
+            profile: "import_profile ${escapeShellArg profile.logicalName} ${escapeShellArg profile.path}"
+          ) profileExports}
+        '';
+      };
+    };
+  };
+
+  meta = {
+    doc = ./portmaster.md;
+    maintainers = with lib.maintainers; [
+      WitteShadovv
+      nyabinary
+    ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1393,6 +1393,7 @@ in
   ] ./podman/tls-ghostunnel.nix { };
   polaris = runTest ./polaris.nix;
   pomerium = handleTestOn [ "x86_64-linux" ] ./pomerium.nix { };
+  portmaster = runTest ./portmaster.nix;
   portunus = runTest ./portunus.nix;
   porxie = runTest ./porxie.nix;
   postfix = handleTest ./postfix.nix { };

--- a/nixos/tests/portmaster.nix
+++ b/nixos/tests/portmaster.nix
@@ -1,0 +1,315 @@
+{ lib, pkgs, ... }:
+
+let
+  stateDir = "/var/lib/portmaster-test";
+
+  fakeApi = pkgs.writeText "fake-portmaster-api.py" ''
+    import json
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+    from urllib.parse import urlparse
+
+    imports_path = "${stateDir}/imports.jsonl"
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format, *args):
+            pass
+
+        def send_json(self, status, value):
+            payload = json.dumps(value).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def do_GET(self):
+            if urlparse(self.path).path == "/api/v1/ping":
+                self.send_json(200, {"status": "ok"})
+            else:
+                self.send_json(404, {"error": "not found"})
+
+        def do_POST(self):
+            if urlparse(self.path).path != "/api/v1/sync/profile/import":
+                self.send_json(404, {"error": "not found"})
+                return
+
+            length = int(self.headers.get("Content-Length", "0"))
+            profile = json.loads(self.rfile.read(length))
+            with open(imports_path, "a", encoding="utf-8") as imports:
+                imports.write(json.dumps(profile, sort_keys=True) + "\n")
+
+            if profile.get("name") == "[NixOS] Rejected":
+                self.send_json(422, {"error": "profile rejected for test"})
+            else:
+                self.send_json(200, {
+                    "restartRequired": False,
+                    "replacesExisting": False,
+                })
+
+    ThreadingHTTPServer(("127.0.0.1", 817), Handler).serve_forever()
+  '';
+
+  fakeCore = pkgs.writeShellApplication {
+    name = "portmaster-core";
+    text = ''
+      if [ "''${1:-}" = "recover-iptables" ]; then
+        exit 0
+      fi
+      exec ${lib.getExe pkgs.python3} ${fakeApi}
+    '';
+  };
+
+  fakeDesktop = pkgs.writeShellApplication {
+    name = "portmaster";
+    text = "exit 0";
+  };
+
+  contextPackage = pkgs.writeShellApplication {
+    name = "portmaster-context-test";
+    text = "exit 0";
+  };
+
+  fakePortmaster = pkgs.runCommandLocal "fake-portmaster" { } ''
+    mkdir -p $out/bin $out/lib/portmaster
+    ln -s ${fakeCore}/bin/portmaster-core $out/bin/portmaster-core
+    ln -s ${fakeCore}/bin/portmaster-core $out/lib/portmaster/portmaster-core
+    ln -s ${fakeDesktop}/bin/portmaster $out/bin/portmaster
+    touch $out/lib/portmaster/portmaster.zip
+    touch $out/lib/portmaster/assets.zip
+  '';
+in
+{
+  name = "portmaster";
+  meta.maintainers = with lib.maintainers; [
+    WitteShadovv
+    nyabinary
+  ];
+
+  nodes.machine = { lib, ... }: {
+    environment.systemPackages = [ pkgs.jq ];
+
+    services.portmaster = {
+      enable = true;
+      package = fakePortmaster;
+      inherit stateDir;
+      settings = {
+        devmode = true;
+        "core/devMode" = false;
+        "core/log/level" = "warning";
+        nested = {
+          fromSettings = true;
+          shared = "settings";
+        };
+      };
+      settingsFile = "/run/portmaster-settings.json";
+      secretsFile = "/run/portmaster-secrets.json";
+      profilePrefix = "[NixOS] ";
+      profiles = {
+        Hello = {
+          packages = [ pkgs.hello ];
+          settings.filter.defaultAction = "permit";
+        };
+        Go.packages = [
+          {
+            package = pkgs.go;
+            directory = "share/go/bin";
+          }
+        ];
+        Extcap.packages = [
+          {
+            package = pkgs.wireshark;
+            directory = "libexec/wireshark/extcap";
+            name = null;
+            strictLast = false;
+          }
+        ];
+        Combined = {
+          packages = [
+            pkgs.hello
+            {
+              package = pkgs.go;
+              directory = "share/go/bin";
+            }
+          ];
+          fingerprints = [
+            {
+              type = "env";
+              key = "COMBINED_TEST";
+              operation = "equals";
+              value = "1";
+            }
+          ];
+        };
+        Context.fingerprints = [
+          {
+            type = "path";
+            operation = "equals";
+            value = builtins.unsafeDiscardStringContext "${contextPackage}/bin/portmaster-context-test";
+          }
+          {
+            type = "path";
+            operation = "equals";
+            value = "${contextPackage}/bin/portmaster-context-test";
+          }
+        ];
+        StoreRegex.packages = [
+          {
+            package = pkgs.hello;
+            type = "cmdline";
+            storeNameRegex = "hello-[0-9.]+";
+            strictHead = false;
+          }
+        ];
+        Vesktop.fingerprints = [
+          {
+            type = "env";
+            key = "CHROME_DESKTOP";
+            operation = "equals";
+            value = "vesktop.desktop";
+          }
+        ];
+        Tagged.fingerprints = [
+          {
+            type = "tag";
+            key = "vendor";
+            operation = "prefix";
+            value = "Safing";
+          }
+        ];
+      };
+    };
+
+    specialisation = {
+      rejected.configuration.services.portmaster.profiles = lib.mkForce {
+        Rejected.fingerprints = [
+          {
+            type = "path";
+            operation = "equals";
+            value = "/bin/rejected";
+          }
+        ];
+      };
+
+      unmanaged.configuration.services.portmaster = {
+        settings = lib.mkForce { };
+        settingsFile = lib.mkForce null;
+        secretsFile = lib.mkForce null;
+        profiles = lib.mkForce { };
+      };
+
+      development.configuration.services.portmaster = {
+        settings = lib.mkForce { devmode = true; };
+        settingsFile = lib.mkForce null;
+        secretsFile = lib.mkForce null;
+        profiles = lib.mkForce { };
+      };
+    };
+
+    systemd.services.portmaster-test-inputs = {
+      wantedBy = [ "portmaster.service" ];
+      before = [ "portmaster.service" ];
+      requiredBy = [ "portmaster.service" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+      script = ''
+        cat > /run/portmaster-settings.json <<'EOF'
+        {
+          "core/log/level": "error",
+          "nested": {
+            "fromFile": true,
+            "shared": "settings-file"
+          }
+        }
+        EOF
+
+        cat > /run/portmaster-secrets.json <<'EOF'
+        {
+          "nested": {
+            "shared": "secrets-file"
+          },
+          "secret/value": "kept-out-of-store"
+        }
+        EOF
+
+        chmod 0600 /run/portmaster-settings.json /run/portmaster-secrets.json
+      '';
+    };
+  };
+
+  testScript =
+    { nodes, ... }:
+    let
+      rejected = "${nodes.machine.system.build.toplevel}/specialisation/rejected";
+      unmanaged = "${nodes.machine.system.build.toplevel}/specialisation/unmanaged";
+      development = "${nodes.machine.system.build.toplevel}/specialisation/development";
+    in
+    ''
+      machine.wait_for_unit("portmaster.service")
+      machine.wait_for_unit("portmaster-managed-profiles.service")
+      machine.succeed("grep -Fx nfnetlink_queue /etc/modules-load.d/nixos.conf")
+      machine.fail("grep -Fx netfilter_queue /etc/modules-load.d/nixos.conf")
+      machine.fail("test -e /usr/lib/portmaster/assets.zip")
+      machine.succeed("systemctl cat portmaster.service | grep -F -- '--bin-dir=${fakePortmaster}/lib/portmaster'")
+      machine.succeed("systemctl cat portmaster.service | grep -F -- '--data-dir=${stateDir}'")
+      machine.succeed("systemctl cat portmaster.service | grep -F -- '--log-dir=${stateDir}/logs'")
+      machine.succeed("systemctl cat portmaster.service | grep -F 'ReadOnlyPaths=/nix/store'")
+      machine.fail("systemctl cat portmaster.service | grep -F -- '--devmode'")
+
+      machine.succeed("test -f ${stateDir}/config.json")
+      machine.succeed("test \"$(stat -c %a ${stateDir}/config.json)\" = 600")
+      machine.succeed("jq -e '.\"core/devMode\" == false' ${stateDir}/config.json")
+      machine.succeed("jq -e 'has(\"devmode\") | not' ${stateDir}/config.json")
+      machine.succeed("jq -e '.\"core/log/level\" == \"error\"' ${stateDir}/config.json")
+      machine.succeed("jq -e '.nested.fromSettings == true' ${stateDir}/config.json")
+      machine.succeed("jq -e '.nested.fromFile == true' ${stateDir}/config.json")
+      machine.succeed("jq -e '.nested.shared == \"secrets-file\"' ${stateDir}/config.json")
+      machine.succeed("jq -e '.\"secret/value\" == \"kept-out-of-store\"' ${stateDir}/config.json")
+      machine.succeed("test -f ${stateDir}/.config.json.nix-managed")
+      machine.succeed("test \"$(stat -c %a ${stateDir}/.config.json.nix-managed)\" = 600")
+      machine.succeed("test \"$(stat -c %a ${stateDir}/config/nix-managed-profiles-api-key)\" = 600")
+      machine.succeed(r"""key=$(cat ${stateDir}/config/nix-managed-profiles-api-key); jq --arg key "$key?read=admin&write=admin" -e '."core/apiKeys" | index($key)' ${stateDir}/config.json""")
+
+      machine.succeed("jq -se 'map(select(.name == \"[NixOS] Hello\")) | length == 1' ${stateDir}/imports.jsonl")
+      machine.succeed("jq -se 'any(.[]; .name == \"[NixOS] Vesktop\" and .fingerprints == [{\"key\":\"CHROME_DESKTOP\",\"operation\":\"equals\",\"type\":\"env\",\"value\":\"vesktop.desktop\"}])' ${stateDir}/imports.jsonl")
+      machine.succeed("jq -se 'any(.[]; .name == \"[NixOS] Tagged\" and .fingerprints[0].type == \"tag\" and .fingerprints[0].operation == \"prefix\")' ${stateDir}/imports.jsonl")
+      machine.fail("grep -F '${pkgs.hello}' ${stateDir}/imports.jsonl")
+      machine.succeed(r"""regex=$(jq -r 'select(.name == "[NixOS] Hello") | .fingerprints[0].value' ${stateDir}/imports.jsonl); matches=$(printf '%s\n' '/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello-2.12.2/bin/hello' '/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello-2.12.2/bin/.hello-wrapped' | grep -E "$regex" | wc -l); test "$matches" -eq 2""")
+      machine.succeed(r"""regex=$(jq -r 'select(.name == "[NixOS] Hello") | .fingerprints[0].value' ${stateDir}/imports.jsonl); ! printf '%s\n' '/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello-2.12.2/bin/not-hello' | grep -Eq "$regex";""")
+      machine.succeed(r"""jq -r 'select(.name == "[NixOS] Go") | .fingerprints[0].value' ${stateDir}/imports.jsonl | grep -F '/share/go/bin/' """)
+      machine.succeed(r"""jq -r 'select(.name == "[NixOS] Extcap") | .fingerprints[0].value' ${stateDir}/imports.jsonl | grep -F '/libexec/wireshark/extcap/' """)
+      machine.fail(r"""jq -r 'select(.name == "[NixOS] Extcap") | .fingerprints[0].value' ${stateDir}/imports.jsonl | grep -F '.*' """)
+      machine.succeed("jq -se 'any(.[]; .name == \"[NixOS] Combined\" and (.fingerprints | length == 3) and any(.fingerprints[]; .type == \"env\" and .key == \"COMBINED_TEST\" and .value == \"1\"))' ${stateDir}/imports.jsonl")
+      machine.succeed(r"""jq -r 'select(.name == "[NixOS] Combined") | .fingerprints[] | select(.type == "path" and (.value | contains("hello"))) | .value' ${stateDir}/imports.jsonl | grep -F '/bin/' """)
+      machine.succeed(r"""jq -r 'select(.name == "[NixOS] Combined") | .fingerprints[] | select(.value | contains("share/go/bin")) | .value' ${stateDir}/imports.jsonl | grep -F '/share/go/bin/' """)
+      machine.succeed(r"""jq -e 'select(.name == "[NixOS] Context") | .fingerprints | length == 1' ${stateDir}/imports.jsonl; context_path=$(jq -r 'select(.name == "[NixOS] Context") | .fingerprints[0].value' ${stateDir}/imports.jsonl); test -x "$context_path" """)
+      machine.succeed(r"""jq -r 'select(.name == "[NixOS] StoreRegex") | .fingerprints[0] | select(.type == "cmdline") | .value' ${stateDir}/imports.jsonl | grep -E '^/nix/store/\[a-z0-9\]' """)
+      machine.succeed(r"""jq -r 'select(.name == "[NixOS] StoreRegex") | .fingerprints[0].value' ${stateDir}/imports.jsonl | grep -F 'hello-[0-9.]+' """)
+
+      machine.execute("${rejected}/bin/switch-to-configuration test >&2")
+      machine.fail("systemctl restart portmaster-managed-profiles.service")
+      machine.succeed("journalctl -u portmaster-managed-profiles.service --no-pager | grep -F 'Failed to import Portmaster profile `Rejected`'")
+      machine.succeed("journalctl -u portmaster-managed-profiles.service --no-pager | grep -F 'profile rejected for test'")
+
+      machine.succeed("${unmanaged}/bin/switch-to-configuration test >&2")
+      machine.wait_for_unit("portmaster.service")
+      machine.fail("systemctl cat portmaster.service | grep -F -- '--devmode'")
+      machine.succeed("test ! -e ${stateDir}/config.json")
+      machine.succeed("test ! -e ${stateDir}/.config.json.nix-managed")
+      machine.succeed("test ! -e ${stateDir}/config/nix-managed-profiles-api-key")
+
+      machine.succeed("printf '%s\n' '{\"manual\":true}' > ${stateDir}/config.json")
+      machine.succeed("chmod 0600 ${stateDir}/config.json")
+
+      machine.succeed("${unmanaged}/bin/switch-to-configuration test >&2")
+      machine.wait_for_unit("portmaster.service")
+      machine.succeed("test -f ${stateDir}/config.json")
+      machine.succeed("jq -e '.manual == true' ${stateDir}/config.json")
+      machine.succeed("test ! -e ${stateDir}/.config.json.nix-managed")
+
+      machine.succeed("${development}/bin/switch-to-configuration test >&2")
+      machine.wait_for_unit("portmaster.service")
+      machine.succeed("systemctl cat portmaster.service | grep -F -- '--devmode'")
+    '';
+}

--- a/pkgs/by-name/po/portmaster/allow-read-only-bin-dir.patch
+++ b/pkgs/by-name/po/portmaster/allow-read-only-bin-dir.patch
@@ -1,0 +1,11 @@
+diff --git a/base/utils/fs.go b/base/utils/fs.go
+--- a/base/utils/fs.go
++++ b/base/utils/fs.go
+@@ -26,0 +27,7 @@ func EnsureDirectory(path string, perm FSPermission) error {
++			//
++			// Public read-only directories are valid executable artifact
++			// directories. In particular, --bin-dir is documented to support
++			// read-only paths.
++			if perm == PublicReadExecPermission && f.Mode().Perm() == 0o555 {
++				return nil
++			}

--- a/pkgs/by-name/po/portmaster/disable-software-updates.patch
+++ b/pkgs/by-name/po/portmaster/disable-software-updates.patch
@@ -1,0 +1,12 @@
+diff --git a/service/core/update_config.go b/service/core/update_config.go
+--- a/service/core/update_config.go
++++ b/service/core/update_config.go
+@@ -86 +86 @@ func registerUpdateConfig() error {
+-		DefaultValue:    true,
++		DefaultValue:    false,
+@@ -119 +119 @@ func initUpdateConfig() {
+-	enableSoftwareUpdates = config.Concurrent.GetAsBool(enableSoftwareUpdatesKey, true)
++	enableSoftwareUpdates = config.Concurrent.GetAsBool(enableSoftwareUpdatesKey, false)
+@@ -132 +132 @@ func configureUpdates() {
+-	module.instance.BinaryUpdates().Configure(enableSoftwareUpdates(), configure.GetBinaryUpdateURLs(releaseChannel()))
++	module.instance.BinaryUpdates().Configure(false, configure.GetBinaryUpdateURLs(releaseChannel()))

--- a/pkgs/by-name/po/portmaster/package.nix
+++ b/pkgs/by-name/po/portmaster/package.nix
@@ -1,0 +1,281 @@
+{
+  lib,
+  buildGoModule,
+  buildNpmPackage,
+  fetchFromGitHub,
+  pkg-config,
+  makeBinaryWrapper,
+  nodejs,
+  glib,
+  gtk3,
+  cairo,
+  pango,
+  gdk-pixbuf,
+  atk,
+  webkitgtk_4_1,
+  libsoup_3,
+  openssl,
+  curl,
+  systemdLibs,
+  iptables,
+  iproute2,
+  libx11,
+  libxcomposite,
+  libxcursor,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxi,
+  libxrender,
+  libxtst,
+  libxrandr,
+  libxscrnsaver,
+  libxcb,
+  alsa-lib,
+  nss,
+  nspr,
+  at-spi2-atk,
+  cups,
+  dbus,
+  expat,
+  fontconfig,
+  freetype,
+  zlib,
+  libayatana-appindicator,
+  zip,
+  rustPlatform,
+  wrapGAppsHook4,
+  librsvg,
+  makeDesktopItem,
+  copyDesktopItems,
+  autoPatchelfHook,
+}:
+
+let
+  portmasterUI = buildNpmPackage (finalAttrs: {
+    pname = "portmaster-ui";
+    version = "2.1.7";
+    src = fetchFromGitHub {
+      owner = "safing";
+      repo = "portmaster";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-DUDfeSdIH3e5yx1KKW6h6+HKKQ3WNllsdairjAkTdJs=";
+    };
+
+    sourceRoot = "${finalAttrs.src.name}/desktop/angular";
+    npmDepsHash = "sha256-yoEGoeXcJIGjjD+r+dQoAdeY7mX3VWOt3LAAO+B0bhA=";
+
+    buildPhase = ''
+      runHook preBuild
+      npm run build
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -r dist/* $out/
+      runHook postInstall
+    '';
+
+    dontFixup = true;
+  });
+
+  portmasterDesktop = rustPlatform.buildRustPackage (finalAttrs: {
+    pname = "portmaster-desktop";
+    version = "2.1.7";
+
+    src = fetchFromGitHub {
+      owner = "safing";
+      repo = "portmaster";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-DUDfeSdIH3e5yx1KKW6h6+HKKQ3WNllsdairjAkTdJs=";
+    };
+
+    sourceRoot = "${finalAttrs.src.name}/desktop/tauri/src-tauri";
+
+    cargoHash = "sha256-q3kgXM06yEuEf+VyywpCHmUGt43RRdSFzTaVlU/jfjc=";
+
+    nativeBuildInputs = [
+      pkg-config
+      wrapGAppsHook4
+    ];
+
+    buildInputs = [
+      glib
+      gtk3
+      cairo
+      pango
+      gdk-pixbuf
+      atk
+      webkitgtk_4_1
+      libsoup_3
+      openssl
+      librsvg
+    ];
+
+    preBuild = ''
+      mkdir -p angular/dist/tauri-builtin
+      ln -s ${portmasterUI}/* angular/dist/tauri-builtin/
+      substituteInPlace tauri.conf.json5 \
+        --replace-fail '"../../angular/dist/tauri-builtin"' '"../angular/dist/tauri-builtin"'
+    '';
+
+    env = {
+      TAURI_KEY_PASSWORD = "";
+      TAURI_PRIVATE_KEY = "";
+    };
+
+    doCheck = false;
+  });
+
+in
+buildGoModule (finalAttrs: {
+  pname = "portmaster";
+  version = "2.1.7";
+
+  src = fetchFromGitHub {
+    owner = "safing";
+    repo = "portmaster";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DUDfeSdIH3e5yx1KKW6h6+HKKQ3WNllsdairjAkTdJs=";
+  };
+
+  vendorHash = "sha256-uPo1tRUfl4kY1sMlLoc0y6ctygRN5MJPrR5TTgERk6U=";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeBinaryWrapper
+    nodejs
+    zip
+    copyDesktopItems
+    autoPatchelfHook
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "portmaster";
+      exec = "portmaster --data /var/lib/portmaster --log-dir /var/lib/portmaster/logs";
+      icon = "portmaster";
+      desktopName = "Portmaster";
+      comment = "Free and open-source application firewall";
+      categories = [
+        "Network"
+        "Security"
+      ];
+      startupNotify = false;
+      terminal = false;
+    })
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    cairo
+    pango
+    gdk-pixbuf
+    atk
+    webkitgtk_4_1
+    libsoup_3
+    openssl
+    curl
+    systemdLibs
+    libx11
+    libxcomposite
+    libxcursor
+    libxdamage
+    libxext
+    libxfixes
+    libxi
+    libxrender
+    libxtst
+    libxrandr
+    libxscrnsaver
+    libxcb
+    alsa-lib
+    nss
+    nspr
+    at-spi2-atk
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    zlib
+    libayatana-appindicator
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/safing/portmaster/base/info.version=${finalAttrs.version}"
+    "-X github.com/safing/portmaster/base/info.commit=nixpkgs"
+  ];
+
+  subPackages = [ "cmds/portmaster-core" ];
+
+  doCheck = false;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib/portmaster \
+      $out/share/icons/hicolor/{16x16,32x32,48x48,64x64,128x128,256x256,512x512}/apps
+
+    install -m755 $GOPATH/bin/portmaster-core $out/lib/portmaster/
+    install -m755 ${portmasterDesktop}/bin/* $out/lib/portmaster/portmaster
+
+    mkdir -p $out/lib/portmaster/ui/modules/portmaster
+    cp -r ${portmasterUI}/* $out/lib/portmaster/ui/modules/portmaster/
+
+    pushd ${portmasterUI}
+    zip -r $out/lib/portmaster/portmaster.zip .
+    popd
+
+    pushd assets
+    zip -r $out/lib/portmaster/assets.zip .
+    popd
+
+    install -Dm644 assets/data/favicons/favicon-96x96.png $out/share/icons/hicolor/96x96/apps/portmaster.png
+
+    ln -s $out/lib/portmaster/portmaster-core $out/bin/portmaster-core
+    ln -s $out/lib/portmaster/portmaster $out/bin/portmaster
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram "$out/lib/portmaster/portmaster-core" \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          iptables
+          iproute2
+        ]
+      }
+
+    wrapProgram "$out/lib/portmaster/portmaster" \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          iptables
+          iproute2
+        ]
+      } \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libayatana-appindicator ]} \
+      --set-default GDK_BACKEND "wayland,x11" \
+      --set WEBKIT_DISABLE_COMPOSITING_MODE "1" \
+      --set WEBKIT_DISABLE_DMABUF_RENDERER "1" \
+      --set LIBGL_ALWAYS_SOFTWARE "1"
+  '';
+
+  meta = {
+    description = "Free and open-source application firewall";
+    homepage = "https://safing.io/portmaster/";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      WitteShadovv
+      nyabinary
+    ];
+    mainProgram = "portmaster";
+  };
+})

--- a/pkgs/by-name/po/portmaster/package.nix
+++ b/pkgs/by-name/po/portmaster/package.nix
@@ -14,6 +14,7 @@
   makeDesktopItem,
   nftables,
   nix-update-script,
+  nixosTests,
   openssl,
   pkg-config,
   rustPlatform,
@@ -266,6 +267,8 @@ buildGoModule (finalAttrs: {
 
   passthru = {
     inherit portmasterDesktop portmasterUI;
+
+    tests = { inherit (nixosTests) portmaster; };
 
     updateScript = nix-update-script {
       extraArgs = [

--- a/pkgs/by-name/po/portmaster/package.nix
+++ b/pkgs/by-name/po/portmaster/package.nix
@@ -1,0 +1,292 @@
+{
+  lib,
+  buildGoModule,
+  buildNpmPackage,
+  buildPackages,
+  cargo-tauri,
+  copyDesktopItems,
+  fetchFromGitHub,
+  glib-networking,
+  iproute2,
+  iptables,
+  libayatana-appindicator,
+  makeBinaryWrapper,
+  makeDesktopItem,
+  nftables,
+  nix-update-script,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  stdenv,
+  unzip,
+  webkitgtk_4_1,
+  wrapGAppsHook4,
+  zip,
+}:
+
+let
+  version = "2.2.1";
+
+  nodejsPython = buildPackages.nodejs.python.withPackages (ps: [ ps.setuptools ]);
+
+  src = fetchFromGitHub {
+    owner = "safing";
+    repo = "portmaster";
+    tag = "v${version}";
+    hash = "sha256-MkVVRPI0yoQ9dl2vyluSz+eNgErfcMveLmeaReJuYIM=";
+  };
+
+  portmasterUI = buildNpmPackage {
+    pname = "portmaster-ui";
+    inherit version src;
+
+    # The main UI is served by portmaster-core; the smaller bootstrap UI is
+    # embedded into the Tauri desktop executable.
+    outputs = [
+      "out"
+      "tauri"
+    ];
+
+    sourceRoot = "${src.name}/desktop/angular";
+    npmDepsHash = "sha256-MVlOjD/rKtR+bcCz51mDhZo65jyqTAa1Al+sK/1hJgw=";
+
+    nativeBuildInputs = [ nodejsPython ];
+
+    # node-gyp 9 still imports distutils. Point it at the setuptools-backed
+    # Python environment explicitly because buildNpmPackage also adds Node's
+    # bare Python interpreter to PATH.
+    env.PYTHON = lib.getExe nodejsPython;
+
+    postPatch = ''
+      # Assets are provided by the separate assets.zip module.
+      rm assets
+    '';
+
+    postBuild = ''
+      NODE_ENV=production npm run ng -- build --configuration production tauri-builtin
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out $tauri
+      mv dist/tauri-builtin/* $tauri/
+      rmdir dist/tauri-builtin
+      cp -r dist/* $out/
+
+      runHook postInstall
+    '';
+
+    dontFixup = true;
+  };
+
+  portmasterDesktop = rustPlatform.buildRustPackage (finalAttrs: {
+    pname = "portmaster-desktop";
+    inherit version src;
+
+    cargoHash = "sha256-QK/L3vUD+MZjFVLgwWm+kZIgXY9ol0y9EIP7aSD45sU=";
+    cargoRoot = "desktop/tauri/src-tauri";
+    buildAndTestSubdir = finalAttrs.cargoRoot;
+
+    postPatch = ''
+      # libappindicator-sys loads AppIndicator with dlopen, so the dependency
+      # cannot be discovered and patched automatically.
+      substituteInPlace $cargoDepsCopy/*/libappindicator-sys-*/src/lib.rs \
+        --replace-fail \
+          "libayatana-appindicator3.so.1" \
+          "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
+    '';
+
+    nativeBuildInputs = [
+      cargo-tauri.hook
+      pkg-config
+      wrapGAppsHook4
+    ];
+
+    buildInputs = [
+      glib-networking
+      libayatana-appindicator
+      openssl
+      webkitgtk_4_1
+    ];
+
+    preBuild = ''
+      mkdir -p desktop/angular/dist
+      ln -s ${portmasterUI.tauri} desktop/angular/dist/tauri-builtin
+    '';
+
+    # The final package creates the distribution archives itself. Use Tauri to
+    # build the desktop executable without reproducing upstream's deb bundle.
+    tauriBuildFlags = [ "--no-bundle" ];
+
+    installPhase = ''
+      runHook preInstall
+
+      install -Dm755 \
+        target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/portmaster \
+        $out/bin/portmaster
+
+      runHook postInstall
+    '';
+
+    # The XDG tests initialize GTK and require a display server.
+    doCheck = false;
+
+    # The final package wraps the binary after placing it in Portmaster's
+    # trusted binary directory.
+    dontWrapGApps = true;
+  });
+in
+buildGoModule (finalAttrs: {
+  pname = "portmaster";
+  inherit version src;
+
+  __structuredAttrs = true;
+
+  patches = [
+    # Portmaster documents --bin-dir as read-only capable. Accept Nix's 0555
+    # store directory instead of trying to change its permissions.
+    ./allow-read-only-bin-dir.patch
+    # Nix owns the program files. Intelligence updates remain enabled and are
+    # written below the service's state directory.
+    ./disable-software-updates.patch
+  ];
+
+  vendorHash = "sha256-22sIbmpbgYtOwrnxcrKfksgbyqaFRH5DZ/UNXr8723I=";
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeBinaryWrapper
+    wrapGAppsHook4
+    zip
+  ];
+
+  buildInputs = [
+    glib-networking
+    libayatana-appindicator
+    openssl
+    webkitgtk_4_1
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "portmaster";
+      desktopName = "Portmaster";
+      genericName = "Application Firewall";
+      exec = "portmaster";
+      icon = "portmaster";
+      comment = "Free and open-source application firewall";
+      categories = [ "System" ];
+      startupWMClass = "portmaster";
+      terminal = false;
+    })
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/safing/portmaster/base/info.version=${version}"
+    "-X github.com/safing/portmaster/base/info.buildSource=nixpkgs"
+  ];
+
+  subPackages = [ "cmds/portmaster-core" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib/portmaster
+
+    install -m755 $GOPATH/bin/portmaster-core $out/lib/portmaster/
+    install -m755 ${portmasterDesktop}/bin/portmaster $out/lib/portmaster/
+
+    pushd ${portmasterUI}
+    zip -q -r -9 -X $out/lib/portmaster/portmaster.zip .
+    popd
+
+    pushd assets/data
+    zip -q -r -9 -X $out/lib/portmaster/assets.zip .
+    popd
+
+    for size in 128 256 512; do
+      install -Dm644 \
+        "assets/data/icons/pm_dark_''${size}.png" \
+        "$out/share/icons/hicolor/''${size}x''${size}/apps/portmaster.png"
+    done
+    install -Dm644 assets/data/icons/pm_light_contrast.svg \
+      "$out/share/icons/hicolor/scalable/apps/portmaster.svg"
+
+    install -Dm644 packaging/linux/portmaster-autostart.desktop \
+      "$out/etc/xdg/autostart/portmaster.desktop"
+    substituteInPlace "$out/etc/xdg/autostart/portmaster.desktop" \
+      --replace-fail \
+        '/usr/bin/portmaster --with-prompts --with-notifications --background' \
+        "$out/bin/portmaster --background"
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    substituteInPlace "$out/share/applications/portmaster.desktop" \
+      --replace-fail 'Exec=portmaster' "Exec=$out/bin/portmaster"
+
+    wrapGApp "$out/lib/portmaster/portmaster"
+    ln -s ../lib/portmaster/portmaster "$out/bin/portmaster"
+
+    makeWrapper "$out/lib/portmaster/portmaster-core" "$out/bin/portmaster-core" \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          iptables
+          iproute2
+          nftables
+        ]
+      }
+  '';
+
+  # The desktop executable is wrapped explicitly in its non-standard location.
+  dontWrapGApps = true;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ unzip ];
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/portmaster-core version | grep -F 'Portmaster ${version}'
+    ${lib.getExe unzip} -tq $out/lib/portmaster/portmaster.zip
+    ${lib.getExe unzip} -tq $out/lib/portmaster/assets.zip
+    ${lib.getExe unzip} -Z1 $out/lib/portmaster/portmaster.zip | grep -Fx index.html
+    ${lib.getExe unzip} -Z1 $out/lib/portmaster/assets.zip | grep -q '^img/flags/'
+    ! ${lib.getExe unzip} -Z1 $out/lib/portmaster/assets.zip | grep -q '^data/'
+    test -x $out/lib/portmaster/.portmaster-wrapped
+    grep -aF \
+      '${libayatana-appindicator}/lib/libayatana-appindicator3.so.1' \
+      $out/lib/portmaster/.portmaster-wrapped
+
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    inherit portmasterDesktop portmasterUI;
+
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "portmasterUI"
+        "--subpackage"
+        "portmasterDesktop"
+      ];
+    };
+  };
+
+  meta = {
+    description = "Free and open-source application firewall";
+    homepage = "https://safing.io/portmaster/";
+    changelog = "https://github.com/safing/portmaster/releases/tag/v${version}";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      WitteShadovv
+      nyabinary
+    ];
+    mainProgram = "portmaster";
+  };
+})


### PR DESCRIPTION
Add Portmaster application firewall package and NixOS service module.

Portmaster is a free and open-source application firewall that puts you back in charge of your computer's network activity. This PR adds both the package definition and a NixOS service module for easy system integration.

Package is built from the official Debian package and includes the core firewall engine, web UI, and all necessary assets. The service module provides proper systemd integration with all required capabilities and security hardening.

https://safing.io/portmaster/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in nixos/tests.
  - [ ] Package tests at `passthru.tests`.
  - [ ] Tests in lib/tests or pkgs/test for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See nixpkgs-review usage.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.
