### PR TITLE
ocamlPackages.lambdapi: 2.6.0 → 3.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/lambdapi/default.nix
+++ b/pkgs/development/ocaml-modules/lambdapi/default.nix
@@ -4,7 +4,6 @@
   buildDunePackage,
   alcotest,
   dedukti,
-  bindlib,
   camlp-streams,
   cmdliner,
   dream,
@@ -20,13 +19,13 @@
 
 buildDunePackage rec {
   pname = "lambdapi";
-  version = "2.6.0";
+  version = "3.0.0";
 
-  minimalOCamlVersion = "4.12";
+  minimalOCamlVersion = "4.14";
 
   src = fetchurl {
     url = "https://github.com/Deducteam/lambdapi/releases/download/${version}/lambdapi-${version}.tbz";
-    hash = "sha256-0B5fE9suq6bk/jMGZxSeAFnUiGxlH/nWtnLbLfyXZe0=";
+    hash = "sha256-EGau0mGP2OakAMUUfb9V6pd86NP+LlGKxnhcZ3WhuL4=";
   };
 
   nativeBuildInputs = [
@@ -35,7 +34,6 @@ buildDunePackage rec {
   ];
   buildInputs = [ lwt_ppx ];
   propagatedBuildInputs = [
-    bindlib
     camlp-streams
     cmdliner
     dream

--- a/pkgs/development/ocaml-modules/pratter/default.nix
+++ b/pkgs/development/ocaml-modules/pratter/default.nix
@@ -2,27 +2,24 @@
   lib,
   fetchFromGitLab,
   buildDunePackage,
-  camlp-streams,
   alcotest,
   qcheck,
   qcheck-alcotest,
 }:
 
 buildDunePackage rec {
-  version = "3.0.0";
+  version = "5.0.1";
   pname = "pratter";
 
-  minimalOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.10";
 
   src = fetchFromGitLab {
     domain = "forge.tedomum.net";
     owner = "koizel";
     repo = "pratter";
     tag = version;
-    hash = "sha256-O9loVYPJ9xoYf221vBbclqNNq2AA3ImUFGHxtfK3Jwc=";
+    hash = "sha256-Ib7EplEvOuYcAS9cfzo5994SqCv2eiysLekYfH09IMw=";
   };
-
-  propagatedBuildInputs = [ camlp-streams ];
 
   checkInputs = [
     alcotest


### PR DESCRIPTION
ocamlPackages.pratter: 3.0.0 → 5.0.1

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
