### PR TITLE
[25.05] nixos/immich: add support for VectorChord

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -539,6 +539,12 @@
   "module-services-suwayomi-server-extra-config": [
     "index.html#module-services-suwayomi-server-extra-config"
   ],
+  "module-services-immich": [
+    "index.html#module-services-immich"
+  ],
+  "module-services-immich-vectorchord-migration": [
+    "index.html#module-services-immich-vectorchord-migration"
+  ],
   "module-services-plausible": [
     "index.html#module-services-plausible"
   ],

--- a/nixos/modules/services/web-apps/immich.md
+++ b/nixos/modules/services/web-apps/immich.md
@@ -1,0 +1,32 @@
+# Immich {#module-services-immich}
+
+[Immich](https://immich.app/) is a self-hosted photo and video management
+solution, similar to SaaS offerings like Google Photos.
+
+## Migrating from `pgvecto-rs` to VectorChord (pre-25.11 installations) {#module-services-immich-vectorchord-migration}
+
+Immich instances that were setup before 25.11 (as in
+`system.stateVersion = 25.11;`) will be automatically migrated to VectorChord.
+Note that this migration is not reversible, so database dumps should be created
+if desired.
+
+See [Immich documentation][vectorchord-migration-docs] for more details about
+the automatic migration.
+
+After a successful migration, `pgvecto-rs` should be removed from the database
+installation, unless other applications depend on it.
+
+1. Make sure VectorChord is enabled ([](#opt-services.immich.database.enableVectorChord)) and Immich has completed the migration. Refer to the [Immich documentation][vectorchord-migration-docs] for details.
+2. Run the following two statements in the PostgreSQL database using a superuser role in Immich's database.
+
+    ```sql
+    DROP EXTENSION vectors;
+    DROP SCHEMA vectors;
+    ```
+
+    - You may use the following command to run these statements against the database: `sudo -u postgres psql immich` (Replace `immich` with the value of [](#opt-services.immich.database.name))
+
+3. Disable `pgvecto-rs` by setting [](#opt-services.immich.database.enableVectors) to `false`.
+4. Rebuild and switch.
+
+[vectorchord-migration-docs]: https://immich.app/docs/administration/postgres-standalone/#migrating-to-vectorchord

--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -436,5 +436,8 @@ in
     };
     users.groups = mkIf (cfg.group == "immich") { immich = { }; };
   };
-  meta.maintainers = with lib.maintainers; [ jvanbruegge ];
+  meta = {
+    maintainers = with lib.maintainers; [ jvanbruegge ];
+    doc = ./immich.md;
+  };
 }

--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -182,6 +182,11 @@ in
         // {
           default = true;
         };
+      enableVectorChord =
+        mkEnableOption "the new VectorChord extension for full-text search in Postgres"
+        // {
+          default = true;
+        };
       createDB = mkEnableOption "the automatic creation of the database for immich." // {
         default = true;
       };
@@ -243,27 +248,43 @@ in
           ensureClauses.login = true;
         }
       ];
-      extensions = ps: with ps; [ pgvecto-rs ];
+      extensions =
+        ps:
+        [ ps.pgvecto-rs ]
+        ++ lib.optionals cfg.database.enableVectorChord [
+          ps.vectors
+          ps.vectorchord
+        ];
       settings = {
-        shared_preload_libraries = [ "vectors.so" ];
+        shared_preload_libraries = [
+          "vectors.so"
+        ]
+        ++ lib.optionals cfg.database.enableVectorChord [ "vchord.so" ];
         search_path = "\"$user\", public, vectors";
       };
     };
     systemd.services.postgresql.serviceConfig.ExecStartPost =
       let
+        extensions = [
+          "unaccent"
+          "uuid-ossp"
+          "vectors"
+          "cube"
+          "earthdistance"
+          "pg_trgm"
+        ]
+        ++ lib.optionals cfg.database.enableVectorChord [
+          "vector"
+          "vchord"
+        ];
         sqlFile = pkgs.writeText "immich-pgvectors-setup.sql" ''
