### PR TITLE
haskellPackages.callPackage: preserve functionArgs

### DIFF
--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -107,29 +107,35 @@ let
       # is that nix has no way to "passthrough" args while preserving the reflection
       # info that callPackage uses to determine the arguments).
       drv = if lib.isFunction fn then fn else import fn;
-      auto = builtins.intersectAttrs (lib.functionArgs drv) scope;
+      drvFunctionArgs = lib.functionArgs drv;
+      auto = builtins.intersectAttrs drvFunctionArgs scope;
 
       # Converts a returned function to a functor attribute set if necessary
       ensureAttrs = v: if builtins.isFunction v then { __functor = _: v; } else v;
 
       # this wraps the `drv` function to add `scope` and `overrideScope` to the result.
-      drvScope =
-        allArgs:
-        ensureAttrs (drv allArgs)
-        // {
-          inherit scope;
-          overrideScope =
-            f:
-            let
-              newScope = mkScope (fix' (extends f scope.__unfix__));
-            in
-            # note that we have to be careful here: `allArgs` includes the auto-arguments that
-            # weren't manually specified. If we would just pass `allArgs` to the recursive call here,
-            # then we wouldn't look up any packages in the scope in the next interation, because it
-            # appears as if all arguments were already manually passed, so the scope change would do
-            # nothing.
-            callPackageWithScope newScope drv manualArgs;
-        };
+      # it's a functor, so that we can pass through `functionArgs`
+      drvScope = {
+        __functor =
+          _: allArgs:
+          ensureAttrs (drv allArgs)
+          // {
+            inherit scope;
+            overrideScope =
+              f:
+              let
+                newScope = mkScope (fix' (extends f scope.__unfix__));
+              in
+              # note that we have to be careful here: `allArgs` includes the auto-arguments that
+              # weren't manually specified. If we would just pass `allArgs` to the recursive call here,
+              # then we wouldn't look up any packages in the scope in the next interation, because it
+              # appears as if all arguments were already manually passed, so the scope change would do
+              # nothing.
+              callPackageWithScope newScope drv manualArgs;
+          };
+        # `drvScope` accepts the same arguments as `drv`
+        __functionArgs = drvFunctionArgs;
+      };
     in
     lib.makeOverridable drvScope (auto // manualArgs);
 


### PR DESCRIPTION
Our wrapper for lib.makeOverridable wraps the underlying function which means the wrapper function doesn't replicate the same set pattern. We can, however, tell lib.functionArgs about the permissible arguments by making the function a functor and adding __functionArgs.


```ShellSession
$ nix-instantiate --eval --strict -E 'with import ./. {}; lib.functionArgs haskellPackages.haskell-language-server.override'
{ Cabal = false; Cabal-syntax = false; Diff = false; QuickCheck = false; aeson = false; aeson-pretty = false; array = false; async = false; base = false; binary = false; bytestring = false; cabal-add = false; containers = false; data-default = false; deepseq = false; directory = false; dlist = false; enummapset = false; eventlog2html = false; extra = false; filepath = false; fourmolu = false; fuzzy = false; ghc = false; ghc-boot = false; ghc-boot-th = false; ghc-exactprint = false; ghcide = false; githash = false; hashable = false; hie-bios = false; hie-compat = false; hiedb = false; hls-graph = false; hls-plugin-api = false; hls-test-utils = false; implicit-hie = false; lens = false; lens-aeson = false; list-t = false; lsp = false; lsp-test = false; lsp-types = false; megaparsec = false; mkDerivation = false; mod = false; mtl = false; network-uri = false; optparse-applicative = false; optparse-simple = false; ormolu = false; parser-combinators = false; pretty = false; prettyprinter = false; process = false; process-extras = false; random = false; regex-applicative = false; regex-tdfa = false; row-types = false; safe-exceptions = false; semigroupoids = false; shake = false; shake-bench = false; sqlite-simple = false; stan = false; stm = false; stm-containers = false; stylish-haskell = false; syb = false; tasty = false; tasty-expected-failure = false; tasty-hunit = false; tasty-quickcheck = false; tasty-rerun = false; template-haskell = false; text = false; text-rope = false; time = false; transformers = false; trial = false; unix = false; unliftio = false; unliftio-core = false; unordered-containers = false; vector = false; yaml = false; }
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
