### PR TITLE
libreoffice: add withJava option

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -130,6 +130,7 @@
   ],
   withFonts ? false,
   withHelp ? true,
+  withJava ? true,
   kdeIntegration ? false,
   variant ? "fresh",
   debugLogging ? variant == "still",
@@ -349,7 +350,6 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   nativeBuildInputs = [
-    ant
     autoconf
     automake
     bison
@@ -359,7 +359,6 @@ stdenv.mkDerivation (finalAttrs: {
     gettext
     gperf
     icu
-    jdk21
     libmysqlclient
     libtool
     libxml2
@@ -374,6 +373,10 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ optionals kdeIntegration [
     qt6.qtbase
+  ]
+  ++ optionals withJava [
+    ant
+    jdk21
   ];
 
   buildInputs =
@@ -409,7 +412,6 @@ stdenv.mkDerivation (finalAttrs: {
       (harfbuzz.override { withIcu = true; })
       hunspell
       icu
-      jre'
       lcms2
       libGL
       libGLU
@@ -474,6 +476,9 @@ stdenv.mkDerivation (finalAttrs: {
       qt6.qtbase
       kdePackages.kcoreaddons
       kdePackages.kio
+    ]
+    ++ optionals withJava [
+      jre'
     ];
 
   preConfigure = ''
@@ -516,7 +521,6 @@ stdenv.mkDerivation (finalAttrs: {
     "--without-buildconfig-recorded"
 
     (lib.withFeature withHelp "help")
-    "--with-beanshell-jar=${bsh}"
     "--with-vendor=NixOS"
     "--disable-report-builder"
     "--disable-online-update"
@@ -524,7 +528,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-dbus"
     "--enable-release-build"
     "--enable-epm"
-    "--with-ant-home=${ant.home}"
+    (lib.withFeature withJava "java")
 
     # Without these, configure does not finish
     "--without-junit"
@@ -543,7 +547,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.withFeature withFonts "fonts")
     "--without-doxygen"
 
-    "--with-system-beanshell"
     "--with-system-cairo"
     "--with-system-coinmp"
     "--with-system-headers"
@@ -595,6 +598,11 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals kdeIntegration [
     "--enable-kf6"
     "--enable-qt6"
+  ]
+  ++ optionals withJava [
+    "--with-system-beanshell"
+    "--with-ant-home=${ant.home}"
+    "--with-beanshell-jar=${bsh}"
   ]
   ++ (
     if variant == "fresh" || variant == "collabora" then
@@ -670,7 +678,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     inherit srcs;
-    jdk = jre';
+    jdk = if withJava then jre' else null;
     python = python311; # for unoconv
     updateScript = [
       ./update.sh


### PR DESCRIPTION
Add a clean-ish way to remove Java from the closure if the user (like me) is happy with a smaller feature set.

"For certain features of the software - but not most - Java is required. Java is notably required for Base."

https://wiki.documentfoundation.org/Development/Java

This causes a rebuild even for the existing case because we add `(lib.withFeature withJava "java")` to the `configureFlags`, but the result should be the same.

Regarding the passthrough: should `jdk` be `null` or just not part of the attrset at all?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
