### PR TITLE
clang-repl-kernel: init at unstable-2025-05-05

### DIFF
--- a/pkgs/development/python-modules/clang-repl-kernel/default.nix
+++ b/pkgs/development/python-modules/clang-repl-kernel/default.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  ipykernel,
+  pexpect,
+  llvmPackages,
+}:
+
+buildPythonPackage {
+  pname = "clang-repl-kernel";
+  version = "unstable-2025-05-05";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pmanstet";
+    repo = "clang_repl_kernel";
+    rev = "0dc16d21abd6f0dd2f7e3a728e90a9dcc7d3e949";
+    hash = "sha256-Bv8a2rpPXceaHxXWTJ/80vIckfytez9c3Myqnu4r4l4=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    ipykernel
+    pexpect
+  ];
+
+  propagatedBuildInputs = [ llvmPackages.clang-tools ];
+
+  postPatch = ''
+    # Drop heavy, UI-only deps from project dependencies
+    substituteInPlace pyproject.toml \
+      --replace-fail '"jupyter-console",' "" \
+      --replace-fail '"notebook",' ""
+  '';
+
+  postInstall = ''
+      # Nix-wrap will add PATH/PYTHONPATH automatically to Python scripts in $out/bin.
+
+      mkdir -p "$out/bin"
+
+      cat > "$out/bin/clang-repl-kernel-start" <<'SH'
+    #!/usr/bin/env python3
+    import sys
+    import runpy
+
+    # Reconstruct sys.argv for the target module
+    sys.argv = ['clang_repl', '-f'] + sys.argv[1:]
+
+    # Programmatically execute `python -m clang_repl`
+    runpy.run_module('clang_repl', run_name='__main__')
+    SH
+
+      chmod +x $out/bin/clang-repl-kernel-start
+
+      mkdir -p $out/share/jupyter/kernels/clang-repl
+
+      cat > $out/share/jupyter/kernels/clang-repl/kernel.json <<EOF
+    {
+      "argv": ["$out/bin/clang-repl-kernel-start", "{connection_file}"],
+      "display_name": "Clang-Repl (C++20)",
+      "language": "c++"
+    }
+    EOF
+  '';
+
+  pythonImportsCheck = [ "clang_repl" ];
+
+  meta = {
+    description = "Minimal Jupyter kernel that wraps LLVM's clang-repl";
+    homepage = "https://github.com/pmanstet/clang_repl_kernel";
+    license = lib.licenses.cc0;
+    maintainers = [ lib.maintainers.romildo ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2594,6 +2594,8 @@ self: super: with self; {
 
   ckzg = callPackage ../development/python-modules/ckzg { };
 
+  clang-repl-kernel = callPackage ../development/python-modules/clang-repl-kernel { };
+
   clarabel = callPackage ../development/python-modules/clarabel { };
 
   clarifai = callPackage ../development/python-modules/clarifai { };


### PR DESCRIPTION
https://github.com/pmanstet/clang_repl_kernel

`clang-repl` based kernel for Jupyter notebooks.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
