### PR TITLE
garage_1: 1.2.0 -> 1.3.0, garage_2: 2.0.0 -> 2.1.0, garage_0_9: remove

### DIFF
--- a/pkgs/tools/filesystems/garage/default.nix
+++ b/pkgs/tools/filesystems/garage/default.nix
@@ -82,9 +82,7 @@ let
         "k2v::poll::test_poll_item"
       ];
 
-      passthru.tests =
-        lib.optionalAttrs (lib.versionAtLeast version "1")
-          nixosTests."garage_${lib.versions.major version}";
+      passthru.tests = nixosTests."garage_${lib.versions.major version}";
 
       meta = {
         description = "S3-compatible object store for small self-hosted geo-distributed deployments";
@@ -104,10 +102,10 @@ let
     };
 in
 rec {
-  garage_1_2_0 = generic {
-    version = "1.2.0";
-    hash = "sha256-JoOwCbChSL7mjegnLHOH2Abfmsnw9BwNsjFj7nqBN6o=";
-    cargoHash = "sha256-vcvD0Fn/etnAuXrM3+rj16cqpEmW2nzRmrjXsftKTFE=";
+  garage_1 = generic {
+    version = "1.3.0";
+    hash = "sha256-6w+jun0UmQHmoXcokGpPM95BbQyOKefTeAelAFKxNCM=";
+    cargoHash = "sha256-mWLsOTWxzMdDfzEDu+WHJ12SVscEVfBVuOTVFbfnk0g=";
   };
 
   garage_2_0_0 = generic {
@@ -115,8 +113,6 @@ rec {
     hash = "sha256-dn7FoouF+5qmW6fcC20bKQSc6D2G9yrWdBK3uN3bF58=";
     cargoHash = "sha256-6VM/EesrUIaQOeDGqzb0kOqMz4hW7zBJUnaRQ9C3cqc=";
   };
-
-  garage_1 = garage_1_2_0;
 
   garage_2 = garage_2_0_0;
 

--- a/pkgs/tools/filesystems/garage/default.nix
+++ b/pkgs/tools/filesystems/garage/default.nix
@@ -30,12 +30,6 @@ let
         inherit hash;
       };
 
-      postPatch = ''
-        # Starting in 0.9.x series, Garage is using mold in local development
-        # and this leaks in this packaging, we remove it to use the default linker.
-        rm .cargo/config.toml || true
-      '';
-
       inherit cargoHash cargoPatches;
 
       nativeBuildInputs = [
@@ -53,33 +47,20 @@ let
 
       OPENSSL_NO_VENDOR = true;
 
-      # See https://git.deuxfleurs.fr/Deuxfleurs/garage/src/tag/v0.8.2/nix/compile.nix#L192-L198
+      # See https://git.deuxfleurs.fr/Deuxfleurs/garage/src/tag/v2.1.0/nix/compile.nix#L71-L78
       # on version changes for checking if changes are required here
       buildFeatures = [
-        "kubernetes-discovery"
         "bundled-libs"
-        "metrics"
-        "k2v"
-        "telemetry-otlp"
-        "lmdb"
-        "sqlite"
         "consul-discovery"
-      ];
-
-      # To make integration tests pass, we include the optional k2v feature here,
-      # but in buildFeatures only for version 0.8+, where it's enabled by default.
-      # See: https://garagehq.deuxfleurs.fr/documentation/reference-manual/k2v/
-      checkFeatures = [
+        "fjall"
+        "journald"
         "k2v"
         "kubernetes-discovery"
-        "bundled-libs"
         "lmdb"
+        "metrics"
         "sqlite"
-      ];
-
-      disabledTests = [
-        # Upstream told us this test is flakey.
-        "k2v::poll::test_poll_item"
+        "syslog"
+        "telemetry-otlp"
       ];
 
       passthru.tests = nixosTests."garage_${lib.versions.major version}";
@@ -108,13 +89,11 @@ rec {
     cargoHash = "sha256-mWLsOTWxzMdDfzEDu+WHJ12SVscEVfBVuOTVFbfnk0g=";
   };
 
-  garage_2_0_0 = generic {
-    version = "2.0.0";
-    hash = "sha256-dn7FoouF+5qmW6fcC20bKQSc6D2G9yrWdBK3uN3bF58=";
-    cargoHash = "sha256-6VM/EesrUIaQOeDGqzb0kOqMz4hW7zBJUnaRQ9C3cqc=";
+  garage_2 = generic {
+    version = "2.1.0";
+    hash = "sha256-GGwF6kVIJ7MPvO6VRj2ebquJEjJQBwpW18P6L2sGVDs=";
+    cargoHash = "sha256-0pT2fqseN1numJZdC0FFg1JXbDq1YmlmBPQVbOpxtkw=";
   };
-
-  garage_2 = garage_2_0_0;
 
   garage = garage_1;
 }

--- a/pkgs/tools/filesystems/garage/default.nix
+++ b/pkgs/tools/filesystems/garage/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   rustPlatform,
   fetchFromGitea,
   openssl,
@@ -59,9 +58,6 @@ let
       buildFeatures = [
         "kubernetes-discovery"
         "bundled-libs"
-      ]
-      ++ lib.optional (lib.versionOlder version "1.0") "sled"
-      ++ [
         "metrics"
         "k2v"
         "telemetry-otlp"
@@ -77,9 +73,6 @@ let
         "k2v"
         "kubernetes-discovery"
         "bundled-libs"
-      ]
-      ++ lib.optional (lib.versionOlder version "1.0") "sled"
-      ++ [
         "lmdb"
         "sqlite"
       ];
@@ -111,14 +104,6 @@ let
     };
 in
 rec {
-  garage_0_9_4 = generic {
-    version = "0.9.4";
-    hash = "sha256-2ZaxenwaVGYYUjUJaGgnGpZNQprQV9+Jns2sXM6cowk=";
-    cargoHash = "sha256-ittesFz1GUGipQecsmMA+GEaVoUY+C9DtEvsO0HFNCc=";
-    cargoPatches = [ ./update-time.patch ];
-    eol = true;
-  };
-
   garage_1_2_0 = generic {
     version = "1.2.0";
     hash = "sha256-JoOwCbChSL7mjegnLHOH2Abfmsnw9BwNsjFj7nqBN6o=";
@@ -130,8 +115,6 @@ rec {
     hash = "sha256-dn7FoouF+5qmW6fcC20bKQSc6D2G9yrWdBK3uN3bF58=";
     cargoHash = "sha256-6VM/EesrUIaQOeDGqzb0kOqMz4hW7zBJUnaRQ9C3cqc=";
   };
-
-  garage_0_9 = garage_0_9_4;
 
   garage_1 = garage_1_2_0;
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -946,7 +946,11 @@ mapAliases {
   gamin = throw "'gamin' has been removed as it is unmaintained upstream"; # Added 2024-04-19
   garage_0_8 = throw "'garage_0_8' has been removed as it is unmaintained upstream"; # Added 2025-06-23
   garage_0_8_7 = throw "'garage_0_8_7' has been removed as it is unmaintained upstream"; # Added 2025-06-23
+  garage_0_9 = throw "'garage_0_9' has been removed as it is unmaintained upstream"; # Added 2025-09-16
+  garage_0_9_4 = throw "'garage_0_9_4' has been removed as it is unmaintained upstream"; # Added 2025-09-16
+  garage_1_2_0 = throw "'garage_1_2_0' has been removed. Use 'garage_1' instead."; # Added 2025-09-16
   garage_1_x = lib.warnOnInstantiate "'garage_1_x' has been renamed to 'garage_1'" garage_1; # Added 2025-06-23
+  garage_2_0_0 = throw "'garage_2_0_0' has been removed. Use 'garage_2' instead."; # Added 2025-09-16
   gbl = throw "'gbl' has been removed because the upstream repository no longer exists"; # Added 2025-01-26
   gcc48 = throw "gcc48 has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2024-09-10
   gcc49 = throw "gcc49 has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2024-09-11

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2881,13 +2881,7 @@ with pkgs;
 
   inherit (callPackages ../tools/filesystems/garage { })
     garage
-    garage_0_9
-    garage_0_9_4
-
-    garage_1_2_0
     garage_1
-
-    garage_2_0_0
     garage_2
     ;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
