### PR TITLE
opencv: invalidate Nix store paths used in version_string.inc

### DIFF
--- a/pkgs/development/libraries/opencv/0001-cmake-OpenCVUtils.cmake-invalidate-Nix-store-paths-b.patch
+++ b/pkgs/development/libraries/opencv/0001-cmake-OpenCVUtils.cmake-invalidate-Nix-store-paths-b.patch
@@ -1,0 +1,34 @@
+From fcc689e1887bcbeb9d1c4441266a63ea2114ae9f Mon Sep 17 00:00:00 2001
+From: Connor Baker <ConnorBaker01@gmail.com>
+Date: Thu, 18 Sep 2025 13:15:43 -0700
+Subject: [PATCH] cmake/OpenCVUtils.cmake: invalidate Nix store paths before
+ including in version_string.inc
+
+Signed-off-by: Connor Baker <ConnorBaker01@gmail.com>
+---
+ cmake/OpenCVUtils.cmake | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/cmake/OpenCVUtils.cmake b/cmake/OpenCVUtils.cmake
+index 5886f4f3cb..9f3a3a74e9 100644
+--- a/cmake/OpenCVUtils.cmake
++++ b/cmake/OpenCVUtils.cmake
+@@ -956,6 +956,15 @@ function(ocv_output_status msg)
+     message(WARNING "String to be inserted to version_string.inc has an unexpected line break: '${msg}'")
+     string(REPLACE "\n" "\\n" msg "${msg}")
+   endif()
++  # The hash portion of Nix store paths are 32 characters long. Replace them with an invalid hash to avoid bloating
++  # the runtime closure by includnig references to the compiler and other build tools.
++  # https://fzakaria.com/2025/03/28/what-s-in-a-nix-store-path
++  # NOTE: This assumes the name of the Nix store is always /nix/store.
++  # NOTE: The regex [a-z0-9] is larger than Nix's base32, but it simplifies things.
++  # NOTE: This assumes all Nix store paths have additional characters after the hash.
++  # NOTE: CMake doesn't support fixed-length matching. See:
++  # https://cmake.org/cmake/help/latest/command/string.html#regex-specification
++  string(REGEX REPLACE "/nix/store/[a-z0-9]+-" "/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-" msg "${msg}")
+   set(OPENCV_BUILD_INFO_STR "${OPENCV_BUILD_INFO_STR}\"${msg}\\n\"\n" CACHE INTERNAL "")
+ endfunction()
+ 
+-- 
+2.48.1
+

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -298,6 +298,7 @@ effectiveStdenv.mkDerivation {
   # Ensures that we use the system OpenEXR rather than the vendored copy of the source included with OpenCV.
   patches = [
     ./cmake-don-t-use-OpenCVFindOpenEXR.patch
+    ./0001-cmake-OpenCVUtils.cmake-invalidate-Nix-store-paths-b.patch
   ]
   ++ optionals enableCuda [
     ./cuda_opt_flow.patch
@@ -320,11 +321,6 @@ effectiveStdenv.mkDerivation {
       ${installExtraFiles face}
       ${installExtraFiles wechat_qrcode}
     '');
-
-  postConfigure = ''
-    [ -e modules/core/version_string.inc ]
-    echo '"(build info elided)"' > modules/core/version_string.inc
-  '';
 
   buildInputs = [
     boost


### PR DESCRIPTION
The current approach of nuking the content of `version_string.inc` in `postConfigure` doesn't work for CUDA-enabled builds; the goal was to avoid Nix including build-time only paths in the closure.

This PR instead replaces the Nix store paths with invalid ones (by turning the hash portion of the path to the string of all `e`s) -- the information in `version_string.inc` is generally useful for debugging and should be preserved.

With the patch applied on `master`, there's no regression with closure size on x86_64-linux without CUDA enabled.

```console
$ nix path-info -Ssh ./without-patch
/nix/store/3yx1386pf3a1zfvm736gdp9h1npm01rx-opencv-4.12.0	  74.9 MiB	   1.1 GiB
$ nix path-info -Ssh ./with-patch
/nix/store/2lz9cgrr3myhhyfmyckrdk49642l77k7-opencv-4.12.0	  74.9 MiB	   1.1 GiB
```

Here's the difference in `opencv_version` without CUDA support:

<details>

```console
$ ./without-patch/bin/opencv_version -v
(build info elided)
$ ./with-patch/bin/opencv_version -v

General configuration for OpenCV 4.12.0 =====================================
  Version control:               unknown

  Extra modules:
    Location (extra):            /build/source/opencv_contrib
    Version control (extra):     unknown

  Platform:
    Timestamp:                   1980-01-01T00:00:00Z
    Host:                        Linux 6.1.92 x86_64
    CMake:                       3.31.7
    CMake generator:             Unix Makefiles
    CMake build tool:            /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gnumake-4.4.1/bin/make
    Configuration:               Release
    Algorithm Hint:              ALGO_HINT_ACCURATE

  CPU/HW features:
    Baseline:                    SSE SSE2 SSE3
      requested:                 SSE3
    Dispatched code generation:  SSE4_1 SSE4_2 AVX FP16 AVX2 AVX512_SKX
      SSE4_1 (19 files):         + SSSE3 SSE4_1
      SSE4_2 (2 files):          + SSSE3 SSE4_1 POPCNT SSE4_2
      AVX (10 files):            + SSSE3 SSE4_1 POPCNT SSE4_2 AVX
      FP16 (1 files):            + SSSE3 SSE4_1 POPCNT SSE4_2 AVX FP16
      AVX2 (39 files):           + SSSE3 SSE4_1 POPCNT SSE4_2 AVX FP16 AVX2 FMA3
      AVX512_SKX (9 files):      + SSSE3 SSE4_1 POPCNT SSE4_2 AVX FP16 AVX2 FMA3 AVX_512F AVX512_COMMON AVX512_SKX

  C/C++:
    Built as dynamic libs?:      YES
    C++ standard:                17
    C++ Compiler:                /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-wrapper-14.3.0/bin/g++  (ver 14.3.0)
    C++ flags (Release):         -fsigned-char -W -Wall -Wreturn-type -Wnon-virtual-dtor -Waddress -Wsequence-point -Wformat -Wformat-security -Wmissing-declarations -Wundef -Winit-self -Wpointer-arith -Wshadow -Wsign-promo -Wuninitialized -Wsuggest-override -Wno-delete-non-virtual-dtor -Wno-comment -Wimplicit-fallthrough=3 -Wno-strict-overflow -fdiagnostics-show-option -pthread -fomit-frame-pointer -ffunction-sections -fdata-sections  -msse3 -fvisibility=hidden -fvisibility-inlines-hidden -fopenmp -O3 -DNDEBUG  -DNDEBUG
    C++ flags (Debug):           -fsigned-char -W -Wall -Wreturn-type -Wnon-virtual-dtor -Waddress -Wsequence-point -Wformat -Wformat-security -Wmissing-declarations -Wundef -Winit-self -Wpointer-arith -Wshadow -Wsign-promo -Wuninitialized -Wsuggest-override -Wno-delete-non-virtual-dtor -Wno-comment -Wimplicit-fallthrough=3 -Wno-strict-overflow -fdiagnostics-show-option -pthread -fomit-frame-pointer -ffunction-sections -fdata-sections  -msse3 -fvisibility=hidden -fvisibility-inlines-hidden -fopenmp -g  -O0 -DDEBUG -D_DEBUG
    C Compiler:                  /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-wrapper-14.3.0/bin/gcc
    C flags (Release):           -fsigned-char -W -Wall -Wreturn-type -Waddress -Wsequence-point -Wformat -Wformat-security -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wundef -Winit-self -Wpointer-arith -Wshadow -Wuninitialized -Wno-comment -Wimplicit-fallthrough=3 -Wno-strict-overflow -fdiagnostics-show-option -pthread -fomit-frame-pointer -ffunction-sections -fdata-sections  -msse3 -fvisibility=hidden -fopenmp -O3 -DNDEBUG  -DNDEBUG
    C flags (Debug):             -fsigned-char -W -Wall -Wreturn-type -Waddress -Wsequence-point -Wformat -Wformat-security -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wundef -Winit-self -Wpointer-arith -Wshadow -Wuninitialized -Wno-comment -Wimplicit-fallthrough=3 -Wno-strict-overflow -fdiagnostics-show-option -pthread -fomit-frame-pointer -ffunction-sections -fdata-sections  -msse3 -fvisibility=hidden -fopenmp -g  -O0 -DDEBUG -D_DEBUG
    Linker flags (Release):      -Wl,--gc-sections -Wl,--as-needed -Wl,--no-undefined  
    Linker flags (Debug):        -Wl,--gc-sections -Wl,--as-needed -Wl,--no-undefined  
    ccache:                      NO
    Precompiled headers:         NO
    Extra dependencies:          dl m pthread rt
    3rdparty dependencies:

  OpenCV modules:
    To be built:                 alphamat aruco bgsegm bioinspired calib3d ccalib core datasets dnn dnn_objdetect dnn_superres dpm face features2d flann fuzzy gapi hdf hfs highgui img_hash imgcodecs imgproc intensity_transform line_descriptor mcc ml objdetect optflow phase_unwrapping photo plot quality rapid reg rgbd saliency sfm shape signal stereo stitching structured_light superres surface_matching text tracking ts video videoio videostab wechat_qrcode xfeatures2d ximgproc xobjdetect xphoto
    Disabled:                    world
    Disabled by dependency:      -
    Unavailable:                 cannops cudaarithm cudabgsegm cudacodec cudafeatures2d cudafilters cudaimgproc cudalegacy cudaobjdetect cudaoptflow cudastereo cudawarping cudev cvv fastcv freetype java julia matlab ovis python2 python3 viz
    Applications:                tests apps
    Documentation:               NO
    Non-free algorithms:         NO

  GUI:                           NONE
    GTK+:                        NO
    VTK support:                 NO

  Media I/O: 
    ZLib:                        /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-zlib-1.3.1/lib/libz.so (ver 1.3.1)
    JPEG:                        /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libjpeg-turbo-3.1.1/lib/libjpeg.so (ver 62)
    WEBP:                        /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libwebp-1.6.0/lib/libwebp.so (ver decoder: 0x0210, encoder: 0x0210, demux: 0x0107)
    AVIF:                        NO
    PNG:                         /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libpng-apng-1.6.49/lib/libpng.so (ver 1.6.49)
    TIFF:                        (ver 42 / 4.7.0)
    JPEG 2000:                   OpenJPEG (ver 2.5.2)
    OpenEXR:                     OpenEXR-3_3 OpenEXRUtil-3_3 OpenEXRCore-3_3 Iex-3_3 IlmThread-3_3 Imath-3_2 (ver 3.3.5)
    GIF:                         YES
    HDR:                         YES
    SUNRASTER:                   YES
    PXM:                         YES
    PFM:                         YES

  Video I/O:
    FFMPEG:                      YES
      avcodec:                   YES (61.19.101)
      avformat:                  YES (61.7.100)
      avutil:                    YES (59.39.100)
      swscale:                   YES (8.3.100)
      avresample:                NO
    GStreamer:                   YES (1.26.5)
    v4l/v4l2:                    YES (linux/videodev2.h)

  Parallel framework:            OpenMP

  Trace:                         YES (with Intel ITT(3.25.4))

  Other third-party libraries:
    VA:                          YES
    Lapack:                      YES (/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-openblas-0.3.30/lib/libopenblas.so -lm -ldl)
    Eigen:                       YES (ver 3.4.0)
    Custom HAL:                  NO
    Protobuf:                    /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-protobuf-32.0/lib/libprotobuf.so.32.0.0 (32.0.0)
    Flatbuffers:                 builtin/3rdparty (23.5.9)

  OpenCL:                        YES (INTELVA)
    Include path:                /build/source/3rdparty/include/opencl/1.2
    Link libraries:              /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-ocl-icd-2.3.3/lib/libOpenCL.so

  Python (for build):            NO

  Java:                          
    ant:                         NO
    Java:                        NO
    JNI:                         NO
    Java wrappers:               NO
    Java tests:                  NO

  Install to:                    /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-opencv-4.12.0
-----------------------------------------------------------------

```

</details>


When CUDA support is enabled (targeting `sm_89`), there's a sizeable reduction:

```console
$ nix path-info -Ssh ./without-patch-cuda
/nix/store/9pvi16k6cpz8ak5lg8hlynh9953n2xgy-opencv-4.12.0	 259.4 MiB	   3.2 GiB
$ nix path-info -Ssh ./with-patch-cuda
/nix/store/r2qyl5ibidm0759qkzvyayqmacy2f10k-opencv-4.12.0	 259.4 MiB	   2.7 GiB
```

Here's the difference in `opencv_version` with CUDA support:

<details>

```console
$ ./without-patch-cuda/bin/opencv_version -v

General configuration for OpenCV 4.12.0 =====================================
  Version control:               unknown

  Extra modules:
    Location (extra):            /build/source/opencv_contrib
    Version control (extra):     unknown

  Platform:
    Timestamp:                   1980-01-01T00:00:00Z
    Host:                        Linux 6.14.0-29-generic x86_64
    CMake:                       3.31.7
    CMake generator:             Unix Makefiles
    CMake build tool:            /nix/store/aqdvlkh0jdwkc22hh5vr9sl6qlw5ha74-gnumake-4.4.1/bin/make
    Configuration:               Release
    Algorithm Hint:              ALGO_HINT_ACCURATE

  CPU/HW features:
    Baseline:                    SSE SSE2 SSE3
      requested:                 SSE3
    Dispatched code generation:  SSE4_1 SSE4_2 AVX FP16 AVX2 AVX512_SKX
      SSE4_1 (19 files):         + SSSE3 SSE4_1
      SSE4_2 (2 files):          + SSSE3 SSE4_1 POPCNT SSE4_2
      AVX (10 files):            + SSSE3 SSE4_1 POPCNT SSE4_2 AVX
      FP16 (1 files):            + SSSE3 SSE4_1 POPCNT SSE4_2 AVX FP16
      AVX2 (39 files):           + SSSE3 SSE4_1 POPCNT SSE4_2 AVX FP16 AVX2 FMA3
      AVX512_SKX (9 files):      + SSSE3 SSE4_1 POPCNT SSE4_2 AVX FP16 AVX2 FMA3 AVX_512F AVX512_COMMON AVX512_SKX

  C/C++:
    Built as dynamic libs?:      YES
    C++ standard:                17
    C++ Compiler:                /nix/store/fp97arzydz32c5gln0fia194n5mynwkw-gcc-wrapper-14.3.0/bin/g++  (ver 14.3.0)
    C++ flags (Release):         -fsigned-char -W -Wall -Wreturn-type -Wnon-virtual-dtor -Waddress -Wsequence-point -Wformat -Wformat-security -Wmissing-declarations -Wundef -Winit-self -Wpointer-arith -Wshadow -Wsign-promo -Wuninitialized -Wsuggest-override -Wno-delete-non-virtual-dtor -Wno-comment -Wimplicit-fallthrough=3 -Wno-strict-overflow -fdiagnostics-show-option -pthread -fomit-frame-pointer -ffunction-sections -fdata-sections  -msse3 -fvisibility=hidden -fvisibility-inlines-hidden -fopenmp -O3 -DNDEBUG  -DNDEBUG
    C++ flags (Debug):           -fsigned-char -W -Wall -Wreturn-type -Wnon-virtual-dtor -Waddress -Wsequence-point -Wformat -Wformat-security -Wmissing-declarations -Wundef -Winit-self -Wpointer-arith -Wshadow -Wsign-promo -Wuninitialized -Wsuggest-override -Wno-delete-non-virtual-dtor -Wno-comment -Wimplicit-fallthrough=3 -Wno-strict-overflow -fdiagnostics-show-option -pthread -fomit-frame-pointer -ffunction-sections -fdata-sections  -msse3 -fvisibility=hidden -fvisibility-inlines-hidden -fopenmp -g  -O0 -DDEBUG -D_DEBUG
    C Compiler:                  /nix/store/fp97arzydz32c5gln0fia194n5mynwkw-gcc-wrapper-14.3.0/bin/gcc
    C flags (Release):           -fsigned-char -W -Wall -Wreturn-type -Waddress -Wsequence-point -Wformat -Wformat-security -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wundef -Winit-self -Wpointer-arith -Wshadow -Wuninitialized -Wno-comment -Wimplicit-fallthrough=3 -Wno-strict-overflow -fdiagnostics-show-option -pthread -fomit-frame-pointer -ffunction-sections -fdata-sections  -msse3 -fvisibility=hidden -fopenmp -O3 -DNDEBUG  -DNDEBUG
    C flags (Debug):             -fsigned-char -W -Wall -Wreturn-type -Waddress -Wsequence-point -Wformat -Wformat-security -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wundef -Winit-self -Wpointer-arith -Wshadow -Wuninitialized -Wno-comment -Wimplicit-fallthrough=3 -Wno-strict-overflow -fdiagnostics-show-option -pthread -fomit-frame-pointer -ffunction-sections -fdata-sections  -msse3 -fvisibility=hidden -fopenmp -g  -O0 -DDEBUG -D_DEBUG
    Linker flags (Release):      -Wl,--gc-sections -Wl,--as-needed -Wl,--no-undefined  
    Linker flags (Debug):        -Wl,--gc-sections -Wl,--as-needed -Wl,--no-undefined  
    ccache:                      NO
    Precompiled headers:         NO
    Extra dependencies:          m pthread cudart_static dl rt nppc nppial nppicc nppidei nppif nppig nppim nppist nppisu nppitc npps cublas cufft -L/nix/store/63cf118cvd5vgc5p5fc1xqklqmd8830z-cuda_cudart-12.8.90-static/lib -L/nix/store/776irwlgfb65a782cxmyk61pck460fs9-glibc-2.40-66/lib -L/nix/store/7bvxr3i91n90cdqvbqz5l3zgj15ppgfn-libnpp-12.3.3.100-lib/lib -L/nix/store/m5g1q3ipc9j924p0sjassdc681g7nirg-libcublas-12.8.4.1-lib/lib -L/nix/store/5xbs13adsqlar57lg9k7zv0kgzvcrnpz-libcufft-11.3.3.83-lib/lib
    3rdparty dependencies:

  OpenCV modules:
    To be built:                 alphamat aruco bgsegm bioinspired calib3d ccalib core cudaarithm cudabgsegm cudacodec cudafeatures2d cudafilters cudaimgproc cudalegacy cudaobjdetect cudaoptflow cudastereo cudawarping cudev datasets dnn dnn_objdetect dnn_superres dpm face features2d flann fuzzy gapi hdf hfs highgui img_hash imgcodecs imgproc intensity_transform line_descriptor mcc ml objdetect optflow phase_unwrapping photo plot quality rapid reg rgbd saliency sfm shape signal stereo stitching structured_light superres surface_matching text tracking ts video videoio videostab wechat_qrcode xfeatures2d ximgproc xobjdetect xphoto
    Disabled:                    world
    Disabled by dependency:      -
    Unavailable:                 cannops cvv fastcv freetype java julia matlab ovis python2 python3 viz
    Applications:                tests apps
    Documentation:               NO
    Non-free algorithms:         NO

  GUI:                           NONE
    GTK+:                        NO
    VTK support:                 NO

  Media I/O: 
    ZLib:                        /nix/store/09sifcahf0j1xnw80k9l33jzcs1p2qbw-zlib-1.3.1/lib/libz.so (ver 1.3.1)
    JPEG:                        /nix/store/ld48pvj263k06rvljmh8la69ghh11yy0-libjpeg-turbo-3.1.1/lib/libjpeg.so (ver 62)
    WEBP:                        /nix/store/8223j8r3dl22yx0dzwd3wb4nk8r8x71w-libwebp-1.6.0/lib/libwebp.so (ver decoder: 0x0210, encoder: 0x0210, demux: 0x0107)
    AVIF:                        NO
    PNG:                         /nix/store/acdymp33g8mgllql8s80li89fafakjam-libpng-apng-1.6.49/lib/libpng.so (ver 1.6.49)
    TIFF:                        (ver 42 / 4.7.0)
    JPEG 2000:                   OpenJPEG (ver 2.5.2)
    OpenEXR:                     OpenEXR-3_3 OpenEXRUtil-3_3 OpenEXRCore-3_3 Iex-3_3 IlmThread-3_3 Imath-3_2 (ver 3.3.5)
    GIF:                         YES
    HDR:                         YES
    SUNRASTER:                   YES
    PXM:                         YES
    PFM:                         YES

  Video I/O:
    FFMPEG:                      YES
      avcodec:                   YES (61.19.101)
      avformat:                  YES (61.7.100)
      avutil:                    YES (59.39.100)
      swscale:                   YES (8.3.100)
      avresample:                NO
    GStreamer:                   YES (1.26.5)
    v4l/v4l2:                    YES (linux/videodev2.h)

  Parallel framework:            OpenMP

  Trace:                         YES (with Intel ITT(3.25.4))

  Other third-party libraries:
    VA:                          YES
    Lapack:                      YES (/nix/store/l0pyq7sz2shg610x06qkvbwh10mqyq5m-openblas-0.3.30/lib/libopenblas.so -lm -ldl)
    Eigen:                       YES (ver 3.4.0)
    Custom HAL:                  NO
    Protobuf:                    /nix/store/64nnmwdia29gkgjg0y2yv0y51q3zix3i-protobuf-32.0/lib/libprotobuf.so.32.0.0 (32.0.0)
    Flatbuffers:                 builtin/3rdparty (23.5.9)

  NVIDIA CUDA:                   YES (ver 12.8, CUFFT CUBLAS FAST_MATH)
    NVIDIA GPU arch:             89
    NVIDIA PTX archs:            89

  OpenCL:                        YES (INTELVA)
    Include path:                /build/source/3rdparty/include/opencl/1.2
    Link libraries:              /nix/store/k0lz0q15y7scws5m8i502mnbycnmjkrl-ocl-icd-2.3.3/lib/libOpenCL.so

  Python (for build):            NO

  Java:                          
    ant:                         NO
    Java:                        NO
    JNI:                         NO
    Java wrappers:               NO
    Java tests:                  NO

  Install to:                    /nix/store/9pvi16k6cpz8ak5lg8hlynh9953n2xgy-opencv-4.12.0
-----------------------------------------------------------------

$ ./with-patch-cuda/bin/opencv_version -v

General configuration for OpenCV 4.12.0 =====================================
  Version control:               unknown

  Extra modules:
    Location (extra):            /build/source/opencv_contrib
    Version control (extra):     unknown

  Platform:
    Timestamp:                   1980-01-01T00:00:00Z
    Host:                        Linux 6.14.0-29-generic x86_64
    CMake:                       3.31.7
    CMake generator:             Unix Makefiles
    CMake build tool:            /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gnumake-4.4.1/bin/make
    Configuration:               Release
    Algorithm Hint:              ALGO_HINT_ACCURATE

  CPU/HW features:
    Baseline:                    SSE SSE2 SSE3
      requested:                 SSE3
    Dispatched code generation:  SSE4_1 SSE4_2 AVX FP16 AVX2 AVX512_SKX
      SSE4_1 (19 files):         + SSSE3 SSE4_1
      SSE4_2 (2 files):          + SSSE3 SSE4_1 POPCNT SSE4_2
      AVX (10 files):            + SSSE3 SSE4_1 POPCNT SSE4_2 AVX
      FP16 (1 files):            + SSSE3 SSE4_1 POPCNT SSE4_2 AVX FP16
      AVX2 (39 files):           + SSSE3 SSE4_1 POPCNT SSE4_2 AVX FP16 AVX2 FMA3
      AVX512_SKX (9 files):      + SSSE3 SSE4_1 POPCNT SSE4_2 AVX FP16 AVX2 FMA3 AVX_512F AVX512_COMMON AVX512_SKX

  C/C++:
    Built as dynamic libs?:      YES
    C++ standard:                17
    C++ Compiler:                /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-wrapper-14.3.0/bin/g++  (ver 14.3.0)
    C++ flags (Release):         -fsigned-char -W -Wall -Wreturn-type -Wnon-virtual-dtor -Waddress -Wsequence-point -Wformat -Wformat-security -Wmissing-declarations -Wundef -Winit-self -Wpointer-arith -Wshadow -Wsign-promo -Wuninitialized -Wsuggest-override -Wno-delete-non-virtual-dtor -Wno-comment -Wimplicit-fallthrough=3 -Wno-strict-overflow -fdiagnostics-show-option -pthread -fomit-frame-pointer -ffunction-sections -fdata-sections  -msse3 -fvisibility=hidden -fvisibility-inlines-hidden -fopenmp -O3 -DNDEBUG  -DNDEBUG
    C++ flags (Debug):           -fsigned-char -W -Wall -Wreturn-type -Wnon-virtual-dtor -Waddress -Wsequence-point -Wformat -Wformat-security -Wmissing-declarations -Wundef -Winit-self -Wpointer-arith -Wshadow -Wsign-promo -Wuninitialized -Wsuggest-override -Wno-delete-non-virtual-dtor -Wno-comment -Wimplicit-fallthrough=3 -Wno-strict-overflow -fdiagnostics-show-option -pthread -fomit-frame-pointer -ffunction-sections -fdata-sections  -msse3 -fvisibility=hidden -fvisibility-inlines-hidden -fopenmp -g  -O0 -DDEBUG -D_DEBUG
    C Compiler:                  /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-wrapper-14.3.0/bin/gcc
    C flags (Release):           -fsigned-char -W -Wall -Wreturn-type -Waddress -Wsequence-point -Wformat -Wformat-security -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wundef -Winit-self -Wpointer-arith -Wshadow -Wuninitialized -Wno-comment -Wimplicit-fallthrough=3 -Wno-strict-overflow -fdiagnostics-show-option -pthread -fomit-frame-pointer -ffunction-sections -fdata-sections  -msse3 -fvisibility=hidden -fopenmp -O3 -DNDEBUG  -DNDEBUG
    C flags (Debug):             -fsigned-char -W -Wall -Wreturn-type -Waddress -Wsequence-point -Wformat -Wformat-security -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wundef -Winit-self -Wpointer-arith -Wshadow -Wuninitialized -Wno-comment -Wimplicit-fallthrough=3 -Wno-strict-overflow -fdiagnostics-show-option -pthread -fomit-frame-pointer -ffunction-sections -fdata-sections  -msse3 -fvisibility=hidden -fopenmp -g  -O0 -DDEBUG -D_DEBUG
    Linker flags (Release):      -Wl,--gc-sections -Wl,--as-needed -Wl,--no-undefined  
    Linker flags (Debug):        -Wl,--gc-sections -Wl,--as-needed -Wl,--no-undefined  
    ccache:                      NO
    Precompiled headers:         NO
    Extra dependencies:          m pthread cudart_static dl rt nppc nppial nppicc nppidei nppif nppig nppim nppist nppisu nppitc npps cublas cufft -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-cuda_cudart-12.8.90-static/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-glibc-2.40-66/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libnpp-12.3.3.100-lib/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libcublas-12.8.4.1-lib/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libcufft-11.3.3.83-lib/lib
    3rdparty dependencies:

  OpenCV modules:
    To be built:                 alphamat aruco bgsegm bioinspired calib3d ccalib core cudaarithm cudabgsegm cudacodec cudafeatures2d cudafilters cudaimgproc cudalegacy cudaobjdetect cudaoptflow cudastereo cudawarping cudev datasets dnn dnn_objdetect dnn_superres dpm face features2d flann fuzzy gapi hdf hfs highgui img_hash imgcodecs imgproc intensity_transform line_descriptor mcc ml objdetect optflow phase_unwrapping photo plot quality rapid reg rgbd saliency sfm shape signal stereo stitching structured_light superres surface_matching text tracking ts video videoio videostab wechat_qrcode xfeatures2d ximgproc xobjdetect xphoto
    Disabled:                    world
    Disabled by dependency:      -
    Unavailable:                 cannops cvv fastcv freetype java julia matlab ovis python2 python3 viz
    Applications:                tests apps
    Documentation:               NO
    Non-free algorithms:         NO

  GUI:                           NONE
    GTK+:                        NO
    VTK support:                 NO

  Media I/O: 
    ZLib:                        /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-zlib-1.3.1/lib/libz.so (ver 1.3.1)
    JPEG:                        /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libjpeg-turbo-3.1.1/lib/libjpeg.so (ver 62)
    WEBP:                        /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libwebp-1.6.0/lib/libwebp.so (ver decoder: 0x0210, encoder: 0x0210, demux: 0x0107)
    AVIF:                        NO
    PNG:                         /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libpng-apng-1.6.49/lib/libpng.so (ver 1.6.49)
    TIFF:                        (ver 42 / 4.7.0)
    JPEG 2000:                   OpenJPEG (ver 2.5.2)
    OpenEXR:                     OpenEXR-3_3 OpenEXRUtil-3_3 OpenEXRCore-3_3 Iex-3_3 IlmThread-3_3 Imath-3_2 (ver 3.3.5)
    GIF:                         YES
    HDR:                         YES
    SUNRASTER:                   YES
    PXM:                         YES
    PFM:                         YES

  Video I/O:
    FFMPEG:                      YES
      avcodec:                   YES (61.19.101)
      avformat:                  YES (61.7.100)
      avutil:                    YES (59.39.100)
      swscale:                   YES (8.3.100)
      avresample:                NO
    GStreamer:                   YES (1.26.5)
    v4l/v4l2:                    YES (linux/videodev2.h)

  Parallel framework:            OpenMP

  Trace:                         YES (with Intel ITT(3.25.4))

  Other third-party libraries:
    VA:                          YES
    Lapack:                      YES (/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-openblas-0.3.30/lib/libopenblas.so -lm -ldl)
    Eigen:                       YES (ver 3.4.0)
    Custom HAL:                  NO
    Protobuf:                    /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-protobuf-32.0/lib/libprotobuf.so.32.0.0 (32.0.0)
    Flatbuffers:                 builtin/3rdparty (23.5.9)

  NVIDIA CUDA:                   YES (ver 12.8, CUFFT CUBLAS FAST_MATH)
    NVIDIA GPU arch:             89
    NVIDIA PTX archs:            89

  OpenCL:                        YES (INTELVA)
    Include path:                /build/source/3rdparty/include/opencl/1.2
    Link libraries:              /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-ocl-icd-2.3.3/lib/libOpenCL.so

  Python (for build):            NO

  Java:                          
    ant:                         NO
    Java:                        NO
    JNI:                         NO
    Java wrappers:               NO
    Java tests:                  NO

  Install to:                    /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-opencv-4.12.0
-----------------------------------------------------------------

```

</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
