### PR TITLE
hping: Update homepage link away from gambling site

### DIFF
--- a/pkgs/by-name/hp/hping/package.nix
+++ b/pkgs/by-name/hp/hping/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Command-line oriented TCP/IP packet assembler/analyzer";
-    homepage = "http://www.hping.org/";
+    homepage = "https://github.com/antirez/hping";
     license = licenses.gpl2Only;
     platforms = platforms.unix;
   };


### PR DESCRIPTION
The [hping.org](https://www.hping.org) URL lapsed sometime in 2023 ([last capture]). It appears to now be owned by a Korean gambling site.

## Things Done

I've updated the homepage link to the [source repository] the package pulls from.

Alternately, we could use the [last capture] link from archive.org, but as far as I can tell that seems to be a less common solution accross nixpkgs (I found 11 instances for mostly very small projects).

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[source repository]: https://github.com/antirez/hping
[last capture]: https://web.archive.org/web/20221105014339/http://hping.org/
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
