### PR TITLE
jasp-desktop: fix build by not depending on removed cran package

### DIFF
--- a/pkgs/by-name/ja/jasp-desktop/modules.nix
+++ b/pkgs/by-name/ja/jasp-desktop/modules.nix
@@ -176,6 +176,7 @@ let
     {
       pname,
       version,
+      rev ? "refs/tags/${version}",
       hash,
       deps,
     }:
@@ -185,8 +186,7 @@ let
         name = "${pname}-${version}-source";
         owner = "jasp-stats";
         repo = pname;
-        tag = "v${version}";
-        inherit hash;
+        inherit rev hash;
       };
       propagatedBuildInputs = deps;
       # some packages have a .Rprofile that tries to activate renv
@@ -713,8 +713,9 @@ in
     };
     jaspRegression = buildJaspModule {
       pname = "jaspRegression";
-      version = "0.95.0";
-      hash = "sha256-9Q5Ei9vjFaDte//1seCj9++ftbDctkHzP8ZpGVETXH0=";
+      version = "0.95.0-unstable-2025-08-27";
+      rev = "b0ecad26bb248964e778ee6d4486d671b83930b2";
+      hash = "sha256-wm/Fz/wA7B96bzj8UylZjFgrrZgwOTdGnCsmfaCPGp0=";
       deps = [
         BAS
         boot
@@ -723,7 +724,6 @@ in
         emmeans
         ggplot2
         ggrepel
-        hmeasure
         jaspAnova
         jaspBase
         jaspDescriptives


### PR DESCRIPTION
The `jasp-desktop` package was not building because `hmeasure` has been removed from CRAN, thus our package set marked it `meta.broken = true;`

Upstream pushed a commit that just vendors the things they depended of from `hmeasure`.

Since `jasp-desktop` pulls in a large subset of the `rPackages` package set, it not building means that people trying to use `rPackages` will have to build a lot of things for themselves.

I had to build a lot of packages manually from `rPackages` to test this PR.
Even using `--max-jobs 1`, I still had to reserve additional swap memory, since some builds take a *lot* of memory.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
