### PR TITLE
thorium-reader: init at 3.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28498,6 +28498,12 @@
     githubId = 40352765;
     name = "Yoctocell";
   };
+  YodaDaCoda = {
+    email = "pickeringw@gmail.com";
+    github = "YodaDaCoda";
+    githubId = 365349;
+    name = "William Brockhus";
+  };
   yogansh = {
     email = "yogansh@yogansh.tech";
     github = "YoganshSharma";

--- a/pkgs/by-name/th/thorium-reader/package.nix
+++ b/pkgs/by-name/th/thorium-reader/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nodejs_24,
+  makeWrapper,
+  electron,
+  copyDesktopItems,
+  makeDesktopItem,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "thorium-reader";
+  version = "3.2.2";
+  nodejs = nodejs_24;
+  npmDepsHash = "sha256-T70Oxn97oDyFSxkJ55nlM2ET0UEWpo8ahnipkUwgTcM=";
+  makeCacheWritable = true;
+
+  src = fetchFromGitHub {
+    owner = "edrlab";
+    repo = "thorium-reader";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+1cc8UxcLaqC6Yrc4RYAKDZ4hzoz0eX31HaiUtp/znE=";
+  };
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  nativeBuildInputs = [
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  postInstall = ''
+    install -Dpm644 resources/icon.png $out/share/icons/hicolor/1024x1024/apps/thorium-reader.png
+
+    cp -r dist/* $out/lib/node_modules/EDRLab.ThoriumReader/
+
+    makeWrapper '${lib.getExe electron}' "$out/bin/thorium-reader" \
+      --add-flags $out/lib/node_modules/EDRLab.ThoriumReader \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+      --set-default ELECTRON_IS_DEV 0 \
+      --inherit-argv0
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "thorium-reader";
+      desktopName = "Thorium";
+      exec = "thorium-reader %u";
+      terminal = false;
+      type = "Application";
+      icon = "thorium-reader";
+      startupWMClass = "thorium-reader";
+      mimeTypes = [
+        "application/epub+zip"
+        "application/daisy+zip"
+        "application/vnd.readium.lcp.license.v1.0+json"
+        "application/audiobook+zip"
+        "application/webpub+zip"
+        "application/audiobook+lcp"
+        "application/pdf+lcp"
+        "x-scheme-handler/thorium"
+        "x-scheme-handler/opds"
+      ];
+      comment = "Desktop application to read ebooks";
+      categories = [ "Office" ];
+    })
+  ];
+
+  meta = {
+    description = "EPUB reader";
+    homepage = "https://www.edrlab.org/software/thorium-reader/";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ YodaDaCoda ];
+    platforms = lib.platforms.all;
+    mainProgram = "thorium-reader";
+  };
+})


### PR DESCRIPTION
https://www.edrlab.org/software/thorium-reader/
https://github.com/edrlab/thorium-reader

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
