### PR TITLE
rocmPackages.hiprt: tidy, disable kernel encryption support

### DIFF
--- a/pkgs/development/rocm-modules/6/hiprt/default.nix
+++ b/pkgs/development/rocm-modules/6/hiprt/default.nix
@@ -58,6 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       mksafavi
     ];
+    teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/development/rocm-modules/6/hiprt/default.nix
+++ b/pkgs/development/rocm-modules/6/hiprt/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   cmake,
   clr,
-  gcc,
   python3,
 }:
 
@@ -20,13 +19,12 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   postPatch = ''
-    g++ contrib/easy-encryption/cl.cpp -o contrib/easy-encryption/bin/linux/ee64 #replacing prebuilt binary
+    rm -rf contrib/easy-encrypt # contains prebuilt easy-encrypt binaries, we disable encryption
     substituteInPlace contrib/Orochi/contrib/hipew/src/hipew.cpp --replace-fail '"/opt/rocm/hip/lib/' '"${clr}/lib'
     substituteInPlace hiprt/hiprt_libpath.h --replace-fail '"/opt/rocm/hip/lib/' '"${clr}/lib/'
   '';
 
   nativeBuildInputs = [
-    gcc # required for replacing easy-encryption binary
     cmake
     python3
   ];
@@ -42,6 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "PRECOMPILE" true)
     # needs accelerator
     (lib.cmakeBool "NO_UNITTEST" true)
+    # we have no need to support baking encrypted kernels into object files
+    (lib.cmakeBool "NO_ENCRYPT" true)
     (lib.cmakeBool "FORCE_DISABLE_CUDA" true)
   ];
 

--- a/pkgs/development/rocm-modules/6/hiprt/default.nix
+++ b/pkgs/development/rocm-modules/6/hiprt/default.nix
@@ -36,13 +36,13 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-D CMAKE_BUILD_TYPE=Release"
-    "-D BAKE_KERNEL=OFF"
-    "-D BAKE_COMPILED_KERNEL=OFF"
-    "-D BITCODE=ON"
-    "-D PRECOMPILE=ON"
-    "-D NO_UNITTEST=ON"
-    "-D FORCE_DISABLE_CUDA=ON"
+    (lib.cmakeBool "BAKE_KERNEL" false)
+    (lib.cmakeBool "BAKE_COMPILED_KERNEL" false)
+    (lib.cmakeBool "BITCODE" true)
+    (lib.cmakeBool "PRECOMPILE" true)
+    # needs accelerator
+    (lib.cmakeBool "NO_UNITTEST" true)
+    (lib.cmakeBool "FORCE_DISABLE_CUDA" true)
   ];
 
   postInstall = ''


### PR DESCRIPTION
@mksafavi @amarshall I'd appreciate if one of you can confirm if this still works for your usecase.

---

Per upstream encryption of kernels was a holdover from when hiprt was closed source.
Let's disable it and drop the need to rebuild easy-encryption.

https://github.com/GPUOpen-LibrariesAndSDKs/HIPRT/issues/11#issuecomment-2105410458

Upstream PR to drop encryption support: https://github.com/GPUOpen-LibrariesAndSDKs/HIPRT/pull/48

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 443608`
Commit: `804e7608b3bbdd64dcf04b8d998f3e05621b39bf`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>blender-hip</li>
    <li>rocmPackages.hiprt (rocmPackages_6.hiprt)</li>
  </ul>
</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`. (blender.passthru.tests)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
