### PR TITLE
swipe-guess: 0.2.1 -> 0.3.1

### DIFF
--- a/pkgs/by-name/sw/swipe-guess/package.nix
+++ b/pkgs/by-name/sw/swipe-guess/package.nix
@@ -2,32 +2,32 @@
   lib,
   stdenv,
   fetchFromSourcehut,
+  scdoc,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "swipe-guess";
-  version = "0.2.1";
+  version = "0.3.1";
 
   src = fetchFromSourcehut {
     owner = "~earboxer";
     repo = "swipeGuess";
-    rev = "v${version}";
-    hash = "sha256-8bPsnqjLeeZ7btTre9j1T93VWY9+FdBdJdxyvBVt34s=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zpV7A42wzoRZBpDBQUKGFCnLNJELqQE69fJTx8TN4uE=";
   };
 
-  dontConfigure = true;
-
-  buildPhase = ''
-    runHook preBuild
-
-    ${lib.getExe stdenv.cc} swipeGuess.c -o swipeGuess
-
-    runHook postBuild
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail "docs words-qwerty-en" "docs" \
+      --replace-fail 'install -m644 words-qwerty-en -D -t "$(DESTDIR)/$(PREFIX)/share/swipeGuess/words/"' ""
   '';
 
-  postInstall = ''
-    install -Dm555 swipeGuess -t $out/bin
-  '';
+  nativeBuildInputs = [ scdoc ];
+
+  makeFlags = [
+    "PREFIX="
+    "DESTDIR=${placeholder "out"}"
+  ];
 
   meta = {
     description = "Completion plugin for touchscreen-keyboards on mobile devices";
@@ -37,4 +37,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://git.sr.ht/~earboxer/swipeGuess/refs/v0.3.1
https://git.sr.ht/~earboxer/swipeGuess/tree/v0.3.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
