### PR TITLE
nss_3_115: init at 3.115.1; nss_latest: reapply 3.116 update; buildMozillaMach: use nss_3_115 for 143

### DIFF
--- a/pkgs/build-support/build-mozilla-mach/default.nix
+++ b/pkgs/build-support/build-mozilla-mach/default.nix
@@ -90,6 +90,7 @@ in
   nspr,
   nss_esr,
   nss_3_114,
+  nss_3_115,
   nss_latest,
   onnxruntime,
   pango,
@@ -573,8 +574,10 @@ buildStdenv.mkDerivation {
       xorg.xorgproto
       zlib
       (
-        if (lib.versionAtLeast version "143") then
+        if (lib.versionAtLeast version "144") then
           nss_latest
+        else if (lib.versionAtLeast version "143") then
+          nss_3_115
         else if (lib.versionAtLeast version "141") then
           nss_3_114
         else

--- a/pkgs/development/libraries/nss/3_115.nix
+++ b/pkgs/development/libraries/nss/3_115.nix
@@ -1,0 +1,6 @@
+import ./generic.nix {
+  version = "3.115.1";
+  hash = "sha256-SuXNqRW0lBPioYxmoGa3ZbfxC7ud6TW3xVpakVwtm14=";
+  filename = "3_115.nix";
+  versionRegex = "NSS_(3)_(115)(?:_(\\d+))?_RTM";
+}

--- a/pkgs/development/libraries/nss/latest.nix
+++ b/pkgs/development/libraries/nss/latest.nix
@@ -5,8 +5,8 @@
 #       Example: nix-shell ./maintainers/scripts/update.nix --argstr package cacert
 
 import ./generic.nix {
-  version = "3.115.1";
-  hash = "sha256-SuXNqRW0lBPioYxmoGa3ZbfxC7ud6TW3xVpakVwtm14=";
+  version = "3.116";
+  hash = "sha256-df/xzelMk6IvcmZvzc69WhEaO3SQzSfEy0xXKhSo/Nk=";
   filename = "latest.nix";
   versionRegex = "NSS_(\\d+)_(\\d+)(?:_(\\d+))?_RTM";
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8466,6 +8466,7 @@ with pkgs;
   };
 
   nss_latest = callPackage ../development/libraries/nss/latest.nix { };
+  nss_3_115 = callPackage ../development/libraries/nss/3_115.nix { };
   nss_3_114 = callPackage ../development/libraries/nss/3_114.nix { };
   nss_esr = callPackage ../development/libraries/nss/esr.nix { };
   nss = nss_esr;


### PR DESCRIPTION

https://github.com/NixOS/nixpkgs/pull/443398#issuecomment-3298887498
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
