### PR TITLE
msi-ec: 0-unstable-2025-05-17 -> 0-unstable-2025-09-17

### DIFF
--- a/pkgs/os-specific/linux/msi-ec/default.nix
+++ b/pkgs/os-specific/linux/msi-ec/default.nix
@@ -9,13 +9,13 @@
 }:
 stdenv.mkDerivation {
   pname = "msi-ec-kmods";
-  version = "0-unstable-2025-05-17";
+  version = "0-unstable-2025-09-17";
 
   src = fetchFromGitHub {
     owner = "BeardOverflow";
     repo = "msi-ec";
-    rev = "796be9047b13c311ac4cdec33913775f4057f600";
-    hash = "sha256-npJbnWFBVb8TK9ynVD/kXWq2iqO0ACKF4UYsu5mQuok=";
+    rev = "ed92e2eb0005ab815f5492c8cb02495289263738";
+    hash = "sha256-9jynXUvSZT2smyciK8GqojC/4MtxtqfQvJcf5RgPXKY=";
   };
 
   dontMakeSourcesWritable = false;
@@ -44,6 +44,6 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl2Plus;
     maintainers = [ lib.maintainers.m1dugh ];
     platforms = lib.platforms.linux;
-    broken = kernel.kernelOlder "5.5";
+    broken = kernel.kernelOlder "6.5";
   };
 }

--- a/pkgs/os-specific/linux/msi-ec/patches/makefile.patch
+++ b/pkgs/os-specific/linux/msi-ec/patches/makefile.patch
@@ -1,12 +1,12 @@
 diff --git a/Makefile b/Makefile
-index bffcbd4..fd1d8a3 100644
+index 9e598ea..0776132 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -1,6 +1,7 @@
- VERSION         := 0.08
+ VERSION         := 0.12
  DKMS_ROOT_PATH  := /usr/src/msi_ec-$(VERSION)
- TARGET ?= $(shell uname -r)
-+KERNELDIR ?= /lib/modules/$(TARGET)/build/
+ KERNELRELEASE ?= $(shell uname -r)
++KERNELDIR ?= /lib/modules/$(KERNELRELEASE)/build/
  
  ccflags-y := -std=gnu11 -Wno-declaration-after-statement
  
@@ -14,11 +14,11 @@ index bffcbd4..fd1d8a3 100644
  all: modules
  
  modules:
--	@$(MAKE) -C /lib/modules/$(TARGET)/build M=$(CURDIR) modules
+-	@$(MAKE) -C /lib/modules/$(KERNELRELEASE)/build M=$(CURDIR) modules
 +	@$(MAKE) -C $(KERNELDIR) M=$(CURDIR) modules
  
  clean:
- 	@$(MAKE) -C /lib/modules/$(TARGET)/build M=$(CURDIR) clean
+ 	@$(MAKE) -C /lib/modules/$(KERNELRELEASE)/build M=$(CURDIR) clean
  
 +modules_install:
 +	@$(MAKE) -C $(KERNELDIR) M=$(CURDIR) modules_install


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
