### PR TITLE
beszel: 0.12.3 -> 0.12.9

### DIFF
--- a/pkgs/by-name/be/beszel/package.nix
+++ b/pkgs/by-name/be/beszel/package.nix
@@ -7,7 +7,7 @@
 }:
 buildGoModule rec {
   pname = "beszel";
-  version = "0.12.3";
+  version = "0.12.9";
 
   src = fetchFromGitHub {
     owner = "henrygd";


### PR DESCRIPTION
https://github.com/henrygd/beszel/releases/tag/v0.12.4

> Add battery charge monitoring.
> [Chore] Improve auto update mechanism by @svenvg93 in https://github.com/henrygd/beszel/pull/1009
> Add fallback mirror to the update commands. (https://github.com/henrygd/beszel/issues/1035)
> Fix blank token field in insecure contexts.
> Allow opening internal router links in new tab.
> Add /api/beszel/user-alerts endpoint. Remove use of batch API for alerts in hub.
> Update Go and JS dependencies.
> New translations by @Radotornado, @AlexVanSteenhoven, @harupong, @dymek37, @NaNomicon, Tommaso Cavazza, Caio Garcia, and others.

https://github.com/henrygd/beszel/releases/tag/v0.12.5

> Fixes a couple of FreeBSD-specific issues.
>
> Downgrade gopsutil to v4.25.6 to fix panic on FreeBSD (#1083)
> Exclude FreeBSD from battery charge monitoring to fix deadlock. (#1081)
> Minor hub UI improvements.

https://github.com/henrygd/beszel/releases/tag/v0.12.6

> Add maximum 1 minute memory usage.
> Add status filtering to Systems Table by @svenvg93 in #927
> Virtualize All Systems table to improve performance with hundreds of systems. (#1100)
> Add missing os.Chmod step to Hub update by @svenvg93 in #1093
> Fix system table links in Safari in #1092
> Use older cuda image in henrygd/beszel-agent-nvidia for increased compatibility by @Impact123 in #1103
> Fix alignment for metrics by @svenvg93 in #1109
> Truncate long system names in web UI (#1104)
> Fix update mirror and add --china-mirrors flag. (#1035)

https://github.com/henrygd/beszel/releases/tag/v0.12.7

> Make LibreHardwareMonitor opt-in with LHM=true environment variable. (#1130)
> Fix bug where token was not refreshed when adding a new system. (#1141)
> Add USER_EMAIL and USER_PASSWORD environment variables to set the email and password of the initial user. (#1137)
> Display system counts (active, paused, down) in All Systems 'view' options. (#1078)
> Remember All Systems sort order during session.
> [Feature] improved support for mips and mipsle architectures by @a-mnich in #1112
> [Bug] Update install script to use crontab on Alpine by @svenvg93 in #1136
> [Fix] fix GitHub workflow errors in forks by @a-mnich in #1113

https://github.com/henrygd/beszel/releases/tag/v0.12.8

> Add per-interface network traffic charts. (#926)
> Add cumulative network traffic charts. (#926)
> Add setting for time format (12h / 24h). (#424)
> Add experimental MFA one-time password (OTP) support (configured in PocketBase; reference OAuth docs).
> Add TRUSTED_AUTH_HEADER environment variable for authentication forwarding. (#399)
> Add AUTO_LOGIN environment variable for automatic login. (#399)
> Add FreeBSD support for agent install script and update command.
> Fix status alerts not being resolved when system comes up. (#1052)
> Add openwrt restart procedure after updating the agent automatically by @sashablue in #1151
> [FIX] OpenWRT auto update by @a-mnich in #1155
> [Fix] zh-CN translation by @fankes in #1160
> Fixing helm chart service/ingress by @twentybit in #1166

https://github.com/henrygd/beszel/releases/tag/v0.12.9

> Fix divide by zero error introduced in 0.12.8 :) (#1175)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
