### PR TITLE
container-canary: init at 0.5.0

### DIFF
--- a/pkgs/by-name/co/container-canary/package.nix
+++ b/pkgs/by-name/co/container-canary/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "container-canary";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "container-canary";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AipqNkHcC8N6PfSDvSvb9O8L/GuQvA/d4y+NZPZipI4=";
+  };
+
+  vendorHash = "sha256-HqSt/LJP9K6LwG9Uf3qqui9LXaOqbCEOL6WzXX5N/VI=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/nvidia/container-canary/internal.Version=${finalAttrs.version}"
+    "-X=github.com/nvidia/container-canary/internal.Buildtime=1970-01-01T00:00:00Z"
+    "-X=github.com/nvidia/container-canary/internal.Commit=${finalAttrs.src.tag}"
+  ];
+
+  checkFlags =
+    let
+      # Skip tests that require access to container runtime like Docker
+      skippedTests = [
+        "TestDockerContainer"
+        "TestDockerContainerRemoves"
+        "TestValidate"
+        "TestValidateFails"
+        "TestFileDoesNotExist"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  postInstall = ''
+    mv $out/bin/container-canary $out/bin/canary
+  ''
+  + (lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd canary \
+      --bash <($out/bin/canary completion bash) \
+      --zsh <($out/bin/canary completion zsh) \
+      --fish <($out/bin/canary completion fish)
+  '');
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool for testing and validating container requirements against versioned manifests";
+    homepage = "https://github.com/NVIDIA/container-canary";
+    changelog = "https://github.com/NVIDIA/container-canary/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kpbaks ];
+    mainProgram = "canary";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [container-canary](https://github.com/NVIDIA/container-canary) at version 0.5.0.

One thing I am bit unsure about is what to name the binary. The project is called `container-canary` but in their [Makefile](https://github.com/NVIDIA/container-canary/blob/4c667f7ebbaff326ef840be8fd97cb316232fcc2/Makefile#L5-L15) they build a binary called `canary`. I have set `meta.mainProgram = "canary";` to match this, but I think that `container-canary` is more clear 🤷.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
