### PR TITLE
froide-govplan: 0-unstable-2025-06-25 -> 0-unstable-2025-07-14

### DIFF
--- a/pkgs/by-name/fr/froide-govplan/froide_avoid_loading_account_module.patch
+++ b/pkgs/by-name/fr/froide-govplan/froide_avoid_loading_account_module.patch
@@ -1,0 +1,18 @@
+diff --git a/froide/helper/templatetags/permission_helper.py b/froide/helper/templatetags/permission_helper.py
+index c9d692e2..5bddaa21 100644
+--- a/froide/helper/templatetags/permission_helper.py
++++ b/froide/helper/templatetags/permission_helper.py
+@@ -1,7 +1,5 @@
+ from django import template
+ 
+-from ..auth import can_moderate_object
+-
+ register = template.Library()
+ 
+ 
+@@ -12,4 +10,4 @@ def has_perm(user, perm):
+ 
+ @register.filter
+ def can_moderate(obj, request):
+-    return can_moderate_object(obj, request)
++    return False

--- a/pkgs/by-name/fr/froide-govplan/package.nix
+++ b/pkgs/by-name/fr/froide-govplan/package.nix
@@ -21,7 +21,7 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "froide-govplan";
-  version = "0-unstable-2025-06-25";
+  version = "0-unstable-2025-07-14";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -29,8 +29,8 @@ python.pkgs.buildPythonApplication rec {
     repo = "froide-govplan";
     # No tagged release yet
     # https://github.com/okfde/froide-govplan/issues/15
-    rev = "9c325e70a84f26fea37b5a34f24d19fd82ea62ff";
-    hash = "sha256-OD4vvKt0FLuiAVGwpspWLB2ZuM1UJkZdv2YcbKKYk9A=";
+    rev = "7d304ae0e34e44f3bc34dce2b7e5f3c62bd64299";
+    hash = "sha256-/0KASLvKWgXBrhYkPeOkWfovNLAuKB5m0PVkQvC6w7s=";
   };
 
   patches = [
@@ -80,17 +80,11 @@ python.pkgs.buildPythonApplication rec {
     django-tinymce
     django-treebeard
     djangocms-alias
-    # Downgrade to last working version
+    # Patch froide to avoid loading account module
     (toPythonModule (
       froide.overridePythonAttrs (prev: {
-        nativeBuildInputs = [ makeBinaryWrapper ];
-        postBuild = "";
+        patches = prev.patches ++ [ ./froide_avoid_loading_account_module.patch ];
         doCheck = false;
-        pnpmDeps = null;
-        src = prev.src.override {
-          rev = "a78a4054f9f37b0a5109a6d8cfbbda742f86a8ca";
-          hash = "sha256-gtOssbsVf3nG+pmLPgvh4685vHh2x+jlXiTjU+JhQa8=";
-        };
       })
     ))
     nh3

--- a/pkgs/by-name/fr/froide/package.nix
+++ b/pkgs/by-name/fr/froide/package.nix
@@ -39,14 +39,14 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "froide";
-  version = "0-unstable-2025-07-01";
+  version = "0-unstable-2025-09-10";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "okfde";
     repo = "froide";
-    rev = "362bddb5a8fdfe762d59cdebd29016568c9531b2";
-    hash = "sha256-c8I/FvXQSkAeacxMQJCpCMKFueNEnLI4R0ElqRbVbNg=";
+    rev = "826415bbc402c3b71c62477f5eed112787169c95";
+    hash = "sha256-K9TMtDfYP6v/lbL7SXeHBa6EngK+fsHgU13C1hat/K0=";
   };
 
   patches = [ ./django_42_storages.patch ];

--- a/pkgs/development/python-modules/django-filingcabinet/default.nix
+++ b/pkgs/development/python-modules/django-filingcabinet/default.nix
@@ -37,7 +37,7 @@
 
 buildPythonPackage rec {
   pname = "django-filingcabinet";
-  version = "0.17-unstable-2025-07-01";
+  version = "0.17-unstable-2025-08-14";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -45,8 +45,8 @@ buildPythonPackage rec {
     repo = "django-filingcabinet";
     # No release tagged yet on GitHub
     # https://github.com/okfde/django-filingcabinet/issues/69
-    rev = "ff39722209acf70bc73fa7074c16ed8a787fceea";
-    hash = "sha256-9SrMWBTk7RQCbVPHOU5rB/pi286hb6UONaLmBOtx6X0=";
+    rev = "e1713921d6d14e0abc8b81315545d7fb6f08c39f";
+    hash = "sha256-R/JNI+PZb0H09ZoYCGV3nbAowkf/YlKia4xkgAgqoNM=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Changes:

- froide https://github.com/okfde/froide/compare/362bddb5a8fdfe762d59cdebd29016568c9531b2...826415bbc402c3b71c62477f5eed112787169c95
- froide-govplan https://github.com/okfde/froide-govplan/compare/9c325e70a84f26fea37b5a34f24d19fd82ea62ff...7d304ae0e34e44f3bc34dce2b7e5f3c62bd64299
- django-filingcabinet https://github.com/okfde/django-filingcabinet/compare/ff39722209acf70bc73fa7074c16ed8a787fceea...e1713921d6d14e0abc8b81315545d7fb6f08c39f
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
