### PR TITLE
discord-rich-presence-plex: init at version 2.16.0

### DIFF
--- a/pkgs/by-name/di/discord-rich-presence-plex/package.nix
+++ b/pkgs/by-name/di/discord-rich-presence-plex/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  python3Packages,
+  python3,
+  fetchFromGitHub,
+  makeWrapper,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "discord-rich-presence-plex";
+  version = "2.16.0";
+  format = "other";
+  src = fetchFromGitHub {
+    owner = "phin05";
+    repo = "discord-rich-presence-plex";
+    tag = "v${version}";
+    hash = "sha256-e1r0w72IOEY5XsjANkAHbfPYEf1B8n6KYVLMWFSLs0g=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+  dontBuild = true;
+  dontUseSetuptoolsBuild = true;
+  dontUseSetuptoolsCheck = true;
+
+  dependencies = with python3Packages; [
+    requests
+    pillow
+    plexapi
+    pyyaml
+    websocket-client
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/discord-rich-presence-plex
+    cp -r * $out/lib/discord-rich-presence-plex/
+
+    mkdir -p $out/bin
+    makeWrapper ${lib.getExe python3} \
+      $out/bin/discord-rich-presence-plex \
+      --add-flags "$out/lib/discord-rich-presence-plex/main.py" \
+      --prefix PYTHONPATH : "$out/lib/discord-rich-presence-plex:$PYTHONPATH" \
+      --set DRPP_NO_PIP_INSTALL "true"
+
+    runHook postInstall
+  '';
+
+  # No tests
+  doCheck = false;
+
+  meta = {
+    homepage = "https://github.com/phin05/discord-rich-presence-plex";
+    changelog = "https://github.com/phin05/discord-rich-presence-plex/releases/tag/v${version}";
+    license = lib.licenses.gpl3Only;
+    description = "Displays your Plex status on Discord using Rich Presence";
+    maintainers = with lib.maintainers; [ hogcycle ];
+    mainProgram = "discord-rich-presence-plex";
+  };
+}


### PR DESCRIPTION
<!-- 
Initial commit for github.com/phin05/discord-rich-presence-plex, a tool using Discord RPC to display Plex's now playing status. 
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
