### PR TITLE
[backport  25.05] local-content-share init and updates 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6876,6 +6876,13 @@
     githubId = 757125;
     name = "Dzmitry Lahoda";
   };
+  e-v-o-l-v-e = {
+    name = "Ivanoe Megnin-Preiss";
+    email = "megninpreiss.ivanoe@gmail.com";
+    github = "e-v-o-l-v-e";
+    githubId = 84813895;
+    matrix = "@evolve:matrix.imp-network.com";
+  };
   e1mo = {
     email = "nixpkgs@e1mo.de";
     matrix = "@e1mo:chaos.jetzt";

--- a/pkgs/by-name/lo/local-content-share/package.nix
+++ b/pkgs/by-name/lo/local-content-share/package.nix
@@ -6,13 +6,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "local-content-share";
-  version = "34";
+  version = "35";
 
   src = fetchFromGitHub {
     owner = "Tanq16";
     repo = "local-content-share";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-3evUm6J/oGoDiuzVf63byKWbmHf7EAf/JElE7r/yfb8=";
+    hash = "sha256-pFYkq1QqGugOVT0uMPC11ChXtxMwGv4JZKGWIqK7y3s=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/lo/local-content-share/package.nix
+++ b/pkgs/by-name/lo/local-content-share/package.nix
@@ -6,13 +6,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "local-content-share";
-  version = "33";
+  version = "34";
 
   src = fetchFromGitHub {
     owner = "Tanq16";
     repo = "local-content-share";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ov7FiqznBQbp0YIi0DNTpsFvP4ui1GNtxXGIPGyvs+k=";
+    hash = "sha256-3evUm6J/oGoDiuzVf63byKWbmHf7EAf/JElE7r/yfb8=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/lo/local-content-share/package.nix
+++ b/pkgs/by-name/lo/local-content-share/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "local-content-share";
+  version = "31";
+
+  src = fetchFromGitHub {
+    owner = "Tanq16";
+    repo = "local-content-share";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BVO804Ndjbg4uEE1bufZcGZxEVdraV29LJ6yBWXTakA=";
+  };
+
+  vendorHash = null;
+
+  # no test file in upstream
+  doCheck = false;
+
+  meta = {
+    description = "Storing/sharing text/files in your local network with no setup on client devices";
+    homepage = "https://github.com/Tanq16/local-content-share";
+    license = lib.licenses.mit;
+    mainProgram = "local-content-share";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ e-v-o-l-v-e ];
+  };
+})

--- a/pkgs/by-name/lo/local-content-share/package.nix
+++ b/pkgs/by-name/lo/local-content-share/package.nix
@@ -6,13 +6,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "local-content-share";
-  version = "31";
+  version = "32";
 
   src = fetchFromGitHub {
     owner = "Tanq16";
     repo = "local-content-share";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-BVO804Ndjbg4uEE1bufZcGZxEVdraV29LJ6yBWXTakA=";
+    hash = "sha256-2TgamuHDASwSKshPkNLAnwnnCU23SvdXWv6sU++yBII=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/lo/local-content-share/package.nix
+++ b/pkgs/by-name/lo/local-content-share/package.nix
@@ -6,13 +6,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "local-content-share";
-  version = "32";
+  version = "33";
 
   src = fetchFromGitHub {
     owner = "Tanq16";
     repo = "local-content-share";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2TgamuHDASwSKshPkNLAnwnnCU23SvdXWv6sU++yBII=";
+    hash = "sha256-ov7FiqznBQbp0YIi0DNTpsFvP4ui1GNtxXGIPGyvs+k=";
   };
 
   vendorHash = null;


### PR DESCRIPTION
<!--
backport local-content-share init and updates to 25.05


-->

## Things done

https://github.com/NixOS/nixpkgs/pull/421331
https://github.com/NixOS/nixpkgs/pull/432080
https://github.com/NixOS/nixpkgs/pull/433657
https://github.com/NixOS/nixpkgs/pull/437230
https://github.com/NixOS/nixpkgs/pull/437230

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
