### PR TITLE
lomiri.lomiri-polkit-agent: 0.3 -> 0.3.1

### DIFF
--- a/pkgs/desktops/lomiri/services/lomiri-polkit-agent/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-polkit-agent/default.nix
@@ -18,22 +18,22 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-polkit-agent";
-  version = "0.3";
+  version = "0.3.1";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-polkit-agent";
     tag = finalAttrs.version;
-    hash = "sha256-3x2gwKhRDXE6tuwM7pXIwsWg/8pQrKLJ1zds8Ljtk+I=";
+    hash = "sha256-6n/NIUstXODq1fGPF6ioXOWR39kTlzKWdAdW1LbnFy0=";
   };
 
   strictDeps = true;
 
   postPatch = ''
-    # GTest needs C++17
-    # Remove when https://gitlab.com/ubports/development/core/lomiri-polkit-agent/-/merge_requests/15 merged & in release
+    # CMake 4 compat
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-polkit-agent/-/commit/cb81d853ce6dd3bb11030f5a23b6a13f926779a1 in release
     substituteInPlace CMakeLists.txt \
-      --replace-fail 'std=c++14' 'std=c++17'
+      --replace-fail 'VERSION 3.5' 'VERSION 3.10'
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lomiri-polkit-agent/-/blob/0.3.1/ChangeLog

<img width="1280" height="800" alt="polkit_agent" src="https://github.com/user-attachments/assets/cf69f74e-1419-4d27-a897-5b109bf36085" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
