### PR TITLE
godot: fix obj being copied to output

### DIFF
--- a/pkgs/development/tools/godot/common.nix
+++ b/pkgs/development/tools/godot/common.nix
@@ -342,34 +342,39 @@ let
         '';
 
         # From: https://github.com/godotengine/godot/blob/4.2.2-stable/SConstruct
-        sconsFlags = mkSconsFlagsFromAttrSet {
-          # Options from 'SConstruct'
-          precision = withPrecision; # Floating-point precision level
-          production = true; # Set defaults to build Godot for use in production
-          platform = withPlatform;
-          inherit target;
-          debug_symbols = true;
+        sconsFlags = mkSconsFlagsFromAttrSet (
+          {
+            # Options from 'SConstruct'
+            precision = withPrecision; # Floating-point precision level
+            production = true; # Set defaults to build Godot for use in production
+            platform = withPlatform;
+            inherit target;
+            debug_symbols = true;
 
-          # Options from 'platform/linuxbsd/detect.py'
-          alsa = withAlsa;
-          dbus = withDbus; # Use D-Bus to handle screensaver and portal desktop settings
-          fontconfig = withFontconfig; # Use fontconfig for system fonts support
-          pulseaudio = withPulseaudio; # Use PulseAudio
-          speechd = withSpeechd; # Use Speech Dispatcher for Text-to-Speech support
-          touch = withTouch; # Enable touch events
-          udev = withUdev; # Use udev for gamepad connection callbacks
-          wayland = withWayland; # Compile with Wayland support
-          x11 = withX11; # Compile with X11 support
+            # Options from 'platform/linuxbsd/detect.py'
+            alsa = withAlsa;
+            dbus = withDbus; # Use D-Bus to handle screensaver and portal desktop settings
+            fontconfig = withFontconfig; # Use fontconfig for system fonts support
+            pulseaudio = withPulseaudio; # Use PulseAudio
+            speechd = withSpeechd; # Use Speech Dispatcher for Text-to-Speech support
+            touch = withTouch; # Enable touch events
+            udev = withUdev; # Use udev for gamepad connection callbacks
+            wayland = withWayland; # Compile with Wayland support
+            x11 = withX11; # Compile with X11 support
 
-          module_mono_enabled = withMono;
+            module_mono_enabled = withMono;
 
-          # aliasing bugs exist with hardening+LTO
-          # https://github.com/godotengine/godot/pull/104501
-          ccflags = "-fno-strict-aliasing";
-          linkflags = "-Wl,--build-id";
+            # aliasing bugs exist with hardening+LTO
+            # https://github.com/godotengine/godot/pull/104501
+            ccflags = "-fno-strict-aliasing";
+            linkflags = "-Wl,--build-id";
 
-          use_sowrap = false;
-        };
+            use_sowrap = false;
+          }
+          // lib.optionalAttrs (lib.versionAtLeast version "4.5") {
+            redirect_build_objects = false; # Avoid copying build objects to output
+          }
+        );
 
         enableParallelBuilding = true;
 


### PR DESCRIPTION
The obj folder with the compilation cache is copied to the output folder adding about 3GiB of storage space.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
