### PR TITLE
nixos/music-assistant: librespot -> spotify

### DIFF
--- a/nixos/modules/services/audio/music-assistant.nix
+++ b/nixos/modules/services/audio/music-assistant.nix
@@ -84,7 +84,7 @@ in
         [
           lsof
         ]
-        ++ lib.optionals (lib.elem "librespot" cfg.providers) [
+        ++ lib.optionals (lib.elem "spotify" cfg.providers) [
           librespot
         ]
         ++ lib.optionals (lib.elem "snapcast" cfg.providers) [


### PR DESCRIPTION
There is no librespot provider. I think there was an oversight in the last commit.

This PR solves the config problem, but MA is still unable to locate librespot because of their binary finding logic: https://github.com/music-assistant/server/blob/072106e84839aecb57e0e9d9d4db4ba2ff8bf074/music_assistant/providers/spotify/helpers.py

So I created also this PR: https://github.com/music-assistant/server/pull/2409, but I see that we already had a patch to accomplish this, but you seem to have removed the content in your [last commit ](https://github.com/NixOS/nixpkgs/commit/9cc767c060f7016e0c58660dbf390e5ea2e2b931#diff-ba34669cfc8df8bcc99cf625f0e24044f67af9fe58d20d6e9f3452dfc9f6e663L1)  @mweinelt.

Edit:
They actually use their own version of librespot: https://github.com/music-assistant/librespot
We have to use theirs if we want the spotify integration to ever work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
