### PR TITLE
zig.hook: allow for global build flag overrides

### DIFF
--- a/pkgs/development/compilers/zig/hook.nix
+++ b/pkgs/development/compilers/zig/hook.nix
@@ -4,6 +4,7 @@
   zig,
   stdenv,
   xcbuild,
+  globalBuildFlags ? [ "-Dcpu=baseline" ],
 }:
 
 makeSetupHook {
@@ -47,10 +48,7 @@ makeSetupHook {
           else
             "-Drelease-safe=true";
       in
-      [
-        "-Dcpu=baseline"
-        releaseType
-      ];
+      globalBuildFlags ++ [ releaseType ];
   };
 
   passthru = { inherit zig; };


### PR DESCRIPTION
I couldn't seem to figure out a way to override `zig_0_14_0.hook` without introducing a parameter to its `hook.nix`. So, here's a patch that allows for global build flags to be added.

AFAICT, this doesn't break anything, while allowing for a fairly easy override:

```
inputs.nixpkgs.url = # branch with this patch applied

# ... overlays in import nixpkgs:

(final: prev: {
          zig_0_14 = prev.zig_0_14.overrideAttrs (finalAttrs: {
            passthru = finalAttrs.passthru // {
              hook = final.callPackage "${nixpkgs}/pkgs/development/compilers/zig/hook.nix" {
                zig = final.zig_0_14;
                globalBuildFlags = [ "-Dcpu=znver3" ];
              };
              zig = finalAttrs.finalPackage;
            };
          });
})

```

The usecase I have for this is overriding the cpu arch to enable vector instructions (similar to targetSystem.gcc.mtune/targetSystem.gcc.arch when importing nixpkgs).

Note this is my first time touching this part of the codebase, so apologies if there actually is a simple way to do the overriding without this patch (or if I've fundamentally misunderstood something)

## Things done

I tested this on my own system [here](https://github.com/DieracDelta/flakes/blob/4338232fb8060ee20959621170ffeda17f0ac3e3/overlays/zig.nix?plain=1#L1).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
