### PR TITLE
nixosTests.uradvd: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1545,6 +1545,7 @@ in
   upnp.nftables = handleTest ./upnp.nix { useNftables = true; };
   uptermd = runTest ./uptermd.nix;
   uptime-kuma = runTest ./uptime-kuma.nix;
+  uradvd = runTest ./uradvd.nix;
   urn-timer = runTest ./urn-timer.nix;
   usbguard = runTest ./usbguard.nix;
   user-activation-scripts = runTest ./user-activation-scripts.nix;

--- a/nixos/tests/uradvd.nix
+++ b/nixos/tests/uradvd.nix
@@ -1,0 +1,33 @@
+{ pkgs, ... }:
+{
+  name = "uradvd";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ aiyion ];
+  };
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      environment.systemPackages = [ pkgs.uradvd ];
+    };
+
+  testScript = ''
+    machine.wait_for_unit("default.target")
+
+    with subtest("help text does not report unexpected features"):
+        expected_help_text = ("Usage: uradvd [-h] -i <interface> -a/-p <prefix> [ -a/-p <prefix> ... ]\n"
+                              "[ --default-lifetime <seconds> ] [ --rdnss <ip> ... ]\n"
+                              "[ --valid-lifetime <seconds> ] [ --preferred-lifetime <seconds> ]\n"
+                              "[ --max-router-adv-interval <seconds> ] [ --min-router-adv-interval <seconds> ]\n"
+                             )
+        print(expected_help_text)
+        actual_help_text = machine.succeed("uradvd -h 2>&1")
+        assert actual_help_text == expected_help_text
+
+    with subtest("uradvd fails without mandatory arguments"):
+        machine.fail("uradvd")
+
+    with subtest("uradvd launches"):
+        machine.succeed("uradvd -i eth1 -p 2001:db8:1::/64 >&2 &")
+  '';
+}

--- a/pkgs/by-name/ur/uradvd/package.nix
+++ b/pkgs/by-name/ur/uradvd/package.nix
@@ -2,6 +2,8 @@
   stdenv,
   lib,
   fetchFromGitHub,
+
+  nixosTests,
 }:
 
 stdenv.mkDerivation {
@@ -30,5 +32,11 @@ stdenv.mkDerivation {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ aiyion ];
     mainProgram = "uradvd";
+  };
+
+  passthru = {
+    tests = {
+      nixosTest = nixosTests.uradvd;
+    };
   };
 }


### PR DESCRIPTION
introduce a help text test and two launch tests, one successful, one not.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - ~Package update: when the change is major or breaking.~
- NixOS Release Notes
  - ~Module addition: when adding a new NixOS module.~
  - ~Module update: when the change is significant.~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
