### PR TITLE
tuned: add missing runtime dependencies

### DIFF
--- a/pkgs/by-name/tu/tuned/package.nix
+++ b/pkgs/by-name/tu/tuned/package.nix
@@ -10,6 +10,7 @@
   gobject-introspection,
   hdparm,
   iproute2,
+  kmod,
   nix-update-script,
   nixosTests,
   pkg-config,
@@ -19,6 +20,7 @@
   util-linux,
   versionCheckHook,
   virt-what,
+  wirelesstools,
   wrapGAppsHook3,
 }:
 
@@ -111,8 +113,10 @@ stdenv.mkDerivation (finalAttrs: {
       gawk
       hdparm
       iproute2
+      kmod
       util-linux
       virt-what
+      wirelesstools
     ])
   ];
 


### PR DESCRIPTION
`iwpriv` from `wirelesstools` and `modprobe`/`modinfo` from `kmod` are required.

From `/var/log/tuned/tuned.log` after applying some profiles and running `tuned-adm verify`:

```
tuned.plugins.plugin_script: script '/nix/store/xqrdyv11b27rlli821yadwhqifj7ap25-tuned-2.26.0/lib/tuned/profiles/powersave/script.sh' error output: '/nix/store/xqrdyv11b27rlli821yadwhqifj7ap25-tuned-2.26.0/lib/tuned/functions: line 315: iwpriv: command not found'
tuned.utils.commands: Executing 'modinfo cpufreq_conservative' error: [Errno 2] No such file or directory: 'modinfo'
tuned.utils.commands: Executing 'modprobe -r cpufreq_conservative' error: [Errno 2] No such file or directory: 'modprobe'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
