### PR TITLE
haskellPackages.pandoc-crossref: revert patch requiring pandoc>=3.8

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -897,8 +897,24 @@ with haskellLib;
   }) super.xml-picklers;
 
   # 2025-08-03: Too strict bounds on open-browser, data-default and containers
-  # https://github.com/lierdakil/pandoc-crossref/issues/478
-  pandoc-crossref = doJailbreak super.pandoc-crossref;
+  # https://github.com/lierdakil/pandoc-crossref/issues/478 krank:ignore-line
+  pandoc-crossref = lib.pipe super.pandoc-crossref [
+    (warnAfterVersion "0.3.21")
+    doJailbreak
+
+    # We are still using pandoc == 3.7.*
+    (appendPatch (
+      lib.warnIf (lib.versionAtLeast self.pandoc.version "3.8")
+        "haskellPackages.pandoc-crossref: remove revert of pandoc-3.8 patch"
+        pkgs.fetchpatch
+        {
+          name = "pandoc-crossref-revert-pandoc-3.8-highlight.patch";
+          url = "https://github.com/lierdakil/pandoc-crossref/commit/b0c35a59d5a802f6525407bfeb31699ffd0b4671.patch";
+          hash = "sha256-MIITL9Qr3+1fKf1sTwHzXPcYTt3YC+vr9CpMgqsBXlc=";
+          revert = true;
+        }
+    ))
+  ];
 
   # Too strict upper bound on data-default-class (< 0.2)
   # https://github.com/stackbuilders/dotenv-hs/issues/203

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -4564,7 +4564,6 @@ broken-packages:
   - pan-os-syslog # failure in job https://hydra.nixos.org/build/233244422 at 2023-09-02
   - pandoc-citeproc # failure in job https://hydra.nixos.org/build/233198462 at 2023-09-02
   - pandoc-columns # failure in job https://hydra.nixos.org/build/233234538 at 2023-09-02
-  - pandoc-crossref # failure in job https://hydra.nixos.org/build/307611190 at 2025-09-19
   - pandoc-csv2table # failure in job https://hydra.nixos.org/build/233229925 at 2023-09-02
   - pandoc-dhall-decoder # failure in job https://hydra.nixos.org/build/307611186 at 2025-09-19
   - pandoc-emphasize-code # failure in job https://hydra.nixos.org/build/252733347 at 2024-03-16


### PR DESCRIPTION
- The linked issue has been resolved, but the updated bounds are only available on master.
- 0.3.21 contains a patch for an interface deprecation in pandoc 3.8 which we need to revert in order to build with pandoc 3.7.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
