### PR TITLE
pkgs/by-name/README: explicitly suggest version specific override interfaces

### DIFF
--- a/pkgs/by-name/README.md
+++ b/pkgs/by-name/README.md
@@ -62,16 +62,12 @@ The above expression is called using these arguments by default:
 ```
 
 But the package might need `pkgs.libbar_2` instead.
-While the function could be changed to take `libbar_2` directly as an argument,
-this would change the `.override` interface, breaking code like `.override { libbar = ...; }`.
-So instead it is preferable to use the same generic parameter name `libbar`
-and override its value in [`pkgs/top-level/all-packages.nix`](../top-level/all-packages.nix):
+While the `libbar` argument could explicitly be overridden in `all-packages.nix` with `libbar_2`, this would hide important information about this package from its interface.
+The fact that the package requires a certain version of `libbar` to work should not be hidden in a separate place.
+It is preferable to use `libbar_2` as a argument name instead.
 
-```nix
-{
-  libfoo = callPackage ../by-name/so/some-package/package.nix { libbar = libbar_2; };
-}
-```
+This approach also has the benefit that, if the expectation of the package changes to require a different version of `libbar`, a downstream user with an override of this argument will receive an error.
+This is comparable to a merge conflict in git: It's much better to be forced to explicitly address the conflict instead of silently keeping the override - which might lead to a different problem that is likely much harder to debug.
 
 ## Manual migration guidelines
 


### PR DESCRIPTION
The current advice of "keeping the override interface" is actively bad, because it hides certain expectations of a package function in an undiscoverable place. Ideally, all information about a package is in one, single place instead.

Version-specific argument names, if required, also have the *benefit* of creating errors with downstream overrides, much like merge conflicts do. Instead of possibly silently breaking certain behavior, they make a change in expectations clear - which might feel annoying when upgrading, but is ultimately much less problematic down the road.

Resolves #404946, as proposed in https://github.com/NixOS/nixpkgs/issues/404946#issuecomment-3224060807

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
