### PR TITLE
dumpyara: init at 1.1.0

### DIFF
--- a/pkgs/by-name/du/dumpyara/package.nix
+++ b/pkgs/by-name/du/dumpyara/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  runCommand,
+  python3Packages,
+  fetchFromGitHub,
+  callPackage,
+  nix-update-script,
+  _7zz,
+  android-tools,
+  cpio,
+  dumpyara,
+  erofs-utils,
+  squashfsTools,
+  zip,
+}:
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "dumpyara";
+  version = "1.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "sebaubuntu-python";
+    repo = "dumpyara";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-V7SX1XR+De3py6B3Fmqn1IehN0sGPxUKJ0YlGpBPHG4=";
+  };
+
+  build-system = with python3Packages; [ poetry-core ];
+
+  dependencies = with python3Packages; [
+    brotli
+    liblp
+    lz4
+    protobuf5
+    py7zr
+    sebaubuntu-libs
+    zstandard
+  ];
+
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [
+      _7zz
+      android-tools
+      cpio
+      erofs-utils
+    ])
+  ];
+
+  passthru = {
+    tests.requiredTools =
+      runCommand "check-required-tools"
+        {
+          nativeBuildInputs = [
+            android-tools
+            dumpyara
+            squashfsTools
+            zip
+          ];
+        }
+        ''
+          echo foo > bar.txt
+          mkbootimg --kernel bar.txt -o boot.img
+          mksquashfs bar.txt system.img
+          zip system.zip *.img
+          dumpyara system.zip
+          touch $out
+        '';
+    updateScript = nix-update-script { };
+  };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Android firmware dumper";
+    homepage = "https://github.com/sebaubuntu-python/dumpyara";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "dumpyara";
+  };
+})

--- a/pkgs/development/python-modules/sebaubuntu-libs/default.nix
+++ b/pkgs/development/python-modules/sebaubuntu-libs/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  android-image-kitchen,
+  gitpython,
+  poetry-core,
+  pyelftools,
+  requests,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "sebaubuntu-libs";
+  version = "2.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "sebaubuntu-python";
+    repo = "sebaubuntu_libs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LV7Me+GmgOvDh0XGoLaftCKtP/fnB5xVqb8nArOMIys=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    gitpython
+    pyelftools
+    requests
+  ];
+
+  postPatch = ''
+    # Patch libaik to use AIK from nixpkgs
+    substituteInPlace sebaubuntu_libs/libaik/__init__.py \
+      --replace-fail \
+        "Repo.clone_from(AIK_REPO, self.path)" "" \
+      --replace-fail \
+        "unpackimg.sh" "${lib.getExe' android-image-kitchen "aik-unpackimg"}" \
+      --replace-fail \
+        "repack.sh" "${lib.getExe' android-image-kitchen "aik-repackimg"}" \
+      --replace-fail \
+        "cleanup.sh" "${lib.getExe' android-image-kitchen "aik-cleanup"}" \
+      --replace-fail \
+        'command = [self.path / script, "--nosudo", *args]' \
+        'command = [script, "--nosudo", *args]' \
+      --replace-fail \
+        'return check_output(command, stderr=STDOUT, universal_newlines=True, encoding="utf-8")' \
+        'return check_output(command, stderr=STDOUT, universal_newlines=True, encoding="utf-8",
+          cwd=self.path)'
+  '';
+
+  # Module has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "sebaubuntu_libs" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "SebaUbuntu's shared libs";
+    homepage = "https://github.com/sebaubuntu-python/sebaubuntu_libs";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17393,6 +17393,8 @@ self: super: with self; {
 
   seatconnect = callPackage ../development/python-modules/seatconnect { };
 
+  sebaubuntu-libs = callPackage ../development/python-modules/sebaubuntu-libs { };
+
   seccomp = callPackage ../development/python-modules/seccomp { };
 
   secp256k1 = callPackage ../development/python-modules/secp256k1 { inherit (pkgs) secp256k1; };


### PR DESCRIPTION
Add dumpyara, a tool for dumping Android firmware.

I have integrated a basic test to check if dumping firmware works. The test creates a SquashFS file containing a simple text file inside a ZIP archive which is then extracted using dumpyara.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
