### PR TITLE
ddev: fix embedded version, use versionCheckHook

### DIFF
--- a/pkgs/by-name/dd/ddev/package.nix
+++ b/pkgs/by-name/dd/ddev/package.nix
@@ -4,8 +4,8 @@
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
-  testers,
-  ddev,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
 buildGoModule rec {
@@ -45,13 +45,13 @@ buildGoModule rec {
       --zsh .gotmp/bin/completions/ddev_zsh_completion.sh
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = ddev;
-    version = "ddev version v${version}";
-    command = ''
-      HOME=$(mktemp -d) ddev --version
-    '';
-  };
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckProgramArg = "--version";
+  versionCheckKeepEnvironment = [ "HOME" ];
 
   meta = with lib; {
     description = "Docker-based local PHP+Node.js web development environments";

--- a/pkgs/by-name/dd/ddev/package.nix
+++ b/pkgs/by-name/dd/ddev/package.nix
@@ -27,8 +27,8 @@ buildGoModule rec {
 
   ldflags = [
     "-extldflags -static"
-    "-X github.com/ddev/ddev/pkg/versionconstants.DdevVersion=${version}"
-    "-X github.com/ddev/ddev/pkg/versionconstants.SegmentKey=${version}"
+    "-X github.com/ddev/ddev/pkg/versionconstants.DdevVersion=v${version}"
+    "-X github.com/ddev/ddev/pkg/versionconstants.SegmentKey=v${version}"
   ];
 
   # Tests need docker.
@@ -47,11 +47,9 @@ buildGoModule rec {
 
   passthru.tests.version = testers.testVersion {
     package = ddev;
+    version = "ddev version v${version}";
     command = ''
-      # DDEV will try to create $HOME/.ddev, so we set $HOME to a temporary
-      # directory.
-      export HOME=$(mktemp -d)
-      ddev --version
+      HOME=$(mktemp -d) ddev --version
     '';
   };
 


### PR DESCRIPTION
closes https://github.com/NixOS/nixpkgs/pull/344503

Rather than force push to that PR i made a new one since the author is unresponsive, to avoid adding unresponsive maintainers.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
