### PR TITLE
nixos/niri: add xwayland-satellite option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -532,3 +532,5 @@ and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
 - `prl-tools` has been moved out of `linuxPackages` because Parallels Guest Tools become driverless since 26.1.0.
 
 - `services.opentelemetry-collector` has a new option `validateConfigFile` option that checks the configuration file during build. It is enabled by default if the configuration file is in the Nix store.
+
+- The `niri` module now has an `xwayland-satellite` option, which is enabled by default.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -346,7 +346,8 @@
   ./programs/wayland/hyprlock.nix
   ./programs/wayland/labwc.nix
   ./programs/wayland/miracle-wm.nix
-  ./programs/wayland/niri.nix
+  ./programs/wayland/niri/default.nix
+  ./programs/wayland/niri/xwayland-satellite.nix
   ./programs/wayland/river.nix
   ./programs/wayland/sway.nix
   ./programs/wayland/uwsm.nix

--- a/nixos/modules/programs/wayland/niri/default.nix
+++ b/nixos/modules/programs/wayland/niri/default.nix
@@ -54,7 +54,7 @@ in
         };
       }
 
-      (import ./wayland-session.nix {
+      (import ../wayland-session.nix {
         inherit lib pkgs;
         enableWlrPortal = false;
         enableXWayland = false;

--- a/nixos/modules/programs/wayland/niri/xwayland-satellite.nix
+++ b/nixos/modules/programs/wayland/niri/xwayland-satellite.nix
@@ -1,0 +1,27 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.niri;
+in
+{
+  options.programs.niri.xwayland-satellite = {
+    enable = lib.mkEnableOption "xwayland-satellite for Niri" // {
+      default = true;
+    };
+
+    package = lib.mkPackageOption pkgs "xwayland-satellite" { };
+  };
+
+  config = lib.mkIf (cfg.enable && cfg.xwayland-satellite.enable) {
+    environment.systemPackages = [ cfg.xwayland-satellite.package ];
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    getchoo
+    sodiboo
+  ];
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

As niri already auto start `xwayland-satellite` in v25.08, user may be interested in adding the xwayland-satellite package to the system. This add an option in the niri module to easily achieve this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
