### PR TITLE
fetchgit: add a gitConfig argument and a config option to set a default

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -208,6 +208,8 @@
 
 - Added `rewriteURL` attribute to the nixpkgs `config`, to allow for rewriting the URLs downloaded by `fetchurl`.
 
+- Added `gitConfig` and `gitConfigFile` option to the nixpkgs `config`, to allow for setting a default `gitConfigFile` for all `fetchgit` invocations.
+
 - The `dockerTools.streamLayeredImage` builder now uses a better algorithm for generating layered docker images, such that much more sharing is possible when the number of store paths exceeds the layer limit. It gives each of the largest store paths its own layer and adds dependencies to those layers when they aren't used elsewhere.
 
 - The systemd initrd will now respect `x-systemd.wants` and `x-systemd.requires` for reliably unlocking multi-disk bcachefs volumes.
@@ -243,6 +245,8 @@
   * `$debug/lib/debug/.build-id/48/3bd7f7229bdb06462222e1e353e4f37e15c293.source` is a symlink to the value of `$src` during build
   * `$debug/lib/debug/.build-id/48/3bd7f7229bdb06462222e1e353e4f37e15c293.sourceoverlay` is a symlink to a directory with the same structure as the expanded `$sourceRoot` but containing only a copy of files which were patched during the build
   * `$debug/lib/debug/.build-id/48/3bd7f7229bdb06462222e1e353e4f37e15c293.debug` is the file containing debug symbols (like before).
+
+- `fetchgit`: Add `gitConfigFile` argument to set a git config (via `$GIT_CONFIG_GLOBAL`) for the fetcher.
 
 - `fetchgit`: Add `rootDir` argument to limit the resulting source to one subdirectory of the whole Git repository. Corresponding `--root-dir` option added to `nix-prefetch-git`.
 

--- a/pkgs/build-support/fetchgit/builder.sh
+++ b/pkgs/build-support/fetchgit/builder.sh
@@ -8,6 +8,11 @@ echo "exporting $url (rev $rev) into $out"
 
 runHook preFetch
 
+if [ -n "$gitConfigFile" ]; then
+  echo "using GIT_CONFIG_GLOBAL=$gitConfigFile"
+  export GIT_CONFIG_GLOBAL="$gitConfigFile"
+fi
+
 $SHELL $fetcher --builder --url "$url" --out "$out" --rev "$rev" --name "$name" \
   ${leaveDotGit:+--leave-dotGit} \
   ${fetchLFS:+--fetch-lfs} \

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenvNoCC,
+  writeText,
   git,
   git-lfs,
   cacert,
