### PR TITLE
buildKernelModule: init

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -4303,6 +4303,9 @@
   "sec-linux-kernel-developing-modules": [
     "index.html#sec-linux-kernel-developing-modules"
   ],
+  "sec-packaging-out-of-tree-kernel-modules": [
+    "index.html#sec-packaging-out-of-tree-kernel-modules"
+  ],
   "ex-edit-compile-run-kernel-modules": [
     "index.html#ex-edit-compile-run-kernel-modules"
   ],

--- a/pkgs/build-support/kernel/build-kernel-module.nix
+++ b/pkgs/build-support/kernel/build-kernel-module.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  callPackage,
+  pkg-config,
+  stdenv,
+  kernel,
+}@topLevelArgs:
+
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+
+  extendDrvArgs =
+    finalAttrs:
+    {
+      pname,
+      version,
+      nativeBuildInputs ? [ ],
+      kernel ? topLevelArgs.kernel,
+      hardeningDisable ? [ ],
+      enableParallelBuilding ? true,
+      ...
+    }@args:
+
+    {
+      name = "${pname}-${kernel.version}-${version}";
+      nativeBuildInputs = nativeBuildInputs ++ kernel.moduleBuildDependencies;
+
+      hardeningDisable = hardeningDisable ++ [ "pic" ];
+      inherit enableParallelBuilding;
+
+      meta = args.meta // {
+        platforms = args.meta.platforms or lib.platforms.linux;
+      };
+    };
+}

--- a/pkgs/os-specific/linux/rtl8821cu/default.nix
+++ b/pkgs/os-specific/linux/rtl8821cu/default.nix
@@ -1,15 +1,16 @@
 {
   lib,
-  stdenv,
+  buildKernelModule,
   fetchFromGitHub,
   kernel,
   kernelModuleMakeFlags,
   bc,
+  nix-update-script,
 }:
 
-stdenv.mkDerivation {
+buildKernelModule {
   pname = "rtl8821cu";
-  version = "${kernel.version}-unstable-2025-05-08";
+  version = "unstable-2025-05-08";
 
   src = fetchFromGitHub {
     owner = "morrownr";
@@ -18,9 +19,7 @@ stdenv.mkDerivation {
     hash = "sha256-ExT7ONQeejFoMwUUXKua7wMnRi+3IYayLmlWIEWteK4=";
   };
 
-  hardeningDisable = [ "pic" ];
-
-  nativeBuildInputs = [ bc ] ++ kernel.moduleBuildDependencies;
+  nativeBuildInputs = [ bc ];
   makeFlags = kernelModuleMakeFlags;
 
   prePatch = ''
@@ -34,13 +33,12 @@ stdenv.mkDerivation {
     mkdir -p "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
   '';
 
-  enableParallelBuilding = true;
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = with lib; {
     description = "Realtek rtl8821cu driver";
     homepage = "https://github.com/morrownr/8821cu-20210916";
     license = licenses.gpl2Only;
-    platforms = platforms.linux;
     maintainers = [ maintainers.contrun ];
   };
 }

--- a/pkgs/os-specific/linux/rtl8821cu/default.nix
+++ b/pkgs/os-specific/linux/rtl8821cu/default.nix
@@ -10,13 +10,13 @@
 
 buildKernelModule {
   pname = "rtl8821cu";
-  version = "unstable-2025-05-08";
+  version = "0-unstable-2025-09-10";
 
   src = fetchFromGitHub {
     owner = "morrownr";
     repo = "8821cu-20210916";
-    rev = "d74134a1c68f59f2b80cdd6c6afb8c1a8a687cbf";
-    hash = "sha256-ExT7ONQeejFoMwUUXKua7wMnRi+3IYayLmlWIEWteK4=";
+    rev = "07fa9cf0fa8b0c08920c359c725dfc250e91422b";
+    hash = "sha256-JAkh0Vnt+Hg16F2xCsFPs5SAmaS2oqdIf45L0hXN0iY=";
   };
 
   nativeBuildInputs = [ bc ];

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -349,6 +349,8 @@ in
         kernelModuleMakeFlags = self.kernel.commonMakeFlags ++ [
           "KBUILD_OUTPUT=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
         ];
+        buildKernelModule = callPackage ../build-support/kernel/build-kernel-module.nix { };
+
         # Obsolete aliases (these packages do not depend on the kernel).
         inherit (pkgs) odp-dpdk pktgen; # added 2018-05
         inherit (pkgs) bcc bpftrace; # added 2021-12


### PR DESCRIPTION
This build helper allows easy building of a kernel module.
In particular this automatically adds `kernel.version` to the derivation name,
which has been a standard practice. Doing this in every kernel module manually is tedius and breaks update scripts.

This structure allows update scripts to easily update the version attribute.

Additionally it sets some default values (like adding `kernel.moduleBuildDependencies`).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
