### PR TITLE
hx-lsp: init at 0.2.11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9889,6 +9889,12 @@
     githubId = 5190539;
     keys = [ { fingerprint = "AD3D 53CB A68A FEC0 8065  BCBB 416A D9E8 E372 C075"; } ];
   };
+  hadziqM = {
+    name = "Hadziq Masfuh";
+    email = "dimascrazz@gmail.com";
+    github = "HadziqM";
+    githubId = 50319538;
+  };
   hagl = {
     email = "harald@glie.be";
     github = "hagl";

--- a/pkgs/by-name/hx/hx-lsp/package.nix
+++ b/pkgs/by-name/hx/hx-lsp/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "hx-lsp";
+  version = "0.2.11";
+
+  src = fetchFromGitHub {
+    owner = "erasin";
+    repo = "hx-lsp";
+    tag = finalAttrs.version;
+    hash = "sha256-wTilbEK3BZehklAd+3SS2tW/vc8WEeMPUsYdDVRC/Ho=";
+  };
+
+  cargoHash = "sha256-dcGInrfWftClvzrxYZvrazm+IWWRfOZmxDJPKwu7GwM=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  meta = {
+    description = "LSP tool providing custom code snippets and Code Actions for Helix Editor";
+    homepage = "https://github.com/erasin/hx-lsp";
+    changelog = "https://github.com/erasin/hx-lsp/releases/tag/${finalAttrs.version}";
+    mainProgram = "hx-lsp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hadziqM ];
+  };
+})


### PR DESCRIPTION
Add hx-lsp 0.2.11, the LSP server snippet for Helix editor

hx-lsp provides language server functionality to use snippet for the Helix text editor.
Homepage: https://github.com/erasin/hx-lsp
License: MIT


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nix-build` locally, binary works (`./result/bin/hx-lsp --help`)
- Nixpkgs Release Notes
  - [ ] Package update: N/A (new package)
- NixOS Release Notes
  - [ ] Module addition: N/A
  - [ ] Module update: N/A
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

