### PR TITLE
beauty-line-icon-theme: 0.0.4 -> 2.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15305,6 +15305,12 @@
     githubId = 208297;
     name = "Luz";
   };
+  lwb-2021 = {
+    email = "lwb-2021@qq.com";
+    github = "lwb-2021";
+    githubId = 91705377;
+    name = "lwb-2021";
+  };
   lx = {
     email = "alex@adnab.me";
     github = "Alexis211";

--- a/pkgs/data/icons/beauty-line-icon-theme/default.nix
+++ b/pkgs/data/icons/beauty-line-icon-theme/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenvNoCC,
-  fetchFromGitHub,
+  fetchFromGitLab,
   breeze-icons,
   gtk3,
   gnome-icon-theme,
@@ -13,19 +13,14 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "BeautyLine";
-  version = "0.0.4";
+  version = "2.4";
 
-  src = fetchFromGitHub {
-    owner = "gvolpe";
-    repo = pname;
-    rev = version;
-    sparseCheckout = [
-      "BeautyLine-V3"
-    ];
-    hash = "sha256-IkkypAj250+OXbf19TampCnqYsSbJVIjeYlxJoyhpzk=";
+  src = fetchFromGitLab {
+    owner = "garuda-linux";
+    repo = "themes-and-settings/artwork/beautyline";
+    rev = "0df6f5df71c19496f9a873f8a52fbb5e84e95b12";
+    hash = "sha256-SsYW4H1qam7kQJ3E4/vHJJOv2E4Pdk3itGncWa6YTqw=";
   };
-
-  sourceRoot = "${src.name}/BeautyLine-V3";
 
   nativeBuildInputs = [
     jdupes
@@ -63,6 +58,6 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://www.gnome-look.org/p/1425426/";
     platforms = platforms.linux;
     license = [ licenses.publicDomain ];
-    maintainers = with maintainers; [ gvolpe ];
+    maintainers = with maintainers; [ lwb-2021 ];
   };
 }


### PR DESCRIPTION
<!--
Update beauty-line-icon-theme to follow the upstream
- new app icons & requested icons added
- support for kde 6

-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
