### PR TITLE
python3Packages.scipp: fix 25.08.0 hash from #438905

### DIFF
--- a/pkgs/development/python-modules/scipp/default.nix
+++ b/pkgs/development/python-modules/scipp/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     repo = "Scipp";
     # https://github.com/scipp/scipp/pull/3722
     tag = version;
-    hash = "sha256-s3whsNYqS7hsqvWX73E8KbDMUZTGWLgeqmN08tXPkwE=";
+    hash = "sha256-nLccJlFnnVTpamph2oIaMxRD5ljrw6GlCnnTx7LfrO0=";
   };
   env = {
     SKIP_CONAN = "true";


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/438905#issuecomment-3313382093

```
HEAD is now at acba0d29e python3Packages.scipp: 25.05.1 -> 25.08.0 (#438905)
these 6 derivations will be built:
  /nix/store/plv0464mjm3v1fnqcvzbb7f89b7cg7r9-source.drv
  /nix/store/z2vpvci0xia1ca10znjpqk07k81hiz9l-python3.12-scipp-25.08.0.drv
  /nix/store/fpmnsl861dv8n5bqzfpyyw8p1zg7q7yv-python3.12-plopp-25.07.1.drv
  /nix/store/nz7c239ig48pc1v03sm6dcpmh37x3l9x-python3.13-scipp-25.08.0.drv
  /nix/store/ih7xvk2972mx9wla0cpwlh6w76i5wf9h-python3.13-plopp-25.07.1.drv
  /nix/store/ma22wk6jjqd9m6gxq2770wg5yr59p1fw-review-shell.drv
...
error: hash mismatch in fixed-output derivation '/nix/store/plv0464mjm3v1fnqcvzbb7f89b7cg7r9-source.drv':
         specified: sha256-s3whsNYqS7hsqvWX73E8KbDMUZTGWLgeqmN08tXPkwE=
            got:    sha256-nLccJlFnnVTpamph2oIaMxRD5ljrw6GlCnnTx7LfrO0=
```

- #438905
- #444225


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
