### PR TITLE
haskell.packages.ghc{94,96,98,912}.haskell-language-server: Fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -262,10 +262,24 @@ with haskellLib;
         super
         // {
           # HLS 2.11: Too strict bound on Diff 1.0.
-          haskell-language-server = dontCheck (doJailbreak super.haskell-language-server);
+          haskell-language-server = lib.pipe super.haskell-language-server [
+            dontCheck
+            doJailbreak
+            (
+              if versionOlder self.ghc.version "9.10" || versionOlder "9.11" self.ghc.version then
+                addBuildDepends [
+                  self.apply-refact
+                  self.hlint
+                  self.refact
+                ]
+              else
+                lib.id
+            )
+          ];
         }
       )
     )
+    hlint
     fourmolu
     ormolu
     haskell-language-server

--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -121,7 +121,7 @@ self: super: {
   tar = self.tar_0_6_3_0;
 
   # A given major version of ghc-exactprint only supports one version of GHC.
-  ghc-exactprint = super.ghc-exactprint_1_6_1_3;
+  ghc-exactprint = dontCheck super.ghc-exactprint_1_6_1_3;
 
   # Too strict upper bound on template-haskell
   # https://github.com/mokus0/th-extras/issues/18
@@ -130,22 +130,32 @@ self: super: {
   # https://github.com/kowainik/relude/issues/436
   relude = dontCheck super.relude;
 
+  haddock-library = doJailbreak super.haddock-library;
+  apply-refact = addBuildDepend self.data-default-class super.apply-refact;
+  path = self.path_0_9_5;
   inherit
     (
       let
         hls_overlay = lself: lsuper: {
           Cabal-syntax = lself.Cabal-syntax_3_10_3_0;
           Cabal = lself.Cabal_3_10_3_0;
+          extensions = dontCheck (doJailbreak (lself.extensions_0_1_0_1));
         };
       in
       lib.mapAttrs (_: pkg: doDistribute (pkg.overrideScope hls_overlay)) {
-        haskell-language-server = allowInconsistentDependencies super.haskell-language-server;
-        fourmolu = doJailbreak self.fourmolu_0_14_0_0; # ansi-terminal, Diff
+        haskell-language-server = allowInconsistentDependencies (
+          addBuildDepends [ self.retrie self.floskell ] super.haskell-language-server
+        );
+        fourmolu = doJailbreak (dontCheck self.fourmolu_0_14_0_0); # ansi-terminal, Diff
         ormolu = doJailbreak self.ormolu_0_7_2_0; # ansi-terminal
         hlint = self.hlint_3_6_1;
         stylish-haskell = self.stylish-haskell_0_14_5_0;
+        retrie = doJailbreak (unmarkBroken super.retrie);
+        floskell = doJailbreak super.floskell;
       }
     )
+    retrie
+    floskell
     haskell-language-server
     fourmolu
     ormolu

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -109,7 +109,6 @@ in
   stm-containers = dontCheck super.stm-containers;
   regex-tdfa = dontCheck super.regex-tdfa;
   hiedb = dontCheck super.hiedb;
-  retrie = dontCheck super.retrie;
   # https://github.com/kowainik/relude/issues/436
   relude = dontCheck (doJailbreak super.relude);
 
@@ -198,6 +197,37 @@ in
   # A given major version of ghc-exactprint only supports one version of GHC.
   ghc-exactprint = addBuildDepend self.extra super.ghc-exactprint_1_7_1_0;
 
-  ghc-lib-parser = doDistribute self.ghc-lib-parser_9_10_3_20250912;
-  ghc-lib-parser-ex = doDistribute self.ghc-lib-parser-ex_9_10_0_0;
+  ghc-lib-parser = doDistribute self.ghc-lib-parser_9_8_5_20250214;
+  ghc-lib-parser-ex = doDistribute self.ghc-lib-parser-ex_9_8_0_2;
+  haddock-library = doJailbreak super.haddock-library;
+  apply-refact = addBuildDepend self.data-default-class super.apply-refact;
+  inherit
+    (
+      let
+        hls_overlay = lself: lsuper: {
+          Cabal-syntax = lself.Cabal-syntax_3_10_3_0;
+          Cabal = lself.Cabal_3_10_3_0;
+          extensions = dontCheck (doJailbreak lself.extensions_0_1_0_1);
+        };
+      in
+      lib.mapAttrs (_: pkg: doDistribute (pkg.overrideScope hls_overlay)) {
+        haskell-language-server = allowInconsistentDependencies (
+          addBuildDepends [ self.retrie self.floskell ] super.haskell-language-server
+        );
+        ormolu = doDistribute self.ormolu_0_7_4_0;
+        fourmolu = doDistribute (dontCheck (doJailbreak self.fourmolu_0_15_0_0));
+        hlint = doDistribute self.hlint_3_8;
+        stylish-haskell = self.stylish-haskell_0_14_6_0;
+        retrie = doJailbreak (unmarkBroken super.retrie);
+        floskell = doJailbreak super.floskell;
+      }
+    )
+    retrie
+    floskell
+    haskell-language-server
+    fourmolu
+    ormolu
+    hlint
+    stylish-haskell
+    ;
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -104,6 +104,37 @@ in
   # A given major version of ghc-exactprint only supports one version of GHC.
   ghc-exactprint = doDistribute super.ghc-exactprint_1_8_0_0;
 
-  ghc-lib-parser = doDistribute self.ghc-lib-parser_9_10_3_20250912;
-  ghc-lib-parser-ex = doDistribute self.ghc-lib-parser-ex_9_10_0_0;
+  haddock-library = doJailbreak super.haddock-library;
+  apply-refact = addBuildDepend self.data-default-class super.apply-refact;
+  ghc-lib-parser = doDistribute self.ghc-lib-parser_9_8_5_20250214;
+  ghc-lib-parser-ex = doDistribute self.ghc-lib-parser-ex_9_8_0_2;
+  inherit
+    (
+      let
+        hls_overlay = lself: lsuper: {
+          Cabal-syntax = lself.Cabal-syntax_3_10_3_0;
+          Cabal = lself.Cabal_3_10_3_0;
+          extensions = dontCheck (doJailbreak super.extensions_0_1_0_1);
+        };
+      in
+      lib.mapAttrs (_: pkg: doDistribute (pkg.overrideScope hls_overlay)) {
+        haskell-language-server = allowInconsistentDependencies (
+          addBuildDepends [ self.retrie self.floskell ] super.haskell-language-server
+        );
+        ormolu = doDistribute self.ormolu_0_7_4_0;
+        fourmolu = doDistribute (dontCheck (doJailbreak self.fourmolu_0_15_0_0));
+        hlint = doDistribute self.hlint_3_8;
+        stylish-haskell = self.stylish-haskell_0_14_6_0;
+        retrie = doJailbreak (unmarkBroken super.retrie);
+        floskell = doJailbreak super.floskell;
+      }
+    )
+    retrie
+    floskell
+    haskell-language-server
+    fourmolu
+    ormolu
+    hlint
+    stylish-haskell
+    ;
 }

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -58,7 +58,9 @@ extra-packages:
   - Cabal-syntax == 3.12.*
   - Cabal-syntax == 3.14.*
   - Cabal-syntax == 3.16.*              # version required for cabal-install and other packages
+  - extensions == 0.1.0.1               # 2025-09-21: needed for Cabal 3.10 (fourmolo/ormolu with ghc 9.8)
   - fourmolu == 0.14.0.0                # 2023-11-13: for ghc-lib-parser 9.6 compat
+  - fourmolu == 0.15.0.0                # 2025-09-21: for ghc-lib-parser 9.8 compat
   - fsnotify < 0.4                      # 2024-04-22: required by spago-0.21
   - fuzzyset == 0.2.4                   # 2023-12-20: Needed for building postgrest > 10
   - ghc-exactprint == 0.6.*             # 2022-12-12: needed for GHC < 9.2
@@ -72,10 +74,10 @@ extra-packages:
   - ghc-lib == 9.10.*                   # 2024-12-30: preserve for GHC 9.10/ghc-tags 1.9
   - ghc-lib-parser == 9.2.*             # 2022-02-17: preserve for GHC 8.10, 9.0
   - ghc-lib-parser == 9.6.*             # 2024-05-19: preserve for GHC 9.2, 9.4
-  - ghc-lib-parser == 9.10.*            # 2024-12-26: preserve for GHC 9.6, 9.8, 9.10
+  - ghc-lib-parser == 9.8.*            # 2024-12-26: preserve for GHC 9.6, 9.8
   - ghc-lib-parser-ex == 9.2.*          # 2022-07-13: preserve for GHC 8.10, 9.0
   - ghc-lib-parser-ex == 9.6.*          # 2024-05-19: preserve for GHC 9.2, 9.4
-  - ghc-lib-parser-ex == 9.10.*         # 2024-12-26: preserve for GHC 9.6, 9.8, 9.10
+  - ghc-lib-parser-ex == 9.8.*         # 2024-12-26: preserve for GHC 9.6, 9.8
   - ghc-tags == 1.5.*                   # 2023-02-18: preserve for ghc-lib == 9.2.*
   - ghc-tags == 1.7.*                   # 2023-02-18: preserve for ghc-lib == 9.6.*
   - ghc-tags == 1.8.*                   # 2023-02-18: preserve for ghc-lib == 9.8.*
@@ -89,13 +91,16 @@ extra-packages:
   - hasql-pool < 1.1                    # 2025-01-19: Needed for building postgrest
   - hasql-transaction < 1.1.1           # 2025-01-19: Needed for building postgrest
   - hlint == 3.6.*                      # 2025-04-14: needed for hls with ghc-lib-parser 9.6
+  - hlint == 3.8.*                      # 2025-09-21: needed for hls with ghc-lib-parser 9.8
   - hpack == 0.38.1                     # 2025-09-18: to match exact version upstream stack-3.7.1 uses
   - hspec-megaparsec == 2.2.0           # 2023-11-18: Latest version compatible with ghc 9.0
   - language-javascript == 0.7.0.0      # required by purescript
   - network-run == 0.4.0                # 2024-10-20: for GHC 9.10/network == 3.1.*
   - ormolu == 0.5.2.0                   # 2023-08-08: preserve for ghc 9.0
   - ormolu == 0.7.2.0                   # 2023-11-13: for ghc-lib-parser 9.6 compat
+  - ormolu == 0.7.4.0                   # 2023-09-21: for ghc-lib-parser 9.8 compat
   - os-string == 1.*                    # 2025-07-30: dummy package we need for pre os-string GHCs
+  - path == 0.9.5                       # 2025-09-21: Pin for hls on ghc 9.4
   - postgresql-binary < 0.14            # 2025-01-19: Needed for building postgrest
   - primitive-unlifted == 0.1.3.1       # 2024-03-16: preserve for ghc 9.2
   - retrie < 1.2.0.0                    # 2022-12-30: preserve for ghc < 9.2
@@ -104,6 +109,7 @@ extra-packages:
   - simple-get-opt < 0.5                # 2025-05-01: for crux-0.7.2
   - stylish-haskell == 0.14.4.0         # 2022-09-19: preserve for ghc 9.0
   - stylish-haskell == 0.14.5.0         # 2025-04-14: needed for hls with ghc-lib 9.6
+  - stylish-haskell == 0.14.6.0         # 2025-09-21: needed for hls with ghc-lib 9.8
   - stylish-haskell == 0.15.0.1         # 2025-04-14: needed for hls with ghc-lib 9.10
   - tar == 0.6.0.0                      # 2025-02-08: last version to not require os-string (which can't be built with GHC < 9.2)
   - tar == 0.6.3.0                      # 2025-08-17: last version to not require file-io and directory-ospath-streaming (for GHC < 9.6)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I hate it. There was a time where this was actually getting easier, but apparently it is getting harder again. Main problem is that too many packages have a tight coupling to Cabal.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
