### PR TITLE
ugrep: add optional wrapping with filter utils; add optional `gnugrep` replacement symlinks

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -370,3 +370,8 @@
 - `cloudflare-ddns`: Added package cloudflare-ddns.
 
 - `lib.cli.toCommandLine`, `lib.cli.toCommandLineShell`, `lib.cli.toCommandLineGNU` and `lib.cli.toCommandLineShellGNU` have been added to address multiple issues in `lib.cli.toGNUCommandLine` and `lib.cli.toGNUCommandLineShell`.
+
+- `ugrep`: Added `wrapWithFilterUtils` package flag for optionally wrapping `ugrep+` and `ug+` with filter utilities for grepping other file types.
+
+- `ugrep`: Added `createGrepReplacementLinks` package flag for optionally creating drop-in replacement symlinks for `gnugrep`.
+

--- a/pkgs/by-name/ug/ugrep/package.nix
+++ b/pkgs/by-name/ug/ugrep/package.nix
@@ -13,6 +13,28 @@
   xz,
   zlib,
   zstd,
+  # The `ugrep+` and `ug+` commands are the same as the
+  # `ugrep` and `ug` commands, but also use filters to
+  # search PDFs, documents, e-books, image metadata,
+  # when these filter tools are present:
+  poppler-utils, # Provides `pdftotext`.
+  antiword,
+  pandoc,
+  exiftool,
+  # Alleviates the need for users to pollute their
+  # environment with these packages, but grows the
+  # closure size massively; hence this is opt-in.
+  wrapWithFilterUtils ? false,
+  # `ugrep` has a compatibility mode for the `gnugrep`
+  # variants. When `$0` is one of the variants, `ugrep`
+  # behaves like it to be drop-in compatible. This can
+  # be done simply through symlinks, just like is done
+  # with `coreutils`. These will of course shadow the
+  # `pkgs.gnugrep` binaries in `system-path`.
+  createGrepReplacementLinks ? false,
+  # All we need is its `meta.priority` to ensure `ugrep`
+  # beats it.
+  gnugrep,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -41,8 +63,39 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postFixup = ''
+    # Needed because `ug+` and `ugrep+` are
+    # just scripts that call `ug` or `ugrep`
+    # with certain arguments. They must be
+    # reachable.
     for i in ug+ ugrep+; do
-      wrapProgram "$out/bin/$i" --prefix PATH : "$out/bin"
+      wrapProgram "$out/bin/$i" --prefix PATH : "${
+        lib.makeBinPath (
+          [ "$out" ]
+          ++ (lib.optionals wrapWithFilterUtils [
+            poppler-utils
+            antiword
+            pandoc
+            exiftool
+          ])
+        )
+      }"
+    done
+  ''
+  + lib.optionalString createGrepReplacementLinks ''
+    # These will be made relative by the
+    # `_makeSymlinksRelativeInAllOutputs`
+    # `postFixupHook`.
+    for i in ${
+      lib.concatStringsSep " " [
+        "grep"
+        "egrep"
+        "fgrep"
+        "zgrep"
+        "zegrep"
+        "zfgrep"
+      ]
+    }; do
+      ln -s "$out/bin/ugrep" "$out/bin/$i"
     done
   '';
 
@@ -52,16 +105,23 @@ stdenv.mkDerivation (finalAttrs: {
     };
   };
 
-  meta = with lib; {
-    description = "Ultra fast grep with interactive query UI";
-    homepage = "https://github.com/Genivia/ugrep";
-    changelog = "https://github.com/Genivia/ugrep/releases/tag/v${finalAttrs.version}";
-    maintainers = with maintainers; [
-      numkem
-      mikaelfangel
-    ];
-    license = licenses.bsd3;
-    platforms = platforms.all;
-    mainProgram = "ug";
-  };
+  meta =
+    with lib;
+    {
+      description = "Ultra fast grep with interactive query UI";
+      homepage = "https://github.com/Genivia/ugrep";
+      changelog = "https://github.com/Genivia/ugrep/releases/tag/v${finalAttrs.version}";
+      maintainers = with maintainers; [
+        numkem
+        mikaelfangel
+      ];
+      license = licenses.bsd3;
+      platforms = platforms.all;
+      mainProgram = "ug";
+    }
+    # Needed to ensure that the grep replacements take precedence over
+    # `gnugrep` when installed. Lower priority values win.
+    // lib.optionalAttrs createGrepReplacementLinks {
+      priority = (gnugrep.meta.priority or meta.defaultPriority) - 1;
+    };
 })


### PR DESCRIPTION
The `ugrep+` and `ug+` commands are the same as the `ugrep` and `ug` commands, but also use filters to search PDFs, documents, e-books, image metadata, when these filter tools are present:

- pdftotext
- antiword
- pandoc
- exiftool

`ugrep+` and `ug+` can now be wrapped to make those utilities accessible without the need for users to clutter their environments through installing them. This is opt-in with the `wrapWithFilterUtils` flag since these packages grow the closure size massively. <ins><b><em>Please view the below section for some further comments regarding this addition.</em></b></ins>

