### PR TITLE
nixos/podman: Introduce new option `extraRuntimes`.

### DIFF
--- a/nixos/tests/podman/default.nix
+++ b/nixos/tests/podman/default.nix
@@ -32,6 +32,12 @@ import ../make-test-python.nix (
           boot.supportedFilesystems = [ "zfs" ];
           networking.hostId = "00000000";
         };
+      rootful_norunc =
+        { pkgs, ... }:
+        {
+          virtualisation.podman.enable = true;
+          virtualisation.podman.extraRuntimes = [ ];
+        };
       rootless =
         { pkgs, ... }:
         {
@@ -80,6 +86,7 @@ import ../make-test-python.nix (
 
 
       rootful.wait_for_unit("sockets.target")
+      rootful_norunc.wait_for_unit("sockets.target")
       rootless.wait_for_unit("sockets.target")
       dns.wait_for_unit("sockets.target")
       docker.wait_for_unit("sockets.target")
@@ -111,6 +118,31 @@ import ../make-test-python.nix (
           rootful.succeed("podman ps | grep sleeping")
           rootful.succeed("podman stop sleeping")
           rootful.succeed("podman rm sleeping")
+
+      # now without installed runc
+      with subtest("Run runc-less container as root with runc"):
+          rootful_norunc.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
+          rootful_norunc.fail(
+              "podman run --runtime=runc -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
+          )
+
+      with subtest("Run runc-less container as root with crun"):
+          rootful_norunc.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
+          rootful_norunc.succeed(
+              "podman run --runtime=crun -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
+          )
+          rootful_norunc.succeed("podman ps | grep sleeping")
+          rootful_norunc.succeed("podman stop sleeping")
+          rootful_norunc.succeed("podman rm sleeping")
+
+      with subtest("Run runc-less container as root with the default backend"):
+          rootful_norunc.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
+          rootful_norunc.succeed(
+              "podman run -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
+          )
+          rootful_norunc.succeed("podman ps | grep sleeping")
+          rootful_norunc.succeed("podman stop sleeping")
+          rootful_norunc.succeed("podman rm sleeping")
 
       # start systemd session for rootless
       rootless.succeed("loginctl enable-linger alice")


### PR DESCRIPTION
This disables the hard, not overridable, dependency on `runc`. It also sharpens the description of `extraPackages` to highlight the difference between those options.

Fixes #443274.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
