### PR TITLE
openproject-cli: init at 0.5.3

### DIFF
--- a/pkgs/by-name/op/openproject-cli/package.nix
+++ b/pkgs/by-name/op/openproject-cli/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  go_1_25,
+}:
+
+buildGoModule rec {
+  pname = "openproject-cli";
+  version = "0.5.3";
+
+  src = fetchFromGitHub {
+    owner = "opf";
+    repo = "openproject-cli";
+    rev = version;
+    hash = "sha256-5dovK9A2l+bT6hLGw8gyciK1p0ucGmdEX3qdC9zvJR4=";
+  };
+
+  vendorHash = "sha256-HiS8yHb8o2xdsCDKmebhJOCZpG/3rmE3zKcoaMYTxTE=";
+
+  # specify Go version explicitly
+  go = go_1_25;
+
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    # Create the canonical alias
+    ln -s "$out/bin/openproject-cli" "$out/bin/op"
+
+    # Set a writable HOME to avoid /homeless-shelter errors
+    export HOME="$PWD/tmp-home"
+    mkdir -p "$HOME"
+
+    # Generate completions into a temporary directory
+    mkdir -p completions
+    PATH="$out/bin:$PATH"
+
+    op completion bash > completions/op
+    op completion zsh > completions/op.zsh
+    op completion fish > completions/op.fish
+
+    # Install to correct standard locations
+    installShellCompletion \
+      --bash completions/op \
+      --zsh completions/op.zsh \
+      --fish completions/op.fish
+  '';
+
+  meta = with lib; {
+    description = "CLI for OpenProject API v3";
+    homepage = "https://github.com/opf/openproject-cli";
+    license = licenses.gpl3Only; # check LICENSE file to confirm
+    platforms = platforms.unix;
+    mainProgram = "openproject-cli";
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Add [OpenProject CLI](https://github.com/opf/openproject-cli),  
a command-line tool for interacting with the OpenProject API v3.  
Provides commands for managing projects, work packages, and notifications.

###### Things done

- [x] Tested using sandboxing (`nix build --option sandbox true`)
- Built on platform(s)
  - [x] macOS aarch64-darwin
  - [x] Linux x86_64
- [x] Tested basic functionality (`op --version`, `openproject-cli --help`)
- [x] Verified shell completions for bash, zsh, and fish
- [x] Ensured proper meta attributes (`mainProgram`, `license`, etc.)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Notes

- Provides both `openproject-cli` and `op` binary aliases.
- No extra dependencies beyond Go standard library.
- Tested with OpenProject 13.x and 14.x instances.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
