### PR TITLE
opencv: allow configuring LAPACK support

### DIFF
--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -35,6 +35,7 @@
   eigen,
   enableBlas ? true,
   blas,
+  enableLapack ? !stdenv.hostPlatform.isDarwin,
   enableVA ? !stdenv.hostPlatform.isDarwin,
   libva,
   enableContrib ? true,
@@ -483,6 +484,7 @@ effectiveStdenv.mkDerivation {
     (cmakeBool "WITH_OPENJPEG" enableJPEG2000)
     (cmakeBool "WITH_JASPER" false) # OpenCV falls back to a vendored copy of Jasper when OpenJPEG is disabled
     (cmakeBool "WITH_TBB" enableTbb)
+    (cmakeBool "WITH_LAPACK" enableLapack)
 
     # CUDA options
     (cmakeBool "WITH_CUDA" enableCuda)
@@ -518,7 +520,6 @@ effectiveStdenv.mkDerivation {
   ]
   ++ optionals effectiveStdenv.hostPlatform.isDarwin [
     (cmakeBool "WITH_OPENCL" false)
-    (cmakeBool "WITH_LAPACK" false)
 
     # Disable unnecessary vendoring that's enabled by default only for Darwin.
     # Note that the opencvFlag feature flags listed above still take


### PR DESCRIPTION
Originally required for OpenCV 4.9 (https://github.com/twistedfall/opencv-rust/issues/619), unclear if this is still relevant for releases after that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
