### PR TITLE
[Backport 25.05] teleport: Re-add possibility for overrides

### DIFF
--- a/pkgs/by-name/te/teleport_16/package.nix
+++ b/pkgs/by-name/te/teleport_16/package.nix
@@ -2,6 +2,8 @@
   buildTeleport,
   buildGo124Module,
   wasm-bindgen-cli_0_2_95,
+  withRdpClient ? true,
+  extPatches ? [ ],
 }:
 buildTeleport rec {
   version = "16.5.15";
@@ -12,4 +14,5 @@ buildTeleport rec {
 
   wasm-bindgen-cli = wasm-bindgen-cli_0_2_95;
   buildGoModule = buildGo124Module;
+  inherit withRdpClient extPatches;
 }

--- a/pkgs/by-name/te/teleport_17/package.nix
+++ b/pkgs/by-name/te/teleport_17/package.nix
@@ -2,6 +2,8 @@
   buildTeleport,
   buildGo124Module,
   wasm-bindgen-cli_0_2_95,
+  withRdpClient ? true,
+  extPatches ? [ ],
 }:
 
 buildTeleport rec {
@@ -13,4 +15,5 @@ buildTeleport rec {
 
   wasm-bindgen-cli = wasm-bindgen-cli_0_2_95;
   buildGoModule = buildGo124Module;
+  inherit withRdpClient extPatches;
 }

--- a/pkgs/by-name/te/teleport_18/package.nix
+++ b/pkgs/by-name/te/teleport_18/package.nix
@@ -2,6 +2,8 @@
   buildTeleport,
   buildGo124Module,
   wasm-bindgen-cli_0_2_99,
+  withRdpClient ? true,
+  extPatches ? [ ],
 }:
 
 buildTeleport rec {
@@ -13,4 +15,5 @@ buildTeleport rec {
 
   wasm-bindgen-cli = wasm-bindgen-cli_0_2_99;
   buildGoModule = buildGo124Module;
+  inherit withRdpClient extPatches;
 }


### PR DESCRIPTION
Manual backport of #4445800.

Backport as requested in https://github.com/NixOS/nixpkgs/pull/441311#issuecomment-3306186720.

@philiptaron @simonzkl 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
