### PR TITLE
grok-cli: init at 0.0.29

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24731,6 +24731,14 @@
     githubId = 1694705;
     name = "Sam Stites";
   };
+  storopoli = {
+    email = "jose@storopoli.com";
+    github = "storopoli";
+    githubId = 43353831;
+    name = "Jose Storopoli";
+    keys = [ { fingerprint = "B8C0 1A87 C046 33C9 F6CD  0DA2 1BD3 8BE8 D065 3A7A"; } ];
+    matrix = "@jose:storopoli.com";
+  };
   strager = {
     email = "strager.nds@gmail.com";
     github = "strager";

--- a/pkgs/by-name/gr/grok-cli/package.nix
+++ b/pkgs/by-name/gr/grok-cli/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  bun,
+  makeBinaryWrapper,
+}:
+
+let
+  pin = lib.importJSON ./pin.json;
+  src = fetchFromGitHub {
+    owner = "superagent-ai";
+    repo = "grok-cli";
+    tag = "@vibe-kit/grok-cli@${pin.version}";
+    hash = pin.srcHash;
+  };
+
+  node_modules = stdenv.mkDerivation {
+    pname = "grok-cli-node_modules";
+    version = pin.version;
+    inherit src;
+
+    impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+      "GIT_PROXY_COMMAND"
+      "SOCKS_SERVER"
+    ];
+    nativeBuildInputs = [ bun ];
+    dontConfigure = true;
+
+    buildPhase = ''
+      bun install --no-progress --frozen-lockfile
+    '';
+
+    installPhase = ''
+      mkdir -p $out/node_modules
+
+      cp -R ./node_modules $out
+    '';
+
+    outputHash = pin."${stdenv.system}";
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  };
+in
+stdenv.mkDerivation {
+  pname = "grok-cli";
+  version = pin.version;
+  inherit src;
+
+  nativeBuildInputs = [
+    bun
+    makeBinaryWrapper
+  ];
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    ln -s ${node_modules}/node_modules .
+    bun run build
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+
+    ln -s ${node_modules}/node_modules $out
+    cp -R ./* $out
+
+    makeBinaryWrapper ${bun}/bin/bun $out/bin/grok \
+      --prefix PATH : ${lib.makeBinPath [ bun ]} \
+      --add-flags "run --prefer-offline --no-install --cwd $out ./dist/index.js"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "An open-source AI agent that brings the power of Grok directly into your terminal.";
+    homepage = "https://github.com/superagent-ai/grok-cli";
+    mainProgram = "grok";
+    maintainers = with maintainers; [ storopoli ];
+    license = with licenses; [ mit ];
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+      "aarch64-linux"
+    ];
+  };
+}

--- a/pkgs/by-name/gr/grok-cli/pin.json
+++ b/pkgs/by-name/gr/grok-cli/pin.json
@@ -1,0 +1,8 @@
+{
+  "version": "0.0.29",
+  "srcHash": "sha256-soPBJuJOwUxctLve1oifsCt1yBXHrM0lNGSPElEcKGg=",
+  "x86_64-linux": "sha256-Xf1wvWE1aG88r7MSU4tYbYB5j3tNy4JTYNjAGnyT5oM=",
+  "x86_64-darwin": "sha256-Xf1wvWE1aG88r7MSU4tYbYB5j3tNy4JTYNjAGnyT5oM=",
+  "aarch64-darwin": "sha256-Xf1wvWE1aG88r7MSU4tYbYB5j3tNy4JTYNjAGnyT5oM=",
+  "aarch64-linux": "sha256-Xf1wvWE1aG88r7MSU4tYbYB5j3tNy4JTYNjAGnyT5oM="
+}


### PR DESCRIPTION
Adds [`grok-cli`](https://github.com/superagent-ai/grok-cli). this is a bun package, I've used something similar to [`helix-gpt` derivation](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/he/helix/package.nix). Tested on my `aarch64-darwin` and it works.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
