### PR TITLE
home-assistant: 2025.9.3 -> 2025.9.4

### DIFF
--- a/pkgs/development/python-modules/bluetooth-auto-recovery/default.nix
+++ b/pkgs/development/python-modules/bluetooth-auto-recovery/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "bluetooth-auto-recovery";
-  version = "1.5.2";
+  version = "1.5.3";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "Bluetooth-Devices";
     repo = "bluetooth-auto-recovery";
     tag = "v${version}";
-    hash = "sha256-9FwQNauWnWQ7BQoKMwYEEc96/iP6iH9SfvHxlZtePOQ=";
+    hash = "sha256-xnEEq3NVScMbMjZWb4lI+kpy2zr6WlXx3XcBhzN1rZ4=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/holidays/default.nix
+++ b/pkgs/development/python-modules/holidays/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "holidays";
-  version = "0.80";
+  version = "0.81";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "vacanza";
     repo = "python-holidays";
     tag = "v${version}";
-    hash = "sha256-zKsJ85dd+SE2OL0t/5aHtXoHsz2WuTkg11mo2wlmeTM=";
+    hash = "sha256-p1+/BRi/4QG524nT9lns1AGc6jeO9KTJNJ2rljkrmko=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/opower/default.nix
+++ b/pkgs/development/python-modules/opower/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "opower";
-  version = "0.15.4";
+  version = "0.15.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tronikos";
     repo = "opower";
     tag = "v${version}";
-    hash = "sha256-+y2lQnF48b2PKocQw6eEDPNTqZSB4aOALMfNOIVS+Yg=";
+    hash = "sha256-K0GYXubMKh2B7KYhZOaecBWArTBayl/Wq5Ha3jJyixE=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/py-melissa-climate/default.nix
+++ b/pkgs/development/python-modules/py-melissa-climate/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "py-melissa-climate";
-  version = "2.1.2";
+  version = "2.1.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "kennedyshead";
     repo = "py-melissa-climate";
-    tag = "V${version}";
-    hash = "sha256-Z1A0G3g8dyoG+zUxUTqI/OxczvUVy2kSI04YP0WeXso=";
+    tag = version;
+    hash = "sha256-zYr+nKdO+lCLLYGSvY16MUs8TxbWcyaoQk9cwNQ704Y=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/pyemoncms/default.nix
+++ b/pkgs/development/python-modules/pyemoncms/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "pyemoncms";
-  version = "0.1.2";
+  version = "0.1.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Open-Building-Management";
     repo = "pyemoncms";
     tag = "v${version}";
-    hash = "sha256-61i7VKmPSMUrUSgnDtKROdDdM0QDqOTsqnLjGLkgGII=";
+    hash = "sha256-Bvcnl3av9SF0CNUjg/QDdvENIEgPg26fAJ522jBrL7Q=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pylamarzocco/default.nix
+++ b/pkgs/development/python-modules/pylamarzocco/default.nix
@@ -4,6 +4,7 @@
   aioresponses,
   bleak,
   buildPythonPackage,
+  cryptography,
   fetchFromGitHub,
   mashumaro,
   pytest-asyncio,
@@ -15,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "pylamarzocco";
-  version = "2.0.11";
+  version = "2.1.0";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -24,7 +25,7 @@ buildPythonPackage rec {
     owner = "zweckj";
     repo = "pylamarzocco";
     tag = "v${version}";
-    hash = "sha256-g0qhNBhcU7Dogcw9WiEk+APk2McU7woXBqgeUS9D8iQ=";
+    hash = "sha256-dUFjbht0QGrWtSl3JIx1dx4UQs5gFNqKw+UObgH25pk=";
   };
 
   build-system = [ setuptools ];
@@ -32,6 +33,7 @@ buildPythonPackage rec {
   dependencies = [
     aiohttp
     bleak
+    cryptography
     mashumaro
   ];
 

--- a/pkgs/development/python-modules/waterfurnace/default.nix
+++ b/pkgs/development/python-modules/waterfurnace/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "waterfurnace";
-  version = "1.1.0";
+  version = "1.2.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "sdague";
     repo = "waterfurnace";
     tag = "v${version}";
-    sha256 = "1ba247fw1fvi7zy31zj2wbjq7fajrbxhp139cl9jj67rfvxfv8xf";
+    sha256 = "sha256-lix8dU9PxlsXIzKNFuUJkd80cUYXfTXSnFLu1ULACkE=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/waterfurnace/default.nix
+++ b/pkgs/development/python-modules/waterfurnace/default.nix
@@ -3,19 +3,16 @@
   buildPythonPackage,
   click,
   fetchFromGitHub,
-  mock,
   pytestCheckHook,
   requests,
-  pythonOlder,
+  setuptools,
   websocket-client,
 }:
 
 buildPythonPackage rec {
   pname = "waterfurnace";
   version = "1.2.0";
-  format = "setuptools";
-
-  disabled = pythonOlder "3.7";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "sdague";
@@ -24,30 +21,26 @@ buildPythonPackage rec {
     sha256 = "sha256-lix8dU9PxlsXIzKNFuUJkd80cUYXfTXSnFLu1ULACkE=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "'pytest-runner'," ""
-  '';
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     click
     requests
     websocket-client
   ];
 
   nativeCheckInputs = [
-    mock
     pytestCheckHook
   ];
 
   pythonImportsCheck = [ "waterfurnace" ];
 
-  meta = with lib; {
+  meta = {
     description = "Python interface to waterfurnace geothermal systems";
-    mainProgram = "waterfurnace-debug";
+    mainProgram = "waterfurnace";
     homepage = "https://github.com/sdague/waterfurnace";
-    changelog = "https://github.com/sdague/waterfurnace/blob/v${version}/HISTORY.rst";
-    license = with licenses; [ asl20 ];
-    maintainers = with maintainers; [ fab ];
+    changelog = "https://github.com/sdague/waterfurnace/blob/${src.tag}/HISTORY.rst";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2025.9.3";
+  version = "2025.9.4";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -358,7 +358,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2025.9.3";
+  hassVersion = "2025.9.4";
 
 in
 python.pkgs.buildPythonApplication rec {
@@ -379,13 +379,13 @@ python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-iGOpLZMrEu0z+VdQMn1OeI1rw4x3WawQemyOdt7j124=";
+    hash = "sha256-d2lsyW2yAkIbq7wx/pLu4Qzroblh/TYDx08r6im8cI8=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-iw5RNM6VoiGfCmGgqfqMQot9ArPlKk/tXJUJZNs7Kzg=";
+    hash = "sha256-mq2cjct4YrURV/T51w/skukwEsUV4iwDphuOftFOUdw=";
   };
 
   build-system = with python.pkgs; [


### PR DESCRIPTION
    https://github.com/home-assistant/core/releases/tag/2025.9.4
    https://github.com/sdague/waterfurnace/blob/v1.2.0/HISTORY.rst
    https://github.com/zweckj/pylamarzocco/releases/tag/v2.1.0
    https://github.com/Open-Building-Management/pyemoncms/releases/tag/v0.1.3
    https://github.com/kennedyshead/py-melissa-climate/compare/2.1.2...2.1.4
    https://github.com/tronikos/opower/releases/tag/v0.15.5
    https://github.com/vacanza/python-holidays/releases/tag/v0.81
    https://github.com/python-hyper/h2/blob/v4.3.0/CHANGELOG.rst
    https://github.com/Bluetooth-Devices/bluetooth-auto-recovery/releases/tag/v1.5.3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc