### PR TITLE
python3Packages.inotify: unstable-2020-08-27 -> 0.2.12

### DIFF
--- a/pkgs/development/python-modules/inotify/default.nix
+++ b/pkgs/development/python-modules/inotify/default.nix
@@ -2,38 +2,34 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pytestCheckHook,
+
+  build,
   setuptools,
+
+  nose2,
+  pytestCheckHook,
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "inotify";
-  version = "unstable-2020-08-27";
+  version = "0.2.12";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dsoprea";
     repo = "PyInotify";
-    rev = "f77596ae965e47124f38d7bd6587365924dcd8f7";
-    hash = "sha256-X0gu4s1R/Kg+tmf6s8SdZBab2HisJl4FxfdwKktubVc=";
+    tag = version;
+    hash = "sha256-x6wvrwLDH/9UMTsAIHwCKR5Avv1givlJFFeBM//FOdg=";
   };
 
-  postPatch = ''
-    # Needed because assertEquals was removed in python 3.12
-    substituteInPlace tests/test_inotify.py \
-      --replace-fail "assertEquals" "assertEqual" \
-  '';
+  build-system = [
+    build
+    setuptools
+  ];
 
-  build-system = [ setuptools ];
-
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  # Disable these tests as they're flaky.
-  # The returned list can be in a different order, which causes the tests to fail.
-  disabledTests = [
-    "test__automatic_new_watches_on_new_paths"
-    "test__cycle"
-    "test__renames"
+  nativeCheckInputs = [
+    nose2
+    pytestCheckHook
   ];
 
   meta = {


### PR DESCRIPTION
Diff: https://github.com/dsoprea/PyInotify/compare/f77596ae965e47124f38d7bd6587365924dcd8f7..0.2.12

Closes: #439090

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
