### PR TITLE
wasmtime: fix pkgsStatic build

### DIFF
--- a/pkgs/by-name/wa/wasmtime/package.nix
+++ b/pkgs/by-name/wa/wasmtime/package.nix
@@ -65,8 +65,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     in
     ''
       moveToOutput lib $dev
-      ${lib.optionalString (!enableShared) "rm $dev/lib/*.so{,.*}"}
-      ${lib.optionalString (!enableStatic) "rm $dev/lib/*.a"}
+      ${lib.optionalString (!enableShared) "rm -f $dev/lib/*.so{,.*}"}
+      ${lib.optionalString (!enableStatic) "rm -f $dev/lib/*.a"}
 
       # copy the build.rs generated c-api headers
       # https://github.com/rust-lang/cargo/issues/9661


### PR DESCRIPTION
Fixes the `postInstall` as reported in https://github.com/NixOS/nixpkgs/pull/440501#issuecomment-3295959112
The `rm` currently fails in `pkgsStatic.wasmtime` because unlike `pkgs.wasmtime.override { enableStatic = true; }`, the `.so` can't be built in the first place.

Apologies to @jcaesar for overlooking this and breaking it.
> I'm entirely confused why this PR seems to expect it to build *.so files for static targets anyway…

I copied the `postInstall` from [tree-sitter](https://github.com/NixOS/nixpkgs/blob/0b96957fb614f693d0cee1bd65fbfc0e610df47f/pkgs/development/tools/parsing/tree-sitter/default.nix#L212-L213) assuming that someone had tested it via pkgsStatic, but it turns out the treesitter postInstall fails before it even reaches that line :upside_down_face: 

Closes #444423

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
