### PR TITLE
treewide: Fix passthru.updateScripts of NGI-maintained derivations

### DIFF
--- a/pkgs/by-name/au/autobase/package.nix
+++ b/pkgs/by-name/au/autobase/package.nix
@@ -27,7 +27,11 @@ buildNpmPackage (finalAttrs: {
     cp ${./package-lock.json} ./package-lock.json
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--generate-lockfile"
+    ];
+  };
 
   meta = {
     description = "Concise multiwriter for data structures with Hypercore";

--- a/pkgs/by-name/do/dokieli/updateDeps.sh
+++ b/pkgs/by-name/do/dokieli/updateDeps.sh
@@ -1,0 +1,28 @@
+#!usr/bin/env bash
+
+export UPDATE_NIX_ATTR_PATH="${UPDATE_NIX_ATTR_PATH:-dokieli}"
+
+oldversion="${UPDATE_NIX_OLD_VERSION-}"
+newversion="$(nix-instantiate . --eval --strict -A "$UPDATE_NIX_ATTR_PATH.version" | cut -d'"' -f2)"
+
+if [ "$oldversion" == "$newversion" ]; then
+  echo "No new version."
+  exit 0
+fi
+
+workdir="$(mktemp -d)"
+
+# File to replace stuff in
+fname="$(nix-instantiate --eval -E "with import ./. {}; (builtins.unsafeGetAttrPos \"version\" $UPDATE_NIX_ATTR_PATH).file" | cut -d'"' -f2)"
+
+oldhash="$(nix-instantiate . --eval --strict -A "$UPDATE_NIX_ATTR_PATH.offlineCache.outputHash" | cut -d'"' -f2)"
+
+newsource="$(nix-build -A "$UPDATE_NIX_ATTR_PATH".src)"
+
+yarn-berry-fetcher missing-hashes "$newsource"/yarn.lock > "$workdir"/missing-hashes.json
+newhash="$(yarn-berry-fetcher prefetch "$newsource"/yarn.lock "$workdir"/missing-hashes.json)"
+
+sed -i "$fname" \
+  -e "s|$oldhash|$newhash|g"
+
+mv "$workdir"/missing-hashes.json "$(dirname "$fname")"/missing-hashes.json

--- a/pkgs/by-name/hy/hypercore/package.nix
+++ b/pkgs/by-name/hy/hypercore/package.nix
@@ -24,7 +24,11 @@ buildNpmPackage (finalAttrs: {
     cp ${./package-lock.json} ./package-lock.json
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--generate-lockfile"
+    ];
+  };
 
   meta = {
     description = "Secure, distributed append-only log";

--- a/pkgs/by-name/hy/hyperswarm/package.nix
+++ b/pkgs/by-name/hy/hyperswarm/package.nix
@@ -24,7 +24,11 @@ buildNpmPackage (finalAttrs: {
     cp ${./package-lock.json} ./package-lock.json
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--generate-lockfile"
+    ];
+  };
 
   meta = {
     description = "Distributed Networking Stack for Connecting Peers";

--- a/pkgs/by-name/mi/misskey/package.nix
+++ b/pkgs/by-name/mi/misskey/package.nix
@@ -3,6 +3,7 @@
   lib,
   nixosTests,
   fetchFromGitHub,
+  gitUpdater,
   nodejs,
   pnpm_9,
   makeWrapper,
@@ -12,7 +13,6 @@
   ffmpeg-headless,
   writeShellScript,
   xcbuild,
-  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -123,7 +123,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     inherit (finalAttrs) pnpmDeps;
     tests.misskey = nixosTests.misskey;
-    updateScript = nix-update-script { };
+    updateScript = gitUpdater { };
   };
 
   meta = {

--- a/pkgs/development/python-modules/highctidh/default.nix
+++ b/pkgs/development/python-modules/highctidh/default.nix
@@ -4,6 +4,7 @@
   setuptools,
   pytestCheckHook,
   fetchFromGitea,
+  gitUpdater,
 }:
 buildPythonPackage rec {
   pname = "highctidh";
@@ -31,6 +32,10 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "highctidh"
   ];
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
 
   meta = {
     description = "Fork of high-ctidh as as a portable shared library with Python bindings";

--- a/pkgs/development/python-modules/msrplib/default.nix
+++ b/pkgs/development/python-modules/msrplib/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "msrplib";
-  version = "0.20.1-unstable-2021-06-01";
+  version = "0.21.0-unstable-2021-06-01";
   pyproject = true;
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/sat-tmp/default.nix
+++ b/pkgs/development/python-modules/sat-tmp/default.nix
@@ -29,6 +29,7 @@ buildPythonPackage rec {
   ];
 
   # no pytest tests exist
+  doCheck = false;
 
   meta = {
     description = "Libervia temporary third party patches";

--- a/pkgs/development/python-modules/sat-tmp/default.nix
+++ b/pkgs/development/python-modules/sat-tmp/default.nix
@@ -31,6 +31,9 @@ buildPythonPackage rec {
   # no pytest tests exist
   doCheck = false;
 
+  # Default-added updateScript doesn't handle Mercurial sources
+  passthru.updateScript = null;
+
   meta = {
     description = "Libervia temporary third party patches";
     longDescription = ''

--- a/pkgs/development/python-modules/sipsimple/default.nix
+++ b/pkgs/development/python-modules/sipsimple/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   fetchurl,
   fetchpatch,
+  nix-update-script,
   cython,
   setuptools,
   alsa-lib,
@@ -141,6 +142,12 @@ buildPythonPackage rec {
 
   passthru = {
     inherit extDeps;
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "^(.*)-mac$"
+      ];
+    };
   };
 
   meta = {

--- a/pkgs/development/python-modules/urwid-satext/default.nix
+++ b/pkgs/development/python-modules/urwid-satext/default.nix
@@ -32,6 +32,9 @@ buildPythonPackage rec {
   # no pytest tests exist
   doCheck = false;
 
+  # Default-added updateScript doesn't handle Mercurial sources
+  passthru.updateScript = null;
+
   meta = {
     description = "SàT extension widgets for Urwid";
     homepage = "https://libervia.org";


### PR DESCRIPTION
When running the `passthru.updateScript`s of packages that I maintain (`nix-shell maintainers/scripts/update.nix --argstr maintainer OPNA2608`), I want the updating process to finish. If it stops halfway through due to an error, then I need to re-run the entire thing. So I want `passthru.updateScript`s to behave well enough that they won't run into a critical error and abort the entire procedure.

So here are some changes to make the `updateScript`s no longer misbehave.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
