### PR TITLE
bluej: fix illegal import

### DIFF
--- a/pkgs/by-name/bl/bluej/package.nix
+++ b/pkgs/by-name/bl/bluej/package.nix
@@ -86,6 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
       --suffix XDG_DATA_DIRS : ${gtk3}/share/gsettings-schemas/${gtk3.name}/ \
       --add-flags "-Dawt.useSystemAAFontSettings=on \
                    --add-opens javafx.graphics/com.sun.glass.ui=ALL-UNNAMED \
+                   --add-opens javafx.graphics/com.sun.javafx.scene.input=ALL-UNNAMED \
                    -cp $out/lib/bluej/boot.jar bluej.Boot"
 
     runHook postInstall


### PR DESCRIPTION
```
Exception in thread "JavaFX Application Thread" java.lang.IllegalAccessError: superinterface check failed: class bluej.editor.flow.FlowEditorPane$1 (in unnamed module @0x630a1c4c) cannot access class com.sun.javafx.scene.input.ExtendedInputMethodRequests (in module javafx.graphics) because module javafx.graphics does not export com.sun.javafx.scene.input to unnamed module @0x630a1c4c
```

This error is encountered when you try to edit a file. Everything seems to work fine now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
