### PR TITLE
cerberus: Fix runtime path look-up

### DIFF
--- a/pkgs/by-name/ce/cerberus/package.nix
+++ b/pkgs/by-name/ce/cerberus/package.nix
@@ -1,12 +1,16 @@
 {
   lib,
+  fetchpatch,
   fetchFromGitHub,
-  writableTmpDirAsHomeHook,
-  unstableGitUpdater,
   ocamlPackages,
   opam,
+  makeBinaryWrapper,
+  writableTmpDirAsHomeHook,
+  unstableGitUpdater,
+  testers,
+  cerberus,
 }:
-ocamlPackages.buildDunePackage {
+ocamlPackages.buildDunePackage rec {
   pname = "cerberus";
   version = "0-unstable-2025-08-18";
 
@@ -17,15 +21,33 @@ ocamlPackages.buildDunePackage {
     hash = "sha256-++fCZvk4ee166eciipTQ8GId6DWrG6aonAzHpK/10f0=";
   };
 
+  patches = [
+    # https://github.com/rems-project/cerberus/pull/980
+    (fetchpatch {
+      name = "fix-runtime-lookup";
+      url = "https://github.com/rems-project/cerberus/commit/262c13331d4809dd3742069dbcd1deedee8227f2.patch";
+      hash = "sha256-yPhzswMDkpjvjYyobnqoF3900l4THe0kaGme1eZXLQc=";
+    })
+  ];
+
+  # Cerberus has not had a true release yet, and it parses out a git rev
+  # for version info. We just patch the "didn't find git revs" to
+  # our version since git is impure
+  postPatch = ''
+    substituteInPlace tools/gen_version.ml \
+      --replace-fail '"unknown"' '"${version}"'
+  '';
+
   minimalOCamlVersion = "4.12";
 
-  strictDeps = true;
+  depsBuildBuild = [
+    ocamlPackages.menhir
+    ocamlPackages.lem
+  ];
 
   nativeBuildInputs = [
-    opam
     writableTmpDirAsHomeHook
-    ocamlPackages.lem
-    ocamlPackages.menhir
+    makeBinaryWrapper
   ];
 
   buildInputs = with ocamlPackages; [
@@ -42,13 +64,31 @@ ocamlPackages.buildDunePackage {
     janeStreet.ppx_sexp_conv
   ];
 
+  # Need to set this or it complains. I don't
+  # think the actual value matters much
   env.OPAM_SWITCH_PREFIX = placeholder "out";
+
+  # Use the make file as it does some codegen
   buildPhase = ''
     runHook preBuild
 
-    make Q= cerberus
+    make DUNEFLAGS="--profile=release" Q= -j$NIX_BUILD_CORES cerberus
 
     runHook postBuild
+  '';
+
+  # Must install both the stdlib
+  # and the executable itself
+  installPhase = ''
+    runHook preInstall
+
+    dune install --prefix $out --libdir $OCAMLFIND_DESTDIR cerberus-lib --docdir $out/share/doc --mandir $out/share/man
+    dune install --prefix $out --libdir $OCAMLFIND_DESTDIR cerberus --docdir $out/share/doc --mandir $out/share/man
+
+    wrapProgram "$out/bin/cerberus" \
+      --set CERB_INSTALL_PREFIX "$out/lib/ocaml/${ocamlPackages.ocaml.version}/site-lib/"
+
+    runHook postInstall
   '';
 
   doInstallCheck = true;
@@ -64,7 +104,14 @@ ocamlPackages.buildDunePackage {
     runHook postInstallCheck
   '';
 
-  passthru.updateScript = unstableGitUpdater { branch = "master"; };
+  passthru = {
+    updateScript = unstableGitUpdater { branch = "master"; };
+
+    # Ensure it still runs after outside the container
+    tests.version = testers.testVersion {
+      package = cerberus;
+    };
+  };
 
   meta = {
     homepage = "https://www.cl.cam.ac.uk/~pes20/cerberus/";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Cerberus has passed its integration tests with flying colors. But once out of the build sandbox it stopped running. I have tracked down the issue.

1. Submitted upstream patch rems-project/cerberus#980 for finding the correct paths after `dune install`ing
2. Also patch the source to give a version number that isn't "unknown"
3. Move codegen binaries to `depsBuildBuild`
4. Add parallelization to buildPhase
5. Build with release profile
6. install the cerberus runtime library too
7. Add wrapper that sets the prefix environment variable
8. Add passthru test to ensure it runs outside the buildsandbox

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
