### PR TITLE
moribito: init at 0.2.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14519,6 +14519,12 @@
     github = "kulczwoj";
     githubId = 58049191;
   };
+  kumpelinus = {
+    name = "Kumpelinus";
+    email = "linus@kump.dev";
+    github = "kumpelinus";
+    githubId = 174106140;
+  };
   KunyaKud = {
     name = "KunyaKud";
     email = "wafuu@posteo.net";

--- a/pkgs/by-name/mo/moribito/package.nix
+++ b/pkgs/by-name/mo/moribito/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  libx11,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "moribito";
+  version = "0.2.6";
+
+  src = fetchFromGitHub {
+    owner = "ericschmar";
+    repo = "moribito";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/p7RVsz9jjPTVkEjhDsSHQmYVOsvpbb1APLGQYVjgiU=";
+  };
+
+  vendorHash = "sha256-O5OmVP5aGlc8Bz2nVAAkhCdTuonB9yXGSz5FO3FxJ1I=";
+
+  subPackages = [ "cmd/moribito" ];
+
+  # Clipboard support
+  env.CGO_ENABLED = 1;
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ libx11 ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal LDAP explorer";
+    homepage = "https://github.com/ericschmar/moribito";
+    changelog = "https://github.com/ericschmar/moribito/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kumpelinus ];
+    mainProgram = "moribito";
+  };
+})


### PR DESCRIPTION
**Summary**

Add **moribito**, a terminal LDAP explorer written in Go (MIT).

* Upstream: [https://github.com/ericschmar/moribito](https://github.com/ericschmar/moribito) (v0.2.6)
* Build: `buildGoModule` with `subPackages = [ "cmd/moribito" ]`
* Linux: enable `CGO` and add `xorg.libX11` for clipboard support (works on Wayland via XWayland)
* Meta: `mainProgram = "moribito"`, `platforms = linux`, `maintainers = [ kumpelinus ]`

Homepage: [https://github.com/ericschmar/moribito](https://github.com/ericschmar/moribito)
Changelog: [https://github.com/ericschmar/moribito/releases/tag/v0.2.6](https://github.com/ericschmar/moribito/releases/tag/v0.2.6)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
