### PR TITLE
projectdo: init at 1.0.0

### DIFF
--- a/pkgs/by-name/pr/projectdo/package.nix
+++ b/pkgs/by-name/pr/projectdo/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  ncurses,
+  nix-update-script,
+}:
+stdenv.mkDerivation rec {
+  pname = "projectdo";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "paldepind";
+    repo = "projectdo";
+    tag = "v${version}";
+    hash = "sha256-bdSwpfHipL1fuXjvVifaKNV477JENYu7SxKMpk3ZP6o=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    make test
+    runHook postCheck
+  '';
+
+  nativeCheckInputs = [
+    ncurses # for `tput`
+  ];
+
+  dontUseJustInstall = true;
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    install -D functions/* -t $out/share/fish/vendor_functions.d
+    install -D completions/* -t $out/share/fish/vendor_completions.d
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Context-aware single-letter project commands to speed up your terminal workflow";
+    homepage = "https://github.com/paldepind/projectdo";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ alinnow ];
+    mainProgram = "projectdo";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
> Context-aware single-letter project commands to speed up your command-line workflow.
> 
>   🏗   `b` to build/compile any project.
>   🚀   `r` to run/start any project.
>   🧪   `t` to test any project.

https://github.com/paldepind/projectdo

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
