### PR TITLE
nixos/netbird: add SYSTEMD_UNIT to pick up logs in debug bundles

### DIFF
--- a/nixos/modules/services/networking/netbird.nix
+++ b/nixos/modules/services/networking/netbird.nix
@@ -414,9 +414,6 @@ in
               NB_LOG_LEVEL = client.logLevel;
               NB_SERVICE = client.service.name;
               NB_WIREGUARD_PORT = toString client.port;
-              # for gathering journald logs into debug bundles
-              # see https://github.com/netbirdio/netbird/blob/2c87fa623654c5eef76bc0226062290201eef13a/client/internal/debug/debug_linux.go#L50-L51
-              SYSTEMD_UNIT = client.service.name;
             }
             // optionalAttrs (client.dns-resolver.address != null) {
               NB_DNS_RESOLVER_ADDRESS = "${client.dns-resolver.address}:${builtins.toString client.dns-resolver.port}";
@@ -545,14 +542,7 @@ in
           after = [ "network.target" ];
           wantedBy = [ "multi-user.target" ];
 
-          path =
-            optionals (!config.services.resolved.enable) [ pkgs.openresolv ]
-            # useful for `netbird debug` system info gathering
-            ++ optionals config.networking.nftables.enable [ pkgs.nftables ]
-            ++ optionals (!config.networking.nftables.enable) [
-              pkgs.iptables
-              pkgs.ipset
-            ];
+          path = optionals (!config.services.resolved.enable) [ pkgs.openresolv ];
 
           serviceConfig = {
             ExecStart = "${getExe client.wrapper} service run";
@@ -573,6 +563,26 @@ in
           };
 
           stopIfChanged = false;
+        }
+      );
+    }
+    # netbird debug bundle related configurations
+    {
+      systemd.services = toClientAttrs (
+        client:
+        nameValuePair client.service.name {
+          /*
+            lets NetBird daemon know which systemd service to gather logs for
+            see https://github.com/netbirdio/netbird/blob/2c87fa623654c5eef76bc0226062290201eef13a/client/internal/debug/debug_linux.go#L50-L51
+          */
+          environment.SYSTEMD_UNIT = client.service.name;
+
+          path =
+            optionals config.networking.nftables.enable [ pkgs.nftables ]
+            ++ optionals (!config.networking.nftables.enable) [
+              pkgs.iptables
+              pkgs.ipset
+            ];
         }
       );
     }

--- a/nixos/modules/services/networking/netbird.nix
+++ b/nixos/modules/services/networking/netbird.nix
@@ -414,6 +414,9 @@ in
               NB_LOG_LEVEL = client.logLevel;
               NB_SERVICE = client.service.name;
               NB_WIREGUARD_PORT = toString client.port;
+              # for gathering journald logs into debug bundles
+              # see https://github.com/netbirdio/netbird/blob/2c87fa623654c5eef76bc0226062290201eef13a/client/internal/debug/debug_linux.go#L50-L51
+              SYSTEMD_UNIT = client.service.name;
             }
             // optionalAttrs (client.dns-resolver.address != null) {
               NB_DNS_RESOLVER_ADDRESS = "${client.dns-resolver.address}:${builtins.toString client.dns-resolver.port}";

--- a/nixos/modules/services/networking/netbird.nix
+++ b/nixos/modules/services/networking/netbird.nix
@@ -585,6 +585,18 @@ in
             ];
         }
       );
+      users.users = toHardenedClientAttrs (
+        client:
+        nameValuePair client.user.name {
+          extraGroups = [
+            /*
+              allows debug bundles to gather systemd logs for `netbird*.service`
+              this is not ideal for hardening as it grants access to the whole journal, not just own logs
+            */
+            "systemd-journal"
+          ];
+        }
+      );
     }
     # Hardening section
     (mkIf (hardenedClients != { }) {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This change allows `netbird debug bundle|for` to correctly discover the systemd unit name and therefore, include the logs in the bundles. At the same time, I pulled in pieces of code related to debug bundles gathering into a single place.

- https://github.com/netbirdio/netbird/blob/2c87fa623654c5eef76bc0226062290201eef13a/client/internal/debug/debug_linux.go#L50-L51
- https://github.com/netbirdio/netbird/blob/2c87fa623654c5eef76bc0226062290201eef13a/client/internal/debug/debug_linux.go#L75-L83

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
