### PR TITLE
shen-sbcl: 39.1 -> 39.2

### DIFF
--- a/pkgs/by-name/sh/shen-sbcl/package.nix
+++ b/pkgs/by-name/sh/shen-sbcl/package.nix
@@ -3,14 +3,15 @@
   stdenvNoCC,
   fetchzip,
   sbcl,
+  installStandardLibrary ? true,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "shen-sbcl";
-  version = "39.1";
+  version = "39.2";
 
   src = fetchzip {
     url = "https://www.shenlanguage.org/Download/S${finalAttrs.version}.zip";
-    hash = "sha256-reN9avgYGYCMiA5BeHLhRK51liKF2ctqIgxf+4IWjVY=";
+    hash = "sha256-V6op0G4aEdKifP6L0ho6cy1FPNax+0aE5ltWxT7Xniw=";
   };
 
   nativeBuildInputs = [ sbcl ];
@@ -30,6 +31,18 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     install -Dm755 sbcl-shen.exe $out/bin/shen-sbcl
 
     runHook postInstall
+  '';
+
+  postPatch = ''
+    # allow SBCL to define *release* global
+    substituteInPlace Primitives/globals.lsp \
+      --replace-fail '"2.0.0"' '(LISP-IMPLEMENTATION-VERSION)'
+
+    # remove interactive prompt during image creation
+    substituteInPlace install.lsp \
+      --replace-fail '(Y-OR-N-P "Load Shen Library? ")' '${
+        if installStandardLibrary then "T" else "NIL"
+      }'
   '';
 
   meta = {


### PR DESCRIPTION
Updates shen-sbcl to 39.2 and supports optionally {in,ex}cluding the Shen standard library.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
