### PR TITLE
nixf-diagnose: 0.1.3 -> 0.1.4

### DIFF
--- a/pkgs/by-name/ni/nixf-diagnose/package.nix
+++ b/pkgs/by-name/ni/nixf-diagnose/package.nix
@@ -8,18 +8,18 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nixf-diagnose";
-  version = "0.1.3";
+  version = "0.1.4";
 
   src = fetchFromGitHub {
     owner = "inclyc";
     repo = "nixf-diagnose";
     tag = finalAttrs.version;
-    hash = "sha256-8kcA2/ZMREKtXUM5rlAWRQL/C8+JNocZegq2ZHqbiSA=";
+    hash = "sha256-vHW2AnUxBuG9mlpMB0f9eK4M1VlJPm5YtwjXksx/uik=";
   };
 
   env.NIXF_TIDY_PATH = lib.getExe nixf;
 
-  cargoHash = "sha256-9rWQfoaMXFs83cYHtJPL0ogA9hPh7q3mK1DG4Q4CCq0=";
+  cargoHash = "sha256-L6wiYUzlzginjhu23EBPAteZ2nTIqUE6mC2q1yfKWs4=";
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Release Notes:
https://github.com/inclyc/nixf-diagnose/releases/tag/0.1.4

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
