### PR TITLE
nixos/loki: refine option descriptions

### DIFF
--- a/nixos/modules/services/monitoring/loki.nix
+++ b/nixos/modules/services/monitoring/loki.nix
@@ -25,7 +25,7 @@ let
 in
 {
   options.services.loki = {
-    enable = mkEnableOption "loki";
+    enable = mkEnableOption "Grafana Loki";
 
     user = mkOption {
       type = types.str;
@@ -49,7 +49,7 @@ in
       type = types.path;
       default = "/var/lib/loki";
       description = ''
-        Specify the directory for Loki.
+        Specify the data directory for Loki.
       '';
     };
 
@@ -58,6 +58,10 @@ in
       default = { };
       description = ''
         Specify the configuration for Loki in Nix.
+
+        See [documentation of Grafana Loki](https://grafana.com/docs/loki/latest/configure/) for all available options.
+
+        Cannot be specified together with {option}`services.loki.configFile`.
       '';
     };
 
@@ -66,6 +70,8 @@ in
       default = null;
       description = ''
         Specify a configuration file that Loki should use.
+
+        Cannot be specified together with {option}`services.loki.configuration`.
       '';
     };
 


### PR DESCRIPTION
- on `.enabled` make clear that Grafana Loki is meant
- on `.configuration` link to documentation
- on `.configFile` & `.configuration` make clear that both cannot specified together

## Things done

(built nothing because only description was updated)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
