### PR TITLE
go: build PIE by default

### DIFF
--- a/pkgs/applications/networking/cluster/linkerd/generic.nix
+++ b/pkgs/applications/networking/cluster/linkerd/generic.nix
@@ -31,11 +31,6 @@ buildGoModule rec {
     env GOFLAGS="" go generate ./jaeger/static
     env GOFLAGS="" go generate ./multicluster/static
     env GOFLAGS="" go generate ./viz/static
-
-    # Necessary for building Musl
-    if [[ $NIX_HARDENING_ENABLE =~ "pie" ]]; then
-        export GOFLAGS="-buildmode=pie $GOFLAGS"
-    fi
   '';
 
   tags = [

--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -269,13 +269,6 @@ lib.extendMkDerivation {
             }
           ''
           + ''
-
-            # currently pie is only enabled by default in pkgsMusl
-            # this will respect the `hardening{Disable,Enable}` flags if set
-            if [[ $NIX_HARDENING_ENABLE =~ "pie" ]]; then
-              export GOFLAGS="-buildmode=pie $GOFLAGS"
-            fi
-
             runHook postConfigure
           ''
         );

--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -250,6 +250,9 @@ lib.extendMkDerivation {
             export GOPATH="$TMPDIR/go"
             export GOPROXY=off
             export GOSUMDB=off
+            if [ -f "$NIX_CC_FOR_TARGET/nix-support/dynamic-linker" ]; then
+              export GO_LDSO=$(cat $NIX_CC_FOR_TARGET/nix-support/dynamic-linker)
+            fi
             cd "$modRoot"
           ''
           + lib.optionalString (finalAttrs.vendorHash != null) ''

--- a/pkgs/development/compilers/go/1.24.nix
+++ b/pkgs/development/compilers/go/1.24.nix
@@ -65,7 +65,9 @@ stdenv.mkDerivation (finalAttrs: {
     ./remove-tools-1.11.patch
     ./go_no_vendor_checks-1.23.patch
     ./go-env-go_ldso.patch
-    ./go-default-pie.patch
+    (replaceVars ./go-default-pie.patch {
+      inherit (stdenv.targetPlatform.go) GOARCH;
+    })
   ];
 
   inherit (stdenv.targetPlatform.go) GOOS GOARCH GOARM;

--- a/pkgs/development/compilers/go/1.24.nix
+++ b/pkgs/development/compilers/go/1.24.nix
@@ -65,6 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./remove-tools-1.11.patch
     ./go_no_vendor_checks-1.23.patch
     ./go-env-go_ldso.patch
+    ./go-default-pie.patch
   ];
 
   inherit (stdenv.targetPlatform.go) GOOS GOARCH GOARM;

--- a/pkgs/development/compilers/go/1.25.nix
+++ b/pkgs/development/compilers/go/1.25.nix
@@ -75,7 +75,9 @@ stdenv.mkDerivation (finalAttrs: {
     ./remove-tools-1.11.patch
     ./go_no_vendor_checks-1.23.patch
     ./go-env-go_ldso.patch
-    ./go-default-pie.patch
+    (replaceVars ./go-default-pie.patch {
+      inherit (stdenv.targetPlatform.go) GOARCH;
+    })
   ];
 
   inherit (stdenv.targetPlatform.go) GOOS GOARCH GOARM;

--- a/pkgs/development/compilers/go/1.25.nix
+++ b/pkgs/development/compilers/go/1.25.nix
@@ -10,8 +10,12 @@
   buildPackages,
   pkgsBuildTarget,
   targetPackages,
+  # for testing
   testers,
+  runCommand,
+  bintools,
   skopeo,
+  clickhouse-backup,
   buildGo125Module,
 }:
 
@@ -19,6 +23,7 @@ let
   goBootstrap = buildPackages.callPackage ./bootstrap122.nix { };
 
   skopeoTest = skopeo.override { buildGoModule = buildGo125Module; };
+  clickhouse-backupTest = clickhouse-backup.override { buildGoModule = buildGo125Module; };
 
   # We need a target compiler which is still runnable at build time,
   # to handle the cross-building case where build != host == target
@@ -70,6 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./remove-tools-1.11.patch
     ./go_no_vendor_checks-1.23.patch
     ./go-env-go_ldso.patch
+    ./go-default-pie.patch
   ];
 
   inherit (stdenv.targetPlatform.go) GOOS GOARCH GOARM;
@@ -179,6 +185,23 @@ stdenv.mkDerivation (finalAttrs: {
         command = "go version";
         version = "go${finalAttrs.version}";
       };
+      # Picked clickhouse-backup as a package that sets CGO_ENABLED=0
+      # Running and outputting the right version proves a working ELF interpreter was picked
+      clickhouse-backup = testers.testVersion { package = clickhouse-backupTest; };
+      clickhouse-backup-is-pie = runCommand "has-pie" { meta.broken = stdenv.hostPlatform.isStatic; } ''
+        ${lib.optionalString (!isCross) ''
+          if ${lib.getExe' bintools "readelf"} -p .comment ${lib.getExe clickhouse-backup} | grep -Fq "GCC: (GNU)"; then
+            echo "${lib.getExe clickhouse-backup} has a GCC .comment, but it should have used the internal go linker"
+            exit 1
+          fi
+        ''}
+        if ${lib.getExe' bintools "readelf"} -h ${lib.getExe clickhouse-backup} | grep -q "Type:.*DYN"; then
+          touch $out
+        else
+          echo "ERROR: clickhouse-backup is NOT PIE"
+          exit 1
+        fi
+      '';
     };
   };
 

--- a/pkgs/development/compilers/go/1.25.nix
+++ b/pkgs/development/compilers/go/1.25.nix
@@ -69,6 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     })
     ./remove-tools-1.11.patch
     ./go_no_vendor_checks-1.23.patch
