### PR TITLE
qidi-studio-bin: init at 2.02.00.61

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18361,6 +18361,13 @@
     github = "niklaskorz";
     githubId = 590517;
   };
+  niklasthorild = {
+    name = "Niklas Thorild";
+    email = "niklas@thorild.se";
+    github = "niklasthorild";
+    githubId = 224864856;
+    keys = [ { fingerprint = "D116 2896 7DD7 4341 DF3C  AB2D 285C 222F EC9C 0336"; } ];
+  };
   NiklasVousten = {
     name = "Niklas Vousten";
     email = "nixpkgs@vousten.dev";

--- a/pkgs/by-name/qi/qidi-studio-bin/package.nix
+++ b/pkgs/by-name/qi/qidi-studio-bin/package.nix
@@ -1,0 +1,53 @@
+{
+  appimageTools,
+  fetchurl,
+  webkitgtk_4_1,
+  lib,
+  makeWrapper,
+}:
+let
+  pname = "qidi-studio";
+  version = "2.02.00.61";
+
+  src = fetchurl {
+    url = "https://github.com/QIDITECH/QIDIStudio/releases/download/v${version}/QIDIStudio_${version}_Ubuntu24.AppImage";
+    hash = "sha256-5oRDxd4xUWQvi5h+DYyLAno9niozoxXxPYlfAgHWTPw=";
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit version pname src;
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+  extraPkgs = pkgs: [
+    webkitgtk_4_1
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/QIDIStudio.desktop $out/share/applications/QIDIStudio.desktop
+    install -m 444 -D ${appimageContents}/QIDIStudio.png \
+      $out/share/icons/hicolor/scalable/apps/QIDIStudio.png
+    substituteInPlace $out/share/applications/QIDIStudio.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=${pname}'
+    wrapProgram "$out/bin/${pname}" \
+      --set-default WEBKIT_DISABLE_COMPOSITING_MODE 0 \
+      --set-default WEBKIT_DISABLE_DMABUF_RENDERER 0 \
+  '';
+
+  meta = {
+    description = "Slicer for QIDI 3D Printers, based on Bambu Studio";
+    longDescription = ''
+      QIDI Studio is a professional 3D printer slicing software，which is perfectly compatible with all printers and 3D printing filaments of QIDI Technology.
+      Multi-platform support, simple inerface, easy to use, complate functions, easy to learn 3D printing.  
+    '';
+    homepage = "https://github.com/QIDITECH/QIDIStudio";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ niklasthorild ];
+    mainProgram = "qidi-studio";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
AppImage version of QIDIStudio packaged for Nix. QIDIStudio is a 3D printer slicing software based on Bambu Studio.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
