### PR TITLE
bcachefs-tools: 1.31.0 -> 1.31.3, nixos/bcachefs: Use out-of-tree module.

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -262,6 +262,8 @@
 
 - Due to [deprecation of gnome-session X11 support](https://blogs.gnome.org/alatiera/2025/06/08/the-x11-session-removal/), `services.desktopManager.pantheon` now defaults to pantheon-wayland session. The X11 session has been removed, see [this issue](https://github.com/elementary/session-settings/issues/91) for details.
 
+- `bcachefs` file systems will now use the out-of-tree module for supported kernels. The in-tree module is unmaintained and users are strongly recommended to switch to kernels that support the out-of-tree module.
+
 - `services.gitea` supports sending notifications with sendmail again. To do this, activate the parameter `services.gitea.mailerUseSendmail` and configure SMTP server.
 
 - `networking.wireless.networks.<name>` now has an option to specify SSID, hence allowing duplicated SSID setup. The BSSID option is added along side with this.

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -230,12 +230,24 @@ in
           }
         ];
 
+        warnings = lib.mkIf config.boot.kernelPackages.bcachefs.meta.broken [
+          ''
+            Using unmaintained in-tree bcachefs kernel module. This
+            will be removed in 26.05. Please use a kernel supported
+            by the out-of-tree module package.
+          ''
+        ];
+
         # Bcachefs upstream recommends using the latest kernel
         boot.kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
 
         # needed for systemd-remount-fs
         system.fsPackages = [ cfg.package ];
         services.udev.packages = [ cfg.package ];
+
+        boot.extraModulePackages = lib.optionals (!config.boot.kernelPackages.bcachefs.meta.broken) [
+          config.boot.kernelPackages.bcachefs
+        ];
 
         systemd = {
           packages = [ cfg.package ];

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -175,25 +175,6 @@ let
             '';
       };
     };
-
-  assertions = [
-    {
-      assertion =
-        let
-          kernel = config.boot.kernelPackages.kernel;
-        in
-        (
-          kernel.kernelAtLeast "6.7"
-          || (lib.elem (kernel.structuredExtraConfig.BCACHEFS_FS or null) [
-            lib.kernel.module
-            lib.kernel.yes
-            (lib.kernel.option lib.kernel.yes)
-          ])
-        );
-
-      message = "Linux 6.7-rc1 at minimum or a custom linux kernel with bcachefs support is required";
-    }
-  ];
 in
 
 {
@@ -230,7 +211,24 @@ in
   config = lib.mkIf (config.boot.supportedFilesystems.bcachefs or false) (
     lib.mkMerge [
       {
-        inherit assertions;
+        assertions = [
+          {
+            assertion =
+              let
+                kernel = config.boot.kernelPackages.kernel;
+              in
+              (
+                kernel.kernelAtLeast "6.7"
+                || (lib.elem (kernel.structuredExtraConfig.BCACHEFS_FS or null) [
+                  lib.kernel.module
+                  lib.kernel.yes
+                  (lib.kernel.option lib.kernel.yes)
+                ])
+              );
+
+            message = "Linux 6.7-rc1 at minimum or a custom linux kernel with bcachefs support is required";
+          }
+        ];
 
         # Bcachefs upstream recommends using the latest kernel
         boot.kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
@@ -248,7 +246,6 @@ in
       }
 
       (lib.mkIf ((config.boot.initrd.supportedFilesystems.bcachefs or false) || (bootFs != { })) {
-        inherit assertions;
         boot.initrd.availableKernelModules = [
           "bcachefs"
           "sha256"

--- a/pkgs/by-name/bc/bcachefs-tools/package.nix
+++ b/pkgs/by-name/bc/bcachefs-tools/package.nix
@@ -29,13 +29,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bcachefs-tools";
-  version = "1.31.0";
+  version = "1.31.3";
 
   src = fetchFromGitHub {
     owner = "koverstreet";
     repo = "bcachefs-tools";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wYlfU4PTcVSPSHbIIDbl8pBOJsBAAl44XBapwFZ528U=";
+    hash = "sha256-sXv6YFM91T08WF5dPU7iQNqWbB/QiL2kMaXm6ZtIDqI=";
   };
 
   nativeBuildInputs = [
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     src = finalAttrs.src;
-    hash = "sha256-ZCzw3cDpQ8fb2jLYdIWrmlNTPStikIs09jx6jzzC2vM=";
+    hash = "sha256-04YrgYfhZ5NfA2BcF2H6Np1SXRiH6CJpkgc9hzlbMAo=";
   };
 
   makeFlags = [
@@ -100,11 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
   checkFlags = [ "BCACHEFS_TEST_USE_VALGRIND=no" ];
 
-  postInstall = ''
-    substituteInPlace $out/libexec/bcachefsck_all \
-      --replace-fail "/usr/bin/python3" "${python3.interpreter}"
-  ''
-  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd bcachefs \
       --bash <($out/sbin/bcachefs completions bash) \
       --zsh  <($out/sbin/bcachefs completions zsh) \

--- a/pkgs/by-name/bc/bcachefs-tools/package.nix
+++ b/pkgs/by-name/bc/bcachefs-tools/package.nix
@@ -69,16 +69,26 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-04YrgYfhZ5NfA2BcF2H6Np1SXRiH6CJpkgc9hzlbMAo=";
   };
 
+  outputs = [
+    "out"
+    "dkms"
+  ];
+
   makeFlags = [
     "PREFIX=${placeholder "out"}"
     "VERSION=${finalAttrs.version}"
     "INITRAMFS_DIR=${placeholder "out"}/etc/initramfs-tools"
+    "DKMSDIR=${placeholder "dkms"}"
 
     # Tries to install to the 'systemd-minimal' and 'udev' nix installation paths
     "PKGCONFIG_SERVICEDIR=$(out)/lib/systemd/system"
     "PKGCONFIG_UDEVDIR=$(out)/lib/udev"
   ]
   ++ lib.optional fuseSupport "BCACHEFS_FUSE=1";
+  installFlags = [
+    "install"
+    "install_dkms"
+  ];
 
   env = {
     CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;

--- a/pkgs/os-specific/linux/bcachefs-kernel-module/default.nix
+++ b/pkgs/os-specific/linux/bcachefs-kernel-module/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  bcachefs-tools,
+  kernelModuleMakeFlags,
+  kernel,
+}:
+
+stdenv.mkDerivation {
+  pname = "bcachefs";
+  version = "${kernel.version}-${bcachefs-tools.version}";
+
+  __structuredAttrs = true;
+
+  src = bcachefs-tools.dkms;
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  enableParallelBuilding = true;
+
+  makeFlags = kernelModuleMakeFlags ++ [
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "INSTALL_MOD_PATH=${placeholder "out"}"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    make -C ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build M=$(pwd) modules_install "''${makeFlags[@]}" "''${installFlags[@]}"
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit (bcachefs-tools.passthru) tests;
+  };
+
+  meta = {
+    description = "out-of-tree bcachefs kernel module";
+
+    inherit (bcachefs-tools.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+
+    broken = !(lib.versionAtLeast kernel.version "6.16" && lib.versionOlder kernel.version "6.18");
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -375,6 +375,8 @@ in
 
         bbswitch = callPackage ../os-specific/linux/bbswitch { };
 
+        bcachefs = callPackage ../os-specific/linux/bcachefs-kernel-module { };
+
         ch9344 = callPackage ../os-specific/linux/ch9344 { };
 
         chipsec = callPackage ../tools/security/chipsec {


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