+    ./go-env-go_ldso.patch
   ];
 
   inherit (stdenv.targetPlatform.go) GOOS GOARCH GOARM;
@@ -104,6 +105,9 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
     export GOCACHE=$TMPDIR/go-cache
+    if [ -f "$NIX_CC/nix-support/dynamic-linker" ]; then
+      export GO_LDSO=$(cat $NIX_CC/nix-support/dynamic-linker)
+    fi
 
     export PATH=$(pwd)/bin:$PATH
 
@@ -111,6 +115,12 @@ stdenv.mkDerivation (finalAttrs: {
       # Independent from host/target, CC should produce code for the building system.
       # We only set it when cross-compiling.
       export CC=${buildPackages.stdenv.cc}/bin/cc
+      # Prefer external linker for cross when CGO is supported, since
+      # we haven't taught go's internal linker to pick the correct ELF
+      # interpreter for cross
+      # When CGO is not supported we rely on static binaries being built
+      # since they don't need an ELF interpreter
+      export GO_EXTLINK_ENABLED=${toString finalAttrs.CGO_ENABLED}
     ''}
     ulimit -a
 

--- a/pkgs/development/compilers/go/go-default-pie.patch
+++ b/pkgs/development/compilers/go/go-default-pie.patch
@@ -1,0 +1,13 @@
+diff --git a/src/internal/platform/supported.go b/src/internal/platform/supported.go
+index f9706a6988..abac42d550 100644
+--- a/src/internal/platform/supported.go
++++ b/src/internal/platform/supported.go
+@@ -249,7 +253,7 @@ func DefaultPIE(goos, goarch string, isRace bool) bool {
+ 	case "darwin":
+ 		return true
+ 	}
+-	return false
++	return BuildModeSupported("gc", "pie", goos, goarch)
+ }
+ 
+ // ExecutableHasDWARF reports whether the linked executable includes DWARF

--- a/pkgs/development/compilers/go/go-default-pie.patch
+++ b/pkgs/development/compilers/go/go-default-pie.patch
@@ -7,7 +7,7 @@ index f9706a6988..abac42d550 100644
  		return true
  	}
 -	return false
