### PR TITLE
mongodb-7_0: 7.0.22 -> 7.0.24, disable --use-system-pcre2

### DIFF
--- a/pkgs/servers/nosql/mongodb/7.0.nix
+++ b/pkgs/servers/nosql/mongodb/7.0.nix
@@ -21,8 +21,8 @@ let
 in
 buildMongoDB {
   inherit avxSupport;
-  version = "7.0.22";
-  sha256 = "sha256-Je4vPG8tz1vqCEXzWyYi5KWQaxzlH0hOKSpWBgPs0Hs=";
+  version = "7.0.24";
+  sha256 = "sha256-ANPg60OAxwwq1FhRTMOQ0dHBOuKpob1sXnAZMJWhtds=";
   patches = [
     # ModuleNotFoundError: No module named 'mongo_tooling_metrics':
     # NameError: name 'SConsToolingMetrics' is not defined:

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -5,8 +5,6 @@
   buildPackages,
   boost,
   gperftools,
-  pcre2,
-  pcre-cpp,
   snappy,
   zlib,
   yaml-cpp,
@@ -49,6 +47,7 @@ let
 
   system-libraries = [
     "boost"
+    #pcre2 -- breaks on pcre2-10.46 with at least version 7.0.24
     "snappy"
     "yaml"
     "zlib"
@@ -57,13 +56,7 @@ let
     #"valgrind" -- mongodb only requires valgrind.h, which is vendored in the source.
     #"wiredtiger"
   ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ "tcmalloc" ]
-  ++ lib.optionals (lib.versionOlder version "7.0") [
-    "pcre"
-  ]
-  ++ lib.optionals (lib.versionAtLeast version "7.0") [
-    "pcre2"
-  ];
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ "tcmalloc" ];
   inherit (lib) systems subtractLists;
 
 in
@@ -92,8 +85,6 @@ stdenv.mkDerivation rec {
     yaml-cpp
     openssl
     openldap
-    pcre2
-    pcre-cpp
     sasl
     snappy
     zlib


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/450088

https://www.mongodb.com/docs/manual/release-notes/7.0-changelog/

disable --use-system-pcre2 which broke after upgrading to pcre2-10.46

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
