### PR TITLE
haskell.compiler.ghc9{4,63}: let krank ignore issue ref in patch

### DIFF
--- a/pkgs/development/compilers/ghc/docs-sphinx-7.patch
+++ b/pkgs/development/compilers/ghc/docs-sphinx-7.patch
@@ -1,6 +1,6 @@
 Fix build of docs after sphinx update.
 https://github.com/sphinx-doc/sphinx/pull/11381
-https://gitlab.haskell.org/ghc/ghc/-/issues/24129
+https://gitlab.haskell.org/ghc/ghc/-/issues/24129 krank:ignore-line
 --- a/docs/users_guide/rtd-theme/layout.html
 +++ b/docs/users_guide/rtd-theme/layout.html
 @@ -67 +67 @@


### PR DESCRIPTION
This is a historical issue that we no longer need workarounds for with recent GHC versions.

Rebuild heavy change split out from #445108.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
