### PR TITLE
snapper-gui: 2020-10-20 -> 0.1-unstable-2022-06-26

### DIFF
--- a/pkgs/by-name/sn/snapper-gui/package.nix
+++ b/pkgs/by-name/sn/snapper-gui/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  nix-update-script,
   python3,
   python3Packages,
   adwaita-icon-theme,
@@ -13,14 +14,14 @@
 
 python3Packages.buildPythonApplication {
   pname = "snapper-gui";
-  version = "2020-10-20";
+  version = "0.1-unstable-2022-06-26";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "ricardomv";
     repo = "snapper-gui";
-    rev = "f0c67abe0e10cc9e2ebed400cf80ecdf763fb1d1";
-    sha256 = "13j4spbi9pxg69zifzai8ifk4207sn0vwh6vjqryi0snd5sylh7h";
+    rev = "191575084a4e951802c32a4177dc704cf435883a";
+    sha256 = "sha256-uy1oLJx4ERGc8OHzmPpnJX81jPB9ztrA0qbmm1UcmTY=";
   };
 
   nativeBuildInputs = [
@@ -43,6 +44,10 @@ python3Packages.buildPythonApplication {
     gtksourceview3
     snapper
   ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
 
   meta = with lib; {
     description = "Graphical interface for snapper";


### PR DESCRIPTION
Diff: https://github.com/ricardomv/snapper-gui/compare/f0c67abe0e10cc9e2ebed400cf80ecdf763fb1d1..191575084a4e951802c32a4177dc704cf435883a

A small update, but I'm really just doing it to add the updateScript and stop
the robot from making unneeded PRs.

Closes: #439413

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
