### PR TITLE
asapo-client: init at 25.03.0

### DIFF
--- a/pkgs/by-name/as/asapo-client/package.nix
+++ b/pkgs/by-name/as/asapo-client/package.nix
@@ -1,0 +1,56 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  cmake,
+  curl,
+  rapidjson,
+  rdkafka,
+  mongoc,
+  cyrus_sasl,
+  python3,
+}:
+stdenv.mkDerivation rec {
+  pname = "asapo-client";
+  version = "25.03.0";
+  src = fetchurl {
+    url = "https://gitlab.desy.de/asapo/asapo/-/archive/${version}/asapo-${version}.tar.gz";
+    hash = "sha256-DzqjHU4iqunrPTNV22D7FHZTBNzTh1A75qxfc2/VHBE=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    curl
+    rdkafka
+    mongoc
+    cyrus_sasl
+    python3
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_PYTHON=OFF"
+    "-DBUILD_CLIENTS_ONLY=ON"
+  ];
+
+  preConfigure = ''
+    export CI_COMMIT_REF_NAME=${version}
+    export CI_COMMIT_TAG=${version}
+  '';
+
+  # The bundled rapidjson doesn't compile with gcc-14 and higher.
+  postPatch = ''
+    rm -r 3d_party/rapidjson/include/rapidjson
+    cp -R ${rapidjson}/include 3d_party/rapidjson
+  '';
+
+  meta = with lib; {
+    description = "Middleware platform for high-performance data analysis";
+    homepage = "https://gitlab.desy.de/asapo/asapo";
+    changelog = "https://gitlab.desy.de/asapo/asapo/-/blob/develop/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pmiddend ];
+    platforms = platforms.linux;
+  };
+
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

ASAP:O is a data streaming solution that we use and develop at DESY. It would be interesting to have at least the client libraries (C/C++) in nixpkgs, so we can, for example, have that as a dependency for the other language bindings (there's already hs-asapo in nixpkgs, but that is marked as broken, probably because of the missing C dependency).

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
