### PR TITLE
ci.eval.compare: extend the performance comparison script

### DIFF
--- a/ci/eval/compare/cmp-stats.py
+++ b/ci/eval/compare/cmp-stats.py
@@ -95,25 +95,16 @@ def dataframe_to_markdown(df: pd.DataFrame) -> str:
 
     # Header (get column names and format them)
     headers = [str(column) for column in df.columns]
-    table = []
+    table = [
+        [
+            row["metric"],
+            # Check for no change and NaN in p_value/t_stat
+            *[None if np.isnan(val) or np.allclose(val, 0) else val for val in row[1:]],
+        ]
+        for _, row in df.iterrows()
+    ]
 
-    # Iterate over rows to build Markdown rows
-    for _, row in df.iterrows():
-        # Check for no change and NaN in p_value/t_stat
-        row_values = []
-        for val in row:
-            if isinstance(val, (float, int)):
-                if np.isnan(val):
-                    row_values.append("-")  # Custom symbol for NaN
-                elif val == 0:
-                    row_values.append("-")  # Custom symbol for no change
-                else:
-                    row_values.append(f"{val:.4f}")
-            else:
-                row_values.append(str(val))
-        table.append(row_values)
-
-    return tabulate(table, headers, tablefmt="github")
+    return tabulate(table, headers, tablefmt="github", floatfmt=".4f", missingval="-")
 
 
 def perform_pairwise_tests(before_metrics: dict, after_metrics: dict) -> pd.DataFrame:

--- a/ci/eval/compare/cmp-stats.py
+++ b/ci/eval/compare/cmp-stats.py
@@ -79,8 +79,19 @@ def load_all_metrics(path: Path) -> dict:
     return metrics
 
 
+def metric_sort_key(name: str) -> str:
+    if name in ("cpuTime", "time.cpu", "time.gc", "time.gcFraction"):
+        return (1, name)
+    elif name.startswith("gc"):
+        return (2, name)
+    else:
+        return (3, name)
+
+
 def dataframe_to_markdown(df: pd.DataFrame) -> str:
-    df = df.sort_values(by=df.columns[0], ascending=True)
+    df = df.sort_values(
+        by=df.columns[0], ascending=True, key=lambda s: s.map(metric_sort_key)
+    )
 
     # Header (get column names and format them)
     headers = [str(column) for column in df.columns]

--- a/ci/eval/compare/cmp-stats.py
+++ b/ci/eval/compare/cmp-stats.py
@@ -152,20 +152,6 @@ def main():
     before_stats = Path(options.before)
     after_stats = Path(options.after)
 
-    # This may happen if the pull request target does not include PR#399720 yet.
-    if not before_stats.exists():
-        print(
-            "⚠️  Skipping comparison: stats directory is missing in the target commit."
-        )
-        exit(0)
-
-    # This should never happen, but we're exiting gracefully anyways
-    if not after_stats.exists():
-        print(
-            "⚠️  Skipping comparison: stats directory missing in current PR evaluation."
-        )
-        exit(0)
-
     before_metrics = load_all_metrics(before_stats)
     after_metrics = load_all_metrics(after_stats)
     df1 = perform_pairwise_tests(before_metrics, after_metrics)

