### PR TITLE
libxml2: 2.14.6 -> 2.15.0

### DIFF
--- a/pkgs/by-name/li/librsvg/expect-any-error-too-many-elements.patch
+++ b/pkgs/by-name/li/librsvg/expect-any-error-too-many-elements.patch
@@ -1,0 +1,23 @@
+diff --git a/rsvg/tests/errors.rs b/rsvg/tests/errors.rs
+index 02b134bee..46391fa5d 100644
+--- a/rsvg/tests/errors.rs
++++ b/rsvg/tests/errors.rs
+@@ -14,15 +14,12 @@ use rsvg::{CairoRenderer, ImplementationLimit, Loader, LoadingError, RenderingEr
+ 
+ #[ignore]
+ #[test]
++#[should_panic]
+ fn too_many_elements() {
+     let name = "tests/fixtures/errors/bug515-too-many-elements.svgz";
+ 
+-    assert!(matches!(
+-        Loader::new().read_path(name),
+-        Err(LoadingError::LimitExceeded(
+-            ImplementationLimit::TooManyLoadedElements
+-        ))
+-    ));
++    // libxml2 might return an error without updating the element count, so just expect any error, not specifically too many elements
++    Loader::new().read_path(name).unwrap();
+ }
+ 
+ fn rendering_instancing_limit(name: &str) {

--- a/pkgs/by-name/li/librsvg/package.nix
+++ b/pkgs/by-name/li/librsvg/package.nix
@@ -64,6 +64,17 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-vBu81BkSCwmNsovqVTNdneJHDU5qn27pcge0EPwVhn0=";
   };
 
+  patches = [
+    # too_many_elements test fails with libxml 2.15.0,
+    # because libxml2 no longer updates the element count
+    # before erroring out, which breaks the librsvg limit check.
+    #
+    # This is okay, because the error is still detected.
+    # The error is simply not reported accurately.
+    # https://gitlab.gnome.org/GNOME/librsvg/-/issues/1201
+    ./expect-any-error-too-many-elements.patch
+  ];
+
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     name = "librsvg-deps-${finalAttrs.version}";

--- a/pkgs/by-name/xm/xmlsec/package.nix
+++ b/pkgs/by-name/xm/xmlsec/package.nix
@@ -1,6 +1,7 @@
 {
   stdenv,
   fetchurl,
+  fetchpatch,
   libxml2,
   gnutls,
   libxslt,
@@ -33,6 +34,11 @@ lib.fix (
     patches = [
       ./lt_dladdsearchdir.patch
       ./remove_bsd_base64_decode_flag.patch
+      (fetchpatch {
+        # xmlDoc.encoding is no longer const in libxml 2.15, so fetch the fix
+        url = "https://github.com/lsh123/xmlsec/commit/ef0e3b5cac04db13ce070b1e5bcad7dd7b0eb49b.patch?full_index=1";
+        hash = "sha256-Hv8PaJXkXLq++NuCAJ4IvsYBPj8wkN7dBTniYucq18o=";
+      })
     ];
 
     postPatch = ''

--- a/pkgs/development/libraries/libxml2/common.nix
+++ b/pkgs/development/libraries/libxml2/common.nix
@@ -5,19 +5,11 @@
   pkg-config,
   autoreconfHook,
   python3,
+  doxygen,
   ncurses,
   findXMLCatalogs,
   libiconv,
-  # Python limits cross-compilation to an allowlist of host OSes.
-  # https://github.com/python/cpython/blob/dfad678d7024ab86d265d84ed45999e031a03691/configure.ac#L534-L562
-  pythonSupport ?
-    enableShared
-    && (
-      stdenv.hostPlatform == stdenv.buildPlatform
-      || stdenv.hostPlatform.isCygwin
-      || stdenv.hostPlatform.isLinux
-      || stdenv.hostPlatform.isWasi
-    ),
+  pythonSupport ? false,
   icuSupport ? false,
   icu,
   zlibSupport ? false,
@@ -52,27 +44,21 @@ stdenv'.mkDerivation (finalAttrs: {
     "bin"
     "dev"
     "out"
-    "devdoc"
   ]
   ++ lib.optional pythonSupport "py"
   ++ lib.optional (enableStatic && enableShared) "static";
   outputMan = "bin";
 
-  patches = [
-    # Unmerged ABI-breaking patch required to fix the following security issues:
-    # - https://gitlab.gnome.org/GNOME/libxslt/-/issues/139
-    # - https://gitlab.gnome.org/GNOME/libxslt/-/issues/140
-    # See also https://gitlab.gnome.org/GNOME/libxml2/-/issues/906
-    # Source: https://github.com/chromium/chromium/blob/4fb4ae8ce3daa399c3d8ca67f2dfb9deffcc7007/third_party/libxml/chromium/xml-attr-extra.patch
-    ./xml-attr-extra.patch
-  ]
-  ++ extraPatches;
+  patches = [ ] ++ extraPatches;
 
   strictDeps = true;
 
   nativeBuildInputs = [
     pkg-config
     autoreconfHook
+  ]
+  ++ lib.optionals pythonSupport [
+    doxygen
   ];
 
   buildInputs =
@@ -101,10 +87,10 @@ stdenv'.mkDerivation (finalAttrs: {
     (lib.withFeature icuSupport "icu")
     (lib.withFeature pythonSupport "python")
     (lib.optionalString pythonSupport "PYTHON=${python3.pythonOnBuildForHost.interpreter}")
-  ]
-  # avoid rebuilds, can be merged into list in version bumps
-  ++ lib.optional enableHttp "--with-http"
-  ++ lib.optional zlibSupport "--with-zlib";
+    (lib.withFeature enableHttp "http")
+    (lib.withFeature zlibSupport "zlib")
+    (lib.withFeature false "docs") # docs are built with xsltproc, which would be a cyclic dependency
+  ];
 
   installFlags = lib.optionals pythonSupport [
     "pythondir=\"${placeholder "py"}/${python3.sitePackages}\""
@@ -159,6 +145,19 @@ stdenv'.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
     pkgConfigModules = [ "libxml-2.0" ];
+    # Python limits cross-compilation to an allowlist of host OSes.
+    # https://github.com/python/cpython/blob/dfad678d7024ab86d265d84ed45999e031a03691/configure.ac#L534-L562
+    broken =
+      pythonSupport
+      && !(
+        enableShared
+        && (
+          stdenv.hostPlatform == stdenv.buildPlatform
+          || stdenv.hostPlatform.isCygwin
+          || stdenv.hostPlatform.isLinux
+          || stdenv.hostPlatform.isWasi
+        )
+      );
   }
   // extraMeta;
 })

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -34,6 +34,13 @@ let
         # same as upstream, fixed conflicts
         # https://gitlab.gnome.org/GNOME/libxml2/-/commit/c340e419505cf4bf1d9ed7019a87cc00ec200434
         ./CVE-2025-6170.patch
