### PR TITLE
tunefish: fix vst3 and refactor dependencies

### DIFF
--- a/pkgs/by-name/tu/tunefish/package.nix
+++ b/pkgs/by-name/tu/tunefish/package.nix
@@ -7,12 +7,12 @@
   alsa-lib,
   curl,
   freetype,
-  gtk3,
   libGL,
   libX11,
+  libXcursor,
   libXext,
   libXinerama,
-  webkitgtk_4_0,
+  libXrandr,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -27,6 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
   };
 
+  strictDeps = true;
+
   nativeBuildInputs = [
     pkg-config
     python3
@@ -36,12 +38,12 @@ stdenv.mkDerivation (finalAttrs: {
     alsa-lib
     curl
     freetype
-    gtk3
     libGL
     libX11
+    libXcursor
     libXext
     libXinerama
-    webkitgtk_4_0
+    libXrandr
   ];
 
   makeFlags = [
@@ -60,11 +62,11 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/lib/{lv2,vst,vst3/Tunefish4.vst3}
+    mkdir -p $out/lib/{lv2,vst,vst3}
 
     pushd src/tunefish4/Builds/LinuxMakefile/build
     cp -r "Tunefish4.lv2" $out/lib/lv2
-    cp -r "Tunefish4.vst3/Contents/x86_64-linux"/* $out/lib/vst3/Tunefish4.vst3
+    cp -r "Tunefish4.vst3" $out/lib/vst3
     cp "Tunefish4.so" $out/lib/vst
     popd
 


### PR DESCRIPTION
## Changes

- Copy vst3 correctly to the output
- Remove vulnerable and unneeded dependencies (webkitgtk_4_0), add libXcursor and libXrandr

Tested in Ardour and now the vst3 variant shows up, whereas it previously didn't.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