--- a/ci/eval/compare/cmp-stats.py
+++ b/ci/eval/compare/cmp-stats.py
@@ -30,12 +30,18 @@ def flatten_data(json_data: dict) -> dict:
         dict: Flattened metrics with keys as metric names.
     """
     flat_metrics = {}
-    for k, v in json_data.items():
-        if isinstance(v, (int, float)):
-            flat_metrics[k] = v
-        elif isinstance(v, dict):
-            for sub_k, sub_v in v.items():
-                flat_metrics[f"{k}.{sub_k}"] = sub_v
+    for key, value in json_data.items():
+        if isinstance(value, (int, float)):
+            flat_metrics[key] = value
+        elif isinstance(value, dict):
+            for subkey, subvalue in value.items():
+                assert isinstance(subvalue, (int, float)), subvalue
+                flat_metrics[f"{key}.{subkey}"] = subvalue
+        else:
+            assert isinstance(value, (float, int, dict)), (
+                f"Value `{value}` has unexpected type"
+            )
+
     return flat_metrics
 
 

--- a/ci/eval/compare/cmp-stats.py
+++ b/ci/eval/compare/cmp-stats.py
@@ -3,6 +3,7 @@ import json
 import numpy as np
 import os
 import pandas as pd
+import warnings
 
 from pathlib import Path
 from scipy.stats import ttest_rel
@@ -148,6 +149,9 @@ def main():
     parser.add_argument("after", help="directory containing comparison (data after)")
 
     options = parser.parse_args()
+
+    # Turn warnings into errors
+    warnings.simplefilter("error")
 
     before_stats = Path(options.before)
     after_stats = Path(options.after)

--- a/ci/eval/compare/cmp-stats.py
+++ b/ci/eval/compare/cmp-stats.py
@@ -139,7 +139,7 @@ def perform_pairwise_tests(before_metrics: dict, after_metrics: dict) -> pd.Data
     return df
 
 
-if __name__ == "__main__":
+def main():
     before_dir = os.environ.get("BEFORE_DIR")
     after_dir = os.environ.get("AFTER_DIR")
 
@@ -169,3 +169,7 @@ if __name__ == "__main__":
     df1 = perform_pairwise_tests(before_metrics, after_metrics)
     markdown_table = dataframe_to_markdown(df1)
     print(markdown_table)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/eval/compare/cmp-stats.py
+++ b/ci/eval/compare/cmp-stats.py
@@ -1,9 +1,10 @@
 import json
-import os
-from scipy.stats import ttest_rel
-import pandas as pd
 import numpy as np
+import os
+import pandas as pd
+
 from pathlib import Path
+from scipy.stats import ttest_rel
 
 # Define metrics of interest (can be expanded as needed)
 METRIC_PREFIXES = ("nr", "gc")

--- a/ci/eval/compare/cmp-stats.py
+++ b/ci/eval/compare/cmp-stats.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 import numpy as np
 import os
@@ -140,15 +141,16 @@ def perform_pairwise_tests(before_metrics: dict, after_metrics: dict) -> pd.Data
 
 
 def main():
-    before_dir = os.environ.get("BEFORE_DIR")
-    after_dir = os.environ.get("AFTER_DIR")
+    parser = argparse.ArgumentParser(
+        description="Performance comparison of Nix evaluation statistics"
+    )
+    parser.add_argument("before", help="directory containing baseline (data before)")
+    parser.add_argument("after", help="directory containing comparison (data after)")
 
-    if not before_dir or not after_dir:
-        print("Error: Environment variables 'BEFORE_DIR' and 'AFTER_DIR' must be set.")
-        exit(1)
+    options = parser.parse_args()
 
-    before_stats = Path(before_dir) / "stats"
-    after_stats = Path(after_dir) / "stats"
+    before_stats = Path(options.before)
+    after_stats = Path(options.after)
 
     # This may happen if the pull request target does not include PR#399720 yet.
     if not before_stats.exists():

--- a/ci/eval/compare/cmp-stats.py
+++ b/ci/eval/compare/cmp-stats.py
@@ -24,6 +24,9 @@ def flatten_data(json_data: dict) -> dict:
     "gc.heapSize": 5404549120
     ...
 
+    See https://github.com/NixOS/nix/blob/187520ce88c47e2859064704f9320a2d6c97e56e/src/libexpr/eval.cc#L2846
+    for the ultimate source of this data.
+
     Args:
         json_data (dict): JSON data containing metrics.
     Returns:
@@ -31,6 +34,10 @@ def flatten_data(json_data: dict) -> dict:
     """
     flat_metrics = {}
     for key, value in json_data.items():
+        # This key is duplicated as `time.cpu`; we keep that copy.
+        if key == "cpuTime":
+            continue
+
         if isinstance(value, (int, float)):
             flat_metrics[key] = value
         elif isinstance(value, dict):
