### PR TITLE
vlc: 3.0.21 -> 3.0.22

### DIFF
--- a/pkgs/by-name/vl/vlc/package.nix
+++ b/pkgs/by-name/vl/vlc/package.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  a52dec,
   alsa-lib,
   autoreconfHook,
   avahi,
@@ -11,8 +10,7 @@
   faad2,
   fetchFromGitLab,
   fetchpatch,
-  # Please unpin FFmpeg on the next upstream release.
-  ffmpeg_6,
+  ffmpeg_7,
   flac,
   flex,
   fluidsynth,
@@ -45,7 +43,6 @@
   libmatroska,
   libmicrodns,
   libmodplug,
-  libmpeg2,
   libmtp,
   libogg,
   libopus,
@@ -106,14 +103,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "${optionalString onlyLibVLC "lib"}vlc";
-  version = "3.0.21";
+  version = "3.0.22";
 
   src = fetchFromGitLab {
     domain = "code.videolan.org";
     owner = "videolan";
     repo = "vlc";
     rev = finalAttrs.version;
-    hash = "sha256-whid+CqDxn9+lkqsL41iU8LTkqLJYVmzl/hh0BUkQJk=";
+    hash = "sha256-EI8w8Nep8Vhgp+5wKOdtbFHiSkURnGqb/AjTfELTq1w=";
   };
 
   depsBuildBuild = optionals waylandSupport [ pkg-config ];
@@ -139,13 +136,12 @@ stdenv.mkDerivation (finalAttrs: {
   # which are not included here for no other reason that nobody has mentioned
   # needing them
   buildInputs = [
-    a52dec
     alsa-lib
     avahi
     cairo
     dbus
     faad2
-    ffmpeg_6
+    ffmpeg_7
     flac
     fluidsynth
     fontconfig
@@ -172,7 +168,6 @@ stdenv.mkDerivation (finalAttrs: {
     libmad
     libmatroska
     libmodplug
-    libmpeg2
     libmtp
     libogg
     libopus
@@ -242,12 +237,6 @@ stdenv.mkDerivation (finalAttrs: {
     (fetchpatch {
       url = "https://code.videolan.org/videolan/vlc/uploads/eb1c313d2d499b8a777314f789794f9d/0001-Add-lssl-and-lcrypto-to-liblive555_plugin_la_LIBADD.patch";
       hash = "sha256-qs3gY1ksCZlf931TSZyMuT2JD0sqrmcRCZwL+wVG0U8=";
-    })
-    # support VAAPI hardware video decoding with newer ffmpeg
-    # upstream merge request: https://code.videolan.org/videolan/vlc/-/merge_requests/6606 (will be included in the next release)
-    (fetchpatch {
-      url = "https://code.videolan.org/videolan/vlc/-/commit/ba5dc03aecc1d96f81b76838f845ebde7348cf62.diff";
-      hash = "sha256-s6AI9O0V3AKOyw9LbQ9CgjaCi5m5+nLacKNLl5ZLC6Q=";
     })
     # make the plugins.dat file generation reproducible
     # upstream merge request: https://code.videolan.org/videolan/vlc/-/merge_requests/7149


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
