### PR TITLE
aks-mcp-server: init at v0.0.08

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20743,6 +20743,12 @@
     githubId = 20863431;
     name = "Prithak S.";
   };
+  priyaananthasankar = {
+    name = "Priya Ananthasankar";
+    github = "priyaananthasankar";
+    githubId = 10415876;
+    email = "priyagituniverse@gmail.com";
+  };
   ProducerMatt = {
     name = "Matthew Pherigo";
     email = "ProducerMatt42@gmail.com";

--- a/pkgs/by-name/ak/aks-mcp-server/package.nix
+++ b/pkgs/by-name/ak/aks-mcp-server/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  makeBinaryWrapper,
+  azure-cli,
+  kubectl,
+  stdenv,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "aks-mcp-server";
+  version = "0.0.8";
+
+  src = fetchFromGitHub {
+    owner = "Azure";
+    repo = "aks-mcp";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-DLdNMMsBu/FpE1+39vydWLAXrotIeQ7xjnaFBYsovQQ=";
+  };
+
+  vendorHash = "sha256-Hks0iGUu5KmnZwm0TmwrYZzy/pIV3Q9mRnzvQkB1t8M=";
+
+  subPackages = [ "cmd/aks-mcp" ];
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeBinaryWrapper
+  ];
+
+  # Disable CGO and set environment variables
+  env.CGO_ENABLED = "0";
+
+  tags = [ "withoutebpf" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/Azure/aks-mcp/internal/version.GitVersion=${finalAttrs.version}"
+    "-X github.com/Azure/aks-mcp/internal/version.GitCommit=${finalAttrs.src.rev}"
+    "-X github.com/Azure/aks-mcp/internal/version.GitTreeState=clean"
+    "-X github.com/Azure/aks-mcp/internal/version.BuildDate=1970-01-01T00:00:00Z"
+  ];
+
+  checkFlags = [
+    "-skip=TestAzure"
+    "-skip=TestExecutor"
+    "-skip=TestClient"
+  ];
+
+  postInstall = ''
+
+
+    wrapProgram $out/bin/aks-mcp \
+      --set-default AKS_MCP_COLLECT_TELEMETRY false \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          azure-cli
+          kubectl
+        ]
+      }
+  '';
+
+  meta = {
+    description = "Model Context Protocol server for Azure Kubernetes Service";
+    longDescription = ''
+      The AKS-MCP server enables AI assistants to interact with Azure Kubernetes
+      Service clusters through the Model Context Protocol. It translates natural
+      language requests into AKS operations and provides cluster information,
+      network details, and resource management capabilities.
+    '';
+    homepage = "https://github.com/Azure/aks-mcp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ priyaananthasankar ];
+    platforms = lib.platforms.unix; # Now supports both Linux and macOS with withoutebpf
+    mainProgram = "aks-mcp-server";
+  };
+})


### PR DESCRIPTION
Model Context Protocol server for Azure Kubernetes Service clusters. Enables AI assistants to interact with AKS through natural language.

Built with withoutebpf tags to avoid platform-specific eBPF dependencies.


<!--
New Package: https://github.com/Azure/aks-mcp 
-->

## Description
Add aks-mcp-server package - Model Context Protocol server for Azure Kubernetes Service.

## Motivation
Enables AI assistants to interact with AKS clusters through natural language, supporting the growing MCP ecosystem.

## Checklist
- [x] Built successfully on multiple platforms
- [x] Follows nixpkgs conventions
- [x] Includes proper meta information
- [x] Uses withoutebpf tags for cross-platform compatibility
- [x] Dependencies properly wrapped

## Testing
```bash
nix-build -A aks-mcp-server
./result/bin/aks-mcp-server --help

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
