### PR TITLE
cinnamon, cjs: Backport fixes to support GLib 2.86.0 typelibs

### DIFF
--- a/pkgs/by-name/ci/cinnamon/package.nix
+++ b/pkgs/by-name/ci/cinnamon/package.nix
@@ -10,6 +10,7 @@
   cjs,
   evolution-data-server,
   fetchFromGitHub,
+  fetchpatch,
   gcr,
   gdk-pixbuf,
   gettext,
@@ -87,6 +88,17 @@ stdenv.mkDerivation rec {
   patches = [
     ./use-sane-install-dir.patch
     ./libdir.patch
+
+    # js: Use DesktopAppInfo form GioUnix, not Gio
+    # https://github.com/linuxmint/cinnamon/pull/13091
+    (fetchpatch {
+      url = "https://github.com/linuxmint/cinnamon/commit/fa3aef20533af4499fb1161011e62e048bbdc396.patch";
+      hash = "sha256-qhgBniaUE/8q9BQ+EXcY7BF6eMJg+wC7EYgktwAMbwM=";
+    })
+    (fetchpatch {
+      url = "https://github.com/linuxmint/cinnamon/commit/330b9ff19f33ec1e94e36048ca46011404f796b4.patch";
+      hash = "sha256-YEQG6C4tx2T3wMfCLZXPFynAzEeIE1eVoadWVENZDFc=";
+    })
   ];
 
   buildInputs = [

--- a/pkgs/by-name/cj/cjs/package.nix
+++ b/pkgs/by-name/cj/cjs/package.nix
@@ -19,13 +19,16 @@
 
 stdenv.mkDerivation rec {
   pname = "cjs";
-  version = "128.0";
+  version = "128.0-unstable-2025-09-15";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cjs";
-    rev = version;
-    hash = "sha256-B9N/oNRvsnr3MLkpcH/aBST6xOJSFdvSUFuD6EldE38=";
+    # Backport fixes to support GLib 2.86.0 typelibs
+    # nixpkgs-update: no auto update
+    # https://github.com/linuxmint/cjs/issues/130
+    rev = "1f39576bafe6bc05bce960e590dc743dd7990e39";
+    hash = "sha256-drKLaTZLIZfPIhcVcCAB48PdM2b0GNLe5xrHGBysVmM=";
   };
 
   outputs = [


### PR DESCRIPTION
cc https://github.com/NixOS/nixpkgs/pull/440720

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

