### PR TITLE
smithy-cli: init at 1.61.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9492,6 +9492,12 @@
     githubId = 105204;
     name = "Godefroid Chapelle";
   };
+  gotha = {
+    email = "h.georgiev@hotmail.com";
+    github = "gotha";
+    githubId = 522391;
+    name = "Hristo Georgiev";
+  };
   govanify = {
     name = "Gauvain 'GovanifY' Roussel-Tarbouriech";
     email = "gauvain@govanify.com";

--- a/pkgs/by-name/sm/smithy-cli/package.nix
+++ b/pkgs/by-name/sm/smithy-cli/package.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  makeWrapper,
+  jdk17_headless,
+}:
+
+stdenvNoCC.mkDerivation (
+  finalAttrs:
+  let
+    version = "1.61.0";
+    downloadBaseUrl = "https://github.com/smithy-lang/smithy/releases/download/${version}";
+    assets = {
+      "x86_64-linux" = {
+        url = "${downloadBaseUrl}/smithy-cli-linux-x86_64.zip";
+        hash = "sha256-535m0qmju+PvLlZm+XclcgG9eIj1uEmZupxMAjOnpAg=";
+      };
+      "aarch64-linux" = {
+        url = "${downloadBaseUrl}/smithy-cli-linux-aarch64.zip";
+        hash = "sha256-MbrwaUN9PPpVe8QZw5oN1Gp1BIEQSYYhsgrWgMNkGwE=";
+      };
+      "x86_64-darwin" = {
+        url = "${downloadBaseUrl}/smithy-cli-darwin-x86_64.zip";
+        hash = "sha256-va21jZm7/R54VCyxJxMhh+ppUhYRZ1PEl8PMVtnlS58=";
+      };
+      "aarch64-darwin" = {
+        url = "${downloadBaseUrl}/smithy-cli-darwin-aarch64.zip";
+        hash = "sha256-R9SGzJvCZx0SnQqua+u+LbMIOwMxn6u2ylWc//xC9Sc=";
+      };
+    };
+
+    sys = stdenvNoCC.hostPlatform.system;
+    asset = assets.${sys} or (throw "smithy-cli: unsupported system ${sys}");
+  in
+  {
+    pname = "smithy-cli";
+    inherit version;
+
+    src = fetchzip {
+      inherit (asset) url hash;
+      stripRoot = true;
+    };
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/libexec/smithy/bin
+      install -Dm555 bin/smithy -t $out/libexec/smithy/bin
+
+      mkdir -p $out/libexec/smithy/lib
+      cp -r ./lib/* $out/libexec/smithy/lib
+
+      # make sure we use nix's java
+      substituteInPlace $out/libexec/smithy/bin/smithy \
+        --replace 'JAVACMD="$JAVA_HOME/bin/java"' 'JAVACMD="java"'
+
+      makeWrapper $out/libexec/smithy/bin/smithy $out/bin/smithy \
+        --set SMITHY_HOME $out/libexec/smithy \
+        --prefix PATH : ${lib.makeBinPath [ jdk17_headless ]}
+
+      runHook postInstall
+    '';
+
+    doInstallCheck = true;
+    installCheckPhase = ''
+      $out/bin/smithy --version >/dev/null
+    '';
+
+    meta = with lib; {
+      description = "Command-line interface for the Smithy IDL and tooling";
+      homepage = "https://github.com/smithy-lang/smithy";
+      license = licenses.asl20;
+      maintainers = with maintainers; [ gotha ];
+      platforms = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+      mainProgram = "smithy";
+    };
+  }
+)


### PR DESCRIPTION

Added new package for [smithy-cli](https://github.com/smithy-lang/smithy)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
