### PR TITLE
karabiner-dk: init at 6.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2498,6 +2498,12 @@
     githubId = 574938;
     name = "Jonathan Glines";
   };
+  auscyber = {
+    email = "ivyp@outlook.com.au";
+    github = "auscyber";
+    name = "Ivy Pierlot";
+    githubId = 12080502;
+  };
   austin-artificial = {
     email = "austin.platt@artificial.io";
     github = "austin-artificial";

--- a/pkgs/by-name/ka/karabiner-dk/package.nix
+++ b/pkgs/by-name/ka/karabiner-dk/package.nix
@@ -1,0 +1,48 @@
+{
+  cpio,
+  xar,
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  driver-version ? null,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "karabiner-driverkit-virtualhiddevice";
+  version = if driver-version != null then driver-version else "6.2.0";
+
+  src = fetchFromGitHub {
+    owner = "pqrs-org";
+    repo = "Karabiner-DriverKit-VirtualHIDDevice";
+    tag = "v6.2.0";
+    sha256 = "sha256-Gw40F9gB+9sDg8swiOCfpCbc1gNHR0NbISOEJmpkWz8=";
+  };
+  nativeBuildInputs = [
+    cpio
+    xar
+  ];
+  unpackPhase = ''
+    runHook preUnpack
+    xar -xf $src/dist/Karabiner-DriverKit-VirtualHIDDevice-${finalAttrs.version}.pkg
+    zcat Payload | cpio -i
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -R ./Applications ./Library $out
+    find $out -name '._embedded.provisionprofile' | xargs rm
+    runHook postInstall
+  '';
+  dontFixup = true;
+  passthru.updateScript = nix-update-script { };
+  meta = {
+    changelog = "https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice/releases/tag/v${finalAttrs.version}";
+    description = "Implements a virtual keyboard and virtual mouse using DriverKit on macOS";
+    homepage = "https://karabiner-elements.pqrs.org/";
+    maintainers = with lib.maintainers; [ auscyber ];
+    license = lib.licenses.unlicense;
+    platforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
- **maintainers: add auscyber**
- **karabiner-dk: add karabiner driverkit package**

Added karabiner driverkit hid device.

This is bundled with karabiner-elements specifically, however kanata and other keybind applications on mac may use different versions. kanata has been updated to use 6.2.0, which doesn't seem to be  used by karabiner-elements and should be considered separate.

The package is notarized, and needs to stay notarized for injection into the macos kernel and therefore fixup is disabled. Additionally, the ._embedded_profile part would normally be scrubbed by fixup, however we need to manually remove that for notarization to maintain while not removing CodeSignature files.

Currently I am working on adding proper modules for this to nix-darwin, so that kanata and kmonad can work on macos properly but firstly this needs to be added to nixpkgs separate from karabiner-elements.

Kanata has a couple thousand stars on github and open prs for home-manager, so this is integral for it to work on macos


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
