### PR TITLE
nixos/filesystems: Remove `default = "auto"` from `fsType`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -144,6 +144,7 @@
                         nixpkgs.hostPlatform = "x86_64-linux";
                         boot.loader.grub.enable = false;
                         fileSystems."/".device = "nodev";
+                        fileSystems."/".fsType = "none";
                         # See https://search.nixos.org/options?show=system.stateVersion&query=stateversion
                         system.stateVersion = lib.trivial.release; # DON'T do this in real configs!
                       }

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -135,6 +135,8 @@
 
 - The packages `iw` and `wirelesstools` (`iwconfig`, `iwlist`, etc.) are no longer installed implicitly if wireless networking has been enabled.
 
+- The `fileSystems.<name>.fsType` option no longer has a default value and must be specified by the user. The value `"auto"` still works as before, though its use is generally discouraged.
+
 - `services.uptime` has been removed because the package it relies on does not exist anymore in nixpkgs.
 
 - `services.kubernetes.addons.dns.coredns` has been renamed to `services.kubernetes.addons.dns.corednsImage` and now expects a

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -796,6 +796,7 @@ in
           "/dev/disk/by-label/${config.isoImage.volumeID}"
         else
           "/dev/root";
+      fsType = "iso9660";
       neededForBoot = true;
       noCheck = true;
     };

--- a/nixos/modules/system/activation/test.nix
+++ b/nixos/modules/system/activation/test.nix
@@ -13,7 +13,10 @@ let
         text = "${expect.dev}";
       };
       documentation.enable = false;
-      fileSystems."/".device = "ignore-root-device";
+      fileSystems."/" = {
+        device = "ignore-root-device";
+        fsType = "none";
+      };
       boot.loader.grub.enable = false;
 
       # Don't do this in an actual config
@@ -26,7 +29,10 @@ let
       system.forbiddenDependenciesRegexes = [ "-dev$" ];
       system.extraDependencies = [ expect.dev ];
       documentation.enable = false;
-      fileSystems."/".device = "ignore-root-device";
+      fileSystems."/" = {
+        device = "ignore-root-device";
+        fsType = "none";
+      };
       boot.loader.grub.enable = false;
 
       # Don't do this in an actual config

--- a/nixos/modules/system/service/systemd/test.nix
+++ b/nixos/modules/system/service/systemd/test.nix
@@ -93,7 +93,10 @@ let
 
       # irrelevant stuff
       system.stateVersion = "25.05";
-      fileSystems."/".device = "/test/dummy";
+      fileSystems."/" = {
+        device = "/test/dummy";
+        fsType = "auto";
+      };
       boot.loader.grub.enable = false;
     }
   );

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -122,7 +122,6 @@ let
         };
 
         fsType = mkOption {
-          default = "auto";
           example = "ext3";
           type = nonEmptyStr;
           description = ''

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -1453,6 +1453,7 @@ in
             else
               {
                 device = "/nix/.ro-store";
+                fsType = "none";
                 options = [ "bind" ];
               }
           );

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -172,6 +172,7 @@ let
               { ... }:
               {
                 fileSystems."/".device = mkDefault "/dev/sda1";
+                fileSystems."/".fsType = mkDefault "auto";
                 boot.loader.grub.device = mkDefault "/dev/sda";
               }
             );
