### PR TITLE
garage-webui: init at 1.1.0

### DIFF
--- a/pkgs/by-name/ga/garage-webui/package.nix
+++ b/pkgs/by-name/ga/garage-webui/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  buildGoModule,
+  nodejs,
+  pnpm_9,
+  nix-update-script,
+}:
+let
+  pnpm = pnpm_9;
+in
+buildGoModule (finalAttrs: {
+  pname = "garage-webui";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "khairul169";
+    repo = "garage-webui";
+    tag = finalAttrs.version;
+    hash = "sha256-bqUAhZBSQkWZ1QsgPslEUDwt8NOg25Os0NGlPoyjPL4=";
+  };
+
+  frontend = stdenv.mkDerivation (finalAttrs': {
+    pname = "${finalAttrs.pname}-frontend";
+    inherit (finalAttrs) version src;
+
+    nativeBuildInputs = [
+      nodejs
+      pnpm.configHook
+    ];
+
+    pnpmDeps = pnpm.fetchDeps {
+      inherit (finalAttrs') pname version src;
+      fetcherVersion = 2;
+      hash = "sha256-8eQhR/fuDFNL8W529Ev7piCaseVaFahgZJQk3AJA3ng=";
+    };
+
+    buildPhase = ''
+      runHook preBuild
+      pnpm run build
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      cp -r dist $out/
+      runHook postInstall
+    '';
+  });
+
+  preBuild = ''
+    cp -r ${finalAttrs.frontend} ./ui/dist
+  '';
+
+  modRoot = "./backend";
+  tags = [ "prod" ];
+  env.CGO_ENABLED = 0;
+  vendorHash = "sha256-7z6r6w/SbBlYYHMxm11xFl/QEYZc2KebnOJZRgYRUYk=";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Simple admin web UI for Garage";
+    homepage = "https://github.com/khairul169/garage-webui";
+    changelog = "https://github.com/khairul169/garage-webui/releases/tag/${finalAttrs.version}";
+    mainProgram = "garage-webui";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ griffi-gh ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds the `garage-webui` package

https://github.com/khairul169/garage-webui
> A simple admin web UI for [Garage](https://garagehq.deuxfleurs.fr/), a self-hosted, S3-compatible, distributed object storage service.

I plan to follow this up by a NixOS module

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
