### PR TITLE
prettier: Add official plugins

### DIFF
--- a/pkgs/by-name/pr/prettier/README.md
+++ b/pkgs/by-name/pr/prettier/README.md
@@ -1,0 +1,3 @@
+Directory structure for plugins shall mirror GitHub repository paths, check
+`./plugins/default.nix` for how these paths are mapped to a flatten attribute
+set for consumption by Prettier package.

--- a/pkgs/by-name/pr/prettier/package.nix
+++ b/pkgs/by-name/pr/prettier/package.nix
@@ -187,6 +187,7 @@ stdenv.mkDerivation (finalAttrs: {
     plugins = import ./plugins {
       inherit
         fetchFromGitHub
+        lib
         nodejs
         stdenv
         ;
@@ -194,6 +195,7 @@ stdenv.mkDerivation (finalAttrs: {
         fetchYarnDeps
         pnpm_9
         rubyPackages_4_0
+        ruby_4_0
         yarnBuildHook
         yarnConfigHook
         yarnInstallHook

--- a/pkgs/by-name/pr/prettier/package.nix
+++ b/pkgs/by-name/pr/prettier/package.nix
@@ -193,12 +193,10 @@ stdenv.mkDerivation (finalAttrs: {
       inherit (pkgs)
         fetchYarnDeps
         pnpm_9
+        rubyPackages_4_0
         yarnBuildHook
         yarnConfigHook
         yarnInstallHook
-        ;
-      inherit (pkgs.ruby)
-        gems
         ;
     };
   };

--- a/pkgs/by-name/pr/prettier/package.nix
+++ b/pkgs/by-name/pr/prettier/package.nix
@@ -27,6 +27,26 @@
   plugins ? [ ],
 }:
 let
+  /**
+    # Example
+
+    ```nix
+    exportRelativePathOf (builtins.fromJSON "./package.json")
+    =>
+    lib/node_modules/prettier-plugin-toml/./lib/index.cjs
+    ```
+
+    # Type
+
+    ```
+    exportRelativePathOf :: AttrSet => String
+    ```
+
+    # Arguments
+
+    packageJsonAttrs
+    : Attribute set with shape similar to `package.json` file
+  */
   ## Blame NodeJS
   exportRelativePathOf =
     let
@@ -64,6 +84,26 @@ let
       lib.attrByPath [ "prettier" "plugins" ] [ "null" ] packageJsonAttrs
     )) packageJsonAttrs;
 
+  /**
+    # Example
+
+    ```nix
+    nodeEntryPointOf pkgs.nodePackages.prettier-plugin-toml
+    =>
+    /nix/store/<NAR_HASH>-prettier-plugin-toml-<VERSION>/lib/node_modules/prettier-plugin-toml/./lib/index.cjs
+    ```
+
+    # Type
+
+    ```
+    nodeEntryPointOf :: AttrSet => String
+    ```
+
+    # Arguments
+
+    plugin
+    : Attribute set with `.packageName` and `.outPath` defined
+  */
   nodeEntryPointOf =
     plugin:
     let
@@ -124,11 +164,10 @@ stdenv.mkDerivation (finalAttrs: {
     yarn install --immutable
     yarn build --clean
 
-    mkdir -p $out/lib/node_modules
-    cp --recursive dist/prettier "$out/lib/node_modules/prettier"
+    cp --recursive dist/prettier "$out"
 
     makeBinaryWrapper "${lib.getExe nodejs}" "$out/bin/prettier" \
-      --add-flags "$out/lib/node_modules/prettier/bin/prettier.cjs"
+      --add-flags "$out/bin/prettier.cjs"
   ''
   + lib.optionalString (builtins.length plugins > 0) ''
     wrapProgram $out/bin/prettier --add-flags "${
@@ -141,6 +180,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
 
   passthru = {
     updateScript = ./update.sh;

--- a/pkgs/by-name/pr/prettier/package.nix
+++ b/pkgs/by-name/pr/prettier/package.nix
@@ -1,3 +1,20 @@
+/**
+  # Example
+
+  Prettier with plugins and Vim Home Manager configuration
+
+  ```nix
+  pkgs.prettier.override {
+    plugins = with pkgs.prettier.plugins; [
+      prettier-plugin-php
+      prettier-plugin-pug
+      prettier-plugin-ruby
+      prettier-plugin-xml
+      # ...
+    ];
+  }
+  ```
+*/
 {
   fetchFromGitHub,
   lib,
@@ -6,6 +23,7 @@
   stdenv,
   versionCheckHook,
   yarn-berry,
+  pkgs,
   plugins ? [ ],
 }:
 let
@@ -49,7 +67,14 @@ let
   nodeEntryPointOf =
     plugin:
     let
-      pluginDir = "${plugin.outPath}/lib/node_modules/${plugin.pname}";
+      pluginDir =
+        let
+          possiblePackageJsonPaths = [
+            "${plugin.outPath}/lib/node_modules/${plugin.packageName}/package.json"
+            "${plugin.outPath}/package.json"
+          ];
+        in
+        builtins.dirOf (lib.head (lib.filter (x: builtins.pathExists x) possiblePackageJsonPaths));
 
       packageJsonAttrs = builtins.fromJSON (builtins.readFile "${pluginDir}/package.json");
 
@@ -64,10 +89,10 @@ let
       pathAbsoluteFallback
     else
       lib.warn ''
-        ${plugin.pname}: error context, tried finding entry point under;
+        ${plugin.packageName}: error context, tried finding entry point under;
         pathAbsoluteNaive -> ${pathAbsoluteNaive}
         pathAbsoluteFallback -> ${pathAbsoluteFallback}
-      '' throw "${plugin.pname}: does not provide parse-able entry point";
+      '' throw "${plugin.packageName}: does not provide parse-able entry point";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "prettier";
@@ -117,7 +142,26 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  passthru.updateScript = ./update.sh;
+  passthru = {
+    updateScript = ./update.sh;
+    plugins = import ./plugins {
+      inherit
+        fetchFromGitHub
+        nodejs
+        stdenv
+        ;
+      inherit (pkgs)
+        fetchYarnDeps
+        pnpm_9
+        yarnBuildHook
+        yarnConfigHook
+        yarnInstallHook
+        ;
+      inherit (pkgs.ruby)
+        gems
+        ;
+    };
+  };
 
   meta = {
     changelog = "https://github.com/prettier/prettier/blob/${finalAttrs.version}/CHANGELOG.md";

--- a/pkgs/by-name/pr/prettier/plugins/default.nix
+++ b/pkgs/by-name/pr/prettier/plugins/default.nix
@@ -1,9 +1,11 @@
 {
   fetchFromGitHub,
   fetchYarnDeps,
-  rubyPackages_4_0,
+  lib,
   nodejs,
   pnpm_9,
+  rubyPackages_4_0,
+  ruby_4_0,
   stdenv,
   yarnBuildHook,
   yarnConfigHook,
@@ -37,8 +39,10 @@
     inherit
       fetchFromGitHub
       fetchYarnDeps
-      rubyPackages_4_0
+      lib
       nodejs
+      rubyPackages_4_0
+      ruby_4_0
       stdenv
       yarnBuildHook
       yarnConfigHook

--- a/pkgs/by-name/pr/prettier/plugins/default.nix
+++ b/pkgs/by-name/pr/prettier/plugins/default.nix
@@ -2,6 +2,7 @@
   fetchFromGitHub,
   fetchYarnDeps,
   nodejs,
+  pnpm_9,
   stdenv,
   yarnBuildHook,
   yarnConfigHook,
@@ -18,6 +19,15 @@
       yarnBuildHook
       yarnConfigHook
       yarnInstallHook
+      ;
+  };
+
+  prettier-plugin-pug = import ./prettier/plugin-pug {
+    inherit
+      fetchFromGitHub
+      nodejs
+      stdenv
+      pnpm_9
       ;
   };
 }

--- a/pkgs/by-name/pr/prettier/plugins/default.nix
+++ b/pkgs/by-name/pr/prettier/plugins/default.nix
@@ -1,7 +1,7 @@
 {
   fetchFromGitHub,
   fetchYarnDeps,
-  gems,
+  rubyPackages_4_0,
   nodejs,
   pnpm_9,
   stdenv,
@@ -37,7 +37,7 @@
     inherit
       fetchFromGitHub
       fetchYarnDeps
-      gems
+      rubyPackages_4_0
       nodejs
       stdenv
       yarnBuildHook

--- a/pkgs/by-name/pr/prettier/plugins/default.nix
+++ b/pkgs/by-name/pr/prettier/plugins/default.nix
@@ -1,0 +1,23 @@
+{
+  fetchFromGitHub,
+  fetchYarnDeps,
+  nodejs,
+  stdenv,
+  yarnBuildHook,
+  yarnConfigHook,
+  yarnInstallHook,
+  ...
+}:
+{
+  prettier-plugin-php = import ./prettier/plugin-php {
+    inherit
+      fetchFromGitHub
+      fetchYarnDeps
+      nodejs
+      stdenv
+      yarnBuildHook
+      yarnConfigHook
+      yarnInstallHook
+      ;
+  };
+}

--- a/pkgs/by-name/pr/prettier/plugins/default.nix
+++ b/pkgs/by-name/pr/prettier/plugins/default.nix
@@ -45,4 +45,16 @@
       yarnInstallHook
       ;
   };
+
+  prettier-plugin-xml = import ./prettier/plugin-xml {
+    inherit
+      fetchFromGitHub
+      fetchYarnDeps
+      nodejs
+      stdenv
+      yarnBuildHook
+      yarnConfigHook
+      yarnInstallHook
+      ;
+  };
 }

--- a/pkgs/by-name/pr/prettier/plugins/default.nix
+++ b/pkgs/by-name/pr/prettier/plugins/default.nix
@@ -1,6 +1,7 @@
 {
   fetchFromGitHub,
   fetchYarnDeps,
+  gems,
   nodejs,
   pnpm_9,
   stdenv,
@@ -28,6 +29,20 @@
       nodejs
       stdenv
       pnpm_9
+      ;
+  };
+
+  ## Prettier: failed to parse buffer
+  prettier-plugin-ruby = import ./prettier/plugin-ruby {
+    inherit
+      fetchFromGitHub
+      fetchYarnDeps
+      gems
+      nodejs
+      stdenv
+      yarnBuildHook
+      yarnConfigHook
+      yarnInstallHook
       ;
   };
 }

--- a/pkgs/by-name/pr/prettier/plugins/prettier/plugin-php/default.nix
+++ b/pkgs/by-name/pr/prettier/plugins/prettier/plugin-php/default.nix
@@ -1,0 +1,49 @@
+{
+  fetchFromGitHub,
+  fetchYarnDeps,
+  nodejs,
+  stdenv,
+  yarnBuildHook,
+  yarnConfigHook,
+  yarnInstallHook,
+  ...
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "prettier-plugin-php";
+  packageName = "@prettier/plugin-php";
+  version = "0.24.0";
+
+  src = fetchFromGitHub {
+    owner = "prettier";
+    repo = "plugin-php";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-u7cBqZI67/QTBp8YpLOgtZUZt/aJxknjGyT4OSTVZNM=";
+  };
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = finalAttrs.src + "/yarn.lock";
+    hash = "sha256-Q8M4Mh0wQNmDkxtUr5bwyRiuFQTyGSGgkOVWhIien4s=";
+  };
+
+  yarnKeepDevDeps = true;
+
+  # buildPhase = ''
+  #   runHook preBuild
+  #   yarn --offline build
+  #   runHook postBuild
+  # '';
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    yarnInstallHook
+    nodejs
+  ];
+
+  meta = {
+    description = "Prettier PHP Plugin";
+    homepage = "https://github.com/prettier/prettier-php#readme";
+    license = "MIT";
+  };
+})

