### PR TITLE
python313Packages.daphne: 4.1.2 -> 4.2.1

### DIFF
--- a/pkgs/development/python-modules/daphne/default.nix
+++ b/pkgs/development/python-modules/daphne/default.nix
@@ -6,42 +6,24 @@
   buildPythonPackage,
   django,
   fetchFromGitHub,
-  fetchpatch2,
   hypothesis,
   pytest-asyncio,
   pytestCheckHook,
-  pythonOlder,
   setuptools,
   twisted,
 }:
 
 buildPythonPackage rec {
   pname = "daphne";
-  version = "4.1.2";
+  version = "4.2.1";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "django";
     repo = "daphne";
     tag = version;
-    hash = "sha256-RAK2CaKKVmVIv1MBK+9xyADOrHq664MQOry4KaGTNCw=";
+    hash = "sha256-MPlvXcg7bBF1yaphjjMtnGsGpp6ca5GsgmXONw/V9Do=";
   };
-
-  patches = [
-    # https://github.com/django/daphne/pull/526
-    (fetchpatch2 {
-      name = "fix-tests-with-Twisted-24.7.0.patch";
-      url = "https://github.com/django/daphne/commit/0370c7a0937011d5345b14d484ec171d3ae9f875.patch";
-      hash = "sha256-/3d2pRcEtGvINGHRQF3RZ8IVIETSZb6rhf+ZHUFSQQo=";
-    })
-  ];
-
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace-fail "pytest-runner" ""
-  '';
 
   build-system = [ setuptools ];
 
@@ -67,7 +49,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Django ASGI (HTTP/WebSocket) server";
     homepage = "https://github.com/django/daphne";
-    changelog = "https://github.com/django/daphne/blob/${version}/CHANGELOG.txt";
+    changelog = "https://github.com/django/daphne/blob/${src.tag}/CHANGELOG.txt";
     license = licenses.bsd3;
     maintainers = [ ];
     mainProgram = "daphne";


### PR DESCRIPTION
Changelog: https://github.com/django/daphne/blob/4.2.1/CHANGELOG.txt


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
