### PR TITLE
python313Packages.asyncua: unpin pytest-asyncio, refactor

### DIFF
--- a/pkgs/development/python-modules/asyncua/default.nix
+++ b/pkgs/development/python-modules/asyncua/default.nix
@@ -8,7 +8,7 @@
   fetchFromGitHub,
   hatchling,
   pyopenssl,
-  pytest-asyncio_0_21,
+  pytest-asyncio,
   pytest-mock,
   pytestCheckHook,
   python-dateutil,
@@ -56,7 +56,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-asyncio_0_21
+    pytest-asyncio
     pytest-mock
   ];
 

--- a/pkgs/development/python-modules/asyncua/default.nix
+++ b/pkgs/development/python-modules/asyncua/default.nix
@@ -13,7 +13,6 @@
   pytestCheckHook,
   python-dateutil,
   pythonAtLeast,
-  pythonOlder,
   pytz,
   sortedcontainers,
   typing-extensions,
@@ -23,8 +22,6 @@ buildPythonPackage rec {
   pname = "asyncua";
   version = "1.1.8";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "FreeOpcUa";
@@ -80,11 +77,11 @@ buildPythonPackage rec {
     "test_encrypted_private_key_handling_failure"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "OPC UA / IEC 62541 Client and Server for Python";
     homepage = "https://github.com/FreeOpcUa/opcua-asyncio";
     changelog = "https://github.com/FreeOpcUa/opcua-asyncio/releases/tag/${src.tag}";
-    license = licenses.lgpl3Plus;
-    maintainers = with maintainers; [ harvidsen ];
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ harvidsen ];
   };
 }


### PR DESCRIPTION
- ~~Update from 1.1.6 to 1.1.8~~
  - ~~Changelog: https://github.com/FreeOpcUa/opcua-asyncio/releases~~
  - Not needed anymore due to https://github.com/NixOS/nixpkgs/commit/5a7943b575948158ee835893a84756e42b081c04
- ~~Change `build-system` to `hatchling`~~
  - Not needed anymore due to https://github.com/NixOS/nixpkgs/commit/59c0e446b3de3423071b36c01ad06be6cdfe6302
- Unpin `pytest-asyncio`
  - See the [1.1.7 release notes](https://github.com/FreeOpcUa/opcua-asyncio/releases/tag/v1.1.7)
- Refactor/modernize a bit

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
