### PR TITLE
buildRebar3: fix OTP 28 compatibility

### DIFF
--- a/pkgs/development/beam-modules/build-rebar3.nix
+++ b/pkgs/development/beam-modules/build-rebar3.nix
@@ -91,7 +91,7 @@ let
 
         buildPhase = ''
           runHook preBuild
-          HOME=. rebar3 bare compile -path ""
+          HOME=. rebar3 bare compile --paths "."
           runHook postBuild
         '';
 


### PR DESCRIPTION
Not sure how long ago this was changed, if `path` was ever correct. I'm not sure *why* the current directory works here, but packages at least compile. 

- [x] Ensure packages with nixosTests pass test builds

```
𑁱 rebar3 help bare compile
Usage: rebar3 bare compile [-p <paths>] [-s <separator>] [-o <outdir>]

  -p, --paths      Wildcard paths of ebin directories to add to code path,
                   separated by a colon
  -s, --separator  In case of multiple return paths, the separator
                   character to use to join them.
  -o, --outdir     Path where build artifacts are located. Defaults to the
                   current directory.
```




<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
