### PR TITLE
plecost: 1.1.4 -> 0-unstable-2022-08-03

### DIFF
--- a/pkgs/by-name/pl/plecost/package.nix
+++ b/pkgs/by-name/pl/plecost/package.nix
@@ -3,29 +3,21 @@
   python3Packages,
   fetchFromGitHub,
   fetchpatch,
+  unstableGitUpdater,
 }:
 
 python3Packages.buildPythonApplication {
   pname = "plecost";
-  version = "1.1.4";
+  version = "0-unstable-2022-08-03";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "iniqua";
     repo = "plecost";
     # Release is untagged
-    rev = "aa40e504bee95cf731f0cc9f228bcf5fdfbe6194";
-    sha256 = "K8ESI2EOqH9zBDfSKgVcTKjCMdRhBiwltIbXDt1vF+M=";
+    rev = "4895e345d71bffe956be43530632e303dd379a5f";
+    hash = "sha256-cXXFLoiLZpo3qiAPztavns4EkOG2aC6UKMf0N4Eun/w=";
   };
-
-  patches = [
-    # Fix compatibility with aiohttp 3.x
-    # Merged - pending next release
-    (fetchpatch {
-      url = "https://github.com/iniqua/plecost/pull/34/commits/c09e7fab934f136f8fbc5f219592cf5fec151cf9.patch";
-      sha256 = "sha256-G7Poo3+d+PQTrg8PCrmsG6nMHt8CXgiuAu+ZNvK8oiw=";
-    })
-  ];
 
   build-system = with python3Packages; [ setuptools ];
 
@@ -40,6 +32,8 @@ python3Packages.buildPythonApplication {
   doCheck = false;
 
   pythonImportsCheck = [ "plecost_lib" ];
+
+  passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
 
   meta = with lib; {
     description = "Vulnerability fingerprinting and vulnerability finder for Wordpress blog engine";


### PR DESCRIPTION
Diff: https://github.com/iniqua/plecost/compare/aa40e504bee95cf731f0cc9f228bcf5fdfbe6194..4895e345d71bffe956be43530632e303dd379a5f

This is an upgrade. Because "the project's tagging system is incompatible with what we expect from versions",
we need to set the version to 0-unstable-date, then set the updater accordingly.

Closes: #440412

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