@@ -80,7 +87,7 @@ def load_all_metrics(path: Path) -> dict:
 
 
 def metric_sort_key(name: str) -> str:
-    if name in ("cpuTime", "time.cpu", "time.gc", "time.gcFraction"):
+    if name in ("time.cpu", "time.gc", "time.gcFraction"):
         return (1, name)
     elif name.startswith("gc"):
         return (2, name)

--- a/ci/eval/compare/cmp-stats.py
+++ b/ci/eval/compare/cmp-stats.py
@@ -9,9 +9,6 @@ from pathlib import Path
 from scipy.stats import ttest_rel
 from tabulate import tabulate
 
-# Define metrics of interest (can be expanded as needed)
-METRIC_PREFIXES = ("nr", "gc")
-
 
 def flatten_data(json_data: dict) -> dict:
     """

--- a/ci/eval/compare/cmp-stats.py
+++ b/ci/eval/compare/cmp-stats.py
@@ -117,25 +117,32 @@ def perform_pairwise_tests(before_metrics: dict, after_metrics: dict) -> pd.Data
                 before_vals.append(before_metrics[fname][key])
                 after_vals.append(after_metrics[fname][key])
 
-        if len(before_vals) >= 2:
-            before_arr = np.array(before_vals)
-            after_arr = np.array(after_vals)
+        if len(before_vals) == 0:
+            continue
 
-            diff = after_arr - before_arr
-            pct_change = 100 * diff / before_arr
+        before_arr = np.array(before_vals)
+        after_arr = np.array(after_vals)
+
+        diff = after_arr - before_arr
+        pct_change = 100 * diff / before_arr
+
+        # If there are enough values to perform a t-test, do so, otherwise mark NaN
+        if len(before_vals) == 1:
+            t_stat, p_val = [float("NaN")] * 2
+        else:
             t_stat, p_val = ttest_rel(after_arr, before_arr)
 
-            results.append(
-                {
-                    "metric": key,
-                    "mean_before": np.mean(before_arr),
-                    "mean_after": np.mean(after_arr),
-                    "mean_diff": np.mean(diff),
-                    "mean_%_change": np.mean(pct_change),
-                    "p_value": p_val,
-                    "t_stat": t_stat,
-                }
-            )
+        results.append(
+            {
+                "metric": key,
+                "mean_before": np.mean(before_arr),
+                "mean_after": np.mean(after_arr),
+                "mean_diff": np.mean(diff),
+                "mean_%_change": np.mean(pct_change),
+                "p_value": p_val,
+                "t_stat": t_stat,
+            }
+        )
 
     df = pd.DataFrame(results).sort_values("p_value")
     return df

--- a/ci/eval/compare/cmp-stats.py
+++ b/ci/eval/compare/cmp-stats.py
@@ -86,8 +86,10 @@ def metric_sort_key(name: str) -> str:
         return (2, name)
     elif name.endswith(("bytes", "Bytes")):
         return (3, name)
-    else:
+    elif name.startswith("nr") or name.endswith("number"):
         return (4, name)
+    else:
+        return (5, name)
 
 
 def dataframe_to_markdown(df: pd.DataFrame) -> str:

--- a/ci/eval/compare/cmp-stats.py
+++ b/ci/eval/compare/cmp-stats.py
@@ -84,8 +84,10 @@ def metric_sort_key(name: str) -> str:
         return (1, name)
     elif name.startswith("gc"):
         return (2, name)
-    else:
+    elif name.endswith(("bytes", "Bytes")):
         return (3, name)
+    else:
+        return (4, name)
 
 
 def dataframe_to_markdown(df: pd.DataFrame) -> str:

--- a/ci/eval/compare/cmp-stats.py
+++ b/ci/eval/compare/cmp-stats.py
@@ -41,23 +41,36 @@ def flatten_data(json_data: dict) -> dict:
     return flat_metrics
 
 
-def load_all_metrics(directory: Path) -> dict:
+def load_all_metrics(path: Path) -> dict:
     """
