### PR TITLE
docs(nixos/release-notes): add note about deepin removal

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -315,13 +315,6 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
-  deepin = {
-    members = [ wineee ];
-    scope = "Maintain deepin desktop environment and related packages.";
-    shortName = "DDE";
-    enableFeatureFreezePing = true;
-  };
-
   deshaw = {
     # Verify additions to this team with at least one already existing member of the team.
     members = [

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -305,6 +305,8 @@
 
 - `services.pds` has been renamed to `services.bluesky-pds`.
 
+- `services.xserver.desktopManager.deepin` and associated packages have been removed due to being unmaintained. See issue [#422090](https://github.com/NixOS/nixpkgs/issues/422090) for more details.
+
 - The new option [networking.ipips](#opt-networking.ipips) has been added to create IP within IP kind of tunnels (including 4in6, ip6ip6 and ipip).
   With the existing [networking.sits](#opt-networking.sits) option (6in4), it is now possible to create all combinations of IPv4 and IPv6 encapsulation.
 


### PR DESCRIPTION
Adds a note to the release notes for 25.11 about the removal of the Deepin Desktop Environment due to being unmaintained.

See: https://github.com/NixOS/nixpkgs/issues/422090
