### PR TITLE
kdePackages.qmlbox2d: revendor Box2D

### DIFF
--- a/pkgs/development/libraries/qmlbox2d/default.nix
+++ b/pkgs/development/libraries/qmlbox2d/default.nix
@@ -6,33 +6,9 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  box2d,
   unstableGitUpdater,
 }:
 
-let
-  inherit (lib) cmakeBool;
-
-  # 2.3.1 is the only supported version
-  box2d' = box2d.overrideAttrs (old: rec {
-    version = "2.3.1";
-    src = fetchFromGitHub {
-      owner = "erincatto";
-      repo = "box2d";
-      tag = "v${version}";
-      hash = "sha256-Z2J17YMzQNZqABIa5eyJDT7BWfXveymzs+DWsrklPIs=";
-    };
-    patches = [ ];
-    postPatch = "";
-    sourceRoot = "${src.name}/Box2D";
-    cmakeFlags = old.cmakeFlags or [ ] ++ [
-      (cmakeBool "BOX2D_INSTALL" true)
-      (cmakeBool "BOX2D_BUILD_SHARED" true)
-      (cmakeBool "BOX2D_BUILD_EXAMPLES" false)
-    ];
-  });
-
-in
 stdenv.mkDerivation {
   pname = "qml-box2d";
   version = "0-unstable-2024-04-15";
@@ -52,13 +28,8 @@ stdenv.mkDerivation {
   ];
 
   buildInputs = [
-    box2d'
     qtbase
     qtdeclarative
-  ];
-
-  cmakeFlags = [
-    (cmakeBool "USE_SYSTEM_BOX2D" true)
   ];
 
   passthru = {

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -171,8 +171,6 @@ makeScopeWithSplicing' {
 
         qmltermwidget = callPackage ../development/libraries/qmltermwidget { };
 
-        qmlbox2d = callPackage ../development/libraries/qmlbox2d { };
-
         qoauth = callPackage ../development/libraries/qoauth { };
 
         qt5ct = callPackage ../tools/misc/qt5ct { };


### PR DESCRIPTION
They require an older version than our main `box2d_2` package (which itself is only used for LibreOffice). Our package works fine with CMake 4, as does the CMake build system they use in their vendored version, but the upstream release of the old version does not. Since this is a somewhat pointless single‐package use of `overrideAttrs`, just let it handle the Box2D build itself.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
