### PR TITLE
gnunet: 0.24.3 -> 0.25.0; libgnunetchat: 0.5.3 -> 0.6.0

### DIFF
--- a/pkgs/by-name/gn/gnunet/package.nix
+++ b/pkgs/by-name/gn/gnunet/package.nix
@@ -39,11 +39,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnunet";
-  version = "0.24.3";
+  version = "0.25.0";
 
   src = fetchurl {
     url = "mirror://gnu/gnunet/gnunet-${finalAttrs.version}.tar.gz";
-    hash = "sha256-WwaJew6ESJu7Q4J47HPkNiRCsuBaY+QAI+wdDMzGxXY=";
+    hash = "sha256-LepmLuhgWUaFKvAtKAbKZP2t7cxxju72uG4LJoIsNv8=";
   };
 
   enableParallelBuilding = true;
@@ -94,6 +94,12 @@ stdenv.mkDerivation (finalAttrs: {
     # builds.
     find . \( -iname \*test\*.c -or -name \*.conf \) | \
       xargs sed -i -e "s|/tmp|$TMPDIR|g"
+
+    # fix error: conflicting types for `GNUNET_TESTING_cmd_{exec,finish}`
+    for name in exec finish; do
+      substituteInPlace src/lib/testing/testing_api_cmd_$name.c \
+        --replace-fail 'const struct GNUNET_TESTING_Command' 'struct GNUNET_TESTING_Command'
+    done
   '';
 
   # unfortunately, there's still a few failures with impure tests

--- a/pkgs/by-name/li/libgnunetchat/package.nix
+++ b/pkgs/by-name/li/libgnunetchat/package.nix
@@ -16,12 +16,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   name = "libgnunetchat";
-  version = "0.5.3";
+  version = "0.6.0";
 
   src = fetchgit {
     url = "https://git.gnunet.org/libgnunetchat.git";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-DhXPYa8ya9cEbwa4btQTrpjfoTGhzBInWXXH4gmDAQw=";
+    hash = "sha256-pRO8i7tHynCqm97RLMBOiWKCl2CAYBE6RXfyIljIiQ0=";
   };
 
   strictDeps = true;
@@ -51,6 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkgConfigModules = [ "gnunetchat" ];
     description = "Library for secure, decentralized chat using GNUnet network services";
     homepage = "https://git.gnunet.org/libgnunetchat.git";
+    changelog = "https://git.gnunet.org/libgnunetchat.git/plain/ChangeLog?h=v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.all;
     teams = with lib.teams; [ ngi ];


### PR DESCRIPTION
- https://git.gnunet.org/gnunet.git/tree/ChangeLog?h=v0.25.0
- https://git.gnunet.org/libgnunetchat.git/plain/ChangeLog?h=v0.6.0

Supersedes #443921

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
