### PR TITLE
lldap: make more overridable. call runHook; use finalAttrs for frontend

### DIFF
--- a/pkgs/by-name/ll/lldap/package.nix
+++ b/pkgs/by-name/ll/lldap/package.nix
@@ -101,6 +101,7 @@ let
 
 in
 rustPlatform.buildRustPackage (
+  finalAttrs:
   commonDerivationAttrs
   // {
     cargoBuildFlags = [
@@ -115,7 +116,7 @@ rustPlatform.buildRustPackage (
     nativeBuildInputs = [ makeWrapper ];
     postInstall = ''
       wrapProgram $out/bin/lldap \
-        --set LLDAP_ASSETS_PATH ${frontend}
+        --set LLDAP_ASSETS_PATH ${finalAttrs.finalPackage.frontend}
     '';
 
     passthru = {
@@ -138,4 +139,5 @@ rustPlatform.buildRustPackage (
       mainProgram = "lldap";
     };
   }
+
 )

--- a/pkgs/by-name/ll/lldap/package.nix
+++ b/pkgs/by-name/ll/lldap/package.nix
@@ -76,15 +76,23 @@ let
       ];
 
       buildPhase = ''
+        runHook preBuild
+
         HOME=`pwd` ./app/build.sh
+
+        runHook postBuild
       '';
 
       installPhase = ''
+        runHook preInstall
+
         mkdir -p $out
         cp -R app/{pkg,static} $out/
         cp app/index_local.html $out/index.html
         cp -R ${staticAssets finalAttrs.src}/* $out/static
         rm $out/static/libraries.txt $out/static/fonts/fonts.txt
+
+        runHook postInstall
       '';
 
       doCheck = false;


### PR DESCRIPTION
Makes it easier and more straightforward to override attrs in lldap.

runHook now gets called in the buildPhase and installPhase of the frontend.
[According to the reference manual](https://nixos.org/manual/nixpkgs/stable/#sec-stdenv-phases):

> When overriding a phase, for example installPhase, it is important to start with runHook preInstall and end it with runHook postInstall, otherwise preInstall and postInstall will not be run. Even if you don’t use them directly, it is good practice to do so anyways for downstream users who would want to add a postInstall by overriding your derivation.

Also, the main lldap derivation now refers to the frontend using finalAttrs. This makes it so that overriding the passthru.frontend actually changes the frontend being used. Otherwise, to change the frontend one would have to override postInstall directly which is less forwards compatible with potential future changes to postInstall like [the one that has already occured since NixOS 25.05](https://github.com/NixOS/nixpkgs/commit/078b5bba8345d56692d19a03a9f993933ee2a991#diff-97941670257b9fe51139d881ccecbd6fa9b5fcb7465d62cedfd1230e6214416fL75).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. (I tried running nixpkgs-review but it wanted to use over 16GB of RAM and got killed)
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
