### PR TITLE
darwin.xcode: add 26

### DIFF
--- a/pkgs/os-specific/darwin/xcode/default.nix
+++ b/pkgs/os-specific/darwin/xcode/default.nix
@@ -43,8 +43,8 @@ let
         '';
       };
       meta = with lib; {
-        homepage = "https://developer.apple.com/downloads/";
-        description = "Apple's XCode SDK";
+        homepage = "https://developer.apple.com/xcode/";
+        description = "Apple's Xcode developer tools";
         license = licenses.unfree;
         platforms = platforms.darwin ++ platforms.linux;
         hydraPlatforms = [ ];

--- a/pkgs/os-specific/darwin/xcode/default.nix
+++ b/pkgs/os-specific/darwin/xcode/default.nix
@@ -45,6 +45,7 @@ let
       meta = with lib; {
         homepage = "https://developer.apple.com/xcode/";
         description = "Apple's Xcode developer tools";
+        maintainers = with lib.maintainers; [ DimitarNestorov ];
         license = licenses.unfree;
         platforms = platforms.darwin ++ platforms.linux;
         hydraPlatforms = [ ];

--- a/pkgs/os-specific/darwin/xcode/default.nix
+++ b/pkgs/os-specific/darwin/xcode/default.nix
@@ -6,9 +6,10 @@
 
 let
   requireXcode =
-    version: sha256:
+    release: sha256:
     let
-      xip = "Xcode_" + version + ".xip";
+      xip = "Xcode_" + release + ".xip";
+      version = lib.removeSuffix "_Universal" (lib.removeSuffix "_Apple_silicon" release);
 
       unxip =
         if stdenv.buildPlatform.isDarwin then
@@ -105,6 +106,8 @@ lib.makeExtensible (self: {
   xcode_16_2 = requireXcode "16.2" "sha256-wQjNuFZu/cN82mEEQbC1MaQt39jLLDsntsbnDidJFEs=";
   xcode_16_3 = requireXcode "16.3" "sha256-hkIlRYUc1SD2lBwhRtqBGJapUIa+tdOyPKG19Su5OUU=";
   xcode_16_4 = requireXcode "16.4" "sha256-voCEZlKrp9NYGmXAsf1FHxO69EgWZHDIWtQZ2qEzElA=";
+  xcode_26 = requireXcode "26_Universal" "sha256-p4INqf85CSIzd7xHRCS9tCigQkOQPKnS/+D5nue3PsY=";
+  xcode_26_Apple_silicon = requireXcode "26_Apple_silicon" "sha256-dlfZ2sM6a9pUPdukoMoqvQAj7EEUyj0a/VkXKwkkFT8=";
   xcode =
     self."xcode_${
       lib.replaceStrings [ "." ] [ "_" ] (

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -172,6 +172,8 @@ makeScopeWithSplicing' {
           xcode_16_2
           xcode_16_3
           xcode_16_4
+          xcode_26
+          xcode_26_Apple_silicon
           xcode
           requireXcode
           ;


### PR DESCRIPTION
|`NIXPKGS_ALLOW_UNFREE=1 nix-build -A darwin.xcode_26`|`NIXPKGS_ALLOW_UNFREE=1 nix-build -A darwin.xcode_26_Apple_silicon`|
|-|-|
|`/nix/store/ilc1y2hkzfkq7ap4ham6ad9bdj8ilkwg-Xcode.app`|`/nix/store/f321s6jn4dz7nvkxf6rmigg5lgr8bnv1-Xcode.app`|
|<img width="1126" height="299" alt="image" src="https://github.com/user-attachments/assets/ef7fb814-efc6-44b1-a4e6-f953461dccb0" />|<img width="1143" height="302" alt="image" src="https://github.com/user-attachments/assets/90241f2a-bcfb-4c02-a474-45106d2d0c58" />|

Apple ships two xips starting Xcode 26
<img width="636" height="91" alt="image" src="https://github.com/user-attachments/assets/cb29a46e-d0cd-4e1b-8b87-a3f1151701dd" />



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
