### PR TITLE
nvchecker: 2.18 -> 2.19; modernize

### DIFF
--- a/pkgs/development/python-modules/nvchecker/default.nix
+++ b/pkgs/development/python-modules/nvchecker/default.nix
@@ -19,11 +19,12 @@
   awesomeversion,
   packaging,
   lxml,
+  zstandard,
 }:
 
 buildPythonPackage rec {
   pname = "nvchecker";
-  version = "2.18";
+  version = "2.19";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -32,7 +33,7 @@ buildPythonPackage rec {
     owner = "lilydjwg";
     repo = "nvchecker";
     tag = "v${version}";
-    hash = "sha256-6uFox07mZeKwyhRXGuU8dMoPhLB5CkgdLaWCfG2dy4k=";
+    hash = "sha256-C8g8uhuWOl3zPCjTaGs21yJ8k3tmvZE8U9LzSXoDSxE=";
   };
 
   build-system = [ setuptools ];
@@ -77,6 +78,8 @@ buildPythonPackage rec {
     awesomeversion = [ awesomeversion ];
     pypi = [ packaging ];
     htmlparser = [ lxml ];
+    rpmrepo = [ lxml ] ++ lib.optionals (pythonOlder "3.14") [ zstandard ];
+    jq = [ jq ];
   };
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/development/python-modules/nvchecker/default.nix
+++ b/pkgs/development/python-modules/nvchecker/default.nix
@@ -1,24 +1,25 @@
 {
   lib,
-  platformdirs,
+  awesomeversion,
   buildPythonPackage,
   docutils,
   fetchFromGitHub,
-  nix-update-script,
   flaky,
   installShellFiles,
+  jq,
+  lxml,
+  nix-update-script,
+  packaging,
+  platformdirs,
   pycurl,
   pytest-asyncio,
-  pytest-httpbin,
   pytestCheckHook,
+  pytest-httpbin,
   pythonOlder,
   setuptools,
   structlog,
   tomli,
   tornado,
-  awesomeversion,
-  packaging,
-  lxml,
   zstandard,
 }:
 
@@ -27,14 +28,14 @@ buildPythonPackage rec {
   version = "2.19";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
-
   src = fetchFromGitHub {
     owner = "lilydjwg";
     repo = "nvchecker";
     tag = "v${version}";
     hash = "sha256-C8g8uhuWOl3zPCjTaGs21yJ8k3tmvZE8U9LzSXoDSxE=";
   };
+
+  __darwinAllowLocalNetworking = true;
 
   build-system = [ setuptools ];
 
@@ -43,7 +44,7 @@ buildPythonPackage rec {
     installShellFiles
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     structlog
     platformdirs
     tornado
@@ -51,7 +52,14 @@ buildPythonPackage rec {
   ]
   ++ lib.optionals (pythonOlder "3.11") [ tomli ];
 
-  __darwinAllowLocalNetworking = true;
+  optional-dependencies = {
+    # vercmp = [ pyalpm ];
+    awesomeversion = [ awesomeversion ];
+    pypi = [ packaging ];
+    htmlparser = [ lxml ];
+    rpmrepo = [ lxml ] ++ lib.optionals (pythonOlder "3.14") [ zstandard ];
+    jq = [ jq ];
+  };
 
   nativeCheckInputs = [
     flaky
@@ -73,22 +81,13 @@ buildPythonPackage rec {
 
   disabledTestMarks = [ "needs_net" ];
 
-  optional-dependencies = {
-    # vercmp = [ pyalpm ];
-    awesomeversion = [ awesomeversion ];
-    pypi = [ packaging ];
-    htmlparser = [ lxml ];
-    rpmrepo = [ lxml ] ++ lib.optionals (pythonOlder "3.14") [ zstandard ];
-    jq = [ jq ];
-  };
-
   passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "New version checker for software";
     homepage = "https://github.com/lilydjwg/nvchecker";
-    changelog = "https://github.com/lilydjwg/nvchecker/releases/tag/v${version}";
+    changelog = "https://github.com/lilydjwg/nvchecker/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.mdaniels5757 ];
+    maintainers = with lib.maintainers; [ mdaniels5757 ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3668,7 +3668,7 @@ with pkgs;
     toPythonApplication (
       nvchecker.overridePythonAttrs (oldAttrs: {
         propagatedBuildInputs =
-          oldAttrs.propagatedBuildInputs ++ lib.flatten (builtins.attrValues oldAttrs.optional-dependencies);
+          oldAttrs.dependencies ++ lib.flatten (builtins.attrValues oldAttrs.optional-dependencies);
       })
     );
 


### PR DESCRIPTION
Upstream changes: https://github.com/lilydjwg/nvchecker/compare/176b08fc665c759b84832fab771ccc588fd81915..e513efb6adf8471effe8c822a33098684c3bca38

Closes: #444339
Closes: #447405

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
