### PR TITLE
rocmPackages.rocprofiler-register: patch old glog cmake policy version

### DIFF
--- a/pkgs/development/rocm-modules/6/rocprofiler-register/default.nix
+++ b/pkgs/development/rocm-modules/6/rocprofiler-register/default.nix
@@ -28,12 +28,19 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
   };
 
+  # vendored glog is too old and breaks on CMake 4, gets bumped in ROCm 7.0
+  postPatch = ''
+    substituteInPlace external/glog/cmake/GetCacheVariables.cmake \
+      --replace-fail "(VERSION 3.3)" "(VERSION 3.5)"
+  '';
+
   nativeBuildInputs = [
     cmake
     clang
     clr
   ];
 
+  # TODO(@LunNova): use system fmt&glog once upstream fixes flag to not vendor
   buildInputs = [
     numactl
     libpciaccess


### PR DESCRIPTION
Required to unbreak rocprofiler-register after the recent CMake 4 bump.

rocprofiler-register vendors CMake 4 incompatible deps. Using system versions of those deps is currently non-trivial, apply CMAKE_POLICY_VERSION_MINIMUM for now.

Raised an upstream issue https://github.com/ROCm/rocm-systems/issues/1070

I may try to PR a fix upstream later but don't want to spend too much time on this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
