### PR TITLE
nrc-wrapper-go: init at v1.3.8-2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17748,6 +17748,12 @@
     githubId = 16916972;
     name = "Martin Zacho";
   };
+  mzntori = {
+    email = "mzntori@proton.me";
+    name = "mzntori";
+    github = "mzntori";
+    githubId = 44904735;
+  };
   n-hass = {
     email = "nick@hassan.host";
     github = "n-hass";

--- a/pkgs/by-name/nr/nrc-wrapper-go/package.nix
+++ b/pkgs/by-name/nr/nrc-wrapper-go/package.nix
@@ -1,0 +1,31 @@
+{
+  fetchFromGitHub,
+  lib,
+  buildGoModule,
+}:
+buildGoModule (finalAttrs: {
+  pname = "nrc-wrapper-go";
+  version = "1.3.8-2";
+
+  src = fetchFromGitHub {
+    owner = "technicfan";
+    repo = "nrc-wrapper-go";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LNLnh3Vnr4OKIXbTg5HgOKopkchKP8XS/eTw2tBe20I=";
+  };
+
+  vendorHash = "sha256-PvwvVavGTV5QGprMn1M2SOq6upaYCzyzM6dNvZzlXo4=";
+
+  postInstall = ''
+    mv $out/bin/main $out/bin/nrc-wrapper
+  '';
+
+  meta = {
+    description = "NoRisk-Client wrapper for 3rd-Party Minecraft launchers written in go";
+    homepage = "https://github.com/technicfan/nrc-wrapper-go/tree/main";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.all;
+    mainProgram = "nrc-wrapper";
+    maintainers = with lib.maintainers; [ mzntori ];
+  };
+})


### PR DESCRIPTION
Wrapper command for Minecraft launchers like prism-launcher that loads NoRiskClient mods. 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
