### PR TITLE
libvdpau-va-gl: pull upstream `cmake-4` fix

### DIFF
--- a/pkgs/by-name/li/libvdpau-va-gl/package.nix
+++ b/pkgs/by-name/li/libvdpau-va-gl/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   pkg-config,
   libX11,
@@ -25,6 +26,25 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "0asndybfv8xb0fx73sjjw5kydqrahqkm6n04lh589pbf18s5qlld";
   };
+
+  patches = [
+    # cmake-4 compatibility
+    (fetchpatch {
+      name = "cmake-4-1.patch";
+      url = "https://github.com/i-rinat/libvdpau-va-gl/commit/30c8ac91f3aa2843f7dc1c1d167e09fad447fd91.patch?full_index=1";
+      hash = "sha256-PFEqBg3NE0fVFBAW4zdDbh8eBfKyPX3BZ8P2M15Qq5A=";
+    })
+    (fetchpatch {
+      name = "cmake-4-2.patch";
+      url = "https://github.com/i-rinat/libvdpau-va-gl/commit/38c7d8fddb092824cbcdf2b11af519775930cc8b.patch?full_index=1";
+      hash = "sha256-XsX/GLIS2Ce7obQJ4uVhLDtTI1TrDAGi3ECxEH6oOFI=";
+    })
+    (fetchpatch {
+      name = "cmake-4-3.patch";
+      url = "https://github.com/i-rinat/libvdpau-va-gl/commit/a845e8720d900e4bcc89e7ee16106ce63b44af0.patch?full_index=1";
+      hash = "sha256-lhiZFDR2ytDmo9hQUT35IJS4KL4+nYWAOnxZlj7u3tM=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Without the change the build fails on` staging` as:

       CMake Error at CMakeLists.txt:2 (cmake_minimum_required):
         Compatibility with CMake < 3.5 has been removed from CMake.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
