### PR TITLE
megasync: 5.15.0.1 -> 5.16.0.2, add darwin support

### DIFF
--- a/pkgs/by-name/me/megasync/darwin.nix
+++ b/pkgs/by-name/me/megasync/darwin.nix
@@ -1,0 +1,47 @@
+{
+  stdenv,
+  pname,
+  meta,
+  fetchurl,
+  undmg,
+  lib,
+}:
+
+stdenv.mkDerivation {
+  inherit pname;
+
+  version = "5.16.0.2";
+
+  src =
+    # WARNING: This Wayback Machine URL redirects to the closest timestamp.
+    # Future maintainers must manually check the timestamp exists and exactly matches at:
+    # https://web.archive.org/web/*/https://mega.nz/MEGAsyncSetupArm64.dmg
+    # https://web.archive.org/web/*/https://mega.nz/MEGAsyncSetup.dmg
+    if stdenv.hostPlatform.isAarch64 then
+      (fetchurl {
+        url = "https://web.archive.org/web/20250926041253/https://mega.nz/MEGAsyncSetupArm64.dmg";
+        hash = "sha256-zXkkWIZkZteDC+wnhgU3HoP33AfLm1YOAGWgrkmc4Sg=";
+      })
+    else
+      (fetchurl {
+        url = "https://web.archive.org/web/20250926041517/https://mega.nz/MEGAsyncSetup.dmg";
+        hash = "sha256-Mehx5ttSmaBp/x8oZue5BwBQoUNwJL00SLeiCGU+jRo=";
+      });
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -r *.app $out/Applications
+
+    runHook postInstall
+  '';
+
+  meta = meta // {
+    maintainers = with lib.maintainers; [ iedame ];
+  };
+}

