### PR TITLE
nixos/systemd: add units for capsule support

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -208,6 +208,10 @@ let
   ++ [
     "systemd-exit.service"
     "systemd-update-done.service"
+
+    # Capsule support
+    "capsule@.service"
+    "capsule.slice"
   ]
   ++ cfg.additionalUpstreamSystemUnits;
 

--- a/nixos/modules/system/boot/systemd/user.nix
+++ b/nixos/modules/system/boot/systemd/user.nix
@@ -30,6 +30,7 @@ let
     "background.slice"
     "basic.target"
     "bluetooth.target"
+    "capsule@.target"
     "default.target"
     "exit.target"
     "graphical-session-pre.target"

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1411,6 +1411,7 @@ in
   systemd-binfmt = handleTestOn [ "x86_64-linux" ] ./systemd-binfmt.nix { };
   systemd-boot = handleTest ./systemd-boot.nix { };
   systemd-bpf = runTest ./systemd-bpf.nix;
+  systemd-capsules = runTest ./systemd-capsules.nix;
   systemd-confinement = handleTest ./systemd-confinement { };
   systemd-coredump = runTest ./systemd-coredump.nix;
   systemd-credentials-tpm2 = runTest ./systemd-credentials-tpm2.nix;

--- a/nixos/tests/systemd-capsules.nix
+++ b/nixos/tests/systemd-capsules.nix
@@ -1,0 +1,47 @@
+{ lib, ... }:
+{
+  name = "systemd-capsules";
+
+  meta.maintainers = with lib.maintainers; [ fpletz ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      environment.systemPackages = [ pkgs.hello ];
+      systemd.user.services.alice-sleep = {
+        wantedBy = [ "capsule@alice.target" ];
+        serviceConfig = {
+          ExecStart = "${pkgs.coreutils}/bin/sleep 999";
+        };
+      };
+    };
+
+  testScript = # python
+    ''
+      machine.wait_for_unit("multi-user.target")
+
+      with subtest("capsule setup"):
+        machine.succeed("systemctl start capsule@alice.service")
+
+      with subtest("imperative user service in capsule"):
+        machine.succeed("systemd-run --capsule=alice --unit=sleeptest.service /run/current-system/sw/bin/sleep 999")
+        machine.succeed("systemctl --capsule=alice status sleeptest.service")
+
+      with subtest("declarative user service in capsule"):
+        machine.succeed("systemctl --capsule=alice status alice-sleep.service")
+        machine.succeed("systemctl --capsule=alice stop alice-sleep.service")
+        machine.fail("systemctl --capsule=alice status alice-sleep.service")
+        machine.succeed("systemctl --capsule=alice start alice-sleep.service")
+        machine.succeed("systemctl --capsule=alice status alice-sleep.service")
+
+      with subtest("interactive shell with terminal in capsule"):
+        hello_output = machine.succeed("systemd-run -t --capsule=alice /run/current-system/sw/bin/bash -i -c 'hello | tee ~/hello'")
+        assert hello_output == "Hello, world!\r\n"
+        machine.copy_from_vm("/var/lib/capsules/alice/hello")
+
+      with subtest("capsule cleanup"):
+        machine.succeed("systemctl --capsule=alice stop sleeptest.service")
+        machine.succeed("systemctl stop capsule@alice.service")
+        machine.succeed("systemctl clean --all capsule@alice.service")
+    '';
+}


### PR DESCRIPTION
Tested these units with equivalent commands taken from the example in the documentation: https://www.freedesktop.org/software/systemd/man/257/capsule@.service.html

Support for capsules was introduced in systemd version 256 (#307068).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
