### PR TITLE
apple-sdk: clean up and improve compatibility with Swift

### DIFF
--- a/pkgs/by-name/ap/apple-sdk/common/add-core-symbolication.nix
+++ b/pkgs/by-name/ap/apple-sdk/common/add-core-symbolication.nix
@@ -42,7 +42,6 @@ in
 self: super: {
   buildPhase = super.buildPhase or "" + ''
     mkdir -p System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/Headers
-    ln -s A System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/Current
     ln -s Versions/Current/Headers System/Library/PrivateFrameworks/CoreSymbolication.framework/Headers
     cp '${CoreSymbolication}/include/'*.h System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/Headers
   '';

--- a/pkgs/by-name/ap/apple-sdk/common/plists.nix
+++ b/pkgs/by-name/ap/apple-sdk/common/plists.nix
@@ -2,15 +2,28 @@
   lib,
   stdenvNoCC,
   xcodePlatform,
+  sdkVersion,
 }:
 
 let
   inherit (lib.generators) toPlist;
 
-  Info = {
-    CFBundleIdentifier = "com.apple.platform.${lib.toLower xcodePlatform}";
-    Type = "Platform";
+  Info = rec {
+    CFBundleIdentifier = "com.apple.platform.${Name}";
+    DefaultProperties = {
+      COMPRESS_PNG_FILES = "NO";
+      DEPLOYMENT_TARGET_SETTING_NAME = stdenvNoCC.hostPlatform.darwinMinVersionVariable;
+      STRIP_PNG_TEXT = "NO";
+    };
+    Description = if stdenvNoCC.hostPlatform.isMacOS then "macOS" else "iOS";
+    FamilyDisplayName = Description;
+    FamilyIdentifier = lib.toLower xcodePlatform;
+    FamilyName = Description;
+    Identifier = CFBundleIdentifier;
+    MinimumSDKVersion = stdenvNoCC.hostPlatform.darwinMinVersion;
     Name = lib.toLower xcodePlatform;
+    Type = "Platform";
+    Version = sdkVersion;
   };
 
   # These files are all based off of Xcode spec files found in

--- a/pkgs/by-name/ap/apple-sdk/common/propagate-inputs.nix
+++ b/pkgs/by-name/ap/apple-sdk/common/propagate-inputs.nix
@@ -56,16 +56,19 @@ self: super: {
       darwin.libsbuf
       # Shipped with the SDK only as a library with no headers
       (lib.getLib darwin.libutil)
-      # Required by some SDK headers
-      cupsHeaders
     ]
     # x86_64-darwin links the object files from Csu when targeting very old releases
     ++ lib.optionals stdenvNoCC.hostPlatform.isx86_64 [ darwin.Csu ];
 
   # The Darwin module for Swift requires certain headers to be included in the SDK (and not just be propagated).
   buildPhase = super.buildPhase or "" + ''
-    for header in '${lib.getDev libiconv}/include/'* '${lib.getDev ncurses}/include/'*; do
+    for header in '${lib.getDev libiconv}/include/'* '${lib.getDev ncurses}/include/'* '${cupsHeaders}/include/'*; do
       ln -s "$header" "usr/include/$(basename "$header")"
     done
   '';
+
+  # Exported to allow the headers to pass the requisites check in the stdenv bootstrap.
+  passthru = (super.passthru or { }) // {
+    cups-headers = cupsHeaders;
+  };
 }

