### PR TITLE
pypy3Packages.sphinx: ignore more failing tests

### DIFF
--- a/pkgs/development/python-modules/sphinx/default.nix
+++ b/pkgs/development/python-modules/sphinx/default.nix
@@ -103,6 +103,17 @@ buildPythonPackage rec {
     export HOME=$TMPDIR
   '';
 
+  disabledTestPaths = lib.optionals isPyPy [
+    # internals are asserted which are sightly different in PyPy
+    "tests/test_extensions/test_ext_autodoc.py"
+    "tests/test_extensions/test_ext_autodoc_autoclass.py"
+    "tests/test_extensions/test_ext_autodoc_autofunction.py"
+    "tests/test_extensions/test_ext_autodoc_automodule.py"
+    "tests/test_extensions/test_ext_autodoc_preserve_defaults.py"
+    "tests/test_util/test_util_inspect.py"
+    "tests/test_util/test_util_typing.py"
+  ];
+
   disabledTests = [
     # requires network access
     "test_latex_images"
@@ -145,13 +156,10 @@ buildPythonPackage rec {
     # https://doc.pypy.org/en/latest/cpython_differences.html#miscellaneous
     "test_autosummary_generate_content_for_module"
     "test_autosummary_generate_content_for_module_skipped"
-    # internals are asserted which are sightly different in PyPy
-    "test_autodoc_inherited_members_None"
-    "test_automethod_for_builtin"
-    "test_builtin_function"
-    "test_isattributedescriptor"
-    "test_methoddescriptor"
-    "test_partialfunction"
+    # Struct vs struct.Struct
+    "test_restify"
+    "test_stringify_annotation"
+    "test_stringify_type_union_operator"
   ];
 
   passthru.tests = {


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
