### PR TITLE
frugally-deep: 0.15.24-p0 -> 0.18.2-unstable-2025-06-16

### DIFF
--- a/pkgs/by-name/fr/frugally-deep/package.nix
+++ b/pkgs/by-name/fr/frugally-deep/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "frugally-deep";
-  version = "0.15.24-p0";
+  version = "0.18.2-unstable-2025-06-16";
 
   src = fetchFromGitHub {
     owner = "Dobiasd";
     repo = "frugally-deep";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-yg2SMsYOOSOgsdwIH1bU3iPM45z6c7WeIrgOddt3um4=";
+    rev = "30a4ce4c932ca810a5a77c4ab943a520bb1048fe";
+    hash = "sha256-tcwCRSHhN61ZFDFVQ/GItvgSSjeLSbFDoNMqwswtvto=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Required to unbreak frugally-deep after the recent CMake 4 bump.

Bump required for CMake 4 compat. Upstream haven't tagged since supporting CMake 4.

Diff: https://github.com/Dobiasd/frugally-deep/compare/v0.15.24-p0...30a4ce4c932ca810a5a77c4ab943a520bb1048fe

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
