### PR TITLE
uradvd: 0-unstable-2025-08-16 -> r26-1e64364d

### DIFF
--- a/pkgs/by-name/ur/uradvd/package.nix
+++ b/pkgs/by-name/ur/uradvd/package.nix
@@ -2,18 +2,26 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  gitMinimal,
+  uradvd,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation {
   pname = "uradvd";
-  version = "0-unstable-2025-08-16";
+  version = "r26-1e64364d";
 
   src = fetchFromGitHub {
     owner = "freifunk-gluon";
     repo = "uradvd";
-    rev = "b37524dfb0292c425fd61f5bffb3101fb1979264";
-    hash = "sha256-PyOAt9dTFdHHF7OlHi9BBTjCN2Hmk8BsHkD2rV94ZDM=";
+    rev = "1e64364d323acb8c71285a6fb85d384334e7007d";
+    deepClone = true;
+    hash = "sha256-+MDhBuCPJ/dcKw4/z4PnXXGoNomIz/0QI32XfLR6fK0=";
   };
+
+  nativeBuildInputs = [
+    gitMinimal
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -22,6 +30,12 @@ stdenv.mkDerivation {
 
     runHook postInstall
   '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   meta = {
     description = "Tiny IPv6 Router Advertisement Daemon";


### PR DESCRIPTION
uradvd started versioning earlier today

and invokes git in its makefile to define it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - ~[NixOS tests] in [nixos/tests].~
  - [x] [Package tests] at `passthru.tests`.
  - ~Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - ~Package update: when the change is major or breaking.~
- NixOS Release Notes
  - ~Module addition: when adding a new NixOS module.~
  - ~Module update: when the change is significant.~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
