### PR TITLE
rubyPackages: Add command to audit packages

### DIFF
--- a/doc/languages-frameworks/ruby.section.md
+++ b/doc/languages-frameworks/ruby.section.md
@@ -273,6 +273,8 @@ To test that it works, you can then try using the gem with:
 NIX_PATH=nixpkgs=$PWD nix-shell -p "ruby.withPackages (ps: with ps; [ name-of-your-gem ])"
 ```
 
+To check the gems for any security vulnerabilities, run `./maintainers/scripts/audit-ruby-packages/audit-ruby-packages.bash`.
+
 ### Packaging applications {#packaging-applications}
 
 A common task is to add a Ruby executable to Nixpkgs; popular examples would be `chef`, `jekyll`, or `sass`. A good way to do that is to use the `bundlerApp` function, that allows you to make a package that only exposes the listed executables. Otherwise, the package may cause conflicts through common paths like `bin/rake` or `bin/bundler` that aren't meant to be used.

--- a/maintainers/scripts/audit-ruby-packages/audit-ruby-packages.bash
+++ b/maintainers/scripts/audit-ruby-packages/audit-ruby-packages.bash
@@ -1,0 +1,6 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bundler-audit
+
+set -o errexit -o nounset -o pipefail
+
+bundle-audit check "$(nix-build --no-out-link maintainers/scripts/audit-ruby-packages/default.nix)"

--- a/maintainers/scripts/audit-ruby-packages/default.nix
+++ b/maintainers/scripts/audit-ruby-packages/default.nix
@@ -1,0 +1,15 @@
+let
+  pkgs = import ../../.. { };
+  lockFileBody = pkgs.lib.concatStringsSep "\n" (
+    pkgs.lib.mapAttrsToList (name: props: "    ${name} (${props.version})") (
+      pkgs.lib.filterAttrs (name: _props: name != "recurseForDerivations") pkgs.rubyPackages
+    )
+  );
+in
+pkgs.runCommand "bundle-audit" { } ''
+  mkdir "$out"
+  echo 'GEM' > "$out/Gemfile.lock"
+  echo '  remote: https://rubygems.org/' >> "$out/Gemfile.lock"
+  echo '  specs:' >> "$out/Gemfile.lock"
+  echo '${lockFileBody}' >> "$out/Gemfile.lock"
+''


### PR DESCRIPTION
To detect known security vulnerabilities in the current package set.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
