### PR TITLE
frugally-deep: revert bump&backport CMake 4 compat, rocmPackages.miopen: add regression test

### DIFF
--- a/pkgs/by-name/fr/frugally-deep/package.nix
+++ b/pkgs/by-name/fr/frugally-deep/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "frugally-deep";
-  version = "0.18.2-unstable-2025-06-16";
+  version = "0.15.24-p0";
 
   src = fetchFromGitHub {
     owner = "Dobiasd";
     repo = "frugally-deep";
-    rev = "30a4ce4c932ca810a5a77c4ab943a520bb1048fe";
-    hash = "sha256-tcwCRSHhN61ZFDFVQ/GItvgSSjeLSbFDoNMqwswtvto=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-yg2SMsYOOSOgsdwIH1bU3iPM45z6c7WeIrgOddt3um4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fr/frugally-deep/package.nix
+++ b/pkgs/by-name/fr/frugally-deep/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  fetchpatch,
   fetchFromGitHub,
   gitUpdater,
   cmake,
@@ -14,6 +15,8 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "frugally-deep";
+  # be careful bumping this, frugally-deep may change its model metadata format
+  # in ways that only fail at runtime
   version = "0.15.24-p0";
 
   src = fetchFromGitHub {
@@ -22,6 +25,15 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-yg2SMsYOOSOgsdwIH1bU3iPM45z6c7WeIrgOddt3um4=";
   };
+
+  patches = [
+    (fetchpatch {
+      # Backport CMake 4 compat so we can stay on 0.15 for now
+      name = "update-minimum-cmake4-huntergate.patch";
+      url = "https://github.com/Dobiasd/frugally-deep/commit/30a4ce4c932ca810a5a77c4ab943a520bb1048fe.patch";
+      hash = "sha256-J5z+jQis8N2mzWu2Qm7J0fPkrplpjgDCOAJT7binz04=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/fr/frugally-deep/package.nix
+++ b/pkgs/by-name/fr/frugally-deep/package.nix
@@ -8,15 +8,18 @@
   functionalplus,
   eigen,
   nlohmann_json,
-  doctest,
   python3Packages,
   buildTests ? false, # Needs tensorflow
+  # for tests
+  doctest,
+  rocmPackages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "frugally-deep";
   # be careful bumping this, frugally-deep may change its model metadata format
-  # in ways that only fail at runtime
+  # in ways that only fail at runtime. MIOpen is currently the only package
+  # relying on this, run passthru.tests.miopen-can-load-models to check
   version = "0.15.24-p0";
 
   src = fetchFromGitHub {
@@ -55,6 +58,11 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = lib.optionals buildTests [ "-DFDEEP_BUILD_UNITTEST=ON" ];
+  passthru.tests.miopen-can-load-models =
+    rocmPackages.miopen.passthru.tests.can-load-models.override
+      {
+        frugally-deep = finalAttrs.finalPackage;
+      };
   passthru.updateScript = gitUpdater;
 
   meta = with lib; {

--- a/pkgs/development/rocm-modules/6/miopen/default.nix
+++ b/pkgs/development/rocm-modules/6/miopen/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  callPackage,
   fetchFromGitHub,
   fetchpatch,
   rocmUpdateScript,
@@ -297,6 +298,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   requiredSystemFeatures = [ "big-parallel" ];
 
+  passthru.tests = {
+    # Ensure all .tn.model files can be loaded by whatever version of frugally-deep we have
+    # This is otherwise hard to verify as MIOpen will only use these models on specific,
+    # expensive Instinct GPUs
+    # If MIOpen stops embedding .tn.model files the test will also fail, and can be deleted,
+    # likely along with the frugally-deep dependency
+    can-load-models = callPackage ./test-frugally-deep-model-loading.nix {
+      inherit (finalAttrs) src version;
+      inherit frugally-deep nlohmann_json;
+    };
+  };
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
     inherit (finalAttrs.src) owner;

--- a/pkgs/development/rocm-modules/6/miopen/test-frugally-deep-model-loading.cpp
+++ b/pkgs/development/rocm-modules/6/miopen/test-frugally-deep-model-loading.cpp
@@ -1,0 +1,55 @@
+#include <fdeep/fdeep.hpp>
+#include <iostream>
+#include <filesystem>
+#include <vector>
+#include <string>
+
+int main() {
+    std::vector<std::string> model_files;
+    std::string src_dir = std::getenv("SRC_DIR") ? std::getenv("SRC_DIR") : ".";
+
+    // collect *tn.model files except _metadata
+    try {
+        for (const auto& entry : std::filesystem::recursive_directory_iterator(src_dir)) {
+            if (entry.is_regular_file()) {
+                std::string path = entry.path().string();
+                if (path.find("tn.model") != std::string::npos && path.find("_metadata.") == std::string::npos) {
+                    model_files.push_back(path);
+                }
+            }
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "Error scanning directory: " << e.what() << std::endl;
+        return 1;
+    }
+
+    if (model_files.empty()) {
+        std::cout << "No *.tn.model files found in " << src_dir << std::endl;
+        return 1;
+    }
+
+    std::cout << "Found " << model_files.size() << " model files to test" << std::endl;
+
+    int failed_count = 0;
+    for (const auto& model_file : model_files) {
+        std::cout << "Loading: " << model_file << " ... ";
+        std::cout.flush();
+
+        try {
+            const auto model = fdeep::load_model(model_file);
+            std::cout << "OK" << std::endl;
+        } catch (const std::exception& e) {
+            std::cout << "FAILED: " << e.what() << std::endl;
+            failed_count++;
+        }
+    }
+
+    if (failed_count > 0) {
+        std::cerr << "\n" << failed_count << " out of " << model_files.size()
+                    << " models failed to load" << std::endl;
+        return 1;
+    }
+
+    std::cout << "\nAll " << model_files.size() << " models loaded successfully!" << std::endl;
+    return 0;
+}

--- a/pkgs/development/rocm-modules/6/miopen/test-frugally-deep-model-loading.nix
+++ b/pkgs/development/rocm-modules/6/miopen/test-frugally-deep-model-loading.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  eigen,
+  frugally-deep,
+  functionalplus,
+  nlohmann_json,
+  src,
+  version,
+}:
+
+stdenv.mkDerivation {
+  pname = "miopen-frugally-deep-model-test";
+  inherit version src;
+
+  dontConfigure = true;
+  dontInstall = true;
+  doCheck = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    $CXX -std=c++20 \
+        -I${lib.getDev eigen}/include/eigen3 \
+        -I${lib.getDev functionalplus}/include \
+        -I${lib.getDev frugally-deep}/include \
+        -I${lib.getDev nlohmann_json}/include \
+        ${./test-frugally-deep-model-loading.cpp} \
+        -o test_models
+
+    runHook postBuild
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    echo "Running model loading tests..."
+    SRC_DIR="${src}" ./test_models
+    mkdir -p $out
+
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Test that frugally-deep can load MIOpen model files";
+    maintainers = with lib.teams; [ rocm ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Reverts #444476

[frugally-deep 0.16+ fails at runtime for MIOpen for some gfx9* cards](https://github.com/ROCm/rocm-libraries/issues/889)

MIOpen is the only package that depends on frugally-deep so reverting my bump from yesterday, backporting CMake 4 compat only, adding a regression test that loads the risky .model files directly without relying on having specific hardware.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
