### PR TITLE
tgt: optionally allow building glusterfs backend

### DIFF
--- a/pkgs/by-name/tg/tgt/glfs-api.patch
+++ b/pkgs/by-name/tg/tgt/glfs-api.patch
@@ -1,0 +1,76 @@
+diff -ur source/usr/bs_glfs.c source.hack/usr/bs_glfs.c
+--- source/usr/bs_glfs.c	1970-01-01 01:00:01.000000000 +0100
++++ source.hack/usr/bs_glfs.c	2025-09-06 21:31:31.694360700 +0100
+@@ -110,7 +110,7 @@
+ 			break;
+ 		}
+ 
+-		ret = glfs_pread(gfd, tmpbuf, length, offset, lu->bsoflags);
++		ret = glfs_pread(gfd, tmpbuf, length, offset, lu->bsoflags, NULL);
+ 
+ 		if (ret != length) {
+ 			set_medium_error(&result, &key, &asc);
+@@ -147,7 +147,7 @@
+ 			break;
+ 		}
+ 
+-		ret = glfs_pread(gfd, tmpbuf, length, offset, SEEK_SET);
++		ret = glfs_pread(gfd, tmpbuf, length, offset, SEEK_SET, NULL);
+ 
+ 		if (ret != length) {
+ 			set_medium_error(&result, &key, &asc);
+@@ -190,7 +190,7 @@
+ 			key = ILLEGAL_REQUEST;
+ 			asc = ASC_INVALID_FIELD_IN_CDB;
+ 		} else {
+-			glfs_fdatasync(gfd);
++			glfs_fdatasync(gfd, NULL, NULL);
+ 		}
+ 		break;
+ 	case WRITE_VERIFY:
+@@ -204,7 +204,7 @@
+ 		length = scsi_get_out_length(cmd);
+ 		write_buf = scsi_get_out_buffer(cmd);
+ write:
+-		ret = glfs_pwrite(gfd, write_buf, length, offset, lu->bsoflags);
++		ret = glfs_pwrite(gfd, write_buf, length, offset, lu->bsoflags, NULL, NULL);
+ 
+ 		if (ret == length) {
+ 			struct mode_pg *pg;
+@@ -222,7 +222,7 @@
+ 			}
+ 			if (((cmd->scb[0] != WRITE_6) && (cmd->scb[1] & 0x8)) ||
+ 			    !(pg->mode_data[0] & 0x04))
+-				glfs_fdatasync(gfd);
++				glfs_fdatasync(gfd, NULL, NULL);
+ 		} else
+ 			set_medium_error(&result, &key, &asc);
+ 
+@@ -258,7 +258,7 @@
+ 			}
+ 
+ 			ret = glfs_pwrite(gfd, tmpbuf, blocksize,
+-					offset, lu->bsoflags);
++					offset, lu->bsoflags, NULL, NULL);
+ 
+ 			if (ret != blocksize)
+ 				set_medium_error(&result, &key, &asc);
+@@ -273,7 +273,7 @@
+ 	case READ_16:
+ 		length = scsi_get_in_length(cmd);
+ 		ret = glfs_pread(gfd, scsi_get_in_buffer(cmd),
+-				length, offset, SEEK_SET);
++				length, offset, SEEK_SET, NULL);
+ 
+ 		if (ret != length) {
+ 			eprintf("Error on read %x %x", ret, length);
+@@ -299,7 +299,7 @@
+ 			break;
+ 		}
+ 
+-		ret = glfs_pread(gfd, tmpbuf, length, offset, lu->bsoflags);
++		ret = glfs_pread(gfd, tmpbuf, length, offset, lu->bsoflags, NULL);
+ 
+ 		if (ret != length)
+ 			set_medium_error(&result, &key, &asc);
+


### PR DESCRIPTION
This allows building tgt with the glusterfs backend, allowing tgt to export an image file on a glusterfs volume via direct use of the glusterfs API, rather than having to go via FUSE.

Given that the upstream code for this seems never to have been updated for a minor glusterfs API change ~2019, I'm guessing there are probably not many users! Therefore leaving disabled by default.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
