### PR TITLE
cryfs: 0.11.4 -> 1.0.1

### DIFF
--- a/pkgs/by-name/cr/cryfs/package.nix
+++ b/pkgs/by-name/cr/cryfs/package.nix
@@ -8,23 +8,22 @@
   boost,
   curl,
   fuse,
+  gtest,
   openssl,
   range-v3,
   spdlog,
-  # cryptopp and gtest on standby - using the vendored ones for now
-  # see https://github.com/cryfs/cryfs/issues/369
   llvmPackages,
 }:
 
 stdenv.mkDerivation rec {
   pname = "cryfs";
-  version = "0.11.4";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "cryfs";
     repo = "cryfs";
     rev = version;
-    hash = "sha256-OkJhLg+YzS3kDhlpUQe9A+OiVBPG/iKs6OU7aKFJ5wY=";
+    hash = "sha256-QzxJUh6nD6243x443b0tIb1v2Zs8jRUk8IVarNqs47M=";
   };
 
   postPatch = ''
@@ -59,20 +58,19 @@ stdenv.mkDerivation rec {
     boost
     curl
     fuse
+    gtest
     openssl
     range-v3
     spdlog
   ]
   ++ lib.optional stdenv.cc.isClang llvmPackages.openmp;
 
-  #nativeCheckInputs = [ gtest ];
-
   cmakeFlags = [
     "-DDEPENDENCY_CONFIG='../cmake-utils/DependenciesFromLocalSystem.cmake'"
     "-DCRYFS_UPDATE_CHECKS:BOOL=FALSE"
     "-DBoost_USE_STATIC_LIBS:BOOL=FALSE" # this option is case sensitive
     "-DBUILD_TESTING:BOOL=${if doCheck then "TRUE" else "FALSE"}"
-  ]; # ++ lib.optional doCheck "-DCMAKE_PREFIX_PATH=${gtest.dev}/lib/cmake";
+  ];
 
   # macFUSE needs to be installed for the test to succeed on Darwin
   doCheck = !stdenv.hostPlatform.isDarwin;


### PR DESCRIPTION
Pushing this cherry‐pick from @K900’s branch for him.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