--- a/pkgs/by-name/pr/prettier/plugins/prettier/plugin-pug/default.nix
+++ b/pkgs/by-name/pr/prettier/plugins/prettier/plugin-pug/default.nix
@@ -1,0 +1,69 @@
+/**
+  ## Attributions
+
+  - https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm
+  - https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm-fetcherVersion
+*/
+{
+  fetchFromGitHub,
+  nodejs,
+  pnpm_9,
+  stdenv,
+  ...
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "prettier-plugin-pug";
+  packageName = "@prettier/plugin-pug";
+  version = "3.4.2";
+
+  src = fetchFromGitHub {
+    owner = "prettier";
+    repo = "plugin-pug";
+    tag = finalAttrs.version;
+    hash = "sha256-4CsKMj8Xnq+dlGzLAG2hV8jTCMYBYhaV/uoKAfztSGs=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm_9.configHook
+    pnpm_9
+  ];
+
+  pnpmDeps = pnpm_9.fetchDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      ;
+    pnpm = pnpm_9;
+    fetcherVersion = 2;
+    hash = "sha256-4IS2dvcODzeakx8ezIQkoz6PLEP8Sm4OFz0EWQ0jXoA=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm build:code
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    cp -r ./node_modules ./dist ./package.json $out/
+
+    runHook postInstall
+  '';
+
+  doCheck = false;
+  doInstallCheck = false;
+
+  meta = {
+    description = "Prettier Pug Plugin";
+    homepage = "https://github.com/prettier/plugin-pug";
+    license = "MIT";
+  };
+})

