### PR TITLE
hugs: Fix build failure

### DIFF
--- a/pkgs/by-name/hu/hugs/package.nix
+++ b/pkgs/by-name/hu/hugs/package.nix
@@ -1,28 +1,27 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   bison,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "hugs98";
   version = "2006-09";
 
-  src = fetchurl {
-    url = "https://www.haskell.org/hugs/downloads/${version}/hugs98-Sep2006.tar.gz";
-    sha256 = "1dj65c39zpy6qqvvrwns2hzj6ipnd4ih655xj7kgyk2nfdvd5x1w";
+  src = fetchFromGitHub {
+    owner = "augustss";
+    repo = "hugs98-plus-Sep2006";
+    rev = "1f7b60e05b12df00d715d535bb01c189bc1b9b3c";
+    hash = "sha256-g6/4kmdWKGDIu5PXVfP8O6Fl3v4bstXWAVkoxZiS6qo=";
   };
 
-  patches = [
-    (fetchurl {
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/hsbase_inline.patch?h=hugs";
-      name = "hsbase_inline.patch";
-      sha256 = "1h0sp16d17hlm6gj7zdbgwrjwi2l4q02m8p0wd60dp4gn9i9js0v";
-    })
-  ];
-
   nativeBuildInputs = [ bison ];
+
+  NIX_CFLAGS_COMPILE = [
+    "-Wno-error=implicit-int"
+    "-Wno-error=implicit-function-declaration"
+  ];
 
   postUnpack = "find -type f -exec sed -i 's@/bin/cp@cp@' {} +";
 
@@ -45,7 +44,6 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    broken = stdenv.hostPlatform.isDarwin;
     mainProgram = "hugs";
     homepage = "https://www.haskell.org/hugs";
     description = "Haskell interpreter";


### PR DESCRIPTION
The new GCC version brings some warnings treated as errors that cause problems in the build.
We change to @augustss' branch in preparation for booting MicroHs via Hugs.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
