### PR TITLE
maintainers: drop tfmoraes

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25536,11 +25536,6 @@
     github = "tfkhdyt";
     githubId = 47195537;
   };
-  tfmoraes = {
-    name = "Thiago Franco de Moraes";
-    github = "tfmoraes";
-    githubId = 351108;
-  };
   tg-x = {
     email = "*@tg-x.net";
     github = "tg-x";

--- a/pkgs/by-name/op/openvino/package.nix
+++ b/pkgs/by-name/op/openvino/package.nix
@@ -191,6 +191,5 @@ stdenv.mkDerivation rec {
     license = with licenses; [ asl20 ];
     platforms = platforms.all;
     broken = stdenv.hostPlatform.isDarwin; # Cannot find macos sdk
-    maintainers = with maintainers; [ tfmoraes ];
   };
 }

--- a/pkgs/by-name/wx/wxGTK31/package.nix
+++ b/pkgs/by-name/wx/wxGTK31/package.nix
@@ -130,7 +130,6 @@ stdenv.mkDerivation rec {
       lgpl2Plus
       wxWindowsException31
     ];
-    maintainers = with maintainers; [ tfmoraes ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/wx/wxGTK32/package.nix
+++ b/pkgs/by-name/wx/wxGTK32/package.nix
@@ -152,7 +152,6 @@ stdenv.mkDerivation rec {
       wxWindowsException31
     ];
     maintainers = with maintainers; [
-      tfmoraes
       fliegendewurst
     ];
     platforms = platforms.unix;

--- a/pkgs/by-name/wx/wxwidgets_3_3/package.nix
+++ b/pkgs/by-name/wx/wxwidgets_3_3/package.nix
@@ -132,7 +132,6 @@ stdenv.mkDerivation (finalAttrs: {
       wxWindowsException31
     ];
     maintainers = with lib.maintainers; [
-      tfmoraes
       fliegendewurst
       wegank
     ];

--- a/pkgs/by-name/ze/zettlr/package.nix
+++ b/pkgs/by-name/ze/zettlr/package.nix
@@ -42,7 +42,6 @@ appimageTools.wrapType2 rec {
     homepage = "https://www.zettlr.com";
     platforms = [ "x86_64-linux" ];
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ tfmoraes ];
     mainProgram = "zettlr";
   };
 }

--- a/pkgs/development/libraries/gdcm/default.nix
+++ b/pkgs/development/libraries/gdcm/default.nix
@@ -121,7 +121,6 @@ stdenv.mkDerivation (finalAttrs: {
       bsd3
       asl20
     ];
-    maintainers = with lib.maintainers; [ tfmoraes ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/development/python-modules/pypubsub/default.nix
+++ b/pkgs/development/python-modules/pypubsub/default.nix
@@ -40,6 +40,5 @@ buildPythonPackage {
       applications.
     '';
     license = licenses.bsd2;
-    maintainers = with maintainers; [ tfmoraes ];
   };
 }


### PR DESCRIPTION
Last active in January 2024.

Dropping according to maintainer guidelines: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md#losing-maintainer-status

@tfmoraes if you'd like to stay a maintainer, please respond within a week.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
