### PR TITLE
ripplerx: init at 1.5.18

### DIFF
--- a/pkgs/by-name/ri/ripplerx/package.nix
+++ b/pkgs/by-name/ri/ripplerx/package.nix
@@ -1,0 +1,120 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  writableTmpDirAsHomeHook,
+  alsa-lib,
+  expat,
+  fontconfig,
+  freetype,
+  libX11,
+  libXcursor,
+  libXext,
+  libXinerama,
+  libXrandr,
+  nix-update-script,
+  makeDesktopItem,
+  copyDesktopItems,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ripplerx";
+  version = "1.5.18";
+
+  src = fetchFromGitHub {
+    owner = "tiagolr";
+    repo = "ripplerx";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lHLAJ8eCmn/WFYxGl/zIq8a2xPKqzpB7tilffJcXhM4=";
+    fetchSubmodules = true;
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    writableTmpDirAsHomeHook # fontconfig cache + $HOME/.{lv2,vst3}
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    alsa-lib
+    expat
+    fontconfig
+    freetype
+    libX11
+    libXcursor
+    libXext
+    libXinerama
+    libXrandr
+  ];
+
+  # JUCE dlopens these at runtime, standalone executable crashes without them
+  NIX_LDFLAGS = [
+    "-lX11"
+    "-lXext"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
+  ];
+
+  # Fontconfig error: Cannot load default config file: No such file: (null)
+  env.FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
+
+  # LTO needs special setup on Linux
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'juce::juce_recommended_lto_flags' '# Not forcing LTO'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib/{lv2,vst3}
+
+    pushd RipplerX_artefacts/Release
+    cp -r "Standalone/RipplerX" $out/bin/ripplerx
+    cp -r "LV2/RipplerX.lv2" $out/lib/lv2
+    cp -r "VST3/RipplerX.vst3" $out/lib/vst3
+    popd
+
+    install -Dm644 ../doc/logo.svg \
+      $out/share/icons/hicolor/scalable/apps/ripplerx.svg
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      desktopName = "RipplerX";
+      comment = "Physically modeled synth";
+      name = "ripplerx";
+      exec = "ripplerx";
+      icon = "ripplerx";
+      terminal = false;
+      categories = [
+        "Audio"
+        "AudioVideo"
+        "Midi"
+        "Music"
+      ];
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Physically modeled synth";
+    longDescription = ''
+      RipplerX is a physically modeled synth, capable of sounds similar to AAS Chromaphone and Ableton Collision.
+    '';
+    homepage = "https://github.com/tiagolr/ripplerx";
+    mainProgram = "ripplerx";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ eljamm ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
RipplerX is a physically modeled synth, capable of sounds similar to AAS Chromaphone and Ableton Collision.

Homepage: https://github.com/tiagolr/ripplerx

Tested in Ardour and both lv2 and vst3 formats are working.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
