### PR TITLE
haskellPackages.cryptonite: let krank ignore issue reference in patch

### DIFF
--- a/pkgs/development/haskell-modules/patches/cryptonite-remove-argon2.patch
+++ b/pkgs/development/haskell-modules/patches/cryptonite-remove-argon2.patch
@@ -23,7 +23,7 @@ index 044ba00..31dc6f1 100644
  
  hash :: (ByteArrayAccess password, ByteArrayAccess salt, ByteArray out)
 -     => Options
-+     => [Proxy "cryptonite:Crypto.KDF.Argon2.hash is known to be broken on this architecture. See https://github.com/haskell-crypto/cryptonite/issues/360"]
++     => [Proxy "cryptonite:Crypto.KDF.Argon2.hash is known to be broken on this architecture. See https://github.com/haskell-crypto/cryptonite/issues/360"] -- abandoned project, krank:ignore-line
       -> password
       -> salt
       -> Int
@@ -50,7 +50,7 @@ index 044ba00..31dc6f1 100644
 -  where
 -    saltLen = B.length salt
 -    passwordLen = B.length password
-+hash options password salt outLen = error "cryptonite:Crypto.KDF.Argon2.hash is known to be broken on this architecture. See https://github.com/haskell-crypto/cryptonite/issues/360"
++hash options password salt outLen = error "cryptonite:Crypto.KDF.Argon2.hash is known to be broken on this architecture. See https://github.com/haskell-crypto/cryptonite/issues/360" -- abandoned project, krank:ignore-line
  
  data Pass
  data Salt


### PR DESCRIPTION
The upstream issue reports closed state because the repository is abandoned.

Rebuild change split out from #445108.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
