### PR TITLE
haskellPackages: update various comments and issue references for the benefit of krank

### DIFF
--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -1249,8 +1249,8 @@ it does for the unstable branches.
 ### Why is topic X not covered in this section? Why is section Y missing? {#haskell-why-not-covered}
 
 We have been working on [moving the nixpkgs Haskell documentation back into the
-nixpkgs manual](https://github.com/NixOS/nixpkgs/issues/121403). Since this
-process has not been completed yet, you may find some topics missing here
+nixpkgs manual](https://github.com/NixOS/nixpkgs/issues/121403). <!-- krank:ignore-line -->
+Since this process has not been completed yet, you may find some topics missing here
 covered in the old [haskell4nix docs](https://haskell4nix.readthedocs.io/).
 
 If you feel any important topic is not documented at all, feel free to comment

--- a/pkgs/development/compilers/ghc/9.0.2-binary.nix
+++ b/pkgs/development/compilers/ghc/9.0.2-binary.nix
@@ -477,7 +477,7 @@ stdenv.mkDerivation {
   # GHC cannot currently produce outputs that are ready for `-pie` linking.
   # Thus, disable `pie` hardening, otherwise `recompile with -fPIE` errors appear.
   # See:
-  # * https://github.com/NixOS/nixpkgs/issues/129247
+  # * https://github.com/NixOS/nixpkgs/issues/129247 krank:ignore-line
   # * https://gitlab.haskell.org/ghc/ghc/-/issues/19580
   hardeningDisable = [ "pie" ];
 

--- a/pkgs/development/compilers/ghc/9.2.4-binary.nix
+++ b/pkgs/development/compilers/ghc/9.2.4-binary.nix
@@ -441,7 +441,7 @@ stdenv.mkDerivation {
   # GHC cannot currently produce outputs that are ready for `-pie` linking.
   # Thus, disable `pie` hardening, otherwise `recompile with -fPIE` errors appear.
   # See:
-  # * https://github.com/NixOS/nixpkgs/issues/129247
+  # * https://github.com/NixOS/nixpkgs/issues/129247 krank:ignore-line
   # * https://gitlab.haskell.org/ghc/ghc/-/issues/19580
   hardeningDisable = [ "pie" ];
 

--- a/pkgs/development/compilers/ghc/9.6.3-binary.nix
+++ b/pkgs/development/compilers/ghc/9.6.3-binary.nix
@@ -420,7 +420,7 @@ stdenv.mkDerivation {
   # GHC cannot currently produce outputs that are ready for `-pie` linking.
   # Thus, disable `pie` hardening, otherwise `recompile with -fPIE` errors appear.
   # See:
-  # * https://github.com/NixOS/nixpkgs/issues/129247
+  # * https://github.com/NixOS/nixpkgs/issues/129247 krank:ignore-line
   # * https://gitlab.haskell.org/ghc/ghc/-/issues/19580
   hardeningDisable = [ "pie" ];
 

--- a/pkgs/development/compilers/ghc/9.8.4-binary.nix
+++ b/pkgs/development/compilers/ghc/9.8.4-binary.nix
@@ -435,7 +435,7 @@ stdenv.mkDerivation {
   # GHC cannot currently produce outputs that are ready for `-pie` linking.
   # Thus, disable `pie` hardening, otherwise `recompile with -fPIE` errors appear.
   # See:
-  # * https://github.com/NixOS/nixpkgs/issues/129247
+  # * https://github.com/NixOS/nixpkgs/issues/129247 krank:ignore-line
   # * https://gitlab.haskell.org/ghc/ghc/-/issues/19580
   hardeningDisable = [ "pie" ];
 

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -185,14 +185,14 @@
           || (lib.versionAtLeast version "9.8" && lib.versionOlder version "9.11");
       in
 
-      # Fix docs build with Sphinx >= 7 https://gitlab.haskell.org/ghc/ghc/-/issues/24129
+      # Fix docs build with Sphinx >= 7 https://gitlab.haskell.org/ghc/ghc/-/issues/24129 krank:ignore-line
       lib.optionals (lib.versionOlder version "9.6.7") [
         ./docs-sphinx-7.patch
       ]
       ++ lib.optionals (lib.versionAtLeast version "9.6" && lib.versionOlder version "9.6.5") [
         # Fix aarch64-linux builds of 9.6.0 - 9.6.4.
         # Fixes a pointer type mismatch in the RTS.
-        # https://gitlab.haskell.org/ghc/ghc/-/issues/24348
+        # https://gitlab.haskell.org/ghc/ghc/-/issues/24348 krank:ignore-line
         (fetchpatch {
           name = "fix-incompatible-pointer-types.patch";
           url = "https://gitlab.haskell.org/ghc/ghc/-/commit/1e48c43483693398001bfb0ae644a3558bf6a9f3.diff";
@@ -211,8 +211,8 @@
           [
             # Determine size of time related types using hsc2hs instead of assuming CLong.
             # Prevents failures when e.g. stat(2)ing on 32bit systems with 64bit time_t etc.
-            # https://github.com/haskell/ghcup-hs/issues/1107
-            # https://gitlab.haskell.org/ghc/ghc/-/issues/25095
+            # https://github.com/haskell/ghcup-hs/issues/1107   krank:ignore-line
+            # https://gitlab.haskell.org/ghc/ghc/-/issues/25095 krank:ignore-line
             # Note that in normal situations this shouldn't be the case since nixpkgs
             # doesn't set -D_FILE_OFFSET_BITS=64 and friends (yet).
             (fetchpatch {
@@ -232,7 +232,7 @@
       ]
       ++ lib.optionals (lib.versionAtLeast version "9.6" && lib.versionOlder version "9.8") [
         # Fix unlit being installed under a different name than is used in the
-        # settings file: https://gitlab.haskell.org/ghc/ghc/-/issues/23317
+        # settings file: https://gitlab.haskell.org/ghc/ghc/-/issues/23317 krank:ignore-line
         (fetchpatch {
           name = "ghc-9.6-fix-unlit-path.patch";
           url = "https://gitlab.haskell.org/ghc/ghc/-/commit/8fde4ac84ec7b1ead238cb158bbef48555d12af9.patch";
@@ -245,7 +245,7 @@
         #
         # These cause problems as they're not eliminated by GHC's dead code
         # elimination on aarch64-darwin. (see
-        # https://github.com/NixOS/nixpkgs/issues/140774 for details).
+        # https://github.com/NixOS/nixpkgs/issues/140774 for details). krank:ignore-line
         (
           if lib.versionOlder version "9.10" then
             ./Cabal-at-least-3.6-paths-fix-cycle-aarch64-darwin.patch
@@ -266,7 +266,8 @@
       # impossible to import an existing flavour in UserSettings, so patching
       # the defaults is actually simpler and less maintenance intensive
       # compared to keeping an entire flavour definition in sync with upstream
-      # manually. See also https://gitlab.haskell.org/ghc/ghc/-/issues/23625
+      # manually.
+      # See also https://gitlab.haskell.org/ghc/ghc/-/issues/23625 krank:ignore-line
       ++ lib.optionals (!enableHyperlinkedSource) [
         (
           if lib.versionOlder version "9.8" then
@@ -285,7 +286,7 @@
       ]
       # Fixes stack overrun in rts which crashes an process whenever
       # freeHaskellFunPtr is called with nixpkgs' hardening flags.
-      # https://gitlab.haskell.org/ghc/ghc/-/issues/25485
+      # https://gitlab.haskell.org/ghc/ghc/-/issues/25485 krank:ignore-line
       # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13599
       ++ lib.optionals (lib.versionOlder version "9.13") [
         (fetchpatch {
@@ -789,7 +790,7 @@ stdenv.mkDerivation (
     # GHC cannot currently produce outputs that are ready for `-pie` linking.
     # Thus, disable `pie` hardening, otherwise `recompile with -fPIE` errors appear.
     # See:
-    # * https://github.com/NixOS/nixpkgs/issues/129247
+    # * https://github.com/NixOS/nixpkgs/issues/129247 krank:ignore-line
     # * https://gitlab.haskell.org/ghc/ghc/-/issues/19580
     hardeningDisable = [
       "format"
@@ -814,7 +815,8 @@ stdenv.mkDerivation (
 
     ''
     # the bindist configure script uses different env variables than the GHC configure script
-    # see https://github.com/NixOS/nixpkgs/issues/267250 and https://gitlab.haskell.org/ghc/ghc/-/issues/24211
+    # see https://github.com/NixOS/nixpkgs/issues/267250 krank:ignore-line
+    # https://gitlab.haskell.org/ghc/ghc/-/issues/24211  krank:ignore-line
     + lib.optionalString (stdenv.targetPlatform.linker == "cctools") ''
       export InstallNameToolCmd=$INSTALL_NAME_TOOL
       export OtoolCmd=$OTOOL

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -134,7 +134,7 @@ let
     # program is built (which we generally always want to have a complete GHC install)
     # and whether it is run on the GHC sources to generate hyperlinked source code
     # (which is impossible for cross-compilation); see:
-    # https://gitlab.haskell.org/ghc/ghc/-/issues/20077
+    # https://gitlab.haskell.org/ghc/ghc/-/issues/20077 krank:ignore-line
     # This implies that currently a cross-compiled GHC will never have a `haddock`
     # program, so it can never generate haddocks for any packages.
     # If this is solved in the future, we'd like to unconditionally
@@ -292,8 +292,8 @@ stdenv.mkDerivation (
     patches = [
       # Determine size of time related types using hsc2hs instead of assuming CLong.
       # Prevents failures when e.g. stat(2)ing on 32bit systems with 64bit time_t etc.
-      # https://github.com/haskell/ghcup-hs/issues/1107
-      # https://gitlab.haskell.org/ghc/ghc/-/issues/25095
+      # https://github.com/haskell/ghcup-hs/issues/1107   krank:ignore-line
+      # https://gitlab.haskell.org/ghc/ghc/-/issues/25095 krank:ignore-line
       # Note that in normal situations this shouldn't be the case since nixpkgs
       # doesn't set -D_FILE_OFFSET_BITS=64 and friends (yet).
       (fetchpatch {
@@ -304,7 +304,7 @@ stdenv.mkDerivation (
         extraPrefix = "libraries/unix/";
       })
 
-      # Fix docs build with Sphinx >= 7 https://gitlab.haskell.org/ghc/ghc/-/issues/24129
+      # Fix docs build with Sphinx >= 7 https://gitlab.haskell.org/ghc/ghc/-/issues/24129 krank:ignore-line
       ./docs-sphinx-7.patch
 
       # Correctly record libnuma's library and include directories in the
@@ -328,7 +328,7 @@ stdenv.mkDerivation (
     # the solution is to backport those changes from GHC 9.6 that skip the intermediate
     # assembly step.
     #
-    # https://gitlab.haskell.org/ghc/ghc/-/issues/25608#note_622589
+    # https://gitlab.haskell.org/ghc/ghc/-/issues/25608#note_622589 krank:ignore-line
     # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6877
     ++ [
       # Need to use this patch so the next one applies, passes file location info to the cc phase
@@ -358,7 +358,7 @@ stdenv.mkDerivation (
 
     # Fixes stack overrun in rts which crashes an process whenever
     # freeHaskellFunPtr is called with nixpkgs' hardening flags.
-    # https://gitlab.haskell.org/ghc/ghc/-/issues/25485
+    # https://gitlab.haskell.org/ghc/ghc/-/issues/25485 krank:ignore-line
     # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13599
     # TODO: patch doesn't apply for < 9.4, but may still be necessary?
     ++ [
@@ -375,7 +375,7 @@ stdenv.mkDerivation (
       #
       # These cause problems as they're not eliminated by GHC's dead code
       # elimination on aarch64-darwin. (see
-      # https://github.com/NixOS/nixpkgs/issues/140774 for details).
+      # https://github.com/NixOS/nixpkgs/issues/140774 for details). krank:ignore-line
       ./Cabal-at-least-3.6-paths-fix-cycle-aarch64-darwin.patch
     ];
 
@@ -592,7 +592,7 @@ stdenv.mkDerivation (
     # GHC cannot currently produce outputs that are ready for `-pie` linking.
     # Thus, disable `pie` hardening, otherwise `recompile with -fPIE` errors appear.
     # See:
-    # * https://github.com/NixOS/nixpkgs/issues/129247
+    # * https://github.com/NixOS/nixpkgs/issues/129247 krank:ignore-line
     # * https://gitlab.haskell.org/ghc/ghc/-/issues/19580
     hardeningDisable = [
       "format"

--- a/pkgs/development/haskell-modules/configuration-arm.nix
+++ b/pkgs/development/haskell-modules/configuration-arm.nix
@@ -117,7 +117,7 @@ self: super:
   # AARCH32-SPECIFIC OVERRIDES
 
   # KAT/ECB/D2 test segfaults on armv7l
-  # https://github.com/haskell-crypto/cryptonite/issues/367
+  # https://github.com/haskell-crypto/cryptonite/issues/367 krank:ignore-line
   cryptonite = dontCheck super.cryptonite;
 }
 // lib.optionalAttrs (with pkgs.stdenv.hostPlatform; isAarch && isAndroid) {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -962,7 +962,6 @@ with haskellLib;
   git-vogue = dontCheck super.git-vogue;
   github-rest = dontCheck super.github-rest; # test suite needs the network
   gitlib-cmdline = dontCheck super.gitlib-cmdline;
-  GLFW-b = dontCheck super.GLFW-b; # https://github.com/bsl/GLFW-b/issues/50
   hackport = dontCheck super.hackport;
   hadoop-formats = dontCheck super.hadoop-formats;
   hashed-storage = dontCheck super.hashed-storage;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -796,8 +796,8 @@ with haskellLib;
     else
       dontDistribute (markBroken super.fclabels);
 
-  # Bounds on base are too strict.
-  # https://github.com/phadej/regex-applicative-text/issues/13
+  # Bounds on base are too strict. Upstream is no longer maintained:
+  # https://github.com/phadej/regex-applicative-text/issues/13 krank:ignore-line
   regex-applicative-text = doJailbreak super.regex-applicative-text;
 
   # Tests require a Kafka broker running locally

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -714,8 +714,8 @@ with haskellLib;
         }) super.algebraic-graphs
       );
 
-  # Too strict bounds on hspec
-  # https://github.com/illia-shkroba/pfile/issues/2
+  # Too strict bounds on filepath, hpsec, tasty, tasty-quickcheck, transformers
+  # https://github.com/illia-shkroba/pfile/issues/3
   pfile = doJailbreak super.pfile;
 
   # Manually maintained

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -841,9 +841,6 @@ with haskellLib;
   # Upstream notified by e-mail.
   permutation = dontCheck super.permutation;
 
-  # https://github.com/jputcu/serialport/issues/25
-  serialport = dontCheck super.serialport;
-
   # Test suite depends on source code being available
   simple-affine-space = dontCheck super.simple-affine-space;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -893,7 +893,7 @@ with haskellLib;
   matterhorn = doJailbreak super.matterhorn;
 
   # Too strict bounds on transformers and resourcet
-  # https://github.com/alphaHeavy/lzma-conduit/issues/23
+  # https://github.com/alphaHeavy/lzma-conduit/issues/23 krank:ignore-line
   lzma-conduit = doJailbreak super.lzma-conduit;
 
   # 2020-06-05: HACK: does not pass own build suite - `dontCheck`

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -685,7 +685,8 @@ with haskellLib;
     postPatch = "sed -i s/home/tmp/ test/Spec.hs";
   }) super.shell-conduit;
 
-  # https://github.com/serokell/nixfmt/issues/130
+  # No maintenance planned until eventual removal
+  # https://github.com/NixOS/nixfmt/issues/340#issuecomment-3315920564
   nixfmt = doJailbreak super.nixfmt;
 
   # Too strict upper bounds on turtle and text

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -531,8 +531,8 @@ broken-packages:
   - bliplib # failure in job https://hydra.nixos.org/build/233195751 at 2023-09-02
   - blockchain # failure in job https://hydra.nixos.org/build/233245492 at 2023-09-02
   - blockhash # failure in job https://hydra.nixos.org/build/233227049 at 2023-09-02
-  - blockio-uring # failure in job https://hydra.nixos.org/build/302801498, https://github.com/well-typed/blockio-uring/issues/44 at 2025-07-27
-  - blockio-uring # https://github.com/well-typed/blockio-uring/issues/44, added 2025-07-27
+  - blockio-uring # failure in job https://hydra.nixos.org/build/302801498, https://github.com/well-typed/blockio-uring/issues/47 at 2025-07-27
+  - blockio-uring # https://github.com/well-typed/blockio-uring/issues/47, added 2025-07-27
   - Blogdown # failure in job https://hydra.nixos.org/build/233239841 at 2023-09-02
   - BlogLiterately # failure in job https://hydra.nixos.org/build/233202164 at 2023-09-02
   - bloodhound-amazonka-auth # failure building library in job https://hydra.nixos.org/build/237245625 at 2023-10-21

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -517,6 +517,8 @@ builtins.intersectAttrs super {
     addExtraLibraries [ pkgs.libGLU pkgs.libGL ] (super.hsqml.override { qt5 = pkgs.qt5Full; })
   );
   monomer = dontCheck super.monomer;
+  # GLFW init fails in sandbox https://github.com/bsl/GLFW-b/issues/50 krank:ignore-line
+  GLFW-b = dontCheck super.GLFW-b;
 
   # Wants to check against a real DB, Needs freetds
   odbc = dontCheck (addExtraLibraries [ pkgs.freetds ] super.odbc);

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -286,6 +286,10 @@ builtins.intersectAttrs super {
     }))
   ];
 
+  # Test suite requires access to an actual serial port
+  # https://github.com/jputcu/serialport/issues/25 krank:ignore-line
+  serialport = dontCheck super.serialport;
+
   # Provides a library and an executable (pretty-derivation)
   nix-derivation = enableSeparateBinOutput super.nix-derivation;
 

--- a/pkgs/development/haskell-modules/generic-stack-builder.nix
+++ b/pkgs/development/haskell-modules/generic-stack-builder.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (
     # Non-NixOS git needs cert
     GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
-    # Fixes https://github.com/commercialhaskell/stack/issues/2358
+    # Fixes https://github.com/commercialhaskell/stack/issues/2358 krank:ignore-line
     LANG = "en_US.UTF-8";
 
     preferLocalBuild = true;

--- a/pkgs/development/haskell-modules/lib/compose.nix
+++ b/pkgs/development/haskell-modules/lib/compose.nix
@@ -114,7 +114,8 @@ rec {
 
     Note that jailbreaking at this time, doesn't lift bounds on
     conditional branches.
-    https://github.com/peti/jailbreak-cabal/issues/7 has further details.
+    https://github.com/peti/jailbreak-cabal/issues/7 (krank:ignore-line)
+    has further details.
   */
   doJailbreak = overrideCabal (drv: {
     jailbreak = true;

--- a/pkgs/development/haskell-modules/lib/default.nix
+++ b/pkgs/development/haskell-modules/lib/default.nix
@@ -94,7 +94,8 @@ rec {
 
     Note that jailbreaking at this time, doesn't lift bounds on
     conditional branches.
-    https://github.com/peti/jailbreak-cabal/issues/7 has further details.
+    https://github.com/peti/jailbreak-cabal/issues/7 (krank:ignore-line)
+    has further details.
   */
   doJailbreak = compose.doJailbreak;
 

--- a/pkgs/development/haskell-modules/non-hackage-packages.nix
+++ b/pkgs/development/haskell-modules/non-hackage-packages.nix
@@ -41,7 +41,8 @@ self: super:
 
   ghc-settings-edit = self.callPackage ../tools/haskell/ghc-settings-edit { };
 
-  # https://github.com/channable/vaultenv/issues/1
+  # Upstream won't upload vaultenv to Hackage:
+  # https://github.com/channable/vaultenv/issues/1 krank:ignore-line
   vaultenv = self.callPackage ../tools/haskell/vaultenv { };
 
   # spago is not released to Hackage.

--- a/pkgs/development/haskell-modules/non-hackage-packages.nix
+++ b/pkgs/development/haskell-modules/non-hackage-packages.nix
@@ -45,8 +45,8 @@ self: super:
   # https://github.com/channable/vaultenv/issues/1 krank:ignore-line
   vaultenv = self.callPackage ../tools/haskell/vaultenv { };
 
-  # spago is not released to Hackage.
-  # https://github.com/spacchetti/spago/issues/512
+  # spago(-legacy) won't be released to Hackage:
+  # https://github.com/spacchetti/spago/issues/512 krank:ignore-line
   spago = self.callPackage ../tools/purescript/spago/spago.nix { };
 
   # Unofficial fork until PRs are merged https://github.com/pcapriotti/optparse-applicative/pulls/roberth

--- a/pkgs/test/haskell/upstreamStackHpackVersion/default.nix
+++ b/pkgs/test/haskell/upstreamStackHpackVersion/default.nix
@@ -5,7 +5,8 @@
 # matches with the version of hpack used by the upstream stack release.  This
 # is because hpack works slightly differently based on the version, and it can
 # be frustrating to use hpack in a team setting when members are using different
-# versions. See for more info: https://github.com/NixOS/nixpkgs/issues/223390
+# versions. See for more info:
+# https://github.com/NixOS/nixpkgs/issues/223390 krank:ignore-line
 #
 # This test is written as a fixed-output derivation, because we need to access
 # accesses the internet to download the upstream stack release.

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -87,7 +87,7 @@ in
       ghc948 = callPackage ../development/compilers/ghc/9.4.8.nix {
         bootPkgs =
           # Building with 9.2 is broken due to
-          # https://gitlab.haskell.org/ghc/ghc/-/issues/21914
+          # https://gitlab.haskell.org/ghc/ghc/-/issues/21914 krank:ignore-line
           bb.packages.ghc902Binary;
         inherit (buildPackages.python3Packages) sphinx;
         inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[krank](https://github.com/guibou/krank) can be used to generate reports of closed issues that are linked from source code. The idea is that such links indicate related workarounds which can be removed if the issue is closed upstream.

I went through the current report (c.f. [html reports derived from regular krank reports](https://krank.sterni.lv/mirror/nixpkgs/haskell-updates.html)) and:

- Cleaned up overrides for closed issues (in other PRs)
- Added links to current / more up to date issues in case the linked issue was closed but not actually resolved for us.
-  Added `krank:ignore-line` for issues where a closed issue doesn't indicate anything actionable (e.g. if the reference is purely informational or the workaround is for a no longer maintained version of GHC), so that it won't show up in future reports.