### PR TITLE
jemalloc: 5.3.0 -> 5.3.0-unstable-2025-09-12

### DIFF
--- a/pkgs/development/libraries/jemalloc/default.nix
+++ b/pkgs/development/libraries/jemalloc/default.nix
@@ -15,7 +15,7 @@
   disableInitExecTls ? false,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "jemalloc";
   version = "5.3.0-unstable-2025-09-12";
 
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   configureScript = "./autogen.sh";
 
   configureFlags = [
-    "--with-version=${lib.versions.majorMinor version}.0-0-g${src.rev}"
+    "--with-version=${lib.versions.majorMinor finalAttrs.version}.0-0-g${finalAttrs.src.rev}"
     "--with-lg-vaddr=${with stdenv.hostPlatform; toString (if isILP32 then 32 else parsed.cpu.bits)}"
   ]
   # see the comment on stripPrefix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
   # jemalloc is unable to correctly detect transparent hugepage support on
   # ARM (https://github.com/jemalloc/jemalloc/issues/526), and the default
   # kernel ARMv6/7 kernel does not enable it, so we explicitly disable support
-  ++ lib.optionals (stdenv.hostPlatform.isAarch32 && lib.versionOlder version "5") [
+  ++ lib.optionals (stdenv.hostPlatform.isAarch32 && lib.versionOlder finalAttrs.version "5") [
     "--disable-thp"
     "je_cv_thp=no"
   ]
@@ -95,4 +95,4 @@ stdenv.mkDerivation rec {
     license = licenses.bsd2;
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/development/libraries/jemalloc/default.nix
+++ b/pkgs/development/libraries/jemalloc/default.nix
@@ -50,13 +50,6 @@ stdenv.mkDerivation (finalAttrs: {
   # see the comment on stripPrefix
   ++ lib.optional stripPrefix "--with-jemalloc-prefix="
   ++ lib.optional disableInitExecTls "--disable-initial-exec-tls"
-  # jemalloc is unable to correctly detect transparent hugepage support on
-  # ARM (https://github.com/jemalloc/jemalloc/issues/526), and the default
-  # kernel ARMv6/7 kernel does not enable it, so we explicitly disable support
-  ++ lib.optionals (stdenv.hostPlatform.isAarch32 && lib.versionOlder finalAttrs.version "5") [
-    "--disable-thp"
-    "je_cv_thp=no"
-  ]
   # The upstream default is dependent on the builders' page size
   # https://github.com/jemalloc/jemalloc/issues/467
   # https://sources.debian.org/src/jemalloc/5.3.0-3/debian/rules/

--- a/pkgs/development/libraries/jemalloc/default.nix
+++ b/pkgs/development/libraries/jemalloc/default.nix
@@ -17,27 +17,16 @@
 
 stdenv.mkDerivation rec {
   pname = "jemalloc";
-  version = "5.3.0";
+  version = "5.3.0-unstable-2025-09-12";
 
   src = fetchFromGitHub {
-    owner = "jemalloc";
+    owner = "facebook";
     repo = "jemalloc";
-    tag = version;
-    hash = "sha256-bb0OhZVXyvN+hf9BpPSykn5cGm87a0C+Y/iXKt9wTSs=";
+    rev = "c0889acb6c286c837530fdbeb96007b0dee8b776";
+    hash = "sha256-lBNgvUhuiRPgzr8JC4zSSCT2KpDBktBVX72zfvAEHvo=";
   };
 
   patches = [
-    # fix tests under --with-jemalloc-prefix=, see https://github.com/jemalloc/jemalloc/pull/2340
-    (fetchpatch {
-      url = "https://github.com/jemalloc/jemalloc/commit/d00ecee6a8dfa90afcb1bbc0858985c17bef6559.patch";
-      hash = "sha256-N5i4IxGJ4SSAgFiq5oGRnrNeegdk2flw9Sh2mP0yl4c=";
-    })
-    # fix linking with libc++, can be removed in the next update (after 5.3.0).
-    # https://github.com/jemalloc/jemalloc/pull/2348
-    (fetchpatch {
-      url = "https://github.com/jemalloc/jemalloc/commit/4422f88d17404944a312825a1aec96cd9dc6c165.patch";
-      hash = "sha256-dunkE7XHzltn5bOb/rSHqzpRniAFuGubBStJeCxh0xo=";
-    })
     # -O3 appears to introduce an unreproducibility where
     # `rtree_read.constprop.0` shows up in some builds but
     # not others, so we fall back to O2:
@@ -55,7 +44,7 @@ stdenv.mkDerivation rec {
   configureScript = "./autogen.sh";
 
   configureFlags = [
-    "--with-version=${version}-0-g0000000000000000000000000000000000000000"
+    "--with-version=${lib.versions.majorMinor version}.0-0-g${src.rev}"
     "--with-lg-vaddr=${with stdenv.hostPlatform; toString (if isILP32 then 32 else parsed.cpu.bits)}"
   ]
   # see the comment on stripPrefix


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Update's jemalloc to use the Facebook fork.

For an unknown reason, in June 2025, the official jemalloc repos were archived. Facebook seems to have picked up development and their version has newer fixes. Unfortunately, it is not tagged yet but it doesn't mean we can't start using it.

Fixes #348660

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
