### PR TITLE
Some CMake v4 fixes

### DIFF
--- a/pkgs/by-name/bu/bullet/package.nix
+++ b/pkgs/by-name/bu/bullet/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   libGLU,
   libGL,
@@ -24,6 +25,14 @@ stdenv.mkDerivation rec {
     libGLU
     libGL
     libglut
+  ];
+
+  patches = [
+    # fix for CMake v4, merged upstream
+    (fetchpatch {
+      url = "https://github.com/bulletphysics/bullet3/commit/d1a4256b3a019117f2bb6cb8c63d6367aaf512e2.patch";
+      hash = "sha256-FklMKYw5dKUcR5kZOkqv+KVLcWL/7r/0SAdYolmrn5A=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/by-name/cx/cxxopts/package.nix
+++ b/pkgs/by-name/cx/cxxopts/package.nix
@@ -8,15 +8,15 @@
   enableUnicodeHelp ? true,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cxxopts";
-  version = "3.2.1";
+  version = "3.3.1";
 
   src = fetchFromGitHub {
     owner = "jarro2783";
     repo = "cxxopts";
-    rev = "v${version}";
-    sha256 = "sha256-aOF3owz7SIV4trJY0PnMtIcwqoUpDbB3tNxZcsl9dzM=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-baM6EX9D0yfrKxuPXyUUV9RqdrVLyygeG6x57xN8lc4=";
   };
 
   buildInputs = lib.optionals enableUnicodeHelp [ icu74.dev ];
@@ -44,4 +44,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.spease ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/by-name/hp/hpipm/package.nix
+++ b/pkgs/by-name/hp/hpipm/package.nix
@@ -10,13 +10,13 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "hpipm";
   #version = "0.1.3";  not building, use master instead
-  version = "0-unstable-2024-07-30";
+  version = "0.1.3-unstable-2025-09-25";
 
   src = fetchFromGitHub {
     owner = "giaf";
     repo = "hpipm";
-    rev = "3ab7d6059d9d7da31ec9ff6a8ca84fd8ec5ab5e2";
-    hash = "sha256-TRNHjW2/YDfGJHTG9sy2nmHyk6+HlBGIabPm87TETE8=";
+    rev = "8f3a2d00f6d1bd7101fb651391fba79377915288";
+    hash = "sha256-XtnUs1RiB7zJOv7zdRzB31hnxDYaiH+Q4SLyE6/kuEg=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/li/libccd/package.nix
+++ b/pkgs/by-name/li/libccd/package.nix
@@ -26,6 +26,14 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  # fix for CMake v4
+  # ref https://github.com/danfis/libccd/pull/82, not merged yet
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      "cmake_minimum_required(VERSION 2.8.11)" \
+      "cmake_minimum_required(VERSION 3.12)"
+  '';
+
   nativeBuildInputs = [ cmake ];
 
   meta = with lib; {

--- a/pkgs/by-name/op/openscenegraph/package.nix
+++ b/pkgs/by-name/op/openscenegraph/package.nix
@@ -135,6 +135,13 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  # ref. https://github.com/openscenegraph/OpenSceneGraph/pull/1373
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      "CMAKE_MINIMUM_REQUIRED(VERSION 2.8.0 FATAL_ERROR)" \
+      "CMAKE_MINIMUM_REQUIRED(VERSION 3.10)"
+  '';
+
   cmakeFlags =
     lib.optional (!withApps) "-DBUILD_OSG_APPLICATIONS=OFF"
     ++ lib.optional withExamples "-DBUILD_OSG_EXAMPLES=ON";

--- a/pkgs/by-name/qd/qdldl/package.nix
+++ b/pkgs/by-name/qd/qdldl/package.nix
@@ -16,6 +16,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-pRlxqy5G8mxKXTIn4ruV/95TzpzNB/ArJX+WrEJRqW4=";
   };
 
+  # fix abs dir concatenation
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      "$<INSTALL_PREFIX>/$""{CMAKE_INSTALL_INCLUDEDIR}" \
+      "$""{CMAKE_INSTALL_INCLUDEDIR}"
+  '';
+
   nativeBuildInputs = [
     cmake
   ];

--- a/pkgs/by-name/tr/trlib/package.nix
+++ b/pkgs/by-name/tr/trlib/package.nix
@@ -30,6 +30,14 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
+  # ref. https://github.com/felixlen/trlib/pull/25
+  # This PR was merged upstream, so the patch can be removed on next release
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      "cmake_minimum_required (VERSION 3.1)" \
+      "cmake_minimum_required (VERSION 3.13)"
+  '';
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [
     blas

--- a/pkgs/development/python-modules/qdldl/default.nix
+++ b/pkgs/development/python-modules/qdldl/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   cmake,
   numpy,
   pybind11,
@@ -15,9 +15,11 @@ buildPythonPackage rec {
   version = "0.1.7.post5";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-CxOZ4cSbW+1arI/WPvCKtwjTQMN/tCb+ABKLwfNrKG4=";
+  src = fetchFromGitHub {
+    owner = "osqp";
+    repo = "qdldl-python";
+    tag = "v${version}";
+    hash = "sha256-XHdvYWORHDYy/EIqmlmFQZwv+vK3I+rPIrvcEW1JyIw=";
   };
 
   dontUseCmakeConfigure = true;

--- a/pkgs/development/python-modules/qdldl/default.nix
+++ b/pkgs/development/python-modules/qdldl/default.nix
@@ -2,12 +2,14 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  replaceVars,
   cmake,
   numpy,
   pybind11,
   setuptools,
   scipy,
   pytestCheckHook,
+  qdldl,
 }:
 
 buildPythonPackage rec {
@@ -22,6 +24,13 @@ buildPythonPackage rec {
     hash = "sha256-XHdvYWORHDYy/EIqmlmFQZwv+vK3I+rPIrvcEW1JyIw=";
   };
 
+  # use up-to-date qdldl for CMake v4
+  patches = [
+    (replaceVars ./use-qdldl.patch {
+      inherit qdldl;
+    })
+  ];
+
   dontUseCmakeConfigure = true;
 
   build-system = [
@@ -34,6 +43,10 @@ buildPythonPackage rec {
   dependencies = [
     numpy
     scipy
+  ];
+
+  propagatedBuildInputs = [
+    qdldl
   ];
 
   pythonImportsCheck = [ "qdldl" ];

--- a/pkgs/development/python-modules/qdldl/default.nix
+++ b/pkgs/development/python-modules/qdldl/default.nix
@@ -52,11 +52,11 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "qdldl" ];
   nativeCheckInputs = [ pytestCheckHook ];
 
-  meta = with lib; {
-    description = "Free LDL factorization routine";
-    homepage = "https://github.com/oxfordcontrol/qdldl";
-    downloadPage = "https://github.com/oxfordcontrol/qdldl-python";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ drewrisinger ];
+  meta = {
+    description = "Python interface to the QDLDL";
+    homepage = "https://github.com/osqp/qdldl-python";
+    changelog = "https://github.com/osqp/qdldl-python/releases/tag/${src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ drewrisinger ];
   };
 }

--- a/pkgs/development/python-modules/qdldl/use-qdldl.patch
+++ b/pkgs/development/python-modules/qdldl/use-qdldl.patch
@@ -1,0 +1,93 @@
+From 0293de5a5bd209386b3c021ee661e85eee1985a9 Mon Sep 17 00:00:00 2001
+From: Guilhem Saurel <guilhem.saurel@laas.fr>
+Date: Sun, 21 Sep 2025 14:55:32 +0200
+Subject: [PATCH] Use up-to-date qdldl for CMake v4
+
+---
+ c/CMakeLists.txt                   | 5 +++--
+ c/amd/include/SuiteSparse_config.h | 2 +-
+ c/amd/include/perm.h               | 2 +-
+ cpp/qdldl.hpp                      | 2 +-
+ setup.py                           | 3 ++-
+ 5 files changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/c/CMakeLists.txt b/c/CMakeLists.txt
+index 728204d..df15d84 100644
+--- a/c/CMakeLists.txt
++++ b/c/CMakeLists.txt
+@@ -12,7 +12,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+ set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/out)
+ 
+-add_subdirectory(qdldl EXCLUDE_FROM_ALL)
++find_package(qdldl REQUIRED CONFIG)
+ 
+ set(
+     amd_src
+@@ -37,7 +37,8 @@ set(
+ 
+ 
+ # Add QDLDL+AMD library
+-add_library(qdldlamd STATIC ${amd_src} $<TARGET_OBJECTS:qdldlobject>)
++add_library(qdldlamd STATIC ${amd_src})
++target_link_libraries(qdldlamd qdldl::qdldl)
+ target_include_directories(qdldlamd PRIVATE
+ 	                   ${CMAKE_CURRENT_SOURCE_DIR}/amd/include
+ 	                   ${CMAKE_CURRENT_SOURCE_DIR}/qdldl/include
+diff --git a/c/amd/include/SuiteSparse_config.h b/c/amd/include/SuiteSparse_config.h
+index ea3cea4..19ac8df 100644
+--- a/c/amd/include/SuiteSparse_config.h
++++ b/c/amd/include/SuiteSparse_config.h
+@@ -42,7 +42,7 @@
+ extern "C" {
+ #endif
+ 
+-#include "qdldl_types.h"
++#include "qdldl/qdldl_types.h"
+ #define DLONG
+ typedef QDLDL_float c_float;
+ 
+diff --git a/c/amd/include/perm.h b/c/amd/include/perm.h
+index 16c2617..841abe1 100644
+--- a/c/amd/include/perm.h
++++ b/c/amd/include/perm.h
+@@ -2,7 +2,7 @@
+ extern "C" {
+ # endif // ifdef __cplusplus
+ 
+-#include "qdldl_types.h"
++#include "qdldl/qdldl_types.h"
+ 
+ /**
+  * C = A(p,p)= PAP' where A and C are symmetric the upper part stored;
+diff --git a/cpp/qdldl.hpp b/cpp/qdldl.hpp
+index 83b4970..1a7b5d1 100644
+--- a/cpp/qdldl.hpp
++++ b/cpp/qdldl.hpp
+@@ -1,5 +1,5 @@
+ // Source code for QDLDL, AMD and permutations
+-#include "qdldl/include/qdldl.h"
++#include "qdldl/qdldl.h"
+ #include "amd/include/amd.h"
+ #include "amd/include/perm.h"
+ #include <stdexcept>
+diff --git a/setup.py b/setup.py
+index edb50ed..c0e4c23 100644
+--- a/setup.py
++++ b/setup.py
+@@ -97,10 +97,11 @@ class build_ext_qdldl(build_ext):
+ qdldl = Extension('qdldl',
+                   sources=glob(os.path.join('cpp', '*.cpp')),
+                   include_dirs=[os.path.join('c'),
+-                                os.path.join('c', 'qdldl', 'include'),
++                                "@qdldl@/include",
+                                 get_pybind_include(),
+                                 get_pybind_include(user=False)],
+                   language='c++',
++                  extra_link_args=['-lqdldl'],
+                   extra_compile_args=compile_args + ['-std=c++11'],
+                   extra_objects=[qdldl_lib])
+ 
+-- 
+2.51.0
+

--- a/pkgs/development/python-modules/qdldl/use-qdldl.patch
+++ b/pkgs/development/python-modules/qdldl/use-qdldl.patch
@@ -80,7 +80,7 @@ index edb50ed..c0e4c23 100644
                    sources=glob(os.path.join('cpp', '*.cpp')),
                    include_dirs=[os.path.join('c'),
 -                                os.path.join('c', 'qdldl', 'include'),
-+                                "@qdldl@/include",
++                                os.path.join("@qdldl@", "include"),
                                  get_pybind_include(),
                                  get_pybind_include(user=False)],
                    language='c++',

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15469,7 +15469,7 @@ self: super: with self; {
 
   qdarkstyle = callPackage ../development/python-modules/qdarkstyle { };
 
-  qdldl = callPackage ../development/python-modules/qdldl { };
+  qdldl = callPackage ../development/python-modules/qdldl { inherit (pkgs) qdldl; };
 
   qdrant-client = callPackage ../development/python-modules/qdrant-client { };
 


### PR DESCRIPTION
Fixed some issues with CMake v4.

All of these build on x86_64-linux:
```
nom build -L .#trlib .#hpipm .#openscenegraph .#bullet .#libccd .#cxxopts .#pystring .#python3Packages.qdldl .#glew
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
