### PR TITLE
python3Packages.webdataset: 0.3.2 -> 1.0.2, python3Packages.open-clip-torch: 3.1.0 -> 3.2.0

### DIFF
--- a/pkgs/development/python-modules/open-clip-torch/default.nix
+++ b/pkgs/development/python-modules/open-clip-torch/default.nix
@@ -24,19 +24,17 @@
   pandas,
   transformers,
   webdataset,
-
-  stdenv,
 }:
 buildPythonPackage rec {
   pname = "open-clip-torch";
-  version = "3.1.0";
+  version = "3.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mlfoundations";
     repo = "open_clip";
     tag = "v${version}";
-    hash = "sha256-xDXxhncX0l9qwbV4Gk4rOROH6Qyit/FSTgjrg4Vbk1s=";
+    hash = "sha256-k4/u0XtfBmPSVKfEK3wHqJXtKAuUNkUnk1TLG2S6PPs=";
   };
 
   build-system = [ pdm-backend ];
@@ -77,14 +75,12 @@ buildPythonPackage rec {
     "test_inference_with_data"
     "test_pretrained_text_encoder"
     "test_training_mt5"
+
     # fails due to type errors
     "test_num_shards"
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux) [
+
+    # hangs forever
     "test_training"
-    "test_training_coca"
-    "test_training_unfreezing_vit"
-    "test_training_clip_with_jit"
   ];
 
   meta = {


### PR DESCRIPTION
## Things done

- **python3Packages.webdataset: 0.3.2 -> 1.0.2**
- **python3Packages.open-clip-torch: 3.1.0 -> 3.2.0**
  
cc @iynaix

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
