### PR TITLE
netgen: 6.2.2505 -> 6.2.2506

### DIFF
--- a/pkgs/by-name/ne/netgen/optional-arm-feature-complex.patch
+++ b/pkgs/by-name/ne/netgen/optional-arm-feature-complex.patch
@@ -1,0 +1,29 @@
+From 1d93dfba00f224787cfc2cde1af2ab5d7f5b87f7 Mon Sep 17 00:00:00 2001
+From: qbisi <qbisicwate@gmail.com>
+Date: Sat, 16 Nov 2024 22:20:00 +0800
+Subject: [PATCH] optional arm feature complex
+
+---
+ libsrc/core/simd_arm64.hpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/libsrc/core/simd_arm64.hpp b/libsrc/core/simd_arm64.hpp
+index 9e0bcce45..dc2190788 100644
+--- a/libsrc/core/simd_arm64.hpp
++++ b/libsrc/core/simd_arm64.hpp
+@@ -154,6 +154,7 @@ namespace ngcore
+     return FNMA(SIMD<double,2> (a), b, c);
+   }
+ 
++#ifdef __ARM_FEATURE_COMPLEX
+   // ARM complex mult:
+   // https://arxiv.org/pdf/1901.07294.pdf
+   // c += a*b    (a0re, a0im, a1re, a1im, ...), 
+@@ -162,6 +163,7 @@ namespace ngcore
+     auto tmp = vcmlaq_f64(c.Data(), a.Data(), b.Data());   // are * b
+     c = vcmlaq_rot90_f64(tmp, a.Data(), b.Data());    // += i*aim * b
+   }
++#endif
+   
+ 
+   NETGEN_INLINE SIMD<double,2> operator+ (SIMD<double,2> a, SIMD<double,2> b)

--- a/pkgs/by-name/ne/netgen/package.nix
+++ b/pkgs/by-name/ne/netgen/package.nix
@@ -48,11 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     # disable some platform specified code used by downstream ngsolve
     # can be enabled with -march=armv8.3-a+simd when compiling ngsolve
     # note compiling netgen itself is not influenced by this feature
-    (fetchpatch2 {
-      url = "https://github.com/NGSolve/netgen/pull/197/commits/1d93dfba00f224787cfc2cde1af2ab5d7f5b87f7.patch";
-      hash = "sha256-3Nom4uGhGLtSGn/k+qKKSxVxrGtGTHqPtcNn3D/gkZU";
-    })
-
+    ./optional-arm-feature-complex.patch
     (fetchpatch2 {
       url = "${patchSource}/use-local-catch2.patch";
       hash = "sha256-h4ob8tl6mvGt5B0qXRFNcl9MxPXxRhYw+PrGr5iRGGk=";


### PR DESCRIPTION
Diff: https://github.com/NGSolve/netgen/compare/v6.2.2505...v6.2.2506

Add a patch to fix segfault when exiting main program.
Fix patch for arm_simd.hpp when compiling without arm complex feature. The previous pr got closed, so the fetchpatch2 url no longer exist.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
