### PR TITLE
lib.trivial: add boolToBit

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -128,6 +128,7 @@ let
         bitNot
         boolToString
         boolToYesNo
+        boolToBit
         mergeAttrs
         flip
         defaultTo

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -261,6 +261,44 @@ in
   boolToYesNo = b: if b then "yes" else "no";
 
   /**
+    Converts a boolean to a bit (an integer with value 0 or 1).
+
+    This function uses the integers 1 and 0 to represent boolean values,
+    where `true` maps to 1 and `false` maps to 0.
+
+    Note that in many shell contexts, an exit code of 0 indicates success,
+    while 1 indicates failure. This function's mapping is inverted from that
+    convention.
+
+    # Inputs
+
+    `b`
+
+    : The boolean to convert
+
+    # Type
+
+    ```
+    boolToBit :: bool -> int
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.trivial.boolToBit` usage example
+
+    ```nix
+    lib.trivial.boolToBit true
+    => 1
+    ```
+    ```nix
+    lib.trivial.boolToBit false
+    => 0
+    ```
+    :::
+  */
+  boolToBit = b: if b then 1 else 0;
+
+  /**
     Merge two attribute sets shallowly, right side trumps left
 
     mergeAttrs :: attrs -> attrs -> attrs


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Inspired by #413036, this is another recurring pattern

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
