### PR TITLE
sssd: 2.9.7 -> 2.11.1

### DIFF
--- a/pkgs/os-specific/linux/sssd/default.nix
+++ b/pkgs/os-specific/linux/sssd/default.nix
@@ -29,6 +29,7 @@
   openldap,
   pcre2,
   libkrb5,
+  libcap,
   cifs-utils,
   glib,
   keyutils,
@@ -51,6 +52,7 @@
   docbook_xsl,
   docbook_xml_dtd_45,
   testers,
+  versionCheckHook,
   nix-update-script,
   nixosTests,
   withSudo ? false,
@@ -61,13 +63,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "sssd";
-  version = "2.9.7";
+  version = "2.11.1";
 
   src = fetchFromGitHub {
     owner = "SSSD";
     repo = "sssd";
     tag = finalAttrs.version;
-    hash = "sha256-29KTvwm9ei1Z7yTSYmzcZtZMVvZpFWIlcLMlvRyWp/w=";
+    hash = "sha256-JN4GVx5rBfNBLaMpLcKgyd+CyNDafz85BXUcfg5kDXQ=";
   };
 
   postPatch = ''
@@ -93,6 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
       --with-pid-path=/run
       --with-python3-bindings
       --with-syslog=journald
+      --with-initscript=systemd
       --without-selinux
       --without-semanage
       --with-xml-catalog-path=''${SGML_CATALOG_FILES%%:*}
@@ -108,12 +111,14 @@ stdenv.mkDerivation (finalAttrs: {
   # Disable parallel install due to missing depends:
   #   libtool:   error: error: relink '_py3sss.la' with the above command before installing i
   enableParallelInstalling = false;
+
   nativeBuildInputs = [
     autoreconfHook
     makeWrapper
     pkg-config
     doxygen
   ];
+
   buildInputs = [
     augeas
     dnsutils
@@ -121,6 +126,7 @@ stdenv.mkDerivation (finalAttrs: {
     curl
     cyrus_sasl
     ding-libs
+    libcap
     libnl
     libunistring
     nss
@@ -129,6 +135,7 @@ stdenv.mkDerivation (finalAttrs: {
     p11-kit
     (python3.withPackages (
       p: with p; [
+        setuptools
         distutils
         python-ldap
       ]
@@ -187,31 +194,34 @@ stdenv.mkDerivation (finalAttrs: {
     rm -f "$out"/modules/ldb/memberof.la
     find "$out" -depth -type d -exec rmdir --ignore-fail-on-non-empty {} \;
   '';
+
   postFixup = ''
     for f in $out/bin/sss{ctl,_cache,_debuglevel,_override,_seed}; do
       wrapProgram $f --prefix LDB_MODULES_PATH : $out/modules/ldb
     done
   '';
 
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
   passthru = {
     tests = {
       inherit (nixosTests) sssd sssd-ldap;
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      version = testers.testVersion {
-        package = finalAttrs.finalPackage;
-        command = "sssd --version";
-      };
     };
     updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "System Security Services Daemon";
     homepage = "https://sssd.io/";
     changelog = "https://sssd.io/release-notes/sssd-${finalAttrs.version}.html";
-    license = licenses.gpl3Plus;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ illustris ];
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ illustris ];
     pkgConfigModules = [
       "ipa_hbac"
       "sss_certmap"

--- a/pkgs/os-specific/linux/sssd/default.nix
+++ b/pkgs/os-specific/linux/sssd/default.nix
@@ -221,7 +221,10 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://sssd.io/release-notes/sssd-${finalAttrs.version}.html";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ illustris ];
+    maintainers = with lib.maintainers; [
+      illustris
+      liberodark
+    ];
     pkgConfigModules = [
       "ipa_hbac"
       "sss_certmap"


### PR DESCRIPTION
Diff : https://github.com/SSSD/sssd/compare/2.9.7...2.11.1
Changelog : 
- https://sssd.io/release-notes/sssd-2.9.7.html
- https://sssd.io/release-notes/sssd-2.10.0.html
- https://sssd.io/release-notes/sssd-2.10.1.html
- https://sssd.io/release-notes/sssd-2.10.2.html
- https://sssd.io/release-notes/sssd-2.11.0.html
- https://sssd.io/release-notes/sssd-2.11.1.html

**Before to merge :** 
Is probably better to split sssd_ltm & sssd ?
Because :
SSSD 2.9.x branch is in long-term maintenance (LTM) phase.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
