### PR TITLE
haskellPackages.callHackageDirect: add optional candidate attribute

### DIFF
--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -262,6 +262,7 @@ package-set { inherit pkgs lib callPackage; } self
       pkg,
       ver,
       sha256,
+      candidate ? false,
       rev ? {
         revision = null;
         sha256 = null;
@@ -271,7 +272,11 @@ package-set { inherit pkgs lib callPackage; } self
     let
       pkgver = "${pkg}-${ver}";
       firstRevision = self.callCabal2nix pkg (pkgs.fetchzip {
-        url = "mirror://hackage/${pkgver}/${pkgver}.tar.gz";
+        url =
+          if candidate then
+            "mirror://hackage/${pkgver}/candidate/${pkgver}.tar.gz"
+          else
+            "mirror://hackage/${pkgver}/${pkgver}.tar.gz";
         inherit sha256;
       }) args;
     in


### PR DESCRIPTION
Hackage repository is append only so a package published once stays there forever.
It is not good for debugging, because repo space quickly gets cluttered.

There is a workaround feature as a release candidate, but its URL is different for a candidate.
PR adds optional boolean flag to alter the URL to download a release candidate instead.

```nix
      "attoparsec-isotropic" = hfinal.callHackageDirect
        { pkg = "attoparsec-isotropic";
          ver = "0.14.6";
          candidate = true;
          sha256 = "sha256-Q0dSfzneZ0POHGQuIFQa7Qrlv+lNsoakJm7PpcJDNsA=";
        } {};
``` 

- Built on platform:
  - [x ] x86_64-linux


Let me mention @maralorn here as a recent merger of another callHackageDirect related PR (https://github.com/NixOS/nixpkgs/pull/284490)