### PR TITLE
nixos/virtualbox-host: fix for kernels >= 6.12

### DIFF
--- a/nixos/modules/virtualisation/virtualbox-host.nix
+++ b/nixos/modules/virtualisation/virtualbox-host.nix
@@ -164,6 +164,16 @@ in
           "vboxnetflt"
         ];
         boot.extraModulePackages = [ kernelModules ];
+        # See https://github.com/VirtualBox/virtualbox/issues/188
+        boot.kernelParams =
+          lib.mkIf
+            (
+              lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.12"
+              && lib.versionOlder config.boot.kernelPackages.kernel.version "6.16"
+            )
+            [
+              "kvm.enable_virt_at_load=0"
+            ];
 
         services.udev.extraRules = ''
           KERNEL=="vboxdrv",    OWNER="root", GROUP="vboxusers", MODE="0660", TAG+="systemd"


### PR DESCRIPTION
A change in Linux 6.12 broke VirtualBox without an added kernel parameter. VirtualBox version 7.2.2 has a fix, but it only works for kernels >= 6.16.

See https://github.com/VirtualBox/virtualbox/issues/188.

fixes #363887

`nixosTests.virtualbox` failed for me both with and without this change, so I can't comment on that. I don't think this change would be a problem, though.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
