### PR TITLE
sway-contrib.*: 0-unstable-2024-03-19 -> 1.11

### DIFF
--- a/pkgs/applications/misc/sway-contrib/default.nix
+++ b/pkgs/applications/misc/sway-contrib/default.nix
@@ -18,12 +18,12 @@
 }:
 
 let
-  version = "0-unstable-2024-03-19";
+  version = "1.11";
   src = fetchFromGitHub {
     owner = "OctopusET";
     repo = "sway-contrib";
-    rev = "5d33a290e3cac3f0fed38ff950939da28e3ebfd7";
-    hash = "sha256-2qYxkXowSSzVcpsPO4JoUqaH/VUkOOWu1RKFXp1CXGs=";
+    tag = version;
+    hash = "sha256-/gWL0hA8hDjpK5YJxuZqmvo0zuVRQkhAkgHlI4JzNP8=";
   };
 
   meta = with lib; {
@@ -54,10 +54,10 @@ in
     ];
     buildInputs = [ bash ];
     installPhase = ''
-      installManPage grimshot.1
-      installShellCompletion --cmd grimshot grimshot-completion.bash
+      installManPage grimshot/grimshot.1
+      installShellCompletion --cmd grimshot grimshot/grimshot-completion.bash
 
-      install -Dm 0755 grimshot $out/bin/grimshot
+      install -Dm 0755 grimshot/grimshot $out/bin/grimshot
       wrapProgram $out/bin/grimshot --set PATH \
         "${
           lib.makeBinPath [


### PR DESCRIPTION
Diff: https://github.com/OctopusET/sway-contrib/compare/5d33a290e3cac3f0fed38ff950939da28e3ebfd7..1.11

Closes: #440059
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