--- a/pkgs/by-name/me/megasync/linux.nix
+++ b/pkgs/by-name/me/megasync/linux.nix
@@ -1,0 +1,147 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+
+  # nativeBuildInputs
+  cmake,
+  libsForQt5,
+  libtool,
+  pkg-config,
+  unzip,
+
+  # buildInputs
+  c-ares,
+  cryptopp,
+  curl,
+  ffmpeg,
+  hicolor-icon-theme,
+  icu,
+  libmediainfo,
+  libsodium,
+  libuv,
+  libxcb,
+  libzen,
+  openssl,
+  readline,
+  sqlite,
+  wget,
+  xorg,
+  zlib,
+  meta,
+  pname,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  inherit pname;
+  version = "5.15.0.1";
+
+  src = fetchFromGitHub rec {
+    owner = "meganz";
+    repo = "MEGAsync";
+    tag = "v${finalAttrs.version}_Linux";
+    hash = "sha256-CqeR1UmwrwUjr8QM2LCkZ4RaEU2bU1fq+QLCN7yfIJk=";
+    fetchSubmodules = false; # DesignTokensImporter cannot be fetched, see #1010 in github:meganz/megasync
+    leaveDotGit = true;
+    postFetch = ''
+      cd $out
+
+      git remote add origin $url
+      git fetch origin
+      git clean -fdx
+      git checkout ${tag}
+      git submodule update --init src/MEGASync/mega
+
+      rm -rf .git
+    ''; # Why so complicated, I just want a single submodule
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/020-megasync-sdk-fix-cmake-dependencies-detection.patch?h=megasync&id=ff59780039697591e7e3a966db058b23bee0451c";
+      hash = "sha256-hQY6tMwiV3B6M6WiFdOESdhahAtuWjdoj2eI2mst/K8=";
+      extraPrefix = "src/MEGASync/mega/";
+      stripLen = true;
+    })
+    (fetchpatch {
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/030-megasync-app-fix-cmake-dependencies-detection.patch?h=megasync&id=ff59780039697591e7e3a966db058b23bee0451c";
+      hash = "sha256-11XWctv1veUEguc9Xvz2hMYw26CaCwu6M4hyA+5r81U=";
+    })
+    ./megasync-fix-cmake-install-bindir.patch
+    ./dont-fetch-clang-format.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace cmake/modules/desktopapp_options.cmake \
+      --replace-fail "ENABLE_ISOLATED_GFX ON" "ENABLE_ISOLATED_GFX OFF"
+
+    for file in $(find src/ -type f \( -iname configure -o -iname \*.sh \) ); do
+      substituteInPlace "$file" --replace-warn "/bin/bash" "${stdenv.shell}"
+    done
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    libsForQt5.qttools
+    libsForQt5.wrapQtAppsHook
+    libtool
+    pkg-config
+    unzip
+  ];
+
+  buildInputs = [
+    c-ares
+    cryptopp
+    curl
+    ffmpeg
+    hicolor-icon-theme
+    icu
+    libmediainfo
+    libsForQt5.qtbase
+    libsForQt5.qtdeclarative
+    libsForQt5.qtgraphicaleffects
+    libsForQt5.qtquickcontrols
+    libsForQt5.qtquickcontrols2
+    libsForQt5.qtsvg
+    libsForQt5.qtx11extras
+    libsodium
+    libuv
+    libxcb
+    libzen
+    openssl
+    readline
+    sqlite
+    wget
+    zlib
+  ];
+
+  dontUseQmakeConfigure = true;
+  enableParallelBuilding = true;
+
+  cmakeFlags = [
+    (lib.cmakeBool "USE_PDFIUM" false) # PDFIUM is not in nixpkgs
+    (lib.cmakeBool "USE_FREEIMAGE" false) # freeimage is insecure
+    (lib.cmakeBool "ENABLE_DESIGN_TOKENS_IMPORTER" false) # cannot be fetched
+    (lib.cmakeBool "USE_BREAKPAD" false)
+    (lib.cmakeBool "ENABLE_DESKTOP_APP_TESTS" false)
+  ];
+
+  preFixup = ''
+    qtWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ xorg.xrdb ]})
+  '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex=^v(.*)_Linux$"
+      ];
+    };
+  };
+
+  meta = meta // {
+    downloadPage = "https://github.com/meganz/MEGAsync";
+    changelog = "https://github.com/meganz/MEGAsync/releases/tag/v${finalAttrs.version}_Linux";
+    maintainers = with lib.maintainers; [ iedame ];
+  };
+})

--- a/pkgs/by-name/me/megasync/linux.nix
+++ b/pkgs/by-name/me/megasync/linux.nix
@@ -12,10 +12,8 @@
   unzip,
 
   # buildInputs
-  c-ares,
   cryptopp,
   curl,
-  ffmpeg,
   hicolor-icon-theme,
   icu,
   libmediainfo,
@@ -35,13 +33,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   inherit pname;
-  version = "5.15.0.1";
+  version = "5.16.0.2";
 
   src = fetchFromGitHub rec {
     owner = "meganz";
     repo = "MEGAsync";
     tag = "v${finalAttrs.version}_Linux";
-    hash = "sha256-CqeR1UmwrwUjr8QM2LCkZ4RaEU2bU1fq+QLCN7yfIJk=";
+    hash = "sha256-Bkye2Is3GbdnYYaS//AkNfrt8ppWP9zE58obcmUm0wE=";
     fetchSubmodules = false; # DesignTokensImporter cannot be fetched, see #1010 in github:meganz/megasync
     leaveDotGit = true;
     postFetch = ''
@@ -70,6 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
     })
     ./megasync-fix-cmake-install-bindir.patch
     ./dont-fetch-clang-format.patch
+    ./megasync-fix-zlib-link.patch
   ];
 
   postPatch = ''
@@ -91,10 +90,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    c-ares
     cryptopp
     curl
-    ffmpeg
     hicolor-icon-theme
     icu
     libmediainfo
@@ -122,9 +119,10 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "USE_PDFIUM" false) # PDFIUM is not in nixpkgs
     (lib.cmakeBool "USE_FREEIMAGE" false) # freeimage is insecure
