### PR TITLE
asr-debugger: init at 0.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -485,6 +485,13 @@
     githubId = 2321000;
     name = "Ruslan Babayev";
   };
+  abus-sh = {
+    email = "git@abus.sh";
+    github = "abus-sh";
+    githubId = 58699376;
+    name = "Abus";
+    keys = [ { fingerprint = "E067 7933 2AD2 D3D2 2498  9136 5CA4 ADDB 1AE3 1E49"; } ];
+  };
   abustany = {
     email = "adrien@bustany.org";
     github = "abustany";

--- a/pkgs/by-name/as/asr-debugger/package.nix
+++ b/pkgs/by-name/as/asr-debugger/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  libGL,
+  libxkbcommon,
+  u-config,
+  wayland,
+  wayland-protocols,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "asr-debugger";
+  version = "v0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "LiveSplit";
+    repo = "asr-debugger";
+    tag = finalAttrs.version;
+    hash = "sha256-8rZX2zFfafkdx+eIYGb8GwBhjTBO/FpWf9elXp9Ad0Y=";
+  };
+
+  cargoHash = "sha256-ju+IAn2s1u/UwYwECBD7gHCDX3PidcjMiwvXp4SFZnc=";
+
+  nativeBuildInputs = [
+    u-config
+    wayland-protocols
+    wayland
+  ];
+
+  addDlopenRunpaths = map (p: "${lib.getLib p}/lib") (
+    lib.optionals stdenv.hostPlatform.isLinux [
+      libxkbcommon
+      wayland
+      libGL
+    ]
+  );
+
+  addDlopenRunpathsPhase = ''
+    elfHasDynamicSection() {
+        patchelf --print-rpath "$1" >& /dev/null
+    }
+
+    while IFS= read -r -d $'\0' path ; do
+      elfHasDynamicSection "$path" || continue
+      for dep in $addDlopenRunpaths ; do
+        patchelf "$path" --add-rpath "$dep"
+      done
+    done < <(
+      for o in $(getAllOutputNames) ; do
+        find "''${!o}" -type f -and "(" -executable -or -iname '*.so' ")" -print0
+      done
+    )
+  '';
+
+  postPhases = lib.optionals stdenv.hostPlatform.isLinux [ "addDlopenRunpathsPhase" ];
+
+  doInstallCheck = true;
+
+  meta = {
+    description = "A debugger for LiveSplit One's new Auto Splitting Runtime.";
+    homepage = "https://github.com/LiveSplit/asr-debugger";
+    changelog = "https://github.com/LiveSplit/asr-debugger/releases/tag/${finalAttrs.version}";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [
+      abus-sh
+    ];
+    mainProgram = "asr-debugger";
+  };
+})

--- a/pkgs/by-name/as/asr-debugger/package.nix
+++ b/pkgs/by-name/as/asr-debugger/package.nix
@@ -12,12 +12,12 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "asr-debugger";
-  version = "v0.1.1";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "LiveSplit";
     repo = "asr-debugger";
-    tag = finalAttrs.version;
+    tag = "v${finalAttrs.version}";
     hash = "sha256-8rZX2zFfafkdx+eIYGb8GwBhjTBO/FpWf9elXp9Ad0Y=";
   };
 
@@ -53,9 +53,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doInstallCheck = true;
 
   meta = {
-    description = "A debugger for LiveSplit One's new Auto Splitting Runtime.";
+    description = "Debugger for LiveSplit One's Auto Splitting Runtime.";
     homepage = "https://github.com/LiveSplit/asr-debugger";
-    changelog = "https://github.com/LiveSplit/asr-debugger/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/LiveSplit/asr-debugger/releases/tag/v${finalAttrs.version}";
     license = with lib.licenses; [
       asl20
       mit

--- a/pkgs/by-name/as/asr-debugger/package.nix
+++ b/pkgs/by-name/as/asr-debugger/package.nix
@@ -23,12 +23,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-ju+IAn2s1u/UwYwECBD7gHCDX3PidcjMiwvXp4SFZnc=";
 
-  nativeBuildInputs = [
-    u-config
-    wayland-protocols
-    wayland
-  ];
-
   addDlopenRunpaths = map (p: "${lib.getLib p}/lib") (
     lib.optionals stdenv.hostPlatform.isLinux [
       libxkbcommon


### PR DESCRIPTION
[asr-debugger](https://github.com/LiveSplit/asr-debugger) is a debugger for the [auto splitting runtime](https://github.com/LiveSplit/livesplit-core/tree/master/crates/livesplit-auto-splitting) created by LiveSplit. This debugger can also be used to profile the performance of autosplitters written for [LiveSplit One](https://github.com/LiveSplit/LiveSplitOne), a cross-platform version of LiveSplit. Autosplitters are used in speedruns to automatically detect in-game events and change the state of the timer accordingly.

## Testing the package

To test this package, you will need a game and an autosplitter WASM file or script for that game. I personally used [this autosplitter](https://github.com/AlexKnauth/silksong-autosplit-wasm/releases/latest) for Hollow Knight: Silksong and [this one](https://github.com/AlexKnauth/hollowknight-autosplit-wasm/releases/latest) for Hollow Knight, though almost any game will have a WASM file or script created by the speedrun community.

After installing the game and downloading the autosplitter file, open asr-debugger. Under the "Main" panel on the left, select the correct "Open" button depending on your file type (WASM vs script) and open the autosplitter file. If this works, a log should appear in the center "Logs" window that says "Auto splitter loaded."

Launch the relevant game. Another log should appear that says "Attached to a new process: [PROCESS NAME]". Additional logs should appear as you interact with the game. For example, Silksong will log the current scene, the player's health, etc.

The "Settings GUI" panel on the right will allow you to create new autosplits to split at. New splits can be created by selecting any "Action" dropdown and choosing "Insert after" or "Insert before". The condition for the split can be changed by selecting the other dropdown. When the first condition is met in the game, the log message "Timer started." should appear. When another condition is met, the log message "Splitted." should appear.

I have manually tested that this works with [the autosplitter for Hollow Knight: Silksong](https://github.com/AlexKnauth/silksong-autosplit-wasm/releases/tag/0.1.9) for all of Any% on my computer running NixOS 25.05 (x86_64). The logged events and the splitting seemed accurate. There aren't currently any automated tests outside of basic unit tests in `file_filters.rs`, though I would be interested in adding additional tests if someone knows a reasonable way to approach testing a GUI app that requires attaching to other processes.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
