### PR TITLE
gimp-with-plugins: list plugins in description

### DIFF
--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -363,7 +363,8 @@ lib.makeScope pkgs.newScope (
     # =============== simple script files ====================
 
     lightning = scriptDerivation {
-      name = "Lightning";
+      pname = "Lightning";
+      version = "0-unstable-2017-08-25";
       src = fetchurl {
         url = "https://github.com/pixlsus/registry.gimp.org_static/raw/master/registry.gimp.org/files/Lightning.scm";
         sha256 = "c14a8f4f709695ede3f77348728a25b3f3ded420da60f3f8de3944b7eae98a49";

--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -369,7 +369,8 @@ lib.makeScope pkgs.newScope (
     # =============== simple script files ====================
 
     lightning = scriptDerivation {
-      name = "Lightning";
+      pname = "Lightning";
+      version = "0-unstable-2017-08-25";
       src = fetchurl {
         url = "https://github.com/pixlsus/registry.gimp.org_static/raw/master/registry.gimp.org/files/Lightning.scm";
         sha256 = "c14a8f4f709695ede3f77348728a25b3f3ded420da60f3f8de3944b7eae98a49";

--- a/pkgs/applications/graphics/gimp/wrapper.nix
+++ b/pkgs/applications/graphics/gimp/wrapper.nix
@@ -43,5 +43,12 @@ symlinkJoin {
     done
   '';
 
-  inherit (gimp) meta;
+  meta = gimp.meta // {
+    description = "${gimp.meta.description} with plugins";
+    longDescription = ''
+      Plugins:
+
+      ${lib.concatMapStringsSep "\n" (p: "- ${p.pname}") selectedPlugins}
+    '';
+  };
 }

--- a/pkgs/applications/graphics/gimp/wrapper.nix
+++ b/pkgs/applications/graphics/gimp/wrapper.nix
@@ -51,5 +51,12 @@ symlinkJoin {
     ln -s ${gimp.man} $man
   '';
 
-  inherit (gimp) meta;
+  meta = gimp.meta // {
+    description = "${gimp.meta.description} with plugins";
+    longDescription = ''
+      Plugins:
+
+      ${lib.concatMapStringsSep "\n" (p: "- ${p.pname}") selectedPlugins}
+    '';
+  };
 }


### PR DESCRIPTION
`gimp` and `gimp-with-plugins` [have the same description](https://discourse.nixos.org/t/difference-between-gimp3-and-gimp3-with-plugins-packages/69485?u=_andrew):

> <img width="1400" height="632" alt="gimp: GNU Image Manipulation Program; gimp-with-plugins: GNU Image Manipulation Program" src="https://github.com/user-attachments/assets/581704ae-a1c7-44d1-a7d8-d2e0dd5c1682" />

Would it be appropriate to list the plugins here? e.g.:

> GNU Image Manipulation Program with plugins: bimp, farbfeld, fourier, gimplensfun, gmic-qt-gimp, Lightning, lqr-plugin, resynthesizer, texturize, wavelet-sharpen

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
