### PR TITLE
coq-lsp: init at 0.2.3+8.17

### DIFF
--- a/pkgs/by-name/co/coq-lsp/package.nix
+++ b/pkgs/by-name/co/coq-lsp/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
       error reporting, completion, and incremental compilation for Coq files.
     '';
     homepage = "https://github.com/ejgallego/coq-lsp";
-    changelog = "https://github.com/ejgallego/coq-lsp/blob/0.2.3+8.20/CHANGES.md";
+    changelog = "https://github.com/ejgallego/coq-lsp/blob/${finalAttrs.src.rev}/CHANGES.md";
     license = licenses.lgpl21Only;
     maintainers = with maintainers; [ thomasjm ];
     platforms = platforms.unix;

--- a/pkgs/by-name/co/coq-lsp/package.nix
+++ b/pkgs/by-name/co/coq-lsp/package.nix
@@ -70,4 +70,4 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = platforms.unix;
     mainProgram = "coq-lsp";
   };
-}
+})

--- a/pkgs/by-name/co/coq-lsp/package.nix
+++ b/pkgs/by-name/co/coq-lsp/package.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   coq_8_20,
   makeWrapper,
-  ocamlPackages,
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/by-name/co/coq-lsp/package.nix
+++ b/pkgs/by-name/co/coq-lsp/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  coq_8_20,
+  makeWrapper,
+  ocamlPackages,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "coq-lsp";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "ejgallego";
+    repo = "coq-lsp";
+    rev = "0.2.3+8.20";
+    hash = "sha256-TUVS8jkgf1MMOOx5y70OaeZkdIgdgmyGQ2/zKxeplEk=";
+  };
+
+  nativeBuildInputs = with coq_8_20.ocamlPackages; [
+    ocaml
+    dune_3
+    findlib
+    makeWrapper
+  ];
+
+  buildInputs = [
+    coq_8_20
+  ]
+  ++ (with coq_8_20.ocamlPackages; [
+    cmdliner
+    dune-build-info
+    menhir
+    ppx_compare
+    ppx_deriving
+    ppx_deriving_yojson
+    ppx_hash
+    ppx_import
+    ppx_sexp_conv
+    result
+    sexplib
+    uri
+    yojson
+  ]);
+
+  buildPhase = ''
+    runHook preBuild
+    dune build -p ${pname} @install
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    dune install -p ${pname} --prefix=$out --libdir $OCAMLFIND_DESTDIR
+    wrapProgram $out/bin/coq-lsp --prefix OCAMLPATH : $OCAMLPATH --prefix PATH : ${lib.makeBinPath [ coq_8_20 ]}
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Language Server Protocol implementation for Coq";
+    longDescription = ''
+      coq-lsp is a Language Server Protocol (LSP) implementation for the Coq
+      proof assistant. It provides modern IDE features like syntax highlighting,
+      error reporting, completion, and incremental compilation for Coq files.
+    '';
+    homepage = "https://github.com/ejgallego/coq-lsp";
+    changelog = "https://github.com/ejgallego/coq-lsp/blob/0.2.3+8.20/CHANGES.md";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ thomasjm ];
+    platforms = platforms.unix;
+    mainProgram = "coq-lsp";
+  };
+}

--- a/pkgs/by-name/co/coq-lsp/package.nix
+++ b/pkgs/by-name/co/coq-lsp/package.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Language Server Protocol implementation for Coq";
     longDescription = ''
       coq-lsp is a Language Server Protocol (LSP) implementation for the Coq

--- a/pkgs/by-name/co/coq-lsp/package.nix
+++ b/pkgs/by-name/co/coq-lsp/package.nix
@@ -6,7 +6,7 @@
   makeWrapper,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "coq-lsp";
   version = "0.2.3";
 


### PR DESCRIPTION
This is packaging [coq-lsp](https://github.com/ejgallego/coq-lsp/), an LSP server to Coq/Rocq.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
