### PR TITLE
godot: avoid builtin libraries where possible

### DIFF
--- a/pkgs/development/tools/godot/Linux-fix-missing-library-with-builtin_glslang-false.patch
+++ b/pkgs/development/tools/godot/Linux-fix-missing-library-with-builtin_glslang-false.patch
@@ -1,0 +1,25 @@
+From 6d43e80c0a455fea5dcb656967e73f755ecdd645 Mon Sep 17 00:00:00 2001
+From: David McFarland <corngood@gmail.com>
+Date: Sun, 9 Mar 2025 19:42:33 -0300
+Subject: [PATCH] Linux: fix missing library with builtin_glslang=false
+
+---
+ platform/linuxbsd/detect.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/platform/linuxbsd/detect.py b/platform/linuxbsd/detect.py
+index b5e80f4a4d..8389096e26 100644
+--- a/platform/linuxbsd/detect.py
++++ b/platform/linuxbsd/detect.py
+@@ -472,7 +472,7 @@ def configure(env: "SConsEnvironment"):
+             env.ParseConfig("pkg-config vulkan --cflags --libs")
+         if not env["builtin_glslang"]:
+             # No pkgconfig file so far, hardcode expected lib name.
+-            env.Append(LIBS=["glslang", "SPIRV"])
++            env.Append(LIBS=["glslang", "glslang-default-resource-limits", "SPIRV"])
+ 
+     if env["opengl3"]:
+         env.Append(CPPDEFINES=["GLES3_ENABLED"])
+-- 
+2.47.1
+

--- a/pkgs/development/tools/godot/common.nix
+++ b/pkgs/development/tools/godot/common.nix
@@ -5,17 +5,27 @@
   callPackage,
   dbus,
   dotnetCorePackages,
+  embree,
+  enet,
   exportTemplatesHash,
   fetchFromGitHub,
   fetchpatch,
   fontconfig,
+  freetype,
   glib,
+  glslang,
+  graphite2,
+  harfbuzz,
   hash,
+  icu,
   installShellFiles,
   lib,
   libdecor,
   libGL,
+  libjpeg_turbo,
   libpulseaudio,
+  libtheora,
+  libwebp,
   libX11,
   libXcursor,
   libXext,
@@ -26,10 +36,16 @@
   libXrandr,
   libXrender,
   makeWrapper,
+  mbedtls,
+  miniupnpc,
+  openxr-loader,
+  pcre2,
   perl,
   pkg-config,
+  recastnavigation,
   runCommand,
   scons,
+  sdl3,
   speechd-minimal,
   stdenv,
   stdenvNoCC,
@@ -55,6 +71,8 @@
   # https://github.com/godotengine/godot/pull/73504
   withWayland ? true,
   withX11 ? true,
+  wslay,
+  zstd,
 }:
 assert lib.asserts.assertOneOf "withPrecision" withPrecision [
   "single"
@@ -369,7 +387,23 @@ let
             ccflags = "-fno-strict-aliasing";
             linkflags = "-Wl,--build-id";
 
+            # libraries that aren't available in nixpkgs
+            builtin_msdfgen = true;
+            builtin_rvo2_2d = true;
+            builtin_rvo2_3d = true;
+            builtin_xatlas = true;
+
+            # using system clipper2 is currently not implemented
+            builtin_clipper2 = true;
+
             use_sowrap = false;
+          }
+          // lib.optionalAttrs (lib.versionOlder version "4.4") {
+            # libraries that aren't available in nixpkgs
+            builtin_squish = true;
+
+            # broken with system packages
+            builtin_miniupnpc = true;
           }
           // lib.optionalAttrs (lib.versionAtLeast version "4.5") {
             redirect_build_objects = false; # Avoid copying build objects to output
@@ -380,22 +414,30 @@ let
 
         strictDeps = true;
 
