### PR TITLE
home-assistant-custom-components.hassio-ecoflow-cloud: init at 1.3.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/hassio-ecoflow-cloud/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/hassio-ecoflow-cloud/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  jsonpath-ng,
+  paho-mqtt,
+  protobuf,
+  nix-update-script,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "tolwi";
+  domain = "ecoflow_cloud";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "tolwi";
+    repo = "hassio-ecoflow-cloud";
+    tag = "v${version}";
+    hash = "sha256-CVm5+zLWN/ayhHRNFUr4PLwedwf4GJXvLOFgrh2qxAc=";
+  };
+
+  dependencies = [
+    jsonpath-ng
+    paho-mqtt
+    protobuf
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/tolwi/hassio-ecoflow-cloud/releases/tag/v${version}";
+    description = "Home Assistant component for EcoFlow Cloud";
+    homepage = "https://github.com/tolwi/hassio-ecoflow-cloud";
+    maintainers = with lib.maintainers; [ ananthb ];
+    # license = lib.licenses.asl20;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
