### PR TITLE
[25.05] ci/eval/compare: add 10.rebuild-nixos-tests label

### DIFF
--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -110,9 +110,15 @@ let
           // lib.mapAttrs' (
             kernel: rebuilds: lib.nameValuePair "10.rebuild-${kernel}-stdenv" (lib.elem "stdenv" rebuilds)
           ) rebuildsByKernel
-          # Set the "11.by: package-maintainer" label to whether all packages directly
-          # changed are maintained by the PR's author.
           // {
+            "10.rebuild-nixos-tests" =
+              lib.elem "nixosTests.simple" (extractPackageNames diffAttrs.rebuilds)
+              &&
+                # Only set this label when no other label with indication for staging has been set.
+                # This avoids confusion whether to target staging or batch this with kernel updates.
+                lib.last (lib.sort lib.lessThan (lib.attrValues rebuildCountByKernel)) <= 500;
+            # Set the "11.by: package-maintainer" label to whether all packages directly
+            # changed are maintained by the PR's author.
             "11.by: package-maintainer" =
               maintainers ? ${githubAuthorId}
               && lib.all (lib.flip lib.elem maintainers.${githubAuthorId}) (

--- a/nixos/tests/simple.nix
+++ b/nixos/tests/simple.nix
@@ -1,21 +1,11 @@
-import ./make-test-python.nix (
-  { pkgs, ... }:
-  {
-    name = "simple";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [ ];
-    };
+import ./make-test-python.nix ({
+  name = "simple";
 
-    nodes.machine =
-      { ... }:
-      {
-        imports = [ ../modules/profiles/minimal.nix ];
-      };
+  nodes.machine = { };
 
-    testScript = ''
-      start_all()
-      machine.wait_for_unit("multi-user.target")
-      machine.shutdown()
-    '';
-  }
-)
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+    machine.shutdown()
+  '';
+})


### PR DESCRIPTION
Manual backport of #439255

Conflict in the simple nixos test, because it was still using the old `import ./make-test-python.nix` etc. on stable.