### PR TITLE
kdePackages.wallpaper-engine-plugin: 0.5.5-unstable-2024-11-03 -> 0.5.4-unstable-2025-06-29

### DIFF
--- a/pkgs/applications/video/glaxnimate/default.nix
+++ b/pkgs/applications/video/glaxnimate/default.nix
@@ -39,14 +39,15 @@ let
     ]
   );
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "glaxnimate";
   version = "0.5.4";
 
   src = fetchFromGitLab {
-    owner = "mattbas";
-    repo = "${pname}";
-    rev = version;
+    domain = "invent.kde.org";
+    owner = "graphics";
+    repo = "glaxnimate";
+    tag = finalAttrs.version;
     hash = "sha256-8oHJCQdP2xxSSDM0MDkSrG89WgCtMKm1AKlddnq3gig=";
     fetchSubmodules = true;
   };
@@ -92,11 +93,11 @@ stdenv.mkDerivation rec {
     }
   );
 
-  meta = with lib; {
+  meta = {
     homepage = "https://gitlab.com/mattbas/glaxnimate";
     description = "Simple vector animation program";
-    license = licenses.gpl3;
-    maintainers = with maintainers; [ tobiasBora ];
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ tobiasBora ];
     mainProgram = "glaxnimate";
   };
-}
+})

--- a/pkgs/kde/third-party/wallpaper-engine-plugin/default.nix
+++ b/pkgs/kde/third-party/wallpaper-engine-plugin/default.nix
@@ -17,13 +17,13 @@
 }:
 mkKdeDerivation {
   pname = "wallpaper-engine-kde-plugin";
-  version = "0.5.5-unstable-2024-11-03";
+  version = "0.5.4-unstable-2025-06-29";
 
   src = fetchFromGitHub {
     owner = "catsout";
     repo = "wallpaper-engine-kde-plugin";
-    rev = "ed58dd8b920dbb2bf0859ab64e0b5939b8a32a0e";
-    hash = "sha256-ICQLtw+qaOMf0lkqKegp+Dkl7eUgPqKDn8Fj5Osb7eA=";
+    rev = "9e60b364e268814a1a778549c579ad45a9b9c7bb";
+    hash = "sha256-zEpELmuK+EvQ1HIWxCSAGyJAjmGgp0yqjtNuC2DTES8=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Should fix the build with CMake 4.

Diff: https://github.com/catsout/wallpaper-engine-kde-plugin/compare/ed58dd8b920dbb2bf0859ab64e0b5939b8a32a0e...9e60b364e268814a1a778549c579ad45a9b9c7bb


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
