### PR TITLE
rido: init at 0.6.0

### DIFF
--- a/pkgs/by-name/ri/rido/package.nix
+++ b/pkgs/by-name/ri/rido/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage {
+  pname = "rido";
+  version = "0.6.0-unstable-2025-09-13";
+
+  src = fetchFromGitHub {
+    owner = "lj3954";
+    repo = "rido";
+    rev = "a1aa36a6108b34d2495256868b3b720170b8c306";
+    hash = "sha256-welK63Bbckr6/OrA2BQmuVPfYVhkOgBttDnC7BlzP4U=";
+  };
+
+  cargoHash = "sha256-yKr6HW0PaNx1ha6yCuimebEf8oG9K0ug8lX5Gq+Cx9o=";
+
+  meta = {
+    description = "Fetch valid URLs and checksums of Microsoft Operating Systems";
+    homepage = "https://github.com/lj3954/rido";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "rido";
+    maintainers = with lib.maintainers; [ stv0g ];
+  };
+}


### PR DESCRIPTION
https://github.com/lj3954/rido

Rido is a library crate which allows applications access to valid URLs and Checksums for various releases of Microsoft Windows. It is inspired by the [Mido](https://github.com/ElliotKillick/Mido) bash script and [Fido](https://github.com/pbatard/Fido) PowerShell script.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
