### PR TITLE
authentik: 2025.6.4 -> 2025.8.3

### DIFF
--- a/pkgs/by-name/au/authentik/package.nix
+++ b/pkgs/by-name/au/authentik/package.nix
@@ -5,23 +5,23 @@
   cacert,
   fetchFromGitHub,
   buildGoModule,
-  runCommand,
   bash,
   chromedriver,
-  openapi-generator-cli,
-  nodejs,
+  nodejs_24,
   python312,
   makeWrapper,
 }:
 
 let
-  version = "2025.6.4";
+  nodejs = nodejs_24;
+
+  version = "2025.8.3";
 
   src = fetchFromGitHub {
     owner = "goauthentik";
     repo = "authentik";
     rev = "version/${version}";
-    hash = "sha256-bs/ThY3YixwBObahcS7BrOWj0gsaUXI664ldUQlJul8=";
+    hash = "sha256-DkvxDwHCfSqEpZ9rRXNR8MP0Mz/y1kHAr38exrHQ39c=";
   };
 
   meta = {
@@ -48,10 +48,10 @@ let
 
     outputHash =
       {
-        "aarch64-linux" = "sha256-+UObt/FhHkEzZUR24ND6phSDqvuzaOuUiyoW0dolsiY=";
-        "x86_64-linux" = "sha256-1qlJf4mVYM5znF3Ifi7CpGMfinUsb/YoXGeM6QLYMis=";
+        "aarch64-linux" = "sha256-uJe1v43d3baBUESU+CQk6fYBdiNOBiT3Tt0vFIbI/HY=";
+        "x86_64-linux" = "sha256-jVi+pgcz96Dj25T4e/s+SHqsZfonzXs1WZYe0lCI48Q=";
       }
-      .${stdenvNoCC.hostPlatform.system} or (throw "authentik-website-deps: unsupported hust platform");
+      .${stdenvNoCC.hostPlatform.system} or (throw "authentik-website-deps: unsupported host platform");
 
     outputHashMode = "recursive";
 
@@ -66,10 +66,15 @@ let
       rm -r ./cache node_modules/.package-lock.json
     '';
 
+    # dependencies of workspace projects are installed into separate node_modules folders with
+    # symlinks between them, so we have to copy all of them
     installPhase = ''
-      mv node_modules $out
+      mkdir $out
+      echo "Copying node_modules folders:"
+      find -type d -name node_modules -prune -print -exec mkdir -p $out/{} \; -exec cp -rT {} $out/{} \;
     '';
 
+    dontCheckForBrokenSymlinks = true;
     dontPatchShebangs = true;
   };
 
@@ -79,56 +84,29 @@ let
 
     nativeBuildInputs = [ nodejs ];
 
-    postPatch = ''
-      substituteInPlace package.json --replace-fail 'cross-env ' ""
-      substituteInPlace ../packages/docusaurus-config/lib/common.js \
-        --replace-fail 'title: "authentik",' 'title: "authentik", future: { experimental_faster : { rspackBundler: false }},'
-    '';
-
     sourceRoot = "${src.name}/website";
 
     buildPhase = ''
       runHook preBuild
 
-      cp -r ${website-deps} node_modules
+      buildRoot=$PWD
+      pushd ${website-deps}
+      find -type d -name node_modules -prune -print -exec cp -rT {} $buildRoot/{} \;
+      popd
+
       chmod -R +w node_modules
 
       pushd node_modules/.bin
-      patchShebangs $(readlink docusaurus)
+      patchShebangs $(readlink docusaurus) $(readlink run-s)
       popd
-      npm run build:schema
       npm run build:api
-      npm run build:docusaurus
 
       runHook postBuild
     '';
 
     installPhase = ''
       mkdir $out
-      cp -r build $out/help
-    '';
-  };
-
-  clientapi = stdenvNoCC.mkDerivation {
-    pname = "authentik-client-api";
-    inherit version src meta;
-
-    postPatch = ''
-      rm Makefile
-
-      substituteInPlace ./scripts/api-ts-config.yaml \
-        --replace-fail '/local' "$(pwd)/"
-    '';
-
-    nativeBuildInputs = [ openapi-generator-cli ];
-    buildPhase = ''
-      runHook preBuild
-      openapi-generator-cli generate -i ./schema.yml \
-      -g typescript-fetch -o $out \
-      -c ./scripts/api-ts-config.yaml \
-        --additional-properties=npmVersion="$(${lib.getExe' nodejs "npm"} --version)" \
-        --git-repo-id authentik --git-user-id goauthentik
-      runHook postBuild
+      cp -r api/build $out/help
     '';
   };
 
