### PR TITLE
rerun: 0.24.1 -> 0.25.1

### DIFF
--- a/pkgs/by-name/re/rerun/package.nix
+++ b/pkgs/by-name/re/rerun/package.nix
@@ -34,13 +34,13 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rerun";
-  version = "0.24.1";
+  version = "0.25.1";
 
   src = fetchFromGitHub {
     owner = "rerun-io";
     repo = "rerun";
     tag = finalAttrs.version;
-    hash = "sha256-unPgvQcYhshdx5NGCl/pLh8UdJ9T6B8Fd0s8G1NSBmE=";
+    hash = "sha256-YppVNVfVqOATLCoUvpeYYrhivKBb6f4G1JCG1Bl+cjc=";
   };
 
   # The path in `build.rs` is wrong for some reason, so we patch it to make the passthru tests work
@@ -49,7 +49,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail '"rerun_sdk/rerun_cli/rerun"' '"rerun_sdk/rerun"'
   '';
 
-  cargoHash = "sha256-zdq8djnmH8srSd9sml7t6wsbxpTaT3x5/7hkDRgelbg=";
+  cargoHash = "sha256-jUn7b6t5hS7KjdymxTTP8mKLT671QgKrv7R9uiOkmJU=";
 
   cargoBuildFlags = [ "--package rerun-cli" ];
   cargoTestFlags = [ "--package rerun-cli" ];

--- a/pkgs/development/python-modules/datafusion/default.nix
+++ b/pkgs/development/python-modules/datafusion/default.nix
@@ -1,40 +1,28 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   rustPlatform,
-  pytestCheckHook,
-  libiconv,
-  numpy,
-  protobuf,
+
+  # nativeBuildInputs
   protoc,
+
+  # buildInputs
+  protobuf,
+
+  # dependencies
   pyarrow,
   typing-extensions,
-  pythonOlder,
+
+  # tests
+  numpy,
+  pytest-asyncio,
+  pytestCheckHook,
 }:
-
-let
-  arrow-testing = fetchFromGitHub {
-    name = "arrow-testing";
-    owner = "apache";
-    repo = "arrow-testing";
-    rev = "4d209492d514c2d3cb2d392681b9aa00e6d8da1c";
-    hash = "sha256-IkiCbuy0bWyClPZ4ZEdkEP7jFYLhM7RCuNLd6Lazd4o=";
-  };
-
-  parquet-testing = fetchFromGitHub {
-    name = "parquet-testing";
-    owner = "apache";
-    repo = "parquet-testing";
-    rev = "50af3d8ce206990d81014b1862e5ce7380dc3e08";
-    hash = "sha256-edyv/r5olkj09aHtm8LHZY0b3jUtLNUcufwI41qKYaY=";
-  };
-in
 
 buildPythonPackage rec {
   pname = "datafusion";
-  version = "40.1.0";
+  version = "48.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -42,13 +30,14 @@ buildPythonPackage rec {
     owner = "apache";
     repo = "arrow-datafusion-python";
     tag = version;
-    hash = "sha256-5WOSlx4XW9zO6oTY16lWQElShLv0ubflVPfSSEGrFgg=";
+    # Fetch arrow-testing and parquet-testing (tests assets)
+    fetchSubmodules = true;
+    hash = "sha256-9IOkb31f4nFo9mWTr+z5ZG8xSXIZSgW3vCBgLaGxpfI=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    name = "datafusion-cargo-deps";
-    inherit src;
-    hash = "sha256-xUpchV4UFEX1HkCpClOwxnEfGLVlOIX4UmzYKiUth9U=";
+    inherit pname src version;
+    hash = "sha256-P9NFvhHAGgYIi36CHEPZPr8hmMNp5zrCcmE7NHx51k4=";
   };
 
   nativeBuildInputs = with rustPlatform; [
@@ -59,9 +48,6 @@ buildPythonPackage rec {
 
   buildInputs = [
     protobuf
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    libiconv
   ];
 
   dependencies = [
@@ -70,28 +56,26 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    pytestCheckHook
     numpy
+    pytest-asyncio
+    pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "datafusion" ];
-
-  pytestFlags = [
-    "--pyargs"
-    pname
+  pythonImportsCheck = [
+    "datafusion"
+    "datafusion._internal"
   ];
 
   preCheck = ''
-    pushd $TMPDIR
-    ln -s ${arrow-testing} ./testing
-    ln -s ${parquet-testing} ./parquet
+    rm -rf python/datafusion
   '';
 
-  postCheck = ''
-    popd
-  '';
+  disabledTests = [
+    # Exception: DataFusion error (requires internet access)
+    "test_register_http_csv"
+  ];
 
-  meta = with lib; {
+  meta = {
     description = "Extensible query execution framework";
     longDescription = ''
       DataFusion is an extensible query execution framework, written in Rust,
@@ -99,7 +83,7 @@ buildPythonPackage rec {
     '';
     homepage = "https://arrow.apache.org/datafusion/";
     changelog = "https://github.com/apache/arrow-datafusion-python/blob/${version}/CHANGELOG.md";
-    license = with licenses; [ asl20 ];
-    maintainers = with maintainers; [ cpcloud ];
+    license = with lib.licenses; [ asl20 ];
+    maintainers = with lib.maintainers; [ cpcloud ];
   };
 }

--- a/pkgs/development/python-modules/rerun-sdk/default.nix
+++ b/pkgs/development/python-modules/rerun-sdk/default.nix
@@ -18,6 +18,7 @@
   typing-extensions,
 
   # tests
+  datafusion,
   pytestCheckHook,
   torch,
 }:
@@ -64,6 +65,7 @@ buildPythonPackage {
   pythonImportsCheck = [ "rerun" ];
 
   nativeCheckInputs = [
+    datafusion
     pytestCheckHook
     torch
   ];
@@ -74,6 +76,9 @@ buildPythonPackage {
   disabledTestPaths = [
     # "fixture 'benchmark' not found"
     "tests/python/log_benchmark/test_log_benchmark.py"
+
+    # ConnectionError: Connection error: transport error
+    "rerun_py/tests/unit/test_datafusion_tables.py"
   ];
 
   meta = {


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/rerun-io/rerun/compare/0.24.1...0.25.1
Changelog: https://github.com/rerun-io/rerun/blob/0.25.1/CHANGELOG.md

cc @SomeoneSerge @robwalt


- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc