### PR TITLE
pythonPackages.tt-burnin: init at 0.2.4

### DIFF
--- a/pkgs/by-name/tt/tt-burnin/package.nix
+++ b/pkgs/by-name/tt/tt-burnin/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  versionCheckHook,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "tt-burnin";
+  version = "0.2.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tenstorrent";
+    repo = "tt-burnin";
+    tag = "v${version}";
+    hash = "sha256-/tnCLhA6zeUkVYhDtdohrZODwHxNTZbnsWgY2Gt16DQ=";
+  };
+
+  # Remove when https://github.com/NixOS/nixpkgs/pull/444714 is merged
+  pythonRelaxDeps = [
+    "pyluwen"
+  ];
+
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = with python3Packages; [
+    pyluwen
+    tt-tools-common
+    jsons
+  ];
+
+  nativeCheckInputs = [
+    versionCheckHook
+  ];
+
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    mainProgram = "tt-burnin";
+    description = "Command line utility to run a high power consumption workload on TT devices";
+    homepage = "https://github.com/tenstorrent/tt-burnin";
+    changelog = "https://github.com/tenstorrent/tt-burnin/blob/${src.tag}/CHANGELOG.md";
+    maintainers = with lib.maintainers; [ RossComputerGuy ];
+    license = with lib.licenses; [ asl20 ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
