### PR TITLE
switcheroo-control: 2.6 -> 3.0

### DIFF
--- a/pkgs/by-name/sw/switcheroo-control/package.nix
+++ b/pkgs/by-name/sw/switcheroo-control/package.nix
@@ -4,39 +4,50 @@
   meson,
   fetchFromGitLab,
   systemd,
+  libdrm,
   libgudev,
   pkg-config,
+  wrapGAppsNoGuiHook,
   glib,
   python3Packages,
 }:
 
-python3Packages.buildPythonApplication rec {
+let
+  version = "3.0";
+in
+python3Packages.buildPythonApplication {
   pname = "switcheroo-control";
-  version = "2.6";
-
-  format = "other";
+  inherit version;
+  pyproject = false;
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "hadess";
     repo = "switcheroo-control";
-    rev = version;
-    hash = "sha256-F+5HhMxM8pcnAGmVBARKWNCL0rIEzHW/jsGHHqYZJug=";
+    tag = version;
+    hash = "sha256-7P0o8fBYe4izRmNL7DimUSJfzj13KXW9we6c/A2iNo8=";
   };
+
+  postPatch = ''
+    substituteInPlace data/meson.build \
+      --replace-fail "rules_dir" "'${placeholder "out"}/lib/udev/rules.d'"
+  '';
 
   nativeBuildInputs = [
     ninja
     meson
     pkg-config
+    wrapGAppsNoGuiHook
   ];
 
   buildInputs = [
     systemd
+    libdrm
     libgudev
     glib
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     python3Packages.pygobject3
   ];
 
@@ -44,6 +55,10 @@ python3Packages.buildPythonApplication rec {
     "-Dsystemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
     "-Dhwdbdir=${placeholder "out"}/etc/udev/hwdb.d"
   ];
+
+  dontWrapGApps = true;
+
+  makeWrapperArgs = [ "\${gappsWrapperArgs[@]}" ];
 
   meta = {
     description = "D-Bus service to check the availability of dual-GPU";


### PR DESCRIPTION
Diff: https://gitlab.freedesktop.org/hadess/switcheroo-control/-/compare/2.6...3.0

Changelog: https://gitlab.freedesktop.org/hadess/switcheroo-control/-/blob/3.0/NEWS


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
