### PR TITLE
prek: 0.1.6 -> 0.2.1

### DIFF
--- a/pkgs/by-name/pr/prek/package.nix
+++ b/pkgs/by-name/pr/prek/package.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "prek";
-  version = "0.1.6";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "j178";
     repo = "prek";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-MVdd67ssP64aEV6rjNA3fxypqKn0lJe/UN2waCEkLJM=";
+    hash = "sha256-pnAyyCvPCObW5NrMY72XsX5SqcnmIKCrQW5v3nyFCcU=";
   };
 
-  cargoHash = "sha256-XW8na9kXgn7gKaN7OYlEGTv8cgtzKXggj1uXlvQh4N4=";
+  cargoHash = "sha256-hSmlWPhR5wt2JIwNnRKX1zkOks5G+SSepIRVTWsu6bo=";
 
   preBuild = ''
     version312_str=$(${python312}/bin/python -c 'import sys; print(sys.version_info[:3])')
@@ -61,6 +61,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # "meta_hooks"
     "reuse_env"
     "docker::docker"
+    "docker::workspace_docker"
     "docker_image::docker_image"
     "pygrep::basic_case_sensitive"
     "pygrep::case_insensitive"
@@ -95,6 +96,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "subdirectory"
     "check_yaml_hook"
     "check_yaml_multiple_document"
+    "builtin_hooks_workspace_mode"
+    "fix_byte_order_marker_hook"
+    "fix_byte_order_marker"
     # does not properly use TMP
     "hook_impl"
   ];
@@ -102,6 +106,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     homepage = "https://github.com/j178/prek";
     description = "Better `pre-commit`, re-engineered in Rust ";
+    mainProgram = "prek";
     changelog = "https://github.com/j178/prek/releases/tag/${finalAttrs.src.tag}";
     license = [ lib.licenses.mit ];
     maintainers = [ lib.maintainers.knl ];


### PR DESCRIPTION
> This is a huge milestone release that introduces Workspace Mode — first‑class monorepo support.

Release notes: https://github.com/j178/prek/releases/tag/v0.2.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
