### PR TITLE
linuxPackages.apfs: 0.3.14 -> 0.3.15

### DIFF
--- a/pkgs/os-specific/linux/apfs/default.nix
+++ b/pkgs/os-specific/linux/apfs/default.nix
@@ -30,7 +30,12 @@ stdenv.mkDerivation {
     "INSTALL_MOD_PATH=$(out)"
   ];
 
-  passthru.tests.apfs = nixosTests.apfs;
+  passthru = {
+    tests.apfs = nixosTests.apfs;
+
+    inherit tag;
+    updateScript = ./update.sh;
+  };
 
   meta = with lib; {
     description = "APFS module for linux";

--- a/pkgs/os-specific/linux/apfs/default.nix
+++ b/pkgs/os-specific/linux/apfs/default.nix
@@ -8,7 +8,7 @@
 }:
 
 let
-  tag = "0.3.14";
+  tag = "0.3.15";
 in
 stdenv.mkDerivation {
   pname = "apfs";
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
     owner = "linux-apfs";
     repo = "linux-apfs-rw";
     rev = "v${tag}";
-    hash = "sha256-bv3WGcIKx5RVj+cQg0U5U1zGPRzjxMlCZmol9QvAmc4=";
+    hash = "sha256-/qJ8QvnVhVXvuxeZ/UYLTXGMPPVnC7fHOSWI1B15r/M=";
   };
 
   hardeningDisable = [ "pic" ];

--- a/pkgs/os-specific/linux/apfs/update.sh
+++ b/pkgs/os-specific/linux/apfs/update.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p ripgrep common-updater-scripts
+
+set -xeu -o pipefail
+
+PACKAGE_DIR="$(realpath "$(dirname "$0")")"
+cd "$PACKAGE_DIR/.."
+while ! test -f default.nix; do cd .. ; done
+NIXPKGS_DIR="$PWD"
+
+latest_version="$(
+  list-git-tags --url=https://github.com/linux-apfs/linux-apfs-rw \
+  | sort --version-sort \
+  | tail -n1
+)"
+
+latest_version_no_v_prefix="${latest_version#"v"}"
+
+cd "$NIXPKGS_DIR"
+update-source-version linuxPackages.apfs "$latest_version_no_v_prefix" \
+  --version-key=tag


### PR DESCRIPTION
https://github.com/linux-apfs/linux-apfs-rw/releases/tag/v0.3.15
Fixes #442599.

Also add an update script and remove the kernel version from the version for the following reasons:
- I don't see how this is useful since the information is already included in the kernel package itself
- We also don't include the version of the Python interpreter in the version of Python packages
- The normal update scripts fail to update this package, requiring a custom script
- Repology gets confused: https://repology.org/project/linux-apfs-rw/versions
- Example code in the NixOS wiki no longer includes the kernel version: https://wiki.nixos.org/w/index.php?title=Linux_kernel&oldid=17621#Packaging_out-of-tree_kernel_modules
- Several other kernel packages in Nixpkgs don't do this

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
