### PR TITLE
lldap: remove runtime reliance on third party CDNs

### DIFF
--- a/pkgs/by-name/ll/lldap/package.nix
+++ b/pkgs/by-name/ll/lldap/package.nix
@@ -10,6 +10,10 @@
   wasm-bindgen-cli_0_2_100,
   wasm-pack,
   which,
+  runCommand,
+  cacert,
+  curl,
+  staticAssetsHash ? "sha256-xVbHD9s3ofbtHCDvjYwmsWXDEJ9z9vRxQDRR6pW6rt8=",
 }:
 
 let
@@ -29,7 +33,35 @@ let
     cargoHash = "sha256-SO7+HiiXNB/KF3fjzSMeiTPjRQq/unEfsnplx4kZv9c=";
   };
 
+  staticAssets =
+    src:
+    runCommand "${commonDerivationAttrs.pname}-static-assets"
+      {
+        outputHash = staticAssetsHash;
+        outputHashAlgo = "sha256";
+        outputHashMode = "recursive";
+
+        inherit src;
+
+        nativeBuildInputs = [
+          curl
+        ];
+
+        env.SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+      }
+      ''
+        mkdir $out
+        mkdir $out/fonts
+        for file in $(cat ${src}/app/static/libraries.txt); do
+          curl $file --location --remote-name --output-dir $out
+        done
+        for file in $(cat ${src}/app/static/fonts/fonts.txt); do
+          curl $file --location --remote-name --output-dir $out/fonts
+        done
+      '';
+
   frontend = rustPlatform.buildRustPackage (
+    finalAttrs:
     commonDerivationAttrs
     // {
       pname = commonDerivationAttrs.pname + "-frontend";
@@ -49,7 +81,10 @@ let
 
       installPhase = ''
         mkdir -p $out
-        cp -R app/{index.html,pkg,static} $out/
+        cp -R app/{pkg,static} $out/
+        cp app/index_local.html $out/index.html
+        cp -R ${staticAssets finalAttrs.src}/* $out/static
+        rm $out/static/libraries.txt $out/static/fonts/fonts.txt
       '';
 
       doCheck = false;


### PR DESCRIPTION
External assets for the frontend are included in the package instead of being fetched from third party CDNs by clients. This is consistent with [upstream's docker image](https://github.com/lldap/lldap/blob/8a803bfb11faa11e04b8eb36cbc39acbcde948f0/Dockerfile#L87) and results in better offline availability and privacy.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
