### PR TITLE
iconpack-obsidian: fix broken symlink

### DIFF
--- a/pkgs/by-name/ic/iconpack-obsidian/package.nix
+++ b/pkgs/by-name/ic/iconpack-obsidian/package.nix
@@ -31,6 +31,8 @@ stdenvNoCC.mkDerivation rec {
   dontDropIconThemeCache = true;
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/icons
     mv Obsidian* $out/share/icons
 
@@ -49,6 +51,8 @@ stdenvNoCC.mkDerivation rec {
       rm -f "$broken_symlink"
       ln -s "$target_svg" "$broken_symlink"
     fi
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/ic/iconpack-obsidian/package.nix
+++ b/pkgs/by-name/ic/iconpack-obsidian/package.nix
@@ -37,6 +37,18 @@ stdenvNoCC.mkDerivation rec {
     for theme in $out/share/icons/*; do
       gtk-update-icon-cache $theme
     done
+
+    # Fix broken symlink only if needed
+    # https://github.com/NixOS/nixpkgs/issues/394218
+
+    broken_symlink="$out/share/icons/Obsidian/actions/96/lock.svg"
+    target_svg="$out/share/icons/Obsidian/actions/scalable/system-lock-screen.svg"
+
+    if [ -h "$broken_symlink" ] && [ ! -e "$broken_symlink" ]; then
+      echo "=== Fixing broken symlink: $broken_symlink"
+      rm -f "$broken_symlink"
+      ln -s "$target_svg" "$broken_symlink"
+    fi
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/394218

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
