### PR TITLE
python3Packages.peeringdb: init at 2.3.0

### DIFF
--- a/pkgs/development/python-modules/confu/default.nix
+++ b/pkgs/development/python-modules/confu/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  python,
+  fetchPypi,
+}:
+
+python.pkgs.buildPythonPackage rec {
+  pname = "confu";
+  version = "1.9.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-vJIdLPFOzL/8oTHnUUmF1dMgGHVlr+cxyHo2fSnNK4c=";
+  };
+
+  build-system = [
+    python.pkgs.poetry-core
+  ];
+
+  dependencies = with python.pkgs; [
+    munge
+  ];
+
+  optional-dependencies = with python.pkgs; {
+    docs = [
+      markdown-include
+      mkdocs
+      pymdgen
+    ];
+  };
+
+  pythonImportsCheck = [
+    "confu"
+  ];
+
+  meta = {
+    description = "Configuration file validation and generation";
+    homepage = "https://pypi.org/project/confu/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ xgwq ];
+    mainProgram = "confu";
+  };
+}

--- a/pkgs/development/python-modules/django-handleref/default.nix
+++ b/pkgs/development/python-modules/django-handleref/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  python,
+  fetchPypi,
+}:
+
+python.pkgs.buildPythonPackage rec {
+  pname = "django-handleref";
+  version = "2.0.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "django_handleref";
+    inherit version;
+    hash = "sha256-iO72vkgqTet0jKCHZcjicX/PsvOaevNhuz5S5ZfvSh0=";
+  };
+
+  build-system = [
+    python.pkgs.poetry-core
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+    --replace poetry.masonry.api poetry.core.masonry.api \
+    --replace "poetry>=" "poetry-core>="
+  '';
+
+  optional-dependencies = with python.pkgs; {
+    docs = [
+      markdown-include
+      mkdocs
+      pymdgen
+    ];
+  };
+
+  pythonImportsCheck = [
+    "django_handleref"
+  ];
+
+  meta = {
+    description = "Django object tracking";
+    homepage = "https://pypi.org/project/django-handleref/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ xgwq ];
+    mainProgram = "django-handleref";
+  };
+}

--- a/pkgs/development/python-modules/django-inet/default.nix
+++ b/pkgs/development/python-modules/django-inet/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  python,
+  fetchPypi,
+}:
+
+python.pkgs.buildPythonPackage rec {
+  pname = "django-inet";
+  version = "1.1.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-PflusfnOk2EiOREjQ01pUg13NmG/yteDWiuidv1L7D8=";
+  };
+
+  build-system = [
+    python.pkgs.poetry-core
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+    --replace poetry.masonry.api poetry.core.masonry.api \
+    --replace "poetry>=" "poetry-core>="
+  '';
+
+  pythonImportsCheck = [
+    "django_inet"
+  ];
+
+  meta = {
+    description = "Django internet utilities";
+    homepage = "https://pypi.org/project/django-inet/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ xgwq ];
+    mainProgram = "django-inet";
+  };
+}

--- a/pkgs/development/python-modules/django-peeringdb/default.nix
+++ b/pkgs/development/python-modules/django-peeringdb/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  python,
+  fetchPypi,
+}:
+
+python.pkgs.buildPythonPackage rec {
+  pname = "django-peeringdb";
+  version = "3.6.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "django_peeringdb";
+    inherit version;
+    hash = "sha256-ukz7uqfmRz7qNsnFKjEG3eiNJHOOZOv/iXWxekLS+g0=";
+  };
+
+  build-system = [
+    python.pkgs.hatchling
+  ];
+
+  dependencies = with python.pkgs; [
+    asgiref
+    django
+    django-countries
+    django-handleref
+    django-inet
+  ];
+
+  pythonImportsCheck = [
+    "django_peeringdb"
+  ];
+
+  meta = {
+    description = "PeeringDB Django models";
+    homepage = "https://pypi.org/project/django-peeringdb/";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ xgwq ];
+    mainProgram = "django-peeringdb";
+  };
+}

--- a/pkgs/development/python-modules/munge/default.nix
+++ b/pkgs/development/python-modules/munge/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  python,
+  fetchPypi,
+}:
+
+python.pkgs.buildPythonPackage rec {
+  pname = "munge";
+  version = "1.4.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-L4wVbmJPzJk/zhv+5blznxG1Bcf1gVYr1rtGYVwfNWo=";
+  };
+
+  build-system = [
+    python.pkgs.hatchling
+  ];
+
+  dependencies = with python.pkgs; [
+    charset-normalizer
+    click
+    pyyaml
+    requests
+    toml
+    tomlkit
+    urllib3
+  ];
+
+  optional-dependencies = with python.pkgs; {
+    toml = [
+      toml
+    ];
+    tomlkit = [
+      tomlkit
+    ];
+    yaml = [
+      pyyaml
+    ];
+  };
+
+  pythonImportsCheck = [
+    "munge"
+  ];
+
+  meta = {
+    description = "Data manipulation library and client";
+    homepage = "https://pypi.org/project/munge/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ xgwq ];
+    mainProgram = "munge";
+  };
+}

