### PR TITLE
collision: 3.10.0 -> 3.11.0

### DIFF
--- a/pkgs/by-name/co/collision/package.nix
+++ b/pkgs/by-name/co/collision/package.nix
@@ -21,13 +21,13 @@
 
 crystal.buildCrystalPackage rec {
   pname = "Collision";
-  version = "3.10.0";
+  version = "3.11.0";
 
   src = fetchFromGitHub {
     owner = "GeopJr";
     repo = "Collision";
     rev = "v${version}";
-    hash = "sha256-ZXGhMicwlkXUw8I6HUNVxY4vCaVixdV76+wYn34Py6Q=";
+    hash = "sha256-OCFy7DFSRsqiw+b6zlJy9Us44zQXf150zVDu3GmclOk=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/co/collision/shards.nix
+++ b/pkgs/by-name/co/collision/shards.nix
@@ -1,40 +1,35 @@
 {
-  blake3 = {
+  "blake3" = {
     url = "https://github.com/geopjr/blake3.cr.git";
     rev = "v1.4.0";
     sha256 = "1kp3rqddcsjj15syfnfvsx694nmpjzxmgawnf7y7dxdakk3przlw";
   };
-  gettext = {
+  "gettext" = {
     url = "https://github.com/geopjr/gettext.cr.git";
     rev = "v1.0.0";
     sha256 = "1y27m4170rr4532j56grzhwbz8hj6z7j3zfkd0jnfwnsxclks1kc";
   };
-  gi-crystal = {
+  "gi-crystal" = {
     url = "https://github.com/hugopl/gi-crystal.git";
     rev = "v0.25.0";
     sha256 = "0lgs85khg6yzmw7vnkjxygrga1618440hayjc51jmjcfh2lff1k2";
   };
-  gtk4 = {
+  "gtk4" = {
     url = "https://github.com/hugopl/gtk4.cr.git";
     rev = "v0.17.0";
     sha256 = "0lv3nvsanxi4g2322zvkf1jxx5zgzaapk228vcw2cl0ja1drm06d";
   };
-  harfbuzz = {
+  "harfbuzz" = {
     url = "https://github.com/hugopl/harfbuzz.cr.git";
-    rev = "v0.2.0";
-    sha256 = "06wgqxwyib5416yp53j2iwcbr3bl4jjxb1flm7z103l365par694";
+    rev = "v0.2.1";
+    sha256 = "08zx5q1mm1h4lzfr38dk8nk7mx1y955zdjl6n48rl619bc1ywdpg";
   };
-  libadwaita = {
+  "libadwaita" = {
     url = "https://github.com/hugopl/libadwaita.cr.git";
     rev = "v0.1.0";
     sha256 = "13iqij1rwqdlsd9gls3gz4i4frlsda3yasdbbmrzpa8d3qm3p8yq";
   };
-  non-blocking-spawn = {
-    url = "https://github.com/geopjr/non-blocking-spawn.git";
-    rev = "v1.1.0";
-    sha256 = "1h43gskannylaai4dz2sjb6rds2h6slm1krg88inan12silhp66c";
-  };
-  pango = {
+  "pango" = {
     url = "https://github.com/hugopl/pango.cr.git";
     rev = "v0.3.1";
     sha256 = "0xlf127flimnll875mcq92q7xsi975rrgdpcpmnrwllhdhfx9qmv";


### PR DESCRIPTION
## Things done
Changelog: https://github.com/GeopJr/Collision/releases/tag/v3.11.0
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
