### PR TITLE
postgresqlPackages.tds_fdw: 2.0.4 -> 2.0.5

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
@@ -8,7 +8,7 @@
 
 postgresqlBuildExtension (finalAttrs: {
   pname = "tds_fdw";
-  version = "2.0.4";
+  version = "2.0.5";
 
   buildInputs = [ freetds ];
 
@@ -16,15 +16,10 @@ postgresqlBuildExtension (finalAttrs: {
     owner = "tds-fdw";
     repo = "tds_fdw";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ruelOHueaHx1royLPvDM8Abd1rQD62R4KXgtHY9qqTw=";
+    hash = "sha256-4ecdErksaZ7SyCKzvSY5sD7rrKljq7BMn+gI9Yz49r0=";
   };
 
   meta = {
-    # PostgreSQL 18 support issue upstream: https://github.com/tds-fdw/tds_fdw/issues/384
-    # Check after next package update.
-    broken = lib.warnIf (
-      finalAttrs.version != "2.0.4"
-    ) "Is postgresql18Packages.tds_fdw still broken?" (lib.versionAtLeast postgresql.version "18");
     description = "PostgreSQL foreign data wrapper to connect to TDS databases (Sybase and Microsoft SQL Server)";
     homepage = "https://github.com/tds-fdw/tds_fdw";
     changelog = "https://github.com/tds-fdw/tds_fdw/releases/tag/v${finalAttrs.version}";


### PR DESCRIPTION
Release Notes:
https://github.com/tds-fdw/tds_fdw/releases/tag/v2.0.5

Now supports PostgreSQL 18.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
