### PR TITLE
udev rules for tuxedo drivers

### DIFF
--- a/nixos/modules/hardware/tuxedo-drivers.nix
+++ b/nixos/modules/hardware/tuxedo-drivers.nix
@@ -31,5 +31,6 @@ in
   config = lib.mkIf cfg.enable {
     boot.kernelModules = [ "tuxedo_keyboard" ];
     boot.extraModulePackages = [ tuxedo-drivers ];
+    services.udev.packages = [ tuxedo-drivers ];
   };
 }

--- a/pkgs/os-specific/linux/tuxedo-drivers/default.nix
+++ b/pkgs/os-specific/linux/tuxedo-drivers/default.nix
@@ -8,6 +8,7 @@
   pahole,
   gitUpdater,
   udevCheckHook,
+  bash,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -26,6 +27,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = ''
     echo "Running postInstallhook"
+    substituteInPlace usr/lib/udev/rules.d/* \
+      --replace-quiet "/bin/bash" "${lib.getExe bash}" \
+      --replace-quiet "/bin/sh" "${lib.getExe bash}"
     install -Dm 0644 -t $out/etc/udev/rules.d usr/lib/udev/rules.d/*
   '';
 


### PR DESCRIPTION
Follow up to https://github.com/NixOS/nixpkgs/pull/441147

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