--- a/pkgs/development/python-modules/peeringdb-py/default.nix
+++ b/pkgs/development/python-modules/peeringdb-py/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  python,
+  fetchPypi,
+}:
+
+python.pkgs.buildPythonPackage rec {
+  pname = "peeringdb";
+  version = "2.3.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version pname;
+    hash = "sha256-CsK7CyV1K0Av6pNeHgOnn4fHJylEeZZbynBaw48Y31o=";
+  };
+
+  build-system = [
+    python.pkgs.hatchling
+  ];
+
+  dependencies = with python.pkgs; [
+    confu
+    httpx
+    munge
+    pyyaml
+    twentyc-rpc
+    django
+    django-countries
+    django-peeringdb
+  ];
+
+  pythonImportsCheck = [
+    "peeringdb"
+  ];
+
+  meta = {
+    description = "PeeringDB Django models";
+    homepage = "https://pypi.org/project/peeringdb/";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ xgwq ];
+    mainProgram = "peeringdb";
+  };
+}

--- a/pkgs/development/python-modules/twentyc-rpc/default.nix
+++ b/pkgs/development/python-modules/twentyc-rpc/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  python,
+  fetchPypi,
+}:
+
+python.pkgs.buildPythonPackage rec {
+  pname = "twentyc-rpc";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "twentyc.rpc";
+    inherit version;
+    hash = "sha256-sR0C662lfdquyr1he6aGrPS9/MsB77LwL6nXrnNhTrE=";
+  };
+
+  build-system = [
+    python.pkgs.poetry-core
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+    --replace poetry.masonry.api poetry.core.masonry.api \
+    --replace "poetry>=" "poetry-core>="
+  '';
+
+  dependencies = with python.pkgs; [
+    requests
+    setuptools
+  ];
+
+  pythonImportsCheck = [
+    "twentyc.rpc"
+  ];
+
+  meta = {
+    description = "Client for 20c's RESTful API";
+    homepage = "https://pypi.org/project/twentyc.rpc/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ xgwq ];
+    mainProgram = "twentyc-rpc";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4035,6 +4035,8 @@ self: super: with self; {
 
   django-payments = callPackage ../development/python-modules/django-payments { };
 
+  django-peeringdb = callPackage ../development/python-modules/django-peeringdb { };
+
   django-pgactivity = callPackage ../development/python-modules/django-pgactivity { };
 
   django-pghistory = callPackage ../development/python-modules/django-pghistory { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18826,6 +18826,8 @@ self: super: with self; {
 
   twentemilieu = callPackage ../development/python-modules/twentemilieu { };
 
+  twentyc-rpc = callPackage ../development/python-modules/twentyc-rpc { };
+
   twiggy = callPackage ../development/python-modules/twiggy { };
 
   twilio = callPackage ../development/python-modules/twilio { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3961,6 +3961,8 @@ self: super: with self; {
 
   django-import-export = callPackage ../development/python-modules/django-import-export { };
 
+  django-inet = callPackage ../development/python-modules/django-inet { };
+
   django-ipware = callPackage ../development/python-modules/django-ipware { };
 
   django-jinja = callPackage ../development/python-modules/django-jinja2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2951,6 +2951,8 @@ self: super: with self; {
 
   confluent-kafka = callPackage ../development/python-modules/confluent-kafka { };
 
+  confu = callPackage ../development/python-modules/confu { };
+
   confusable-homoglyphs = callPackage ../development/python-modules/confusable-homoglyphs { };
 
   confuse = callPackage ../development/python-modules/confuse { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9809,6 +9809,8 @@ self: super: with self; {
 
   mung = callPackage ../development/python-modules/mung { };
 
+  munge = callPackage ../development/python-modules/munge { };
+
   munkres = callPackage ../development/python-modules/munkres { };
 
   murmurhash = callPackage ../development/python-modules/murmurhash { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11605,6 +11605,8 @@ self: super: with self; {
 
   peco = callPackage ../development/python-modules/peco { };
 
+  peeringdb-py = callPackage ../development/python-modules/peeringdb-py { };
+
   peewee = callPackage ../development/python-modules/peewee { };
 
   peewee-migrate = callPackage ../development/python-modules/peewee-migrate { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3943,6 +3943,8 @@ self: super: with self; {
 
   django-guardian = callPackage ../development/python-modules/django-guardian { };
 
+  django-handleref = callPackage ../development/python-modules/django-handleref { };
+
   django-haystack = callPackage ../development/python-modules/django-haystack { };
 
   django-hcaptcha = callPackage ../development/python-modules/django-hcaptcha { };


### PR DESCRIPTION
This PR adds the PeeringDB Python client. It is available as a CLI Tool and a python module.
https://pypi.org/project/peeringdb/

Some dependencies were not already in nixpkgs and were also packaged:
- [munge](https://pypi.org/project/munge/)
- [confu](https://pypi.org/project/confu/)
- [twentyc-rpc](https://pypi.org/project/twentyc.rpc/)
- [django-handleref](https://pypi.org/project/django-handleref/)
- [django-inet](https://pypi.org/project/django-inet/)
- [django-peeringdb](https://pypi.org/project/django-peeringdb/)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
