### PR TITLE
haskellPackages.{cabal-cargs,binrep,regression-simple,arbtt,dataframe,patat,monad-bayes}: jailbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -390,6 +390,14 @@ with haskellLib;
   # There are numerical tests on random data, that may fail occasionally
   lapack = dontCheck super.lapack;
 
+  # fpr-calc test suite depends on random >= 1.3
+  # see https://github.com/IntersectMBO/lsm-tree/issues/797
+  bloomfilter-blocked =
+    lib.warnIf (lib.versionAtLeast self.random.version "1.3")
+      "haskellPackages.bloomfilter-blocked: dontCheck can potentially be removed"
+      dontCheck
+      super.bloomfilter-blocked;
+
   # support for transformers >= 0.6
   lifted-base = appendPatch (fetchpatch {
     url = "https://github.com/basvandijk/lifted-base/commit/6b61483ec7fd0d5d5d56ccb967860d42740781e8.patch";

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -208,28 +208,9 @@ with haskellLib;
     }
   );
 
-  # Expected test output for these accidentally checks the absolute location of the source directory
-  # https://github.com/dan-t/cabal-cargs/issues/9
-  cabal-cargs = overrideCabal (drv: {
-    testFlags = drv.testFlags or [ ] ++ [
-      "-p"
-      "!/FindCabalFilePure withoutSandbox/"
-      "-p"
-      "!/FromCabalFilePure withoutSandbox/"
-      "-p"
-      "!/FromLibSrcPure withoutSandbox/"
-      "-p"
-      "!/FromExeSrcFilePure withoutSandbox/"
-      "-p"
-      "!/FindCabalFilePure withSandbox/"
-      "-p"
-      "!/FromCabalFilePure withSandbox/"
-      "-p"
-      "!/FromLibSrcPure withSandbox/"
-      "-p"
-      "!/FromExeSrcFilePure withSandbox/"
-    ];
-  }) super.cabal-cargs;
+  # 2025-09-20: Too strict bound on filepath (<1.5)
+  # https://github.com/dan-t/cabal-cargs/issues/10
+  cabal-cargs = doJailbreak super.cabal-cargs;
 
   # Extensions wants a specific version of Cabal for its list of Haskell
   # language extensions.
@@ -439,6 +420,10 @@ with haskellLib;
   # https://github.com/sw17ch/data-clist/pull/28
   data-clist = doJailbreak super.data-clist;
 
+  # 2025-09-20: Allow QuickCheck >= 2.15
+  # https://github.com/raehik/binrep/issues/14
+  binrep = warnAfterVersion "1.1.0" (doJailbreak super.binrep);
+
   # 2024-06-23: Hourglass is archived and had its last commit 6 years ago.
   # Patch is needed to add support for time 1.10, which is only used in the tests
   # https://github.com/vincenthz/hs-hourglass/pull/56
@@ -518,6 +503,10 @@ with haskellLib;
   ];
   ghc-datasize = disableLibraryProfiling super.ghc-datasize;
   ghc-vis = disableLibraryProfiling super.ghc-vis;
+
+  # 2025-09-20: Too strict upper bound on base (<4.20)
+  # https://github.com/phadej/regression-simple/issues/13
+  regression-simple = doJailbreak super.regression-simple;
 
   # Fix 32bit struct being used for 64bit syscall on 32bit platforms
   # https://github.com/haskellari/lukko/issues/15
@@ -915,6 +904,10 @@ with haskellLib;
         }
     ))
   ];
+
+  # Too strict bounds on QuickCheck (<2.15), containers (<0.7), hashable (<1.5), pandoc (<3.7)
+  # https://github.com/jaspervdj/patat/issues/194
+  patat = doJailbreak super.patat;
 
   # Too strict upper bound on data-default-class (< 0.2)
   # https://github.com/stackbuilders/dotenv-hs/issues/203
@@ -2707,6 +2700,9 @@ with haskellLib;
   # 2025-08-06: Upper bounds on containers <0.7 and hedgehog < 1.5 too strict.
   hermes-json = doJailbreak super.hermes-json;
 
