### PR TITLE
aic8800: init at 4.0+git20250410.b99ca8b6-2

### DIFF
--- a/pkgs/by-name/ai/aic8800-firmware/package.nix
+++ b/pkgs/by-name/ai/aic8800-firmware/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  name = "aic8800-firmware";
+  version = "4.0+git20250410.b99ca8b6-4deepin2";
+
+  src = fetchFromGitHub {
+    owner = "deepin-community";
+    repo = "aic8800";
+    rev = finalAttrs.version;
+    hash = "sha256-6MRfsuz+dzBvcmZ1gx1h8S/Xjr05ZbLftgb3RJ7Kp3k=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/firmware/aic8800_fw/
+    cp -rv firmware/* $out/lib/firmware/aic8800_fw/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/deepin-community/aic8800";
+    description = "Aicsemi aic8800 Wi-Fi driver firmware";
+    # Yes, it's unfree. The vendor doesn't provide a redistributable license.
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ Cryolitia ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/os-specific/linux/aic8800/default.nix
+++ b/pkgs/os-specific/linux/aic8800/default.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  kernel,
+  kernelModuleMakeFlags,
+  dpkg,
+  aic8800-firmware,
+}:
+let
+  variant = [
+    "pcie"
+    "sdio"
+    "usb"
+  ];
+in
+stdenv.mkDerivation {
+  name = "aic8800";
+  version = aic8800-firmware.version;
+  src = aic8800-firmware.src;
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies ++ [ dpkg ];
+
+  makeFlags = kernelModuleMakeFlags ++ [
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  outputs = [ "out" ] ++ variant;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -pv $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/
+  ''
+  + lib.strings.concatLines (
+    lib.lists.forEach variant (
+      name:
+      let
+        directory = "lib/modules/${kernel.modDirVersion}/kernel/drivers/aic8800_${lib.strings.toUpper name}";
+      in
+      ''
+        find ./src/"${lib.strings.toUpper name}"/ -name "*.ko" -exec install {} -Dm444 -v -t ${placeholder name}/${directory} \;
+        ln -sv ${placeholder name}/${directory} $out/${directory}
+      ''
+    )
+  )
+  + ''
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/deepin-community/aic8800";
+    description = "Aicsemi aic8800 Wi-Fi driver";
+    # https://github.com/radxa-pkg/aic8800/issues/54
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ Cryolitia ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -694,6 +694,8 @@ in
 
         xpad-noone = callPackage ../os-specific/linux/xpad-noone { };
 
+        aic8800 = callPackage ../os-specific/linux/aic8800 { };
+
       }
       // lib.optionalAttrs config.allowAliases {
         zfs = throw "linuxPackages.zfs has been removed, use zfs_* instead, or linuxPackages.\${pkgs.zfs.kernelModuleAttribute}"; # added 2025-01-23


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`aic8800` is Aicsemi's WIFI chip.

We use the well maintained Radxa's repo[1]. Radxa is a manufacturers of open source single-board computers, whoes many products use aic8800.

1. https://github.com/radxa-pkg/aic8800

Because of kernel packages, I would not build it before PR, but use nixpkgs-review to start build on my matrix.

Because of lacking of hardware, I could not test them (until I boot my Radxa Q6A). Welcome for real hardware test.

- close https://github.com/NixOS/nixpkgs/issues/342133
- (instead) close https://github.com/NixOS/nixpkgs/pull/437452

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
