### PR TITLE
uv: 0.8.17 -> 0.8.18

### DIFF
--- a/pkgs/by-name/uv/uv/package.nix
+++ b/pkgs/by-name/uv/uv/package.nix
@@ -18,16 +18,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "uv";
-  version = "0.8.17";
+  version = "0.8.18";
 
   src = fetchFromGitHub {
     owner = "astral-sh";
     repo = "uv";
     tag = finalAttrs.version;
-    hash = "sha256-WN0IXmzFQSUGsIvGiFRE6CKH26wmaIFOWRrTauI5ZFs=";
+    hash = "sha256-e6UrCx2QalJhi9aGHj1LRWFwZIQz/IQzn1haZXpXVr8=";
   };
 
-  cargoHash = "sha256-f/MwnPWOArMfX0zRfZTvCoLaiNGR26YUGYJa0r24Ioc=";
+  cargoHash = "sha256-tpbgURy5pIjaRe5ViHhVwTFy0YtTf+1GhrZNO3F22tA=";
 
   buildInputs = [
     rust-jemalloc-sys


### PR DESCRIPTION
CHANGELOG: https://github.com/astral-sh/uv/releases/tag/0.8.18

```console
$ nom-build -A uv -A python3Packages.uv -A python3Packages.uv-build --option sandbox true
┏━ Dependency Graph with 2 roots:
┃ ┌─ ✔ uv-0.8.18 ⏱ 11m28s
┃ ✔ python3.13-uv-0.8.18 ⏱ 1s
┃ ✔ python3.13-uv-build-0.8.18 ⏱ 11m21s
┣━━━ Builds         
┗━ ∑ ⏵ 0 │ ✔ 3 │ ⏸ 0 │ Finished at 15:12:48 after 11m32s
/nix/store/qdk59jhk4bmmigsfq6mq2n8wzr2pz563-uv-0.8.18
/nix/store/636mr3rj9ismkjy74pdldvad06qnra9s-python3.13-uv-0.8.18
/nix/store/yknwkfy13lys668dxd4j4q7wl6459jdr-python3.13-uv-build-0.8.18
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