+    (lib.cmakeBool "USE_FFMPEG" false) # FFmpeg not needed without FreeImage
     (lib.cmakeBool "ENABLE_DESIGN_TOKENS_IMPORTER" false) # cannot be fetched
-    (lib.cmakeBool "USE_BREAKPAD" false)
-    (lib.cmakeBool "ENABLE_DESKTOP_APP_TESTS" false)
+    (lib.cmakeBool "USE_BREAKPAD" false) # Crash reporting disabled
+    (lib.cmakeBool "ENABLE_DESKTOP_APP_TESTS" false) # Skip desktop app tests
   ];
 
   preFixup = ''

--- a/pkgs/by-name/me/megasync/megasync-fix-zlib-link.patch
+++ b/pkgs/by-name/me/megasync/megasync-fix-zlib-link.patch
@@ -1,0 +1,18 @@
+--- a/src/MEGASync/CMakeLists.txt
++++ b/src/MEGASync/CMakeLists.txt
+@@ -81,6 +81,7 @@ set_target_properties(MEGAsync
+ 
+ 
+ find_package(Qt5 REQUIRED COMPONENTS Widgets Core Gui Network Qml Quick QuickWidgets LinguistTools)
++find_package(ZLIB REQUIRED)
+ qt5_create_translation(QM_OUTPUT ${CMAKE_CURRENT_SOURCE_DIR} gui/translations/translation.source.ts
+     OPTIONS -locations none -no-ui-lines -no-obsolete)
+ 
+@@ -155,6 +156,7 @@ target_link_libraries(MEGAsync
+     Qt5::Qml
+     Qt5::Quick
+     Qt5::QuickWidgets
++    ZLIB::ZLIB
+ )
+ 
+ ## Adjust compilation flags for warnings and errors ##

--- a/pkgs/by-name/me/megasync/package.nix
+++ b/pkgs/by-name/me/megasync/package.nix
@@ -1,154 +1,30 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
-  fetchpatch,
+  callPackage,
+  ...
+}@args:
 
-  # nativeBuildInputs
-  cmake,
-  libsForQt5,
-  libtool,
-  pkg-config,
-  unzip,
+let
+  extraArgs = removeAttrs args [ "callPackage" ];
 
