### PR TITLE
tcping-rs: 1.2.18 -> 1.2.19

### DIFF
--- a/pkgs/by-name/tc/tcping-rs/package.nix
+++ b/pkgs/by-name/tc/tcping-rs/package.nix
@@ -6,16 +6,16 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "tcping-rs";
-  version = "1.2.18";
+  version = "1.2.19";
 
   src = fetchFromGitHub {
     owner = "lvillis";
     repo = "tcping-rs";
     tag = version;
-    hash = "sha256-G9LZ9XlIl/JYji/GgznQnIbnV83qi9kZqCkaZJ0kENI=";
+    hash = "sha256-I7rcIemdPGFPBeOoIRft0tq49ikDs49UH5sEobL6fOA=";
   };
 
-  cargoHash = "sha256-INbXvNfn3vmXzZgaDUwl1wgbQ2wVQcCP0ZV2dpZedQY=";
+  cargoHash = "sha256-k+Hm6dHy6igk1deeVrWrAOdhlz0h/jen6pVNaGvB7Ak=";
 
   checkFlags = [
     # This test requires external network access


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update `tcping-rs` from 1.2.18 to 1.2.19. Changelog [here](https://github.com/lvillis/tcping-rs/blob/1.2.19/CHANGELOG.md).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
