### PR TITLE
maintainers: remove MGlolenstine

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16590,13 +16590,6 @@
     githubId = 71893;
     name = "Michael Maclean";
   };
-  mglolenstine = {
-    email = "mglolenstine@gmail.com";
-    github = "MGlolenstine";
-    githubId = 9406770;
-    matrix = "@mglolenstine:matrix.org";
-    name = "MGlolenstine";
-  };
   mgregoire = {
     email = "gregoire@martinache.net";
     github = "M-Gregoire";

--- a/pkgs/by-name/be/beebeep/package.nix
+++ b/pkgs/by-name/be/beebeep/package.nix
@@ -37,6 +37,6 @@ stdenv.mkDerivation rec {
     mainProgram = "beebeep";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ mglolenstine ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/ca/cargo-ndk/package.nix
+++ b/pkgs/by-name/ca/cargo-ndk/package.nix
@@ -25,6 +25,6 @@ rustPlatform.buildRustPackage rec {
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [ mglolenstine ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/fe/fermyon-spin/package.nix
+++ b/pkgs/by-name/fe/fermyon-spin/package.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = with licenses; [ asl20 ];
     mainProgram = "spin";
-    maintainers = with maintainers; [ mglolenstine ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/by-name/li/libaal/package.nix
+++ b/pkgs/by-name/li/libaal/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.namesys.com/";
     description = "Support library for Reiser4";
     license = lib.licenses.gpl2;
-    maintainers = with lib.maintainers; [ mglolenstine ];
+    maintainers = with lib.maintainers; [ ];
     platforms = with lib.platforms; linux;
   };
 }

--- a/pkgs/by-name/pi/picoprobe-udev-rules/package.nix
+++ b/pkgs/by-name/pi/picoprobe-udev-rules/package.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation {
     description = "Picoprobe udev rules list";
     platforms = platforms.linux;
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ mglolenstine ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/pi/pizarra/package.nix
+++ b/pkgs/by-name/pi/pizarra/package.nix
@@ -62,6 +62,6 @@ rustPlatform.buildRustPackage rec {
     '';
     homepage = "https://pizarra.categulario.xyz/en/";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ mglolenstine ];
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
Inactive on nixpkgs since April, despite 5 PRs requesting their review.

Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/tree/99b4fe0118ad739cbd4f9d60d76c020317908135/maintainers#losing-maintainer-status)

@MGlolenstine: if you'd like to stay involved, please respond to this PR within a week.
