### PR TITLE
unittest-cpp: fix build with CMake 4

### DIFF
--- a/pkgs/by-name/li/libsidplayfp/package.nix
+++ b/pkgs/by-name/li/libsidplayfp/package.nix
@@ -13,7 +13,6 @@
   libgcrypt,
   perl,
   pkg-config,
-  unittest-cpp,
   xa,
 }:
 
@@ -52,8 +51,6 @@ stdenv.mkDerivation (finalAttrs: {
     libexsid
     libgcrypt
   ];
-
-  checkInputs = [ unittest-cpp ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/un/unittest-cpp/package.nix
+++ b/pkgs/by-name/un/unittest-cpp/package.nix
@@ -25,6 +25,14 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  # Fix the build with CMake 4.
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+        'cmake_minimum_required(VERSION 2.8.1)' \
+        'cmake_minimum_required(VERSION 3.10)'
+  '';
+
   # Fix 'Version:' setting in .pc file. TODO: remove once upstreamed:
   #     https://github.com/unittest-cpp/unittest-cpp/pull/188
   cmakeFlags = [ "-DPACKAGE_VERSION=${version}" ];

--- a/pkgs/development/libraries/enchant/2.x.nix
+++ b/pkgs/development/libraries/enchant/2.x.nix
@@ -10,7 +10,6 @@
   hspell,
   nuspell,
   libvoikko,
-  unittest-cpp,
 
   withHspell ? true,
   withAspell ? true,
@@ -58,7 +57,6 @@ stdenv.mkDerivation rec {
   ];
 
   checkInputs = [
-    unittest-cpp
   ];
 
   # libtool puts these to .la files


### PR DESCRIPTION
`enchant` is the only remaining user, but what can you do.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
