### PR TITLE
nixosTests.dashy: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -428,6 +428,7 @@ in
   cyrus-imap = runTest ./cyrus-imap.nix;
   dae = runTest ./dae.nix;
   darling-dmg = runTest ./darling-dmg.nix;
+  dashy = runTest ./web-apps/dashy.nix;
   davis = runTest ./davis.nix;
   db-rest = runTest ./db-rest.nix;
   dconf = runTest ./dconf.nix;

--- a/nixos/tests/web-apps/dashy.nix
+++ b/nixos/tests/web-apps/dashy.nix
@@ -1,0 +1,75 @@
+{ pkgs, lib, ... }:
+let
+
+  customSettings = {
+    pageInfo = {
+      title = "My Custom Dashy Title";
+    };
+
+    sections = [
+      {
+        name = "My Section";
+        items = [
+          {
+            name = "NixOS";
+            url = "https://nixos.org";
+          }
+        ];
+      }
+    ];
+  };
+
+  customSettingsYaml = (pkgs.formats.yaml_1_1 { }).generate "custom-conf.yaml" customSettings;
+in
+{
+  name = "dashy";
+  meta.maintainers = [ lib.maintainers.therealgramdalf ];
+
+  defaults =
+    { config, ... }:
+    {
+      services.dashy = {
+        enable = true;
+        virtualHost = {
+          enableNginx = true;
+          domain = "dashy.local";
+        };
+      };
+
+      networking.extraHosts = "127.0.0.1 dashy.local";
+
+      services.nginx.virtualHosts."${config.services.dashy.virtualHost.domain}".listen = [
+        {
+          addr = "127.0.0.1";
+          port = 80;
+        }
+      ];
+    };
+  nodes = {
+    machine = { };
+
+    machine-custom = {
+      services.dashy.settings = customSettings;
+    };
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("nginx.service")
+    machine.wait_for_open_port(80)
+
+    actual = machine.succeed("curl -v --stderr - http://dashy.local/", timeout=10)
+    expected = "<title>Dashy</title>"
+    assert expected in actual, \
+      f"unexpected reply from Dashy, expected: '{expected}' got: '{actual}'"
+
+    machine_custom.wait_for_unit("nginx.service")
+    machine_custom.wait_for_open_port(80)
+
+    actual_custom = machine_custom.succeed("curl -s --stderr - http://dashy.local/conf.yml", timeout=10).strip()
+    expected_custom = machine_custom.succeed("cat ${customSettingsYaml}").strip()
+
+    assert expected_custom == actual_custom, \
+      f"unexpected reply from Dashy, expected: '{expected_custom}' got: '{actual_custom}'"
+  '';
+}

--- a/pkgs/by-name/da/dashy-ui/package.nix
+++ b/pkgs/by-name/da/dashy-ui/package.nix
@@ -10,7 +10,7 @@
   prefetch-yarn-deps,
   nodejs_20,
   nodejs-slim_20,
-  yq-go,
+  remarshal_0_17,
   settings ? { },
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -30,11 +30,11 @@ stdenv.mkDerivation (finalAttrs: {
   # - Despite JSON being valid YAML (and the JSON passing the config validator),
   # there seem to be some issues with JSON in the final build - potentially due to
   # the way the client parses things
-  # - Instead, we use `yq-go` to convert it to yaml
+  # - Instead, we use `remarshal` to convert it to yaml
   # Config validation needs to happen after yarnConfigHook, since it's what sets the yarn offline cache
   preBuild = lib.optional (settings != { }) ''
     echo "Writing settings override..."
-    yq --output-format yml '${builtins.toFile "conf.json" ''${builtins.toJSON settings}''}' > user-data/conf.yml
+    json2yaml '${builtins.toFile "conf.json" (builtins.toJSON settings)}' user-data/conf.yml
     yarn validate-config --offline
   '';
   installPhase = ''
@@ -59,8 +59,8 @@ stdenv.mkDerivation (finalAttrs: {
     })
     yarnBuildHook
     nodejs_20
-    # For yaml parsing
-    yq-go
+    # For yaml conversion
+    remarshal_0_17
   ];
   doDist = false;
   meta = {

--- a/pkgs/by-name/da/dashy-ui/package.nix
+++ b/pkgs/by-name/da/dashy-ui/package.nix
@@ -8,6 +8,7 @@
   yarn,
   fixup-yarn-lock,
   prefetch-yarn-deps,
+  nixosTests,
   nodejs_20,
   nodejs-slim_20,
   remarshal_0_17,
@@ -26,6 +27,11 @@ stdenv.mkDerivation (finalAttrs: {
     yarnLock = finalAttrs.src + "/yarn.lock";
     hash = "sha256-r36w3Cz/V7E/xPYYpvfQsdk2QXfCVDYE9OxiFNyKP2s=";
   };
+
+  passthru.tests = {
+    dashy = nixosTests.dashy;
+  };
+
   # - If no settings are passed, use the default config provided by upstream
   # - Despite JSON being valid YAML (and the JSON passing the config validator),
   # there seem to be some issues with JSON in the final build - potentially due to


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added a `nixosTest` to `services.dashy`, testing that the package built is serveable by Nginx. The test spawns two nodes: one with the default configuration provided upstream, the second with a custom configuration applied. 
The first node is checked simply to see if the server responds with expected content. The second nodes `/conf.yml` is queried and compared to the YAML given to the builder to ensure that custom settings are applied as expected, returning the expected vs. received content if they differ.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
