### PR TITLE
pgbackrest: 2.55.1 -> 2.56.0

### DIFF
--- a/nixos/modules/services/backup/pgbackrest.nix
+++ b/nixos/modules/services/backup/pgbackrest.nix
@@ -55,6 +55,9 @@ let
   fullConfig = {
     global = normalize (cfg.settings // flattenWithIndex cfg.repos "repo");
   }
+  // lib.mapAttrs' (
+    cmd: settings: lib.nameValuePair "global:${cmd}" (normalize settings)
+  ) cfg.commands
   // lib.mapAttrs (
     _: cfg': normalize (cfg'.settings // flattenWithIndex cfg'.instances "pg")
   ) cfg.stanzas;
@@ -95,7 +98,6 @@ in
   };
 
   # TODO: Add enableServer option and corresponding pgBackRest TLS server service.
-  # TODO: Allow command-specific options
   # TODO: Write wrapper around pgbackrest to turn --repo=<name> into --repo=<number>
   # The following two are dependent on improvements upstream:
   #   https://github.com/pgbackrest/pgbackrest/issues/2621
@@ -328,6 +330,55 @@ in
         }
       '';
     };
+
+    commands =
+      lib.genAttrs
+        [
+          # List of commands from https://pgbackrest.org/command.html:
+          "annotate"
+          "archive-get"
+          "archive-push"
+          "backup"
+          "check"
+          "expire"
+          "help"
+          "info"
+          "repo-get"
+          "repo-ls"
+          "restore"
+          "server"
+          "server-ping"
+          "stanza-create"
+          "stanza-delete"
+          "stanza-upgrade"
+          "start"
+          "stop"
+          "verify"
+          "version"
+        ]
+        (
+          command:
+          lib.mkOption {
+            type = lib.types.submodule {
+              freeformType = settingsType;
+
+              # The following options are not fully supported / tested, yet, but point to files with secrets.
+              # Users can already set those options, but we'll force non-store paths.
+              options.tls-server-cert-file = secretPathOption;
+              options.tls-server-key-file = secretPathOption;
+            };
+            default = { };
+            description = ''
+              Options for the '${command}' command.
+
+              An attribute set of options as described in:
+              <https://pgbackrest.org/configuration.html>
+
+              All globally available options, i.e. all except stanza options, can be used.
+              Repository options should be set via [`repos`](#opt-services.pgbackrest.repos) instead.
+            '';
+          }
+        );
   };
 
   config = lib.mkIf cfg.enable (

--- a/nixos/modules/services/backup/pgbackrest.nix
+++ b/nixos/modules/services/backup/pgbackrest.nix
@@ -459,6 +459,9 @@ in
             user = "postgres";
           };
         };
+        # If PostgreSQL runs on the same machine, any restore will have to be done with that user.
+        # Keeping the lock file in a directory writeable by the postgres user prevents errors.
+        services.pgbackrest.commands.restore.lock-path = "/tmp/postgresql";
         services.postgresql.identMap = ''
           postgres pgbackrest postgres
         '';

--- a/pkgs/by-name/pg/pgbackrest/package.nix
+++ b/pkgs/by-name/pg/pgbackrest/package.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pgbackrest";
-  version = "2.55.1";
+  version = "2.56.0";
 
   src = fetchFromGitHub {
     owner = "pgbackrest";
     repo = "pgbackrest";
     tag = "release/${finalAttrs.version}";
-    hash = "sha256-A1dTywcCHBu7Ml0Q9k//VVPFN1C3kmmMkq4ok9T4g94=";
+    hash = "sha256-GDHpeTz85cgKTbcuaTlwJ1SUNMedSylqKWdrgH8Zp8Q=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
fixes https://github.com/NixOS/nixpkgs/pull/427240
changelog: https://github.com/pgbackrest/pgbackrest/releases/tag/release%2F2.56.0

wip
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
