### PR TITLE
tunnelgraf: override paramiko

### DIFF
--- a/pkgs/by-name/tu/tunnelgraf/package.nix
+++ b/pkgs/by-name/tu/tunnelgraf/package.nix
@@ -46,7 +46,7 @@ python3.pkgs.buildPythonApplication rec {
   meta = {
     description = "Tool to manage SSH tunnel hops to many endpoints";
     homepage = "https://github.com/denniswalker/tunnelgraf";
-    changelog = "https://github.com/denniswalker/tunnelgraf/releases/tag/v${version}";
+    changelog = "https://github.com/denniswalker/tunnelgraf/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "tunnelgraf";

--- a/pkgs/by-name/tu/tunnelgraf/package.nix
+++ b/pkgs/by-name/tu/tunnelgraf/package.nix
@@ -1,10 +1,28 @@
 {
   lib,
   fetchFromGitHub,
+  fetchPypi,
   python3,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+let
+  py = python3.override {
+    packageOverrides = self: super: {
+
+      # Doesn't work with latest paramiko
+      paramiko = super.paramiko.overridePythonAttrs (oldAttrs: rec {
+        version = "3.4.0";
+        src = fetchPypi {
+          pname = "paramiko";
+          inherit version;
+          hash = "sha256-qsCPJqMdxN/9koIVJ9FoLZnVL572hRloEUqHKPPCdNM=";
+        };
+        doCheck = false;
+      });
+    };
+  };
+in
+py.pkgs.buildPythonApplication rec {
   pname = "tunnelgraf";
   version = "1.0.6";
   pyproject = true;
@@ -19,14 +37,14 @@ python3.pkgs.buildPythonApplication rec {
   pythonRelaxDeps = [
     "click"
     "deepmerge"
-    "paramiko"
     "psutil"
     "pydantic"
+    "python-hosts"
   ];
 
-  build-system = with python3.pkgs; [ hatchling ];
+  build-system = with py.pkgs; [ hatchling ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with py.pkgs; [
     click
     deepmerge
     paramiko

--- a/pkgs/development/python-modules/sshtunnel/default.nix
+++ b/pkgs/development/python-modules/sshtunnel/default.nix
@@ -35,6 +35,8 @@ buildPythonPackage rec {
     "test_get_keys"
     "connect_via_proxy"
     "read_ssh_config"
+    # Test doesn't work with paramiko < 4.0.0 and the patch above
+    "test_read_private_key_file"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
https://hydra.nixos.org/build/307012764

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
