### PR TITLE
seafile-client: 9.0.14 -> 9.0.15

### DIFF
--- a/pkgs/by-name/se/seafile-client/package.nix
+++ b/pkgs/by-name/se/seafile-client/package.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation rec {
   pname = "seafile-client";
-  version = "9.0.14";
+  version = "9.0.15";
 
   src = fetchFromGitHub {
     owner = "haiwen";
     repo = "seafile-client";
-    rev = "v${version}";
-    hash = "sha256-ZMhU0uXAC3tH1e3ktiHhC5YCDwFOnILretPgjYYa9DQ=";
+    tag = "v${version}";
+    hash = "sha256-BV1+9/+ryZB1BQyRJ5JaIU6bbOi4h8vt+V+FQIfUJp8=";
   };
 
   patches = [
@@ -57,6 +57,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://github.com/haiwen/seafile-client";
+    changelog = "https://github.com/haiwen/seafile-client/releases/tag/${src.tag}";
     description = "Desktop client for Seafile, the Next-generation Open Source Cloud Storage";
     license = licenses.asl20;
     platforms = platforms.linux;

--- a/pkgs/by-name/se/seafile-client/package.nix
+++ b/pkgs/by-name/se/seafile-client/package.nix
@@ -5,15 +5,12 @@
   fetchFromGitHub,
   pkg-config,
   cmake,
-  qttools,
-  qt5compat,
+  qt6,
   libuuid,
   seafile-shared,
   jansson,
   libsearpc,
   withShibboleth ? true,
-  qtwebengine,
-  wrapQtAppsHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -40,17 +37,17 @@ stdenv.mkDerivation rec {
     libuuid
     pkg-config
     cmake
-    wrapQtAppsHook
-    qttools
+    qt6.wrapQtAppsHook
+    qt6.qttools
   ];
 
   buildInputs = [
-    qt5compat
+    qt6.qt5compat
     seafile-shared
     jansson
     libsearpc
   ]
-  ++ lib.optional withShibboleth qtwebengine;
+  ++ lib.optional withShibboleth qt6.qtwebengine;
 
   cmakeFlags = lib.optional withShibboleth "-DBUILD_SHIBBOLETH_SUPPORT=ON";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12848,8 +12848,6 @@ with pkgs;
 
   scantailor-universal = callPackage ../applications/graphics/scantailor/universal.nix { };
 
-  seafile-client = qt6Packages.callPackage ../applications/networking/seafile-client { };
-
   seq66 = qt5.callPackage ../applications/audio/seq66 { };
 
   sfxr-qt = libsForQt5.callPackage ../applications/audio/sfxr-qt { };


### PR DESCRIPTION
### Update `seafile-client`

- Release: https://github.com/haiwen/seafile-client/releases/tag/v9.0.15
- Changes: https://github.com/haiwen/seafile-client/compare/v9.0.14...v9.0.15
- Migrated from ‎`pkgs/applications/networking/seafile-client/default.nix` to ‎`pkgs/by-name/se/seafile-client/package.nix`.
- Resolves https://github.com/NixOS/nixpkgs/issues/441134.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
