### PR TITLE
apparmor-parser: use full path for `aa-status`

### DIFF
--- a/pkgs/by-name/ap/apparmor-parser/package.nix
+++ b/pkgs/by-name/ap/apparmor-parser/package.nix
@@ -9,6 +9,7 @@
 
   # apparmor deps
   libapparmor,
+  apparmor-bin-utils,
 
   # testing
   perl,
@@ -28,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace rc.apparmor.functions \
       --replace-fail "/sbin/apparmor_parser" "$out/bin/apparmor_parser" # FIXME
     substituteInPlace rc.apparmor.functions \
-      --replace-fail "/usr/sbin/aa-status" '$(which aa-status)'
+      --replace-fail "/usr/sbin/aa-status" "${lib.getExe' apparmor-bin-utils "aa-status"}"
     sed -i rc.apparmor.functions -e '2i . ${./fix-rc.apparmor.functions.sh}'
   '';
 


### PR DESCRIPTION
`apparmor.service` calls the `aa-remove-unknown` script.
Because that script uses `/bin/sh` and not Bash, the service always produces an error:

```
$ journalctl -eu apparmor
...
aa-remove-unknown[683760]: /nix/store/7sac10q78g90jpcm2li12cd71rkq0lkp-apparmor-parser-4.1.1/lib/apparmor/rc.apparmor.functions: line 54: which: command not found
```

This patch changes the use of `which` to `command -v`, the POSIX-compliant method for looking up the path of an executable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
