### PR TITLE
 python3Packages.sss: init at 2.9.7

### DIFF
--- a/pkgs/development/python-modules/sss/default.nix
+++ b/pkgs/development/python-modules/sss/default.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  buildPythonPackage,
+  python,
+  sssd,
+
+  # tests
+  pytestCheckHook,
+}:
+
+let
+  sssdForPython = sssd.override {
+    python3 = python;
+  };
+in
+buildPythonPackage rec {
+  pname = "sss";
+  inherit (sssdForPython) version;
+
+  format = "other";
+  dontUnpack = true;
+  dontBuild = true;
+
+  dependencies = [
+    sssdForPython
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/${python.sitePackages}
+
+    cp -r ${sssdForPython}/${python.sitePackages}/SSSDConfig $out/${python.sitePackages}/
+    install -m 755 ${sssdForPython}/${python.sitePackages}/*.so $out/${python.sitePackages}/
+
+    runHook postInstall
+  '';
+
+  pythonImportsCheck = [
+    "sssd"
+    "pysss"
+    "pysss_murmur"
+    "pysss_nss_idmap"
+    "pyhbac"
+    "SSSDConfig"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  # No tests
+  doCheck = false;
+
+  meta = {
+    description = "Python bindings for SSSD (System Security Services Daemon)";
+    longDescription = ''
+      This package provides Python bindings for SSSD including:
+      - sssd: SSSD Python utilities module
+      - pysss: Core Python module for SSSD operations
+      - pysss_murmur: MurmurHash implementation
+      - pysss_nss_idmap: NSS ID mapping functionality
+      - pyhbac: HBAC (Host-Based Access Control) module
+      - SSSDConfig: Configuration management module
+    '';
+    inherit (sssd.meta)
+      homepage
+      changelog
+      platforms
+      maintainers
+      ;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17535,6 +17535,8 @@ self: super: with self; {
 
   ssort = callPackage ../development/python-modules/ssort { };
 
+  sss = callPackage ../development/python-modules/sss { };
+
   st-pages = callPackage ../development/python-modules/st-pages { };
 
   stable-baselines3 = callPackage ../development/python-modules/stable-baselines3 { };


### PR DESCRIPTION
The goal fix :

```
Traceback (most recent call last):
  File "/run/current-system/sw/bin/sss_obfuscate", line 8, in <module>
    import pysss
ModuleNotFoundError: No module named 'pysss'

```

Related to : 
https://packages.debian.org/trixie/python3-sss
https://packages.fedoraproject.org/pkgs/sssd/python3-sss/
https://github.com/SSSD/sssd/blob/master/src/python/pysss.c

Is not related to : 
https://pypi.org/project/sss/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