+
+        # Unmerged ABI-breaking patch required to fix the following security issues:
+        # - https://gitlab.gnome.org/GNOME/libxslt/-/issues/139
+        # - https://gitlab.gnome.org/GNOME/libxslt/-/issues/140
+        # See also https://gitlab.gnome.org/GNOME/libxml2/-/issues/906
+        # Source: https://github.com/chromium/chromium/blob/4fb4ae8ce3daa399c3d8ca67f2dfb9deffcc7007/third_party/libxml/chromium/xml-attr-extra.patch
+        ./xml-attr-extra.patch
       ];
       freezeUpdateScript = true;
       extraMeta = {
@@ -43,13 +50,13 @@ let
       };
     };
     libxml2 = callPackage ./common.nix {
-      version = "2.14.6";
+      version = "2.15.0";
       src = fetchFromGitLab {
         domain = "gitlab.gnome.org";
         owner = "GNOME";
         repo = "libxml2";
         tag = "v${packages.libxml2.version}";
-        hash = "sha256-EIcNL5B/o74hyc1N+ShrlKsPL5tHhiGgkCR1D7FcDjw=";
+        hash = "sha256-jumHSiIMDzqG2hvPUdcBP8LsszcU+loOY+vqEh/0Yqo=";
       };
       extraMeta = {
         maintainers = with lib.maintainers; [

--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -39,16 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
     # https://gitlab.gnome.org/GNOME/libxslt/-/issues/144
     # Source: https://gitlab.gnome.org/GNOME/libxslt/-/merge_requests/77
     ./77-Use-a-dedicated-node-type-to-maintain-the-list-of-cached-rv-ts.patch
-
-    # Fix type confusion in xmlNode.psvi between stylesheet and source nodes
-    # https://gitlab.gnome.org/GNOME/libxslt/-/issues/139
-    # Fix heap-use-after-free in xmlFreeID caused by `atype` corruption
-    # https://gitlab.gnome.org/GNOME/libxslt/-/issues/140
-    #
-    # Depends on unmerged libxml2 patch that breaks ABI.
-    #
-    # Source: https://github.com/chromium/chromium/blob/4fb4ae8ce3daa399c3d8ca67f2dfb9deffcc7007/third_party/libxslt/chromium/new-unified-atype-extra.patch
-    ./new-unified-atype-extra.patch
   ];
 
   strictDeps = true;

--- a/pkgs/development/python-modules/lxml/default.nix
+++ b/pkgs/development/python-modules/lxml/default.nix
@@ -17,15 +17,20 @@
 
 buildPythonPackage rec {
   pname = "lxml";
-  version = "6.0.1";
+  version = "6.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lxml";
     repo = "lxml";
     tag = "lxml-${version}";
-    hash = "sha256-iY47nhAbA8ScnjmK2/7lVCBP8f65v1zOs3TcgQULlQ0=";
+    hash = "sha256-Ri5SzfQJFghRcMAKHS5QKD365OZlio895fSlumq83vs=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'Cython>=3.1.4' 'Cython'
+  '';
 
   build-system = [
     cython


### PR DESCRIPTION
Rel notes: https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.15.0

closes https://github.com/NixOS/nixpkgs/issues/444172

~~Very much untested, here be dragons! These things *build*, but i expect there to be significant fallout and breakage.~~ Testing done (see https://github.com/NixOS/nixpkgs/pull/444599#issuecomment-3317725718), ~~but there is a potential security regression. DO NOT MERGE YET!~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
