### PR TITLE
metal-cli: remove nshalman as maintainer

### DIFF
--- a/pkgs/by-name/me/metal-cli/package.nix
+++ b/pkgs/by-name/me/metal-cli/package.nix
@@ -50,7 +50,6 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       Br1ght0ne
-      nshalman
       teutat3s
     ];
     mainProgram = "metal";


### PR DESCRIPTION
I no longer work at Equinix Metal, nor am I using their service these days.