### PR TITLE
betaflight-configurator: support x86_64-darwin

### DIFF
--- a/pkgs/by-name/be/betaflight-configurator/package.nix
+++ b/pkgs/by-name/be/betaflight-configurator/package.nix
@@ -1,8 +1,10 @@
 {
   lib,
   stdenv,
+  stdenvNoCC,
   fetchurl,
   unzip,
+  undmg,
   makeDesktopItem,
   nwjs,
   wrapGAppsHook3,
@@ -20,40 +22,72 @@ let
     desktopName = "Betaflight Configurator";
     genericName = "Flight controller configuration tool";
   };
+  platform =
+    if stdenv.hostPlatform.isLinux then
+      {
+        suffix = "linux64-portable.zip";
+        hash = "sha256-UB5Vr5wyCUZbOaQNckJQ1tAXwh8VSLNI1IgTiJzxV08=";
+        installPhase = ''
+          mkdir -p $out/bin \
+                   $out/opt/${pname}
+          cp -r . $out/opt/${pname}/
+          install -m 444 -D icon/bf_icon_128.png $out/share/icons/hicolor/128x128/apps/${pname}.png
+          cp -r ${desktopItem}/share/applications $out/share/
+          makeWrapper ${nwjs}/bin/nw $out/bin/${pname} --add-flags $out/opt/${pname}
+        '';
+      }
+    else if stdenv.hostPlatform.system == "x86_64-darwin" then
+      {
+        suffix = "macOS.dmg";
+        hash = "sha256-qd2t0tmD5ihlyrejg59aZRPjyDmgxMPHm1+pcw7Vo70=";
+        installPhase =
+          let
+            appName = "Betaflight\\ Configurator.app";
+          in
+          ''
+            mkdir -p $out/{Applications/${appName},bin}
+            cp -R . $out/Applications/${appName}
+            cat > $out/bin/${pname} << EOF
+            #!${stdenvNoCC.shell}
+            open -na $out/Applications/${appName} --args "\$@"
+            EOF
+            chmod +x $out/bin/${pname}
+          '';
+      }
+    else
+      throw "Unsupported system: ${stdenv.hostPlatform.system}";
 in
 stdenv.mkDerivation rec {
   inherit pname;
   version = "10.10.0";
   src = fetchurl {
-    url = "https://github.com/betaflight/${pname}/releases/download/${version}/${pname}_${version}_linux64-portable.zip";
-    sha256 = "sha256-UB5Vr5wyCUZbOaQNckJQ1tAXwh8VSLNI1IgTiJzxV08=";
+    url = "https://github.com/betaflight/${pname}/releases/download/${version}/${pname}_${version}_${platform.suffix}";
+    inherit (platform) hash;
   };
 
   # remove large unneeded files
-  postUnpack = ''
+  postUnpack = lib.optionalString stdenv.hostPlatform.isLinux ''
     find -name "lib*.so" -delete
   '';
 
   nativeBuildInputs = [
-    wrapGAppsHook3
     unzip
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    wrapGAppsHook3
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.system == "x86_64-darwin") [
+    undmg
   ];
 
-  buildInputs = [
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     gsettings-desktop-schemas
     gtk3
   ];
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/bin \
-             $out/opt/${pname}
-
-    cp -r . $out/opt/${pname}/
-    install -m 444 -D icon/bf_icon_128.png $out/share/icons/hicolor/128x128/apps/${pname}.png
-    cp -r ${desktopItem}/share/applications $out/share/
-
-    makeWrapper ${nwjs}/bin/nw $out/bin/${pname} --add-flags $out/opt/${pname}
+    ${platform.installPhase}
     runHook postInstall
   '';
 
@@ -69,6 +103,6 @@ stdenv.mkDerivation rec {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ wucke13 ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ [ "x86_64-darwin" ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Pretty straightforward, although I restructured some things to avoid sprinkling `if linux then ... else if darwin` everywhere (if it's more idiomatic I could create a separate darwin.nix derivation).
Getting nwjs to build on Darwin seems somewhat involved, so this only supports x86_64 (what upstream packages).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin (with Rosetta 2)
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