--- a/pkgs/by-name/ap/apple-sdk/common/propagate-xcrun.nix
+++ b/pkgs/by-name/ap/apple-sdk/common/propagate-xcrun.nix
@@ -38,11 +38,15 @@ self: super: {
     # Include `libtool` in the toolchain, so `xcrun -find libtool` can find it without requiring `cctools.libtool`
     # as a `nativeBuildInput`.
     mkdir -p "$toolchainsPath/usr/bin"
-    ln -s '${cctools.libtool}/bin/${stdenv.cc.targetPrefix}libtool' "$toolchainsPath/usr/bin/libtool"
+    if [ -e '${cctools.libtool}/bin/${stdenv.cc.targetPrefix}libtool' ]; then
+      ln -s '${cctools.libtool}/bin/${stdenv.cc.targetPrefix}libtool' "$toolchainsPath/usr/bin/libtool"
+    fi
 
     # Include additional binutils required by some packages (such as Chromium).
     for tool in lipo nm otool size strip; do
-      ln -s '${darwin.binutils-unwrapped}/bin/${stdenv.cc.targetPrefix}'$tool "$toolchainsPath/usr/bin/$tool"
+      if [ -e '${darwin.binutils-unwrapped}/bin/${stdenv.cc.targetPrefix}'$tool ]; then
+        ln -s '${darwin.binutils-unwrapped}/bin/${stdenv.cc.targetPrefix}'$tool "$toolchainsPath/usr/bin/$tool"
+      fi
     done
   '';
 }

--- a/pkgs/by-name/ap/apple-sdk/common/propagate-xcrun.nix
+++ b/pkgs/by-name/ap/apple-sdk/common/propagate-xcrun.nix
@@ -3,11 +3,12 @@
   pkgsBuildHost,
   stdenv,
   stdenvNoCC,
+  sdkVersion,
 }:
 
 let
   plists = import ./plists.nix {
-    inherit lib stdenvNoCC;
+    inherit lib stdenvNoCC sdkVersion;
     xcodePlatform = if stdenvNoCC.hostPlatform.isMacOS then "MacOSX" else "iPhoneOS";
   };
   inherit (pkgsBuildHost) darwin cctools xcbuild;

--- a/pkgs/by-name/ap/apple-sdk/package.nix
+++ b/pkgs/by-name/ap/apple-sdk/package.nix
@@ -90,6 +90,11 @@ stdenvNoCC.mkDerivation (
         ln -s "${sdkName}" "$sdkpath/MacOSX${sdkMajor}.sdk"
         ln -s "${sdkName}" "$sdkpath/MacOSX.sdk"
 
+        # Swift adds these locations to its search paths. Avoid spurious warnings by making sure they exist.
+        mkdir -p "$platformPath/Developer/Library/Frameworks"
+        mkdir -p "$platformPath/Developer/Library/PrivateFrameworks"
+        mkdir -p "$platformPath/Developer/usr/lib"
+
         runHook postInstall
       '';
 

--- a/pkgs/by-name/ap/apple-sdk/package.nix
+++ b/pkgs/by-name/ap/apple-sdk/package.nix
@@ -58,12 +58,6 @@ stdenvNoCC.mkDerivation (
 
     dontConfigure = true;
 
-    # TODO(@connorbaker):
-    # This is a quick fix unblock builds broken by https://github.com/NixOS/nixpkgs/pull/370750.
-    # Fails due to a reflexive symlink:
-    # $out/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/A
-    dontCheckForBrokenSymlinks = true;
-
     strictDeps = true;
 
     setupHooks = [

--- a/pkgs/by-name/ap/apple-sdk/package.nix
+++ b/pkgs/by-name/ap/apple-sdk/package.nix
@@ -41,7 +41,7 @@ let
     # Avoid infinite recursions by not propagating certain packages, so they can themselves build with the SDK.
     ++ lib.optionals (!enableBootstrap) [
       (callPackage ./common/propagate-inputs.nix { })
-      (callPackage ./common/propagate-xcrun.nix { })
+      (callPackage ./common/propagate-xcrun.nix { inherit sdkVersion; })
     ]
     # This has to happen last.
     ++ [

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -1121,6 +1121,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
             with prevStage;
             [
               apple-sdk
+              apple-sdk.cups-headers
               bashNonInteractive
               bzip2.bin
               bzip2.out


### PR DESCRIPTION
These changes are precursors to the Swift 6.2 update and will be required to use the SDK from nixpkgs with Swift Build. I’ve also included a fix for the broken symlinks issue. I can split that out if necessary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
