### PR TITLE
libbgcode: enable tests

### DIFF
--- a/pkgs/by-name/li/libbgcode/package.nix
+++ b/pkgs/by-name/li/libbgcode/package.nix
@@ -9,7 +9,7 @@
   boost,
   catch2_3,
 }:
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libbgcode";
   version = "0-unstable-2025-02-19";
 
@@ -29,7 +29,16 @@ stdenv.mkDerivation {
     heatshrink
     zlib
     boost
+  ];
+
+  checkInputs = [
     catch2_3
+  ];
+
+  doCheck = true;
+
+  cmakeFlags = [
+    (lib.cmakeBool "LibBGCode_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   meta = with lib; {
@@ -40,4 +49,4 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ lach ];
     platforms = platforms.unix;
   };
-}
+})


### PR DESCRIPTION
With this change, unit tests are run. Previously they were not.
The cmakeFlags are needed to make the cross build work.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test