### PR TITLE
sm64coopdx 1.3 -> 1.3.2

### DIFF
--- a/pkgs/by-name/sm/sm64coopdx/package.nix
+++ b/pkgs/by-name/sm/sm64coopdx/package.nix
@@ -37,13 +37,13 @@ in
 # note: there is a generic builder in pkgs/games/sm64ex/generic.nix that is meant to help build sm64ex and its forks; however sm64coopdx has departed significantly enough in its build that it doesn't make sense to use that other than the baseRom derivation
 stdenv.mkDerivation (finalAttrs: {
   pname = "sm64coopdx";
-  version = "1.3.0";
+  version = "1.3.2";
 
   src = fetchFromGitHub {
     owner = "coop-deluxe";
     repo = "sm64coopdx";
-    rev = "v1.3"; # it seems coopdx has taken on some stylistic versioning...
-    hash = "sha256-ssbvNnBBxahzJRIX5Vhze+Nfh3ADoy+NrUIF2RZHye8=";
+    rev = "v1.3.2"; # it seems coopdx has taken on some stylistic versioning...
+    hash = "sha256:37cbb0c7658a3129d14709881e21243348fe225bfba060e8bcdb7222b4b0496a";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/sm/sm64coopdx/package.nix
+++ b/pkgs/by-name/sm/sm64coopdx/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "coop-deluxe";
     repo = "sm64coopdx";
     rev = "v1.3.2"; # it seems coopdx has taken on some stylistic versioning...
-    hash = "sha256:37cbb0c7658a3129d14709881e21243348fe225bfba060e8bcdb7222b4b0496a";
+    hash = "sha256-FHH3+pGowkT8asDmU9qxPNDKy4VPKlkA0X7e4gnX9KY=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -116,7 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ lib.maintainers.shelvacu ];
     mainProgram = "sm64coopdx";
     homepage = "https://sm64coopdx.com/";
-    changelog = "https://github.com/coop-deluxe/sm64coopdx/releases/tag/v1.3";
+    changelog = "https://github.com/coop-deluxe/sm64coopdx/releases/tag/v1.3.2";
     sourceProvenance = with lib.sourceTypes; [
       fromSource
       # The lua engine, discord sdk, and coopnet library are vendored pre-built. See https://github.com/coop-deluxe/sm64coopdx/tree/v1.0.3/lib


### PR DESCRIPTION
sm64coopdx is outdated by ~5 months. Update it!

<img width="1056" height="798" alt="image" src="https://github.com/user-attachments/assets/254b371f-4acc-4b66-95ea-00fb74add02c" />

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
