### PR TITLE
frigate: add GPU drivers to LD_LIBRARY_PATH

### DIFF
--- a/nixos/modules/services/video/frigate.nix
+++ b/nixos/modules/services/video/frigate.nix
@@ -687,12 +687,12 @@ in
         CONFIG_FILE = "/run/frigate/frigate.yml";
         HOME = "/var/lib/frigate";
         PYTHONPATH = cfg.package.pythonPath;
+        LD_LIBRARY_PATH = makeLibraryPath (
+          with pkgs; [ addDriverRunpath.driverLink ] ++ optionals (withCoral) [ libedgetpu ]
+        );
       }
       // optionalAttrs (cfg.vaapiDriver != null) {
         LIBVA_DRIVER_NAME = cfg.vaapiDriver;
-      }
-      // optionalAttrs withCoral {
-        LD_LIBRARY_PATH = makeLibraryPath (with pkgs; [ libedgetpu ]);
       };
       path =
         with pkgs;


### PR DESCRIPTION
My Nvidia GPU wasn't being picked up by Frigate in the system metrics on the web page, but was working to do hardware acceleration. I've done the same as #442525 to get this working for me.

I've tested this in my own config by adding
```nix
  systemd.services.frigate.environment.LD_LIBRARY_PATH = lib.mkForce (
    lib.makeLibraryPath (
      with pkgs;
      [
        libedgetpu
        addDriverRunpath.driverLink
      ]
    )
  );
```
and my GPU stats are now appearing.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
