### PR TITLE
szurubooru: replace pillow-avif-plugin, pyheif, heif-image-plugin with pillow-heif via patch

### DIFF
--- a/pkgs/servers/web-apps/szurubooru/001-server-pillow-heif.patch
+++ b/pkgs/servers/web-apps/szurubooru/001-server-pillow-heif.patch
@@ -1,0 +1,66 @@
+commit f89ce378d3b405d69635da28dfd57adced23aa17
+Author: kuflierl <41301536+kuflierl@users.noreply.github.com>
+Date:   Mon Sep 15 20:14:08 2025 +0200
+
+    server: replace pillow-avif-plugin, pyheif, heif-image-plugin with pillow-heif
+
+diff --git a/requirements.txt b/requirements.txt
+index ffe18f0c..16a72750 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -1,12 +1,10 @@
+ alembic>=0.8.5
+ certifi>=2017.11.5
+ coloredlogs==5.0
+-heif-image-plugin==0.3.2
+ numpy>=1.8.2
+-pillow-avif-plugin~=1.1.0
+-pillow>=4.3.0
++pillow>=11.2.1
++pillow-heif>=1.0.0
+ psycopg2-binary>=2.6.1
+-pyheif==0.6.1
+ pynacl>=1.2.1
+ pyRFC3339>=1.0
+ pytz>=2018.3
+diff --git a/szurubooru/func/image_hash.py b/szurubooru/func/image_hash.py
+index 76d5a846..b89541eb 100644
+--- a/szurubooru/func/image_hash.py
++++ b/szurubooru/func/image_hash.py
+@@ -4,13 +4,13 @@ from datetime import datetime
+ from io import BytesIO
+ from typing import Any, Callable, List, Optional, Set, Tuple
+ 
+-import HeifImagePlugin
++from pillow_heif import register_heif_opener
+ import numpy as np
+-import pillow_avif
+ from PIL import Image
+ 
+ from szurubooru import config, errors
+ 
++register_heif_opener()
+ logger = logging.getLogger(__name__)
+ 
+ # Math based on paper from H. Chi Wong, Marshall Bern and David Goldberg
+diff --git a/szurubooru/func/images.py b/szurubooru/func/images.py
+index e135d182..f4b5aa5b 100644
+--- a/szurubooru/func/images.py
++++ b/szurubooru/func/images.py
+@@ -7,14 +7,14 @@ import subprocess
+ from io import BytesIO
+ from typing import List
+ 
+-import HeifImagePlugin
+-import pillow_avif
++from pillow_heif import register_heif_opener
+ from PIL import Image as PILImage
+ 
+ from szurubooru import errors
+ from szurubooru.func import mime, util
+ 
+ logger = logging.getLogger(__name__)
++register_heif_opener()
+ 
+ 
+ def convert_heif_to_png(content: bytes) -> bytes:

--- a/pkgs/servers/web-apps/szurubooru/server.nix
+++ b/pkgs/servers/web-apps/szurubooru/server.nix
@@ -20,10 +20,6 @@ let
         doCheck = false;
       });
 
-      pyheif = super.pyheif.overridePythonAttrs (oldAttrs: {
-        doCheck = false;
-      });
-
       sqlalchemy = super.sqlalchemy.overridePythonAttrs (oldAttrs: rec {
         version = "1.3.23";
         src = fetchPypi {
@@ -50,18 +46,20 @@ python.pkgs.buildPythonApplication {
 
   src = "${src}/server";
 
+  patches = [
+    ./001-server-pillow-heif.patch
+  ];
+
   nativeBuildInputs = with python.pkgs; [ setuptools ];
   propagatedBuildInputs = with python.pkgs; [
     alembic
     certifi
     coloredlogs
-    heif-image-plugin
     legacy-cgi
     numpy
-    pillow-avif-plugin
     pillow
+    pillow-heif
     psycopg2-binary
-    pyheif
     pynacl
     pyrfc3339
     pytz


### PR DESCRIPTION
patches out the broken and unmaintained package `pyheif` and replaces it with `pillow-heif`. `pillow-avif-plugin` has also been striped out due to native AVIF support in pillow.

Will open the way for dropping the broken packages: pyheif and heif-image-plugin (#443260).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