A `createGrepReplacementLinks` flag was also added to optionally create symlinks to serve as `gnugrep` drop-in replacements. This works just like with `coreutils`. We ensure that these variants beat `gnugrep`'s priority value so `ugrep` wins when building `system-path` with `buildEnv`. <ins><b><em>We optionally just subtract one from `gnugrep.meta.priority` or `lib.meta.defaultPriority` to do this. Should we just remove the check altogether and just give the package a higher priority as standard? What priority value should we use? If there are any suggestions for doing this in a better manner, do comment.</em></b></ins> I did consider adding an exclusions flag to exclude certain variants, but it seemed overkill.

Suggestions/votes for what approach is best are welcome.

References:

- <https://github.com/Genivia/ugrep#filter>
- <https://github.com/Genivia/ugrep#grep>

## Other possible implementations

> NOTE: Some of this is a bit out of sync with the actual diff, since `createGrepReplacementLinks` was added after this. The ideas remain the same in any case.

There are many possible ways to go about adding this in. Here are some other examples.

### Enabling the flag by default and creating a `ugrepMinimal` version with it disabled

This would following what was done with [`fish`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/fi/fish/package.nix) and [`fishMinimal`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/fi/fishMinimal/package.nix) as an example.

```patch
diff --git a/pkgs/by-name/ug/ugrep/package.nix b/pkgs/by-name/ug/ugrep/package.nix
index 5765e0898b09..2abb3cce9d8a 100644
--- a/pkgs/by-name/ug/ugrep/package.nix
+++ b/pkgs/by-name/ug/ugrep/package.nix
@@ -13,6 +13,17 @@
   xz,
   zlib,
   zstd,
+  # The `ugrep+` and `ug+` commands are the same as the
+  # `ugrep` and `ug` commands, but also use filters to
+  # search PDFs, documents, e-books, image metadata,
+  # when these filter tools are present:
+  poppler-utils, # Provides `pdftotext`.
+  antiword,
+  pandoc,
+  exiftool,
+  # Alleviates the need for users to pollute their
+  # environment with these packages.
+  wrapWithFilterUtils ? true,
 }:

 stdenv.mkDerivation (finalAttrs: {
@@ -42,7 +53,18 @@ stdenv.mkDerivation (finalAttrs: {

   postFixup = ''
     for i in ug+ ugrep+; do
-      wrapProgram "$out/bin/$i" --prefix PATH : "$out/bin"
+      wrapProgram "$out/bin/$i" --prefix PATH : "${
+        with lib;
+        makeBinPath (
+          [ "$out" ]
+          ++ (optionals wrapWithFilterUtils [
+            poppler-utils
+            antiword
+            pandoc
+            exiftool
+          ])
+        )
+      }"
     done
   '';

diff --git a/pkgs/by-name/ug/ugrepMinimal/package.nix b/pkgs/by-name/ug/ugrepMinimal/package.nix
new file mode 100644
index 000000000000..0e80d665f132
--- /dev/null
+++ b/pkgs/by-name/ug/ugrepMinimal/package.nix
@@ -0,0 +1,3 @@
+{ ugrep }:
+
+ugrep.override { wrapWithFilterUtils = false; }
```

### Flags per-utility

Having to enable each filter inclusion is an option, similar to what we do with [`git`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/version-management/git/default.nix) and [`subversion`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/version-management/subversion/default.nix).

In this case, we could also have various versions of the package like we do for `git` with various combinations of flags, such as `ugrepMinimal`, `ugrepFull`, `ugrepWithPDF`, etc.

```patch
diff --git a/pkgs/by-name/ug/ugrep/package.nix b/pkgs/by-name/ug/ugrep/package.nix
index 5765e0898b09..8f63b4cf4787 100644
--- a/pkgs/by-name/ug/ugrep/package.nix
+++ b/pkgs/by-name/ug/ugrep/package.nix
@@ -13,6 +13,21 @@
   xz,
   zlib,
   zstd,
+  # The `ugrep+` and `ug+` commands are the same as the
+  # `ugrep` and `ug` commands, but also use filters to
+  # search PDFs, documents, e-books, image metadata,
+  # when these filter tools are present:
+  poppler-utils, # Provides `pdftotext`.
+  antiword,
+  pandoc,
+  exiftool,
+  # Alleviates the need for users to pollute their
+  # environment with these packages, but grow the
+  # closure size substantially; hence these are opt-in.
+  pdfSupport ? false,
+  docSupport ? false,
+  pandocSupport ? false,
+  imageSupport ? false,
 }:

 stdenv.mkDerivation (finalAttrs: {
@@ -42,7 +57,16 @@ stdenv.mkDerivation (finalAttrs: {

   postFixup = ''
     for i in ug+ ugrep+; do
-      wrapProgram "$out/bin/$i" --prefix PATH : "$out/bin"
+      wrapProgram "$out/bin/$i" --prefix PATH : "${
+        with lib;
+        makeBinPath (
+          [ "$out" ]
+          ++ (optional pdfSupport poppler-utils)
+          ++ (optional docSupport antiword)
+          ++ (optional pandocSupport pandoc)
+          ++ (optional imageSupport exiftool)
+        )
+      }"
     done
   '';
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
