### PR TITLE
gss: properly autoreconf

### DIFF
--- a/pkgs/by-name/gs/gss/package.nix
+++ b/pkgs/by-name/gs/gss/package.nix
@@ -1,9 +1,17 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  autoreconfHook,
+  fetchzip,
+  autoconf,
+  automake,
+  gengetopt,
+  gettext,
+  gnulib,
   gtk-doc,
+  help2man,
+  libtool,
+  perl,
+  texinfo,
   withShishi ? !stdenv.hostPlatform.isDarwin,
   shishi,
 }:
@@ -12,9 +20,24 @@ stdenv.mkDerivation rec {
   pname = "gss";
   version = "1.0.4";
 
-  src = fetchurl {
-    url = "mirror://gnu/gss/gss-${version}.tar.gz";
-    hash = "sha256-7M6r3vTK4/znIYsuy4PrQifbpEtTthuMKy6IrgJBnHM=";
+  # The dist tarballs do not contain everything necessary to
+  # autoreconf.  Trying to use autoreconfHook with a dist tarball
+  # produces a broken result that fails to build for some platforms.
+  # If we want to autoreconf, we need to build from a git snapshot.
+  #
+  # See this explanation from the maintainer, about an existing
+  # package that exhibits the same problem (that we were able to
+  # produce when building for Darwin an musl.)
+  #
+  # https://lists.gnu.org/archive/html/help-libidn/2021-07/msg00009.html
+  src = fetchzip {
+    url = "https://gitweb.git.savannah.gnu.org/gitweb/?p=gss.git;a=snapshot;h=v${version};sf=tgz";
+    extension = "tar.gz";
+    hash = "sha256-yT19kwAhGzbIoMjRbrrsn6CyvkMH5v1nxxWpnGYmZUw=";
+  };
+
+  env = {
+    GNULIB_SRCDIR = gnulib.src;
   };
 
   # krb5context test uses certificates that expired on 2024-07-11.
@@ -24,15 +47,22 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    autoreconfHook
+    autoconf
+    automake
+    gengetopt
+    gettext
     gtk-doc
+    help2man
+    libtool
+    perl
+    texinfo
   ];
 
   buildInputs = lib.optional withShishi shishi;
 
-  # ./stdint.h:89:5: error: expected value in expression
-  preConfigure = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    export GNULIBHEADERS_OVERRIDE_WINT_T=0
+  preConfigure = ''
+    patchShebangs doc/gdoc
+    ./autogen.sh
   '';
 
   configureFlags = [


### PR DESCRIPTION
Should let us drop the Darwin hack, and not have to apply it on other platfomrs, like musl, too.

I used Nixpkgs' gnulib source because it works, but if it stops working in future we could use fetchgit to get the gnulib submodule.

Closes: https://github.com/NixOS/nixpkgs/pull/436189


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
