### PR TITLE
icingaweb2: wrap icingacli to include dependencies in ICINGAWEB_LIBDIR

### DIFF
--- a/pkgs/servers/icingaweb2/default.nix
+++ b/pkgs/servers/icingaweb2/default.nix
@@ -30,7 +30,7 @@ stdenvNoCC.mkDerivation rec {
     ln -s ${icingaweb2-ipl} $out/share/icinga-php/ipl
     ln -s ${icingaweb2-thirdparty} $out/share/icinga-php/vendor
 
-    wrapProgram $out/bin/icingacli --prefix PATH : "${lib.makeBinPath [ php83 ]}"
+    wrapProgram $out/bin/icingacli --prefix PATH : "${lib.makeBinPath [ php83 ]}" --suffix ICINGAWEB_LIBDIR : $out/share/icinga-php
   '';
 
   passthru.tests = { inherit (nixosTests) icingaweb2; };

--- a/pkgs/servers/icingaweb2/default.nix
+++ b/pkgs/servers/icingaweb2/default.nix
@@ -4,6 +4,8 @@
   fetchFromGitHub,
   makeWrapper,
   php83,
+  icingaweb2-ipl,
+  icingaweb2-thirdparty,
   nixosTests,
 }:
 
@@ -21,9 +23,12 @@ stdenvNoCC.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
-    mkdir -p $out/share
+    mkdir -p $out/share/icinga-php
     cp -ra application bin etc library modules public schema $out
     cp -ra doc $out/share
+
+    ln -s ${icingaweb2-ipl} $out/share/icinga-php/ipl
+    ln -s ${icingaweb2-thirdparty} $out/share/icinga-php/vendor
 
     wrapProgram $out/bin/icingacli --prefix PATH : "${lib.makeBinPath [ php83 ]}"
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

as a new dir in icingaweb2 with symlinks (to icingaweb2-{ipl,thirdparty}). Now one can just invoke icingacli without explicitly specifying ICINGAWEB_LIBDIR or creating dirs and symlinks, but icingacli doesn't complain like this:

    Class "ipl\I18n\GettextTranslator" not found

I work at @Icinga btw.

fixes #380864

ok.

@oxzi ok?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
