### PR TITLE
seniorpw: init at 0.8.1

### DIFF
--- a/pkgs/by-name/se/seniorpw/package.nix
+++ b/pkgs/by-name/se/seniorpw/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  cargo,
+  rustc,
+  rustPlatform,
+  tree,
+  git,
+  wl-clipboard,
+  dmenu-wayland,
+}:
+stdenv.mkDerivation rec {
+  pname = "seniorpw";
+  version = "0.8.1";
+
+  src = fetchFromGitLab {
+    owner = "retirement-home";
+    repo = "seniorpw";
+    tag = version;
+    hash = "sha256-t5LSqeG1N9PbjS/KqwMrq30dUrxR26h692ttCFhvhcU=";
+  };
+
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
+
+  cargoRoot = "src/seniorpw";
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src cargoRoot;
+    hash = "sha256-6/GSrjikqC6pr7iRYFP48k2iTQLO1/djzu4/PVvGgf8";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail '--locked ' '--offline ' \
+      --replace-fail '$(PREFIX)/local/bin' '$(PREFIX)/bin' \
+      --replace-fail '$(PREFIX)/local/share' '$(PREFIX)/share'
+  '';
+
+  installPhase = ''
+    make install PREFIX=$out
+  '';
+
+  propagatedBuildInputs = [
+    tree
+    git
+    wl-clipboard
+    dmenu-wayland
+  ];
+
+  meta = {
+    description = "Password manager using age as backend, inspired by pass";
+    homepage = "https://gitlab.com/retirement-home/seniorpw";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ claes ];
+    platforms = lib.platforms.unix;
+    mainProgram = "seniorpw";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Seniorpw is a Rust-based password manager that uses age for encryption and is inspired by the Pass password manager

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
