### PR TITLE
vaporizer2: init at 3.5.0-unstable-2024-09-14

### DIFF
--- a/pkgs/by-name/va/vaporizer2/package.nix
+++ b/pkgs/by-name/va/vaporizer2/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  juce,
+  pkg-config,
+  alsa-lib,
+  fftwFloat,
+  fontconfig,
+  freetype,
+  libGL,
+  libX11,
+  libXcursor,
+  libXext,
+  libXinerama,
+  libXrandr,
+  libjack2,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vaporizer2";
+  version = "3.5.0-unstable-2024-09-14";
+
+  src = fetchFromGitHub {
+    owner = "VASTDynamics";
+    repo = "Vaporizer2";
+    rev = "1c56c4be304255f1c397dad725ea784f15a55ef5";
+    hash = "sha256-/J0HqiXc84JEIsEyb1MlzAqpmJZEe8jP07fEcJSEZz8=";
+    fetchSubmodules = true;
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    juce
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    fftwFloat
+    fontconfig
+    freetype
+    libGL
+    libX11
+    libXcursor
+    libXext
+    libXinerama
+    libXrandr
+    libjack2
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "USE_SYSTEM_JUCE" "ON")
+  ];
+
+  # LTO needs special setup on Linux
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'juce::juce_recommended_lto_flags' '# Not forcing LTO'
+  '';
+
+  meta = {
+    description = "Wavetable synthesizer";
+    longDescription = ''
+      Hybrid wavetable additive / subtractive VST / AU / AAX synthesizer / sampler workstation plugin
+    '';
+    homepage = "https://www.vast-dynamics.com/?q=Vaporizer2";
+    downloadPage = "https://github.com/VASTDynamics/Vaporizer2";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ eljamm ];
+    mainProgram = "VASTvaporizer2";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Vaporizer2 hybrid wavetable additive / subtractive VST / AU / AAX synthesizer / sampler workstation plugin.

Homepage: https://github.com/VASTDynamics/Vaporizer2

Tested the standalone executable and the plugins (in Ardour) and it seems to be working correctly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
