### PR TITLE
python3Packages.cryptoparser: clean up package from unwanted files

### DIFF
--- a/pkgs/development/python-modules/cryptoparser/default.nix
+++ b/pkgs/development/python-modules/cryptoparser/default.nix
@@ -42,6 +42,14 @@ buildPythonPackage rec {
     urllib3
   ];
 
+  postInstall = ''
+    find $out -name "__pycache__" -type d | xargs rm -rv
+
+    # Prevent creating more binary byte code later (e.g. during
+    # pythonImportsCheck)
+    export PYTHONDONTWRITEBYTECODE=1
+  '';
+
   pythonImportsCheck = [ "cryptoparser" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/cryptoparser/default.nix
+++ b/pkgs/development/python-modules/cryptoparser/default.nix
@@ -24,6 +24,11 @@ buildPythonPackage rec {
     hash = "sha256-bEvhMVcm9sXlfhxUD2K4N10nusgxpGYFJQLtJE1/qok=";
   };
 
+  patches = [
+    # https://gitlab.com/coroner/cryptoparser/-/merge_requests/2
+    ./fix-dirs-exclude.patch
+  ];
+
   build-system = [
     setuptools
     setuptools-scm

--- a/pkgs/development/python-modules/cryptoparser/fix-dirs-exclude.patch
+++ b/pkgs/development/python-modules/cryptoparser/fix-dirs-exclude.patch
@@ -1,0 +1,27 @@
+From 512b5d6e30784594db46bcd0071d63da7065e478 Mon Sep 17 00:00:00 2001
+From: Ivan Mincik <ivan.mincik@gmail.com>
+Date: Wed, 17 Sep 2025 14:09:31 +0200
+Subject: [PATCH] Fix directories exclude from package
+
+* correctly exclude submodules directory
+* also exclude docs directory
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 73897d6..74d43e4 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -75,7 +75,7 @@ technical_name = 'cryptoparser'
+ license-files = ['LICENSE.txt']
+ 
+ [tool.setuptools.packages.find]
+-exclude = ['submodules']
++exclude = ['submodules*', 'docs']
+ 
+ [tool.tox]
+ envlist = [
+-- 
+GitLab
+


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.cryptoparser: fix directories exclude from python package**
- **python3Packages.cryptoparser: remove python bytecode from package**

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
