### PR TITLE
add-determinism: Fix meta.mainProgram, add compat symlink

### DIFF
--- a/pkgs/by-name/ad/add-determinism/package.nix
+++ b/pkgs/by-name/ad/add-determinism/package.nix
@@ -28,6 +28,10 @@ rustPlatform.buildRustPackage rec {
     ln -s ${./Cargo.lock} Cargo.lock
   '';
 
+  postInstall = ''
+    ln -s add-det $out/bin/add-determinism
+  '';
+
   doCheck = !stdenv.hostPlatform.isDarwin; # it seems to be running forever on darwin
 
   nativeBuildInputs = [
@@ -47,6 +51,6 @@ rustPlatform.buildRustPackage rec {
       sharzy
     ];
     platforms = lib.platforms.all;
-    mainProgram = "add-determinism";
+    mainProgram = "add-det";
   };
 }


### PR DESCRIPTION
The program has been renamed to add-det in 0.7.0, and upstream recommends distros add a compatibility symlink. \[1] The symlink approach has been taken by Arch Linux. \[2]

Correct meta.mainProgram to point to add-det, and add this symlink as was recommended.

\[1]: https://github.com/keszybz/add-determinism/releases/tag/v0.7.0
\[2]: https://gitlab.archlinux.org/archlinux/packaging/packages/add-determinism/-/blob/5be4e2122665d4eb207239b82ec73ea1107784e2/PKGBUILD

See also: https://github.com/chipsalliance/t1/pull/1175

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
