### PR TITLE
treewide: remove optional builtins prefixes from prelude functions

### DIFF
--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -22,7 +22,7 @@ let
   anyMatchingFiles = files: builtins.any anyMatchingFile files;
 
   attrsWithMaintainers = lib.pipe (changedattrs ++ removedattrs) [
-    (builtins.map (
+    (map (
       name:
       let
         # Some packages might be reported as changed on a different platform, but
@@ -46,7 +46,7 @@ let
   relevantFilenames =
     drv:
     (lib.lists.unique (
-      builtins.map (pos: lib.strings.removePrefix (toString ../..) pos.file) (
+      map (pos: lib.strings.removePrefix (toString ../..) pos.file) (
         builtins.filter (x: x != null) [
           ((drv.meta or { }).maintainersPosition or null)
           ((drv.meta or { }).teamsPosition or null)
@@ -73,7 +73,7 @@ let
       )
     ));
 
-  attrsWithFilenames = builtins.map (
+  attrsWithFilenames = map (
     pkg: pkg // { filenames = relevantFilenames pkg.package; }
   ) attrsWithMaintainers;
 
@@ -81,7 +81,7 @@ let
 
   listToPing = lib.concatMap (
     pkg:
-    builtins.map (maintainer: {
+    map (maintainer: {
       id = maintainer.githubId;
       inherit (maintainer) github;
       packageName = pkg.name;
@@ -92,7 +92,7 @@ let
   byMaintainer = lib.groupBy (ping: toString ping.${if byName then "github" else "id"}) listToPing;
 
   packagesPerMaintainer = lib.attrsets.mapAttrs (
-    maintainer: packages: builtins.map (pkg: pkg.packageName) packages
+    maintainer: packages: map (pkg: pkg.packageName) packages
   ) byMaintainer;
 in
 packagesPerMaintainer

--- a/ci/eval/compare/utils.nix
+++ b/ci/eval/compare/utils.nix
@@ -66,7 +66,7 @@ rec {
   */
   convertToPackagePlatformAttrs =
     packagePlatformPaths:
-    builtins.filter (x: x != null) (builtins.map convertToPackagePlatformAttr packagePlatformPaths);
+    builtins.filter (x: x != null) (map convertToPackagePlatformAttr packagePlatformPaths);
 
   /*
     Converts a list of `packagePlatformPath`s directly to a list of (unique) package names
@@ -91,7 +91,7 @@ rec {
     let
       packagePlatformAttrs = convertToPackagePlatformAttrs (uniqueStrings packagePlatformPaths);
     in
-    uniqueStrings (builtins.map (p: p.name) packagePlatformAttrs);
+    uniqueStrings (map (p: p.name) packagePlatformAttrs);
 
   /*
     Group a list of `packagePlatformAttr`s by platforms

--- a/ci/eval/outpaths.nix
+++ b/ci/eval/outpaths.nix
@@ -95,7 +95,7 @@ let
 
 in
 tweak (
-  (builtins.removeAttrs nixpkgsJobs blacklist)
+  (removeAttrs nixpkgsJobs blacklist)
   // {
     nixosTests.simple = nixosJobs.tests.simple;
   }

--- a/flake.nix
+++ b/flake.nix
@@ -91,7 +91,7 @@
                   )
                 ];
               }
-              // builtins.removeAttrs args [ "modules" ]
+              // removeAttrs args [ "modules" ]
             );
         }
       );

--- a/maintainers/scripts/convert-to-import-cargo-lock/default.nix
+++ b/maintainers/scripts/convert-to-import-cargo-lock/default.nix
@@ -8,7 +8,7 @@ rustPlatform.buildRustPackage {
     filter =
       name: type:
       let
-        name' = builtins.baseNameOf name;
+        name' = baseNameOf name;
       in
       name' != "default.nix" && name' != "target";
   };

--- a/maintainers/scripts/haskell/test-configurations.nix
+++ b/maintainers/scripts/haskell/test-configurations.nix
@@ -65,7 +65,7 @@ let
   inherit (pkgs) lib;
 
   # see usage explanation for the input format `files` allows
-  files' = builtins.map builtins.baseNameOf (if !builtins.isList files then [ files ] else files);
+  files' = map baseNameOf (if !builtins.isList files then [ files ] else files);
 
   packageSetsWithVersionedHead =
     pkgs.haskell.packages
@@ -99,7 +99,7 @@ let
       # match the major and minor version of the GHC the config is intended for, if any
       configVersion = lib.concatStrings (builtins.match "ghc-([0-9]+).([0-9]+).x" configName);
       # return all package sets under haskell.packages matching the version components
-      setsForVersion = builtins.map (name: packageSetsWithVersionedHead.${name}) (
+      setsForVersion = map (name: packageSetsWithVersionedHead.${name}) (
         builtins.filter (
           setName:
           lib.hasPrefix "ghc${configVersion}" setName && (skipBinaryGHCs -> !(lib.hasInfix "Binary" setName))
@@ -120,7 +120,7 @@ let
 
   # attribute set that has all the attributes of haskellPackages set to null
   availableHaskellPackages = builtins.listToAttrs (
-    builtins.map (attr: lib.nameValuePair attr null) (builtins.attrNames pkgs.haskellPackages)
+    map (attr: lib.nameValuePair attr null) (builtins.attrNames pkgs.haskellPackages)
   );
 
   # evaluate a configuration and only return the attributes changed by it,
@@ -155,7 +155,7 @@ let
             sets = setsForFile fileName;
             attrs = overriddenAttrs fileName;
           in
-          lib.concatMap (set: builtins.map (attr: set.${attr}) attrs) sets
+          lib.concatMap (set: map (attr: set.${attr}) attrs) sets
         ) files'
       );
 in

--- a/maintainers/scripts/rebuild-amount.sh
+++ b/maintainers/scripts/rebuild-amount.sh
@@ -69,7 +69,7 @@ nixexpr() {
           ];
 
         in
-          tweak (builtins.removeAttrs hydraJobs blacklist)
+          tweak (removeAttrs hydraJobs blacklist)
 EONIX
 }
 

--- a/maintainers/scripts/update.nix
+++ b/maintainers/scripts/update.nix
@@ -120,7 +120,7 @@ let
     let
       maintainer =
         if !builtins.hasAttr maintainer' lib.maintainers then
-          builtins.throw "Maintainer with name `${maintainer'} does not exist in `maintainers/maintainer-list.nix`."
+          throw "Maintainer with name `${maintainer'} does not exist in `maintainers/maintainer-list.nix`."
         else
           builtins.getAttr maintainer' lib.maintainers;
     in
@@ -147,7 +147,7 @@ let
       pathContent = lib.attrByPath prefix null pkgs;
     in
     if pathContent == null then
-      builtins.throw "Attribute path `${path}` does not exist."
+      throw "Attribute path `${path}` does not exist."
     else
       packagesWithPath prefix (path: pkg: (get-script pkg != null)) pathContent;
 
@@ -158,9 +158,9 @@ let
       package = lib.attrByPath (lib.splitString "." path) null pkgs;
     in
     if package == null then
-      builtins.throw "Package with an attribute name `${path}` does not exist."
+      throw "Package with an attribute name `${path}` does not exist."
     else if get-script package == null then
-      builtins.throw "Package with an attribute name `${path}` does not have a `passthru.updateScript` attribute defined."
+      throw "Package with an attribute name `${path}` does not have a `passthru.updateScript` attribute defined."
     else
       {
         attrPath = path;
@@ -178,7 +178,7 @@ let
     else if path != null then
       packagesWithUpdateScript path pkgs
     else
-      builtins.throw "No arguments provided.\n\n${helpText}";
+      throw "No arguments provided.\n\n${helpText}";
 
   helpText = ''
     Please run:
@@ -242,7 +242,7 @@ let
       name = package.name;
       pname = lib.getName package;
       oldVersion = lib.getVersion package;
-      updateScript = map builtins.toString (lib.toList (updateScript.command or updateScript));
+      updateScript = map toString (lib.toList (updateScript.command or updateScript));
       supportedFeatures = updateScript.supportedFeatures or [ ];
       attrPath = updateScript.attrPath or attrPath;
     };

--- a/pkgs/by-name/fa/factorio/package.nix
+++ b/pkgs/by-name/fa/factorio/package.nix
@@ -150,7 +150,6 @@ let
                 else
                   ''
                     # Deliberately failing since username/token was not provided, so we can't fetch.
-                    # We can't use builtins.throw since we want the result to be used if the tar is in the store already.
                     exit 1
                   '';
               failureHook = ''

--- a/shell.nix
+++ b/shell.nix
@@ -19,7 +19,7 @@ let
   inherit (import ./ci { inherit nixpkgs system; }) pkgs fmt;
 
   # For `nix-shell -A hello`
-  curPkgs = builtins.removeAttrs (import ./. { inherit system; }) [
+  curPkgs = removeAttrs (import ./. { inherit system; }) [
     # Although this is what anyone may expect from a `_type = "pkgs"`,
     # this file is intended to produce a shell in the first place,
     # and a `_type` tag could confuse some code.


### PR DESCRIPTION
```
commit d17f0c1bf89bcffad26838bbe0278250656659bd
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-09-20 19:18:20 +0200

    factorio: remove redundant comment

commit e4421a5c7a5b010dd931d398d3eb9dbd66c8e5ae
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-09-19 22:04:21 +0200

    treewide: remove optional builtins prefixes from prelude functions

    Remove optional builtins prefixes from prelude functions by running:

        builtins=(
          abort
          baseNameOf
          break
          derivation
          derivationStrict
          dirOf
          false
          fetchGit
          fetchMercurial
          fetchTarball
          fetchTree
          fromTOML
          import
          isNull
          map
          null
          placeholder
          removeAttrs
          scopedImport
          throw
          toString
          true
        )

        fd --type file --exec-batch sed --in-place --regexp-extended "
          s/\<builtins\.($(
            printf '%s\n' "${builtins[@]}" |
              paste --delimiter '|' --serial -
          ))\>/\1/g
        "

        nix fmt
```

Related PRs intentionally split up to simplify review and merging:

1. https://github.com/NixOS/nixpkgs/pull/447401
2. https://github.com/NixOS/nixpkgs/pull/447402
3. https://github.com/NixOS/nixpkgs/pull/447404
4. https://github.com/NixOS/nixpkgs/pull/447403
5. https://github.com/NixOS/nixpkgs/pull/444432

> Aside from the small [0.49% CPU time reduction](https://github.com/NixOS/nixpkgs/actions/runs/17882775243?pr=444432), this is primarily motivated by the fact that this ensures a consistent code style and that `builtins.false` and `builtins.map` are IMHO ugly considering they are in the prelude.
>
> -- https://github.com/NixOS/nixpkgs/pull/444432#issuecomment-3315117848

Pinging @Aleksanaa because (IIRC) I have seen plenty treewide cleanups from her.

## Changelog

### v3: https://github.com/NixOS/nixpkgs/commit/dec908b169b25e4eee5cd694f1a073894654135f

- Move [`doc`](https://github.com/NixOS/nixpkgs/pull/447401), [`lib`](https://github.com/NixOS/nixpkgs/pull/447402), [`pkgs`](https://github.com/NixOS/nixpkgs/pull/447404), and [`nixos`](https://github.com/NixOS/nixpkgs/pull/447403) changes into smaller PRs.

### v2: https://github.com/NixOS/nixpkgs/commit/e4421a5c7a5b010dd931d398d3eb9dbd66c8e5ae

- Rebase on top of commit 9b2c4d6e3268 ("kdePackages.plasma-wayland-protocols: 1.18.0 -> 1.19.0 (#444047)").

  <details><summary>For convenience, here are the relevant rebase changes.</summary>

  ```diff
  --- v1 (72bf0b950a2ed83af04a8766d80a787855fea625)
  +++ v2 (e4421a5c7a5b010dd931d398d3eb9dbd66c8e5ae)
  @@ -3159,15 +3159,15 @@
            threads = toString (if processCfg.threads == null then cfg.sidekiqThreads else processCfg.threads);
          in
   diff --git a/nixos/modules/services/web-apps/mealie.nix b/nixos/modules/services/web-apps/mealie.nix
  -index d2176c6b10b3..133338a96c45 100644
  +index 1b22fcfd35c8..e692865cb6c2 100644
   --- a/nixos/modules/services/web-apps/mealie.nix
   +++ b/nixos/modules/services/web-apps/mealie.nix
  -@@ -84,7 +84,7 @@ in
  +@@ -96,7 +96,7 @@ in
            DynamicUser = true;
            User = "mealie";
            ExecStartPre = "${pkg}/libexec/init_db";
  --        ExecStart = "${lib.getExe pkg} -b ${cfg.listenAddress}:${builtins.toString cfg.port}";
  -+        ExecStart = "${lib.getExe pkg} -b ${cfg.listenAddress}:${toString cfg.port}";
  +-        ExecStart = "${lib.getExe pkg} -b ${cfg.listenAddress}:${builtins.toString cfg.port} ${lib.escapeShellArgs cfg.extraOptions}";
  ++        ExecStart = "${lib.getExe pkg} -b ${cfg.listenAddress}:${toString cfg.port} ${lib.escapeShellArgs cfg.extraOptions}";
            EnvironmentFile = lib.mkIf (cfg.credentialsFile != null) cfg.credentialsFile;
            StateDirectory = "mealie";
            StandardOutput = "journal";
  @@ -3257,15 +3257,13 @@
   -            FORCE_HTTPS = builtins.toString cfg.forceHttps;
   -            ENABLE_UPDATES = builtins.toString cfg.enableUpdateCheck;
   -            WEB_CONCURRENCY = builtins.toString cfg.concurrency;
  --            MAXIMUM_IMPORT_SIZE = builtins.toString cfg.maximumImportSize;
   +            FORCE_HTTPS = toString cfg.forceHttps;
   +            ENABLE_UPDATES = toString cfg.enableUpdateCheck;
   +            WEB_CONCURRENCY = toString cfg.concurrency;
  -+            MAXIMUM_IMPORT_SIZE = toString cfg.maximumImportSize;
                DEBUG = cfg.debugOutput;
                GOOGLE_ANALYTICS_ID = lib.optionalString (cfg.googleAnalyticsId != null) cfg.googleAnalyticsId;
                SENTRY_DSN = lib.optionalString (cfg.sentryDsn != null) cfg.sentryDsn;
  -@@ -710,12 +710,12 @@ in
  +@@ -709,13 +709,13 @@ in
                TEAM_LOGO = lib.optionalString (cfg.logo != null) cfg.logo;
                DEFAULT_LANGUAGE = cfg.defaultLanguage;

  @@ -3277,7 +3275,9 @@
   +            RATE_LIMITER_DURATION_WINDOW = toString cfg.rateLimiter.durationWindow;

                FILE_STORAGE = cfg.storage.storageType;
  +-            FILE_STORAGE_IMPORT_MAX_SIZE = builtins.toString cfg.maximumImportSize;
   -            FILE_STORAGE_UPLOAD_MAX_SIZE = builtins.toString cfg.storage.uploadMaxSize;
  ++            FILE_STORAGE_IMPORT_MAX_SIZE = toString cfg.maximumImportSize;
   +            FILE_STORAGE_UPLOAD_MAX_SIZE = toString cfg.storage.uploadMaxSize;
                FILE_STORAGE_LOCAL_ROOT_DIR = cfg.storage.localRootDir;
              }
  @@ -4754,19 +4754,6 @@

      # parallel install creates a bad symlink at $out/lib/sane/libsane.so.1 which prevents finding plugins
      # https://github.com/NixOS/nixpkgs/issues/224569
  -diff --git a/pkgs/applications/misc/ganttproject-bin/default.nix b/pkgs/applications/misc/ganttproject-bin/default.nix
  -index 0065eac9c8d5..2c884625aa3a 100644
  ---- a/pkgs/applications/misc/ganttproject-bin/default.nix
  -+++ b/pkgs/applications/misc/ganttproject-bin/default.nix
  -@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
  -       mkdir -pv "$out/bin"
  -       wrapProgram "$out/share/ganttproject/ganttproject" \
  -         --set JAVA_HOME "${jre}" \
  --        --prefix _JAVA_OPTIONS " " "${builtins.toString javaOptions}"
  -+        --prefix _JAVA_OPTIONS " " "${toString javaOptions}"
  -
  -       mv -v "$out/share/ganttproject/ganttproject" "$out/bin"
  -
   diff --git a/pkgs/applications/misc/sweethome3d/linux.nix b/pkgs/applications/misc/sweethome3d/linux.nix
   index 11d5fee2ffb9..46f24c071cf9 100644
   --- a/pkgs/applications/misc/sweethome3d/linux.nix
  @@ -5434,19 +5421,6 @@
                    {
                      url = module.resolved;
                    }
  -diff --git a/pkgs/build-support/ocaml/dune.nix b/pkgs/build-support/ocaml/dune.nix
  -index cc550775dd3e..be0932556f9c 100644
  ---- a/pkgs/build-support/ocaml/dune.nix
  -+++ b/pkgs/build-support/ocaml/dune.nix
  -@@ -66,7 +66,7 @@ else
  -       strictDeps = true;
  -
  -     }
  --    // (builtins.removeAttrs args [
  -+    // (removeAttrs args [
  -       "minimalOCamlVersion"
  -       "duneVersion"
  -     ])
   diff --git a/pkgs/build-support/ocaml/topkg.nix b/pkgs/build-support/ocaml/topkg.nix
   index 4c2d5d26d6c6..4326a61913e9 100644
   --- a/pkgs/build-support/ocaml/topkg.nix
  @@ -6423,6 +6397,19 @@
          str = lib.strings.concatStringsSep "\n" lst;
        in
        builtins.toFile "modules.conf" str;
  +diff --git a/pkgs/by-name/ga/ganttproject-bin/package.nix b/pkgs/by-name/ga/ganttproject-bin/package.nix
  +index ab7fbcac624e..b8ba41626fc5 100644
  +--- a/pkgs/by-name/ga/ganttproject-bin/package.nix
  ++++ b/pkgs/by-name/ga/ganttproject-bin/package.nix
  +@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
  +       mkdir -pv "$out/bin"
  +       wrapProgram "$out/share/ganttproject/ganttproject" \
  +         --set JAVA_HOME "${jre}" \
  +-        --prefix _JAVA_OPTIONS " " "${builtins.toString javaOptions}"
  ++        --prefix _JAVA_OPTIONS " " "${toString javaOptions}"
  +
  +       mv -v "$out/share/ganttproject/ganttproject" "$out/bin"
  +
   diff --git a/pkgs/by-name/ge/geoserver/package.nix b/pkgs/by-name/ge/geoserver/package.nix
   index 9364e1e84384..7d03232a5d76 100644
   --- a/pkgs/by-name/ge/geoserver/package.nix
  @@ -7172,8 +7159,21 @@
      pname = attrs.project.name;
      inherit (attrs.project) version;
    in
  +diff --git a/pkgs/by-name/ni/nixos-init/package.nix b/pkgs/by-name/ni/nixos-init/package.nix
  +index b34f6d570899..aab7354c8856 100644
  +--- a/pkgs/by-name/ni/nixos-init/package.nix
  ++++ b/pkgs/by-name/ni/nixos-init/package.nix
  +@@ -7,7 +7,7 @@
  + }:
  +
  + let
  +-  cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
  ++  cargoToml = fromTOML (builtins.readFile ./Cargo.toml);
  + in
  + rustPlatform.buildRustPackage (finalAttrs: {
  +   pname = cargoToml.package.name;
   diff --git a/pkgs/by-name/ol/ollama/package.nix b/pkgs/by-name/ol/ollama/package.nix
  -index 929e8ba2353f..25390c373793 100644
  +index 63af415a6d6d..0fc029c214c1 100644
   --- a/pkgs/by-name/ol/ollama/package.nix
   +++ b/pkgs/by-name/ol/ollama/package.nix
   @@ -179,7 +179,7 @@ goBuild (finalAttrs: {
  @@ -8411,16 +8411,16 @@
          teams = [ teams.java ];
          inherit knownVulnerabilities;
   diff --git a/pkgs/development/compilers/vala/default.nix b/pkgs/development/compilers/vala/default.nix
  -index 709e13a0fd43..6495cd8755bb 100644
  +index b494ce36ab12..586657b523f4 100644
   --- a/pkgs/development/compilers/vala/default.nix
   +++ b/pkgs/development/compilers/vala/default.nix
   @@ -104,7 +104,7 @@ let
                let
                  roundUpToEven = num: num + lib.mod num 2;
                in
  --            "${pname}_${lib.versions.major version}_${builtins.toString (roundUpToEven (lib.toInt (lib.versions.minor version)))}";
  -+            "${pname}_${lib.versions.major version}_${toString (roundUpToEven (lib.toInt (lib.versions.minor version)))}";
  -           packageName = pname;
  +-            "vala_${lib.versions.major version}_${builtins.toString (roundUpToEven (lib.toInt (lib.versions.minor version)))}";
  ++            "vala_${lib.versions.major version}_${toString (roundUpToEven (lib.toInt (lib.versions.minor version)))}";
  +           packageName = "vala";
              freeze = true;
            };
   diff --git a/pkgs/development/compilers/zulu/11.nix b/pkgs/development/compilers/zulu/11.nix
  ```
  </details>


### v1: https://github.com/NixOS/nixpkgs/commit/72bf0b950a2ed83af04a8766d80a787855fea625

- Rebase on top of commit 52c032768a8b ("alcom: 1.0.1 -> 1.1.4 (#442493)").
- Remove all prelude elements, as indicated by https://github.com/NixOS/nix/pull/14015.
- Add commit 7be355365ec4 ("factorio: remove redundant comment"), as per https://github.com/NixOS/nixpkgs/pull/444432#discussion_r2364900657.

### v0: https://github.com/NixOS/nixpkgs/pull/444432/commits/c65f82b5b63b58f451ade27e43d30fca12a61cad

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
