### PR TITLE
onnxruntime: fix build with CMake 4

### DIFF
--- a/pkgs/by-name/mi/microsoft-gsl/package.nix
+++ b/pkgs/by-name/mi/microsoft-gsl/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   gtest,
   pkg-config,
@@ -10,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "microsoft-gsl";
-  version = "4.0.0";
+  version = "4.2.0";
 
   src = fetchFromGitHub {
     owner = "Microsoft";
     repo = "GSL";
     rev = "v${version}";
-    hash = "sha256-cXDFqt2KgMFGfdh6NGE+JmP4R0Wm9LNHM0eIblYe6zU=";
+    hash = "sha256-NrnYfCCeQ50oHYFbn9vh5Z4mfyxc0kAM3qnzQdq9gyM=";
   };
 
   nativeBuildInputs = [
@@ -25,17 +24,8 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [ gtest ];
 
-  # negate the `-Werror` flag as Microsoft doesn't build with clang
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-error";
-
-  patches = [
-    # nvcc doesn't recognize the "gsl" attribute namespace (microsoft/onnxruntime#13573)
-    # only affects nvcc
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/microsoft/onnxruntime/4bfa69def85476b33ccfaf68cf070f3fb65d39f7/cmake/patches/gsl/1064.patch";
-      hash = "sha256-0jESA+VENWQms9HGE0jRiZZuWLJehBlbArxSaQbYOrM=";
-    })
-  ];
+  # C++17 required by latest gtest
+  env.NIX_CFLAGS_COMPILE = "-std=c++17";
 
   doCheck = true;
 

--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -8,7 +8,6 @@
   cpuinfo,
   eigen,
   flatbuffers_23,
-  gbenchmark,
   glibcLocales,
   gtest,
   howard-hinnant-date,
@@ -54,25 +53,6 @@ let
     repo = "safeint";
     tag = "3.0.28";
     hash = "sha256-pjwjrqq6dfiVsXIhbBtbolhiysiFlFTnx5XcX77f+C0=";
-  };
-
-  pytorch_clog = effectiveStdenv.mkDerivation {
-    pname = "clog";
-    version = "3c8b153";
-    src = "${cpuinfo.src}/deps/clog";
-
-    nativeBuildInputs = [
-      cmake
-      gbenchmark
-      gtest
-    ];
-    cmakeFlags = [
-      (lib.cmakeBool "USE_SYSTEM_GOOGLEBENCHMARK" true)
-      (lib.cmakeBool "USE_SYSTEM_GOOGLETEST" true)
-      (lib.cmakeBool "USE_SYSTEM_LIBS" true)
-      # 'clog' tests set 'CXX_STANDARD 11'; this conflicts with our 'gtest'.
-      (lib.cmakeBool "CLOG_BUILD_TESTS" false)
-    ];
   };
 
   onnx = fetchFromGitHub {
@@ -139,7 +119,6 @@ effectiveStdenv.mkDerivation rec {
     libpng
     nlohmann_json
     microsoft-gsl
-    pytorch_clog
     zlib
   ]
   ++ lib.optionals (lib.meta.availableOn effectiveStdenv.hostPlatform cpuinfo) [

--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -17,8 +17,9 @@
   python3Packages,
   re2,
   zlib,
-  microsoft-gsl,
   protobuf,
+  microsoft-gsl,
+  darwinMinVersionHook,
   pythonSupport ? true,
   cudaSupport ? config.cudaSupport,
   ncclSupport ? config.cudaSupport,
@@ -149,7 +150,10 @@ effectiveStdenv.mkDerivation rec {
         nccl
       ]
     )
-  );
+  )
+  ++ lib.optionals effectiveStdenv.hostPlatform.isDarwin [
+    (darwinMinVersionHook "13.3")
+  ];
 
   nativeCheckInputs = [
     gtest

--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -72,8 +72,8 @@ let
   dlpack = fetchFromGitHub {
     owner = "dmlc";
     repo = "dlpack";
-    tag = "v0.6";
-    hash = "sha256-YJdZ0cMtUncH5Z6TtAWBH0xtAIu2UcbjnVcCM4tfg20=";
+    rev = "5c210da409e7f1e51ddf445134a4376fdbd70d7d";
+    hash = "sha256-YqgzCyNywixebpHGx16tUuczmFS5pjCz5WjR89mv9eI=";
   };
 
   isCudaJetson = cudaSupport && cudaPackages.flags.isJetsonBuild;


### PR DESCRIPTION
See commit messages for details.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
