### PR TITLE
treewide: update AppArmor policies

### DIFF
--- a/nixos/modules/security/apparmor/includes.nix
+++ b/nixos/modules/security/apparmor/includes.nix
@@ -19,7 +19,7 @@ let
           mode ? "r",
           trail ? "",
         }:
-        lib.optionalString (hasAttr path etc) "${mode} ${config.environment.etc.${path}.source}${trail},";
+        lib.optionalString (hasAttr path etc) "${config.environment.etc.${path}.source}${trail} ${mode},";
     in
     if isAttrs arg then go arg else go { path = arg; };
 in
@@ -93,19 +93,19 @@ in
     ];
     "abstractions/base" = ''
       include "${pkgs.apparmor-profiles}/etc/apparmor.d/abstractions/base"
-      r ${pkgs.stdenv.cc.libc}/share/locale/**,
-      r ${pkgs.stdenv.cc.libc}/share/locale.alias,
-      r ${config.i18n.glibcLocales}/lib/locale/locale-archive,
+      ${pkgs.stdenv.cc.libc}/share/locale/** r,
+      ${pkgs.stdenv.cc.libc}/share/locale.alias r,
+      ${config.i18n.glibcLocales}/lib/locale/locale-archive r,
       ${etcRule "localtime"}
-      r ${pkgs.tzdata}/share/zoneinfo/**,
-      r ${pkgs.stdenv.cc.libc}/share/i18n/**,
+      ${pkgs.tzdata}/share/zoneinfo/** r,
+      ${pkgs.stdenv.cc.libc}/share/i18n/** r,
     '';
     "abstractions/bash" = ''
       include "${pkgs.apparmor-profiles}/etc/apparmor.d/abstractions/bash"
 
       # bash inspects filesystems at startup
       # and /etc/mtab is linked to /proc/mounts
-      r @{PROC}/mounts,
+      @{PROC}/mounts r,
 
       # system-wide bash configuration
     ''
@@ -296,8 +296,8 @@ in
       # looking up users by name or id, groups by name or id, hosts by name
       # or IP, etc. These operations may be performed through files, dns,
       # NIS, NIS+, LDAP, hesiod, wins, etc. Allow them all here.
-      mr ${getLib pkgs.nss}/lib/libnss_*.so*,
-      mr ${getLib pkgs.nss}/lib64/libnss_*.so*,
+      ${getLib pkgs.nss}/lib/libnss_*.so* mr,
+      ${getLib pkgs.nss}/lib64/libnss_*.so* mr,
     ''
     + lib.concatMapStringsSep "\n" etcRule [
       "group"
@@ -463,11 +463,11 @@ in
       include "${pkgs.apparmor-profiles}/etc/apparmor.d/abstractions/ssl_certs"
 
       # For the NixOS module: security.acme
-      r /var/lib/acme/*/cert.pem,
-      r /var/lib/acme/*/chain.pem,
-      r /var/lib/acme/*/fullchain.pem,
+      /var/lib/acme/*/cert.pem r,
+      /var/lib/acme/*/chain.pem r,
+      /var/lib/acme/*/fullchain.pem r,
 
-      r /etc/pki/tls/certs/,
+      /etc/pki/tls/certs/ r,
 
     ''
     + lib.concatMapStringsSep "\n" etcRule [
@@ -510,8 +510,8 @@ in
     ];
     "abstractions/ssl_keys" = ''
       # security.acme NixOS module
-      r /var/lib/acme/*/full.pem,
-      r /var/lib/acme/*/key.pem,
+      /var/lib/acme/*/full.pem r,
+      /var/lib/acme/*/key.pem r,
     '';
     "abstractions/vulkan" = ''
       include "${pkgs.apparmor-profiles}/etc/apparmor.d/abstractions/vulkan"

--- a/nixos/modules/services/networking/murmur.nix
+++ b/nixos/modules/services/networking/murmur.nix
@@ -401,40 +401,40 @@ in
     ];
 
     security.apparmor.policies."bin.mumble-server".profile = ''
+      abi <abi/4.0>,
       include <tunables/global>
 
-      ${cfg.package}/bin/{mumble-server,.mumble-server-wrapped} {
+      profile ${cfg.package}/bin/{mumble-server,.mumble-server-wrapped} {
         include <abstractions/base>
         include <abstractions/nameservice>
         include <abstractions/ssl_certs>
         include "${pkgs.apparmorRulesFromClosure { name = "mumble-server"; } cfg.package}"
-        pix ${cfg.package}/bin/.mumble-server-wrapped,
+        ${cfg.package}/bin/.mumble-server-wrapped pix,
 
-        r ${config.environment.etc."os-release".source},
-        r ${config.environment.etc."lsb-release".source},
-        owner rwk ${cfg.stateDir}/murmur.sqlite,
-        owner rw ${cfg.stateDir}/murmur.sqlite-journal,
-        owner r ${cfg.stateDir}/,
-        r /run/murmur/murmurd.pid,
-        r /run/murmur/murmurd.ini,
-        r ${configFile},
-    ''
-    + lib.optionalString cfg.logToFile ''
-      rw /var/log/murmur/murmurd.log,
-    ''
-    + lib.optionalString (cfg.sslCert != null) ''
-      r ${cfg.sslCert},
-    ''
-    + lib.optionalString (cfg.sslKey != null) ''
-      r ${cfg.sslKey},
-    ''
-    + lib.optionalString (cfg.sslCa != null) ''
-      r ${cfg.sslCa},
-    ''
-    + lib.optionalString (cfg.dbus != null) ''
-      dbus bus=${cfg.dbus}
-    ''
-    + ''
+        ${config.environment.etc."os-release".source} r,
+        ${config.environment.etc."lsb-release".source} r,
+        owner ${cfg.stateDir}/murmur.sqlite rwk,
+        owner ${cfg.stateDir}/murmur.sqlite-journal rw,
+        owner ${cfg.stateDir}/ r,
+        /run/murmur/murmurd.pid r,
+        /run/murmur/murmurd.ini r,
+        ${configFile} r,
+        ${lib.optionalString cfg.logToFile ''
+          /var/log/murmur/murmurd.log rw,
+        ''}
+        ${lib.optionalString (cfg.sslCert != null) ''
+          ${cfg.sslCert} r,
+        ''}
+        ${lib.optionalString (cfg.sslKey != null) ''
+          ${cfg.sslKey} r,
+        ''}
+        ${lib.optionalString (cfg.sslCa != null) ''
+          ${cfg.sslCa} r,
+        ''}
+        ${lib.optionalString (cfg.dbus != null) ''
+          dbus bus=${cfg.dbus},
+        ''}
+        include if exists <local/bin.mumble-server>
       }
     '';
   };

--- a/nixos/modules/services/torrent/transmission.nix
+++ b/nixos/modules/services/torrent/transmission.nix
@@ -585,23 +585,23 @@ in
       include "${cfg.package.apparmor}/bin.transmission-daemon"
     '';
     security.apparmor.includes."local/bin.transmission-daemon" = ''
-      r ${config.systemd.services.transmission.environment.CURL_CA_BUNDLE},
+      ${config.systemd.services.transmission.environment.CURL_CA_BUNDLE} r,
 
-      owner rw ${cfg.home}/${settingsDir}/**,
-      rw ${cfg.settings.download-dir}/**,
+      owner ${cfg.home}/${settingsDir}/** rw,
+      ${cfg.settings.download-dir}/** rw,
       ${optionalString cfg.settings.incomplete-dir-enabled ''
-        rw ${cfg.settings.incomplete-dir}/**,
+        ${cfg.settings.incomplete-dir}/** rw,
       ''}
       ${optionalString cfg.settings.watch-dir-enabled ''
-        r${optionalString cfg.settings.trash-original-torrent-files "w"} ${cfg.settings.watch-dir}/**,
+        ${cfg.settings.watch-dir}/** r${optionalString cfg.settings.trash-original-torrent-files "w"},
       ''}
       profile dirs {
-        rw ${cfg.settings.download-dir}/**,
+        ${cfg.settings.download-dir}/** rw,
         ${optionalString cfg.settings.incomplete-dir-enabled ''
-          rw ${cfg.settings.incomplete-dir}/**,
+          ${cfg.settings.incomplete-dir}/** rw,
         ''}
         ${optionalString cfg.settings.watch-dir-enabled ''
-          r${optionalString cfg.settings.trash-original-torrent-files "w"} ${cfg.settings.watch-dir}/**,
+          ${cfg.settings.watch-dir}/** r${optionalString cfg.settings.trash-original-torrent-files "w"},
         ''}
       }
 
@@ -612,12 +612,12 @@ in
           # any existing profile for script-torrent-done-filename
           # FIXME: to be tested as I'm not sure it works well with NoNewPrivileges=
           # https://gitlab.com/apparmor/apparmor/-/wikis/AppArmorStacking#seccomp-and-no_new_privs
-          px ${cfg.settings.script-torrent-done-filename} -> &@{dirs},
+          ${cfg.settings.script-torrent-done-filename} px -> &@{dirs},
         ''
       }
 
       ${optionalString (cfg.webHome != null) ''
-        r ${cfg.webHome}/**,
+        ${cfg.webHome}/** r,
       ''}
     '';
   };

--- a/nixos/modules/services/web-apps/miniflux.nix
+++ b/nixos/modules/services/web-apps/miniflux.nix
@@ -207,15 +207,18 @@ in
     environment.systemPackages = [ cfg.package ];
 
     security.apparmor.policies."bin.miniflux".profile = ''
+      abi <abi/4.0>,
       include <tunables/global>
-      ${cfg.package}/bin/miniflux {
+
+      profile ${cfg.package}/bin/miniflux {
         include <abstractions/base>
         include <abstractions/nameservice>
         include <abstractions/ssl_certs>
         include <abstractions/golang>
         include "${pkgs.apparmorRulesFromClosure { name = "miniflux"; } cfg.package}"
-        r ${cfg.package}/bin/miniflux,
-        rw /run/miniflux/**,
+        ${cfg.package}/bin/miniflux r,
+        /run/miniflux/** rw,
+        include if exists <local/bin.miniflux>
       }
     '';
   };

--- a/pkgs/applications/networking/p2p/transmission/4.nix
+++ b/pkgs/applications/networking/p2p/transmission/4.nix
@@ -175,21 +175,22 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     mkdir $apparmor
     cat >$apparmor/bin.transmission-daemon <<EOF
+    abi <abi/4.0>,
     include <tunables/global>
-    $out/bin/transmission-daemon {
+    profile $out/bin/transmission-daemon {
       include <abstractions/base>
       include <abstractions/nameservice>
       include <abstractions/ssl_certs>
       include "${apparmorRules}"
-      r @{PROC}/sys/kernel/random/uuid,
-      r @{PROC}/sys/vm/overcommit_memory,
-      r @{PROC}/@{pid}/environ,
-      r @{PROC}/@{pid}/mounts,
-      rwk /tmp/tr_session_id_*,
+      @{PROC}/sys/kernel/random/uuid r,
+      @{PROC}/sys/vm/overcommit_memory r,
+      @{PROC}/@{pid}/environ r,
+      @{PROC}/@{pid}/mounts r,
+      /tmp/tr_session_id_* rwk,
 
-      r $out/share/transmission/public_html/**,
+      $out/share/transmission/public_html/** r,
 
-      include <local/bin.transmission-daemon>
+      include if exists <local/bin.transmission-daemon>
     }
     EOF
     install -Dm0444 -t $out/share/icons ../qt/icons/transmission.svg

--- a/pkgs/by-name/in/inetutils/package.nix
+++ b/pkgs/by-name/in/inetutils/package.nix
@@ -71,16 +71,18 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir $apparmor
     cat >$apparmor/bin.ping <<EOF
-    $out/bin/ping {
+    abi <abi/4.0>,
+    include <tunables/global>
+    profile $out/bin/ping {
       include <abstractions/base>
       include <abstractions/consoles>
       include <abstractions/nameservice>
       include "${apparmorRulesFromClosure { name = "ping"; } [ stdenv.cc.libc ]}"
-      include <local/bin.ping>
       capability net_raw,
       network inet raw,
       network inet6 raw,
       mr $out/bin/ping,
+      include if exists <local/bin.ping>
     }
     EOF
   '';

--- a/pkgs/by-name/li/libapparmor/apparmorRulesFromClosure.nix
+++ b/pkgs/by-name/li/libapparmor/apparmorRulesFromClosure.nix
@@ -9,18 +9,18 @@
   # TODO: factorize here some other common paths
   # that may emerge from use cases.
   baseRules ? [
-    "r $path"
-    "r $path/etc/**"
-    "mr $path/share/**"
+    "$path r"
+    "$path/etc/** r"
+    "$path/share/** mr"
     # Note that not all libraries are prefixed with "lib",
     # eg. glibc-2.30/lib/ld-2.30.so
-    "mr $path/lib/**.so*"
-    "mr $path/lib64/**.so*"
+    "$path/lib/**.so* mr"
+    "$path/lib64/**.so* mr"
     # eg. glibc-2.30/lib/gconv/gconv-modules
-    "r $path/lib/**"
-    "r $path/lib64/**"
+    "$path/lib/** r"
+    "$path/lib64/** r"
     # Internal executables
-    "ixr $path/libexec/**"
+    "$path/libexec/** ixr"
   ],
   name ? "",
 }:


### PR DESCRIPTION
The AppArmor policies in nixpkgs do not follow some recommended conventions.
This PR changes the AppArmor policies to consistently do the following:

1. include ABI version `abi <abi/4.0>,`
2. include `<tunables/global>` at toplevel and `<abstractions/base>` at the start of a profile
3. conditionally include the corresponding `<local/*>` file at the end of a profile
4. use the `profile` keyword ([as recommended by the docs](https://gitlab.com/apparmor/apparmor/-/wikis/QuickProfileLanguage#profiles))
5. write file rules with the pathname first ([as recommended by the docs](https://gitlab.com/apparmor/apparmor/-/wikis/QuickProfileLanguage#file-rules)).

Changes 2 and 3 are the most important to allow customization.
For example, the `miniflux` AppArmor policy did not include the `/run/credentials/miniflux.service/*` path, and I wanted to pass one of the files via systemd credentials. Because the AppArmor profile did not have a `include if exists <local/bin.miniflux>` line, I could not extend the profile and had to `lib.mkOverride` the policy file.

The other changes are meant to keep the nixpkgs policies in-line with the policies found in the apparmor project.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
