### PR TITLE
treewide: re-add removed maintainer contact

### DIFF
--- a/pkgs/by-name/al/alsa-lib-with-plugins/package.nix
+++ b/pkgs/by-name/al/alsa-lib-with-plugins/package.nix
@@ -17,6 +17,11 @@ runCommand "${alsa-lib.pname}-${alsa-lib.version}"
   {
     meta = with lib; {
       description = "Wrapper to ease access to ALSA plugins";
+      longDescription = ''
+        Wrapper to ease access to ALSA plugins.
+
+        maintainer e-mail contact: Isidor Zeuner (gm6k) <nix@quidecco.pl>
+      '';
       mainProgram = "aserver";
       platforms = platforms.linux;
     };

--- a/pkgs/by-name/mi/minetest-mapserver/package.nix
+++ b/pkgs/by-name/mi/minetest-mapserver/package.nix
@@ -19,6 +19,11 @@ buildGoModule rec {
 
   meta = {
     description = "Realtime mapserver for minetest";
+    longDescription = ''
+      Realtime mapserver for minetest.
+
+      maintainer e-mail contact: Isidor Zeuner (gm6k) <nix@quidecco.pl>
+    '';
     mainProgram = "mapserver";
     homepage = "https://github.com/minetest-mapserver/mapserver/blob/master/readme.md";
     changelog = "https://github.com/minetest-mapserver/mapserver/releases/tag/v${version}";

--- a/pkgs/development/python-modules/pyldavis/default.nix
+++ b/pkgs/development/python-modules/pyldavis/default.nix
@@ -43,6 +43,11 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/bmabey/pyLDAvis";
     description = "Python library for interactive topic model visualization";
+    longDescription = ''
+      Python library for interactive topic model visualization.
+
+      maintainer e-mail contact: Isidor Zeuner (gm6k) <nix@quidecco.pl>
+    '';
     license = licenses.bsd3;
     sourceProvenance = with sourceTypes; [ fromSource ];
     platforms = platforms.all;


### PR DESCRIPTION
These packages have been damaged by removing a way to contact the maintainer.

This PR fixes it for both legal and practical reasons.

In some jurisdictions like the EU, availability of personal data has to be ensured, and removing the maintainer entry effectively made the maintainer contact unavailable where it is required. Furthermore, removing it hurts users of the affected packages, because it makes it hard for them to contact someone who is familiar with the packages when issues arise.

Re-adding the necessary information to the affected packages solves these issues.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
