### PR TITLE
aws-*: update

### DIFF
--- a/pkgs/by-name/aw/aws-c-auth/package.nix
+++ b/pkgs/by-name/aw/aws-c-auth/package.nix
@@ -16,13 +16,13 @@
 stdenv.mkDerivation rec {
   pname = "aws-c-auth";
   # nixpkgs-update: no auto update
-  version = "0.9.0";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-auth";
-    rev = "v${version}";
-    hash = "sha256-HzDUINTmgjW7rNEe+5iwZBv6ayxNKmGAJy+Lg4tp1t0=";
+    tag = "v${version}";
+    hash = "sha256-8oQTTqBuEzhBUWqXHVYrGtaX44SmB2sJQZchiweHekM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/aw/aws-c-event-stream/package.nix
+++ b/pkgs/by-name/aw/aws-c-event-stream/package.nix
@@ -15,13 +15,13 @@
 stdenv.mkDerivation rec {
   pname = "aws-c-event-stream";
   # nixpkgs-update: no auto update
-  version = "0.5.5";
+  version = "0.5.7";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-event-stream";
     rev = "v${version}";
-    hash = "sha256-wVjpDKKwoksq5gFtvhH76c7ciP0XmMozhkWmzY6GwgU=";
+    hash = "sha256-JvjUrIj1bh5WZEzkauLSLIolxrT8CKIMjO7p1c35XZI=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/aw/aws-c-io/package.nix
+++ b/pkgs/by-name/aw/aws-c-io/package.nix
@@ -12,13 +12,13 @@
 stdenv.mkDerivation rec {
   pname = "aws-c-io";
   # nixpkgs-update: no auto update
-  version = "0.21.2";
+  version = "0.22.0";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-io";
     rev = "v${version}";
-    hash = "sha256-QNf4TJIqtypDliiu6I72CbgjyJhdS9Uuim9tZOb3SJs=";
+    hash = "sha256-NOEjXk4s/FV4CdmyXOr4Oh2y+pFNrUMP/Sy+X+fVQc4=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/aw/aws-c-s3/package.nix
+++ b/pkgs/by-name/aw/aws-c-s3/package.nix
@@ -17,13 +17,13 @@
 stdenv.mkDerivation rec {
   pname = "aws-c-s3";
   # nixpkgs-update: no auto update
-  version = "0.8.6";
+  version = "0.8.7";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-s3";
     rev = "v${version}";
-    hash = "sha256-g2w1igjv0N0o6+bewypJm2coHTvhYN2v8usdMN7TBI4=";
+    hash = "sha256-8yUwgiZ50BiItapeg0zIc5vr0+OFHvzIRrwWH4lQFBM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/aw/aws-crt-cpp/package.nix
+++ b/pkgs/by-name/aw/aws-crt-cpp/package.nix
@@ -20,7 +20,7 @@
 stdenv.mkDerivation rec {
   pname = "aws-crt-cpp";
   # nixpkgs-update: no auto update
-  version = "0.33.1";
+  version = "0.34.3";
 
   outputs = [
     "out"
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     owner = "awslabs";
     repo = "aws-crt-cpp";
     rev = "v${version}";
-    sha256 = "sha256-C8KWe5+CXujD8nN3gLkjaaMld15sat/ohwEKhyWELKI=";
+    sha256 = "sha256-jKmIsWAzxnfsNgHavR6crhIQXVJq/PbQgaj4KVGrMP0=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/aw/aws-sdk-cpp/package.nix
+++ b/pkgs/by-name/aw/aws-sdk-cpp/package.nix
@@ -35,13 +35,13 @@ in
 stdenv.mkDerivation rec {
   pname = "aws-sdk-cpp";
   # nixpkgs-update: no auto update
-  version = "1.11.612";
+  version = "1.11.647";
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "aws-sdk-cpp";
     rev = version;
-    hash = "sha256-W4eKgUvN2NLYEOO47HTJYJpEmyn10gNK29RIrvoXkek=";
+    hash = "sha256-RJKR0xw3HTNItaLGyYCjibmfK3UBDA4hfAZzQ0xYg9U=";
   };
 
   postPatch = ''


### PR DESCRIPTION
CC @peterwaller-arm

Related:
- #442740

Previously:
- https://github.com/NixOS/nixpkgs/pull/428410

I built and tested Nix with these patches.

## Updates

1. **aws-c-auth**: Updated from version `0.9.0` to `0.9.1`
   [Diff](https://github.com/awslabs/aws-c-auth/compare/v0.9.0...v0.9.1)

2. **aws-c-event-stream**: Updated from version `0.5.5` to `0.5.7`
   [Diff](https://github.com/awslabs/aws-c-event-stream/compare/v0.5.5...v0.5.7)

3. **aws-c-s3**: Updated from version `0.8.6` to `0.8.7`
   [Diff](https://github.com/awslabs/aws-c-s3/compare/v0.8.6...v0.8.7)

4. **aws-c-io**: Updated from version `0.21.2` to `0.22.0`
   [Diff](https://github.com/awslabs/aws-c-io/compare/v0.21.2...v0.22.0)

5. **aws-crt-cpp**: Updated from version `0.33.1` to `0.34.3`
   [Diff](https://github.com/awslabs/aws-crt-cpp/compare/v0.33.1...v0.34.3)

6. **aws-sdk-cpp**: Updated from version `1.11.612` to `1.11.647`
   [Diff](https://github.com/aws/aws-sdk-cpp/compare/1.11.612...1.11.647)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
