### PR TITLE
cbor-diag: 0.9.6 -> 0.10.2

### DIFF
--- a/pkgs/by-name/cb/cbor-diag/Gemfile.lock
+++ b/pkgs/by-name/cb/cbor-diag/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     cbor-canonical (0.1.2)
     cbor-deterministic (0.1.3)
-    cbor-diag (0.9.6)
+    cbor-diag (0.10.2)
       cbor-canonical
       cbor-deterministic
       cbor-packed
@@ -24,4 +24,4 @@ DEPENDENCIES
   cbor-diag
 
 BUNDLED WITH
-   2.6.6
+   2.7.1

--- a/pkgs/by-name/cb/cbor-diag/gemset.nix
+++ b/pkgs/by-name/cb/cbor-diag/gemset.nix
@@ -32,10 +32,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0c0a4pfvnhkh8dmih1igm7qm2ligzvccppjskpz85v69xizfsj71";
+      sha256 = "1w64msy9wdyagcl2rcr7lynmdrazjb8wr6406r47x6k007q8jpd3";
       type = "gem";
     };
-    version = "0.9.6";
+    version = "0.10.2";
   };
   cbor-packed = {
     groups = [ "default" ];


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
