### PR TITLE
fire: 1.0.2-unstable-2025-08-16 -> 1.5.0b-unstable-2025-09-20

### DIFF
--- a/pkgs/by-name/fi/fire/package.nix
+++ b/pkgs/by-name/fi/fire/package.nix
@@ -78,14 +78,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "fire";
-  version = "1.0.2-unstable-2025-08-16";
+  version = "1.5.0b-unstable-2025-09-20";
 
   src = fetchFromGitHub {
     owner = "jerryuhoo";
     repo = "Fire";
-    rev = "e74e9351a18921c5b7419646eee377e38524c47a";
+    rev = "34a424a4fc50984213b6e98e3aaae3dcb8e960c4";
     fetchSubmodules = true;
-    hash = "sha256-2hx5nba7o+ot+KtypSZJb3pKJk8mUIdI1sNqnT2va0Q=";
+    hash = "sha256-ZTsZ/J5aeyjg4pxhjjIkgoTB5sSg2jpeKAp/uc4V+aQ=";
   };
 
   postPatch =
@@ -101,6 +101,9 @@ stdenv.mkDerivation (finalAttrs: {
         --replace-fail 'set(FORMATS' 'set(FORMATS ${formatsListing}) #' \
         --replace-fail 'BUNDLE_ID "''${BUNDLE_ID}"' 'BUNDLE_ID "''${BUNDLE_ID}" LV2URI "https://www.bluewingsmusic.com/Fire/"' \
         --replace-fail 'COPY_PLUGIN_AFTER_BUILD TRUE' 'COPY_PLUGIN_AFTER_BUILD FALSE'
+
+      # Regression tests require big sound files stored in LFS, skip them
+      rm -v tests/RegressionTests.cpp
     ''
     + lib.optionalString stdenv.hostPlatform.isLinux ''
       # Remove hardcoded LTO flags: needs extra setup on Linux


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
