### PR TITLE
onlyoffice-desktopeditors: 9.0.0 -> 9.1.0

### DIFF
--- a/pkgs/by-name/on/onlyoffice-desktopeditors/package.nix
+++ b/pkgs/by-name/on/onlyoffice-desktopeditors/package.nix
@@ -22,6 +22,7 @@
   gst_all_1,
   gtk2,
   gtk3,
+  libnotify,
   libpulseaudio,
   libudev0-shim,
   libdrm,
@@ -66,11 +67,11 @@ let
 
   derivation = stdenv.mkDerivation rec {
     pname = "onlyoffice-desktopeditors";
-    version = "9.0.4";
+    version = "9.1.0";
     minor = null;
     src = fetchurl {
       url = "https://github.com/ONLYOFFICE/DesktopEditors/releases/download/v${version}/onlyoffice-desktopeditors_amd64.deb";
-      hash = "sha256-wO4t9lE7gHmu41/Q2lYHVZu/oFwaBLY2BndomaFdYho=";
+      hash = "sha256-D36E7hYCTJ9Lw9XnB8nxMGMJDJRhM+K+bviuM9uuzhk=";
     };
 
     nativeBuildInputs = [
@@ -95,6 +96,7 @@ let
       gst_all_1.gstreamer
       gtk2
       gtk3
+      libnotify
       libpulseaudio
       libdrm
       nspr

--- a/pkgs/by-name/on/onlyoffice-desktopeditors/package.nix
+++ b/pkgs/by-name/on/onlyoffice-desktopeditors/package.nix
@@ -66,11 +66,11 @@ let
 
   derivation = stdenv.mkDerivation rec {
     pname = "onlyoffice-desktopeditors";
-    version = "9.0.0";
+    version = "9.0.4";
     minor = null;
     src = fetchurl {
       url = "https://github.com/ONLYOFFICE/DesktopEditors/releases/download/v${version}/onlyoffice-desktopeditors_amd64.deb";
-      hash = "sha256-mGjFFuuplGINgjuIEHoO3AO4ppkum1lifj5ukbfWWS8=";
+      hash = "sha256-wO4t9lE7gHmu41/Q2lYHVZu/oFwaBLY2BndomaFdYho=";
     };
 
     nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR intends to update the version of **onlyoffice-desktopeditors**. 
One of the important changes in the updated version is a fix for running the application when the `--system-title-bar` flag is passed (or the equivalent `titlebar=system` option in `DesktopEditors.conf` is set), which was broken in `9.0.0` and caused the application to crash on startup.

- Aforementioned bugfix reference: https://community.onlyoffice.com/t/onlyoffice-desktopeditors-crashed-after-upgrading-to-version-9-0-0-172/14922/10
- Upstream changelog reference: https://github.com/ONLYOFFICE/DesktopEditors/blob/master/CHANGELOG.md#903

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
