### PR TITLE
nixos/onlyoffice: fix nginx syntax error

### DIFF
--- a/nixos/modules/services/web-apps/onlyoffice.nix
+++ b/nixos/modules/services/web-apps/onlyoffice.nix
@@ -145,7 +145,7 @@ in
               '';
             "~* ^(\\/cache\\/files.*)(\\/.*)".extraConfig = ''
               alias /var/lib/onlyoffice/documentserver/App_Data$1;
-              more_set_headers Content-Disposition "attachment; filename*=UTF-8''$arg_filename";
+              more_set_headers "Content-Disposition: attachment; filename*=UTF-8''$arg_filename";
 
               set $secure_link_secret verysecretstring;
               secure_link $arg_md5,$arg_expires;


### PR DESCRIPTION
The `more_set_headers` syntax was wrong.

Syntax docs: https://github.com/openresty/headers-more-nginx-module?tab=readme-ov-file#more_set_headers

This led to:

```
{\"Exception\":\"InvalidArgumentException\",\"Message\":\"\\\"attachment;\\\" is not valid header name.\",\"Code\":0,\"Trace\":[
{\"file\":\"/nix/store/4y4c191pd9pa5nd78i8flvkf50gd4lvp-nextcloud-31.0.8/3rdparty/guzzlehttp/psr7/src/MessageTrait.php\",\"line\":153,\"function\":\"assertHeader\",\"class\":\"GuzzleHttp\\\\Psr7\\\\Response\",\"type\":\"->\"},
```

Introduced in https://github.com/NixOS/nixpkgs/pull/419765 /cc @wjjunyor


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
