### PR TITLE
nixos/systemd/initrd: overwrite /nixos-closure link in initrd-find-nixos-closure

### DIFF
--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -641,7 +641,7 @@ in
             # Assume the directory containing the init script is the closure.
             closure="$(dirname "$closure")"
 
-            ln --symbolic "$closure" /nixos-closure
+            ln -sf "$closure" /nixos-closure
 
             # If we are not booting a NixOS closure (e.g. init=/bin/sh),
             # we don't know what root to prepare so we don't do anything


### PR DESCRIPTION
In my case the closure was already symlinked and when the activation service ran before switching root, it would fail, causing the system to not be able to leave the first stage, saying "Switch root target does not contain usable init".

On regular, mutable NixOS systems this is usually not an issue, however, when building read-only images where `/nix/store` is mounted to `/sysroot/nix/store`, edge cases like this are more likely to happen.

<img width="1547" height="51" alt="image" src="https://github.com/user-attachments/assets/303b888c-c440-4503-b855-99af88b97013" />
<img width="1026" height="106" alt="Screenshot From 202509" src="https://github.com/user-attachments/assets/b57bf6ea-1d98-430d-855b-697113f7694f" />


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