@@ -141,10 +119,10 @@ let
 
     outputHash =
       {
-        "aarch64-linux" = "sha256-e4v7f3+/e++CI9xa9G2/47y8Dga+vluyUtBXGyaWFcI=";
-        "x86_64-linux" = "sha256-m0vYUevOz6pof8XqiZHXzgPhkQLUUFOdblmfOjHJUJc=";
+        "aarch64-linux" = "sha256-4JkNwQACS3tiiLuj41cGRWNspljVQxlsJvCM9KE2JrQ=";
+        "x86_64-linux" = "sha256-LD+zXc8neRbEwq1mx9y7b+08p8hxvo/RW6QzsFQgaUs=";
       }
-      .${stdenvNoCC.hostPlatform.system} or (throw "authentik-webui-deps: unsupported hust platform");
+      .${stdenvNoCC.hostPlatform.system} or (throw "authentik-webui-deps: unsupported host platform");
     outputHashMode = "recursive";
 
     nativeBuildInputs = [
@@ -152,52 +130,35 @@ let
       cacert
     ];
 
-    postPatch = ''
-      substituteInPlace packages/core/version/node.js \
-        --replace-fail 'import PackageJSON from "../../../../package.json" with { type: "json" };' "" \
-        --replace-fail '(PackageJSON.version);' '"${version}";'
-    '';
-
     buildPhase = ''
-      npm ci --cache ./cache
-
-      rm -r node_modules/chromedriver node_modules/.bin/chromedriver
+      npm ci --cache ./cache --ignore-scripts
 
       rm -r ./cache node_modules/.package-lock.json
-      rm node_modules/@goauthentik/{core,web-sfe,esbuild-plugin-live-reload}
-      cp -r packages/core node_modules/@goauthentik/
-      cp -r packages/sfe node_modules/@goauthentik/web-sfe
     '';
 
+    # dependencies of workspace projects are installed into separate node_modules folders with
+    # symlinks between them, so we have to copy all of them
     installPhase = ''
-      mv node_modules $out
+      mkdir $out
+      echo "Copying node_modules folders:"
+      find -type d -name node_modules -prune -print -exec mkdir -p $out/{} \; -exec cp -rT {} $out/{} \;
     '';
 
