### PR TITLE
python313Packages.pyicu: 2.15.2 -> 2.15.3

### DIFF
--- a/pkgs/development/python-modules/atopile/default.nix
+++ b/pkgs/development/python-modules/atopile/default.nix
@@ -185,11 +185,12 @@ buildPythonPackage rec {
   disabledTests = [
     # timeout
     "test_build_error_logging"
-    "test_performance_mifs_bus_params"
-    "test_resistor"
-    "test_reserved_attrs"
     "test_examples_build"
     "test_net_names_deterministic"
+    "test_performance_mifs_bus_params"
+    "test_regression_rp2040_usb_diffpair"
+    "test_reserved_attrs"
+    "test_resistor"
     # requires internet
     "test_simple_pick"
     "test_simple_negative_pick"

--- a/pkgs/development/python-modules/pyicu/default.nix
+++ b/pkgs/development/python-modules/pyicu/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "pyicu";
-  version = "2.15.2";
+  version = "2.15.3";
   pyproject = true;
 
   src = fetchFromGitLab {
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "main";
     repo = "pyicu";
     tag = "v${version}";
-    hash = "sha256-Div3c4Lk9VTV1HrmvYKDn1a7moDNjG4OHA9Kv3+niKs=";
+    hash = "sha256-vbrl6n7X85sQIdgj+Z0Xr6x/L8roK5Z/mNj53zyWQGs=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/spsdk-mcu-link/default.nix
+++ b/pkgs/development/python-modules/spsdk-mcu-link/default.nix
@@ -43,6 +43,7 @@ buildPythonPackage rec {
   ];
 
   pythonRelaxDeps = [
+    "hidapi"
     "pyusb"
   ];
 


### PR DESCRIPTION
Diff: https://gitlab.pyicu.org/main/pyicu/-/compare/v2.15.2...v2.15.3

Changelog: https://gitlab.pyicu.org/main/pyicu/-/raw/v2.15.3/CHANGES


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
