### PR TITLE
stack: provide hpack 0.38.1 to match upstream binaries

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2228,12 +2228,15 @@ with haskellLib;
 
   # stack-3.7.1 requires Cabal < 3.12
   stack =
+    let
+      stack' = super.stack.overrideScope (self: super: { hpack = self.hpack_0_38_1; });
+    in
     if lib.versionOlder self.ghc.version "9.10" then
-      super.stack
+      stack'
     else
       lib.pipe
         # to reduce rebuilds, don't override Cabal in the entire scope
-        ((super.stack.override { Cabal = self.Cabal_3_10_3_0; }).overrideScope (
+        ((stack'.override { Cabal = self.Cabal_3_10_3_0; }).overrideScope (
           self: super:
           let
             downgradeCabal =

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -89,6 +89,7 @@ extra-packages:
   - hasql-pool < 1.1                    # 2025-01-19: Needed for building postgrest
   - hasql-transaction < 1.1.1           # 2025-01-19: Needed for building postgrest
   - hlint == 3.6.*                      # 2025-04-14: needed for hls with ghc-lib-parser 9.6
+  - hpack == 0.38.1                     # 2025-09-18: to match exact version upstream stack-3.7.1 uses
   - hspec-megaparsec == 2.2.0           # 2023-11-18: Latest version compatible with ghc 9.0
   - language-javascript == 0.7.0.0      # required by purescript
   - lsp < 2.5                           # 2024-07-08: need for koka

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1881,16 +1881,23 @@ builtins.intersectAttrs super {
   extensions = enableSeparateBinOutput super.extensions;
 
   # These test cases access the network
-  hpack = overrideCabal (drv: {
-    testFlags = drv.testFlags or [ ] ++ [
-      "--skip"
-      "/Hpack.Defaults/ensureFile/with 404/does not create any files/"
-      "--skip"
-      "/Hpack.Defaults/ensureFile/downloads file if missing/"
-      "--skip"
-      "/EndToEnd/hpack/defaults/fails if defaults don't exist/"
-    ];
-  }) super.hpack;
+  inherit
+    (lib.mapAttrs (
+      _:
+      overrideCabal (drv: {
+        testFlags = drv.testFlags or [ ] ++ [
+          "--skip"
+          "/Hpack.Defaults/ensureFile/with 404/does not create any files/"
+          "--skip"
+          "/Hpack.Defaults/ensureFile/downloads file if missing/"
+          "--skip"
+          "/EndToEnd/hpack/defaults/fails if defaults don't exist/"
+        ];
+      })
+    ) super)
+    hpack
+    hpack_0_38_1
+    ;
 
   doctest = overrideCabal (drv: {
     testFlags = drv.testFlags or [ ] ++ [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