--- a/pkgs/by-name/pr/prettier/plugins/prettier/plugin-ruby/default.nix
+++ b/pkgs/by-name/pr/prettier/plugins/prettier/plugin-ruby/default.nix
@@ -7,15 +7,16 @@
 {
   fetchFromGitHub,
   fetchYarnDeps,
-  rubyPackages_4_0,
+  lib,
   nodejs,
+  rubyPackages_4_0,
+  ruby_4_0,
   stdenv,
   yarnBuildHook,
   yarnConfigHook,
   yarnInstallHook,
   ...
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "prettier-plugin-ruby";
   packageName = "@prettier/plugin-ruby";
@@ -29,11 +30,28 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   yarnOfflineCache = fetchYarnDeps {
-    yarnLock = finalAttrs.src + "/yarn.lock";
+    yarnLock = "${finalAttrs.src}/yarn.lock";
     hash = "sha256-KG6LwkBN3Ao85mIt244SNzOsLNxYM/g9meWJ5AknHis=";
   };
 
   yarnKeepDevDeps = true;
+
+  patchPhase =
+    let
+      rubyDeps = with rubyPackages_4_0; [
+        prettier_print
+        syntax_tree
+        syntax_tree-haml
+        syntax_tree-rbs
+      ];
+
+      rubyEnv = ruby_4_0.withPackages (ps: rubyDeps);
+    in
+    ''
+      sed -i '/default: "ruby"/ {
+        s|ruby|${lib.getExe rubyEnv}|;
+      }' ./src/plugin.js
+    '';
 
   buildPhase = ''
     runHook preBuild
