### PR TITLE
networkmanager-fortisslvpn: add fix for pppd-2.5.2

### DIFF
--- a/pkgs/by-name/ne/networkmanager-fortisslvpn/package.nix
+++ b/pkgs/by-name/ne/networkmanager-fortisslvpn/package.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
       inherit openfortivpn;
     })
     ./support-ppp-2.5.0.patch
+    ./pppd-accept-remote.patch
   ];
 
   strictDeps = true;

--- a/pkgs/by-name/ne/networkmanager-fortisslvpn/pppd-accept-remote.patch
+++ b/pkgs/by-name/ne/networkmanager-fortisslvpn/pppd-accept-remote.patch
@@ -1,0 +1,32 @@
+From cea75ece3eaecb17922feda81a4ee81718536d1a Mon Sep 17 00:00:00 2001
+From: Mikhail Novosyolov <m.novosyolov@rosalinux.ru>
+Date: Fri, 14 Mar 2025 07:14:43 +0300
+Subject: [PATCH] Fix routing with pppd 2.5
+
+Tested on ROSA 13 with pppd-2.5.2 and openfortivpn-1.23.1.
+Without this change, routes are not set up correctly and connection does not work properly.
+
+Solution is from https://aur.archlinux.org/packages/networkmanager-fortisslvpn (see PKGBLUILD and comments).
+---
+ src/nm-fortisslvpn-service.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/nm-fortisslvpn-service.c b/src/nm-fortisslvpn-service.c
+index 8796ace..8f69333 100644
+--- a/src/nm-fortisslvpn-service.c
++++ b/src/nm-fortisslvpn-service.c
+@@ -225,7 +225,11 @@ run_openfortivpn (NMFortisslvpnPlugin *plugin, NMSettingVpn *s_vpn, GError **err
+ 	g_ptr_array_add (argv, (gpointer) g_strdup ("-c"));
+ 	g_ptr_array_add (argv, (gpointer) g_strdup (priv->config_file));
+ 
++#if WITH_PPP_VERSION >= PPP_VERSION(2,5,0)
++	g_ptr_array_add (argv, (gpointer) g_strdup ("--pppd-accept-remote"));
++#else
+ 	g_ptr_array_add (argv, (gpointer) g_strdup ("--no-routes"));
++#endif
+ 	g_ptr_array_add (argv, (gpointer) g_strdup ("--no-dns"));
+ 	ip4_config = nm_connection_get_setting_ip4_config (priv->connection);
+ 	if (!nm_setting_ip_config_get_ignore_auto_dns (ip4_config)) {
+-- 
+GitLab
+


### PR DESCRIPTION
To fix the current broken state https://github.com/NixOS/nixpkgs/issues/231038#issuecomment-1868513910
I pulled the patch from https://gitlab.gnome.org/GNOME/NetworkManager-fortisslvpn/-/merge_requests/40/diffs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
