### PR TITLE
openvswitch: split out lib, dev, tools to reduce closure size

### DIFF
--- a/pkgs/by-name/op/openvswitch/package.nix
+++ b/pkgs/by-name/op/openvswitch/package.nix
@@ -41,7 +41,10 @@ stdenv.mkDerivation rec {
 
   outputs = [
     "out"
+    "dev"
+    "lib"
     "man"
+    "tools"
   ];
 
   patches = [
@@ -100,10 +103,16 @@ stdenv.mkDerivation rec {
     installShellCompletion --bash utilities/ovs-appctl-bashcomp.bash
     installShellCompletion --bash utilities/ovs-vsctl-bashcomp.bash
 
-    wrapProgram $out/bin/ovs-l3ping \
+    mkdir -p $tools/{bin,share/openvswitch/scripts}
+    mv $out/share/openvswitch/bugtool-plugins $tools/share/openvswitch
+    mv $out/share/openvswitch/scripts/ovs-{bugtool*,check-dead-ifs,monitor-ipsec,vtep} $tools/share/openvswitch/scripts
+    mv $out/share/openvswitch/scripts/usdt $tools/share/openvswitch/scripts
+    mv $out/bin/ovs-{bugtool,dpctl-top,l3ping,parse-backtrace,pcap,tcpdump,tcpundump,test,vlan-test} $tools/bin
+
+    wrapProgram $tools/bin/ovs-l3ping \
       --prefix PYTHONPATH : $out/share/openvswitch/python
 
-    wrapProgram $out/bin/ovs-tcpdump \
+    wrapProgram $tools/bin/ovs-tcpdump \
       --prefix PATH : ${lib.makeBinPath [ tcpdump ]} \
       --prefix PYTHONPATH : $out/share/openvswitch/python
   '';

--- a/pkgs/by-name/op/openvswitch/package.nix
+++ b/pkgs/by-name/op/openvswitch/package.nix
@@ -163,6 +163,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       adamcstephens
+      booxter
       kmcopper
       netixx
       xddxdd

--- a/pkgs/by-name/op/openvswitch/package.nix
+++ b/pkgs/by-name/op/openvswitch/package.nix
@@ -100,6 +100,8 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   postInstall = ''
+    # Install bash completions in correct location
+    rm -f $out/etc/bash_completion.d/ovs-*.bash
     installShellCompletion --bash utilities/ovs-appctl-bashcomp.bash
     installShellCompletion --bash utilities/ovs-vsctl-bashcomp.bash
 

--- a/pkgs/by-name/op/openvswitch/package.nix
+++ b/pkgs/by-name/op/openvswitch/package.nix
@@ -102,8 +102,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     # Install bash completions in correct location
     rm -f $out/etc/bash_completion.d/ovs-*.bash
-    installShellCompletion --bash utilities/ovs-appctl-bashcomp.bash
-    installShellCompletion --bash utilities/ovs-vsctl-bashcomp.bash
+    installShellCompletion utilities/ovs-appctl-bashcomp.bash
+    installShellCompletion utilities/ovs-vsctl-bashcomp.bash
 
     mkdir -p $tools/{bin,share/openvswitch/scripts}
     mv $out/share/openvswitch/bugtool-plugins $tools/share/openvswitch


### PR DESCRIPTION
- **openvswitch: split out dev, lib and tools**
- **openvswitch: don't install completions to wrong location**
- **openvswitch: let installShellCompletion detect shell type by extension**
- **openvswitch: add booxter to maintainers**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
