### PR TITLE
prisma-language-server: remove buildNpmPackage boilerplate, remove unused build inputs

### DIFF
--- a/pkgs/by-name/pr/prisma-language-server/package.nix
+++ b/pkgs/by-name/pr/prisma-language-server/package.nix
@@ -2,8 +2,6 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
-  pkg-config,
-  libsecret,
 }:
 
 buildNpmPackage (finalAttrs: {
@@ -18,15 +16,7 @@ buildNpmPackage (finalAttrs: {
   };
 
   sourceRoot = "${finalAttrs.src.name}/packages/language-server";
-
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ libsecret ];
-
   npmDepsHash = "sha256-UAGz/qCYf+jsgCWqvR52mW6Ze3WWP9EHuE4k9wCbnH0=";
-
-  npmPackFlags = [ "--ignore-scripts" ];
-
-  NODE_OPTIONS = "--openssl-legacy-provider";
 
   meta = {
     description = "Language server for Prisma";


### PR DESCRIPTION
Adding the prisma-language-server was my first ever merged PR, and to write it I copied the npmBuildPackage example from the manual. This included boilerplate that ended up not being useful. This removes said boilerplate. 
Regression testing was done using nvim-lspconfig and all features work as expected.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
