### PR TITLE
librepods: 0.1.0-unstable-2025-12-07 -> 0.2.0-alpha.2, nixos/librepods: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -257,6 +257,7 @@
   ./programs/lazygit.nix
   ./programs/less.nix
   ./programs/liboping.nix
+  ./programs/librepods.nix
   ./programs/lix.nix
   ./programs/localsend.nix
   ./programs/mdevctl.nix

--- a/nixos/modules/programs/librepods.nix
+++ b/nixos/modules/programs/librepods.nix
@@ -1,0 +1,42 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.librepods;
+in
+{
+  options = {
+    programs.librepods = {
+      enable = lib.mkOption {
+        default = false;
+        type = lib.types.bool;
+        description = ''
+          Whether to configure system to enable librepods.
+          To grant access to a user, it must be part of librepods group:
+          `users.users.alice.extraGroups = ["librepods"];`
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = with pkgs; [ librepods ];
+    users.groups.librepods = { };
+
+    security.wrappers.librepods = {
+      source = lib.getExe pkgs.librepods;
+      capabilities = "cap_net_admin+ep";
+      owner = "root";
+      group = "librepods";
+      permissions = "u+rx,g+x";
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    thefossguy
+    Cameo007
+  ];
+}

--- a/pkgs/by-name/li/librepods/package.nix
+++ b/pkgs/by-name/li/librepods/package.nix
@@ -42,6 +42,9 @@ stdenv.mkDerivation (finalAttrs: {
     description = "AirPods liberated from Apple's ecosystem";
     license = lib.licenses.gpl3;
     mainProgram = "librepods";
-    maintainers = [ lib.maintainers.thefossguy ];
+    maintainers = with lib.maintainers; [
+      thefossguy
+      Cameo007
+    ];
   };
 })

--- a/pkgs/by-name/li/librepods/package.nix
+++ b/pkgs/by-name/li/librepods/package.nix
@@ -9,15 +9,15 @@
   lib,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "librepods";
-  version = "0.1.0-unstable-2025-12-07";
+  version = "0.2.0-alpha.2";
 
   src = fetchFromGitHub {
     owner = "kavishdevar";
     repo = "librepods";
-    rev = "0e1f784737122913c21b429810d059aadfb4479e";
-    hash = "sha256-nXEMIyQWEDMjyKGPAleqqSttznNmrdSHKT4Kr2tLHBY=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-37dLiXC+eO4f5waLKgMMpHXH1m6W54O/l2axJsnyU5M=";
   };
 
   sourceRoot = "source/linux";
@@ -41,6 +41,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/kavishdevar/librepods";
     description = "AirPods liberated from Apple's ecosystem";
     license = lib.licenses.gpl3;
+    mainProgram = "librepods";
     maintainers = [ lib.maintainers.thefossguy ];
   };
-}
+})


### PR DESCRIPTION
Add librepods: `AirPods libreated from Apple's ecosystem.`

[https://github.com/kavishdevar/librepods](https://github.com/kavishdevar/librepods)

There is just one problem when running it.

```
qt.bluetooth.bluez: Missing CAP_NET_ADMIN permission. Cannot determine whether a found address is of random or public type.
```

Running librepods as root is a workaround for this but
1. I don't think you should need to run such an app as root
3. it doesn't work with `pactl`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
