### PR TITLE
nixos/miniflux: use freeformType

### DIFF
--- a/nixos/modules/services/web-apps/miniflux.nix
+++ b/nixos/modules/services/web-apps/miniflux.nix
@@ -17,7 +17,7 @@ let
     ;
   cfg = config.services.miniflux;
 
-  defaultAddress = "localhost:8080";
+  boolToInt = b: if b then 1 else 0;
 
   pgbin = "${config.services.postgresql.package}/bin";
   preStart = pkgs.writeScript "miniflux-pre-start" ''
@@ -44,25 +44,53 @@ in
       };
 
       config = mkOption {
-        type =
-          with types;
-          attrsOf (oneOf [
-            str
-            int
-          ]);
-        example = literalExpression ''
-          {
-            CLEANUP_FREQUENCY = 48;
-            LISTEN_ADDR = "localhost:8080";
-          }
-        '';
+        type = types.submodule {
+          freeformType =
+            with types;
+            attrsOf (oneOf [
+              str
+              int
+            ]);
+          options = {
+            LISTEN_ADDR = mkOption {
+              type = types.str;
+              default = "localhost:8080";
+              description = ''
+                Address to listen on. Use absolute path for a Unix socket.
+                Multiple addresses can be specified, separated by commas.
+              '';
+              example = "127.0.0.1:8080, 127.0.0.1:8081";
+            };
+            DATABASE_URL = mkOption {
+              type = types.str;
+              defaultText = "user=miniflux host=/run/postgresql dbname=miniflux";
+              description = ''
+                Postgresql connection parameters.
+                See [lib/pq](https://pkg.go.dev/github.com/lib/pq#hdr-Connection_String_Parameters) for more details.
+              '';
+            };
+            RUN_MIGRATIONS = mkOption {
+              type = with types; coercedTo bool boolToInt int;
+              default = true;
+              description = "Run database migrations.";
+            };
+            CREATE_ADMIN = mkOption {
+              type = with types; coercedTo bool boolToInt int;
+              default = true;
+              description = "Create an admin user from environment variables.";
+            };
+            WATCHDOG = mkOption {
+              type = with types; coercedTo bool boolToInt int;
+              default = true;
+              description = "Enable or disable Systemd watchdog.";
+            };
+          };
+        };
+        default = { };
         description = ''
           Configuration for Miniflux, refer to
           <https://miniflux.app/docs/configuration.html>
           for documentation on the supported values.
-
-          Correct configuration for the database is already provided.
-          By default, listens on ${defaultAddress}.
         '';
       };
 
@@ -87,11 +115,7 @@ in
       }
     ];
     services.miniflux.config = {
-      LISTEN_ADDR = mkDefault defaultAddress;
       DATABASE_URL = lib.mkIf cfg.createDatabaseLocally "user=miniflux host=/run/postgresql dbname=miniflux";
-      RUN_MIGRATIONS = 1;
-      CREATE_ADMIN = lib.mkDefault 1;
-      WATCHDOG = 1;
     };
 
     services.postgresql = lib.mkIf cfg.createDatabaseLocally {


### PR DESCRIPTION
@tnias The NixOS test fails because of AppArmor, everything else works.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
