### PR TITLE
python3Packages.pycurl-requests: init at 0.5.0

### DIFF
--- a/pkgs/development/python-modules/pycurl-requests/default.nix
+++ b/pkgs/development/python-modules/pycurl-requests/default.nix
@@ -1,0 +1,50 @@
+{
+  buildPythonPackage,
+  chardet,
+  fetchFromGitHub,
+  lib,
+  pycurl,
+  setuptools,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  version = "0.5.0";
+  pname = "pycurl-requests";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "dcoles";
+    repo = "pycurl-requests";
+    tag = "v${version}";
+    hash = "sha256-3EEwwCuJZHf9ePC4sMRHL6tujdGVF6LfHVAIDpLXV7k=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    chardet
+    pycurl
+  ];
+
+  disabledTests = [
+    # tests that require network access
+    "test_connecterror_refused"
+    "test_get_connect_timeout"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pycurl_requests" ];
+
+  meta = {
+    description = "Requests-compatible interface for PycURL";
+    homepage = "https://github.com/dcoles/pycurl-requests";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ polyfloyd ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12795,6 +12795,8 @@ self: super: with self; {
 
   pycurl = callPackage ../development/python-modules/pycurl { };
 
+  pycurl-requests = callPackage ../development/python-modules/pycurl-requests { };
+
   pycxx = callPackage ../development/python-modules/pycxx { };
 
   pycycling = callPackage ../development/python-modules/pycycling { };


### PR DESCRIPTION
Glue to use requests with libcurl as transport backend.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
