### PR TITLE
audit: remove bash

### DIFF
--- a/nixos/modules/security/auditd.nix
+++ b/nixos/modules/security/auditd.nix
@@ -259,9 +259,6 @@ in
     systemd.tmpfiles.packages = [ pkgs.audit.out ];
     systemd.packages = [ pkgs.audit.out ];
 
-    # will try to look in /etc for rules to load, which we don't set up
-    systemd.services.audit-rules.enable = lib.mkDefault false;
-
     systemd.services.auditd = {
       wantedBy = [ "multi-user.target" ];
 

--- a/nixos/modules/security/auditd.nix
+++ b/nixos/modules/security/auditd.nix
@@ -256,15 +256,18 @@ in
       };
     };
 
-    systemd.tmpfiles.packages = [ pkgs.audit.out ];
     systemd.packages = [ pkgs.audit.out ];
 
     systemd.services.auditd = {
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {
+        # https://github.com/linux-audit/audit-userspace/pull/501
+        # set up audit directories using systemd service instead of tmpfiles
         LogsDirectory = "audit";
+        LogsDirectoryMode = "0700";
         RuntimeDirectory = "audit";
+        RuntimeDirectoryMode = "0755";
         ExecStart = [
           # the upstream unit does not allow symlinks, so clear and rewrite the ExecStart
           ""

--- a/pkgs/by-name/au/audit/package.nix
+++ b/pkgs/by-name/au/audit/package.nix
@@ -114,6 +114,9 @@ stdenv.mkDerivation (finalAttrs: {
     installShellCompletion --bash init.d/audit.bash_completion
   '';
 
+  # audit-rules.service relies on augenrules, and is not useful on a nixos system.
+  # It is intended to collect rule files from /etc/audit/rules.d, which we don't set up.
+  # Instead, we load audit rules in a dedicated module.
   postFixup = ''
     substituteInPlace $bin/bin/augenrules \
       --replace-fail "/sbin/auditctl -R" "$bin/bin/auditctl -R" \
@@ -127,6 +130,8 @@ stdenv.mkDerivation (finalAttrs: {
           coreutils
         ]
       }
+
+      rm $out/lib/systemd/system/audit-rules.service
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/au/audit/package.nix
+++ b/pkgs/by-name/au/audit/package.nix
@@ -116,7 +116,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   postFixup = ''
     substituteInPlace $bin/bin/augenrules \
-      --replace-fail "/sbin/auditctl" "$bin/bin/auditctl" \
+      --replace-fail "/sbin/auditctl -R" "$bin/bin/auditctl -R" \
+      --replace-fail "auditctl -s" "$bin/bin/auditctl -s" \
       --replace-fail "/bin/ls" "ls"
     wrapProgram $bin/bin/augenrules \
       --prefix PATH : ${


### PR DESCRIPTION
Remove bash from audit, even if `services.auditd` is enabled.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