-          CREATE EXTENSION IF NOT EXISTS unaccent;
-          CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
-          CREATE EXTENSION IF NOT EXISTS vectors;
-          CREATE EXTENSION IF NOT EXISTS cube;
-          CREATE EXTENSION IF NOT EXISTS earthdistance;
-          CREATE EXTENSION IF NOT EXISTS pg_trgm;
+          ${lib.concatMapStringsSep "\n" (ext: "CREATE EXTENSION IF NOT EXISTS \"${ext}\";") extensions}
 
           ALTER SCHEMA public OWNER TO ${cfg.database.user};
           ALTER SCHEMA vectors OWNER TO ${cfg.database.user};
           GRANT SELECT ON TABLE pg_vector_index_stat TO ${cfg.database.user};
 
-          ALTER EXTENSION vectors UPDATE;
+          ${lib.concatMapStringsSep "\n" (ext: "ALTER EXTENSION \"${ext}\" UPDATE;") extensions}
         '';
       in
       [

--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -330,7 +330,8 @@ in
 
     systemd.services.immich-server = {
       description = "Immich backend server (Self-hosted photo and video backup solution)";
-      after = [ "network.target" ];
+      requires = lib.mkIf cfg.database.enable [ "postgresql.service" ];
+      after = [ "network.target" ] ++ lib.optionals cfg.database.enable [ "postgresql.service" ];
       wantedBy = [ "multi-user.target" ];
       inherit (cfg) environment;
       path = [
@@ -357,7 +358,8 @@ in
 
     systemd.services.immich-machine-learning = mkIf cfg.machine-learning.enable {
       description = "immich machine learning";
-      after = [ "network.target" ];
+      requires = lib.mkIf cfg.database.enable [ "postgresql.service" ];
+      after = [ "network.target" ] ++ lib.optionals cfg.database.enable [ "postgresql.service" ];
       wantedBy = [ "multi-user.target" ];
       inherit (cfg.machine-learning) environment;
       serviceConfig = commonServiceConfig // {

--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -187,6 +187,12 @@ in
         // {
           default = true;
         };
+      enableVectors =
+        mkEnableOption "pgvecto.rs in the database. You may disable this, if you have migrated to VectorChord and deleted the `vectors` schema."
+        // {
+          default = lib.versionOlder config.system.stateVersion "25.11";
+          defaultText = lib.literalExpression "lib.versionOlder config.system.stateVersion \"25.11\"";
+        };
       createDB = mkEnableOption "the automatic creation of the database for immich." // {
         default = true;
       };
@@ -236,6 +242,17 @@ in
         assertion = !isPostgresUnixSocket -> cfg.secretsFile != null;
         message = "A secrets file containing at least the database password must be provided when unix sockets are not used.";
       }
+      {
+        # When removing this assertion, please adjust the nixosTests accordingly.
+        assertion =
+          (cfg.database.enable && cfg.database.enableVectors)
+          -> lib.versionOlder config.services.postgresql.package.version "17";
+        message = "Immich doesn't support PostgreSQL 17+ when using pgvecto.rs. Consider disabling it using services.immich.database.enableVectors if it is not needed anymore.";
+      }
+      {
+        assertion = cfg.database.enable -> (cfg.database.enableVectorChord || cfg.database.enableVectors);
+        message = "At least one of services.immich.database.enableVectorChord and services.immich.database.enableVectors has to be enabled.";
+      }
     ];
 
     services.postgresql = mkIf cfg.database.enable {
@@ -250,16 +267,17 @@ in
       ];
       extensions =
         ps:
-        [ ps.pgvecto-rs ]
+        lib.optionals cfg.database.enableVectors [ ps.pgvecto-rs ]
         ++ lib.optionals cfg.database.enableVectorChord [
-          ps.vectors
+          ps.pgvector
           ps.vectorchord
         ];
       settings = {
-        shared_preload_libraries = [
-          "vectors.so"
-        ]
-        ++ lib.optionals cfg.database.enableVectorChord [ "vchord.so" ];
+        shared_preload_libraries =
+          lib.optionals cfg.database.enableVectors [
+            "vectors.so"
+          ]
+          ++ lib.optionals cfg.database.enableVectorChord [ "vchord.so" ];
         search_path = "\"$user\", public, vectors";
       };
     };
