### PR TITLE
ocamlPackages.xtmpl: 0.19.0 → 1.1.0

### DIFF
--- a/pkgs/applications/misc/stog/default.nix
+++ b/pkgs/applications/misc/stog/default.nix
@@ -22,19 +22,18 @@
 
 buildDunePackage rec {
   pname = "stog";
-  version = "1.0.0";
+  version = "1.1.0";
   minimalOCamlVersion = "4.13";
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "zoggy";
     repo = "stog";
-    rev = version;
-    hash = "sha256-hMb6D6VSq2o2NjycwxZt3mZKy1FR+3afEwbOmTc991g=";
+    tag = version;
+    hash = "sha256-seaVco5AoOxjEuw8zYsrA25vcyo1Un3eUJUU9FT57WU=";
   };
 
   nativeBuildInputs = [ menhir ];
   buildInputs = [
-    fmt
     lwt_ppx
     ocf_ppx
     ppx_blob
@@ -43,11 +42,11 @@ buildDunePackage rec {
   propagatedBuildInputs = [
     dune-build-info
     dune-site
+    fmt
     higlo
     logs
     lwt
     ocf
-    ppx_blob
     ptime
     uri
     uutf

--- a/pkgs/development/ocaml-modules/xtmpl/default.nix
+++ b/pkgs/development/ocaml-modules/xtmpl/default.nix
@@ -3,6 +3,7 @@
   buildDunePackage,
   fetchFromGitLab,
   iri,
+  logs,
   re,
   sedlex,
   uutf,
@@ -10,18 +11,18 @@
 
 buildDunePackage rec {
   pname = "xtmpl";
-  version = "0.19.0";
-  duneVersion = "3";
+  version = "1.1.0";
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "zoggy";
     repo = "xtmpl";
-    rev = version;
-    sha256 = "sha256:0vwj0aayg60wm98d91fg3hmj90730liljy4cn8771dpxvz8m07bw";
+    tag = version;
+    hash = "sha256-CgVbSjHuRp+5IZdfkxGzaBP8p7pQdXu6S/MMgiPMw3E=";
   };
 
   propagatedBuildInputs = [
     iri
+    logs
     re
     sedlex
     uutf

--- a/pkgs/development/ocaml-modules/xtmpl/ppx.nix
+++ b/pkgs/development/ocaml-modules/xtmpl/ppx.nix
@@ -6,8 +6,6 @@
 
 buildDunePackage {
   pname = "xtmpl_ppx";
-  minimalOCamlVersion = "4.11";
-  duneVersion = "3";
 
   inherit (xtmpl) src version;
 


### PR DESCRIPTION
ocamlPackages.stog: 1.0.0 → 1.1.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
