### PR TITLE
hyprlandPlugins.mkHyprlandPlugin: support finalAttrs through lib.extendMkDerivation; update hyprland plugins

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hy3.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hy3.nix
@@ -6,14 +6,14 @@
   mkHyprlandPlugin,
   nix-update-script,
 }:
-mkHyprlandPlugin hyprland rec {
+mkHyprlandPlugin (finalAttrs: {
   pluginName = "hy3";
   version = "hl0.50.0";
 
   src = fetchFromGitHub {
     owner = "outfoxxed";
     repo = "hy3";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-1BTJSqkj+lkIry27HuqA5UB7uRqAUvGT7LAUDQhKjU0=";
   };
 
@@ -33,4 +33,4 @@ mkHyprlandPlugin hyprland rec {
       johnrtitor
     ];
   };
-}
+})

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hy3.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hy3.nix
@@ -8,13 +8,13 @@
 }:
 mkHyprlandPlugin (finalAttrs: {
   pluginName = "hy3";
-  version = "hl0.50.0";
+  version = "0.51.0";
 
   src = fetchFromGitHub {
     owner = "outfoxxed";
     repo = "hy3";
-    tag = finalAttrs.version;
-    hash = "sha256-1BTJSqkj+lkIry27HuqA5UB7uRqAUvGT7LAUDQhKjU0=";
+    tag = "hl${finalAttrs.version}";
+    hash = "sha256-HjbofK4rSLkkUvOZHdoAY6kn7Ok2bXo14eOKr8hKRHE=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hy3.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hy3.nix
@@ -21,7 +21,12 @@ mkHyprlandPlugin (finalAttrs: {
 
   dontStrip = true;
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "hl(.*)"
+    ];
+  };
 
   meta = {
     homepage = "https://github.com/outfoxxed/hy3";

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hycov.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hycov.nix
@@ -1,20 +1,19 @@
 {
   lib,
   mkHyprlandPlugin,
-  hyprland,
   cmake,
   fetchFromGitHub,
   nix-update-script,
 }:
 
-mkHyprlandPlugin hyprland rec {
+mkHyprlandPlugin (finalAttrs: {
   pluginName = "hycov";
   version = "0.41.2.1";
 
   src = fetchFromGitHub {
     owner = "DreamMaoMao";
     repo = "hycov";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-NRnxbkuiq1rQ+uauo7D+CEe73iGqxsWxTQa+1SEPnXQ=";
   };
 
@@ -30,4 +29,4 @@ mkHyprlandPlugin hyprland rec {
     platforms = lib.platforms.linux;
     broken = true; # Doesn't work after Hyprland v0.41.2 https://gitee.com/DreamMaoMao/hycov/issues/IANYC8#note_31512295_link
   };
-}
+})

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hypr-dynamic-cursors.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hypr-dynamic-cursors.nix
@@ -2,11 +2,10 @@
   lib,
   mkHyprlandPlugin,
   fetchFromGitHub,
-  hyprland,
   nix-update-script,
 }:
 
-mkHyprlandPlugin hyprland {
+mkHyprlandPlugin {
   pluginName = "hypr-dynamic-cursors";
   version = "0-unstable-2025-09-01";
 

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprgrass.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprgrass.nix
@@ -1,7 +1,6 @@
 {
   lib,
   mkHyprlandPlugin,
-  hyprland,
   fetchFromGitHub,
   cmake,
   doctest,
@@ -11,7 +10,7 @@
   nix-update-script,
 }:
 
-mkHyprlandPlugin hyprland {
+mkHyprlandPlugin {
   pluginName = "hyprgrass";
   version = "0.8.2-unstable-2025-05-08";
 

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprland-plugins.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprland-plugins.nix
@@ -13,13 +13,13 @@ let
             mkHyprlandPlugin,
           }:
           let
-            version = "0.50.0";
+            version = "0.51.0";
 
             hyprland-plugins-src = fetchFromGitHub {
               owner = "hyprwm";
               repo = "hyprland-plugins";
               tag = "v${version}";
-              hash = "sha256-XJJ+frO4NOxVkoSGc1Mag8ESumzx2FmVRspOgFlMqF8=";
+              hash = "sha256-6jAtMjnWq8kty/dpPbIKxIupUG+WAE2AKMIKhxdLYNo=";
             };
           in
           mkHyprlandPlugin {

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprland-plugins.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprland-plugins.nix
@@ -10,7 +10,6 @@ let
             lib,
             cmake,
             fetchFromGitHub,
-            hyprland,
             mkHyprlandPlugin,
           }:
           let
@@ -23,7 +22,7 @@ let
               hash = "sha256-XJJ+frO4NOxVkoSGc1Mag8ESumzx2FmVRspOgFlMqF8=";
             };
           in
-          mkHyprlandPlugin hyprland {
+          mkHyprlandPlugin {
             pluginName = name;
             inherit version;
 
@@ -34,7 +33,6 @@ let
               description = "Hyprland ${description} plugin";
               license = lib.licenses.bsd3;
               teams = [ lib.teams.hyprland ];
-              inherit (hyprland.meta) platforms;
             };
           }
         )

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprspace.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprspace.nix
@@ -1,12 +1,11 @@
 {
   lib,
   fetchFromGitHub,
-  hyprland,
   mkHyprlandPlugin,
   nix-update-script,
 }:
 
-mkHyprlandPlugin hyprland {
+mkHyprlandPlugin {
   pluginName = "hyprspace";
   version = "0-unstable-2025-07-16";
 

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprsplit.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprsplit.nix
@@ -2,19 +2,18 @@
   lib,
   meson,
   fetchFromGitHub,
-  hyprland,
   ninja,
   mkHyprlandPlugin,
   nix-update-script,
 }:
-mkHyprlandPlugin hyprland rec {
+mkHyprlandPlugin (finalAttrs: {
   pluginName = "hyprsplit";
   version = "0.50.1";
 
   src = fetchFromGitHub {
     owner = "shezdy";
     repo = "hyprsplit";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-D0zfdUJXBRnNMmv/5qW+X4FJJ3/+t7yQmwJFkBuEgck=";
   };
 
@@ -29,9 +28,8 @@ mkHyprlandPlugin hyprland rec {
     homepage = "https://github.com/shezdy/hyprsplit";
     description = "Hyprland plugin for awesome / dwm like workspaces";
     license = lib.licenses.bsd3;
-    inherit (hyprland.meta) platforms;
     maintainers = with lib.maintainers; [
       aacebedo
     ];
   };
-}
+})


### PR DESCRIPTION
We don't need to pass `hyprland` to plugin manually now, it should be overridable when required too.

CC @fufexan, would love if https://github.com/hyprwm/hyprland-plugins had a tag

0 rebuilds as of https://github.com/NixOS/nixpkgs/pull/443076/commits/1e788edb892a8c6c00b3669f06db34e64e511352, nice.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
