### PR TITLE
ocamlPackages.odoc: 2.4.4 → 3.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/odoc-parser/default.nix
+++ b/pkgs/development/ocaml-modules/odoc-parser/default.nix
@@ -6,12 +6,15 @@
   astring,
   result,
   camlp-streams,
-  version ? "2.4.4",
+  version ? if lib.versionAtLeast ocaml.version "4.08" then "3.1.0" else "2.4.4",
 }:
 
 let
   param =
     {
+      "3.1.0" = {
+        sha256 = "sha256-NVs8//STSQPLrti1HONeMz6GCZMtIwKUIAqfLUL/qRQ=";
+      };
       "2.4.4" = {
         sha256 = "sha256-fiU6VbXI9hD54LSJQOza8hwBVTFDr5O0DJmMMEmeUfM=";
       };
@@ -41,8 +44,6 @@ lib.throwIf (param ? max_version && lib.versionAtLeast ocaml.version param.max_v
     pname = "odoc-parser";
     inherit version;
 
-    minimalOCamlVersion = "4.02";
-
     src = fetchurl {
       url =
         if lib.versionAtLeast version "2.4" then
@@ -54,8 +55,8 @@ lib.throwIf (param ? max_version && lib.versionAtLeast ocaml.version param.max_v
 
     propagatedBuildInputs = [
       astring
-      result
     ]
+    ++ lib.optional (!lib.versionAtLeast version "3.1.0") result
     ++ lib.optional (lib.versionAtLeast version "1.0.1") camlp-streams;
 
     meta = {

--- a/pkgs/development/ocaml-modules/odoc/default.nix
+++ b/pkgs/development/ocaml-modules/odoc/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildDunePackage,
-  ocaml,
   ocaml-crunch,
   astring,
   cmdliner,
@@ -19,7 +18,7 @@
   fmt,
 }:
 
-buildDunePackage rec {
+buildDunePackage {
   pname = "odoc";
   inherit (odoc-parser) version src;
 
@@ -31,7 +30,6 @@ buildDunePackage rec {
     astring
     cmdliner
     fpath
-    result
     tyxml
     odoc-parser
     fmt
@@ -48,7 +46,7 @@ buildDunePackage rec {
     jq
     ppx_expect
   ];
-  doCheck = lib.versionAtLeast ocaml.version "4.08" && lib.versionOlder yojson.version "2.0";
+  doCheck = true;
 
   preCheck = ''
     # some run.t files check the content of patchShebangs-ed scripts, so patch
@@ -63,6 +61,6 @@ buildDunePackage rec {
     license = lib.licenses.isc;
     maintainers = [ lib.maintainers.vbgl ];
     homepage = "https://github.com/ocaml/odoc";
-    changelog = "https://github.com/ocaml/odoc/blob/${version}/CHANGES.md";
+    changelog = "https://github.com/ocaml/odoc/blob/${odoc-parser.version}/CHANGES.md";
   };
 }


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