+    dontCheckForBrokenSymlinks = true;
     dontPatchShebangs = true;
   };
 
   webui = stdenvNoCC.mkDerivation {
     pname = "authentik-webui";
-    inherit version meta;
+    inherit src version meta;
 
-    src = runCommand "authentik-webui-source" { } ''
-      mkdir $out
-      cp -r ${src}/web $out/
-      ln -s ${src}/package.json $out/
-      chmod -R +w $out/web
-      ln -s ${src}/website $out/web/
-      cp -r ${webui-deps} $out/web/node_modules
-      chmod -R +w $out/web/node_modules
-      ln -s ${clientapi} $out/web/node_modules/@goauthentik/api
-    '';
+    sourceRoot = "${src.name}/web";
 
     nativeBuildInputs = [
       nodejs
     ];
 
     postPatch = ''
-      cd web
-
       substituteInPlace packages/core/version/node.js \
         --replace-fail 'import PackageJSON from "../../../../package.json" with { type: "json" };' "" \
         --replace-fail '(PackageJSON.version);' '"${version}";'
@@ -205,6 +166,11 @@ let
 
     buildPhase = ''
       runHook preBuild
+
+      buildRoot=$PWD
+      pushd ${webui-deps}
+      find -type d -name node_modules -prune -print -exec cp -rT {} $buildRoot/{} \;
+      popd
 
       pushd node_modules/.bin
       patchShebangs $(readlink rollup)
@@ -241,6 +207,28 @@ let
     packageOverrides = final: prev: {
       # https://github.com/goauthentik/authentik/pull/14709
       django = final.django_5_1;
+
+      django-dramatiq-postgres = prev.buildPythonPackage {
+        pname = "django-dramatiq-postgres";
+        inherit version src meta;
+        pyproject = true;
+
+        sourceRoot = "${src.name}/packages/django-dramatiq-postgres";
+
+        build-system = with final; [ hatchling ];
+
+        propagatedBuildInputs =
+          with final;
+          [
+            cron-converter
+            django
+            django-pgtrigger
+            dramatiq
+            structlog
+            tenacity
+          ]
+          ++ dramatiq.optional-dependencies.watch;
+      };
 
       # Running authentik currently requires a custom version.
       # Look in `pyproject.toml` for changes to the rev in the `[tool.uv.sources]` section.
@@ -285,6 +273,19 @@ let
         pythonImportsCheck = [ "rest_framework" ];
       };
 
+      # authentik is currently not compatible with v1.18 and fails with the following error:
+      # > AttributeError: 'Namespace' object has no attribute 'worker_fork_timeout'. Did you mean: 'worker_shutdown_timeout'?
+      dramatiq = prev.dramatiq.overrideAttrs (_: rec {
+        version = "1.17.1";
+
+        src = fetchFromGitHub {
+          owner = "Bogdanp";
+          repo = "dramatiq";
+          tag = "v${version}";
+          hash = "sha256-NeUGhG+H6r+JGd2qnJxRUbQ61G7n+3tsuDugTin3iJ4=";
+        };
+      });
+
       tenant-schemas-celery = prev.tenant-schemas-celery.overrideAttrs (_: rec {
         version = "3.0.0";
 
@@ -292,7 +293,7 @@ let
           owner = "maciej-gol";
           repo = "tenant-schemas-celery";
           tag = version;
-          hash = "sha256-rGLrP8rE9SACMDVpNeBU85U/Sb2lNhsgEgHJhAsdKNM=";
+          hash = "sha256-3ZUXSAOBMtj72sk/VwPV24ysQK+E4l1HdwKa78xrDtg=";
         };
       });
 
@@ -335,14 +336,17 @@ let
             django
             django-countries
             django-cte
+            django-dramatiq-postgres
             django-filter
             django-guardian
             django-model-utils
             django-pglock
+            django-pgtrigger
             django-prometheus
             django-redis
             django-storages
             django-tenants
+            djangoql
             djangorestframework
             djangorestframework-guardian
             docker
@@ -427,7 +431,7 @@ let
 
     env.CGO_ENABLED = 0;
 
-    vendorHash = "sha256-7oX7e7Ni5I6zblEQIeXjYOt4+QNSjH4Rpn7B5Cr5LMc=";
+    vendorHash = "sha256-wTTEDBRYCW1UFaeX49ufLT0c17sacJzcCaW/8cPNYR4=";
 
     postInstall = ''
       mv $out/bin/server $out/bin/authentik

--- a/pkgs/development/python-modules/cron-converter/default.nix
+++ b/pkgs/development/python-modules/cron-converter/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  unittestCheckHook,
+  setuptools,
+  python-dateutil,
+  python,
+}:
+buildPythonPackage rec {
+  pname = "cron-converter";
+  version = "1.2.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Sonic0";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-XpkpEMurRrhq1S4XnhPRW5CCBk+HzljOSQfZ98VJ7UE=";
+  };
+
+  build-system = [ setuptools ];
+
+  propagatedBuildInputs = [ python-dateutil ];
+
+  checkPhase = ''
+    ${python.interpreter} -m unittest discover -s tests/unit -v
+    ${python.interpreter} -m unittest discover -s tests/integration -v
+  '';
+
+  pythonImportsCheck = [ "cron_converter" ];
+
+  meta = with lib; {
+    description = "Cron string parser and iteration for the datetime object with a cron like format";
+    homepage = "https://github.com/Sonic0/cron-converter";
+    changelog = "https://github.com/Sonic0/cron-converter/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ b4dm4n ];
+  };
+}

