### PR TITLE
wizard-engine: init at 25β.2881

### DIFF
--- a/pkgs/by-name/vi/virgil3/package.nix
+++ b/pkgs/by-name/vi/virgil3/package.nix
@@ -1,0 +1,79 @@
+{
+  coreutils,
+  fetchFromGitHub,
+  jdk,
+  lib,
+  makeWrapper,
+  stdenv,
+  versionCheckHook,
+  which,
+}:
+
+stdenv.mkDerivation {
+  # We put the major version number 3 in the package name instead of the version
+  # because it also appears in the *.v3 file extension for source files, as well
+  # as the compiler binary name v3c. Also, the version reported by the compiler
+  # itself is "Aeneas III-9.*" which wouldn't match unless we spelled it with
+  # Roman numerals here too, but we're not allowed to do that anyway.
+  pname = "virgil3";
+  version = "9.1864";
+
+  src = fetchFromGitHub {
+    owner = "titzer";
+    repo = "virgil";
+    rev = "0c28b4ed11d205cfc366673da6338ebd7518a11b";
+    hash = "sha256-79GzGqiPprCwrJINLmN0dG2qMUXZXqawWsMPT7fR96M=";
+  };
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  # Needed for bootstrapping.
+  preConfigure = ''
+    export PATH=$PWD/bin:$PATH
+  '';
+
+  nativeBuildInputs = [
+    jdk
+    makeWrapper
+    which
+  ];
+
+  # The bin/v3c file in the source repository is a shell script, but that file
+  # is also in .gitignore and gets overwritten during the build to instead be a
+  # symlink pointing to one of the Aeneas binaries under bin/current depending
+  # on the detected platform.
+  installPhase =
+    let
+      path = lib.makeBinPath [
+        coreutils
+        jdk
+      ];
+    in
+    ''
+      runHook preInstall
+      mkdir -p $out/bin
+      if [ -f bin/Aeneas.jar ]; then
+        mv $(readlink bin/Aeneas.jar) $out/bin/Aeneas.jar
+      fi
+      mv $(readlink bin/v3c) $out/bin/v3c
+      mv bin/v3c-* $out/bin/
+      mv lib $out/lib
+      mv rt $out/rt
+      wrapProgram $out/bin/v3c --prefix PATH : ${path}
+      wrapProgram $out/bin/v3c-jar --prefix PATH : ${path}
+      runHook postInstall
+    '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Fast and lightweight native programming language";
+    homepage = "https://github.com/titzer/virgil";
+    license = lib.licenses.asl20;
+    mainProgram = "v3c";
+    maintainers = with lib.maintainers; [ samestep ];
+  };
+}

--- a/pkgs/by-name/wi/wizard-engine/package.nix
+++ b/pkgs/by-name/wi/wizard-engine/package.nix
@@ -1,0 +1,78 @@
+{
+  fetchFromGitHub,
+  jdk,
+  lib,
+  makeWrapper,
+  stdenv,
+  versionCheckHook,
+  virgil3,
+  which,
+}:
+
+stdenv.mkDerivation {
+  pname = "wizard-engine";
+  version = "25β.2881";
+
+  src = fetchFromGitHub {
+    owner = "titzer";
+    repo = "wizard-engine";
+    rev = "06338ec23bbcd877c3a3f6913389c9e7bf74645e";
+    # We need the full .git history here to mimic the behavior of the project's
+    # build.sh script which uses Git to compute the minor version number.
+    deepClone = true;
+    leaveDotGit = true;
+    postFetch = ''
+      cd $out
+      git rev-list --count HEAD > REVS
+      rm -rf .git
+    '';
+    hash = "sha256-N999o8iZ8ik4mceiXmGLBK7lJlWhidoP44+5iEx7OOg=";
+  };
+
+  patches = [ ./revs.patch ];
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  nativeBuildInputs = [
+    jdk
+    makeWrapper
+    virgil3
+    which
+  ];
+
+  installPhase =
+    if (stdenv.hostPlatform.system == "x86_64-linux") then
+      ''
+        runHook preInstall
+        mkdir -p $out/bin
+        mv bin/wizeng.x86-64-linux $out/bin/wizeng
+        runHook postInstall
+      ''
+    else
+      ''
+        runHook preInstall
+        mkdir -p $out/bin
+        mv bin/wizeng.jvm.jar $out/bin/wizeng.jvm.jar
+        mv bin/wizeng.jvm $out/bin/wizeng
+        runHook postInstall
+      '';
+
+  # Allowing the default fixup phase to run causes the x86 binary to segfault.
+  fixupPhase = ''
+    runHook preFixup
+    runHook postFixup
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Research WebAssembly Engine";
+    homepage = "https://github.com/titzer/wizard-engine";
+    license = lib.licenses.asl20;
+    mainProgram = "wizeng";
+    maintainers = with lib.maintainers; [ samestep ];
+  };
+}

--- a/pkgs/by-name/wi/wizard-engine/revs.patch
+++ b/pkgs/by-name/wi/wizard-engine/revs.patch
@@ -1,0 +1,15 @@
+diff --git a/build.sh b/build.sh
+index f3a86446..eec9590c 100755
+--- a/build.sh
++++ b/build.sh
+@@ -102,9 +102,7 @@ function make_build_file() {
+ 		local build_data="$target $build_time by ${USER}@${HOST}"
+ 	fi
+ 
+-        # TODO: handle case where build is not in a git repo
+-	# TODO: use -redef-field instead of generating a build file
+-        REVS="$(git rev-list --count HEAD)"
++        REVS=$(< REVS)
+ 	echo "var unused__ = (Version.buildData = \"$build_data\", Version.minorVersion = $REVS);" > $build_file
+ 
+ 	echo $build_file


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds a Nix package for the [Wizard Research Engine](https://github.com/titzer/wizard-engine) for WebAssembly, along with a package for the [Virgil programming language](https://github.com/titzer/virgil) in which Wizard is written.

As an example, you can create this `foo.wat` file:

```wat
(module
  (func (export "main") (result i32)
    (i32.const 42)))
```

And then run it with Wizard via this command:

```
$ nix run .#wasm-tools -- parse foo.wat -o foo.wasm && nix run .#wizard-engine -- foo.wasm ; echo $?
42
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
