### PR TITLE
Qdrant 1.14.0

### DIFF
--- a/pkgs/by-name/qd/qdrant/package.nix
+++ b/pkgs/by-name/qd/qdrant/package.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "qdrant";
-  version = "1.13.6";
+  version = "1.14.0";
 
   src = fetchFromGitHub {
     owner = "qdrant";
     repo = "qdrant";
     tag = "v${version}";
-    hash = "sha256-l/nWlpV3eecTzFK3MnHzmXGYocxKw+YPsyfHWuE/rwg=";
+    hash = "sha256-o9Nv4UsFgVngKWpe5sUR8tovtpB81tJBSm6We6DN20c=";
   };
 
-  cargoHash = "sha256-VUUL+oz8nCCNvDohDLfRai+KKd6uG0RLti31mk40wVY=";
+  cargoHash = "sha256-xt7uu+YZGazbKwXEKXeIwcGg8G4djQx7nKpQYFv/L3Y=";
 
   nativeBuildInputs = [
     protobuf


### PR DESCRIPTION
Qdrant update from 1.13.6 to 1.14.0

Config updated from : 
https://github.com/NixOS/nixpkgs/blob/d916df777523d75f7c5acca79946652f032f633e/pkgs/by-name/qd/qdrant/package.nix#L44