### PR TITLE
linuxManualConfig: Handle only y and m in readConfig, plus one minor fix

### DIFF
--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -32,24 +32,18 @@ let
 
   readConfig =
     configfile:
-    lib.listToAttrs (
-      map
-        (
-          line:
-          let
-            match = lib.match "(.*)=\"?(.*)\"?" line;
-          in
-          {
-            name = lib.elemAt match 0;
-            value = lib.elemAt match 1;
-          }
-        )
-        (
-          lib.filter (line: !(lib.hasPrefix "#" line || line == "")) (
-            lib.splitString "\n" (builtins.readFile configfile)
-          )
-        )
-    );
+    let
+      matchLine =
+        line:
+        let
+          match = lib.match "(CONFIG_[^=]+)=([ym])" line;
+        in
+        lib.optional (match != null) {
+          name = lib.elemAt match 0;
+          value = lib.elemAt match 1;
+        };
+    in
+    lib.listToAttrs (lib.concatMap matchLine (lib.splitString "\n" (builtins.readFile configfile)));
 in
 lib.makeOverridable (
   {

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -819,7 +819,7 @@ in
       src,
       modDirVersion ? lib.versions.pad 3 version,
       configfile,
-      allowImportFromDerivation ? true,
+      allowImportFromDerivation ? false,
     }:
     recurseIntoAttrs (
       packagesFor (manualConfig {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Parsing Linux `.config` is hard. See discussion in #302802 and #434608.

We can avoid almost all of the work and cover all in-Nixpkgs usages by only ever parsing `y` and `m` values. (`n` shows up as `# CONFIG_FOO is not set`, which then does not show up in the attrset. Nobody has complained about this.)

While this is a breaking change, I think this is obscure enough that nobody is relying on the behavior for types other than `bool` and `tristate`.

This should be 0 rebuilds.

While we're at this, have `allowImportFromDerivation` default to `false` in `linuxPackages_custom`. Originally, I thought the docs need updating to remove mentions of `allowImportFromDerivation`, but apparently it's already gone.

cc @jmbaur current `readConfig` author

cc @tpwrules

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
