### PR TITLE
chromium,chromedriver: 140.0.7339.127 -> 140.0.7339.185

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,6 +1,6 @@
 {
   "chromium": {
-    "version": "140.0.7339.127",
+    "version": "140.0.7339.185",
     "chromedriver": {
       "version": "140.0.7339.133",
       "hash_darwin": "sha256-Xf2f4AyowRkG7FTd8p3l3CMF3YCpjyprMD0pM+yPOhA=",
@@ -21,8 +21,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "9412745860d8c3dfed9cf38f5daa943b163f8c69",
-        "hash": "sha256-rAyS5AhWHL9+6N4+2PFYKPJjzErj8LfIm5ptcsTTV8E=",
+        "rev": "eeea00e459e8b6cd69698eda5b236a0d4cb3234d",
+        "hash": "sha256-BjjFH7/HhPBw/b7XmRZVNUrJYAUkWgCR0upHBn+Q5Ec=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -132,8 +132,8 @@
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "8550f9c1ff8859d25cc49bdfacef083cff2c5121",
-        "hash": "sha256-gDtFhalOMFWR25XLVbYB/GE1lSQd1ClZ8h175qkC6PU="
+        "rev": "67be7fddacc4f4bcb21d0cf7bf8bb18752d8fb08",
+        "hash": "sha256-ulw+gDGpUn8uWuNedlfQADwnSYYbPWpHN5Q+pJbwKGc="
       },
       "src/third_party/dawn/third_party/glfw": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
@@ -792,8 +792,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "fdb12b460f148895f6af2ff0e0d870ff8889f154",
-        "hash": "sha256-x8a8VYFrAZ0huj3WRlczrhg0quXx4cztz8nDs9ToWYg="
+        "rev": "6d56a0bd0840ce46c80ada63f8c962bd1bb336aa",
+        "hash": "sha256-VtW/nwKo3jCYfLBHvpAVdLJIRNxw27RAP1K+WgaO5Uc="
       }
     }
   },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2025/09/stable-channel-update-for-desktop_17.html

This update includes 4 security fixes. Google is aware that an exploit
for CVE-2025-10585 exists in the wild.

CVEs:
CVE-2025-10585 CVE-2025-10500 CVE-2025-10501 CVE-2025-10502

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
