### PR TITLE
canokey-qemu: mark broken

### DIFF
--- a/nixos/tests/systemd-initrd-luks-fido2.nix
+++ b/nixos/tests/systemd-initrd-luks-fido2.nix
@@ -2,6 +2,11 @@
 {
   name = "systemd-initrd-luks-fido2";
 
+  meta = {
+    # `canokey-qemu` is marked broken.
+    broken = true;
+  };
+
   nodes.machine =
     { pkgs, config, ... }:
     {

--- a/pkgs/applications/virtualization/qemu/canokey-qemu.nix
+++ b/pkgs/applications/virtualization/qemu/canokey-qemu.nix
@@ -57,5 +57,10 @@ stdenv.mkDerivation rec {
     description = "CanoKey QEMU Virt Card";
     license = licenses.asl20;
     maintainers = with maintainers; [ oxalica ];
+    # Uses a four‐year‐old patched vendored version of Mbed TLS for
+    # cryptography that doesn’t build with CMake 4. Doesn’t build with
+    # gurrent versions of `canokey-core`, either. No upstream
+    # development since 2023.
+    broken = true;
   };
 }

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -90,7 +90,7 @@
   tpmSupport ? !minimal,
   uringSupport ? stdenv.hostPlatform.isLinux && !userOnly,
   liburing,
-  canokeySupport ? !minimal,
+  canokeySupport ? false,
   canokey-qemu,
   capstoneSupport ? !minimal,
   capstone,


### PR DESCRIPTION
Uses a four‐year‐old patched vendored version of Mbed TLS for cryptography that doesn’t build with CMake 4. Doesn’t build with current versions of `canokey-core`, either. No upstream development since 2023.

This was only used in‐tree by the `systemd-initrd-luks-fido2` NixOS test, which is not a channel blocker and that I couldn’t find a historical failure for that wasn’t related to issues with the test driver.

cc @tlaurion as Alyssa mentioned you were invested in the support here. Unfortunately it seems like CanoKey upstream has somewhat abandoned the QEMU library. Even if it was bumped to work with the current `canokey-core`, `canokey-crypto` is still on the same version of Mbed TLS from 2021. I get the impression that upstream are not very invested in the software QEMU support, and are focused on hardware keys that use separate accelerated cryptography implementations. Maybe they could use help getting things updated?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
