### PR TITLE
kimai: fix bundled assets missing

### DIFF
--- a/nixos/tests/kimai.nix
+++ b/nixos/tests/kimai.nix
@@ -17,5 +17,8 @@
     machine.wait_for_unit("nginx.service")
     machine.wait_for_open_port(80)
     machine.succeed("curl -v --location --fail http://localhost/")
+    # Make sure bundled assets are served.
+    # https://github.com/NixOS/nixpkgs/issues/442208
+    machine.succeed("curl -v --location --fail http://localhost/bundles/tabler/tabler.css")
   '';
 }

--- a/pkgs/by-name/ki/kimai/package.nix
+++ b/pkgs/by-name/ki/kimai/package.nix
@@ -41,13 +41,16 @@ php.buildComposerProject2 (finalAttrs: {
   vendorHash = "sha256-I4v4WkPGLc8vBPjCiYzPxcLn4rH3HWtQXSqwGVKXeGg=";
 
   composerNoPlugins = false;
-  composerNoScripts = false;
 
   postInstall = ''
     # Make available the console utility, as Kimai doesn't list this in
     # composer.json.
     mkdir -p "$out"/share/php/kimai "$out"/bin
     ln -s "$out"/share/php/kimai/bin/console "$out"/bin/console
+
+    # Install bundled assets. This is normally done in the `composer install`
+    # post-install script, but it's being skipped.
+    (cd "$out"/share/php/kimai && php ./bin/console assets:install)
   '';
 
   passthru.tests = {


### PR DESCRIPTION
We were relying on `composerNoScripts = false` to make sure post-install command `assets:install` is run. `assets:install` copies assets from `vendor/` directory into `public/` directory, placing it in appropriate places.

However, with commit 80bb9aec24 ("kimai: switch to buildComposerProject2 and tag"), we switched to `buildComposerProject2` which has moved `composer install` step to `composerVendor` derivation. By design, `composerVendor` ignores anything that happens outside `vendor/`, so the assets was not copied into final derivation.

So stop relying on `composerNoScripts = false` and run `assets:install` ourselves in `postInstall` step. A side effect of this is that there is another post-install step being skipped (`cache:clear`). However we simply handle caches outside of the derivation (it's handled in the module), so that's not a problem.

Fixes: https://github.com/NixOS/nixpkgs/issues/442208

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
