### PR TITLE
pantheon.elementary-session-settings: Drop x11 session

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -252,7 +252,7 @@
 
 - mate-wayland-session 1.28.4 is now using the default wayfire decorator instead of firedecor, thus `services.xserver.desktopManager.mate.enableWaylandSession` is no longer shipping firedecor. If you are experiencing broken window decorations after upgrade, backup and remove `~/.config/mate/wayfire.ini` and re-login.
 
-- Due to [deprecation of gnome-session X11 support](https://blogs.gnome.org/alatiera/2025/06/08/the-x11-session-removal/), `services.desktopManager.pantheon` now defaults to pantheon-wayland session. The X11 session will be removed before gnome-session 49 lands.
+- Due to [deprecation of gnome-session X11 support](https://blogs.gnome.org/alatiera/2025/06/08/the-x11-session-removal/), `services.desktopManager.pantheon` now defaults to pantheon-wayland session. The X11 session has been removed, see [this issue](https://github.com/elementary/session-settings/issues/91) for details.
 
 - `services.gitea` supports sending notifications with sendmail again. To do this, activate the parameter `services.gitea.mailerUseSendmail` and configure SMTP server.
 

--- a/nixos/tests/pantheon.nix
+++ b/nixos/tests/pantheon.nix
@@ -75,11 +75,19 @@
           machine.succeed("getfacl -p /dev/snd/timer | grep -q ${user.name}")
 
       with subtest("Check if Pantheon components actually start"):
-          # We specifically check gsd-xsettings here since it is manually pulled up by gala.
-          # https://github.com/elementary/gala/pull/2140
-          for i in ["gala", "io.elementary.wingpanel", "io.elementary.dock", "gsd-media-keys", "gsd-xsettings", "io.elementary.desktop.agent-polkit"]:
-              machine.wait_until_succeeds(f"pgrep -f {i}")
-          machine.wait_until_succeeds("pgrep -xf ${pkgs.pantheon.elementary-files}/libexec/io.elementary.files.xdg-desktop-portal")
+          pgrep_list = [
+              "${pkgs.pantheon.gala}/bin/gala",
+              "io.elementary.wingpanel",
+              "io.elementary.dock",
+              "${pkgs.pantheon.gnome-settings-daemon}/libexec/gsd-media-keys",
+              # We specifically check gsd-xsettings here since it is manually pulled up by gala.
+              # https://github.com/elementary/gala/pull/2140
+              "${pkgs.pantheon.gnome-settings-daemon}/libexec/gsd-xsettings",
+              "${pkgs.pantheon.pantheon-agent-polkit}/libexec/policykit-1-pantheon/io.elementary.desktop.agent-polkit",
+              "${pkgs.pantheon.elementary-files}/libexec/io.elementary.files.xdg-desktop-portal"
+          ]
+          for i in pgrep_list:
+              machine.wait_until_succeeds(f"pgrep -xf {i}")
 
       with subtest("Check if various environment variables are set"):
           cmd = "xargs --null --max-args=1 echo < /proc/$(pgrep -xf ${pkgs.pantheon.gala}/bin/gala)/environ"
@@ -93,7 +101,7 @@
           machine.succeed(f"{cmd} | grep 'SSH_AUTH_SOCK' | grep 'gcr'")
 
       with subtest("Wait for elementary videos autostart"):
-          machine.wait_until_succeeds("pgrep -f io.elementary.videos")
+          machine.wait_until_succeeds("pgrep -xf /run/current-system/sw/bin/io.elementary.videos")
           machine.wait_for_text("No Videos Open")
           machine.screenshot("videos")
 

--- a/pkgs/desktops/pantheon/desktop/elementary-session-settings/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-session-settings/default.nix
@@ -58,8 +58,9 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dmimeapps-list=false"
-    "-Dfallback-session=GNOME"
     "-Ddetect-program-prefixes=true"
+    # https://github.com/elementary/session-settings/issues/91
+    "-Dx11=false"
     "--sysconfdir=${placeholder "out"}/etc"
   ];
 
@@ -70,7 +71,7 @@ stdenv.mkDerivation rec {
     cp -av ${./pantheon-mimeapps.list} $out/share/applications/pantheon-mimeapps.list
 
     # absolute path patched sessions
-    substituteInPlace $out/share/{xsessions/pantheon.desktop,wayland-sessions/pantheon-wayland.desktop} \
+    substituteInPlace $out/share/wayland-sessions/pantheon-wayland.desktop \
       --replace-fail "Exec=gnome-session" "Exec=${gnome-session}/bin/gnome-session" \
       --replace-fail "TryExec=io.elementary.wingpanel" "TryExec=${wingpanel}/bin/io.elementary.wingpanel"
   '';
@@ -79,7 +80,6 @@ stdenv.mkDerivation rec {
     updateScript = nix-update-script { };
 
     providedSessions = [
-      "pantheon"
       "pantheon-wayland"
     ];
   };


### PR DESCRIPTION
cc https://github.com/NixOS/nixpkgs/pull/440720

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

