### PR TITLE
julia: build from source on aarch64-darwin

### DIFF
--- a/pkgs/development/compilers/julia/default.nix
+++ b/pkgs/development/compilers/julia/default.nix
@@ -1,4 +1,6 @@
 {
+  stdenv,
+  lib,
   callPackage,
   fetchpatch2,
   gcc14Stdenv,
@@ -89,10 +91,19 @@ in
       (import ./generic.nix {
         version = "1.12.6";
         hash = "sha256-cR86qNbsXJAEWT6489U+NWTNdZrLqK1K2ulnr8IDMsw=";
+        patches = lib.optionals stdenv.hostPlatform.isDarwin [
+          ./patches/1.12/0001-zlib-rpath.patch
+          ./patches/1.12/0002-lbt-blas-detection.patch
+        ];
       })
-      {
-        stdenv = gcc14Stdenv;
-        gfortran = gfortran14;
-      }
+      (
+        if stdenv.cc.isGNU then
+          {
+            stdenv = gcc14Stdenv;
+            gfortran = gfortran14;
+          }
+        else
+          { }
+      )
   );
 }

--- a/pkgs/development/compilers/julia/generic.nix
+++ b/pkgs/development/compilers/julia/generic.nix
@@ -19,6 +19,10 @@
   libxml2,
   zlib,
   buildPackages,
+  darwin,
+  unzip,
+  ncurses,
+  curl,
 }:
 
 let
