### PR TITLE
love2d: add Darwin platform support

### DIFF
--- a/pkgs/development/interpreters/love/11.nix
+++ b/pkgs/development/interpreters/love/11.nix
@@ -8,6 +8,7 @@
   libGL,
   openal,
   luajit,
+  lua5_1,
   freetype,
   physfs,
   libmodplug,
@@ -40,11 +41,8 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     SDL2
-    xorg.libX11 # SDl2 optional depend, for SDL_syswm.h
-    libGLU
-    libGL
     openal
-    luajit
+    (if stdenv.isDarwin then lua5_1 else luajit)
     freetype
     physfs
     libmodplug
@@ -54,22 +52,43 @@ stdenv.mkDerivation rec {
     libtheora
     which
     libtool
+  ]
+  ++ lib.optionals stdenv.isLinux [
+    xorg.libX11 # SDL2 optional depend, for SDL_syswm.h
+    libGLU
+    libGL
   ];
 
   preConfigure = "$shell ./platform/unix/automagic";
 
   configureFlags = [
-    "--with-lua=luajit"
+    (if stdenv.isDarwin then "--with-lua=lua" else "--with-lua=luajit")
   ];
 
   env.NIX_CFLAGS_COMPILE = "-DluaL_reg=luaL_Reg"; # needed since luajit-2.1.0-beta3
+
+  # Fix Darwin bundle/dylib linking and macOS function calls
+  preBuild = lib.optionalString stdenv.isDarwin ''
+    # Fix libtool to use dynamiclib instead of bundle for Darwin
+    substituteInPlace libtool \
+      --replace "-bundle" "-dynamiclib" \
+      --replace "-Wl,-bundle" "-Wl,-dynamiclib"
+
+    substituteInPlace src/love.cpp \
+      --replace "love::macosx::checkDropEvents()" "std::string(\"\")" \
+      --replace "love::macosx::getLoveInResources()" "std::string(\"\")"
+  '';
+
+  postFixup = lib.optionalString stdenv.isDarwin ''
+    install_name_tool -change ".libs/liblove-11.5.so" "$out/lib/liblove-11.5.so" "$out/bin/love"
+  '';
 
   meta = {
     homepage = "https://love2d.org";
     description = "Lua-based 2D game engine/scripting language";
     mainProgram = "love";
     license = lib.licenses.zlib;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = [ lib.maintainers.raskin ];
   };
 }


### PR DESCRIPTION
## Description

This PR adds Darwin/macOS platform support to Love2D 11.x, addressing the long-standing issue where Love2D was not available on macOS through nixpkgs.

## Context

This PR addresses issue #369476 and replaces previous attempts:
- **PR #442769**: Had temporary .md files in git history (closed by maintainer request)
- **PR #443702**: Had merge conflicts and non-deterministic build issues (closed)
- **PR #444598**: Created on wrong repository (closed)

This implementation starts from a fresh upstream branch to avoid the issues encountered in previous attempts.

## Changes

### Platform Support
- Added Darwin to the platforms list in meta
- Updated buildInputs to conditionally use appropriate dependencies for each platform

### Darwin-Specific Fixes
- **Lua Implementation**: Use \`lua5_1\` instead of \`luajit\` on Darwin (per upstream recommendation)
- **Linking Issues**: Fix libtool to use \`-dynamiclib\` instead of \`-bundle\` for proper macOS dynamic library creation
- **macOS Function Calls**: Patch out macOS-specific function calls that cause build failures
- **Library Paths**: Add postFixup to correct dynamic library path references

### Build Configuration
- Conditional configureFlags for Lua backend selection
- Platform-specific buildInputs (X11/OpenGL only on Linux)
- Proper handling of Darwin vs Linux differences

## Testing

- ✅ **Build Success**: Love2D builds successfully on Darwin
- ✅ **Functionality**: Love2D runs and reports correct version
- ✅ **Code Formatting**: Applied \`nix fmt\` formatting
- ⚠️ **Non-deterministic Build**: Expected due to libtool script modification (known limitation)

## Known Limitations

The build is non-deterministic due to the libtool script modification required for Darwin support. This is a known limitation that affects the reproducibility of the build, but the package functions correctly.

## Related Issues

Fixes #369476

## Checklist

- [x] Tested on Darwin/macOS
- [x] Builds successfully
- [x] Code formatted with \`nix fmt\`
- [x] References related issue
- [x] Clean commit history from fresh upstream branch