### PR TITLE
[DRAFT] hm: improve architecture detection ("unrecognized command-line option '-msse4.1'")

### DIFF
--- a/pkgs/by-name/hm/hm/package.nix
+++ b/pkgs/by-name/hm/hm/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitLab,
+  fetchFromGitHub,
   fetchpatch,
   gitUpdater,
   cmake,
@@ -12,21 +12,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "hm";
   version = "18.0";
 
-  src = fetchFromGitLab {
-    domain = "vcgit.hhi.fraunhofer.de";
-    owner = "jvet";
+  src = fetchFromGitHub {
+    owner = "johnrichardrinehart";
     repo = "HM";
-    tag = "HM-${finalAttrs.version}";
-    hash = "sha256-zWBwrnCNKi2sIopdu2XQj/7IoTsJQzlcIFNNKM0glDQ=";
+    rev = "f3947be0720bfd9ce3312478d64cd35a619c5eae";
+    hash = "sha256-kY7YE+S1NJs9yjUnVKjZ8jbIJm/nv/s0DNmNZej66b8=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fix-building-on-arm.patch";
-      url = "https://vcgit.hhi.fraunhofer.de/jvet/HM/-/commit/fd37cd88f557478b591dc0b9157d027354d82e2f.patch";
-      hash = "sha256-xP54lBvDabc9Dy1UklH2BJH7fUGLTA4sf9WLt7WzoU8=";
-    })
-  ];
 
   cmakeFlags = [
     (lib.cmakeBool "HIGH_BITDEPTH" true)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This resolves `hm`'s failed architecture detection since they predicate on `CMAKE_SYSTEM_PROCESSOR` equalling `arm64` but, for at least one of my `aarch64-linux` hosts, this is set to `aarch64` (configured within `pkgs/build-support/lib/cmake.nix`, I think).

Since this change set is pointing to my fork in GitHub which I don't plan to maintain, and since I can't figure out how to push a patch/MR to their GitLab instance, I'm opening this to provide resolution to other folks while the upstream maintainers and I figure out how to proceed.

I emailed the maintainers about pulling [something like this patch](https://github.com/johnrichardrinehart/hm/commit/f3947be0720bfd9ce3312478d64cd35a619c5eae) into their source. We'll see what they say.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
