### PR TITLE
ocamlPackages.bdd: unstable-2022-07-14 -> 0.5

### DIFF
--- a/pkgs/development/ocaml-modules/bdd/default.nix
+++ b/pkgs/development/ocaml-modules/bdd/default.nix
@@ -5,33 +5,31 @@
   stdlib-shims,
 }:
 
-buildDunePackage {
+buildDunePackage rec {
   pname = "bdd";
-  version = "unstable-2022-07-14";
-
-  duneVersion = "3";
+  version = "0.5";
 
   src = fetchFromGitHub {
     owner = "backtracking";
     repo = "ocaml-bdd";
-    rev = "6d1b1d3c24e5784b87e599a00230ce652acb2dcc";
-    hash = "sha256-3mJZlAFQsI7AgrNQOe6N94CDfX5gXYqQBooV0jcoYEA=";
+    tag = version;
+    hash = "sha256-bhgKpo7gGkjbI75pzckfQulZnTstj6G5QcErLgIGneU=";
   };
 
   # Fix build with OCaml 4.02
   postPatch = ''
     substituteInPlace lib/bdd.ml \
-      --replace "Buffer.truncate Format.stdbuf 0;" "Buffer.clear Format.stdbuf;"
+      --replace-fail "Buffer.truncate Format.stdbuf 0;" "Buffer.clear Format.stdbuf;"
   '';
 
   propagatedBuildInputs = [
     stdlib-shims
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Quick implementation of a Binary Decision Diagrams (BDD) library for OCaml";
     homepage = "https://github.com/backtracking/ocaml-bdd";
-    license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ wegank ];
+    license = lib.licenses.lgpl21Only;
+    maintainers = with lib.maintainers; [ wegank ];
   };
 }


### PR DESCRIPTION
https://github.com/backtracking/ocaml-bdd/compare/6d1b1d3c24e5784b87e599a00230ce652acb2dcc...0.5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
