### PR TITLE
nixos/netbird: automated login using Setup Keys file

### DIFF
--- a/nixos/modules/services/networking/netbird.nix
+++ b/nixos/modules/services/networking/netbird.nix
@@ -20,6 +20,7 @@ let
     mapAttrsToList
     mkAliasOptionModule
     mkDefault
+    mkEnableOption
     mkIf
     mkMerge
     mkOption
@@ -31,6 +32,7 @@ let
     optionalAttrs
     optionalString
     optionals
+    pipe
     toShellVars
     versionAtLeast
     versionOlder
@@ -40,6 +42,7 @@ let
     attrsOf
     bool
     enum
+    listOf
     nullOr
     package
     path
@@ -220,6 +223,26 @@ in
 
                   As of 2024-02-13 it is not possible to start a NetBird client daemon without immediately
                   connecting to the network, but it is [planned for a near future](https://github.com/netbirdio/netbird/projects/2#card-91718018).
+                '';
+              };
+
+              login.enable = mkEnableOption "automated login for NetBird client";
+              login.setupKeyFile = mkOption {
+                type = nullOr str;
+                default = null;
+                example = "/run/secrets/netbird-priv/setup-key";
+                description = ''
+                  A Setup Key file path used for automated login of the machine.
+                '';
+              };
+              login.systemdDependencies = mkOption {
+                type = listOf str;
+                default = [ ];
+                example = lib.literalExpression ''
+                  [ "sops-install-secrets.service" ]
+                '';
+                description = ''
+                  Additional systemd dependencies required to succeed before the Setup Key file becomes available.
                 '';
               };
 
@@ -645,6 +668,71 @@ in
         });
       '';
     })
+    # Setup Keys login automation
+    {
+      systemd.services = pipe cfg.clients [
+        (filterAttrs (_: client: client.login.enable))
+        (mapAttrs' (
+          _: client:
+          nameValuePair "${client.service.name}-login" {
+            after = [ "${client.service.name}.service" ] ++ client.login.systemdDependencies;
+            requires = [ "${client.service.name}.service" ] ++ client.login.systemdDependencies;
+            wantedBy = [ "${client.service.name}.service" ];
+
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+
+              User = client.user.name;
+              Group = client.user.group;
+
+              RemoveIPC = true;
+              PrivateTmp = "disconnected"; # "disconnected" puts /tmp on `tmpfs`
+              ProtectSystem = "strict";
+              ProtectHome = "yes";
+
+              LoadCredential = [ "setup-key:${client.login.setupKeyFile}" ];
+            };
+
+            environment.NB_SETUP_KEY_FILE = "%d/setup-key";
+            /*
+              might want to do something similar to the docker entrypoint (watching log messages) instead
+              see https://github.com/netbirdio/netbird/blob/dc30dcacce4c322502975f1f491e6774efd7e1e9/client/netbird-entrypoint.sh
+            */
+            script = ''
+              set -x
+              # uses a file on a `tmpfs`, because variable updates get lost in the loop
+              status_file="/tmp/status.txt"
+
+              refresh_status() {
+                '${lib.getExe client.wrapper}' status &>"$status_file" || :
+              }
+
+              print_short_setup_key() {
+                cut -b1-8 <"$NB_SETUP_KEY_FILE"
+              }
+
+              main() {
+                refresh_status
+                <"$status_file" sed 's/^/STATUS:PRE-CONNECT : /g'
+
+                until refresh_status && <"$status_file" grep --quiet 'Connected\|NeedsLogin' ; do
+                  sleep 1
+                done
+                <"$status_file" sed 's/^/STATUS:POST-CONNECT: /g'
+
+                if <"$status_file" grep --quiet 'NeedsLogin' ; then
+                  echo "Using Setup Key File with key: $(print_short_setup_key)" >&2
+                  '${lib.getExe client.wrapper}' up --setup-key-file="$NB_SETUP_KEY_FILE"
+                fi
+              }
+
+              main "$@"
+            '';
+          }
+        ))
+      ];
+    }
     # migration & temporary fixups section
     {
       systemd.services = toClientAttrs (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I noticed some people are misusing the Setup Key feature by pulling it into `/nix/store`, thought I would upstream my setup for automated handling of Setup Keys.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
