### PR TITLE
lvm2: 2.03.34 -> 2.03.35

### DIFF
--- a/pkgs/os-specific/linux/lvm2/2_03.nix
+++ b/pkgs/os-specific/linux/lvm2/2_03.nix
@@ -1,4 +1,4 @@
 import ./common.nix {
-  version = "2.03.34";
-  hash = "sha256-P05459bEkii00XPqCOvhWIc9VEV/un0x0qvr3d0Odbk=";
+  version = "2.03.35";
+  hash = "sha256-6/KLNCdTXitavZmRzYObYWIqDb+4yG3w968fadyqg3E=";
 }

--- a/pkgs/os-specific/linux/lvm2/common.nix
+++ b/pkgs/os-specific/linux/lvm2/common.nix
@@ -204,6 +204,7 @@ stdenv.mkDerivation rec {
       moveToOutput bin/blkdeactivate $scripts
       moveToOutput bin/lvmdump $scripts
       moveToOutput bin/lvm_import_vdo $scripts
+      moveToOutput bin/lvmpersist $scripts
       moveToOutput libexec/lvresize_fs_helper $scripts/lib
     ''
     + lib.optionalString (!enableCmdlib) ''


### PR DESCRIPTION
## Things done
Closes https://github.com/NixOS/nixpkgs/issues/444858

https://gitlab.com/lvmteam/lvm2/-/tags/v2_03_35

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