-  # buildInputs
-  c-ares,
-  cryptopp,
-  curl,
-  ffmpeg,
-  hicolor-icon-theme,
-  icu,
-  libmediainfo,
-  libsodium,
-  libuv,
-  libxcb,
-  libzen,
-  openssl,
-  readline,
-  sqlite,
-  wget,
-  xorg,
-  zlib,
-
-  nix-update-script,
-}:
-stdenv.mkDerivation (finalAttrs: {
   pname = "megasync";
-  version = "5.15.0.1";
-
-  src = fetchFromGitHub rec {
-    owner = "meganz";
-    repo = "MEGAsync";
-    tag = "v${finalAttrs.version}_Linux";
-    hash = "sha256-CqeR1UmwrwUjr8QM2LCkZ4RaEU2bU1fq+QLCN7yfIJk=";
-    fetchSubmodules = false; # DesignTokensImporter cannot be fetched, see #1010 in github:meganz/megasync
-    leaveDotGit = true;
-    postFetch = ''
-      cd $out
-
-      git remote add origin $url
-      git fetch origin
-      git clean -fdx
-      git checkout ${tag}
-      git submodule update --init src/MEGASync/mega
-
-      rm -rf .git
-    ''; # Why so complicated, I just want a single submodule
-  };
-
-  patches = [
-    (fetchpatch {
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/020-megasync-sdk-fix-cmake-dependencies-detection.patch?h=megasync&id=ff59780039697591e7e3a966db058b23bee0451c";
-      hash = "sha256-hQY6tMwiV3B6M6WiFdOESdhahAtuWjdoj2eI2mst/K8=";
-      extraPrefix = "src/MEGASync/mega/";
-      stripLen = true;
-    })
-    (fetchpatch {
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/030-megasync-app-fix-cmake-dependencies-detection.patch?h=megasync&id=ff59780039697591e7e3a966db058b23bee0451c";
-      hash = "sha256-11XWctv1veUEguc9Xvz2hMYw26CaCwu6M4hyA+5r81U=";
-    })
-    ./megasync-fix-cmake-install-bindir.patch
-    ./dont-fetch-clang-format.patch
-  ];
-
-  postPatch = ''
-    substituteInPlace cmake/modules/desktopapp_options.cmake \
-      --replace-fail "ENABLE_ISOLATED_GFX ON" "ENABLE_ISOLATED_GFX OFF"
-
-    for file in $(find src/ -type f \( -iname configure -o -iname \*.sh \) ); do
-      substituteInPlace "$file" --replace-warn "/bin/bash" "${stdenv.shell}"
-    done
-  '';
-
-  nativeBuildInputs = [
-    cmake
-    libsForQt5.qttools
-    libsForQt5.wrapQtAppsHook
-    libtool
-    pkg-config
-    unzip
-  ];
-
-  buildInputs = [
-    c-ares
-    cryptopp
-    curl
-    ffmpeg
-    hicolor-icon-theme
-    icu
-    libmediainfo
-    libsForQt5.qtbase
-    libsForQt5.qtdeclarative
-    libsForQt5.qtgraphicaleffects
-    libsForQt5.qtquickcontrols
-    libsForQt5.qtquickcontrols2
-    libsForQt5.qtsvg
-    libsForQt5.qtx11extras
-    libsodium
-    libuv
-    libxcb
-    libzen
-    openssl
-    readline
-    sqlite
-    wget
-    zlib
-  ];
-
-  dontUseQmakeConfigure = true;
-  enableParallelBuilding = true;
-
-  cmakeFlags = [
-    (lib.cmakeBool "USE_PDFIUM" false) # PDFIUM is not in nixpkgs
-    (lib.cmakeBool "USE_FREEIMAGE" false) # freeimage is insecure
-    (lib.cmakeBool "ENABLE_DESIGN_TOKENS_IMPORTER" false) # cannot be fetched
-    (lib.cmakeBool "USE_BREAKPAD" false)
-    (lib.cmakeBool "ENABLE_DESKTOP_APP_TESTS" false)
-  ];
-
-  preFixup = ''
-    qtWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ xorg.xrdb ]})
-  '';
-
-  passthru = {
-    updateScript = nix-update-script {
-      extraArgs = [
-        "--version-regex=^v(.*)_Linux$"
-      ];
-    };
-  };
 
   meta = {
     description = "Easy automated syncing between your computers and your MEGA Cloud Drive";
     homepage = "https://mega.nz/";
-    downloadPage = "https://github.com/meganz/MEGAsync";
-    changelog = "https://github.com/meganz/MEGAsync/releases/tag/v${finalAttrs.version}_Linux";
     license = lib.licenses.unfreeRedistributable;
     platforms = [
       "i686-linux"
       "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
     ];
-    maintainers = with lib.maintainers; [ iedame ];
     mainProgram = "megasync";
   };
-})
+
+in
+if stdenv.hostPlatform.isDarwin then
+  callPackage ./darwin.nix (extraArgs // { inherit pname meta; })
+else
+  callPackage ./linux.nix (extraArgs // { inherit pname meta; })


### PR DESCRIPTION
closes #445263

Changelog: https://github.com/meganz/MEGAsync/releases/tag/v5.16.0.2_Linux
Diff: https://github.com/meganz/MEGAsync/compare/v5.15.0.1_Linux...v5.16.0.2_Linux

- Added darwin support for `megasync`
- Removed unused dependencies
- Fixed ZLIB linking issue with new patch
- Added inline comments explaining CMake flag choices
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
