### PR TITLE
pkgs-lib/pythonVars: add support for imports and lib.mkRaw

### DIFF
--- a/nixos/doc/manual/development/settings-options.section.md
+++ b/nixos/doc/manual/development/settings-options.section.md
@@ -358,6 +358,37 @@ have a predefined type and string generator already declared under
 
     :   Outputs the xml with header.
 
+`pkgs.formats.pythonVars` { }
+
+:   A function taking an empty attribute set (for future extensibility)
+    and returning a set with python variable specific attributes `type`, `lib`, and
+    `generate` as specified [below](#pkgs-formats-result).
+
+    The `lib` attribute contains functions to be used in settings, for
+    generating special Python values:
+
+    `mkRaw pythonCode`
+
+    :   Outputs the given string as raw Python code
+
+    `_imports`
+
+    `_imports` is a special value you can set to specify additional modules to be
+    imported on top of the file.
+
+    `Example usage:`
+
+    ```nix
+      let
+        format = pkgs.formats.pythonVars { };
+      in {
+        _imports = [ "re" ];
+
+        conditional = format.lib.mkRaw "1 if True else 2";
+        function_result = format.lib.mkRaw "re.findall(r'\\bf[a-z]*', 'which foot or hand fell fastest')";
+      }
+    ```
+
 `pkgs.formats.cdn` { }
 
 :   A function taking an empty attribute set (for future extensibility)

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -904,6 +904,63 @@ runBuildTests {
     '';
   };
 
+  pythonVars = shouldPass (
+    let
+      format = formats.pythonVars { };
+    in
+    {
+      inherit format;
+      input = {
+        _imports = [
+          "re"
+          "a.b.c"
+        ];
+
+        int = 10;
+        float = 3.141;
+        bool = true;
+        str = "foo";
+        str_special = "foo\ntesthello'''";
+        null = null;
+        list = [
+          null
+          1
+          "str"
+          true
+          (format.lib.mkRaw "1 if True else 2")
+        ];
+        attrs = {
+          foo = null;
+          conditional = format.lib.mkRaw "1 if True else 2";
+        };
+        func = format.lib.mkRaw "re.findall(r'\\bf[a-z]*', 'which foot or hand fell fastest')";
+      };
+      expected = ''
+        import re
+        import a.b.c
+
+        attrs = {
+            "conditional": 1 if True else 2,
+            "foo": None,
+        }
+        bool = True
+        float = 3.141
+        func = re.findall(r"\bf[a-z]*", "which foot or hand fell fastest")
+        int = 10
+        list = [
+            None,
+            1,
+            "str",
+            True,
+            1 if True else 2,
+        ]
+        null = None
+        str = "foo"
+        str_special = "foo\ntesthello''''"
+      '';
+    }
+  );
+
   phpReturn = shouldPass {
     format = formats.php { };
     input = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR extends `formats.pythonVars` with the possibility of providing raw python statements, as well as adding imports to the top of the generated file. This can be useful when generating settings files for more complex python apps that expects you to import utils to help set your settings, as well as things like making the python application fetch secrets from the environment or from files.

Also added test + docs.

## Things done

Built the nixos manual with `nix build .#htmlDocs.nixosManual.x86_64-linux` to make sure it looks somewhat sane.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [X] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality. (`pkgs/pkgs-lib/test/formats.txt`, `nix build .#pkgs.tests.pkgs-lib.formats`)
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
  - [ ] NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
