### PR TITLE
nixos/profiles: remove redundant lessopen default

### DIFF
--- a/nixos/modules/profiles/minimal.nix
+++ b/nixos/modules/profiles/minimal.nix
@@ -24,8 +24,6 @@ in
   };
 
   programs = {
-    # The lessopen package pulls in Perl.
-    less.lessopen = mkDefault null;
     command-not-found.enable = mkDefault false;
     fish.generateCompletions = mkDefault false;
   };

--- a/nixos/modules/profiles/perlless.nix
+++ b/nixos/modules/profiles/perlless.nix
@@ -8,7 +8,6 @@
 
   # Random perl remnants
   system.tools.nixos-generate-config.enable = lib.mkDefault false;
-  programs.less.lessopen = lib.mkDefault null;
   boot.loader.grub.enable = lib.mkDefault false;
   environment.defaultPackages = lib.mkDefault [ ];
   documentation.info.enable = lib.mkDefault false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Relates to: https://github.com/NixOS/nixpkgs/issues/309599 https://github.com/NixOS/nixpkgs/pull/316979

Starting in 25.05 `programs.less.lessopen.default = null`. Cleaning up redundant profile config for minimal and perlless profiles.

Confirmed working for minimal profile by building a minimal vm and checking if `LESSOPEN` is set in env:

```
nix build -f ./nixos -I nixos-config=./nixos/modules/installer/cd-dvd/installation-cd-minimal.nix config.system.build.vm
```

Confirmed working for perlless profile by running vmTest:

```
nix build .#vmTests.activation-perlless
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
