### PR TITLE
rocmPackages.llvm: use same LLVM version for bootstrap and override

### DIFF
--- a/pkgs/development/rocm-modules/6/llvm/default.nix
+++ b/pkgs/development/rocm-modules/6/llvm/default.nix
@@ -244,7 +244,6 @@ let
   );
 in
 rec {
-  inherit (llvmPackagesRocm) libunwind;
   inherit (llvmPackagesRocm) libcxx;
   inherit args;
   # Pass through original attrs for debugging where non-overridden llvm/clang is getting used
@@ -473,8 +472,6 @@ rec {
       lld
       lld.lib
       lld.dev
-      libunwind
-      libunwind.dev
       compiler-rt
       compiler-rt.dev
       rocmcxx

--- a/pkgs/development/rocm-modules/6/llvm/default.nix
+++ b/pkgs/development/rocm-modules/6/llvm/default.nix
@@ -1,10 +1,8 @@
 {
   lib,
   stdenv,
-  # default LLVM version is used as stdenv to build our toolchain
-  llvmPackages,
   # LLVM version closest to ROCm fork to override
-  llvmPackages_20,
+  llvmPackages_19,
   overrideCC,
   rocm-device-libs,
   fetchFromGitHub,
@@ -39,11 +37,10 @@ let
   version = "6.4.3";
   # major version of this should be the clang version ROCm forked from
   rocmLlvmVersion = "19.0.0-rocm";
-  # llvmPackages_base version should be close to rocmLlvmVersion,
-  # may be one off because AMD backports a lot and the +1 patches
-  # may be easier to get to build
-  llvmPackages_base = llvmPackages_20;
-  llvmPackagesNoBintools = llvmPackages.override {
+  # llvmPackages_base version should match rocmLlvmVersion
+  # so libllvm's bitcode is compatible with the built toolchain
+  llvmPackages_base = llvmPackages_19;
+  llvmPackagesNoBintools = llvmPackages_base.override {
     bootBintools = null;
     bootBintoolsNoLibc = null;
   };
@@ -55,7 +52,7 @@ let
       # oddly fuse-ld=lld fails without this override
       overrideCC llvmPackagesNoBintools.stdenv (
         llvmPackagesNoBintools.libstdcxxClang.override {
-          inherit (llvmPackages) bintools;
+          inherit (llvmPackages_base) bintools;
         }
       );
 
@@ -131,7 +128,6 @@ let
   };
   llvmMajorVersion = lib.versions.major rocmLlvmVersion;
   # An llvmPackages (pkgs/development/compilers/llvm/) built from ROCm LLVM's source tree
-  # optionally using LLVM libcxx
   llvmPackagesRocm = llvmPackages_base.override (_old: {
     stdenv = stdenvToBuildRocmLlvm;
 
@@ -139,6 +135,7 @@ let
     # ROCm LLVM is closer to 20 official
     # gitRelease = {}; officialRelease = null;
     officialRelease = { }; # Set but empty because we're overriding everything from it.
+    # this version determines which patches are applied
     version = rocmLlvmVersion;
     src = llvmSrc;
     monorepoSrc = llvmSrc;


### PR DESCRIPTION
mixing and matching these doesn't work because LLVM bitcode isn't backwards compatible
When default `llvmPackages` moved to `llvmPackages_21` `rocm-device-libraries` started
to fail with errors like `Not a constant range list attribute (Producer: 'LLVM21.1.1' Reader: 'LLVM 19.0.0')`

This only worked before because `llvmPackages` happened to be 19 at time of merge of #427944, but #407738 got merged a day later :sweat_smile: 

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 443943 --package rocmPackages.gfx906.miopen --package rocmPackages.gfx906.aotriton --package rocmPackages.clr --package rocmPackages.gfx906.hipblas --package rocmPackages.gfx906.rocsolver --package rocmPackages.gfx906.rccl --package rocmPackages.gfx906.rocmlir --package rocmPackages.gfx906.rocprofiler`
Commit: `1a954472e6b8705633953b2bd139c9b2747c3f08`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 11 packages built:</summary>
  <ul>
    <li>rocmPackages.clr</li>
    <li>rocmPackages.clr.debug (rocmPackages.clr.debug.debug, rocmPackages.clr.debug.icd)</li>
    <li>rocmPackages.clr.icd (rocmPackages.clr.icd.debug, rocmPackages.clr.icd.icd)</li>
    <li>rocmPackages.gfx906.aotriton</li>
    <li>rocmPackages.gfx906.aotriton.debug (rocmPackages.gfx906.aotriton.debug.debug)</li>
    <li>rocmPackages.gfx906.hipblas</li>
    <li>rocmPackages.gfx906.miopen</li>
    <li>rocmPackages.gfx906.rccl</li>
    <li>rocmPackages.gfx906.rocmlir</li>
    <li>rocmPackages.gfx906.rocprofiler</li>
    <li>rocmPackages.gfx906.rocsolver</li>
  </ul>
</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] ~~aarch64-linux~~
  - [ ] ~~x86_64-darwin~~
  - [ ] ~~aarch64-darwin~~
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran **partial** `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
