### PR TITLE
ytsurf: init at 1.9.5

### DIFF
--- a/pkgs/by-name/yt/ytsurf/package.nix
+++ b/pkgs/by-name/yt/ytsurf/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  yt-dlp,
+  ffmpeg,
+  mpv,
+  chafa,
+  curl,
+  jq,
+  xh,
+  fzf,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ytsurf";
+  version = "1.9.5";
+
+  src = fetchFromGitHub {
+    owner = "Stan-breaks";
+    repo = "ytsurf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+KoTQYQfIsVrel2ctcioVC6SCZdVn2lGblQLTW9YGIE=";
+  };
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  propagatedUserEnvPkgs = [
+    yt-dlp
+    ffmpeg
+    mpv
+    chafa
+    curl
+    jq
+    xh
+    fzf
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D ytsurf.sh $out/bin/${finalAttrs.meta.mainProgram}
+    wrapProgram $out/bin/${finalAttrs.meta.mainProgram} \
+      --suffix PATH : ${lib.makeBinPath finalAttrs.propagatedUserEnvPkgs}
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Search for YouTube videos from your terminal";
+    homepage = "https://github.com/Stan-breaks/ytsurf";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "ytsurf";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
