### PR TITLE
piper-tts: fix espeakbridge cmake output name

### DIFF
--- a/pkgs/by-name/pi/piper-tts/cmake-system-libs.patch
+++ b/pkgs/by-name/pi/piper-tts/cmake-system-libs.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2db7493..c8464ff 100644
+index 2db7493..675c64b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -4,93 +4,129 @@
+@@ -4,93 +4,133 @@
  cmake_minimum_required(VERSION 3.26)
  project(piper LANGUAGES C CXX)
  
@@ -80,9 +80,6 @@ index 2db7493..c8464ff 100644
 -    target_compile_definitions(espeakbridge PRIVATE LIBESPEAK_NG_EXPORT)
  
 -    # Fix .dll suffix
--    set_target_properties(espeakbridge PROPERTIES
--        PREFIX ""
--        SUFFIX ".pyd"
 +if (ESPEAKNG_FOUND)
 +    message(STATUS "Found system espeak-ng via pkg-config")
 +
@@ -95,6 +92,11 @@ index 2db7493..c8464ff 100644
 +    target_link_libraries(espeakbridge PRIVATE
 +        ${ESPEAKNG_LIBRARIES}
 +        ${UCD_STATIC_LIB}
++    )
++
+     set_target_properties(espeakbridge PROPERTIES
+         PREFIX ""
+-        SUFFIX ".pyd"
      )
 +
 +    install(TARGETS espeakbridge


### PR DESCRIPTION
Fixes: #445002


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
