### PR TITLE
nixos/virtualisation: add sharedDirectories.<name>.readOnly option

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -311,7 +311,17 @@ let
           concatStringsSep " \\\n    " (
             mapAttrsToList (
               tag: share:
-              "-virtfs local,path=${share.source},security_model=${share.securityModel},mount_tag=${tag}"
+              "-virtfs ${
+                lib.concatStrings (
+                  lib.intersperse "," [
+                    "local"
+                    "path=${share.source}"
+                    "security_model=${share.securityModel}"
+                    "mount_tag=${tag}"
+                    "readonly=${if share.readOnly then "on" else "off"}"
+                  ]
+                )
+              }"
             ) config.virtualisation.sharedDirectories
           )
         } \
@@ -551,6 +561,14 @@ in
               - `mapped-xattr`: some of the file attributes like uid, gid, mode bits and link target are stored as file attributes
               - `mapped-file`: the attributes are stored in the hidden .virtfs_metadata directory. Directories exported by this security model cannot interact with other unix tools
               - `none`: same as "passthrough" except the sever won't report failures if it fails to set file attributes like ownership
+            '';
+          };
+          options.readOnly = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              If the guest is disallowed from writing to the share.
+              The host is allowed to do so anyway, regardless of this setting.
             '';
           };
         }


### PR DESCRIPTION
To reduce bandwidth and/or enforce network isolation, a user may wish to clone and update large repositories on the host. However, since those repositories may still contain integral information or be accessed concurrently, the user may *also* desire to disallow the guest to write to the repository.

This is exactly what this option solves, assuming that QEMU is used. A practical application I had right now was for postmarketOS: Cloning [1] takes rather long on my machine, I don't want to duplicate it for every builder VM nor them to influence each other.

[1]: https://gitlab.postmarketos.org/postmarketOS/pmaports


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
