### PR TITLE
poco: 1.14.1 -> 1.14.2

### DIFF
--- a/pkgs/by-name/po/poco/package.nix
+++ b/pkgs/by-name/po/poco/package.nix
@@ -19,12 +19,12 @@
 stdenv.mkDerivation rec {
   pname = "poco";
 
-  version = "1.14.1";
+  version = "1.14.2";
 
   src = fetchFromGitHub {
     owner = "pocoproject";
     repo = "poco";
-    hash = "sha256-acq2eja61sH/QHwMPmiDNns2jvXRTk0se/tHj9XRSiU=";
+    hash = "sha256-koREkrfAHWfpqITN5afiXwZg37Wve2Ftx8sr8t2bSV4=";
     rev = "poco-${version}-release";
   };
 


### PR DESCRIPTION
Fixes CVE-2025-6375 (and other issues that do not seem to have a CVE ID assigned).

Changes:
https://github.com/pocoproject/poco/releases/tag/poco-1.14.2-release


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 443831`
Commit: `0dd2e6e3fc8e2cbbcc4d688f69b33e74539da100`

---
### `x86_64-linux`
<details>
  <summary>:x: 2 packages failed to build:</summary>
  <ul>
    <li>quake3arena</li>
    <li>quake3arena-hires</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 17 packages built:</summary>
  <ul>
    <li>collabora-online</li>
    <li>craftos-pc</li>
    <li>ioq3-scion</li>
    <li>ioquake3</li>
    <li>multipass</li>
    <li>mumble</li>
    <li>mumble_overlay</li>
    <li>murmur</li>
    <li>poco</li>
    <li>poco.dev</li>
    <li>pothos</li>
    <li>projectm-sdl-cpp</li>
    <li>quake3demo</li>
    <li>quake3demo-hires</li>
    <li>sanjuuni</li>
    <li>vscode-extensions.jackmacwindows.craftos-pc</li>
    <li>wahay</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
