### PR TITLE
grooveauthor: init at 1.1.3

### DIFF
--- a/pkgs/by-name/gr/grooveauthor/package.nix
+++ b/pkgs/by-name/gr/grooveauthor/package.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  autoPatchelfHook,
+  copyDesktopItems,
+  makeDesktopItem,
+  wrapGAppsHook3,
+  alsa-lib,
+  dotnetCorePackages,
+  gtk3,
+  libGL,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "grooveauthor";
+  version = "1.1.3";
+
+  src = fetchzip {
+    url = "https://github.com/PerryAsleep/GrooveAuthor/releases/download/v${finalAttrs.version}/GrooveAuthor-v${finalAttrs.version}-linux-x64.tar.gz";
+    hash = "sha256-XuELs7Sj/M32ros5clKxKuVo/CdCja39Lwc+zsFGvFU=";
+    stripRoot = false;
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+    wrapGAppsHook3
+  ];
+
+  runtimeDependencies = [ gtk3 ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      desktopName = "GrooveAuthor";
+      name = finalAttrs.pname;
+      genericName = "Editor for StepMania";
+      icon = "GrooveAuthor";
+      exec = "GrooveAuthor";
+      categories = [
+        "AudioVideo"
+        "AudioVideoEditing"
+      ];
+      keywords = [
+        "GrooveAuthor"
+        "StepMania"
+        "ITG"
+        "ITGmania"
+        "DDR"
+        "PIU"
+        "Pump It Up"
+        "Dance"
+        "StepF2"
+        "StepP1"
+      ];
+      prefersNonDefaultGPU = true;
+      singleMainWindow = true;
+      terminal = false;
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm444 grooveauthor/Icon.svg $out/share/icons/hicolor/scalable/apps/GrooveAuthor.svg
+    mv grooveauthor $out/bin
+    rm $out/bin/{GrooveAuthor.desktop,Icon.svg}
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --set DOTNET_ROOT ${dotnetCorePackages.runtime_8_0}/share/dotnet
+      --suffix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath [
+          alsa-lib
+          libGL
+        ]
+      }"
+    )
+  '';
+
+  meta = {
+    description = "GrooveAuthor is an editor for authoring StepMania charts";
+    homepage = "https://github.com/PerryAsleep/GrooveAuthor";
+    license = with lib.licenses; [
+      mit
+      mspl
+    ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "GrooveAuthor";
+  };
+})


### PR DESCRIPTION
Add GrooveAuthor, an editor for StepMania charts.

I was unfortunately unable to build GrooveAuthor from source due to dependency on MonoGame which requires a Wine environment during build time for Linux targets to compile DirectX shaders.

Cc: @rehtlaw

Can be tested using `nix run github:ungeskriptet/nixpkgs/grooveauthor#grooveauthor`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
