### PR TITLE
nixos/ec2-data: sshd.service -> sshd-keygen.service

### DIFF
--- a/nixos/modules/virtualisation/ec2-data.nix
+++ b/nixos/modules/virtualisation/ec2-data.nix
@@ -23,9 +23,9 @@ with lib;
 
       wantedBy = [
         "multi-user.target"
-        "sshd.service"
+        "sshd-keygen.service"
       ];
-      before = [ "sshd.service" ];
+      before = [ "sshd-keygen.service" ];
       after = [ "fetch-ec2-metadata.service" ];
 
       path = [ pkgs.iproute2 ];
@@ -80,7 +80,7 @@ with lib;
     systemd.services.print-host-key = {
       description = "Print SSH Host Key";
       wantedBy = [ "multi-user.target" ];
-      after = [ "sshd.service" ];
+      after = [ "sshd-keygen.service" ];
       script = ''
         # Print the host public key on the console so that the user
         # can obtain it securely by parsing the output of


### PR DESCRIPTION
SSH key generation was split out into its own systemd service in https://github.com/NixOS/nixpkgs/pull/372979, but dependent service definitions weren't updated.

The `apply-ec2-data` service needs to run before SSH key generation, as it fetches host keys defined in ec2 user data and these keys should take priority over generating new ones. Currently, the ordering doesn't specify which should run first of `apply-ec2-data` and `sshd-keygen`; in practice it seems that `sshd-keygen` often wins the race, though.

Update the dependencies so that `apply-ec2-data` always runs first.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
