### PR TITLE
swiftbar: 2.0.0 -> 2.0.1

### DIFF
--- a/pkgs/by-name/sw/swiftbar/package.nix
+++ b/pkgs/by-name/sw/swiftbar/package.nix
@@ -5,15 +5,15 @@
   makeWrapper,
 }:
 let
-  build = "520";
+  build = "536";
 in
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "swiftbar";
-  version = "2.0.0";
+  version = "2.0.1";
 
   src = fetchzip {
-    url = "https://github.com/swiftbar/SwiftBar/releases/download/v${version}/SwiftBar.v${version}.b${build}.zip";
-    hash = "sha256-eippK01Q+J9jdwvnGcnr7nw3KwyQQqh051lHN3Xmy+c=";
+    url = "https://github.com/swiftbar/SwiftBar/releases/download/v${finalAttrs.version}/SwiftBar.v${finalAttrs.version}.b${build}.zip";
+    hash = "sha256-K46XQvhLs8rnQ0psveL2dZ/+bTZnaeWVLtrUm29RQYU=";
     stripRoot = false;
   };
 
@@ -37,11 +37,11 @@ stdenvNoCC.mkDerivation rec {
   meta = {
     description = "Powerful macOS menu bar customization tool";
     homepage = "https://swiftbar.app";
-    changelog = "https://github.com/swiftbar/SwiftBar/releases/tag/v${version}";
+    changelog = "https://github.com/swiftbar/SwiftBar/releases/tag/v${finalAttrs.version}";
     mainProgram = "SwiftBar";
     license = lib.licenses.mit;
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     maintainers = with lib.maintainers; [ matteopacini ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/swiftbar/SwiftBar/releases/tag/v2.0.1
https://github.com/swiftbar/SwiftBar/compare/v2.0.0...v2.0.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