-    Loads all stats JSON files in the specified directory and extracts metrics.
+    Loads all stats JSON files in the specified file or directory and extracts metrics.
+    These stats JSON files are created by Nix when the `NIX_SHOW_STATS` environment variable is set.
+
+    If the provided path is a directory, it must have the structure $path/$system/$stats,
+    where $path is the provided path, $system is some system from `lib.systems.doubles.*`,
+    and $stats is a stats JSON file.
+
+    If the provided path is a file, it is a stats JSON file.
 
     Args:
-        directory (Path): Directory containing JSON files.
+        path (Path): Directory containing JSON files or a stats JSON file.
+
     Returns:
         dict: Dictionary with filenames as keys and extracted metrics as values.
     """
     metrics = {}
-    for system_dir in directory.iterdir():
-        assert system_dir.is_dir()
+    if path.is_dir():
+        for system_dir in path.iterdir():
+            assert system_dir.is_dir()
 
-        for chunk_output in system_dir.iterdir():
-            with chunk_output.open() as f:
-                data = json.load(f)
-            metrics[f"{system_dir.name}/${chunk_output.name}"] = flatten_data(data)
+            for chunk_output in system_dir.iterdir():
+                with chunk_output.open() as f:
+                    data = json.load(f)
+
+                metrics[f"{system_dir.name}/${chunk_output.name}"] = flatten_data(data)
+    else:
+        with path.open() as f:
+            metrics[path.name] = flatten_data(json.load(f))
 
     return metrics
 
@@ -106,11 +119,11 @@ def perform_pairwise_tests(before_metrics: dict, after_metrics: dict) -> pd.Data
             for metric_keys in file_metrics.keys()
         }
     )
-
     results = []
 
     for key in all_keys:
-        before_vals, after_vals = [], []
+        before_vals = []
+        after_vals = []
 
         for fname in common_files:
             if key in before_metrics[fname] and key in after_metrics[fname]:
@@ -152,8 +165,12 @@ def main():
     parser = argparse.ArgumentParser(
         description="Performance comparison of Nix evaluation statistics"
     )
-    parser.add_argument("before", help="directory containing baseline (data before)")
-    parser.add_argument("after", help="directory containing comparison (data after)")
+    parser.add_argument(
+        "before", help="File or directory containing baseline (data before)"
+    )
+    parser.add_argument(
+        "after", help="File or directory containing comparison (data after)"
+    )
 
     options = parser.parse_args()
 

--- a/ci/eval/compare/cmp-stats.py
+++ b/ci/eval/compare/cmp-stats.py
@@ -8,6 +8,7 @@ import warnings
 from pathlib import Path
 from scipy.stats import ttest_rel
 from tabulate import tabulate
+from typing import Final
 
 
 def flatten_data(json_data: dict) -> dict:
@@ -86,6 +87,49 @@ def load_all_metrics(path: Path) -> dict:
     return metrics
 
 
+def metric_table_name(name: str, explain: bool) -> str:
+    """
+    Returns the name of the metric, plus a footnote to explain it if needed.
+    """
+    return f"{name}[^{name}]" if explain else name
+
+
+METRIC_EXPLANATION_FOOTNOTE: Final[str] = """
+
+[^time.cpu]: Number of seconds of CPU time accounted by the OS to the Nix evaluator process. On UNIX systems, this comes from [`getrusage(RUSAGE_SELF)`](https://man7.org/linux/man-pages/man2/getrusage.2.html).
+[^time.gc]: Number of seconds of CPU time accounted by the Boehm garbage collector to performing GC.
+[^time.gcFraction]: What fraction of the total CPU time is accounted towards performing GC.
+[^gc.cycles]: Number of times garbage collection has been performed.
+[^gc.heapSize]: Size in bytes of the garbage collector heap.
+[^gc.totalBytes]: Size in bytes of all allocations in the garbage collector.
+[^envs.bytes]: Size in bytes of all `Env` objects allocated by the Nix evaluator. These are almost exclusively created by [`nix-env`](https://nix.dev/manual/nix/stable/command-ref/nix-env.html).
+[^list.bytes]: Size in bytes of all [lists](https://nix.dev/manual/nix/stable/language/syntax.html#list-literal) allocated by the Nix evaluator.
+[^sets.bytes]: Size in bytes of all [attrsets](https://nix.dev/manual/nix/stable/language/syntax.html#list-literal) allocated by the Nix evaluator.
+[^symbols.bytes]: Size in bytes of all items in the Nix evaluator symbol table.
+[^values.bytes]: Size in bytes of all values allocated by the Nix evaluator.
+[^envs.number]: The count of all `Env` objects allocated.
+[^nrAvoided]: The number of thunks avoided being created.
+[^nrExprs]: The number of expression objects ever created.
+[^nrFunctionCalls]: The number of function calls ever made.
+[^nrLookups]: The number of lookups into an attrset ever made.
+[^nrOpUpdateValuesCopied]: The number of attrset values copied in the process of merging attrsets.
+[^nrOpUpdates]: The number of attrsets merge operations (`//`) performed.
+[^nrPrimOpCalls]: The number of function calls to primops (Nix builtins) ever made.
+[^nrThunks]: The number of [thunks](https://nix.dev/manual/nix/latest/language/evaluation.html#laziness) ever made. A thunk is a delayed computation, represented by an expression reference and a closure.
+[^sets.number]: The number of attrsets ever made.
+[^symbols.number]: The number of symbols ever added to the symbol table.
+[^values.number]: The number of values ever made.
+[^envs.elements]: The number of values contained within an `Env` object.
+[^list.concats]: The number of list concatenation operations (`++`) performed.
+[^list.elements]: The number of values contained within a list.
+[^sets.elements]: The number of values contained within an attrset.
+[^sizes.Attr]: Size in bytes of the `Attr` type.
+[^sizes.Bindings]: Size in bytes of the `Bindings` type.
+[^sizes.Env]: Size in bytes of the `Env` type.
+[^sizes.Value]: Size in bytes of the `Value` type.
+"""
+
+
 def metric_sort_key(name: str) -> str:
     if name in ("time.cpu", "time.gc", "time.gcFraction"):
         return (1, name)
@@ -99,7 +143,7 @@ def metric_sort_key(name: str) -> str:
         return (5, name)
 
 
-def dataframe_to_markdown(df: pd.DataFrame) -> str:
+def dataframe_to_markdown(df: pd.DataFrame, explain: bool) -> str:
     df = df.sort_values(
         by=df.columns[0], ascending=True, key=lambda s: s.map(metric_sort_key)
     )
@@ -108,14 +152,18 @@ def dataframe_to_markdown(df: pd.DataFrame) -> str:
     headers = [str(column) for column in df.columns]
     table = [
         [
-            row["metric"],
+            # The metric acts as its own footnote name
+            metric_table_name(row["metric"], explain),
             # Check for no change and NaN in p_value/t_stat
             *[None if np.isnan(val) or np.allclose(val, 0) else val for val in row[1:]],
         ]
         for _, row in df.iterrows()
     ]
 
-    return tabulate(table, headers, tablefmt="github", floatfmt=".4f", missingval="-")
+    result = tabulate(table, headers, tablefmt="github", floatfmt=".4f", missingval="-")
+    if explain:
+        result += METRIC_EXPLANATION_FOOTNOTE
+    return result
 
 
 def perform_pairwise_tests(before_metrics: dict, after_metrics: dict) -> pd.DataFrame:
@@ -174,6 +222,9 @@ def main():
         description="Performance comparison of Nix evaluation statistics"
     )
     parser.add_argument(
+        "--explain", action="store_true", help="Explain the evaluation statistics"
+    )
+    parser.add_argument(
         "before", help="File or directory containing baseline (data before)"
     )
     parser.add_argument(
@@ -191,7 +242,7 @@ def main():
     before_metrics = load_all_metrics(before_stats)
     after_metrics = load_all_metrics(after_stats)
     df1 = perform_pairwise_tests(before_metrics, after_metrics)
-    markdown_table = dataframe_to_markdown(df1)
+    markdown_table = dataframe_to_markdown(df1, explain=options.explain)
     print(markdown_table)
 
 

--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -209,7 +209,7 @@ runCommand "compare"
         echo
       } >> $out/step-summary.md
 
-      cmp-stats ${combined}/before/stats ${combined}/after/stats >> $out/step-summary.md
+      cmp-stats --explain ${combined}/before/stats ${combined}/after/stats >> $out/step-summary.md
 
     else
       # Package chunks are the same in both revisions

--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -5,7 +5,45 @@
   runCommand,
   writeText,
   python3,
+  stdenvNoCC,
+  makeWrapper,
 }:
+let
+  python = python3.withPackages (ps: [
+    ps.numpy
+    ps.pandas
+    ps.scipy
+  ]);
+
+  cmp-stats = stdenvNoCC.mkDerivation {
+    pname = "cmp-stats";
+    version = lib.trivial.release;
+
+    dontUnpack = true;
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share/cmp-stats
+
+      cp ${./cmp-stats.py} "$out/share/cmp-stats/cmp-stats.py"
+
+      makeWrapper ${python.interpreter} "$out/bin/cmp-stats" \
+          --add-flags "$out/share/cmp-stats/cmp-stats.py"
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Performance comparison of Nix evaluation statistics";
+      license = lib.licenses.mit;
+      mainProgram = "cmp-stats";
+      maintainers = with lib.maintainers; [ philiptaron ];
+    };
+  };
+in
 {
   combinedDir,
   touchedFilesJson,
@@ -140,14 +178,7 @@ runCommand "compare"
     # Don't depend on -dev outputs to reduce closure size for CI.
     nativeBuildInputs = map lib.getBin [
       jq
-      (python3.withPackages (
-        ps: with ps; [
-          numpy
-          pandas
-          scipy
-        ]
-      ))
-
+      cmp-stats
     ];
     maintainers = builtins.toJSON maintainers;
     passAsFile = [ "maintainers" ];
@@ -181,7 +212,7 @@ runCommand "compare"
         echo
       } >> $out/step-summary.md
 
-      python3 ${./cmp-stats.py} >> $out/step-summary.md
+      cmp-stats >> $out/step-summary.md
 
     else
       # Package chunks are the same in both revisions

--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -13,6 +13,7 @@ let
     ps.numpy
     ps.pandas
     ps.scipy
+    ps.tabulate
   ]);
 
   cmp-stats = stdenvNoCC.mkDerivation {

--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -182,10 +182,6 @@ runCommand "compare"
     ];
     maintainers = builtins.toJSON maintainers;
     passAsFile = [ "maintainers" ];
-    env = {
-      BEFORE_DIR = "${combined}/before";
-      AFTER_DIR = "${combined}/after";
-    };
   }
   ''
     mkdir $out
@@ -212,7 +208,7 @@ runCommand "compare"
         echo
       } >> $out/step-summary.md
 
-      cmp-stats >> $out/step-summary.md
+      cmp-stats ${combined}/before/stats ${combined}/after/stats >> $out/step-summary.md
 
     else
       # Package chunks are the same in both revisions


### PR DESCRIPTION
I'm still grinding away at making local performance evaluation easier (for me) which means the output in the terminal, not just displayed on GitHub.

- 2a605761fd6d7b6d72381c90168f933fd8823648: format `cmp-stats.py` with `ruff`
- caa1c3ea034a3b82e413a7e7ec3f78d678c10d7d: sort imports in `cmp-stats.py`
- 6902fd974ead4f67fd78979a1237cf622887413e: extract `main` function in `cmp-stats.py`
- 825652acd7ca9aa05397d3862bd5e5aa11bbe6d3: extract a derivation for `cmp-stats` (not very useful yet)
- 216d70de695758aed1d84a3cdf68e74cca157d6a: use argument parsing instead of environment variables to pass `before`/`after` to `cmp-stats.py`
- c3984479797949ee3134b7d026537382d6adddea: require the directories to exist (they always should)
- f96d7b0c5f00afe6e6a897e5efacab42759d33db: turn warnings into errors
- be9c436f12a0828c299c395df4b8ff7bbddda3a8: allow `before_vals == 1` but avoid the t-test
- fa4ec24588a4686caf10dbc322544678e2f61cc7: support passing single files to `cmp-stats`
- 39290150dbb244a2ae0f2f701fbd7f5cdf53807a: instead of manually tabulating, use `tabulate`
- 17b07c7342a33d128abaea1044539beacaac5052: delete unreferenced global
- 605c9ec241c30387f6a3a0e0df9f974b71d0ace4: assert types in `flatten_data`
- 7b68ad82e81663dcd52a14cb66656d42e6c4d857: sort time metrics first, then `GC` metrics, then everything else
- 9ec1b59689fcae8e6878e510a5f926650ca4f31d: make the table format using `tabulate` not manually
- ee1af1e20d0faf9e9b5da4ee3a2e30889b334f87: put things with `bytes` together
- 8fa3f56856c1bf15bdecde7227862e27882bec10: put things with `counts` together
- 60935a3db2c99f348b9a17f822f759166554c82f: remove the duplicate `cpuTime` key
- 13558513d378c12e804bb6e45801a7674029572b: explain the various metrics under the `--explain` flag
- cd04b6cec470c57630718fd54a02273d56f508ea: split out equivalent values into their own table

CC especially @hsjobeki who authored this script initially.

<details>
<summary>Example output after this stack</summary>

<pre>
## Unchanged values

| metric                                          |      value |
|-------------------------------------------------|------------|
| gc.cycles[^gc.cycles]                           |          8 |
| list.bytes[^list.bytes]                         |   86015784 |
| sets.bytes[^sets.bytes]                         | 1565743344 |
| symbols.bytes[^symbols.bytes]                   |    1562982 |
| nrExprs[^nrExprs]                               |    2062000 |
| nrOpUpdateValuesCopied[^nrOpUpdateValuesCopied] |   69919185 |
| nrOpUpdates[^nrOpUpdates]                       |    2262178 |
| sets.number[^sets.number]                       |    5185001 |
| symbols.number[^symbols.number]                 |     115347 |
| list.concats[^list.concats]                     |    2594502 |
| list.elements[^list.elements]                   |   10751973 |
| sets.elements[^sets.elements]                   |   92673958 |
| sizes.Attr[^sizes.Attr]                         |         16 |
| sizes.Bindings[^sizes.Bindings]                 |         16 |
| sizes.Env[^sizes.Env]                           |          8 |
| sizes.Value[^sizes.Value]                       |         16 |

## Updated values

| metric                            |     mean_before |      mean_after |    mean_diff |   mean_pct_change |   p_value |   t_stat |
|-----------------------------------|-----------------|-----------------|--------------|-------------------|-----------|----------|
| time.cpu[^time.cpu]               |         18.8087 |         11.2072 |      -7.6015 |          -41.0333 |    -      | -24.4449 |
| time.gc[^time.gc]                 |         11.4545 |          3.3914 |      -8.0632 |          -70.9961 |    -      | -26.1901 |
| time.gcFraction[^time.gcFraction] |          0.6132 |          0.2972 |      -0.3160 |          -50.9002 |    -      | -34.7920 |
| gc.heapSize[^gc.heapSize]         | 1564224463.2381 | 1563831247.2381 | -393216.0000 |           -0.0090 |    0.3279 |  -0.9841 |
| gc.totalBytes[^gc.totalBytes]     | 2698527253.9048 | 2698527510.6667 |     256.7619 |            0.0000 |    0.4304 |   0.7924 |
| envs.bytes[^envs.bytes]           |  378176483.4286 |  378176438.4762 |     -44.9524 |           -0.0000 |    0.0448 |  -2.0372 |
| values.bytes[^values.bytes]       |  515033878.8571 |  515033842.2857 |     -36.5714 |           -0.0000 |    0.0448 |  -2.0372 |
| envs.number[^envs.number]         |   18953859.5833 |   18953856.9167 |      -2.6667 |           -0.0000 |    0.0448 |  -2.0372 |
| nrAvoided[^nrAvoided]             |   23268150.2381 |   23268145.8571 |      -4.3810 |           -0.0000 |    0.0448 |  -2.0372 |
| nrFunctionCalls[^nrFunctionCalls] |   17027531.0238 |   17027528.7381 |      -2.2857 |           -0.0000 |    0.0448 |  -2.0372 |
| nrLookups[^nrLookups]             |    8488292.3214 |    8488291.9405 |      -0.3810 |           -0.0000 |    0.0448 |  -2.0372 |
| nrPrimOpCalls[^nrPrimOpCalls]     |   10226978.2381 |   10226975.8571 |      -2.3810 |           -0.0000 |    0.0448 |  -2.0372 |
| nrThunks[^nrThunks]               |   24483311.0476 |   24483308.7619 |      -2.2857 |           -0.0000 |    0.0448 |  -2.0372 |
| values.number[^values.number]     |   32189617.4286 |   32189615.1429 |      -2.2857 |           -0.0000 |    0.0448 |  -2.0372 |
| envs.elements[^envs.elements]     |   28318200.8452 |   28318197.8929 |      -2.9524 |           -0.0000 |    0.0448 |  -2.0372 |

[^time.cpu]: Number of seconds of CPU time accounted by the OS to the Nix evaluator process. On UNIX systems, this comes from [`getrusage(RUSAGE_SELF)`](https://man7.org/linux/man-pages/man2/getrusage.2.html).
[^time.gc]: Number of seconds of CPU time accounted by the Boehm garbage collector to performing GC.
[^time.gcFraction]: What fraction of the total CPU time is accounted towards performing GC.
[^gc.cycles]: Number of times garbage collection has been performed.
[^gc.heapSize]: Size in bytes of the garbage collector heap.
[^gc.totalBytes]: Size in bytes of all allocations in the garbage collector.
[^envs.bytes]: Size in bytes of all `Env` objects allocated by the Nix evaluator. These are almost exclusively created by [`nix-env`](https://nix.dev/manual/nix/stable/command-ref/nix-env.html).
[^list.bytes]: Size in bytes of all [lists](https://nix.dev/manual/nix/stable/language/syntax.html#list-literal) allocated by the Nix evaluator.
[^sets.bytes]: Size in bytes of all [attrsets](https://nix.dev/manual/nix/stable/language/syntax.html#list-literal) allocated by the Nix evaluator.
[^symbols.bytes]: Size in bytes of all items in the Nix evaluator symbol table.
[^values.bytes]: Size in bytes of all values allocated by the Nix evaluator.
[^envs.number]: The count of all `Env` objects allocated.
[^nrAvoided]: The number of thunks avoided being created.
[^nrExprs]: The number of expression objects ever created.
[^nrFunctionCalls]: The number of function calls ever made.
[^nrLookups]: The number of lookups into an attrset ever made.
[^nrOpUpdateValuesCopied]: The number of attrset values copied in the process of merging attrsets.
[^nrOpUpdates]: The number of attrsets merge operations (`//`) performed.
[^nrPrimOpCalls]: The number of function calls to primops (Nix builtins) ever made.
[^nrThunks]: The number of thunks ever made. A thunk is a delayed computation, represented by an expression reference and a closure.
[^sets.number]: The number of attrsets ever made.
[^symbols.number]: The number of symbols ever added to the symbol table.
[^values.number]: The number of values ever made.
[^envs.elements]: The number of values contained within an `Env` object.
[^list.concats]: The number of list concatenation operations (`++`) performed.
[^list.elements]: The number of values contained within a list.
[^sets.elements]: The number of values contained within an attrset.
[^sizes.Attr]: Size in bytes of the `Attr` type.
[^sizes.Bindings]: Size in bytes of the `Bindings` type.
[^sizes.Env]: Size in bytes of the `Env` type.
[^sizes.Value]: Size in bytes of the `Value` type.</pre>

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
