### PR TITLE
tea: 0.10.1 -> 0.11.0

### DIFF
--- a/pkgs/by-name/te/tea/package.nix
+++ b/pkgs/by-name/te/tea/package.nix
@@ -3,21 +3,40 @@
   buildGoModule,
   fetchFromGitea,
   installShellFiles,
+  stdenv,
 }:
 
 buildGoModule rec {
   pname = "tea";
-  version = "0.10.1";
+  version = "0.11.0";
 
   src = fetchFromGitea {
     domain = "gitea.com";
     owner = "gitea";
     repo = "tea";
     rev = "v${version}";
-    sha256 = "sha256-Dhb3y13sxkyE+2BjNj7YcsjiIPgznIVyuzWs0F8LNfU=";
+    sha256 = "sha256-jM/TR3bApWv0ci98Vb/0YPjlmLuO91WPY9eMHBInIQI=";
   };
 
-  vendorHash = "sha256-mKCsBPBWs3+61em53cEB0shTLXgUg4TivJRogy1tYXw=";
+  vendorHash = "sha256-Y9YDwfubT+RR1v6BTFD+A8GP2ArQaIIoMJmak+Vcx88=";
+
+  ldflags = [
+    "-X code.gitea.io/tea/cmd.Version=${version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd tea \
+      --bash <($out/bin/tea completion bash) \
+      --fish <($out/bin/tea completion fish) \
+      --zsh <($out/bin/tea completion zsh)
+
+    mkdir $out/share/powershell/ -p
+    $out/bin/tea completion pwsh > $out/share/powershell/tea.Completion.ps1
+
+    $out/bin/tea man --out $out/share/man/man1/tea.1
+  '';
 
   meta = with lib; {
     description = "Gitea official CLI client";
@@ -29,20 +48,4 @@ buildGoModule rec {
     ];
     mainProgram = "tea";
   };
-
-  ldflags = [
-    "-X code.gitea.io/tea/cmd.Version=${version}"
-  ];
-
-  nativeBuildInputs = [ installShellFiles ];
-
-  postInstall = ''
-    installShellCompletion --cmd tea \
-      --bash <($out/bin/tea completion bash) \
-      --fish <($out/bin/tea completion fish) \
-      --zsh <($out/bin/tea completion zsh)
-
-    mkdir $out/share/powershell/ -p
-    $out/bin/tea completion pwsh > $out/share/powershell/tea.Completion.ps1
-  '';
 }


### PR DESCRIPTION
Diff: https://gitea.com/gitea/tea/compare/v0.10.1...v0.11.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
