### PR TITLE
wavelib: init at 0-unstable-2025-12-12

### DIFF
--- a/pkgs/by-name/wa/wavelib/package.nix
+++ b/pkgs/by-name/wa/wavelib/package.nix
@@ -1,0 +1,40 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+}:
+
+stdenv.mkDerivation {
+  pname = "wavelib";
+  version = "0-unstable-2025-12-12";
+
+  src = fetchFromGitHub {
+    owner = "rafat";
+    repo = "wavelib";
+    rev = "7f61bf592f3c470b2a7d8199431fde821d7253ac";
+    hash = "sha256-M8HnyZ/ARnF7D7GuTx7vhuaJtpQVl5sV2qBe0LBynW4=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  checkPhase = ''
+    runHook preCheck
+    Bin/Release/wavelibLibTests
+    runHook postCheck
+  '';
+
+  # Don't install the test binary
+  postInstall = ''
+    rm -r $out/bin
+  '';
+
+  meta = {
+    description = "C Implementation of Discrete Wavelet Transform (DWT,SWT and MODWT)";
+    homepage = "https://github.com/rafat/wavelib";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ rowanG077 ];
+  };
+}


### PR DESCRIPTION
Handy library to do stuff with wavelets. 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
