### PR TITLE
nixos/systemd-boot: atomically update copied destination files

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import warnings
 import json
 from typing import NamedTuple, Any, Sequence
@@ -64,7 +65,9 @@ class SystemIdentifier(NamedTuple):
 
 def copy_if_not_exists(source: Path, dest: Path) -> None:
     if not dest.exists():
-        shutil.copyfile(source, dest)
+        _hdl, tmpfile = tempfile.mkstemp(dir=dest.parent, prefix=dest.name)
+        shutil.copyfile(source, tmpfile)
+        shutil.move(tmpfile, dest)
 
 
 def generation_dir(profile: str | None, generation: int) -> Path:

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -65,9 +65,10 @@ class SystemIdentifier(NamedTuple):
 
 def copy_if_not_exists(source: Path, dest: Path) -> None:
     if not dest.exists():
-        _hdl, tmpfile = tempfile.mkstemp(dir=dest.parent, prefix=dest.name)
-        shutil.copyfile(source, tmpfile)
-        shutil.move(tmpfile, dest)
+        tmpfd, tmppath = tempfile.mkstemp(dir=dest.parent, prefix=dest.name, suffix='.tmp.')
+        shutil.copyfile(source, tmppath)
+        os.fsync(tmpfd)
+        shutil.move(tmppath, dest)
 
 
 def generation_dir(profile: str | None, generation: int) -> Path:


### PR DESCRIPTION
We absolutely do not want to leave an incomplete file behind in /boot
since an incomplete initrd would render the machine unbootable. Errors
while writing are relatively common, mostly due to full /boot
partitions.

systemd-boot-builder does never attempt to re-write already existing
files which means that such situations are not fixable by re-running
nixos-rebuild etc. Instead the user needs to know about internals of the
systemd-boot and manually delete the correct file to recover from a
partially written kernel or (more commonly) initrd in /boot.

Note that this used to be a non issue since systemd-boot-builder used to
always delete all kernels and initrds before copying kernels and
initrds, so dest.exist() would always return False. This was fixed in
https://github.com/sternenseemann/nixpkgs/commit/f2ca99055823b3c2ce762ea2d4a315086a530c3d, revealing the underlying bad
assumption (that copyfile() always succeeds or fails without writing
anything).

The solution is to write to a temporary file first and move it to the
destination path only after this has succeeded. This way, if an error
occurs during copying, only {dest}.tmp is left behind which would be
cleaned up by subsequent runs of remove_old_entries() (hence we don't
need to try and prevent tmpfile name collisions).

Resolves #444066.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
