### PR TITLE
spidermonkey_115: 115.27.0 -> 115.28.0

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/115.nix
+++ b/pkgs/development/interpreters/spidermonkey/115.nix
@@ -1,4 +1,4 @@
 import ./common.nix {
-  version = "115.27.0";
-  hash = "sha512-owhm6oQaRPSQ/F7xoEDCbvT6zBGACf98zbJitUxbf3XXS0FqHlwB7rkAQ+GVeAnoClfts6yOY8F/H8NFBBEF8w==";
+  version = "115.28.0";
+  hash = "sha512-lnfF4YA/aGV9GKTlsmXsjqiL/J778qbEKQuTW/PG7jsMMcp4ACacAmxRISKvw2MPmCFd7JYzNvJhpXNDK6umnw==";
 }


### PR DESCRIPTION
https://github.com/mozilla-firefox/firefox/commits/FIREFOX_115_28_0esr_RELEASE/js/src/build
https://github.com/mozilla-firefox/firefox/commits/FIREFOX_115_28_0esr_RELEASE/build




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

