### PR TITLE
asciinema_3: 3.0.0-rc.5 -> 3.0.0

### DIFF
--- a/pkgs/by-name/as/asciinema_3/package.nix
+++ b/pkgs/by-name/as/asciinema_3/package.nix
@@ -10,17 +10,17 @@
 let
   self = rustPlatform.buildRustPackage {
     pname = "asciinema";
-    version = "3.0.0-rc.5";
+    version = "3.0.0";
 
     src = fetchFromGitHub {
       name = "asciinema-source-${self.version}";
       owner = "asciinema";
       repo = "asciinema";
       rev = "v${self.version}";
-      hash = "sha256-CxssC3ftnXgxdvRO7CrVgBSVkh7DPjXRNRet4fB2BKc=";
+      hash = "sha256-P92EZyg8f/mm66SmXAyPX9f4eMgOP6lyn3Uqhqh+D0I=";
     };
 
-    cargoHash = "sha256-OsynIQeGjXHD1E9iDH4P7Jksr1APtGZkchzZB0DawIw=";
+    cargoHash = "sha256-2DQqtCcvSO43+RcMN2/BGqvf+cp/WvzUY4dxVpNcbGU=";
 
     env.ASCIINEMA_GEN_DIR = "gendir";
 

--- a/pkgs/by-name/as/asciinema_3/package.nix
+++ b/pkgs/by-name/as/asciinema_3/package.nix
@@ -35,13 +35,6 @@ let
         --zsh gendir/completion/_asciinema
     '';
 
-    checkFlags = [
-      # ---- pty::tests::exec_quick stdout ----
-      # thread 'pty::tests::exec_quick' panicked at src/pty.rs:494:10:
-      # called `Result::unwrap()` on an `Err` value: EBADF: Bad file number
-      "--skip=pty::tests::exec_quick"
-    ];
-
     strictDeps = true;
 
     passthru = {


### PR DESCRIPTION
Builds locally - will test later today to make sure this actually functions, then I'll undraft.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
