### PR TITLE
nixos/umurmur: fix settings freeformType

### DIFF
--- a/nixos/modules/services/networking/umurmur.nix
+++ b/nixos/modules/services/networking/umurmur.nix
@@ -53,14 +53,14 @@ in
             let
               valueType =
                 with lib.types;
-                oneOf [
+                (attrsOf (oneOf [
                   bool
                   int
                   float
                   str
                   path
-                  (listOf (attrsOf valueType))
-                ]
+                  (listOf valueType)
+                ]))
                 // {
                   description = "uMurmur config value";
                 };


### PR DESCRIPTION
I got this evaluation error in the umurmur NixOS module:
```
building the system configuration...
error:
       … while calling the 'head' builtin
         at /nix/store/lvwgkdy9nrki8qcrdsqnpfrk7562m1dc-source/lib/attrsets.nix:1701:13:
         1700|           if length values == 1 || pred here (elemAt values 1) (head values) then
         1701|             head values
             |             ^
         1702|           else

       … while evaluating the attribute 'value'
         at /nix/store/lvwgkdy9nrki8qcrdsqnpfrk7562m1dc-source/lib/modules.nix:1118:7:
         1117|     // {
         1118|       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |       ^
         1119|       inherit (res.defsFinal') highestPrio;

       … while evaluating the option `system.build.toplevel':

       … while evaluating definitions from `/nix/store/lvwgkdy9nrki8qcrdsqnpfrk7562m1dc-source/nixos/modules/system/activation/top-level.nix':

       … while evaluating the option `warnings':

       … while evaluating definitions from `/nix/store/lvwgkdy9nrki8qcrdsqnpfrk7562m1dc-source/nixos/modules/system/boot/systemd.nix':

       … while evaluating the option `systemd.services.firewall.serviceConfig':

       … while evaluating definitions from `/nix/store/lvwgkdy9nrki8qcrdsqnpfrk7562m1dc-source/nixos/modules/services/networking/firewall-iptables.nix':

       … while evaluating the option `networking.firewall.allInterfaces.default.allowedTCPPorts':

       … while evaluating definitions from `/nix/store/lvwgkdy9nrki8qcrdsqnpfrk7562m1dc-source/nixos/modules/services/networking/firewall.nix':

       … while evaluating the option `networking.firewall.allowedTCPPorts':

       … while evaluating definitions from `/nix/store/lvwgkdy9nrki8qcrdsqnpfrk7562m1dc-source/nixos/modules/services/networking/umurmur.nix':

       … while evaluating the option `services.umurmur.settings':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: evaluation aborted with the following error message: '(t.merge.v2 defs).value must only be accessed when `.headError == null`. This is a bug in code that consumes a module system type.'
```

Seems to be the same kind of error as https://github.com/NixOS/nixpkgs/issues/438459 @hsjobeki

I verified that my change fixes the evaluation error.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
