### PR TITLE
whdd: init at 3.1

### DIFF
--- a/pkgs/by-name/wh/whdd/package.nix
+++ b/pkgs/by-name/wh/whdd/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeWrapper,
+  pkg-config,
+  ncurses,
+  dialog,
+  coreutils,
+  gawk,
+  gnugrep,
+  smartmontools,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "whdd";
+  version = "3.1";
+
+  src = fetchFromGitHub {
+    owner = "whdd";
+    repo = "whdd";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-cwaWI3dvjaOgBRlJcxioFb9Xjdv45XmQ71EgCvuArdo=";
+  };
+
+  buildInputs = [
+    dialog
+    ncurses
+  ];
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+
+  enableParallelBuilding = true;
+  strictDeps = true;
+
+  installFlags = [ "DESTDIR=${placeholder "out"}" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/whdd \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          smartmontools
+          gnugrep
+          gawk
+          coreutils
+        ]
+      }
+  '';
+
+  meta = {
+    homepage = "https://whdd.github.io/";
+    description = "HDD diagnostic and data recovery tool for Linux";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    mainProgram = "whdd";
+    maintainers = [ lib.maintainers.hehongbo ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[WHDD](https://github.com/whdd/whdd), as their description said, is an "HDD diagnostic and data recovery tool for Linux".

Many retro hardware users may remember MHDD on MS-DOS. WHDD is inspired by MHDD — essentially a modern Linux clone — but without DOS limitations such as the 2 TB disk capacity cap. It supports modern protocols and provides detailed, sensitive measurements of read/write times for each LBA. With this information, you can assess how much a disk has aged and whether it’s still trustworthy for storing data.

For the most accurate scanning results, it’s recommended to close as many running programs as possible.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
