### PR TITLE
nixos/beszel: init module (server monitoring app)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18650,6 +18650,11 @@
     githubId = 47303199;
     name = "Simon Gutgesell";
   };
+  non-bin = {
+    name = "Alice Jacka";
+    github = "non-bin";
+    githubId = 36313060;
+  };
   noodlez1232 = {
     email = "contact@nathanielbarragan.xyz";
     matrix = "@noodlez1232:matrix.org";

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -116,6 +116,8 @@
 
 - [paisa](https://github.com/ananthakumaran/paisa), a personal finance tracker and dashboard. Available as [services.paisa](#opt-services.paisa.enable).
 
+- [beszel](https://github.com/henrygd/beszel), Lightweight server monitoring hub with historical data, docker stats, and alerts. Available as [services.beszel.agent](#opt-services.beszel.agent.enable) and [services.beszel.hub](#opt-services.beszel.hub.enable).
+
 - [conman](https://github.com/dun/conman), a serial console management program. Available as [services.conman](#opt-services.conman.enable).
 
 - [KMinion](https://github.com/redpanda-data/kminion), feature-rich Prometheus exporter for Apache Kafka. Available as [services.prometheus.exporters.kafka](options.html#opt-services.prometheus.exporters.kafka).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -967,6 +967,7 @@
   ./services/monitoring/apcupsd.nix
   ./services/monitoring/arbtt.nix
   ./services/monitoring/below.nix
+  ./services/monitoring/beszel.nix
   ./services/monitoring/bosun.nix
   ./services/monitoring/cadvisor.nix
   ./services/monitoring/certspotter.nix

--- a/nixos/modules/services/monitoring/beszel.nix
+++ b/nixos/modules/services/monitoring/beszel.nix
@@ -1,0 +1,81 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.beszel;
+in
+{
+  meta.maintainers = [ lib.maintainers.non-bin ];
+
+  options.services.beszel = {
+    agent = {
+      enable = lib.mkEnableOption "agent";
+      key = lib.mkOption {
+        type = lib.types.str;
+        description = "Public key(s) for SSH authentication";
+        example = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGBvkz0O6T8dzn1yJTkj3wOSu/7IehuxVPSM5tKzsx5x";
+      };
+      listen = lib.mkOption {
+        type = lib.types.str;
+        default = "0.0.0.0:45876";
+        description = "Address and port to listen on";
+        example = "127.0.0.1:3265";
+      };
+    };
+
+    hub = {
+      enable = lib.mkEnableOption "hub";
+      httpListen = lib.mkOption {
+        type = lib.types.str;
+        default = "0.0.0.0:80";
+        description = "Address and port to listen for http traffic";
+        example = "192.168.0.4:8090";
+      };
+      httpsListen = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+        description = "Address and port to listen for https traffic. If specified, http traffic will be redirected to https";
+        example = "0.0.0.0:443";
+      };
+      domains = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = "Domains to listen on. If specified, http traffic will be redirected to https, and httpsListen will default to `0.0.0.0:443`";
+        example = [ "example.com" ];
+      };
+    };
+  };
+
+  config = {
+    environment.systemPackages = lib.mkIf (cfg.agent.enable || cfg.hub.enable) [ pkgs.beszel ];
+
+    systemd.services = {
+      beszel-agent = lib.mkIf cfg.agent.enable {
+        description = "Beszel Monitoring System monitoring agent";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "networking.target" ];
+        serviceConfig = {
+          ExecStart = ''${pkgs.beszel}/bin/beszel-agent -key "${cfg.agent.key}" -listen "${cfg.agent.listen}"'';
+        };
+      };
+
+      beszel-hub = lib.mkIf cfg.hub.enable {
+        description = "Beszel Monitoring System hub server";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "networking.target" ];
+        serviceConfig = {
+          ExecStart = ''${pkgs.beszel}/bin/beszel-hub serve ${
+            if ((lib.length cfg.hub.domains) > 0) then
+              (''"'' + (lib.concatStringsSep ''" "'' cfg.hub.domains) + ''"'')
+            else
+              ""
+          } --http "${cfg.hub.httpListen}" --https "${cfg.hub.httpsListen}"'';
+          WorkingDirectory = "/var/db/beszel";
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
https://github.com/henrygd/beszel

> Beszel is a lightweight server monitoring platform that includes Docker statistics, historical data, and alert functions.
> 
> It has a friendly web interface, simple configuration, and is ready to use out of the box. It supports automatic backup, multi-user, OAuth authentication, and API access.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