-+	return BuildModeSupported("gc", "pie", goos, goarch)
++	return goarch == "@GOARCH@" && BuildModeSupported("gc", "pie", goos, goarch)
  }
  
  // ExecutableHasDWARF reports whether the linked executable includes DWARF

--- a/pkgs/development/compilers/go/go-env-go_ldso.patch
+++ b/pkgs/development/compilers/go/go-env-go_ldso.patch
@@ -1,0 +1,44 @@
+diff --git a/src/cmd/dist/buildruntime.go b/src/cmd/dist/buildruntime.go
+index 87e8867176..dbb635011f 100644
+--- a/src/cmd/dist/buildruntime.go
++++ b/src/cmd/dist/buildruntime.go
+@@ -62,7 +62,7 @@ func mkbuildcfg(file string) {
+ 	fmt.Fprintf(&buf, "const DefaultGORISCV64 = `%s`\n", goriscv64)
+ 	fmt.Fprintf(&buf, "const defaultGOEXPERIMENT = `%s`\n", goexperiment)
+ 	fmt.Fprintf(&buf, "const defaultGO_EXTLINK_ENABLED = `%s`\n", goextlinkenabled)
+-	fmt.Fprintf(&buf, "const defaultGO_LDSO = `%s`\n", defaultldso)
++	fmt.Fprintf(&buf, "const DefaultGO_LDSO = `%s`\n", defaultldso)
+ 	fmt.Fprintf(&buf, "const version = `%s`\n", findgoversion())
+ 	fmt.Fprintf(&buf, "const defaultGOOS = runtime.GOOS\n")
+ 	fmt.Fprintf(&buf, "const defaultGOARCH = runtime.GOARCH\n")
+diff --git a/src/cmd/link/internal/ld/elf.go b/src/cmd/link/internal/ld/elf.go
+index 6ff1d94383..147a7d91c9 100644
+--- a/src/cmd/link/internal/ld/elf.go
++++ b/src/cmd/link/internal/ld/elf.go
+@@ -1927,8 +1927,12 @@ func asmbElf(ctxt *Link) {
+ 		sh.Flags = uint64(elf.SHF_ALLOC)
+ 		sh.Addralign = 1
+ 
+-		if interpreter == "" && buildcfg.GOOS == runtime.GOOS && buildcfg.GOARCH == runtime.GOARCH && buildcfg.GO_LDSO != "" {
+-			interpreter = buildcfg.GO_LDSO
++		if interpreter == "" {
++			if goLdso := os.Getenv("GO_LDSO"); goLdso != "" {
++				interpreter = goLdso
++			} else if buildcfg.GOOS == runtime.GOOS && buildcfg.GOARCH == runtime.GOARCH {
++				interpreter = buildcfg.DefaultGO_LDSO
++			}
+ 		}
+ 
+ 		if interpreter == "" {
+diff --git a/src/internal/buildcfg/cfg.go b/src/internal/buildcfg/cfg.go
+index 7e4ee365df..8aaa70fb36 100644
+--- a/src/internal/buildcfg/cfg.go
++++ b/src/internal/buildcfg/cfg.go
+@@ -33,7 +33,6 @@ var (
+ 	GORISCV64 = goriscv64()
+ 	GOWASM    = gowasm()
+ 	ToolTags  = toolTags()
+-	GO_LDSO   = defaultGO_LDSO
+ 	GOFIPS140 = gofips140()
+ 	Version   = version
+ )


### PR DESCRIPTION
In #439314 we configured `gcc` to enable PIE by default, without needing a wrapper's involvement.  
This change aims to achieve the same outcome for go.

This change was originally going to be included in #442510 which drops the PIE hardening flag as obsolete, but has been split since it was getting a bit too complicated to roll together.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-linux -> aarch64-multiplatform cross
  - [x] x86_64-linux -> ppc64-elfv1 cross
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
