### PR TITLE
various: fix Scudo allocator due to LLVM update

### DIFF
--- a/nixos/modules/config/malloc.nix
+++ b/nixos/modules/config/malloc.nix
@@ -52,7 +52,7 @@ let
             or (throw "scudo not supported on ${pkgs.stdenv.hostPlatform.system}");
       in
       {
-        libPath = "${pkgs.llvmPackages.compiler-rt}/lib/linux/libclang_rt.scudo-${systemPlatform}.so";
+        libPath = "${pkgs.llvmPackages.compiler-rt}/lib/linux/libclang_rt.scudo_standalone-${systemPlatform}.so";
         description = ''
           A user-mode allocator based on LLVM Sanitizer’s CombinedAllocator,
           which aims at providing additional mitigations against heap based

--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -39,7 +39,7 @@ in
     nix.settings.allowed-users = mkDefault [ "@users" ];
 
     environment.memoryAllocator.provider = mkDefault "scudo";
-    environment.variables.SCUDO_OPTIONS = mkDefault "ZeroContents=1";
+    environment.variables.SCUDO_OPTIONS = mkDefault "zero_contents=true";
 
     security.lockKernelModules = mkDefault true;
 

--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -102,7 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
   env = {
     NIX_CFLAGS_COMPILE = toString (
       [
-        "-DSCUDO_DEFAULT_OPTIONS=DeleteSizeMismatch=0:DeallocationTypeMismatch=0"
+        "-DSCUDO_DEFAULT_OPTIONS=delete_size_mismatch=false:dealloc_type_mismatch=false"
       ]
       ++ lib.optionals (!haveLibc) [
         # The compiler got stricter about this, and there is a usellvm patch below


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The commit 01e8f570c67955ab92be0ef352066f16b63940f2 unpinned the LLVM version of the Scudo allocator. When running with the hardened profile this led to building errors due to the changed path of the Scudo library and runtime errors due to changed spelling of the options.

This MR adjusts the library path (thanks to @CUB3D) and updates the spelling of all existing Scudo options according to the Scudo documentation [1]. For more details see the commit messages.
I built and tested these changes on my system with `imports = [(modulesPath + "/profiles/hardened.nix")];`.

Closes #437368

[1] https://llvm.org/docs/ScudoHardenedAllocator.html

@emilazy I hope it is fine to ping you for this MR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
