### PR TITLE
nixos/services.qdrant: add options to override packages

### DIFF
--- a/nixos/modules/services/search/qdrant.nix
+++ b/nixos/modules/services/search/qdrant.nix
@@ -17,6 +17,10 @@ in
     services.qdrant = {
       enable = lib.mkEnableOption "Vector Search Engine for the next generation of AI applications";
 
+      package = lib.mkPackageOption pkgs "qdrant" { };
+
+      webUIPackage = lib.mkPackageOption pkgs "qdrant-web-ui" { };
+
       settings = lib.mkOption {
         description = ''
           Configuration for Qdrant
@@ -64,7 +68,7 @@ in
 
   config = lib.mkIf cfg.enable {
     services.qdrant.settings = {
-      service.static_content_dir = lib.mkDefault pkgs.qdrant-web-ui;
+      service.static_content_dir = lib.mkDefault cfg.webUIPackage;
       storage.storage_path = lib.mkDefault "/var/lib/qdrant/storage";
       storage.snapshots_path = lib.mkDefault "/var/lib/qdrant/snapshots";
       # The following default values are the same as in the default config,
@@ -106,7 +110,7 @@ in
 
       serviceConfig = {
         LimitNOFILE = 65536;
-        ExecStart = "${pkgs.qdrant}/bin/qdrant --config-path ${configFile}";
+        ExecStart = "${cfg.package}/bin/qdrant --config-path ${configFile}";
         DynamicUser = true;
         Restart = "on-failure";
         StateDirectory = "qdrant";


### PR DESCRIPTION
This makes it possible to deploy a different version of Qdrant, such as an unstable version, using the nixos qdrant module.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