-        patches =
-          lib.optionals (lib.versionOlder version "4.4") [
-            (fetchpatch {
-              name = "wayland-header-fix.patch";
-              url = "https://github.com/godotengine/godot/commit/6ce71f0fb0a091cffb6adb4af8ab3f716ad8930b.patch";
-              hash = "sha256-hgAtAtCghF5InyGLdE9M+9PjPS1BWXWGKgIAyeuqkoU=";
-            })
-            # Fix a crash in the mono test project build. It no longer seems to
-            # happen in 4.4, but an existing fix couldn't be identified.
-            ./CSharpLanguage-fix-crash-in-reload_assemblies-after-.patch
-          ]
-          ++ lib.optional (lib.versionAtLeast version "4.5") ./fix-freetype-link-error.patch;
+        patches = [
+          ./Linux-fix-missing-library-with-builtin_glslang-false.patch
+        ]
+        ++ lib.optionals (lib.versionOlder version "4.4") [
+          (fetchpatch {
+            name = "wayland-header-fix.patch";
+            url = "https://github.com/godotengine/godot/commit/6ce71f0fb0a091cffb6adb4af8ab3f716ad8930b.patch";
+            hash = "sha256-hgAtAtCghF5InyGLdE9M+9PjPS1BWXWGKgIAyeuqkoU=";
+          })
+          # Fix a crash in the mono test project build. It no longer seems to
+          # happen in 4.4, but an existing fix couldn't be identified.
+          ./CSharpLanguage-fix-crash-in-reload_assemblies-after-.patch
+        ]
+        ++ lib.optional (lib.versionAtLeast version "4.5") ./fix-freetype-link-error.patch;
 
         postPatch = ''
           # this stops scons from hiding e.g. NIX_CFLAGS_COMPILE
           perl -pi -e '{ $r += s:(env = Environment\(.*):\1\nenv["ENV"] = os.environ: } END { exit ($r != 1) }' SConstruct
+
+          # disable all builtin libraries by default
+          perl -pi -e '{ $r |= s:(opts.Add\(BoolVariable\("builtin_.*, )True(\)\)):\1False\2: } END { exit ($r != 1) }' SConstruct
+
+          substituteInPlace platform/linuxbsd/detect.py \
+            --replace-fail /usr/include/recastnavigation ${lib.escapeShellArg (lib.getDev recastnavigation)}/include/recastnavigation
 
           substituteInPlace thirdparty/glad/egl.c \
             --replace-fail \
@@ -423,36 +465,57 @@ let
           pkg-config
         ];
 
-        buildInputs =
-          lib.optionals (editor && withMono) dotnet-sdk.packages
-          ++ lib.optional withAlsa alsa-lib
-          ++ lib.optional (withX11 || withWayland) libxkbcommon
-          ++ lib.optionals withX11 [
-            libX11
-            libXcursor
-            libXext
-            libXfixes
-            libXi
-            libXinerama
-            libXrandr
-            libXrender
-          ]
-          ++ lib.optionals withWayland [
-            # libdecor
-            wayland
-          ]
-          ++ lib.optionals withDbus [
-            dbus
-          ]
-          ++ lib.optionals withFontconfig [
-            fontconfig
-          ]
-          ++ lib.optional withPulseaudio libpulseaudio
-          ++ lib.optionals withSpeechd [
-            speechd-minimal
-            glib
-          ]
-          ++ lib.optional withUdev udev;
+        buildInputs = [
+          embree
+          enet
+          freetype
+          glslang
+          graphite2
+          (harfbuzz.override { withIcu = true; })
+          icu
+          libtheora
+          libwebp
+          mbedtls
+          miniupnpc
+          openxr-loader
+          pcre2
+          recastnavigation
+          wslay
+          zstd
+        ]
+        ++ lib.optionals (lib.versionAtLeast version "4.5") [
+          libjpeg_turbo
+          sdl3
+        ]
+        ++ lib.optionals (editor && withMono) dotnet-sdk.packages
+        ++ lib.optional withAlsa alsa-lib
+        ++ lib.optional (withX11 || withWayland) libxkbcommon
+        ++ lib.optionals withX11 [
+          libX11
+          libXcursor
+          libXext
+          libXfixes
+          libXi
+          libXinerama
+          libXrandr
+          libXrender
+        ]
+        ++ lib.optionals withWayland [
+          libdecor
+          wayland
+        ]
+        ++ lib.optionals withDbus [
+          dbus
+        ]
+        ++ lib.optionals withFontconfig [
+          fontconfig
+        ]
+        ++ lib.optional withPulseaudio libpulseaudio
+        ++ lib.optionals withSpeechd [
+          speechd-minimal
+          glib
+        ]
+        ++ lib.optional withUdev udev;
 
         nativeBuildInputs = [
           installShellFiles


### PR DESCRIPTION
This tries to use as much from nixpkgs as possible.  It should help reduce build times, centralise dependencies, and avoid issues with library conflicts like:

https://github.com/godotengine/godot/pull/104893#issuecomment-3308472172

TODO:

- [x] fix 4.5 build failure
- [x] decide what to do about "System-provided icu4c or harfbuzz cause known issues for GDExtension (see github.com/godotengine/godot/issues/91401 and github.com/godotengine/godot/issues/100301)."

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
