### PR TITLE
tbb_2022: unbreak build on non-x86/non-aarch64

### DIFF
--- a/pkgs/by-name/tb/tbb_2022/package.nix
+++ b/pkgs/by-name/tb/tbb_2022/package.nix
@@ -5,6 +5,7 @@
   cmake,
   ninja,
   ctestCheckHook,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -36,6 +37,25 @@ stdenv.mkDerivation (finalAttrs: {
     #
     # <https://github.com/uxlfoundation/oneTBB/pull/1849>
     ./fix-libtbbmalloc-dlopen.patch
+
+    # These two fix build errors outside of x86 and aarch64, one for gcc and one for clang:
+    #
+    # <https://github.com/uxlfoundation/oneTBB/pull/1768>
+    # <https://github.com/uxlfoundation/oneTBB/pull/1792>
+    #
+    # /nix/store/2hb2iha41g11y92c5w9yr7q5cp6hmyyv-riscv64-unknown-linux-gnu-gcc-wrapper-14.3.0/bin/riscv64-unknown-linux-gnu-g++ -D__TBB_BUILD -D__TBB_SKIP_DEPENDENCY_SIGNATURE_VERIFICATION=1 -I/build/source/src/tbb/../../include -O3 -DNDEBUG -std=c++11 -flto=auto -fno-fat-lto-objects -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -flifetime-dse=1 -Wall -Wextra -Werror -Wfatal-errors -fcf-protection=full -fstack-clash-protection -D__TBB_GNU_ASM_VERSION=2044 -fno-strict-overflow -fno-delete-null-pointer-checks -fwrapv -Wformat -Wformat-security -Werror=format-security -fstack-protector-strong -D_FORTIFY_SOURCE=2 -ffile-prefix-map=/build/source/= -ffile-prefix-map=..//= -MD -MT src/tbb/CMakeFiles/tbb.dir/governor.cpp.o -MF src/tbb/CMakeFiles/tbb.dir/governor.cpp.o.d -o src/tbb/CMakeFiles/tbb.dir/governor.cpp.o -c /build/source/src/tbb/governor.cpp
+    # cc1plus: error: '-fcf-protection=full' is not supported for this target
+    # compilation terminated due to -Wfatal-errors.
+    #
+    # Remove these when updating to a new release of TBB.
+    (fetchpatch {
+      url = "https://github.com/uxlfoundation/oneTBB/commit/65d46656f56200a7e89168824c4dbe4943421ff9.patch";
+      hash = "sha256-hhHDuvUsWSqs7AJ5smDYUP1yYZmjV2VISBeKHcFAfG4=";
+    })
+    (fetchpatch {
+      url = "https://github.com/uxlfoundation/oneTBB/commit/e57411968661ab1205322ba1c84fc1cd90a306c6.patch";
+      hash = "sha256-PFixW4lYqA5oy4LSwewvxgJbjVKJceRHnp8mgW9zBF0=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
TBB has added hardening options that only work on x86_64 and aarch64 to all platforms, leading to compile failures like:

```
/nix/store/2hb2iha41g11y92c5w9yr7q5cp6hmyyv-riscv64-unknown-linux-gnu-gcc-wrapper-14.3.0/bin/riscv64-unknown-linux-gnu-g++ -D__TBB_BUILD -D__TBB_SKIP_DEPENDENCY_SIGNATURE_VERIFICATION=1 -I/build/source/src/tbb/../../include -O3 -DNDEBUG -std=c++11 -flto=auto -fno-fat-lto-objects -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -flifetime-dse=1 -Wall -Wextra -Werror -Wfatal-errors -fcf-protection=full -fstack-clash-protection -D__TBB_GNU_ASM_VERSION=2044 -fno-strict-overflow -fno-delete-null-pointer-checks -fwrapv -Wformat -Wformat-security -Werror=format-security -fstack-protector-strong -D_FORTIFY_SOURCE=2 -ffile-prefix-map=/build/source/= -ffile-prefix-map=..//= -MD -MT src/tbb/CMakeFiles/tbb.dir/governor.cpp.o -MF src/tbb/CMakeFiles/tbb.dir/governor.cpp.o.d -o src/tbb/CMakeFiles/tbb.dir/governor.cpp.o -c /build/source/src/tbb/governor.cpp cc1plus: error: '-fcf-protection=full' is not supported for this target compilation terminated due to -Wfatal-errors.
```

This PR cherry-picks the upstream patches for it into the release build.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] riscv64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
