### PR TITLE
unixODBCDrivers.mariadb: fix build for musl

### DIFF
--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -57,6 +57,8 @@
     patches = [
       # Fix `call to undeclared function 'sleep'` with clang 16
       ./mariadb-connector-odbc-unistd.patch
+
+      ./mariadb-connector-odbc-musl.patch
     ];
 
     nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/unixODBCDrivers/mariadb-connector-odbc-musl.patch
+++ b/pkgs/development/libraries/unixODBCDrivers/mariadb-connector-odbc-musl.patch
@@ -1,0 +1,41 @@
+From fe6e6412ac0fb155843585647c045a1fba2ee3f2 Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Sat, 20 Sep 2025 14:11:13 +0200
+Subject: [PATCH] Add missing <cstdint> includes
+
+These files use types from <cstdint> without including it.  Without
+the includes, the build fails for musl.
+---
+Link: https://github.com/mariadb-corporation/mariadb-connector-odbc/pull/65
+
+ driver/interface/Exception.h | 1 +
+ driver/template/CArray.h     | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/driver/interface/Exception.h b/driver/interface/Exception.h
+index 1b2eb847..82f06273 100644
+--- a/driver/interface/Exception.h
++++ b/driver/interface/Exception.h
+@@ -21,6 +21,7 @@
+ #ifndef _EXCEPTION_H_
+ #define _EXCEPTION_H_
+ 
++#include <cstdint>
+ #include <stdexcept>
+ #include "class/SQLString.h"
+ 
+diff --git a/driver/template/CArray.h b/driver/template/CArray.h
+index 2c4be514..bd0e9912 100644
+--- a/driver/template/CArray.h
++++ b/driver/template/CArray.h
+@@ -24,6 +24,7 @@
+ #include <initializer_list>
+ #include <vector>
+ #include <stdexcept>
++#include <cstdint>
+ #include <cstring>
+ #include <string>
+ 
+-- 
+2.51.0
+


### PR DESCRIPTION
Fixes: 9e4b2ce5c7c2 ("unixODBCDrivers.mariadb: 3.1.20 -> 3.2.6")


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
