### PR TITLE
jugglinglab: add desktop entry

### DIFF
--- a/pkgs/by-name/ju/jugglinglab/package.nix
+++ b/pkgs/by-name/ju/jugglinglab/package.nix
@@ -34,6 +34,13 @@ maven.buildMavenPackage rec {
     ./fix-default-maven-plugin-versions.patch
   ];
 
+  # use non-absolute paths for Exec and Icon fields in the desktop item
+  postPatch = ''
+    substituteInPlace "bin/packaging/debian/Juggling Lab.desktop" \
+      --replace-fail "/opt/juggling-lab/bin/Juggling\ Lab" "jugglinglab" \
+      --replace-fail "/opt/juggling-lab/lib/Juggling_Lab.png" "jugglinglab"
+  '';
+
   mvnHash = "sha256-1Uzo9nRw+YR/sd7CC9MTPe/lttkRX6BtmcsHaagP1Do=";
 
   # fix jar timestamps for reproducibility
@@ -53,6 +60,14 @@ maven.buildMavenPackage rec {
     ${lib.optionalString (platformName != null) ''
       install -Dm755 bin/ortools-lib/ortools-${platformName}/* -t $out/lib/ortools-lib
     ''}
+
+    install -Dm644 \
+      "bin/packaging/debian/Juggling Lab.png" \
+      "$out/share/icons/hicolor/256x256/apps/jugglinglab.png"
+
+    install -Dm644 \
+      "bin/packaging/debian/Juggling Lab.desktop" \
+      "$out/share/applications/jugglinglab.desktop"
 
     runHook postInstall
   '';


### PR DESCRIPTION
Added `share/applications/jugglinglab.desktop` desktop entry:
```
[Desktop Entry]
Categories=Simulation;Sports;Graphics
Comment=Juggling visualizer
Exec=jugglinglab
Icon=jugglinglab
Name=Juggling Lab
Type=Application
Version=1.5
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
