### PR TITLE
dpkg: fix build on case-insensitive filesystems; add install check

### DIFF
--- a/pkgs/by-name/dp/dpkg/package.nix
+++ b/pkgs/by-name/dp/dpkg/package.nix
@@ -14,17 +14,30 @@
   autoreconfHook,
   pkg-config,
   diffutils,
+  versionCheckHook,
   glibc ? !stdenv.hostPlatform.isDarwin,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "dpkg";
   version = "1.22.21";
 
   src = fetchgit {
     url = "https://git.launchpad.net/ubuntu/+source/dpkg";
-    rev = "applied/${version}";
-    hash = "sha256-UiXZfwvgsgyXR6olNzKelt/3Fgtp7KU8UbTRRkDl8wY=";
+    tag = "applied/${finalAttrs.version}";
+    leaveDotGit = true;
+    # Fix filename conflict on case-insensitive filesystems
+    postFetch = ''
+      pushd $out
+      git checkout HEAD -- scripts/t/Dpkg_BuildTree.t
+      mv scripts/t/Dpkg_BuildTree.t scripts/t/Dpkg_BuildTreeC.t
+      substituteInPlace scripts/Makefile.am --replace-fail t/Dpkg_BuildTree.t t/Dpkg_BuildTreeC.t
+      substituteInPlace scripts/Makefile.in --replace-fail t/Dpkg_BuildTree.t t/Dpkg_BuildTreeC.t
+      git checkout HEAD -- scripts/t/dpkg_buildtree.t
+      rm -rf .git
+      popd
+    '';
+    hash = "sha256-LK6nOPewjRyKyHdwJgmLILoZ6sEfJzRtC7pIeWz01lA=";
   };
 
   configureFlags = [
@@ -48,7 +61,7 @@ stdenv.mkDerivation rec {
     PATH=$TMPDIR:$PATH
 
     for i in $(find . -name Makefile.in); do
-      substituteInPlace $i --replace "install-data-local:" "disabled:" ;
+      substituteInPlace $i --replace-quiet "install-data-local:" "disabled:" ;
     done
 
     # Skip check broken when cross-compiling.
@@ -61,21 +74,26 @@ stdenv.mkDerivation rec {
 
     # Dpkg commands sometimes calls out to shell commands
     substituteInPlace lib/dpkg/dpkg.h \
-       --replace '"dpkg-deb"' \"$out/bin/dpkg-deb\" \
-       --replace '"dpkg-split"' \"$out/bin/dpkg-split\" \
-       --replace '"dpkg-query"' \"$out/bin/dpkg-query\" \
-       --replace '"dpkg-divert"' \"$out/bin/dpkg-divert\" \
-       --replace '"dpkg-statoverride"' \"$out/bin/dpkg-statoverride\" \
-       --replace '"dpkg-trigger"' \"$out/bin/dpkg-trigger\" \
-       --replace '"dpkg"' \"$out/bin/dpkg\" \
-       --replace '"debsig-verify"' \"$out/bin/debsig-verify\" \
-       --replace '"rm"' \"${coreutils}/bin/rm\" \
-       --replace '"cat"' \"${coreutils}/bin/cat\" \
-       --replace '"diff"' \"${diffutils}/bin/diff\"
+       --replace-fail '"dpkg-deb"' \"$out/bin/dpkg-deb\" \
+       --replace-fail '"dpkg-split"' \"$out/bin/dpkg-split\" \
+       --replace-fail '"dpkg-query"' \"$out/bin/dpkg-query\" \
+       --replace-fail '"dpkg-divert"' \"$out/bin/dpkg-divert\" \
+       --replace-fail '"dpkg-statoverride"' \"$out/bin/dpkg-statoverride\" \
+       --replace-fail '"dpkg-trigger"' \"$out/bin/dpkg-trigger\" \
+       --replace-fail '"dpkg"' \"$out/bin/dpkg\" \
+       --replace-fail '"debsig-verify"' \"$out/bin/debsig-verify\" \
+       --replace-fail '"rm"' \"${coreutils}/bin/rm\" \
+       --replace-fail '"cat"' \"${coreutils}/bin/cat\" \
+       --replace-fail '"diff"' \"${diffutils}/bin/diff\"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # realpath("/var/lib/dpkg", NULL) gives EPERM on sandboxed darwin instead of the expected ENOENT,
+    # which makes some tests fail.
+    sed -i '/opts normalize/a AT_SKIP_IF([true])' src/at/chdir.at
   ''
   + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     substituteInPlace src/main/help.c \
-       --replace '"ldconfig"' \"${glibc.bin}/bin/ldconfig\"
+       --replace-fail '"ldconfig"' \"${glibc.bin}/bin/ldconfig\"
   '';
 
   buildInputs = [
@@ -96,7 +114,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     for i in $out/bin/*; do
       if head -n 1 $i | grep -q perl; then
-        substituteInPlace $i --replace \
+        substituteInPlace $i --replace-fail \
           "${perl}/bin/perl" "${perl}/bin/perl -I $out/${perl.libPrefix}"
       fi
     done
@@ -105,6 +123,10 @@ stdenv.mkDerivation rec {
     cp -r scripts/t/origins $out/etc/dpkg
   '';
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
   setupHook = ./setup-hook.sh;
 
   meta = with lib; {
@@ -112,7 +134,7 @@ stdenv.mkDerivation rec {
     homepage = "https://wiki.debian.org/Teams/Dpkg";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
-    broken = stdenv.hostPlatform.isDarwin;
     maintainers = with maintainers; [ siriobalmelli ];
+    mainProgram = "dpkg";
   };
-}
+})


### PR DESCRIPTION
Context: https://github.com/NixOS/nixpkgs/pull/370245#discussion_r2126471012

~~Not sure whether this will break the update script though. Only the non-darwin version should be updated regularly.~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
