### PR TITLE
linux: Fix $dev/.../source/arch for arm64 COMPAT_VDSO=y

### DIFF
--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -489,12 +489,12 @@ lib.makeOverridable (
           # headers on 3.10 though.
 
           chmod u+w -R ..
-          arch=$(cd $dev/lib/modules/${modDirVersion}/build/arch; ls)
+          buildArchDir="$dev/lib/modules/${modDirVersion}/build/arch"
 
           # Remove unused arches
           for d in $(cd arch/; ls); do
-            if [ "$d" = "$arch" ]; then continue; fi
-            if [ "$arch" = arm64 ] && [ "$d" = arm ]; then continue; fi
+            if [ -d "$buildArchDir/$d" ]; then continue; fi
+            if [ -d "$buildArchDir/arm64" ] && [ "$d" = arm ]; then continue; fi
             rm -rf arch/$d
           done
 
@@ -508,7 +508,7 @@ lib.makeOverridable (
           find .  -type f -name '*.lds' -print0 | xargs -0 -r chmod u-w
 
           # Keep root and arch-specific Makefiles
-          chmod u-w Makefile arch/"$arch"/Makefile*
+          chmod u-w Makefile arch/*/Makefile*
 
           # Keep whole scripts dir
           chmod u-w -R scripts


### PR DESCRIPTION
When ARCH=arm64 and CONFIG_COMPAT_VDSO=y, the $dev/.../build/ directory ends up not only containing arch/arm64/, but also
arch/arm/vdso/vdsomunge, which messes up our detection of what arch/* directory to keep in $dev/.../source.

Instead of detecting on one arch to keep in source/arch/, keep source/arch/$d/ if build/arch/$d/ exists. Also port the existing logic of keeping arch/arm/ when arch/arm64/ is to be kept.

CONFIG_COMPAT_VDSO default to y when CONFIG_CC_IS_CLANG=y, so this fixes pkgsLLVM.linux.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