@@ -68,6 +72,13 @@ stdenv.mkDerivation rec {
     perl
     gnum4
     openssl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    curl
+    darwin.DarwinTools
+    darwin.sigtool
+    darwin.autoSignDarwinBinariesHook
+    unzip
   ];
 
   buildInputs = [
@@ -98,6 +109,11 @@ stdenv.mkDerivation rec {
                      'cd $(dir $<) && $(TAR) -zxf $< && sed -i "s|/usr/bin/env perl|${lib.getExe buildPackages.perl}|" openssl-$(OPENSSL_VER)/Configure'
   '';
 
+  preBuild = lib.optionalString (lib.versionAtLeast version "1.11") ''
+    # terminfo dirs normally inaccessible in build sandbox
+    export TERMINFO="${ncurses.out}/share/terminfo/";
+  '';
+
   makeFlags = [
     "prefix=$(out)"
     "USE_BINARYBUILDER=0"
@@ -111,14 +127,23 @@ stdenv.mkDerivation rec {
   ];
 
   # remove forbidden reference to $TMPDIR
-  preFixup = ''
+  preFixup = lib.optionalString stdenv.hostPlatform.isElf ''
     for file in libcurl.so libgmpxx.so libmpfr.so; do
       patchelf --shrink-rpath --allowed-rpath-prefixes ${builtins.storeDir} "$out/lib/julia/$file"
     done
   '';
 
+  # Code signing is done as part of the build process, but that
+  # doesn't quite work so we re-sign it here.
+  postFixup = lib.optionalString (stdenv.hostPlatform.isDarwin) ''
+    codesign -s - --force --entitlements ./contrib/mac/app/Entitlements.plist $out/bin/julia
+  '';
+
   # tests are flaky for aarch64-linux on hydra
-  doInstallCheck = if (lib.versionOlder version "1.10") then !stdenv.hostPlatform.isAarch64 else true;
+  # some tests not working on aarch64-darwin for unrelated reasons
+  doInstallCheck =
+    stdenv.hostPlatform.isLinux
+    && (lib.versionAtLeast version "1.10" || !stdenv.hostPlatform.isAarch64);
 
   preInstallCheck = ''
     export JULIA_TEST_USE_MULTIPLE_WORKERS="true"
@@ -164,6 +189,7 @@ stdenv.mkDerivation rec {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
+      "aarch64-darwin"
     ];
   };
 }

--- a/pkgs/development/compilers/julia/patches/1.12/0001-zlib-rpath.patch
+++ b/pkgs/development/compilers/julia/patches/1.12/0001-zlib-rpath.patch
@@ -1,0 +1,25 @@
+From 512188bcee5104687a203a7e57242e79a9e05472 Mon Sep 17 00:00:00 2001
+From: George Huebner <george@feyor.sh>
+Date: Fri, 16 Jan 2026 09:53:02 -0600
+Subject: [PATCH] fix zlib linking issue
+
+---
+ deps/llvm.mk | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/deps/llvm.mk b/deps/llvm.mk
+index 09dd4f187d..ccd27760b6 100644
+--- a/deps/llvm.mk
++++ b/deps/llvm.mk
+@@ -70,7 +70,7 @@ LLVM_EXPERIMENTAL_TARGETS :=
+ LLVM_CFLAGS :=
+ LLVM_CXXFLAGS :=
+ LLVM_CPPFLAGS :=
+-LLVM_LDFLAGS :=
++LLVM_LDFLAGS := "-L$(build_shlibdir)" -rpath "$(build_shlibdir)" # hacky way to force zlib to be found when linking against libLLVM and sysroot is set
+ LLVM_CMAKE :=
+ 
+ LLVM_CMAKE += -DLLVM_ENABLE_PROJECTS="$(LLVM_ENABLE_PROJECTS)"
+-- 
+2.52.0
+

--- a/pkgs/development/compilers/julia/patches/1.12/0002-lbt-blas-detection.patch
+++ b/pkgs/development/compilers/julia/patches/1.12/0002-lbt-blas-detection.patch
@@ -1,0 +1,63 @@
+From 703ab0a26202358f28e6de584d6ecde96f585264 Mon Sep 17 00:00:00 2001
+From: George Huebner <george@feyor.sh>
+Date: Tue, 28 Oct 2025 18:04:55 -0500
+Subject: [PATCH] fix LBT blas detection on darwin
+
+---
+ deps/blastrampoline.mk             |  7 +++++++
+ deps/patches/lbt-suffix-hint.patch | 25 +++++++++++++++++++++++++
+ 2 files changed, 32 insertions(+)
+ create mode 100644 deps/patches/lbt-suffix-hint.patch
+
+diff --git a/deps/blastrampoline.mk b/deps/blastrampoline.mk
+index cfa28a4d8b..53f6d1e4bd 100644
+--- a/deps/blastrampoline.mk
++++ b/deps/blastrampoline.mk
+@@ -18,6 +18,13 @@ $(BUILDDIR)/$(BLASTRAMPOLINE_SRC_DIR)/build-compiled: $(BUILDDIR)/$(BLASTRAMPOLI
+ 	cd $(dir $@)/src && $(MAKE) $(BLASTRAMPOLINE_BUILD_OPTS)
+ 	echo 1 > $@
+ 
++$(BUILDDIR)/$(BLASTRAMPOLINE_SRC_DIR)/lbt-suffix-hint.patch.applied: $(BUILDDIR)/$(BLASTRAMPOLINE_SRC_DIR)/source-extracted
++	cd $(dir $@) && \
++		patch -p1 -f < $(SRCDIR)/patches/lbt-suffix-hint.patch
++	echo 1 > $@
++
++$(BUILDDIR)/$(BLASTRAMPOLINE_SRC_DIR)/build-compiled: $(BUILDDIR)/$(BLASTRAMPOLINE_SRC_DIR)/lbt-suffix-hint.patch.applied
++
+ define BLASTRAMPOLINE_INSTALL
+ 	$(MAKE) -C $(BLASTRAMPOLINE_BUILD_ROOT) install $(BLASTRAMPOLINE_BUILD_OPTS) DESTDIR="$2"
+ endef
+diff --git a/deps/patches/lbt-suffix-hint.patch b/deps/patches/lbt-suffix-hint.patch
+new file mode 100644
+index 0000000000..d5b5a43c13
+--- /dev/null
++++ b/deps/patches/lbt-suffix-hint.patch
+@@ -0,0 +1,25 @@
++From 70c929f9182f0c93d60cc68b439f119da80994aa Mon Sep 17 00:00:00 2001
++From: George Huebner <george@feyor.sh>
++Date: Tue, 28 Oct 2025 17:59:35 -0500
++Subject: [PATCH] correctly identify BLAS as ILP64 on darwin
++
++---
++ src/autodetection.c | 2 ++
++ 1 file changed, 2 insertions(+)
++
++diff --git a/src/autodetection.c b/src/autodetection.c
++index 86ee124..6a4e1cb 100644
++--- a/src/autodetection.c
+++++ b/src/autodetection.c
++@@ -61,6 +61,8 @@ const char * autodetect_symbol_suffix(void * handle, const char * suffix_hint) {
++     const char * suffixes[] = {
++         // Possibly-NULL suffix that we should search over
++         suffix_hint,
+++         
+++        "64_",
++ 
++         // First, search for LP64-mangling suffixes, so that when we are loading libs from an
++         // CLI environment, (where suffix hints are not easy) we want to give the most stable
++-- 
++2.50.1
++
+-- 
+2.50.1
+

--- a/pkgs/development/julia-modules/default.nix
+++ b/pkgs/development/julia-modules/default.nix
@@ -7,6 +7,7 @@
   makeWrapper,
   python3,
   runCommand,
+  writableTmpDirAsHomeHook,
   writeTextFile,
 
   # Artifacts dependencies
@@ -221,6 +222,10 @@ let
               pyyaml
             ]
           ))
+        ];
+
+        nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+          writableTmpDirAsHomeHook
         ];
       }
       ''


### PR DESCRIPTION
~~*This PR is stacked on top of #434986*~~

This is my attempt to build Julia fully from source on aarch64-darwin: ~currently this only includes 1.10, but once I iron out the kinks I can port the changes to all stable releases of Julia in nixpkgs~.

I'm not a huge fan of vendoring patches in nixpkgs, but I think in this case it's easier than a bunch of tweaking in `postPatch`.

The main fixes backported are
- https://github.com/JuliaLinearAlgebra/libblastrampoline/pull/148
- https://github.com/madler/zlib/issues/1076 (in zlib and in libgit2's version of zlib)
- https://github.com/JuliaLang/julia/pull/53894

I still need to fix something in libblastrampoline that is incorrectly detecting the built OpenBLAS as 32 bit (checking exported symbols with `objdump -t` confirms that libopenblas64_.dylib is indeed 64 bit), but for testing purposes this can be bypassed with `LBT_FORCE_INTERFACE=ilp64` (edit: fixed).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
