### PR TITLE
vo1ded-panel: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27326,6 +27326,12 @@
     githubId = 209139160;
     name = "VnPower";
   };
+  vo1dsh4d0w = {
+    email = "filipmyslinski2006@gmail.com";
+    github = "Vo1dSh4d0w";
+    githubId = 97691234;
+    name = "Filip Myslinski";
+  };
   vog = {
     email = "v@njh.eu";
     github = "vog";

--- a/pkgs/by-name/vo/vo1ded-panel/package.nix
+++ b/pkgs/by-name/vo/vo1ded-panel/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  ags,
+  astal,
+  fetchFromGitHub,
+}:
+ags.bundle {
+  pname = "vo1ded-panel";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "Vo1dSh4d0w";
+    repo = "vo1ded-panel";
+    rev = "3fabccbb55836a6779ce3b690214c26c5720bda4";
+    hash = "sha256-9A/hK1iS11No6kqwnOsz9w5/9k5i/rCQ9299YI8V9SE=";
+  };
+
+  strictDeps = true;
+  dependencies = [
+    astal.hyprland
+    astal.tray
+    astal.wireplumber
+  ];
+
+  meta = {
+    homepage = "https://github.com/Vo1dSh4d0w/vo1ded-panel";
+    description = "Simple shell for Hyprland made with ags";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vo1dsh4d0w ];
+    mainProgram = "vo1ded-panel";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION


## Things done
Added [vo1ded-panel](https://github.com/Vo1dSh4d0w/vo1ded-panel), a simple shell for Hyprland based on ags.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
