### PR TITLE
haskellPackages.mkDerivation: enforce unix line endings in cabal files

### DIFF
--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -260,6 +260,14 @@ the same package with the `previousIntermediates` argument to support
 incremental builds. See [“Incremental builds”](#haskell-incremental-builds) for
 more information. Defaults to `false`.
 
+`dontConvertCabalFileToUnix`
+: By default, `haskellPackages.mkDerivation` converts the `.cabal` file of a
+given package to Unix line endings.
+This is intended to work around
+[Hackage converting revised `.cabal` files to DOS line endings](https://github.com/haskell/hackage-server/issues/316)
+which frequently causes patches to stop applying.
+You can pass `true` to disable this behavior.
+
 `enableLibraryProfiling`
 : Whether to enable [profiling][profiling] for libraries contained in the
 package. Enabled by default if supported.

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -32,6 +32,8 @@
 
 - GHC 8.6, 8.10, 9.0, 9.2, and their package sets have been removed.
 
+- The `haskellPackages.mkDerivation` builder now converts packages' cabal files to Unix line endings before `patchPhase`. This behavior can be disabled using `dontConvertCabalFileToUnix`.
+
 - Support for bootstrapping native GHC compilers on 32‐bit ARM and little‐endian 64‐bit PowerPC has been dropped.
   The latter was probably broken anyway.
   If there is interest in restoring support for these architectures, it should be possible to cross‐compile a bootstrap GHC binary.

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -711,9 +711,6 @@ builtins.intersectAttrs super {
     patches = drv.patches or [ ] ++ [
       ./patches/GLUT.patch
     ];
-    prePatch = drv.prePatch or "" + ''
-      ${lib.getBin pkgs.buildPackages.dos2unix}/bin/dos2unix *.cabal
-    '';
   }) super.GLUT;
 
   libsystemd-journal = addExtraLibrary pkgs.systemd super.libsystemd-journal;
@@ -1627,12 +1624,6 @@ builtins.intersectAttrs super {
   # Additionally install documentation
   jacinda = overrideCabal (drv: {
     enableSeparateDocOutput = true;
-    # Test suite is broken by DOS line endings inserted by Hackage revisions
-    # https://github.com/vmchale/jacinda/issues/5
-    postPatch = ''
-      ${drv.postPatch or ""}
-      ${pkgs.buildPackages.dos2unix}/bin/dos2unix *.cabal
-    '';
     postInstall = ''
       ${drv.postInstall or ""}
 

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -184,6 +184,11 @@ in
   # See https://nixos.org/manual/nixpkgs/unstable/#haskell-packaging-helpers
   # or its source doc/languages-frameworks/haskell.section.md
   disallowGhcReference ? false,
+  # By default we convert the `.cabal` file to Unix line endings to work around
+  # Hackage converting them to DOS line endings when revised, see
+  # <https://github.com/haskell/hackage-server/issues/316>.
+  # Pass `true` to disable this behavior.
+  dontConvertCabalFileToUnix ? false,
   # Cabal 3.8 which is shipped by default for GHC >= 9.3 always calls
   # `pkg-config --libs --static` as part of the configure step. This requires
   # Requires.private dependencies of pkg-config dependencies to be present in
@@ -600,6 +605,9 @@ lib.fix (
         optionalString (editedCabalFile != null) ''
           echo "Replace Cabal file with edited version from ${newCabalFileUrl}."
           cp ${newCabalFile} ${pname}.cabal
+        ''
+        + lib.optionalString (!dontConvertCabalFileToUnix) ''
+          sed -i '${pname}.cabal' -e 's/\r$//'
         ''
         + prePatch;
 


### PR DESCRIPTION
```
Automatically use sed(1) to remove DOS line endings from .cabal files.
This is intended to work around Hackage producing revised cabal files
with DOS line endings (https://github.com/haskell/hackage-server/issues/316).
This frequently leads to

- patches failing to apply. Unfortunately there is no way to apply a
  patch with Unix line endings to a file with DOS line endings with
  GNU patch(1). Only the following combinations are supported:

  file  patch  comment
  Unix  Unix
  DOS   DOS    using --binary
  DOS   Unix   Haven't tested it, but I assume it works because
               patch(1) converts the file to Unix line endings
               implicitly (which can be disabled using --binary),
               but never the patch…

- Test suites sometimes involve the .cabal file which can be
  affected by the line endings.

This behavior is enabled by default to prevent cases where (unrevised)
packages regress when they get a revision later. Of course, the behavior
is a little nonsensical for non-Hackage packages, but it is probably
rarely an issue in practice. When DOS line endings need to be preserved,
the user can pass `dontConvertCabalFileToUnix = true`.

Supersedes https://github.com/NixOS/nixpkgs/pull/279248.
Resolves https://github.com/NixOS/nixpkgs/issues/206840.
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