--- a/pkgs/development/python-modules/python-kadmin-rs/default.nix
+++ b/pkgs/development/python-modules/python-kadmin-rs/default.nix
@@ -27,6 +27,12 @@ buildPythonPackage rec {
     hash = "sha256-FEOWsUQhLXU1xqaTLe6GKO1OYi5fVDyT1dowiAyzbGI=";
   };
 
+  postPatch = ''
+    # https://github.com/authentik-community/kadmin-rs/issues/213
+    substituteInPlace kadmin-sys/build.rs \
+      --replace-fail 'bindgen::builder()' 'bindgen::builder().allowlist_type("krb5_boolean")'
+  '';
+
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     hash = "sha256-tvjwNfjMc8k4GK9rZXFG9CfcSlUW/B95YimLtH4iEbM=";

--- a/pkgs/development/python-modules/watchdog-gevent/default.nix
+++ b/pkgs/development/python-modules/watchdog-gevent/default.nix
@@ -1,8 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
-  fetchpatch,
+  fetchPypi,
   gevent,
   pytestCheckHook,
   setuptools,
@@ -12,31 +11,24 @@
 
 buildPythonPackage rec {
   pname = "watchdog-gevent";
-  version = "0.1.1";
+  version = "0.2.1";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
 
-  src = fetchFromGitHub {
-    owner = "Bogdanp";
-    repo = "watchdog_gevent";
-    tag = "v${version}";
-    hash = "sha256-FESm3fNuLmOg2ilI/x8U9LuAimHLnahcTHYzW/nzOVY=";
+  src = fetchPypi {
+    pname = "watchdog_gevent";
+    inherit version;
+    hash = "sha256-rmuU0PjIzhxZVs2GX2ErYfRWzxmAF0S7olo0n+jowzc=";
   };
-
-  patches = [
-    # Add new event_filter argument to GeventEmitter
-    (fetchpatch {
-      name = "new-event_filter-argument.patch";
-      url = "https://github.com/Bogdanp/watchdog_gevent/commit/a98b6599aefb6f1ea6f9682485ed460c52f6e55f.patch";
-      hash = "sha256-lbUtl8IbnJjlsIpbC+wXLvYB+ZtUuHWqFtf31Bfqc2I=";
-    })
-  ];
 
   postPatch = ''
     sed -i setup.cfg \
       -e 's:--cov watchdog_gevent::' \
       -e 's:--cov-report html::'
+
+    substituteInPlace tests/test_observer.py \
+      --replace-fail 'events == [FileModifiedEvent(__file__)]' 'FileModifiedEvent(__file__) in events'
   '';
 
   build-system = [ setuptools ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3120,6 +3120,8 @@ self: super: with self; {
     }
   );
 
+  cron-converter = callPackage ../development/python-modules/cron-converter { };
+
   cron-descriptor = callPackage ../development/python-modules/cron-descriptor { };
 
   croniter = callPackage ../development/python-modules/croniter { };


### PR DESCRIPTION
This update turned out to be a bit difficult and bigger than expected. But in thee end it hopefully makes future updates a bit more straightforward.

There are some global changes needed:
- The `python-kadmin-rs` fix is the same as #443983. I extracted it into it's own PR, because it unbreaks at least the current `authentik` build, without waiting for this big update.
- `watchdog-gevent` was also broken ( [hydra job](https://hydra.nixos.org/job/nixpkgs/trunk/python313Packages.watchdog-gevent.x86_64-linux) ), but since there are no other dependents, there should be no need for a separate PR

The authentik update itself includes some noteworthy changes:
- `dramatiq` needs to be downgraded, because otherwise the mentioned error message appears
- The `web{site,ui}-deps` build is rewritten.

  The `web{site,ui}` package make use of workspace dependencies, which come with their own `node_modules` folders. Prior this rewrite, these were manually copied/moved to the "correct" place, but this was very fragile and basically changed with every update.

  Now, the `*-deps` builds collect all `node_modules` folders from the workspace and copy them to the output as-is. This includes some cross-package symlinks which are (temporarily) broken and therefore `dontCheckForBrokenSymlinks` needs to be set. These symlinks point to the correct destination again, after the `node_modules` folders are restored into the actual build directory.
- I removed the `clientapi` build, because the correct version is already installed by `npm` and this removes the need to manually move it to the correct place.

Fixes #440023

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
