### PR TITLE
cc-wrapper: make availability warnings into errors

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -216,6 +216,9 @@
   "sec-building-packages-with-llvm-using-clang-stdenv": [
     "index.html#sec-building-packages-with-llvm-using-clang-stdenv"
   ],
+  "sec-darwin-availability-checks": [
+    "index.html#sec-darwin-availability-checks"
+  ],
   "sec-darwin-libcxx-deployment-targets": [
     "index.html#sec-darwin-libcxx-deployment-targets"
   ],

--- a/doc/stdenv/platform-notes.chapter.md
+++ b/doc/stdenv/platform-notes.chapter.md
@@ -47,6 +47,17 @@ See below for how to use a newer deployment target.
 For example, `std::print` depends on features that are only available on macOS 13.3 or newer.
 To make them available, set the deployment target to 13.3 using `darwinMinVersionHook`.
 
+#### Package fails to build due to missing API availability checks {#sec-darwin-availability-checks}
+
+This is normally a bug in the package or a misconfigured deployment target.
+* If it is using an API from a newer release (e.g., from macOS 26.0 while targeting macOS 14.0), it needs to use an availability check.
+  The code should be patched to use [`__builtin_available`](https://clang.llvm.org/docs/LanguageExtensions.html#objective-c-available).
+  Note that while the linked documentation is for Objective-C, it is applicable to C and C++ except that you use `__builtin_available` in place of `@available`.
+* If the package intends to require the newer platform (i.e., it does not support running on older versions with reduced functionality), use `darwinMinVersionHook` to set the deployment target to the required version.
+  See below for how to use a newer deployment target.
+* If the package actually handles this through some other mechanism (e.g., MoltenVK relies on the running platform’s MSL version), the error can be suppressed.
+  To suppress the error, add `-Wno-error=unguarded-availability` to `env.NIX_CFLAGS_COMPILE`.
+
 #### Package requires a non-default SDK or fails to build due to missing frameworks or symbols {#sec-darwin-troubleshooting-using-sdks}
 
 In some cases, you may have to use a non-default SDK.

--- a/pkgs/build-support/cc-wrapper/add-clang-cc-cflags-before.sh
+++ b/pkgs/build-support/cc-wrapper/add-clang-cc-cflags-before.sh
@@ -35,3 +35,7 @@ elif [[ $0 != *cpp ]]; then
         extraBefore+=(-mabi=@explicitAbiValue@)
     fi
 fi
+
+if [[ "@darwinMinVersion@" ]]; then
+    extraBefore+=(-Werror=unguarded-availability)
+fi

--- a/pkgs/by-name/mo/moltenvk/package.nix
+++ b/pkgs/by-name/mo/moltenvk/package.nix
@@ -98,7 +98,11 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   env.NIX_CFLAGS_COMPILE = toString (
-    lib.optional (stdenv.cc.libcxx != null) "-isystem ${lib.getInclude stdenv.cc.libcxx}/include/c++/v1"
+    # MoltenVK does its own checks for availability by probing the version at runtime and checking the MSL version.
+    [ "-Wno-error=unguarded-availability" ]
+    ++ lib.optional (
+      stdenv.cc.libcxx != null
+    ) "-isystem ${lib.getInclude stdenv.cc.libcxx}/include/c++/v1"
     ++ [
       "-I${lib.getDev spirv-cross}/include/spirv_cross"
       "-I${lib.getDev spirv-headers}/include/spirv/unified1"

--- a/pkgs/by-name/mo/moltenvk/package.nix
+++ b/pkgs/by-name/mo/moltenvk/package.nix
@@ -51,6 +51,13 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   postPatch = ''
+    # Update the deployment target for the minimum target used by nixpkgs.
+    while IFS= read -d "" proj; do
+      echo "Updating deployment target to ${stdenv.hostPlatform.darwinMinVersion}: $proj"
+      substituteInPlace "$proj" \
+        --replace-fail 'MACOSX_DEPLOYMENT_TARGET = 10.15' "MACOSX_DEPLOYMENT_TARGET = $MACOSX_DEPLOYMENT_TARGET"
+    done < <(grep -Z -rl --include=project.pbxproj MACOSX_DEPLOYMENT_TARGET)
+
     # Move `mvkGitRevDerived.h` to a stable location
     substituteInPlace Scripts/gen_moltenvk_rev_hdr.sh \
       --replace-fail '$'''{BUILT_PRODUCTS_DIR}' "$NIX_BUILD_TOP/$sourceRoot/build/include" \


### PR DESCRIPTION
This is a prerequisite to updating the minimum version to 14.0. It makes failing to check for API availability into an error when the API is for a newer version than the deployment target.

### Notes

* This only affects Clang. Swift already makes this an error. GCC does not support availability checks. Other language ecosystems are unaffected.
* This is also a trial run for possibly using only the newest SDK on Darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
