### PR TITLE
nixos/miniflux: add apparmor paths for new go runtime

### DIFF
--- a/nixos/modules/security/apparmor/includes.nix
+++ b/nixos/modules/security/apparmor/includes.nix
@@ -431,6 +431,13 @@ in
     "abstractions/python" = ''
       include "${pkgs.apparmor-profiles}/etc/apparmor.d/abstractions/python"
     '';
+    "abstractions/golang" = ''
+      # Container-aware GOMAXPROCS
+      owner @{PROC}/@{pid}/mountinfo r,
+      owner @{PROC}/@{pid}/cgroup r,
+      @{sys}/fs/cgroup/**/{cpu.cfs_quota_us,cpu.cfs_period_us} r, # V1
+      @{sys}/fs/cgroup/**/cpu.max r, # V2
+    '';
     "abstractions/qt5" = ''
       include "${pkgs.apparmor-profiles}/etc/apparmor.d/abstractions/qt5"
     ''

--- a/nixos/modules/services/web-apps/miniflux.nix
+++ b/nixos/modules/services/web-apps/miniflux.nix
@@ -189,7 +189,6 @@ in
         include <abstractions/golang>
         include "${pkgs.apparmorRulesFromClosure { name = "miniflux"; } cfg.package}"
         r ${cfg.package}/bin/miniflux,
-        r @{sys}/kernel/mm/transparent_hugepage/hpage_pmd_size,
         rw /run/miniflux/**,
       }
     '';

--- a/nixos/modules/services/web-apps/miniflux.nix
+++ b/nixos/modules/services/web-apps/miniflux.nix
@@ -186,6 +186,7 @@ in
         include <abstractions/base>
         include <abstractions/nameservice>
         include <abstractions/ssl_certs>
+        include <abstractions/golang>
         include "${pkgs.apparmorRulesFromClosure { name = "miniflux"; } cfg.package}"
         r ${cfg.package}/bin/miniflux,
         r @{sys}/kernel/mm/transparent_hugepage/hpage_pmd_size,


### PR DESCRIPTION
This patch fixes "DENIED" audit log entries of `nixosTests.miniflux`.
The failure was discovered by other miniflux PRs https://github.com/NixOS/nixpkgs/pull/443744 and https://github.com/NixOS/nixpkgs/pull/444352.

"Container-aware GOMAXPROCS" was introduced in golang version 1.25.0.

Release notes: https://tip.golang.org/doc/go1.25#container-aware-gomaxprocs

> At startup (defaultGOMAXPROCSInit), we read /proc/self/cgroup and
> /proc/self/mountinfo to find our current CPU cgroup and open its
> limit file(s), which remain open for the entire process lifetime. We
> periodically read the current limit by  rereading the limit file(s)
> from the beginning.
>
> https://github.com/golang/go/blob/go1.25.0/src/runtime/cgroup_linux.go#L13

Since this is kinda relevant to all (future) golang applications, I put the extra paths in an abstraction.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (I ran nixosTests.miniflux and nixosTests.apparmor on x86_64-linux)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
