### PR TITLE
prisma-language-server: init at 6.16.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17179,6 +17179,12 @@
     githubId = 85857;
     name = "Martin Milata";
   };
+  mmkaram = {
+    name = "Mahdy Karam";
+    github = "mmkaram";
+    githubId = 64036912;
+    matrix = "@mmkaram:matrix.org";
+  };
   mmlb = {
     email = "i@m.mmlb.dev";
     github = "mmlb";

--- a/pkgs/by-name/pr/prisma-language-server/package.nix
+++ b/pkgs/by-name/pr/prisma-language-server/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  pkg-config,
+  libsecret,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "prisma-language-server";
+  version = "6.16.2";
+
+  src = fetchFromGitHub {
+    owner = "prisma";
+    repo = "language-tools";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-UZP0pLcbMeaYI0ytOJ68l/ZEC9dBhohJZyTU99p+1QM=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/packages/language-server";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libsecret ];
+
+  npmDepsHash = "sha256-UAGz/qCYf+jsgCWqvR52mW6Ze3WWP9EHuE4k9wCbnH0=";
+
+  npmPackFlags = [ "--ignore-scripts" ];
+
+  NODE_OPTIONS = "--openssl-legacy-provider";
+
+  meta = {
+    description = "Language server for Prisma";
+    homepage = "https://github.com/prisma/language-tools";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mmkaram ];
+    mainProgram = "prisma-language-server";
+  };
+})


### PR DESCRIPTION
This PR reinstates the previously removed `@prisma/language-server` package, which was taken out in [March 2025](https://github.com/NixOS/nixpkgs/commit/8af4a78d0d0486de96e0207eba72ff43382eb2dd) due to upstream build issues. Originally part of the nodePackages set, I consulted with members of the Nix NodeJS and Nixpkgs/NixOS Matrix channels and was advised to move the package into the /by-name overlay as a better fit.

 [Here](https://github.com/prisma/language-tools#readme) is a link to the homepage as listed on npmjs.com.

This is my first serious PR, I am anxiously awaiting everyone's feedback.


## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
