### PR TITLE
nixos/image/repart: allow replacing `/nix/store`

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -287,8 +287,14 @@
   "sec-image-repart": [
     "index.html#sec-image-repart"
   ],
+  "sec-image-repart-store-paths": [
+    "index.html#sec-image-repart-store-paths"
+  ],
   "sec-image-repart-store-partition": [
     "index.html#sec-image-repart-store-partition"
+  ],
+  "sec-image-repart-store-subvolume": [
+    "index.html#sec-image-repart-store-subvolume"
   ],
   "sec-image-repart-appliance": [
     "index.html#sec-image-repart-appliance"

--- a/nixos/modules/image/repart.nix
+++ b/nixos/modules/image/repart.nix
@@ -15,69 +15,83 @@ let
 
   inherit (utils.systemdUtils.lib) GPTMaxLabelLength;
 
-  partitionOptions = {
-    options = {
-      storePaths = lib.mkOption {
-        type = with lib.types; listOf path;
-        default = [ ];
-        description = "The store paths to include in the partition.";
-      };
-
-      stripNixStorePrefix = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = ''
-          Whether to strip `/nix/store/` from the store paths. This is useful
-          when you want to build a partition that only contains store paths and
-          is mounted under `/nix/store`.
-        '';
-      };
-
-      contents = lib.mkOption {
-        type =
-          with lib.types;
-          attrsOf (submodule {
-            options = {
-              source = lib.mkOption {
-                type = types.path;
-                description = "Path of the source file.";
-              };
-            };
-          });
-        default = { };
-        example = lib.literalExpression ''
-          {
-            "/EFI/BOOT/BOOTX64.EFI".source =
-              "''${pkgs.systemd}/lib/systemd/boot/efi/systemd-bootx64.efi";
-
-            "/loader/entries/nixos.conf".source = systemdBootEntry;
-          }
-        '';
-        description = "The contents to end up in the filesystem image.";
-      };
-
-      repartConfig = lib.mkOption {
-        type =
-          with lib.types;
-          attrsOf (oneOf [
-            str
-            int
-            bool
-            (listOf str)
-          ]);
-        example = {
-          Type = "home";
-          SizeMinBytes = "512M";
-          SizeMaxBytes = "2G";
+  partitionOptions =
+    { config, ... }:
+    {
+      options = {
+        storePaths = lib.mkOption {
+          type = with lib.types; listOf path;
+          default = [ ];
+          description = "The store paths to include in the partition.";
         };
-        description = ''
-          Specify the repart options for a partiton as a structural setting.
-          See {manpage}`repart.d(5)`
-          for all available options.
-        '';
+
+        # Superseded by `nixStorePrefix`. Unfortunately, `mkChangedOptionModule`
+        # does not support submodules.
+        stripNixStorePrefix = lib.mkOption {
+          default = "_mkMergedOptionModule";
+          visible = false;
+        };
+
+        nixStorePrefix = lib.mkOption {
+          type = lib.types.path;
+          default = "/nix/store";
+          description = ''
+            The prefix to use for store paths. Defaults to `/nix/store`. This is
+            useful when you want to build a partition that only contains store
+            paths and is mounted under `/nix/store` or if you want to create the
+            store paths below a parent path (e.g., `/@nix/nix/store`).
+          '';
+        };
+
+        contents = lib.mkOption {
+          type =
+            with lib.types;
+            attrsOf (submodule {
+              options = {
+                source = lib.mkOption {
+                  type = types.path;
+                  description = "Path of the source file.";
+                };
+              };
+            });
+          default = { };
+          example = lib.literalExpression ''
+            {
+              "/EFI/BOOT/BOOTX64.EFI".source =
+                "''${pkgs.systemd}/lib/systemd/boot/efi/systemd-bootx64.efi";
+
+              "/loader/entries/nixos.conf".source = systemdBootEntry;
+            }
+          '';
+          description = "The contents to end up in the filesystem image.";
+        };
+
+        repartConfig = lib.mkOption {
+          type =
+            with lib.types;
+            attrsOf (oneOf [
+              str
+              int
+              bool
+              (listOf str)
+            ]);
+          example = {
+            Type = "home";
+            SizeMinBytes = "512M";
+            SizeMaxBytes = "2G";
+          };
+          description = ''
+            Specify the repart options for a partiton as a structural setting.
+            See {manpage}`repart.d(5)`
+            for all available options.
+          '';
+        };
+      };
+
+      config = lib.mkIf (config.stripNixStorePrefix == true) {
+        nixStorePrefix = "/";
       };
     };
-  };
 
   mkfsOptionsToEnv =
     opts:
@@ -350,7 +364,7 @@ in
           }
         ) cfg.partitions;
 
-        warnings = lib.filter (v: v != null) (
+        warnings = lib.flatten (
           lib.mapAttrsToList (
             fileName: partitionConfig:
             let
@@ -358,20 +372,23 @@ in
               suggestedMaxLabelLength = GPTMaxLabelLength - 2;
               labelLength = builtins.stringLength repartConfig.Label;
             in
-            if (repartConfig ? Label && labelLength >= suggestedMaxLabelLength) then
-              ''
-                The partition label '${repartConfig.Label}'
-                defined for '${fileName}' is ${toString labelLength} characters long.
-                The suggested maximum label length is ${toString suggestedMaxLabelLength}.
+            lib.optional (repartConfig ? Label && labelLength >= suggestedMaxLabelLength) ''
+              The partition label '${repartConfig.Label}'
+              defined for '${fileName}' is ${toString labelLength} characters long.
+              The suggested maximum label length is ${toString suggestedMaxLabelLength}.
 
-                If you use sytemd-sysupdate style A/B updates, this might
-                not leave enough space to increment the version number included in
-                the label in a future release. For example, if your label is
-                ${toString GPTMaxLabelLength} characters long (the maximum enforced by UEFI) and
-                you're at version 9, you cannot increment this to 10.
-              ''
-            else
-              null
+              If you use sytemd-sysupdate style A/B updates, this might
+              not leave enough space to increment the version number included in
+              the label in a future release. For example, if your label is
+              ${toString GPTMaxLabelLength} characters long (the maximum enforced by UEFI) and
+              you're at version 9, you cannot increment this to 10.
+            ''
+            ++ lib.optional (partitionConfig.stripNixStorePrefix != "_mkMergedOptionModule") ''
+              The option definition `image.repart.paritions.${fileName}.stripNixStorePrefix`
+              has changed to `image.repart.paritions.${fileName}.nixStorePrefix` and now
+              accepts the path to use as prefix directly. Use `nixStorePrefix = "/"` to
+              achieve the same effect as setting `stripNixStorePrefix = true`.
+            ''
           ) cfg.partitions
         );
       };


### PR DESCRIPTION
If the Nix store cannot be located beneath `/nix/store` or in the root of the partition, using the `stripNixStorePrefix` option is not enough. In my case, I want to put the Nix store into a Btrfs subvolume, which systemd-repart can create offline. Therefore, I have added a new option, `nixStorePrefix`, which defines the prefix directly and deprecates the `stripNixStorePrefix` option. I have tried to make everything as compatible as possible. Unfortunately, I couldn't use `mkChangedOptionModule` since it doesn't support submodules.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
