### PR TITLE
use latest patch for bisect_ppx

### DIFF
--- a/pkgs/development/ocaml-modules/bisect_ppx/default.nix
+++ b/pkgs/development/ocaml-modules/bisect_ppx/default.nix
@@ -19,10 +19,20 @@ buildDunePackage rec {
   };
 
   # Ensure compatibility with ppxlib 0.36
-  patches = lib.optional (lib.versionAtLeast ppxlib.version "0.36") (fetchpatch {
-    url = "https://github.com/aantron/bisect_ppx/commit/f35fdf4bdcb82c308d70f7c9c313a77777f54bdf.patch";
-    hash = "sha256-hQMDU6zrHDV9JszGAj2p4bd9zlqqjc1TLU+cfMEgz9c=";
-  });
+  patches = lib.optionals (lib.versionAtLeast ppxlib.version "0.36") [
+    (fetchpatch {
+      url = "https://github.com/aantron/bisect_ppx/commit/f35fdf4bdcb82c308d70f7c9c313a77777f54bdf.patch";
+      hash = "sha256-hQMDU6zrHDV9JszGAj2p4bd9zlqqjc1TLU+cfMEgz9c=";
+    })
+    (fetchpatch {
+      url = "https://github.com/aantron/bisect_ppx/commit/07bfceec652773de4b140cebc236a15e2429809e.patch";
+      hash = "sha256-9gDIndPIZMkIkd847qd2QstsZJInBPuWXAUIzZMkHcw=";
+    })
+    (fetchpatch {
+      url = "https://github.com/aantron/bisect_ppx/commit/4f0cb2a2e1b0b786b6b5f1c94985b201aa012f12.patch";
+      hash = "sha256-20nr7ApKPnnol0VEOirwXdJX+AiFRzBzAq4YzCWn7W0=";
+    })
+  ];
 
   minimalOCamlVersion = "4.11";
 


### PR DESCRIPTION
Hi,

The current patch applied to `bisect_ppx` was needed to make it work with the latest `ppxlib`, but the patch was actually incorrect. This issue is here: https://github.com/aantron/bisect_ppx/issues/450 ; it has been fixed in the PR where the original patch was taken from: https://github.com/aantron/bisect_ppx/pull/448

I am simply adding the new patch here.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
