### PR TITLE
libsigsegv: disable stackoverflow tests on x86_64-darwin

### DIFF
--- a/pkgs/by-name/li/libsigsegv/disable-stackoverflow-tests.patch
+++ b/pkgs/by-name/li/libsigsegv/disable-stackoverflow-tests.patch
@@ -1,0 +1,18 @@
+--- a/tests/Makefile.in
++++ b/tests/Makefile.in
+@@ -92,13 +92,11 @@
+ host_triplet = @host@
+ TESTS = test-catch-segv1$(EXEEXT) test-catch-segv2$(EXEEXT) \
+ 	test-segv-dispatcher1$(EXEEXT) \
+-	test-catch-stackoverflow1$(EXEEXT) \
+-	test-catch-stackoverflow2$(EXEEXT) $(am__EXEEXT_1) \
++	$(am__EXEEXT_1) \
+ 	$(am__EXEEXT_2)
+ noinst_PROGRAMS = test-catch-segv1$(EXEEXT) test-catch-segv2$(EXEEXT) \
+ 	test-segv-dispatcher1$(EXEEXT) \
+-	test-catch-stackoverflow1$(EXEEXT) \
+-	test-catch-stackoverflow2$(EXEEXT) $(am__EXEEXT_1) \
++	$(am__EXEEXT_1) \
+ 	$(am__EXEEXT_2)
+ @CYGWIN_TRUE@am__append_1 = cygwin1
+ @CYGWIN_TRUE@am__append_2 = cygwin1


### PR DESCRIPTION
Disable tests that fail on Rosetta, preventing Hydra from building binaries for x86_64-darwin.

This *should* fix #327716 in a way that does not disable the tests completely: they should still run if building on a native x86 machine. However, I do not have an ARM64 machine to test that the `uname` trick has the desired effect, so somebody will need to confirm that this works as I hope.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin (native, not Rosetta)
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
