### PR TITLE
python3Packages.cmsis-svd: 0.4-unstable-2024-01-25 -> 0.6

### DIFF
--- a/pkgs/development/python-modules/cmsis-svd/default.nix
+++ b/pkgs/development/python-modules/cmsis-svd/default.nix
@@ -7,16 +7,16 @@
   lxml,
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "cmsis-svd";
-  version = "0.4-unstable-2024-01-25";
+  version = "0.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cmsis-svd";
     repo = "cmsis-svd";
-    rev = "38d21d30abd0d4c2f34fd79d83b34392ed4bb7a3";
-    hash = "sha256-lFA0sNHVj4a4+EwOTmFUbM/nhmzJ4mx4GvT6Ykutakk=";
+    tag = "python-${version}";
+    hash = "sha256-fx9eR9/Nw/oxPaP9rm1G6sjGI7iU4bhkmTS7f8i2RrQ=";
   };
 
   preBuild = ''
@@ -38,6 +38,7 @@ buildPythonPackage {
   meta = {
     description = "CMSIS SVD parser";
     homepage = "https://github.com/cmsis-svd/cmsis-svd";
+    changelog = "https://github.com/cmsis-svd/cmsis-svd/blob/${src.rev}/CHANGELOG";
     maintainers = [ lib.maintainers.dump_stack ];
     license = lib.licenses.asl20;
   };


### PR DESCRIPTION
Diff: https://github.com/cmsis-svd/cmsis-svd/compare/38d21d30abd0d4c2f34fd79d83b34392ed4bb7a3..python-0.6

Changelog: https://github.com/cmsis-svd/cmsis-svd/blob/python-0.6/CHANGELOG

Closes: #438520

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
