### PR TITLE
pinecone: 0.11.0-unstable-2023-08-10 -> 0.11.0-unstable-2025-03-04

### DIFF
--- a/pkgs/by-name/pi/pinecone/package.nix
+++ b/pkgs/by-name/pi/pinecone/package.nix
@@ -1,18 +1,18 @@
 {
   lib,
-  buildGoModule,
+  buildGo124Module,
   fetchFromGitHub,
 }:
 
-buildGoModule {
+buildGo124Module {
   pname = "pinecone";
-  version = "0.11.0-unstable-2023-08-10";
+  version = "0.11.0-unstable-2025-03-04";
 
   src = fetchFromGitHub {
     owner = "matrix-org";
     repo = "pinecone";
-    rev = "ea4c33717fd74ef7d6f49490625a0fa10e3f5bbc";
-    hash = "sha256-q4EFWXSkQJ2n+xAWuBxdP7nrtv3eFql9LoavWo10dfs=";
+    rev = "b35aec69f59eb9bb8bd5a8c6be30fc276d3cce96";
+    hash = "sha256-0jqvWdFjN4Kzhkv4Oe1obsKGW0i/MGEMX3ZhcxpsdxA=";
   };
 
   vendorHash = "sha256-+P10K7G0UwkbCGEi6sYTQSqO7LzIf/xmaHIr7v110Ao=";


### PR DESCRIPTION
This pull request bumps `pinecone` to the latest commit on main, including a fix for GHSA-fr62-mg2q-7wqv. Go has also been pinned to `1.24` to mitigate a build failure (https://github.com/golang/go/issues/74462)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
