### PR TITLE
metis: 5.1.0 -> 5.2.1 + cmake4 patch; gklib: init at 5.1.1-unstable-2025-07-15

### DIFF
--- a/pkgs/by-name/gk/gklib/package.nix
+++ b/pkgs/by-name/gk/gklib/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  llvmPackages,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gklib";
+  version = "5.1.1-unstable-2023-03-27";
+
+  src = fetchFromGitHub {
+    owner = "KarypisLab";
+    repo = "GKlib";
+    rev = "8bd6bad750b2b0d90800c632cf18e8ee93ad72d7";
+    hash = "sha256-tunepMLaRDR5FQVL/9S7/w6e1j+f2+pg01H/0/z/ZCI=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = lib.optional stdenv.cc.isClang llvmPackages.openmp;
+
+  cmakeFlags = [
+    (lib.cmakeBool "OPENMP" true)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    # Turns off using clflush/sfence insns in gkuniq test app
+    # https://github.com/KarypisLab/GKlib/issues/11#issuecomment-1532597211
+    (lib.cmakeBool "NO_X86" (!stdenv.hostPlatform.isx86))
+  ];
+
+  meta = {
+    description = "Library of various helper routines and frameworks used by many of the lab's software";
+    homepage = "https://github.com/KarypisLab/GKlib";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ qbisi ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/gk/gklib/package.nix
+++ b/pkgs/by-name/gk/gklib/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gklib";
-  version = "5.1.1-unstable-2023-03-27";
+  version = "5.1.1-unstable-2025-07-15";
 
   src = fetchFromGitHub {
     owner = "KarypisLab";
     repo = "GKlib";
-    rev = "8bd6bad750b2b0d90800c632cf18e8ee93ad72d7";
-    hash = "sha256-tunepMLaRDR5FQVL/9S7/w6e1j+f2+pg01H/0/z/ZCI=";
+    rev = "6e7951358fd896e2abed7887196b6871aac9f2f8";
+    hash = "sha256-jT0hT5Y3E8GnE8OJWzDj5rtz9s59sMEXLduUnBV0I0Y=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/me/metis/package.nix
+++ b/pkgs/by-name/me/metis/package.nix
@@ -25,6 +25,12 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sci-libs/metis/files/metis-5.2.1-add-gklib-as-required.patch?id=c78ecbd3fdf9b33e307023baf0de12c4448dd283";
       hash = "sha256-uoXMi6pMs5VrzUmjsLlQYFLob1A8NAt9CbFi8qhQXVQ=";
     })
+    # cmake 4 compatibility
+    (fetchpatch {
+      name = "metis-cmake-minimum-required-bump.patch";
+      url = "https://github.com/KarypisLab/METIS/commit/350931887dfc00c2e3cb7551c5abf30e0297126a.patch";
+      hash = "sha256-vX1GSZOLDxO9IIAQmNa9ADreEWSHCU9eF9L8qiSHye8=";
+    })
   ];
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/me/metis/package.nix
+++ b/pkgs/by-name/me/metis/package.nix
@@ -1,34 +1,49 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  unzip,
+  fetchFromGitHub,
+  fetchpatch,
   cmake,
+  gklib,
+  llvmPackages,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "metis";
-  version = "5.1.0";
+  version = "5.2.1";
 
