### PR TITLE
home-assistant-custom-components.lovelace_gen: init at 0.1.3

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/lovelace_gen/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/lovelace_gen/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  jinja2,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "thomasloven";
+  domain = "lovelace_gen";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "thomasloven";
+    repo = "hass-lovelace_gen";
+    tag = version;
+    hash = "sha256-YGqvdoOs9/Etfldoee3mgDQjtveLa/LovwX/IduYyjg=";
+  };
+
+  dependencies = [ jinja2 ];
+
+  meta = with lib; {
+    changelog = "https://github.com/thomasloven/hass-lovelace_gen/releases/tag/${version}";
+    description = "Improve the lovelace yaml parser for Home Assistant";
+    homepage = "https://github.com/thomasloven/hass-lovelace_gen";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jpinz ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Added https://github.com/thomasloven/hass-lovelace_gen

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