@@ -54,13 +72,6 @@ stdenv.mkDerivation (finalAttrs: {
     yarnBuildHook
     yarnInstallHook
     nodejs
-  ];
-
-  propagatedBuildInputs = with rubyPackages_4_0; [
-    prettier_print
-    syntax_tree
-    syntax_tree-haml
-    syntax_tree-rbs
   ];
 
   meta = {

--- a/pkgs/by-name/pr/prettier/plugins/prettier/plugin-ruby/default.nix
+++ b/pkgs/by-name/pr/prettier/plugins/prettier/plugin-ruby/default.nix
@@ -1,0 +1,69 @@
+/**
+  ## Attributions
+
+  - https://nixos.wiki/wiki/Packaging/Ruby
+  - https://github.com/NixOS/nixpkgs/blob/711f1d946e67ccf0e2191d85a1c0d0dcfb5df704/doc/languages-frameworks/ruby.section.md
+*/
+{
+  fetchFromGitHub,
+  fetchYarnDeps,
+  gems,
+  nodejs,
+  stdenv,
+  yarnBuildHook,
+  yarnConfigHook,
+  yarnInstallHook,
+  ...
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "prettier-plugin-ruby";
+  packageName = "@prettier/plugin-ruby";
+  version = "4.0.4";
+
+  src = fetchFromGitHub {
+    owner = "prettier";
+    repo = "plugin-ruby";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-gEgs2L7q6WX/Cwtf4hsFzKZeJs2oXBckfQxINq2/Ahg=";
+  };
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = finalAttrs.src + "/yarn.lock";
+    hash = "sha256-KG6LwkBN3Ao85mIt244SNzOsLNxYM/g9meWJ5AknHis=";
+  };
+
+  yarnKeepDevDeps = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    ## Note: source code is raw/vanilla Oracle™ JavaScript® and Ruby so no build needed
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    cp -r . $out
+  '';
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    yarnInstallHook
+    nodejs
+  ];
+
+  buildInputs = with gems; [
+    prettier_print
+    syntax_tree
+    syntax_tree-haml
+    syntax_tree-rbs
+  ];
+
+  meta = {
+    description = "Prettier Ruby Plugin";
+    homepage = "https://github.com/prettier/prettier-ruby#readme";
+    license = "MIT";
+  };
+})

