### PR TITLE
python3Packages.python-sat: update, more tests, pull from PyPI for r-ryantm updates

### DIFF
--- a/pkgs/development/python-modules/python-sat/default.nix
+++ b/pkgs/development/python-modules/python-sat/default.nix
@@ -9,7 +9,7 @@
 }:
 buildPythonPackage rec {
   pname = "python-sat";
-  version = "1.8.dev20";
+  version = "1.8.dev24";
   pyproject = true;
 
   build-system = [ setuptools ];
@@ -17,16 +17,8 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit version;
     pname = "python_sat";
-    hash = "sha256-8uUi6DtPVh/87EWSgTtGq7UhAs+Glw8KARPkK3ukeMg=";
+    hash = "sha256-f9NnaPcHdNNInWTvpkg91ieaYejJ29kAAOLcbnbDmM0=";
   };
-
-  # Fix hard-coded g++ reference for darwin, where stdenv uses clang
-  # FIXME: remove once https://github.com/pysathq/pysat/pull/204 is merged and
-  # has hit PyPI
-  postPatch = ''
-    substituteInPlace solvers/patches/glucose421.patch \
-      --replace-fail "+CXX      := g++" "+CXX      := c++"
-  '';
 
   preBuild = ''
     export MAKEFLAGS="-j$NIX_BUILD_CORES"

--- a/pkgs/development/python-modules/python-sat/default.nix
+++ b/pkgs/development/python-modules/python-sat/default.nix
@@ -1,21 +1,20 @@
 {
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchPypi,
   lib,
   six,
   pypblib,
   pytestCheckHook,
 }:
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "python-sat";
-  version = "0.1.8.dev20";
+  version = "1.8.dev20";
   format = "setuptools";
 
-  src = fetchFromGitHub {
-    owner = "pysathq";
-    repo = "pysat";
-    rev = "d94f51e5eff2feef35abbc25480659eafa615cc0"; # upstream does not tag releases
-    hash = "sha256-fKZcdEVuqpv8jWnK8Cr1UJ7szJqXivK6x3YPYHH5ccI=";
+  src = fetchPypi {
+    inherit version;
+    pname = "python_sat";
+    hash = "sha256-8uUi6DtPVh/87EWSgTtGq7UhAs+Glw8KARPkK3ukeMg=";
   };
 
   # Build SAT solver backends in parallel and fix hard-coded g++ reference for


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Update to `1.8.dev24`.
- Fix `pytest` import issue to allow running all tests.
- The upstream git repo does not tag releases, so receiving updates from there is tedious. This way the automatic update script should correctly find new releases. Also, all tests are still included in the PyPI sources, so we're not missing out on tests.
- Change to `pyproject = true`
- Update description in metadata to match the description in [the upstream GitHub repo](https://github.com/pysathq/pysat)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