@@ -476,7 +477,10 @@ rec {
           modules = singleton (
             { ... }:
             {
-              fileSystems."/".device = mkDefault "/dev/sda1";
+              fileSystems."/" = {
+                device = mkDefault "/dev/sda1";
+                fsType = "ext4";
+              };
               boot.loader.grub.device = mkDefault "/dev/sda";
               system.stateVersion = mkDefault lib.trivial.release;
             }

--- a/nixos/tests/appliance-repart-image-verity-store.nix
+++ b/nixos/tests/appliance-repart-image-verity-store.nix
@@ -32,6 +32,7 @@
         # bind-mount the store
         "/nix/store" = {
           device = "/usr/nix/store";
+          fsType = "none";
           options = [ "bind" ];
         };
       };

--- a/nixos/tests/early-mount-options.nix
+++ b/nixos/tests/early-mount-options.nix
@@ -4,6 +4,7 @@
 
   nodes.machine = {
     virtualisation.fileSystems."/var" = {
+      fsType = "none";
       options = [
         "bind"
         "nosuid"

--- a/nixos/tests/grow-partition.nix
+++ b/nixos/tests/grow-partition.nix
@@ -30,6 +30,7 @@ let
 
       fileSystems = {
         "/".device = rootFsDevice;
+        "/".fsType = "ext4";
       };
 
       # Needed for installing bootloader

--- a/nixos/tests/image-contents.nix
+++ b/nixos/tests/image-contents.nix
@@ -19,7 +19,10 @@ let
         ../modules/testing/test-instrumentation.nix
         ../modules/profiles/qemu-guest.nix
         {
-          fileSystems."/".device = "/dev/disk/by-label/nixos";
+          fileSystems."/" = {
+            device = "/dev/disk/by-label/nixos";
+            fsType = "ext4";
+          };
           boot.loader.grub.device = "/dev/vda";
           boot.loader.timeout = 0;
           nixpkgs.pkgs = pkgs;

--- a/nixos/tests/non-default-filesystems.nix
+++ b/nixos/tests/non-default-filesystems.nix
@@ -18,6 +18,7 @@ with pkgs.lib;
         virtualisation.fileSystems."/test-bind-dir/bind" = {
           device = "/";
           neededForBoot = true;
+          fsType = "none";
           options = [ "bind" ];
         };
 
@@ -25,6 +26,7 @@ with pkgs.lib;
           depends = [ "/nix/store" ];
           device = builtins.toFile "empty" "";
           neededForBoot = true;
+          fsType = "none";
           options = [ "bind" ];
         };
       };

--- a/nixos/tests/qemu-vm-external-disk-image.nix
+++ b/nixos/tests/qemu-vm-external-disk-image.nix
@@ -23,6 +23,7 @@ let
 
       fileSystems = {
         "/".device = rootFsDevice;
+        "/".fsType = "ext4";
       };
 
       system.switch.enable = true;

--- a/nixos/tests/systemd-initrd-luks-password.nix
+++ b/nixos/tests/systemd-initrd-luks-password.nix
@@ -32,7 +32,10 @@
         };
         virtualisation.rootDevice = "/dev/mapper/cryptroot";
         # test mounting device unlocked in initrd after switching root
-        virtualisation.fileSystems."/cryptroot2".device = "/dev/mapper/cryptroot2";
+        virtualisation.fileSystems."/cryptroot2" = {
+          device = "/dev/mapper/cryptroot2";
+          fsType = "auto";
+        };
       };
     };
 

--- a/nixos/tests/systemd-initrd-luks-unl0kr.nix
+++ b/nixos/tests/systemd-initrd-luks-unl0kr.nix
@@ -75,7 +75,10 @@ in
         virtualisation.rootDevice = "/dev/mapper/cryptroot";
         virtualisation.fileSystems."/".autoFormat = true;
         # test mounting device unlocked in initrd after switching root
-        virtualisation.fileSystems."/cryptroot2".device = "/dev/mapper/cryptroot2";
+        virtualisation.fileSystems."/cryptroot2" = {
+          device = "/dev/mapper/cryptroot2";
+          fsType = "auto";
+        };
       };
     };
 

--- a/nixos/tests/vm-variant.nix
+++ b/nixos/tests/vm-variant.nix
@@ -10,7 +10,10 @@ let
     modules = [
       {
         system.stateVersion = "25.05";
-        fileSystems."/".device = "/dev/null";
+        fileSystems."/" = {
+          device = "/dev/null";
+          fsType = "none";
+        };
         boot.loader.grub.device = "nodev";
         nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform.system;
         virtualisation.vmVariant.networking.hostName = "vm";

--- a/pkgs/test/nixos-functions/default.nix
+++ b/pkgs/test/nixos-functions/default.nix
@@ -27,7 +27,10 @@ lib.optionalAttrs (stdenv.hostPlatform.isLinux) (
       (pkgs.nixos {
         system.nixos = dummyVersioning;
         boot.loader.grub.enable = false;
-        fileSystems."/".device = "/dev/null";
+        fileSystems."/" = {
+          device = "/dev/null";
+          fsType = "none";
+        };
         system.stateVersion = lib.trivial.release;
       }).toplevel;
   }


### PR DESCRIPTION
NixOS has traditionally enabled the `ext` family of file systems by default. Originally, when switching to systemd initrd, we wanted to transition to making this explicit so that initrds could be made without `ext`. The problem is that anyone with `fsType = "auto";` for an `ext` file system in initrd will fail to boot, which is not really an acceptable regression as we switch to systemd initrd by default.

By removing `default = "auto"` from `fsType`, we rule out the vast majority of these regressions as eval errors, since most users of `fsType = "auto"` for ext file systems are using it because of the default value.

In hindsight, this is probably what #225352 was really about.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