--- a/pkgs/by-name/pr/prettier/plugins/prettier/plugin-ruby/default.nix
+++ b/pkgs/by-name/pr/prettier/plugins/prettier/plugin-ruby/default.nix
@@ -7,7 +7,7 @@
 {
   fetchFromGitHub,
   fetchYarnDeps,
-  gems,
+  rubyPackages_4_0,
   nodejs,
   stdenv,
   yarnBuildHook,
@@ -44,7 +44,9 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   installPhase = ''
-    cp -r . $out
+    mkdir $out
+
+    cp -r ./bin ./exe ./lib ./node_modules ./package.json ./prettier.gemspec ./src $out/
   '';
 
   nativeBuildInputs = [
@@ -54,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
     nodejs
   ];
 
-  buildInputs = with gems; [
+  propagatedBuildInputs = with rubyPackages_4_0; [
     prettier_print
     syntax_tree
     syntax_tree-haml

--- a/pkgs/by-name/pr/prettier/plugins/prettier/plugin-xml/default.nix
+++ b/pkgs/by-name/pr/prettier/plugins/prettier/plugin-xml/default.nix
@@ -1,0 +1,72 @@
+/**
+  ## Notes
+
+  Git Tag 3.4.2 was unpublished, nuking changes that made it compatible with
+  NodeJS, so `rev` is currently used, check following links for details;
+
+  - https://github.com/prettier/plugin-xml/blob/main/CHANGELOG.md
+  - https://github.com/prettier/plugin-xml/commit/e8481dceaf50a4c4c6be853c4cd80d4b604d1465
+
+  The `package.json` defines a "script.prepare" that Yarn implicitly executes
+  which also requires husky for development, this is disabled explicitly in
+  `buildPhase` here as it is unnecessary.
+*/
+{
+  fetchFromGitHub,
+  fetchYarnDeps,
+  nodejs,
+  stdenv,
+  yarnBuildHook,
+  yarnConfigHook,
+  yarnInstallHook,
+  ...
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "prettier-plugin-xml";
+  packageName = "@prettier/plugin-xml";
+  version = "3.4.2";
+
+  src = fetchFromGitHub {
+    owner = "prettier";
+    repo = "plugin-xml";
+    # tag = "v${finalAttrs.version}";
+    rev = "cc686f6c8b9dab4ffef8c5da41a7fe8faba013e3";
+    hash = "sha256-N65TxaOa/uGGQutGcVDttUBc/bA1tF0UNuiY/kOkK1o=";
+  };
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = finalAttrs.src + "/yarn.lock";
+    hash = "sha256-jryulyIx+pMVVOLkeDcWVMJGIT67kIQEnHAloPImQRU=";
+  };
+
+  yarnKeepDevDeps = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    yarn --ignore-scripts --offline install
+    node ./bin/languages.js
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    mkdir $out
+
+    cp -r ./package.json ./bin ./src ./node_modules $out/
+  '';
+
+  nativeBuildInputs = [
+    nodejs
+    yarnBuildHook
+    yarnConfigHook
+    yarnInstallHook
+  ];
+
+  meta = {
+    description = "Prettier XML Plugin";
+    homepage = "https://github.com/prettier/prettier-xml#readme";
+    license = "MIT";
+  };
+})


### PR DESCRIPTION
Main intent is to provide Prettier plugins for PR #442463 to consume.

Prettier provides, at time of this commit, four [official](https://prettier.io/docs/plugins/#official-plugins) plugins.  And there are about two dozen [community](https://prettier.io/docs/plugins/#community-plugins) plugins available too.

So it seems wise to leverage existing code, where possible, and follow examples provided by similar NPM projects that have been packaged with plugins.

Much of these changes are based on examples found from;

- `./pkgs/by-name/le/lessc/plugins/`
- `./pkgs/development/node-packages/`

...  as well as documentation provided in;

- `./doc/languages-frameworks/javascript.section.md`

Most of the changes from above references are under;

- `./pkgs/by-name/pr/prettier/plugins/aliases.nix`, within the `mapAliases` call near end of file
- `./pkgs/by-name/pr/prettier/plugins/node-packages.json`, which lists NPM package names
- `./pkgs/by-name/pr/prettier/package.nix`, which updates doc-comment and adds `passthru.plugins`

...  Other files were either copy/pasted, and slightly modified, or generated via the `./pkgs/by-name/pr/prettier/plugins/generate.sh` script.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Tested basic functionality of all Prettier plugins
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

---

## Edit 2025-09-14 16:41 UTC

Not sure what should be done about the [linter](https://github.com/NixOS/nixpkgs/actions/runs/17713859233/job/50336131144?pr=442943#step:6:183) error;

> - pkgs/by-name/pr/prettier: File plugins/composition.nix at line 4 contains the nix search path expression "<nixpkgs>" which may point outside the directory of that package.

...  because the `plugins/composition.nix` file's first line clearly states `# This file has been generated by node2nix 1.11.1. Do not edit!`, so manually fixing things are likely to be undone by next person (or myself) who updates plugins via the `generate.sh` script.

The `plugins/default.nix` is passing/forwarding the attrs in, so manually removing the `? ...` stuff _shouldn't_ break anything.