### PR TITLE
rustPlatform.buildRustPackage: add overridable global RUSTFLAGS

### DIFF
--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -13,6 +13,7 @@
   buildPackages,
   rustc,
   windows,
+  GLOBAL_RUSTFLAGS ? "",
 }:
 
 let
@@ -97,10 +98,10 @@ lib.extendMkDerivation {
           PKG_CONFIG_ALLOW_CROSS = if stdenv.buildPlatform != stdenv.hostPlatform then 1 else 0;
           RUST_LOG = logLevel;
           # Prevent shadowing *_RUSTFLAGS environment variables
-          ${if args ? RUSTFLAGS || isDarwinDebug then "RUSTFLAGS" else null} =
-            lib.optionalString isDarwinDebug "-C split-debuginfo=packed "
+          ${if args ? RUSTFLAGS || GLOBAL_RUSTFLAGS != "" || isDarwinDebug then "RUSTFLAGS" else null} =
+            (lib.optionalString isDarwinDebug "-C split-debuginfo=packed ")
             # Workaround the existing RUSTFLAGS specified as a list.
-            + interpolateString (args.RUSTFLAGS or "");
+            + interpolateString (args.RUSTFLAGS or GLOBAL_RUSTFLAGS);
         }
         // args.env or { };
 


### PR DESCRIPTION
Indirectly addresses #412763 by allowing RUSTFLAGS to be globally overridden.

## Things done

Adds a `GLOBAL_RUSTFLAGS` argument to the `buildRustPackage` function. This allows for adding globlal options to RUSTFLAGS that apply to all rust derivations  built with `buildRustPackage`. If a package sets RUSTFLAGS, then we give precedence to those flags, having them replace GLOBAL_RUSTFLAGS rather than combining them. This is because they may conflict.

-----

Additional context/details:

Haskell allows its builder to be overridden to include march and mcpu options through an overlay:

```
          final: prev:
          let
            inherit (final) lib;
            makeGhcOptions = opts: lib.concatStringsSep " " (map (opt: "--ghc-option=${opt}") opts);
          in

          {
            haskell = prev.haskell // {
              packages = prev.haskell.packages // {
                ghc984 = prev.haskell.packages.ghc984.override {
                  overrides = hfinal: hprev: {
                    mkDerivation =
                      args:
                      hprev.mkDerivation (
                        args
                        // {
                          configureFlags = (args.configureFlags or [ ]) ++ [
                            (makeGhcOptions [
                              "-fllvm"
                              "-optc=-march=znver3"
                              "-optlo=-mcpu=znver3"
                              # "-optlo=-flto"
                              "-O2"
                            ])
                          ];
                        }
                      );
                  };
                };
              };
            };
          }
```

To be clear, this is allowing all haskell derivations to compile with these custom compiler flags during the buildPhase. It's a global override.

It would be nice to have this, but for rust compile flags. A way to do this is to globally add to the RUSTFLAGS environment variable that is used when building all rust projects. My usecase, just as in the haskell case, would be to add in `"-C target-cpu=znver3 ";`. With this patch, an example of an overlay to override the RUSTFLAGS would be:

```nix
final: prev: {
          makeRustPlatform =
            final.callPackage "${nixpkgs}/pkgs/development/compilers/rust/make-rust-platform.nix"
              {
                GLOBAL_RUSTFLAGS = "-C target-cpu=znver3 ";
              };
          }
```

Assuming `nixpkgs` is an flake input to the nixpkgs repo (or otherwise obtained nixpkgs).


---

Testing:

I've been using iterations of this patch on [my system config](https://github.com/DieracDelta/flakes/blob/6d7ae3846812e2643473ddd468eb9813bd3e8bc8/flake.nix?plain=1#L157) for about 6 months.  EDIT: note that this is an older version of the patch. I will change this once I have actually done a full system update with the patch.


One question related to testing is does this take effect? An example test I've done was on `tdf`. The instructions used by `tdf` compiled through my system config generated by elfx86exts:

```
elfx86exts $(realpath $(which tdf))
File format and CPU architecture: Elf, X86_64
MODE64 (call)
CMOV (cmovne)
AVX (vmovaps)
NOVLX (vmovaps)
SSE2 (movdqa)
SSE1 (movups)
BMI (tzcnt)
BMI2 (mulx)
AVX2 (vpbroadcastb)
PCLMUL (vpclmulqdq)
SSE4A (insertq)
FMA4 (vfmaddsd)
Instruction set extensions used: AVX, AVX2, BMI, BMI2, CMOV, FMA4, MODE64, NOVLX, PCLMUL, SSE1, SSE2, SSE4A
CPU Generation: Unknown
```

`tdf` compiled just with `nix build "github:nixos/nixpkgs"#tdf` without my system config:

```
elfx86exts tdf
File format and CPU architecture: Elf, X86_64
MODE64 (call)
CMOV (cmovne)
SSE1 (xorps)
SSE2 (movdqa)
BMI (tzcnt)
AVX (vmovd)
NOVLX (vpxor)
AVX2 (vpsadbw)
PCLMUL (pclmulqdq)
SSE41 (pmovzxdq)
SSSE3 (pshufb)
FMA4 (vfmaddsd)
Instruction set extensions used: AVX, AVX2, BMI, CMOV, FMA4, MODE64, NOVLX, PCLMUL, SSE1, SSE2, SSE41, SSSE3
CPU Generation: Unknown
```

Note the difference: SSE4A vs SSE41. [SSE4A](https://en.wikipedia.org/wiki/SSE4#SSE4a) is a AMD specific instruction set not implemented by intel, which is something enabled by znver3.

Disclaimer: this is the first time I've worked this part of nixpkgs, so apologies if I've made some mistake or misunderstood something.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
