### PR TITLE
lixPackageSets.git: 2.94.0-pre-20250912_d90e4a65812c -> 2.94.0-pre-20250920_3ee839cc5ed4

### DIFF
--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -26,7 +26,6 @@ assert lib.assertMsg (
   boehmgc,
   boost,
   brotli,
-  busybox,
   busybox-sandbox-shell,
   bzip2,
   callPackage,
@@ -55,6 +54,7 @@ assert lib.assertMsg (
   nlohmann_json,
   ninja,
   openssl,
+  pkgsStatic,
   rustc,
   toml11,
   pegtl,
@@ -291,7 +291,7 @@ stdenv.mkDerivation (finalAttrs: {
     lib.optionals
       (stdenv.hostPlatform.isLinux && finalAttrs.doInstallCheck && lib.versionAtLeast version "2.94")
       [
-        (lib.mesonOption "build-test-shell" "${busybox}/bin")
+        (lib.mesonOption "build-test-shell" "${pkgsStatic.busybox}/bin")
       ];
 
   ninjaFlags = [ "-v" ];

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -57,7 +57,10 @@ let
           boehmgc =
             # TODO: Why is this called `boehmgc-nix_2_3`?
             let
-              boehmgc-nix_2_3 = boehmgc.override { enableLargeConfig = true; };
+              boehmgc-nix_2_3 = boehmgc.override {
+                enableLargeConfig = true;
+                initialMarkStackSize = 1048576;
+              };
             in
             # Since Lix 2.91 does not use boost coroutines, it does not need boehmgc patches either.
             if lib.versionOlder lix-args.version "2.91" then
@@ -214,14 +217,14 @@ lib.makeExtensible (
       attrName = "git";
 
       lix-args = rec {
-        version = "2.94.0-pre-20250912_${builtins.substring 0 12 src.rev}";
+        version = "2.94.0-pre-20251001_${builtins.substring 0 12 src.rev}";
 
         src = fetchFromGitea {
           domain = "git.lix.systems";
           owner = "lix-project";
           repo = "lix";
-          rev = "d90e4a65812c6d3dd90aed7e44941eba3215f876";
-          hash = "sha256-rbf0ptj4BTSwsitKQu3FuaiJwhNDePGBeBJovm5HLdQ=";
+          rev = "f1ef994f120a723839a6d837cc2b33914a30a4db";
+          hash = "sha256-Rmq98EchbKygPo+2g0nDsZ7QNMLe+loiMbflV5VKDzc=";
         };
 
         patches = [

--- a/pkgs/tools/package-management/lix/revert-toml11-bump.patch
+++ b/pkgs/tools/package-management/lix/revert-toml11-bump.patch
@@ -38,7 +38,7 @@ index 9d4b5e6abf..3e26773eac 100644
          );
      } catch (std::exception & e) { // NOLINT(lix-foreign-exceptions) // TODO: toml::syntax_error
 diff --git a/meson.build b/meson.build
-index 7b229ccefb..d4a36eb285 100644
+index bede78a647..a72016522e 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -363,7 +363,10 @@
@@ -53,91 +53,28 @@ index 7b229ccefb..d4a36eb285 100644
  
  pegtl = dependency(
    'pegtl',
-diff --git a/misc/toml11.nix b/misc/toml11.nix
-deleted file mode 100644
-index c53be3da1b..0000000000
---- a/misc/toml11.nix
-+++ /dev/null
-@@ -1,47 +0,0 @@
--{
--  lib,
--  stdenv,
--  fetchFromGitHub,
--  cmake,
--}:
--
--stdenv.mkDerivation (finalAttrs: {
--  pname = "toml11";
--  version = "4.4.0";
--
--  src = fetchFromGitHub {
--    owner = "ToruNiina";
--    repo = "toml11";
--    rev = "v${finalAttrs.version}";
--    hash = "sha256-sgWKYxNT22nw376ttGsTdg0AMzOwp8QH3E8mx0BZJTQ=";
--  };
--
--  nativeBuildInputs = [
--    cmake
--  ];
--
--  meta = with lib; {
--    homepage = "https://github.com/ToruNiina/toml11";
--    description = "TOML for Modern C++";
--    longDescription = ''
--      toml11 is a C++11 (or later) header-only toml parser/encoder depending
--      only on C++ standard library.
--
--      - It is compatible to the latest version of TOML v1.0.0.
--      - It is one of the most TOML standard compliant libraries, tested with
--        the language agnostic test suite for TOML parsers by BurntSushi.
--      - It shows highly informative error messages.
--      - It has configurable container. You can use any random-access containers
--        and key-value maps as backend containers.
--      - It optionally preserves comments without any overhead.
--      - It has configurable serializer that supports comments, inline tables,
--        literal strings and multiline strings.
--      - It supports user-defined type conversion from/into toml values.
--      - It correctly handles UTF-8 sequences, with or without BOM, both on posix
--        and Windows.
--    '';
--    license = licenses.mit;
--    maintainers = with maintainers; [ ];
--    platforms = platforms.unix ++ platforms.windows;
--  };
--})
 diff --git a/package.nix b/package.nix
-index eb0e5c602a..c1c948ee7e 100644
+index eb0e5c602a..9357b8ebd1 100644
 --- a/package.nix
 +++ b/package.nix
-@@ -55,8 +55,6 @@
-   rustc,
-   sqlite,
+@@ -57,7 +57,6 @@
    systemtap-lix ? __forDefaults.systemtap-lix,
--  # FIXME: remove default after dropping NixOS 25.05
--  toml11-lix ? __forDefaults.toml11-lix,
-   toml11,
+   # FIXME: remove default after dropping NixOS 25.05
+   toml11-lix ? __forDefaults.toml11-lix,
+-  toml11,
    util-linuxMinimal ? utillinuxMinimal,
    utillinuxMinimal ? null,
-@@ -117,9 +115,6 @@
-     build-release-notes = callPackage ./maintainers/build-release-notes.nix { };
+   xz,
+@@ -118,8 +117,7 @@
  
      passt-lix = callPackage ./misc/passt.nix { };
--
+ 
 -    toml11-lix =
 -      if lib.versionOlder toml11.version "4.4.0" then callPackage ./misc/toml11.nix { } else toml11;
++    toml11-lix = callPackage ./misc/toml11.nix { };
    },
  }:
  
-@@ -344,7 +339,7 @@
-     libarchive
-     boost
-     lowdown
--    toml11-lix
-+    toml11
-     pegtl
-     capnproto
-     dtrace-headers
 diff --git a/tests/functional2/lang/fromTOML-overflowing/eval-fail-overflow.err.exp b/tests/functional2/lang/fromTOML-overflowing/eval-fail-overflow.err.exp
 deleted file mode 100644
 index 0c90e85edf..0000000000
@@ -176,17 +113,17 @@ index a287e18655..0000000000
 -        1 | attr = -9223372036854775809
 -          |                            ^-- must be < 2^63
 -       
-diff --git a/tests/functional2/lang/fromTOML-overflowing/eval-okay-overflow.out.exp b/tests/functional2/lang/fromTOML-overflowing/eval-okay-overflow.out.exp
-new file mode 100644
-index 0000000000..e241ca9ba4
---- /dev/null
-+++ b/tests/functional2/lang/fromTOML-overflowing/eval-okay-overflow.out.exp
-@@ -0,0 +1,1 @@
-+{ attr = 9223372036854775807; }
-diff --git a/tests/functional2/lang/fromTOML-overflowing/eval-okay-underflow.out.exp b/tests/functional2/lang/fromTOML-overflowing/eval-okay-underflow.out.exp
-new file mode 100644
-index 0000000000..83b822591f
---- /dev/null
-+++ b/tests/functional2/lang/fromTOML-overflowing/eval-okay-underflow.out.exp
-@@ -0,0 +1,1 @@
-+{ attr = -9223372036854775808; }
+diff --git a/tests/functional2/lang/fromTOML-overflowing/in-overflow.nix b/tests/functional2/lang/fromTOML-overflowing/in-overflow.nix
+deleted file mode 100644
+index 17f0448b3d..0000000000
+--- a/tests/functional2/lang/fromTOML-overflowing/in-overflow.nix
++++ /dev/null
+@@ -1,1 +0,0 @@
+-builtins.fromTOML ''attr = 9223372036854775808''
+diff --git a/tests/functional2/lang/fromTOML-overflowing/in-underflow.nix b/tests/functional2/lang/fromTOML-overflowing/in-underflow.nix
+deleted file mode 100644
+index 923fdf3545..0000000000
+--- a/tests/functional2/lang/fromTOML-overflowing/in-underflow.nix
++++ /dev/null
+@@ -1,1 +0,0 @@
+-builtins.fromTOML ''attr = -9223372036854775809''


### PR DESCRIPTION
Now with toml11 ≥4 support.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
