### PR TITLE
{openonload,tcpdirect}: init at 9.0

### DIFF
--- a/pkgs/by-name/op/openonload/openonload.pc.in
+++ b/pkgs/by-name/op/openonload/openonload.pc.in
@@ -1,0 +1,10 @@
+prefix=@dev@
+includedir=${prefix}/include
+libdir=@lib@/lib
+
+Name: openonload
+Description: OpenOnLoad high performance network stack from Solarflare
+URL: http://www.openonload.org/
+Version: @version@
+Cflags: -isystem${includedir}
+Libs: -L${libdir} -Wl,-rpath,${libdir} @dash_l@

--- a/pkgs/by-name/op/openonload/package.nix
+++ b/pkgs/by-name/op/openonload/package.nix
@@ -1,0 +1,158 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  coreutils,
+  libpcap,
+  which,
+  libcap,
+  makeWrapper,
+  nix-update-script,
+  perl,
+  libmnl,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "openonload";
+  version = "9.0.2";
+
+  src = fetchFromGitHub {
+    owner = "Xilinx-CNS";
+    repo = "onload";
+    rev = "v${version}";
+    hash = "sha256-wyvTtOjD6fwuT2OGGhr10F0Q7hXE97mGREhq7Ns14hw=";
+  };
+
+  nativeBuildInputs = [
+    which
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libcap
+    libpcap
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+    export PATH="$PWD/scripts:$PATH"
+    patchShebangs --build \
+      scripts/ \
+      src/driver/
+    substituteInPlace \
+      scripts/mmaketool \
+      scripts/onload \
+      scripts/onload_build \
+      scripts/onload_install \
+      scripts/shell-fns/fns \
+      scripts/shell-fns/mmake-fns \
+      --replace-fail "/bin/pwd" "${coreutils}/bin/pwd"
+    substituteInPlace \
+      scripts/mmaketool \
+      scripts/onload_install \
+      scripts/sfcaffinity_config \
+      --replace-fail "/bin/ls" "${coreutils}/bin/ls"
+
+    # Disable compiler checks that are disabled for Ubuntu: https://github.com/Xilinx-CNS/onload/blob/713eff9c3a105c51fb062527e01e1663c4e61e28/scripts/mmakebuildtree#L337-L344
+    substituteInPlace scripts/mmakebuildtree \
+    --replace-fail 'W_NO_UNUSED_RESULT=
+    ' ""
+    export W_NO_UNUSED_RESULT=1 W_NO_IGNORED_ATTRIBUTES=1
+
+    # Patch unit tests to be run during check phase
+    substituteInPlace src/tests/onload/{oof,cplane_unit,cplane_sysunit,onload_remote_monitor/internal_tests}/mmake.mk \
+      --replace-fail '/usr/bin/timeout' '${coreutils}/bin/timeout'
+
+    # Honor NIX_BUILD_CORES in onload_build script
+    substituteInPlace scripts/onload_build --replace-fail 'nproc' 'echo "$NIX_BUILD_CORES"'
+    runHook postConfigure
+  '';
+
+  # This only builds the 64 bit libraries, not the kernel module.
+  buildPhase = ''
+    runHook preBuild
+    ./scripts/onload_build --user64
+    runHook postBuild
+  '';
+
+  doCheck = true;
+  nativeCheckInputs = [
+    perl
+  ];
+  checkInputs = [
+    libmnl
+  ];
+  checkPhase = ''
+    runHook preCheck
+    # Build all tests in parallel, the script does it in sequence
+    make -C "$(mmaketool --toppath)/build/$(mmaketool --userbuild)" -j$NIX_BUILD_CORES
+    scripts/run_unit_tests.sh
+    runHook postCheck
+  '';
+
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    i_prefix=$out scripts/onload_install --nobuild --userfiles --headers \
+      --bindir=/bin \
+      --sbindir=/bin \
+      --usrsbindir=/bin \
+      --libexecdir=/libexec \
+      --includedir=/include \
+      --lib64dir=/lib
+
+    mkdir -p $dev/lib
+    mv -v $out/include $dev
+    mv -v $out/lib/*.a $dev/lib
+    mkdir -p $lib
+    mv -v $out/lib $lib
+
+    substituteInPlace $out/bin/onload --replace-fail "/usr/libexec" "$out/libexec"
+    # This tool looks for libonload.so in environment, point default to the actual library
+    wrapProgram $out/bin/onload \
+      --set-default ONLOAD_PRELOAD $out/lib/libonload.so
+
+    # These scripts assume other binaries from this package are in PATH
+    wrapProgram $out/bin/onload_tcpdump \
+      --prefix PATH : $out/bin
+    wrapProgram $out/bin/orm_webserver \
+      --prefix PATH : $out/bin
+
+    cp -v $(find build/gnu_x86_64/tools -type f -executable -print | grep -v '/debug/' | grep -v '.so$') $out/bin
+    # Capture the test apps for validating performance/host set-up
+    cp -v $(find build/gnu_x86_64/tests/ef_vi -type f -executable -print) $out/bin
+
+    mkdir -p $dev/lib/pkgconfig/
+    export dash_l="-lonload_ext"
+    substituteAll ${./openonload.pc.in} $dev/lib/pkgconfig/openonload.pc
+    export dash_l="-l:libonload_ext.a"
+    substituteAll ${./openonload.pc.in} $dev/lib/pkgconfig/openonload-static.pc
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    # The test apps have a build directory in RPATH, which patchelf can't
+    # remove by default because the required library libefcp.so is there.
+    # By removing the library, patchelf is unblocked from removing the build
+    # directory from RPATH. This doesn't break the binary because the library
+    # is also available from other RPATH entries.
+    rm -v build/gnu_x86_64/lib/cplane/*.so*
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "OpenOnLoad high performance network stack from Solarflare";
+    homepage = "https://www.openonload.org";
+    license = lib.licenses.gpl2;
+    maintainers = with maintainers; [ YorikSar ];
+    # ARM64 build fails, see https://github.com/Xilinx-CNS/onload/issues/253
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/by-name/tc/tcpdirect/package.nix
+++ b/pkgs/by-name/tc/tcpdirect/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libpcap,
+  which,
+  libcap,
+  makeWrapper,
+  nix-update-script,
+  openonload,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tcpdirect";
+  version = "9.0.2.45";
+
+  src = fetchFromGitHub {
+    owner = "Xilinx-CNS";
+    repo = "tcpdirect";
+    rev = "tcpdirect-${version}";
+    hash = "sha256-7VQwep078hXdXE4pqGUe2CLqnPdDuWupcyuC+NCM5Ms=";
+  };
+
+  nativeBuildInputs = [
+    which
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libcap
+    libpcap
+    openonload
+  ];
+
+  enableParallelBuilding = true;
+  makeFlags = [
+    "CITOOLS_LIB=${lib.getDev openonload}/lib/libcitools1.a"
+    "CIUL_LIB=${lib.getDev openonload}/lib/libciul1.a"
+  ];
+
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin $lib/lib $dev/lib $dev/include
+
+    cp -dv \
+      build/bin/zf_internal/shared/* \
+      build/bin/zf_apps/shared/* \
+      build/bin/zf_stackdump \
+      build/bin/trade_sim/shared/* \
+      $out/bin
+
+    cp -dv build/lib/libonload_zf.so* $lib/lib
+    cp -dv build/lib/libonload_zf_static.a $dev/lib
+    cp -rdv src/include/zf $dev/include
+
+    mkdir -p $dev/lib/pkgconfig
+    export dash_l="-lonload_zf"
+    substituteAll ${./tcpdirect.pc.in} $dev/lib/pkgconfig/tcpdirect.pc
+    export dash_l="-l:libonload_zf_static.a"
+    substituteAll ${./tcpdirect.pc.in} $dev/lib/pkgconfig/tcpdirect-static.pc
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    # zf_init from libonload_zf dynamically loads libefcp.so from openonload
+    patchelf --add-rpath ${openonload.lib}/lib $lib/lib/libonload_zf.so
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "Ultra low latency kernel bypass TCP and UDP implementation for AMD Solarflare network adapters";
+    homepage = "https://www.openonload.org";
+    license = lib.licenses.mit;
+    maintainers = with maintainers; [ YorikSar ];
+    # ARM64 build fails, see https://github.com/Xilinx-CNS/onload/issues/253
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/by-name/tc/tcpdirect/tcpdirect.pc.in
+++ b/pkgs/by-name/tc/tcpdirect/tcpdirect.pc.in
@@ -1,0 +1,10 @@
+prefix=@dev@
+includedir=${prefix}/include
+libdir=@lib@/lib
+
+Name: tcpdirect
+Description: Low latency, zero-copy TCP and UDP stack for SolarFlare NICs
+URL: http://www.xilinx.com
+Version: @version@
+Cflags: -isystem${includedir}
+Libs: -L${libdir} -Wl,-rpath,${libdir} @dash_l@


### PR DESCRIPTION
Adds `openonload` (high performance network stack for AMD Solarflare network cards) and `tcpdirect`(a kernel-bypass implementation of TCP and UDP for same hardware).

The reason this is one PR is that the latter depends on the former.

This was tested on-hardware and seems to work fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
