### PR TITLE
persistent-cache-cpp: 1.0.7 -> 1.0.9

### DIFF
--- a/pkgs/by-name/pe/persistent-cache-cpp/package.nix
+++ b/pkgs/by-name/pe/persistent-cache-cpp/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  fetchpatch,
   gitUpdater,
   testers,
   boost,
@@ -18,13 +17,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "persistent-cache-cpp";
-  version = "1.0.7";
+  version = "1.0.9";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lib-cpp/persistent-cache-cpp";
     rev = finalAttrs.version;
-    hash = "sha256-bOABrRSy5Mzeaqoc5ujcGXyBAaCJLv/488M7fkr0npE=";
+    hash = "sha256-1ETr4b0HEJIM6a4ObtKWtxn0y4gQy9fzBjE4QhMPGqU=";
   };
 
   outputs = [
@@ -33,31 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     "doc"
   ];
 
-  patches = [
-    # PersistentStringCacheImpl.exceptions test fails on LLVM's libcxx, it depends on std::system_error producing a very specific exception text
-    # Expects "Unknown error 666", gets "unspecified generic_category error"
-    # Remove when https://gitlab.com/ubports/development/core/lib-cpp/persistent-cache-cpp/-/merge_requests/14 merged & in release
-    (fetchpatch {
-      name = "0001-persistent-cache-cpp-persistent_string_cache_impl_test-libcxx-fix.patch";
-      url = "https://gitlab.com/ubports/development/core/lib-cpp/persistent-cache-cpp/-/commit/a696dbd3093b8333f9ee1f0cad846b2256c729c5.patch";
-      hash = "sha256-SJxdXeM7W+WKEmiLTwnQYAM7YmPayEk6vPb46y4thv4=";
-    })
-
-    # Enable usage of BUILD_TESTING to opting out of tests
-    # Remove when https://gitlab.com/ubports/development/core/lib-cpp/persistent-cache-cpp/-/merge_requests/15 merged & in release
-    (fetchpatch {
-      name = "0002-persistent-cache-cpp-Enable-opting-out-of-tests.patch";
-      url = "https://gitlab.com/ubports/development/core/lib-cpp/persistent-cache-cpp/-/commit/1fb06d28c16325e90046e93662c0f5fd16c29b4a.patch";
-      hash = "sha256-2/6EYBh71S4dzqWEde+3dLOGp015fN6IifAj1bI1XAI=";
-    })
-  ];
-
   postPatch = ''
-    # GTest needs C++17
-    # Remove when https://gitlab.com/ubports/development/core/lib-cpp/persistent-cache-cpp/-/merge_requests/19 merged & in release
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'std=c++14' 'std=c++17'
-
     # Wrong concatenation
     substituteInPlace data/libpersistent-cache-cpp.pc.in \
       --replace "\''${prefix}/@CMAKE_INSTALL_LIBDIR@" "\''${prefix}/lib"
@@ -65,9 +40,6 @@ stdenv.mkDerivation (finalAttrs: {
     # Runs in parallel to other tests, limit to 1 thread
     substituteInPlace tests/headers/compile_headers.py \
       --replace 'multiprocessing.cpu_count()' '1'
-
-    sed '1i#include <iomanip>' \
-      -i tests/core/persistent_string_cache/speed_test.cpp
   ''
   + lib.optionalString finalAttrs.finalPackage.doCheck ''
     patchShebangs tests/{headers,whitespace}/*.py
@@ -108,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = gitUpdater { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Cache of key-value pairs with persistent storage for C++ 11";
     longDescription = ''
       A persistent cache for arbitrary (possibly large amount of data, such as
@@ -116,9 +88,9 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://gitlab.com/ubports/development/core/lib-cpp/persistent-cache-cpp";
     changelog = "https://gitlab.com/ubports/development/core/lib-cpp/persistent-cache-cpp/-/blob/${finalAttrs.version}/ChangeLog";
-    license = licenses.lgpl3Only;
-    teams = [ teams.lomiri ];
-    platforms = platforms.unix;
+    license = lib.licenses.lgpl3Only;
+    teams = [ lib.teams.lomiri ];
+    platforms = lib.platforms.unix;
     pkgConfigModules = [
       "libpersistent-cache-cpp"
     ];


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lib-cpp/persistent-cache-cpp/-/blob/1.0.9/ChangeLog?ref_type=tags

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
