### PR TITLE
mautrix-{gmessages,meta,signal,slack,whatsapp}: remove olm in favor of goolm

### DIFF
--- a/pkgs/by-name/ma/mautrix-gmessages/package.nix
+++ b/pkgs/by-name/ma/mautrix-gmessages/package.nix
@@ -16,22 +16,23 @@
 
 buildGoModule rec {
   pname = "mautrix-gmessages";
-  version = "0.7.0";
+  version = "25.10";
+  tag = "v0.2510.0";
 
   src = fetchFromGitHub {
     owner = "mautrix";
     repo = "gmessages";
-    tag = "v${version}";
-    hash = "sha256-mcWvNRHRdgcw6ualaaJmUjHOrbOJfufyaHfdp20eoaY=";
+    tag = tag;
+    hash = "sha256-6E2mB9EUED5qD65RS78HQ7krJKyQqryKxVPjUMVRytU=";
   };
 
-  vendorHash = "sha256-nIKRFdJsJrlmncvkXSL3agqTEqlmnEbp/3HZUfYVXpI=";
+  vendorHash = "sha256-6Zwi/6VWDTXtzhWt8dfNoTp//2Tco72b88Mf/tBhasg=";
 
   ldflags = [
     "-s"
     "-w"
     "-X"
-    "main.Tag=${version}"
+    "main.Tag=${tag}"
   ];
 
   buildInputs = lib.optional (!withGoolm) olm;

--- a/pkgs/by-name/ma/mautrix-gmessages/package.nix
+++ b/pkgs/by-name/ma/mautrix-gmessages/package.nix
@@ -16,16 +16,16 @@
 
 buildGoModule rec {
   pname = "mautrix-gmessages";
-  version = "0.6.5";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "mautrix";
     repo = "gmessages";
     tag = "v${version}";
-    hash = "sha256-AIw7Grh4BEDT33N4004XjOtIepguO2SbdUmTHGJ1A2M=";
+    hash = "sha256-mcWvNRHRdgcw6ualaaJmUjHOrbOJfufyaHfdp20eoaY=";
   };
 
-  vendorHash = "sha256-73a+OyauFJv2Rx6tbjwN9SBaXu4ZL5qM5xFt5m8a7c4=";
+  vendorHash = "sha256-nIKRFdJsJrlmncvkXSL3agqTEqlmnEbp/3HZUfYVXpI=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/ma/mautrix-gmessages/package.nix
+++ b/pkgs/by-name/ma/mautrix-gmessages/package.nix
@@ -2,16 +2,9 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  olm,
   nix-update-script,
   testers,
   mautrix-gmessages,
-  # This option enables the use of an experimental pure-Go implementation of the
-  # Olm protocol instead of libolm for end-to-end encryption. Using goolm is not
-  # recommended by the mautrix developers, but they are interested in people
-  # trying it out in non-production-critical environments and reporting any
-  # issues they run into.
-  withGoolm ? false,
 }:
 
 buildGoModule rec {
@@ -35,8 +28,7 @@ buildGoModule rec {
     "main.Tag=${tag}"
   ];
 
-  buildInputs = lib.optional (!withGoolm) olm;
-  tags = lib.optional withGoolm "goolm";
+  tags = "goolm";
 
   doCheck = false;
 

--- a/pkgs/by-name/ma/mautrix-meta/package.nix
+++ b/pkgs/by-name/ma/mautrix-meta/package.nix
@@ -52,7 +52,7 @@ buildGoModule rec {
 
   meta = {
     homepage = "https://github.com/mautrix/meta";
-    description = "Matrix <-> Facebook and Matrix <-> Instagram hybrid puppeting/relaybot bridge";
+    description = "Matrix-Meta puppeting bridge";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [
       eyjhb

--- a/pkgs/by-name/ma/mautrix-meta/package.nix
+++ b/pkgs/by-name/ma/mautrix-meta/package.nix
@@ -15,21 +15,29 @@
 
 buildGoModule rec {
   pname = "mautrix-meta";
-  version = "0.5.3";
+  version = "25.10";
+  tag = "v0.2510.0";
 
   subPackages = [ "cmd/mautrix-meta" ];
 
   src = fetchFromGitHub {
     owner = "mautrix";
     repo = "meta";
-    rev = "v${version}";
-    hash = "sha256-k23ygwKQjKFov/8TJ6BKlcgIv5Jsy7oSBjcCCS5YVm4=";
+    tag = tag;
+    hash = "sha256-DcpOdJ0k3tuAuCIoN6RqXanvu2Xz6fKYhH2pkbAilvk=";
   };
 
   buildInputs = lib.optional (!withGoolm) olm;
   tags = lib.optional withGoolm "goolm";
 
-  vendorHash = "sha256-xibBQNwXzpbvS9nVBBRyJK95I5EqF1Xde1TL1BEZmnA=";
+  vendorHash = "sha256-NwnNFruc5Z162PkbShcgJkrQfcxHIF6UrP8vLbJkicI=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X"
+    "main.Tag=${tag}"
+  ];
 
   passthru = {
     tests = {

--- a/pkgs/by-name/ma/mautrix-meta/package.nix
+++ b/pkgs/by-name/ma/mautrix-meta/package.nix
@@ -4,13 +4,6 @@
   nix-update-script,
   lib,
   nixosTests,
-  olm,
-  # This option enables the use of an experimental pure-Go implementation of the
-  # Olm protocol instead of libolm for end-to-end encryption. Using goolm is not
-  # recommended by the mautrix developers, but they are interested in people
-  # trying it out in non-production-critical environments and reporting any
-  # issues they run into.
-  withGoolm ? false,
 }:
 
 buildGoModule rec {
@@ -27,8 +20,7 @@ buildGoModule rec {
     hash = "sha256-DcpOdJ0k3tuAuCIoN6RqXanvu2Xz6fKYhH2pkbAilvk=";
   };
 
-  buildInputs = lib.optional (!withGoolm) olm;
-  tags = lib.optional withGoolm "goolm";
+  tags = "goolm";
 
   vendorHash = "sha256-NwnNFruc5Z162PkbShcgJkrQfcxHIF6UrP8vLbJkicI=";
 

--- a/pkgs/by-name/ma/mautrix-slack/package.nix
+++ b/pkgs/by-name/ma/mautrix-slack/package.nix
@@ -2,15 +2,8 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  olm,
   nix-update-script,
   versionCheckHook,
-  # This option enables the use of an experimental pure-Go implementation of
-  # the Olm protocol instead of libolm for end-to-end encryption. Using goolm
-  # is not recommended by the mautrix developers, but they are interested in
-  # people trying it out in non-production-critical environments and reporting
-  # any issues they run into.
-  withGoolm ? false,
 }:
 buildGoModule rec {
   pname = "mautrix-slack";
@@ -26,8 +19,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-9MsHRU2EqMTWEMVraJ/6/084X5yx3zzSdxP8zSYFJ1E=";
 
-  buildInputs = lib.optional (!withGoolm) olm;
-  tags = lib.optional withGoolm "goolm";
+  tags = "goolm";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";

--- a/pkgs/by-name/ma/mautrix-whatsapp/package.nix
+++ b/pkgs/by-name/ma/mautrix-whatsapp/package.nix
@@ -3,13 +3,6 @@
   nix-update-script,
   buildGoModule,
   fetchFromGitHub,
-  olm,
-  # This option enables the use of an experimental pure-Go implementation of
-  # the Olm protocol instead of libolm for end-to-end encryption. Using goolm
-  # is not recommended by the mautrix developers, but they are interested in
-  # people trying it out in non-production-critical environments and reporting
-  # any issues they run into.
-  withGoolm ? false,
 }:
 
 buildGoModule rec {
@@ -24,8 +17,7 @@ buildGoModule rec {
     hash = "sha256-jJIVlK4vTJpwjugKNtWZhO31t7YX+q3W+ZmU1w/itvM=";
   };
 
-  buildInputs = lib.optional (!withGoolm) olm;
-  tags = lib.optional withGoolm "goolm";
+  tags = "goolm";
 
   vendorHash = "sha256-LvGapdyGYXNUsC0qniwdoA3pUrOivfFq+nEilw5xFNM=";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I've removed support for libolm as it is marked as insecure and got [deprecated](https://gitlab.matrix.org/matrix-org/olm/-/commit/6d4b5b07887821a95b144091c8497d09d377f985) a while ago.
It made sense to keep olm around, but tbe deprecation was over a year ago.

Goolm is supported by those packages and should replace the old olm version.

If I should change the default to goolm while keeping olm support, please let me know.
I just don't think that olm should be the default.
If you disagree, please let me know why and I can close this pull request.

There was a discussion about dropping goolm upstream: mautrix/go#262

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
