### PR TITLE
imgui: 1.91.4 -> 1.92.3

### DIFF
--- a/pkgs/by-name/im/imgui/package.nix
+++ b/pkgs/by-name/im/imgui/package.nix
@@ -14,6 +14,8 @@
   vulkan-headers,
   vulkan-loader,
   imgui,
+  xorg,
+  wayland,
 
   # NOTE: Not coming from vcpkg
   IMGUI_LINK_GLVND ?
@@ -72,7 +74,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "imgui";
-  version = "1.91.4";
+  version = "1.92.3";
   outputs = [
     # Note: no "dev" because vcpkg installs include/ and imgui-config.cmake
     # into different prefixes but expects the merged layout at import time
@@ -84,7 +86,7 @@ stdenv.mkDerivation rec {
     owner = "ocornut";
     repo = "imgui";
     tag = "v${version}";
-    hash = "sha256-6j4keBOAzbBDsV0+R4zTNlsltxz2dJDGI43UIrHXDNM=";
+    hash = "sha256-J+h7jJ+4wqr6RivtzyTDMXKxFoGs7dQbzqdu51XgEbc=";
   };
 
   cmakeRules = "${vcpkgSource}/ports/imgui";
@@ -92,7 +94,13 @@ stdenv.mkDerivation rec {
     cp "$cmakeRules"/{CMakeLists.txt,*.cmake.in} ./
   '';
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXrandr
+    wayland
+  ];
 
   propagatedBuildInputs =
     lib.optionals IMGUI_LINK_GLVND [ libGL ]


### PR DESCRIPTION
Probably this PR is WIP.

For some reason it failed to build glfw without adding as native deps xorg and wayland, this was not needed before and I have no idea why.

There are almost 400 dependent packages and imgui has had api changes, no idea yet what packages are affected.

I create this but first we should understand if this is safe to merge or not

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