-  src = fetchurl {
-    url = "http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-${version}.tar.gz";
-    sha256 = "1cjxgh41r8k6j029yxs8msp3z6lcnpm16g5pvckk35kc7zhfpykn";
+  src = fetchFromGitHub {
+    owner = "KarypisLab";
+    repo = "METIS";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eddLR6DvZ+2LeR0DkknN6zzRvnW+hLN2qeI+ETUPcac=";
   };
 
-  cmakeFlags = [
-    "-DGKLIB_PATH=../GKlib"
-    # remove once updated past https://github.com/KarypisLab/METIS/commit/521a2c360dc21ace5c4feb6dc0b7992433e3cb0f
-    "-DCMAKE_SKIP_BUILD_RPATH=ON"
+  patches = [
+    # fix gklib link error
+    (fetchpatch {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sci-libs/metis/files/metis-5.2.1-add-gklib-as-required.patch?id=c78ecbd3fdf9b33e307023baf0de12c4448dd283";
+      hash = "sha256-uoXMi6pMs5VrzUmjsLlQYFLob1A8NAt9CbFi8qhQXVQ=";
+    })
   ];
-  nativeBuildInputs = [
-    unzip
-    cmake
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ gklib ] ++ lib.optional stdenv.cc.isClang llvmPackages.openmp;
+
+  preConfigure = ''
+    make config
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeBool "OPENMP" true)
+    (lib.cmakeBool "SHARED" (!stdenv.hostPlatform.isStatic))
   ];
 
   meta = {
     description = "Serial graph partitioning and fill-reducing matrix ordering";
-    homepage = "http://glaros.dtc.umn.edu/gkhome/metis/metis/overview";
+    homepage = "https://github.com/KarypisLab/METIS";
     license = lib.licenses.asl20;
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/me/metis/package.nix
+++ b/pkgs/by-name/me/metis/package.nix
@@ -50,6 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Serial graph partitioning and fill-reducing matrix ordering";
     homepage = "https://github.com/KarypisLab/METIS";
     license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ qbisi ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/pa/parmetis/package.nix
+++ b/pkgs/by-name/pa/parmetis/package.nix
@@ -3,31 +3,35 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  gklib,
   metis,
   mpi,
 }:
 
 stdenv.mkDerivation {
   pname = "parmetis";
-  version = "4.0.3";
+  version = "4.0.3-unstable-2023-03-26";
 
   src = fetchFromGitHub {
     owner = "KarypisLab";
     repo = "ParMETIS";
-    rev = "d90a2a6cf08d1d35422e060daa28718376213659";
-    hash = "sha256-22YQxwC0phdMLX660wokRgmAif/9tRbUmQWwNMZ//7M=";
+    rev = "8ee6a372ca703836f593e3c450ca903f04be14df";
+    hash = "sha256-L9SLyr7XuBUniMH3JtaBrUHIGzVTF5pr014xovQf2cI=";
   };
 
   nativeBuildInputs = [ cmake ];
   enableParallelBuilding = true;
-  buildInputs = [ mpi ];
+  buildInputs = [
+    gklib
+    metis
+    mpi
+  ];
 
   configurePhase = ''
     runHook preConfigure
 
-    tar xf ${metis.src}
-    mv metis-* metis
-    make config metis_path=metis gklib_path=metis/GKlib prefix=$out
+    make config metis_path=${metis} gklib_path=${gklib} prefix=$out \
+       shared=${if stdenv.hostPlatform.isStatic then "0" else "1"}
 
     runHook postConfigure
   '';

--- a/pkgs/by-name/so/sofa/package.nix
+++ b/pkgs/by-name/so/sofa/package.nix
@@ -40,6 +40,12 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/sofa-framework/sofa/commit/700b6cdd94fe24a51b2a7014fb0fc83e6abe1fbc.patch";
       hash = "sha256-czc1u03USQt18d7cMPmXYguBhSb5JOJLplPvoixp+3w=";
     })
+    (fetchpatch {
+      # Compat with metis > 5.1
+      name = "sofamatrix-allow-newer-metis-versions.patch";
+      url = "https://github.com/sofa-framework/sofa/commit/f1a45da7c77776ea9559b1958576b0187a8b9958.patch";
+      hash = "sha256-YPMBKG1Ju5XON14CmSYNqljpqEbFRvI5SgKwOnxs7+I=";
+    })
   ];
 
   propagatedNativeBuildInputs = [


### PR DESCRIPTION
Rebased @natsukium's stale PR #318147 and applied upstream patch for cmake 4 compat

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