@@ -64,6 +65,8 @@ lib.makeOverridable (
       fetchTags ? false,
       # make this subdirectory the root of the result
       rootDir ? "",
+      # GIT_CONFIG_GLOBAL (as a file)
+      gitConfigFile ? null,
     }:
 
     /*
@@ -148,6 +151,7 @@ lib.makeOverridable (
           postFetch
           fetchTags
           rootDir
+          gitConfigFile
           ;
         rev = revWithTag;
 

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -1,4 +1,5 @@
 {
+  config,
   lib,
   stdenvNoCC,
   writeText,
@@ -66,7 +67,7 @@ lib.makeOverridable (
       # make this subdirectory the root of the result
       rootDir ? "",
       # GIT_CONFIG_GLOBAL (as a file)
-      gitConfigFile ? null,
+      gitConfigFile ? config.gitConfigFile,
     }:
 
     /*

--- a/pkgs/build-support/fetchgit/tests.nix
+++ b/pkgs/build-support/fetchgit/tests.nix
@@ -7,7 +7,6 @@
   cacert,
   nix,
   closureInfo,
-  lib,
   ...
 }:
 {
@@ -196,13 +195,18 @@
         hash = "sha256-7DszvbCNTjpzGRmpIVAWXk20P0/XTrWZ79KSOGLrUWY=";
       };
 
-  withGitConfig = testers.invalidateFetcherByDrvHash fetchgit {
-    name = "fetchgit-with-config";
-    url = "https://doesntexist.forsure/NixOS/nix";
-    rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a";
-    sha256 = "sha256-7DszvbCNTjpzGRmpIVAWXk20P0/XTrWZ79KSOGLrUWY=";
-    gitConfigFile = builtins.toFile "gitconfig" (lib.generators.toGitINI {
-      url."https://github.com".insteadOf = "https://doesntexist.forsure";
-    });
-  };
+  withGitConfig =
+    let
+      pkgs = import ../../.. {
+        config.gitConfig = {
+          url."https://github.com".insteadOf = "https://doesntexist.forsure";
+        };
+      };
+    in
+    pkgs.testers.invalidateFetcherByDrvHash pkgs.fetchgit {
+      name = "fetchgit-with-config";
+      url = "https://doesntexist.forsure/NixOS/nix";
+      rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a";
+      sha256 = "sha256-7DszvbCNTjpzGRmpIVAWXk20P0/XTrWZ79KSOGLrUWY=";
+    };
 }

--- a/pkgs/build-support/fetchgit/tests.nix
+++ b/pkgs/build-support/fetchgit/tests.nix
@@ -7,6 +7,7 @@
   cacert,
   nix,
   closureInfo,
+  lib,
   ...
 }:
 {
@@ -194,4 +195,14 @@
         rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a";
         hash = "sha256-7DszvbCNTjpzGRmpIVAWXk20P0/XTrWZ79KSOGLrUWY=";
       };
+
+  withGitConfig = testers.invalidateFetcherByDrvHash fetchgit {
+    name = "fetchgit-with-config";
+    url = "https://doesntexist.forsure/NixOS/nix";
+    rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a";
+    sha256 = "sha256-7DszvbCNTjpzGRmpIVAWXk20P0/XTrWZ79KSOGLrUWY=";
+    gitConfigFile = builtins.toFile "gitconfig" (lib.generators.toGitINI {
+      url."https://github.com".insteadOf = "https://doesntexist.forsure";
+    });
+  };
 }

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -105,6 +105,40 @@ let
       '';
     };
 
+    gitConfig = mkOption {
+      type = types.attrsOf (types.attrsOf types.anything);
+      description = ''
+        The default [git configuration](https://git-scm.com/docs/git-config#_variables) for all [`pkgs.fetchgit`](#fetchgit) calls.
+
+        Among many other potential uses, this can be used to override URLs to point to local mirrors.
+
+        Changing this will not cause any rebuilds because `pkgs.fetchgit` produces a [fixed-output derivation](https://nix.dev/manual/nix/stable/glossary.html?highlight=fixed-output%20derivation#gloss-fixed-output-derivation).
+
+        To set the configuration file directly, use the [`gitConfigFile`](#opt-gitConfigFile) option instead.
+
+        To set the configuration file for individual calls, use `fetchurl { gitConfigFile = "..."; }`.
+      '';
+      default = { };
+      example = {
+        url."https://my-github-mirror.local".insteadOf = [ "https://github.com" ];
+      };
+    };
+
+    # A rendered version of gitConfig that can be reused by all pkgs.fetchgit calls
+    gitConfigFile = mkOption {
+      type = types.nullOr types.path;
+      description = ''
+        A path to a [git configuration](https://git-scm.com/docs/git-config#_variables) file, to be used for all [`pkgs.fetchgit`](#fetchgit) calls.
+
+        This overrides the [`gitConfig`](#opt-gitConfig) option, see its documentation for more details.
+      '';
+      default =
+        if config.gitConfig != { } then
+          builtins.toFile "gitconfig" (lib.generators.toGitINI config.gitConfig)
+        else
+          null;
+    };
+
     doCheckByDefault = mkMassRebuild {
       feature = "run `checkPhase` by default";
     };


### PR DESCRIPTION
Adds a `gitConfig` argument to `fetchgit`, and a config option to provide a default for all `fetchgit` invocations.

This is most useful for overriding URLs with custom mirrors, via `insteadOf` (as demonstrated in the example).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
