### PR TITLE
net-cpp: 3.1.1 -> 3.2.0

### DIFF
--- a/pkgs/by-name/ne/net-cpp/package.nix
+++ b/pkgs/by-name/ne/net-cpp/package.nix
@@ -2,8 +2,8 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  fetchpatch,
   gitUpdater,
+  makeFontsConf,
   testers,
   # https://gitlab.com/ubports/development/core/lib-cpp/net-cpp/-/issues/5
   boost186,
@@ -19,6 +19,7 @@
   properties-cpp,
   python3,
   validatePkgConfig,
+  writableTmpDirAsHomeHook,
 }:
 
 let
@@ -30,39 +31,19 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "net-cpp";
-  version = "3.1.1";
+  version = "3.2.0";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lib-cpp/net-cpp";
     rev = finalAttrs.version;
-    hash = "sha256-MSqdP3kGI9hDdxFv2a0yd5ZkFkf1lMurB+KDIZLR9jg=";
+    hash = "sha256-JfVSAwBWtHw7a0CtY5C1xuxThO3FbS4MgNuIO1CGuts=";
   };
 
   outputs = [
     "out"
     "dev"
     "doc"
-  ];
-
-  patches = [
-    # Be more lenient with how quickly HTTP test server must be up, for slower hardware / archs
-    (fetchpatch {
-      url = "https://salsa.debian.org/ubports-team/net-cpp/-/raw/941d9eceaa66a06eabb1eb79554548b47d4a60ab/debian/patches/1007_wait-for-flask.patch";
-      hash = "sha256-nsGkZBuqahsg70PLUxn5EluDjmfZ0/wSnOYimfAI4ag=";
-    })
-
-    # Bump std version to 14 for gtest 1.13+
-    (fetchpatch {
-      url = "https://salsa.debian.org/ubports-team/net-cpp/-/raw/f3a031eb7e4ce7df00781100f16de58a4709afcb/debian/patches/0001-Bump-std-version-to-14-needed-for-googletest-1.13.0.patch";
-      hash = "sha256-3ykqCfZjtTx7zWQ5rkMhVp7D5fkpoCjl0CVFwwEd4U4=";
-    })
-
-    # Fix newer flask rejecting large chunks by default
-    (fetchpatch {
-      url = "https://salsa.debian.org/ubports-team/net-cpp/-/raw/f2050b5318cba3860fa1042e9b81e1b792b972c4/debian/patches/1008_set-MAX-CONTENT-LENGTH-for-flask-server-to-let-it-accept-big-chunks-of-data.patch";
-      hash = "sha256-lfMRjpmysrhzdG6OOSpBGvYJCi1hrERI/SRf+rAakbA=";
-    })
   ];
 
   postPatch = lib.optionalString finalAttrs.finalPackage.doCheck ''
@@ -78,6 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     doxygen
     graphviz
     validatePkgConfig
+    writableTmpDirAsHomeHook # makes doc generation quieter
   ];
 
   buildInputs = [
@@ -99,9 +81,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    # https://gitlab.com/ubports/development/core/lib-cpp/net-cpp/-/issues/4
-    (lib.cmakeBool "ENABLE_WERROR" false)
+    (lib.cmakeBool "ENABLE_WERROR" true)
   ];
+
+  env.FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
@@ -113,13 +96,13 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = gitUpdater { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Simple yet beautiful networking API for C++11";
     homepage = "https://gitlab.com/ubports/development/core/lib-cpp/net-cpp";
     changelog = "https://gitlab.com/ubports/development/core/lib-cpp/net-cpp/-/blob/${finalAttrs.version}/ChangeLog";
-    license = licenses.lgpl3Only;
-    teams = [ teams.lomiri ];
-    platforms = platforms.linux;
+    license = lib.licenses.lgpl3Only;
+    teams = [ lib.teams.lomiri ];
+    platforms = lib.platforms.linux;
     pkgConfigModules = [
       "net-cpp"
     ];


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lib-cpp/net-cpp/-/blob/3.2.0/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
