### PR TITLE
fava: 1.30.5 -> 1.30.6

### DIFF
--- a/pkgs/by-name/fa/fava/package.nix
+++ b/pkgs/by-name/fa/fava/package.nix
@@ -8,17 +8,17 @@
 let
   src = buildNpmPackage (finalAttrs: {
     pname = "fava-frontend";
-    version = "1.30.5";
+    version = "1.30.6";
 
     src = fetchFromGitHub {
       owner = "beancount";
       repo = "fava";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-46ze+1sdgXq9Unhu1ec4buXbH3s/PCcfCx+rmYc+fZw=";
+      hash = "sha256-AMbKGIfR/URu7RpyBKSR3lzfIliRWjnUNNjLvu9KmfM=";
     };
     sourceRoot = "${finalAttrs.src.name}/frontend";
 
-    npmDepsHash = "sha256-ImBNqccAd61c9ASzklcooQyh7BYdgJW9DTcQRmFHqho=";
+    npmDepsHash = "sha256-geou0+Ges0jjrlXG9m3u1GMdf0Qt2pTd8vRGh9gAWJ4=";
     makeCacheWritable = true;
 
     preBuild = ''
@@ -34,7 +34,7 @@ let
 in
 python3Packages.buildPythonApplication {
   pname = "fava";
-  version = "1.30.5";
+  version = "1.30.6";
   pyproject = true;
 
   inherit src;


### PR DESCRIPTION
Update fava to a new upstream version
Broken tests are caused by beanquery and fixed in https://github.com/NixOS/nixpkgs/pull/444290

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
