### PR TITLE
ipget: 0.11.3 -> 0.12.0

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -745,6 +745,7 @@ in
   invoiceplane = runTest ./invoiceplane.nix;
   iodine = runTest ./iodine.nix;
   iosched = runTest ./iosched.nix;
+  ipget = runTest ./ipget.nix;
   ipv6 = runTest ./ipv6.nix;
   iscsi-multipath-root = runTest ./iscsi-multipath-root.nix;
   iscsi-root = runTest ./iscsi-root.nix;

--- a/nixos/tests/ipget.nix
+++ b/nixos/tests/ipget.nix
@@ -1,0 +1,28 @@
+{ lib, ... }:
+{
+  name = "ipget";
+  meta.maintainers = with lib.maintainers; [
+    Luflosi
+  ];
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      services.kubo.enable = true;
+      environment.systemPackages = with pkgs; [ ipget ];
+    };
+
+  testScript = ''
+    start_all()
+
+    with subtest("Add file to IPFS"):
+        ipfs_hash = machine.succeed(
+            "echo -n fnord | ipfs add --quieter"
+        )
+
+    with subtest("Download the file with ipget"):
+        machine.succeed(f"ipget --output file.txt /ipfs/{ipfs_hash}")
+        contents = machine.succeed("cat file.txt")
+        assert contents == "fnord", f"Unexpected file contents: {contents}"
+  '';
+}

--- a/pkgs/by-name/ip/ipget/package.nix
+++ b/pkgs/by-name/ip/ipget/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule rec {
   pname = "ipget";
-  version = "0.11.3";
+  version = "0.12.0";
 
   src = fetchFromGitHub {
     owner = "ipfs";
     repo = "ipget";
     rev = "v${version}";
-    hash = "sha256-Q9rgbfPAdAulNuDQ1bXM08aK0IEerbsKqjK8aMnBwcM=";
+    hash = "sha256-7/wXrjnd7YD2qhVvP0yBMJDkDZjxJC1vZcQuqVd44rU=";
   };
 
-  vendorHash = "sha256-2boqKf/7y/71ThNodUuZXaRHZadx+TU0d6swHHN1VyM=";
+  vendorHash = "sha256-b6Lulzi7zgO0VdWboxi5Vibx8cjuZ6r6O1PJvYubZu4=";
 
   postPatch = ''
     # main module (github.com/ipfs/ipget) does not contain package github.com/ipfs/ipget/sharness/dependencies

--- a/pkgs/by-name/ip/ipget/package.nix
+++ b/pkgs/by-name/ip/ipget/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nixosTests,
 }:
 
 buildGoModule rec {
@@ -23,6 +24,10 @@ buildGoModule rec {
   '';
 
   doCheck = false;
+
+  passthru.tests = {
+    inherit (nixosTests) ipget;
+  };
 
   meta = with lib; {
     description = "Retrieve files over IPFS and save them locally";

--- a/pkgs/by-name/ip/ipget/package.nix
+++ b/pkgs/by-name/ip/ipget/package.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   nixosTests,
+  nix-update-script,
 }:
 
 buildGoModule rec {
@@ -28,6 +29,8 @@ buildGoModule rec {
   passthru.tests = {
     inherit (nixosTests) ipget;
   };
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Retrieve files over IPFS and save them locally";

--- a/pkgs/by-name/ku/kubo/package.nix
+++ b/pkgs/by-name/ku/kubo/package.nix
@@ -32,7 +32,7 @@ buildGoModule rec {
   subPackages = [ "cmd/ipfs" ];
 
   passthru.tests = {
-    inherit (nixosTests) kubo;
+    inherit (nixosTests) kubo ipget;
     repoVersion = callPackage ./test-repoVersion.nix { };
   };
 


### PR DESCRIPTION
https://github.com/ipfs/ipget/releases/tag/v0.12.0

Also add an update script and a NixOS VM test.

Closes #444602.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
