### PR TITLE
plasma-applet-resources-monitor: init at 3.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7676,6 +7676,12 @@
     githubId = 5493775;
     name = "Ente";
   };
+  EntranceJew = {
+    email = "EntranceJew@gmail.com";
+    github = "EntranceJew";
+    githubId = 5711436;
+    name = "EntranceJew";
+  };
   Enzime = {
     github = "Enzime";
     githubId = 10492681;

--- a/pkgs/by-name/pl/plasma-applet-resources-monitor/package.nix
+++ b/pkgs/by-name/pl/plasma-applet-resources-monitor/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  kdePackages,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "plasma-applet-resources-monitor";
+  version = "3.1.1";
+
+  src = fetchFromGitHub {
+    owner = "orblazer";
+    repo = "plasma-applet-resources-monitor";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-du38PM5kLiBWwEvli8mfUGTfMGqdS86CkMttTepMhFk=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    kdePackages.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    kdePackages.libplasma
+    kdePackages.libksysguard
+    kdePackages.kdeplasma-addons
+  ];
+
+  meta = {
+    description = "Resources monitor - Plasma 6 widget";
+    longDescription = ''
+      Plasmoid for monitoring CPU, memory, network traffic, GPUs and disks IO.
+    '';
+    license = lib.licenses.gpl3Only; # TODO: gpl3Plus established in e60aa0168c39d8470631714924ccce653f8a75c2
+    homepage = "https://github.com/orblazer/plasma-applet-resources-monitor/";
+    maintainers = with lib.maintainers; [ EntranceJew ];
+    inherit (kdePackages.kwindowsystem.meta) platforms;
+  };
+})

--- a/pkgs/by-name/pl/plasma-applet-resources-monitor/package.nix
+++ b/pkgs/by-name/pl/plasma-applet-resources-monitor/package.nix
@@ -10,6 +10,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "plasma-applet-resources-monitor";
   version = "3.1.1";
 
+ __structuredAttrs = true;
+ strictDeps = true;
+
   src = fetchFromGitHub {
     owner = "orblazer";
     repo = "plasma-applet-resources-monitor";


### PR DESCRIPTION
adds the plasmoid that is nice and cool

<img width="227" height="58" alt="image" src="https://github.com/user-attachments/assets/9c9510a2-832c-47e0-a73c-03dd09faf66c" />

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  ```
  [ej@COIN:~/git/nixpkgs]$ nix-build --attr pkgs.PACKAGE.passthru.tests
  error: attribute 'PACKAGE' in selection path 'pkgs.PACKAGE.passthru.tests' not found

  [ej@COIN:~/git/nixpkgs]$ nix-build --attr nixosTests.NAME
  error: attribute 'NAME' in selection path 'nixosTests.NAME' not found

  [ej@COIN:~/git/nixpkgs]$ nix-build --attr tests.PACKAGE
  error: attribute 'PACKAGE' in selection path 'tests.PACKAGE' not found
  ```
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
```
[nix-shell:~/git/nixpkgs]$ nixpkgs-review pr 443059
-> Fetching eval results from GitHub actions
-> Successfully fetched rebuilds: no local evaluation needed
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0 pull/443059/merge:refs/nixpkgs-review/1
remote: Enumerating objects: 1209, done.
remote: Counting objects: 100% (616/616), done.
remote: Compressing objects: 100% (318/318), done.
remote: Total 449 (delta 347), reused 197 (delta 115), pack-reused 0 (from 0)
Receiving objects: 100% (449/449), 111.04 KiB | 1.50 MiB/s, done.
Resolving deltas: 100% (347/347), completed with 75 local objects.
From https://github.com/NixOS/nixpkgs
 * [new branch]                master                 -> refs/nixpkgs-review/0
 * [new ref]                   refs/pull/443059/merge -> refs/nixpkgs-review/1
$ git worktree add /home/ej/.cache/nixpkgs-review/pr-443059/nixpkgs 0fb1ebc4aa4db3cdc2f3ea185390c9f38613c56c
Preparing worktree (detached HEAD 0fb1ebc4aa4d)
Updating files: 100% (49023/49023), done.
HEAD is now at 0fb1ebc4aa4d Merge 69a5709a847368b5826712a0f7841e5024a27816 into b8f26bc0c6110569099f702227e51591152434be
warning: ignoring the client-specified setting 'system', because it is a restricted setting and you are not a trusted user

$ nix build --file /nix/store/y6fnhlzflry74nyi706qfvpbmgp23iiy-nixpkgs-review-3.4.0/lib/python3.12/site-packages/nixpkgs_review/nix/review-shell.nix --nix-path 'nixpkgs=/home/ej/.cache/nixpkgs-review/pr-443059/nixpkgs nixpkgs-overlays=/tmp/nix-shell-588797-0/tmpd7mbt2qp' --extra-experimental-features 'nix-command no-url-literals' --no-link --keep-going --no-allow-import-from-derivation --option build-use-sandbox relaxed --argstr local-system x86_64-linux --argstr nixpkgs-path /home/ej/.cache/nixpkgs-review/pr-443059/nixpkgs --argstr nixpkgs-config-path /tmp/nix-shell-588797-0/tmpe46luvg9.nix --argstr attrs-path /home/ej/.cache/nixpkgs-review/pr-443059/attrs.nix
warning: ignoring the client-specified setting 'sandbox', because it is a restricted setting and you are not a trusted user

Link to currently reviewing PR:
https://github.com/NixOS/nixpkgs/pull/443059
--------- Report for 'x86_64-linux' ---------
1 package built:
plasma-applet-resources-monitor

Logs can be found under:
/home/ej/.cache/nixpkgs-review/pr-443059/logs


$ /nix/store/2ca366rh9gnxfcwyjc0jch5xayy3h51l-nix-2.28.5/bin/nix-shell --argstr local-system x86_64-linux --argstr nixpkgs-path /home/ej/.cache/nixpkgs-review/pr-443059/nixpkgs --argstr nixpkgs-config-path /tmp/nix-shell-588797-0/tmpe46luvg9.nix --argstr attrs-path /home/ej/.cache/nixpkgs-review/pr-443059/attrs.nix --nix-path 'nixpkgs=/home/ej/.cache/nixpkgs-review/pr-443059/nixpkgs nixpkgs-overlays=/tmp/nix-shell-588797-0/tmpd7mbt2qp' /nix/store/y6fnhlzflry74nyi706qfvpbmgp23iiy-nixpkgs-review-3.4.0/lib/python3.12/site-packages/nixpkgs_review/nix/review-shell.nix

[nix-shell:~/.cache/nixpkgs-review/pr-443059]$ 
```
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
```
[ej@COIN:~/git/nixpkgs]$ ./result/bin/
bash: ./result/bin/: No such file or directory

[ej@COIN:~/git/nixpkgs]$ ls result
ls: cannot access 'result': No such file or directory

[ej@COIN:~/git/nixpkgs]$ ls ./result/bin/
ls: cannot access './result/bin/': No such file or directory
```
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