+  # Allow containers >= 0.7, https://github.com/nomeata/arbtt/issues/181
+  arbtt = doJailbreak super.arbtt;
+
   # hexstring is not compatible with newer versions of base16-bytestring
   # See https://github.com/solatis/haskell-hexstring/issues/3
   hexstring = overrideCabal (old: {
@@ -3322,17 +3318,22 @@ with haskellLib;
   brillo-juicy = warnAfterVersion "0.2.4" (doJailbreak super.brillo-juicy);
   brillo = warnAfterVersion "1.13.3" (doJailbreak super.brillo);
 
-  # Floating point precision issues. Test suite is only checked on x86_64.
-  # https://github.com/tweag/monad-bayes/issues/368
-  monad-bayes = dontCheckIf (
-    let
-      inherit (pkgs.stdenv) hostPlatform;
-    in
-    !hostPlatform.isx86_64
-    # Presumably because we emulate x86_64-darwin via Rosetta, x86_64-darwin
-    # also fails on Hydra
-    || hostPlatform.isDarwin
-  ) super.monad-bayes;
+  monad-bayes =
+    # Floating point precision issues. Test suite is only checked on x86_64.
+    # https://github.com/tweag/monad-bayes/issues/368
+    dontCheckIf
+      (
+        let
+          inherit (pkgs.stdenv) hostPlatform;
+        in
+        !hostPlatform.isx86_64
+        # Presumably because we emulate x86_64-darwin via Rosetta, x86_64-darwin
+        # also fails on Hydra
+        || hostPlatform.isDarwin
+      )
+      # Too strict bounds on brick (<2.6), vty (<6.3)
+      # https://github.com/tweag/monad-bayes/issues/378
+      (doJailbreak super.monad-bayes);
 
   crucible =
     lib.pipe
@@ -3485,6 +3486,10 @@ with haskellLib;
   # i.e. tests assume existence of .git and also fail for some versions of CVC5,
   # including the current one in nixpkgs.
   liquid-fixpoint = dontCheck super.liquid-fixpoint;
+
+  # 2025-09-20: Too strict upper bound on text (<2.1.3)
+  # https://github.com/mchav/dataframe/issues/61
+  dataframe = doJailbreak (warnAfterVersion "0.3.0.4" super.dataframe);
 
   # 2025-8-26: Too strict bounds on containers and text, see: https://github.com/stackbuilders/inflections-hs/pull/83
   inflections = doJailbreak super.inflections;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -231,7 +231,6 @@ broken-packages:
   - arbor-monad-logger # failure in job https://hydra.nixos.org/build/233228659 at 2023-09-02
   - arbor-monad-metric # failure in job https://hydra.nixos.org/build/233236175 at 2023-09-02
   - arbor-postgres # failure in job https://hydra.nixos.org/build/233232935 at 2023-09-02
-  - arbtt # failure in job https://hydra.nixos.org/build/307516851 at 2025-09-19
   - arch-hs # failure in job https://hydra.nixos.org/build/233225768 at 2023-09-02
   - archiver # failure in job https://hydra.nixos.org/build/233245795 at 2023-09-02
   - archlinux # failure in job https://hydra.nixos.org/build/233202430 at 2023-09-02
@@ -485,8 +484,6 @@ broken-packages:
   - bindings-wlc # failure in job https://hydra.nixos.org/build/233332720 at 2023-09-02
   - bindynamic # failure in job https://hydra.nixos.org/build/295091957 at 2025-04-22
   - binembed # failure in job https://hydra.nixos.org/build/233219100 at 2023-09-02
-  - binrep # failure in job https://hydra.nixos.org/build/307517077 at 2025-09-19
-  - binrep-instances # failure in job https://hydra.nixos.org/build/295092045 at 2025-04-22
   - binsm # failure in job https://hydra.nixos.org/build/233232355 at 2023-09-02
   - bio # failure in job https://hydra.nixos.org/build/233225273 at 2023-09-02
   - bio-sequence # failure in job https://hydra.nixos.org/build/233236140 at 2023-09-02
@@ -654,7 +651,6 @@ broken-packages:
   - cabal-auto-expose # failure in job https://hydra.nixos.org/build/233195440 at 2023-09-02
   - cabal-build-programs # failure in job https://hydra.nixos.org/build/257091363 at 2024-04-27
   - cabal-bundle-clib # failure in job https://hydra.nixos.org/build/233199225 at 2023-09-02
-  - cabal-cargs # failure in job https://hydra.nixos.org/build/307517214 at 2025-09-19
   - cabal-constraints # failure in job https://hydra.nixos.org/build/233214316 at 2023-09-02
   - cabal-db # failure in job https://hydra.nixos.org/build/233197235 at 2023-09-02
   - cabal-debian # failure in job https://hydra.nixos.org/build/233255267 at 2023-09-02
@@ -1258,7 +1254,6 @@ broken-packages:
   - database-migrate # failure in job https://hydra.nixos.org/build/233201597 at 2023-09-02
   - database-study # failure in job https://hydra.nixos.org/build/233222466 at 2023-09-02
   - datadog # failure in job https://hydra.nixos.org/build/233191124 at 2023-09-02
-  - dataframe # failure in job https://hydra.nixos.org/build/307517771 at 2025-09-19
   - DataIndex # failure in job https://hydra.nixos.org/build/233254506 at 2023-09-02
   - datalog # failure in job https://hydra.nixos.org/build/233242707 at 2023-09-02
   - datapacker # failure in job https://hydra.nixos.org/build/233206524 at 2023-09-02
@@ -4072,7 +4067,6 @@ broken-packages:
   - mollie-api-haskell # failure in job https://hydra.nixos.org/build/233200867 at 2023-09-02
   - monad-atom # failure in job https://hydra.nixos.org/build/233243367 at 2023-09-02
   - monad-atom-simple # failure in job https://hydra.nixos.org/build/233259038 at 2023-09-02
-  - monad-bayes # failure in job https://hydra.nixos.org/build/307520391 at 2025-09-19
   - monad-branch # failure in job https://hydra.nixos.org/build/233251253 at 2023-09-02
   - monad-choice # failure in job https://hydra.nixos.org/build/233255987 at 2023-09-02
   - monad-fork # failure in job https://hydra.nixos.org/build/233206855 at 2023-09-02
@@ -4653,7 +4647,6 @@ broken-packages:
   - pasta-curves # failure in job https://hydra.nixos.org/build/233196512 at 2023-09-02
   - pastis # failure in job https://hydra.nixos.org/build/233218498 at 2023-09-02
   - pasty # failure in job https://hydra.nixos.org/build/233251812 at 2023-09-02
-  - patat # failure in job https://hydra.nixos.org/build/307611198 at 2025-09-19
   - patches-vector # failure in job https://hydra.nixos.org/build/233244862 at 2023-09-02
   - path-formatting # failure in job https://hydra.nixos.org/build/233199358 at 2023-09-02
   - path-sing # failure in job https://hydra.nixos.org/build/237234354 at 2023-10-21
@@ -5309,7 +5302,6 @@ broken-packages:
   - registry-messagepack # failure in job https://hydra.nixos.org/build/303231364 at 2025-07-27
   - registry-options # failure in job https://hydra.nixos.org/build/295096594 at 2025-04-22
   - regress # failure in job https://hydra.nixos.org/build/233208901 at 2023-09-02
-  - regression-simple # failure in job https://hydra.nixos.org/build/307521504 at 2025-09-19
   - regular # failure in job https://hydra.nixos.org/build/233232656 at 2023-09-02
   - rehoo # failure in job https://hydra.nixos.org/build/233246417 at 2023-09-02
   - rei # failure in job https://hydra.nixos.org/build/233221328 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -309,7 +309,6 @@ dont-distribute-packages:
  - blockio
  - blogination
  - BlogLiterately-diagrams
- - bloomfilter-blocked
  - bloxorz
  - blubber
  - bluetile
@@ -679,6 +678,7 @@ dont-distribute-packages:
  - datadog-tracing
  - datafix
  - dataflow
+ - dataframe_0_3_0_4
  - datasets
  - date-conversions
  - dbjava
@@ -2957,7 +2957,6 @@ dont-distribute-packages:
  - rfc-psql
  - rfc-redis
  - rfc-servant
- - rhine-bayes
  - rhythm-game-tutorial
  - rib
  - ribosome
@@ -3453,7 +3452,6 @@ dont-distribute-packages:
  - tasklite
  - tasklite-core
  - tasty-bdd
- - tasty-bench-fit
  - tasty-groundhog-converters
  - tasty-integrate
  - tasty-jenkins-xml


### PR DESCRIPTION
cabal-cargs' old override is obsolete as of 1.7.0.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
