### PR TITLE
nixos/zram: prevent implicitly disabling negative-sized ZRAM

### DIFF
--- a/nixos/modules/config/zram.nix
+++ b/nixos/modules/config/zram.nix
@@ -49,7 +49,7 @@ in
 
       memoryPercent = lib.mkOption {
         default = 50;
-        type = lib.types.int;
+        type = lib.types.ints.positive;
         description = ''
           Maximum total amount of memory that can be stored in the zram swap devices
           (as a percentage of your total memory). Defaults to 1/2 of your total


### PR DESCRIPTION
```
Prevent implicitly disabling a negative-sized ZRAM because disabling the
ZRAM should probably always be done by disabling the zrawmSwap.enable
option.

Fixes: cd1b48bc3541 ("nixos: Add zram swap module")
```

For reference, I have verified (without this PR) that a negative-sized ZRAM (`zrawmSwap.memoryPercent = -250;`) results in the ZRAM being silently disabled and that a ZRAM above 100% size (`zrawmSwap.memoryPercent = 250;`) works correctly as intended by the Kernel. This means a more restrictive `type = lib.types.ints.between 0 100;` declaration should not be used because it reduces Kernel functionality.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
