### PR TITLE
fetchurl: reuse lib.normalizeHashes

### DIFF
--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -2,7 +2,7 @@
 { lib }:
 let
   commonH = hashTypes: rec {
-    hashNames = [ "hash" ] ++ hashTypes;
+    hashNames = lib.unique ([ "hash" ] ++ hashTypes);
     hashSet = lib.genAttrs hashNames (lib.const { });
   };
 
@@ -75,7 +75,7 @@ rec {
 
     # Type
     ```
-    normalizeHash :: { hashTypes :: List String, required :: Bool } -> AttrSet -> AttrSet
+    normalizeHash :: { hashTypes :: List String, required :: Bool, fetcher :: String } -> AttrSet -> AttrSet
     ```
 
     # Arguments
@@ -85,10 +85,14 @@ rec {
 
     required
     : whether to throw if no hash was present in the input; otherwise returns the original input, unmodified
+
+    fetcher
+    : the name of the fetcher, possibly with other details such as the URL, for use in error messages and warnings
   */
   normalizeHash =
     {
       hashTypes ? [ "sha256" ],
+      fetcher ? "fetcher",
       required ? true,
     }:
     let
@@ -104,6 +108,7 @@ rec {
         intersectAttrs
         removeAttrs
         optionalAttrs
+        attrNames
         ;
 
       inherit (commonH hashTypes) hashNames hashSet;
@@ -120,9 +125,11 @@ rec {
             hashesAsNVPairs = attrsToList (intersectAttrs hashSet args);
           in
           if hashesAsNVPairs == [ ] then
-            throwIf required "fetcher called without `hash`" null
+            throwIf required "${fetcher} called without a required hash argument (pass one of ${
+              concatMapStringsSep ", " (a: "`${a}`") hashNames
+            })" null
           else if tail hashesAsNVPairs != [ ] then
-            throw "fetcher called with mutually-incompatible arguments: ${
+            throw "${fetcher} called with mutually-incompatible arguments: ${
               concatMapStringsSep ", " (a: a.name) hashesAsNVPairs
             }"
           else
@@ -134,9 +141,13 @@ rec {
         outputHash =
           if h.value == "" then
             let
-              fakeHash = fakeH.${h.name} or (throw "no “fake hash” defined for ${h.name}");
+              fakeHash =
+                fakeH.${h.name}
+                  or (throw "${fetcher}: no “fake hash” defined for hash algorithm ${h.name}; pass in a real hash or try one of ${
+                    concatMapStringsSep ", " (a: "`${a}`") (attrNames fakeH)
+                  }");
             in
-            warn "found empty ${h.name}, assuming '${fakeHash}'" fakeHash
+            warn "${fetcher}: found empty ${h.name}, assuming '${fakeHash}'" fakeHash
           else
             h.value;
       });

--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -97,6 +97,7 @@ rec {
         head
         tail
         throwIf
+        warn
         ;
       inherit (lib.attrsets)
         attrsToList
@@ -132,7 +133,10 @@ rec {
         outputHashAlgo = if h.name == "hash" then null else h.name;
         outputHash =
           if h.value == "" then
-            fakeH.${h.name} or (throw "no “fake hash” defined for ${h.name}")
+            let
+              fakeHash = fakeH.${h.name} or (throw "no “fake hash” defined for ${h.name}");
+            in
+            warn "found empty ${h.name}, assuming '${fakeHash}'" fakeHash
           else
             h.value;
       });


### PR DESCRIPTION
- **fetchurl: re-use lib.normalizeHashes**

  Reuses the normalizeHashes function instead of reimplementing it.

  I've tested this manually and the behaviour seems to be the same.
- **normalizeHash: trace when a fake hash is assumed**
  Needed to keep the neat trace when only empty hashes are passed.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
