### PR TITLE
nixos/make-options-doc: Fix declaration paths

### DIFF
--- a/nixos/lib/make-options-doc/mergeJSON.py
+++ b/nixos/lib/make-options-doc/mergeJSON.py
@@ -52,12 +52,6 @@ for arg in sys.argv[1:]:
 options = pivot(json.load(open(sys.argv[1 + optOffset], 'r')))
 overrides = pivot(json.load(open(sys.argv[2 + optOffset], 'r')))
 
-# fix up declaration paths in lazy options, since we don't eval them from a full nixpkgs dir
-for (k, v) in options.items():
-    # The _module options are not declared in nixos/modules
-    if v.value['loc'][0] != "_module":
-        v.value['declarations'] = list(map(lambda s: f'nixos/modules/{s}' if isinstance(s, str) else s, v.value['declarations']))
-
 # merge both descriptions
 for (k, v) in overrides.items():
     cur = options.setdefault(k, v).value


### PR DESCRIPTION
This fixes a problem where most NixOS option declaration paths started
with `nixos/modules/nixos/modules/`, which should have been only
just `nixos/modules/`.
    
Since dcc0ee9ea10ddfb31f1eb4827379ef0aa91e95d5, we use a source path that includes both the `modules` and `nixos/modules`, so we don't need to additionally prefix `nixos/modules` anymore.

Manually checked with

    nix-build nixos/release.nix -A options
    jq < result/share/doc/nixos/options.json '[ ."_module.args".declarations, ."meta.maintainers".declarations, ."nixpkgs.system".declarations, ."zramSwap.swapDevices".declarations ]'

Used samples:

- `_module` for options defined in `lib/`
- `meta.maintainers` for options defined in `modules/`
- `nixpkgs.system` for options defined in `nixos/` with `meta.buildDocsInSandbox = false;`
- `zramSwap.swapDevices` for regular `nixos/` without that

I'm a big fan of automated tests, but in this case I am not doing that because
- the solution is a simplification, and
- no obvious place for the test, and it would couple with unrelated downstream code more than I would like.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Context

- Bug since https://github.com/NixOS/nixpkgs/pull/431450
  - dcc0ee9ea10ddfb31f1eb4827379ef0aa91e95d5

- Thank you @pveierland for bisecting

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
