### PR TITLE
clickhouse: remove reference to clang

### DIFF
--- a/pkgs/by-name/cl/clickhouse/generic.nix
+++ b/pkgs/by-name/cl/clickhouse/generic.nix
@@ -21,14 +21,17 @@
   darwin,
   findutils,
   libiconv,
+  removeReferencesTo,
   rustSupport ? true,
   rustc,
   cargo,
   rustPlatform,
   nix-update-script,
 }:
-
-llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
+let
+  llvmStdenv = llvmPackages_19.stdenv;
+in
+llvmStdenv.mkDerivation (finalAttrs: {
   pname = "clickhouse" + lib.optionalString lts "-lts";
   inherit version;
 
@@ -70,6 +73,7 @@ llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
     python3
     perl
     llvmPackages_19.lld
+    removeReferencesTo
   ]
   ++ lib.optionals stdenv.hostPlatform.isx86_64 [
     nasm
@@ -154,7 +158,11 @@ llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
     substituteInPlace $out/etc/clickhouse-server/config.xml \
       --replace-fail "<errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>" "<console>1</console>" \
       --replace-fail "<level>trace</level>" "<level>warning</level>"
+    remove-references-to -t ${llvmStdenv.cc} $out/bin/clickhouse
   '';
+
+  # canary for the remove-references-to hook failing
+  disallowedReferences = [ llvmStdenv.cc ];
 
   # Basic smoke test
   doCheck = true;


### PR DESCRIPTION
Reduces the closure size from
```
pb3p2b30pwfv8szjf4m3mhzdcv5waaky-clickhouse-25.8.2.29-lts
NAR Size: 649.24 MiB | Closure Size: 2.37 GiB | Added Size: 2.37 GiB
```
to
```
x54n1j156kqdn5qha4jsrlfyahqxd9dv-clickhouse-25.8.2.29-lts
NAR Size: 649.24 MiB | Closure Size: 1.2 GiB | Added Size: 1.2 GiB
```
by removing the references to clang in the output. `llvm-19.*.*-lib` is still in the closure, so this shouldn't break anything.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
