### PR TITLE
cargo-auditable: 0.6.5 -> 0.7.1

### DIFF
--- a/pkgs/by-name/co/cosmic-initial-setup/package.nix
+++ b/pkgs/by-name/co/cosmic-initial-setup/package.nix
@@ -27,14 +27,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   buildFeatures = [ "nixos" ];
 
-  # cargo-auditable fails during the build when compiling the `crabtime::function`
-  # procedural macro. It panics because the `--out-dir` flag is not passed to
-  # the rustc wrapper.
-  #
-  # Reported this issue upstream in:
-  # https://github.com/rust-secure-code/cargo-auditable/issues/225
-  auditable = false;
-
   nativeBuildInputs = [
     libcosmicAppHook
     just

--- a/pkgs/development/compilers/rust/cargo-auditable.nix
+++ b/pkgs/development/compilers/rust/cargo-auditable.nix
@@ -10,18 +10,18 @@
 let
   args = rec {
     pname = "cargo-auditable";
-    version = "0.7.0";
+    version = "0.7.1";
 
     src = fetchFromGitHub {
       owner = "rust-secure-code";
       repo = "cargo-auditable";
       tag = "v${version}";
-      hash = "sha256-hFdG3LEPhk1UqlmWwFaHs9d2xyl6edb4WfOYgcE9/8I=";
+      hash = "sha256-t5il9CVhYZtmKrWxBoDpKZaGTPjpBO6Cotw0vuAthvc=";
     };
 
     cargoDeps = rustPlatform.fetchCargoVendor {
       inherit pname version src;
-      hash = "sha256-2dAlo+5rwzU2DxsbjBfri/lF6NFIvNeY7gx8we/5aQs=";
+      hash = "sha256-2ZbRANFMExILSUrrft2fRWjScy0kMreyQMtHWA7iRds=";
     };
 
     checkFlags = [

--- a/pkgs/development/compilers/rust/cargo-auditable.nix
+++ b/pkgs/development/compilers/rust/cargo-auditable.nix
@@ -10,23 +10,31 @@
 let
   args = rec {
     pname = "cargo-auditable";
-    version = "0.6.5";
+    version = "0.7.0";
 
     src = fetchFromGitHub {
       owner = "rust-secure-code";
       repo = "cargo-auditable";
-      rev = "v${version}";
-      sha256 = "sha256-zjv2/qZM0vRyz45DeKRtPHaamv2iLtjpSedVTEXeDr8=";
+      tag = "v${version}";
+      hash = "sha256-hFdG3LEPhk1UqlmWwFaHs9d2xyl6edb4WfOYgcE9/8I=";
     };
 
     cargoDeps = rustPlatform.fetchCargoVendor {
       inherit pname version src;
-      hash = "sha256-oTPGmoGlNfPVZ6qha/oXyPJp94fT2cNlVggbIGHf2bc=";
+      hash = "sha256-2dAlo+5rwzU2DxsbjBfri/lF6NFIvNeY7gx8we/5aQs=";
     };
 
     checkFlags = [
       # requires wasm32-unknown-unknown target
       "--skip=test_wasm"
+      # Fails starting from 0.6.6 due to rustc argument parsing changes
+      # (pico-args eq-separator feature or --emit flag handling).
+      "--skip=test_self_hosting"
+      # Fails starting from 0.7.0 when the test runs with sbom=true.
+      # The test sets CARGO_BUILD_SBOM=true which propagates to nested cargo builds.
+      # Nested builds try to use `-Z sbom`, but stable Cargo doesn't support this flag.
+      # (RUSTC_BOOTSTRAP=1 only affects rustc, not Cargo's -Z flags)
+      "--skip=test_proc_macro"
     ];
 
     meta = with lib; {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Related: rust-secure-code/cargo-auditable#225

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
