### PR TITLE
[Backport release-25.05] sqlite3-to-mysql: 2.4.0 -> 2.4.5

### DIFF
--- a/pkgs/by-name/sq/sqlite3-to-mysql/package.nix
+++ b/pkgs/by-name/sq/sqlite3-to-mysql/package.nix
@@ -10,14 +10,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "sqlite3-to-mysql";
-  version = "2.4.0";
+  version = "2.4.1";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "techouse";
     repo = "sqlite3-to-mysql";
     tag = "v${version}";
-    hash = "sha256-1XYDCHR1GitMr6wgpj+roCzf5q4tMr6eGLMWzZgzpBY=";
+    hash = "sha256-sX70CmNt4mhZSyzh1x/FEovMpjiJMLFIfxgVIS9CuMY=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/by-name/sq/sqlite3-to-mysql/package.nix
+++ b/pkgs/by-name/sq/sqlite3-to-mysql/package.nix
@@ -10,37 +10,39 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "sqlite3-to-mysql";
-  version = "2.4.2";
+  version = "2.4.5";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "techouse";
     repo = "sqlite3-to-mysql";
     tag = "v${version}";
-    hash = "sha256-wyUJW7G92O3jnwSL5zFy/k/jI6c1H23xYcq7S8wAmsc=";
+    hash = "sha256-oJQR54g6TAf1jZOa2RXJxmBVbC65nmb2KRQpgppK6us=";
   };
 
   build-system = with python3Packages; [
     hatchling
   ];
 
-  dependencies = with python3Packages; [
-    click
-    mysql-connector
-    pytimeparse2
-    pymysql
-    pymysqlsa
-    simplejson
-    sqlalchemy
-    sqlalchemy-utils
-    tqdm
-    tabulate
-    unidecode
-    packaging
-    mysql80
-    python-dateutil
-    types-python-dateutil
-  ];
+  dependencies =
+    with python3Packages;
+    [
+      click
+      mysql-connector
+      pytimeparse2
+      pymysql
+      pymysqlsa
+      simplejson
+      sqlalchemy
+      sqlalchemy-utils
+      tqdm
+      tabulate
+      unidecode
+      packaging
+      mysql80
+      python-dateutil
+    ]
+    ++ lib.optionals (pythonOlder "3.11") [ typing-extensions ];
 
   pythonRelaxDeps = [
     "mysql-connector-python"

--- a/pkgs/by-name/sq/sqlite3-to-mysql/package.nix
+++ b/pkgs/by-name/sq/sqlite3-to-mysql/package.nix
@@ -10,14 +10,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "sqlite3-to-mysql";
-  version = "2.4.1";
+  version = "2.4.2";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "techouse";
     repo = "sqlite3-to-mysql";
     tag = "v${version}";
-    hash = "sha256-sX70CmNt4mhZSyzh1x/FEovMpjiJMLFIfxgVIS9CuMY=";
+    hash = "sha256-wyUJW7G92O3jnwSL5zFy/k/jI6c1H23xYcq7S8wAmsc=";
   };
 
   build-system = with python3Packages; [


### PR DESCRIPTION
backport of #443202

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
