### PR TITLE
lcagent: init at 0.1.0

### DIFF
--- a/pkgs/by-name/lc/lcagent/package.nix
+++ b/pkgs/by-name/lc/lcagent/package.nix
@@ -1,0 +1,51 @@
+{
+  fetchFromGitea,
+  lib,
+  stdenv,
+  flex,
+  bison,
+  librecast,
+  libsodium,
+  lcrq,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lcagent";
+  version = "0.1.0";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "librecast";
+    repo = "lcagent";
+    tag = finalAttrs.version;
+    hash = "sha256-Kr3VQ56V+Neo4CrKX5AasuftXNNJCx4NnsPz1UBBCog=";
+  };
+
+  nativeBuildInputs = [
+    bison
+    flex
+  ];
+
+  buildInputs = [
+    lcrq
+    librecast
+    libsodium
+  ];
+  installFlags = [ "PREFIX=$(out)" ];
+  doCheck = true;
+
+  meta = {
+    changelog = "https://codeberg.org/librecast/lcagent/src/tag/v${finalAttrs.version}/CHANGELOG.md";
+    description = "Librecast multicast agent";
+    homepage = "https://librecast.net/lcagent.html";
+    license = [
+      lib.licenses.gpl2Only
+      lib.licenses.gpl3Only
+    ];
+    mainProgram = "lcagent";
+    maintainers = with lib.maintainers; [
+      jleightcap
+      jasonodoom
+    ];
+    platforms = lib.platforms.gnu;
+  };
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

> lcagent is the Librecast multicast agent.
>
> In server mode lcagent can be configured to listen on Librecast Channels (multicast groups) and execute programs in response to packet data received on those Channels.

https://librecast.net/lcagent.html

extension of existing project packages: librecast, lcsync, lcrq.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc