### PR TITLE
open5gs{,-webui}: fix webui

### DIFF
--- a/pkgs/by-name/op/open5gs-webui/package.nix
+++ b/pkgs/by-name/op/open5gs-webui/package.nix
@@ -1,0 +1,13 @@
+{
+  buildNpmPackage,
+  open5gs,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "${open5gs.pname}-webui";
+  inherit (open5gs) src version meta;
+
+  sourceRoot = "${finalAttrs.src.name}/webui";
+
+  npmDepsHash = "sha256-IpqineYa15GBqoPDJ7RpaDsq+MQIIDcdq7yhwmH4Lzo=";
+})

--- a/pkgs/by-name/op/open5gs/package.nix
+++ b/pkgs/by-name/op/open5gs/package.nix
@@ -1,7 +1,5 @@
 {
   stdenv,
-  nodejs,
-  buildNpmPackage,
   lib,
   fetchFromGitHub,
   meson,
@@ -62,21 +60,6 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-2k+S+OXfdskJPtDUFSxb/+2UZcUiOZzRSSGgsEJWolc=";
   };
 
-  webui = buildNpmPackage {
-    pname = finalAttrs.pname + "-webui";
-    inherit (finalAttrs) src version meta;
-
-    sourceRoot = "${finalAttrs.src.name}/webui";
-
-    npmDepsHash = "sha256-IpqineYa15GBqoPDJ7RpaDsq+MQIIDcdq7yhwmH4Lzo=";
-
-    installPhase = ''
-      rm -rf node_modules
-      mkdir $out
-      cp -r * $out
-    '';
-  };
-
   nativeBuildInputs = [
     meson
     ninja
@@ -113,9 +96,6 @@ stdenv.mkDerivation (finalAttrs: {
     cp -R --no-preserve=mode,ownership ${finalAttrs.diameter} subprojects/freeDiameter
     cp -R --no-preserve=mode,ownership ${finalAttrs.libtins} subprojects/libtins
     cp -R --no-preserve=mode,ownership ${finalAttrs.promc} subprojects/prometheus-client-c
-
-    rm -rf webui/*
-    cp -r ${finalAttrs.webui}/* webui/
   '';
 
   postInstall = ''


### PR DESCRIPTION
As it is now, the built webui won’t work since to be able to start it, it needs node_modules and the .next directory. Restore the normal NPM installPhase which will copy all the necessary files.

The webui isn’t used during the main open5gs build, so move it to its own separate package.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
