### PR TITLE
haskellPackages.cabal2nix-unstable: use correct output on Darwin

### DIFF
--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -356,18 +356,18 @@ self: super:
     # the latter in the future!
     cabal2nix = overrideCabal (old: {
       postInstall = ''
-        remove-references-to -t ${self.hpack} "$out/bin/cabal2nix"
+        remove-references-to -t ${self.hpack} "''${!outputBin}/bin/cabal2nix"
         # Note: The `data` output is needed at runtime.
-        remove-references-to -t ${self.distribution-nixpkgs.out} "$out/bin/hackage2nix"
+        remove-references-to -t ${self.distribution-nixpkgs.out} "''${!outputBin}/bin/hackage2nix"
 
         ${old.postInstall or ""}
       '';
     }) super.cabal2nix;
     cabal2nix-unstable = overrideCabal (old: {
       postInstall = ''
-        remove-references-to -t ${self.hpack} "$out/bin/cabal2nix"
+        remove-references-to -t ${self.hpack} "''${!outputBin}/bin/cabal2nix"
         # Note: The `data` output is needed at runtime.
-        remove-references-to -t ${self.distribution-nixpkgs-unstable.out} "$out/bin/hackage2nix"
+        remove-references-to -t ${self.distribution-nixpkgs-unstable.out} "''${!outputBin}/bin/hackage2nix"
 
         ${old.postInstall or ""}
       '';


### PR DESCRIPTION
cabal2nix doesn't have a separate bin output, but cabal2nix-unstable does (now?), so copying over the code doesn't work. Just stop hardcoding the bin output in both cases.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