@@ -268,10 +286,12 @@ in
         extensions = [
           "unaccent"
           "uuid-ossp"
-          "vectors"
           "cube"
           "earthdistance"
           "pg_trgm"
+        ]
+        ++ lib.optionals cfg.database.enableVectors [
+          "vectors"
         ]
         ++ lib.optionals cfg.database.enableVectorChord [
           "vector"
@@ -281,7 +301,7 @@ in
           ${lib.concatMapStringsSep "\n" (ext: "CREATE EXTENSION IF NOT EXISTS \"${ext}\";") extensions}
 
           ALTER SCHEMA public OWNER TO ${cfg.database.user};
-          ALTER SCHEMA vectors OWNER TO ${cfg.database.user};
+          ${lib.optionalString cfg.database.enableVectors "ALTER SCHEMA vectors OWNER TO ${cfg.database.user};"}
           GRANT SELECT ON TABLE pg_vector_index_stat TO ${cfg.database.user};
 
           ${lib.concatMapStringsSep "\n" (ext: "ALTER EXTENSION \"${ext}\" UPDATE;") extensions}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -640,6 +640,7 @@ in
   image-contents = handleTest ./image-contents.nix { };
   immich = handleTest ./web-apps/immich.nix { };
   immich-public-proxy = handleTest ./web-apps/immich-public-proxy.nix { };
+  immich-vectorchord-migration = runTest ./web-apps/immich-vectorchord-migration.nix;
   incron = handleTest ./incron.nix { };
   incus = pkgs.recurseIntoAttrs (
     handleTest ./incus {

--- a/nixos/tests/web-apps/immich-vectorchord-migration.nix
+++ b/nixos/tests/web-apps/immich-vectorchord-migration.nix
@@ -1,0 +1,71 @@
+{ ... }:
+{
+  name = "immich-vectorchord-migration";
+
+  nodes.machine =
+    { lib, pkgs, ... }:
+    {
+      # These tests need a little more juice
+      virtualisation = {
+        cores = 2;
+        memorySize = 2048;
+        diskSize = 4096;
+      };
+
+      environment.systemPackages = with pkgs; [ immich-cli ];
+
+      services.immich = {
+        enable = true;
+        environment.IMMICH_LOG_LEVEL = "verbose";
+        # Simulate an existing setup
+        database.enableVectorChord = lib.mkDefault false;
+        database.enableVectors = lib.mkDefault true;
+      };
+
+      # TODO: Remove when PostgreSQL 17 is supported.
+      services.postgresql.package = pkgs.postgresql_16;
+
+      specialisation."immich-vectorchord-enabled".configuration = {
+        services.immich.database.enableVectorChord = true;
+      };
+
+      specialisation."immich-vectorchord-only".configuration = {
+        services.immich.database = {
+          enableVectorChord = true;
+          enableVectors = false;
+        };
+      };
+    };
+
+  testScript =
+    { nodes, ... }:
+    let
+      specBase = "${nodes.machine.system.build.toplevel}/specialisation";
+      vectorchordEnabled = "${specBase}/immich-vectorchord-enabled";
+      vectorchordOnly = "${specBase}/immich-vectorchord-only";
+    in
+    ''
+      def psql(command: str):
+        machine.succeed(f"sudo -u postgres psql -d ${nodes.machine.services.immich.database.name} -c '{command}'")
+
+      def immich_works():
+        machine.wait_for_unit("immich-server.service")
+
+        machine.wait_for_open_port(2283) # Server
+        machine.wait_for_open_port(3003) # Machine learning
+        machine.succeed("curl --fail http://localhost:2283/")
+
+      immich_works()
+
+      machine.succeed("${vectorchordEnabled}/bin/switch-to-configuration test")
+
+      immich_works()
+
+      psql("DROP EXTENSION vectors;")
+      psql("DROP SCHEMA vectors;")
+
+      machine.succeed("${vectorchordOnly}/bin/switch-to-configuration test")
+
+      immich_works()
+    '';
+}

--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -249,7 +249,7 @@ stdenv.mkDerivation {
 
   passthru = {
     tests = {
-      inherit (nixosTests) immich;
+      inherit (nixosTests) immich immich-vectorchord-migration;
     };
 
     machine-learning = immich-machine-learning;


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/428568 to 25.05

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
