### PR TITLE
sdrplay: add darwin support

### DIFF
--- a/pkgs/by-name/sd/sdrplay/darwin.nix
+++ b/pkgs/by-name/sd/sdrplay/darwin.nix
@@ -1,0 +1,56 @@
+{
+  pname,
+  version,
+  src,
+  meta,
+  lib,
+  stdenv,
+  xar,
+  cpio,
+  libusb1,
+  fixDarwinDylibNames,
+}:
+stdenv.mkDerivation {
+  inherit
+    pname
+    version
+    src
+    meta
+    ;
+
+  nativeBuildInputs = [
+    xar
+    cpio
+    fixDarwinDylibNames
+  ];
+
+  unpackPhase = ''
+    xar -xf $src
+    zcat SDRplayAPI.pkg/Payload | cpio -i
+  '';
+
+  dontBuild = true;
+
+  env = {
+    majorVersion = lib.versions.major version;
+    majorMinorVersion = lib.versions.majorMinor version;
+  };
+
+  installPhase = ''
+    root="$PWD/Library/SDRplayAPI/${version}"
+
+    mkdir -p $out/{bin,lib}
+
+    cp "$root/bin/sdrplay_apiService" "$out/bin"
+    cp -r "$root/include" "$out/include"
+
+    lib="$out/lib/libsdrplay_api.$majorMinorVersion.dylib"
+    cp "$root/lib/libsdrplay_api.so.$majorMinorVersion" "$lib"
+    ln -s "$lib" "$out/lib/libsdrplay_api.$majorVersion.dylib"
+    ln -s "$lib" "$out/lib/libsdrplay_api.dylib"
+  '';
+
+  postFixup = ''
+    install_name_tool -add_rpath "${lib.getLib libusb1}/lib" $out/bin/sdrplay_apiService
+  '';
+}

--- a/pkgs/by-name/sd/sdrplay/linux.nix
+++ b/pkgs/by-name/sd/sdrplay/linux.nix
@@ -1,0 +1,54 @@
+{
+  pname,
+  version,
+  src,
+  meta,
+  stdenv,
+  lib,
+  fetchurl,
+  autoPatchelfHook,
+  udev,
+  libusb1,
+}:
+let
+  arch = stdenv.hostPlatform.qemuArch;
+in
+stdenv.mkDerivation rec {
+  inherit
+    pname
+    version
+    src
+    meta
+    ;
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [
+    libusb1
+    udev
+    (lib.getLib stdenv.cc.cc)
+  ];
+
+  unpackPhase = ''
+    sh "$src" --noexec --target source
+  '';
+
+  sourceRoot = "source";
+
+  dontBuild = true;
+
+  env = {
+    majorVersion = lib.versions.major version;
+    majorMinorVersion = lib.versions.majorMinor version;
+  };
+
+  installPhase = ''
+    mkdir -p $out/{bin,lib,include}
+    libName="libsdrplay_api"
+    cp "${arch}/$libName.so.$majorMinorVersion" $out/lib/
+    ln -s "$out/lib/$libName.so.$majorMinorVersion" "$out/lib/$libName.so.$majorVersion"
+    ln -s "$out/lib/$libName.so.$majorVersion" "$out/lib/$libName.so"
+    cp "${arch}/sdrplay_apiService" $out/bin/
+    cp -r inc/* $out/include/
+  '';
+}

--- a/pkgs/by-name/sd/sdrplay/package.nix
+++ b/pkgs/by-name/sd/sdrplay/package.nix
@@ -1,79 +1,59 @@
 {
+  callPackage,
+  fetchurl,
   stdenv,
   lib,
-  fetchurl,
-  autoPatchelfHook,
-  udev,
-  libusb1,
 }:
+
 let
-  arch =
-    if stdenv.hostPlatform.isx86_64 then
-      "x86_64"
-    else if stdenv.hostPlatform.isi686 then
-      "i686"
-    else if stdenv.hostPlatform.isAarch64 then
-      "aarch64"
-    else
-      throw "unsupported architecture";
+  version = "3.15.1";
 
-  version = "3.07.1";
-
-  srcs = rec {
-    aarch64 = {
-      url = "https://www.sdrplay.com/software/SDRplay_RSP_API-ARM64-${version}.run";
-      hash = "sha256-GJPFW6W8Ke4mnczcSLFYfioOMGCfFn2/EIA07VnmVGY=";
-    };
-
-    x86_64 = {
+  sources = rec {
+    x86_64-linux = {
       url = "https://www.sdrplay.com/software/SDRplay_RSP_API-Linux-${version}.run";
-      sha256 = "1a25c7rsdkcjxr7ffvx2lwj7fxdbslg9qhr8ghaq1r53rcrqgzmf";
+      hash = "sha256-CTcyv10Xz9G2LqHh4qOW9tKBEcB+rztE2R7xJIU4QBQ=";
     };
 
-    i686 = x86_64;
+    x86_64-darwin = {
+      url = "https://www.sdrplay.com/software/SDRplayAPI-macos-installer-universal-3.15.1.pkg";
+      hash = "sha256-XRSM7aH653XS0t9bP89G3uJ7YiLiU1xMBjwvLqL3rMM=";
+    };
+
+    aarch64-linux = x86_64-linux;
+    aarch64-darwin = x86_64-darwin;
   };
+
+  platforms = lib.attrNames sources;
+
+  package = if stdenv.hostPlatform.isLinux then ./linux.nix else ./darwin.nix;
+
 in
-stdenv.mkDerivation rec {
+
+callPackage package {
   pname = "sdrplay";
   inherit version;
 
-  src = fetchurl srcs."${arch}";
+  src =
+    let
+      inherit (stdenv.hostPlatform) system;
+      source =
+        if lib.hasAttr system sources then
+          sources."${system}"
+        else
+          throw "SDRplay is not supported on ${system}";
 
-  nativeBuildInputs = [ autoPatchelfHook ];
-
-  buildInputs = [
-    libusb1
-    udev
-    (lib.getLib stdenv.cc.cc)
-  ];
-
-  unpackPhase = ''
-    sh "$src" --noexec --target source
-  '';
-
-  sourceRoot = "source";
-
-  dontBuild = true;
-
-  installPhase = ''
-    mkdir -p $out/{bin,lib,include,lib/udev/rules.d}
-    majorVersion="${lib.concatStringsSep "." (lib.take 1 (builtins.splitVersion version))}"
-    majorMinorVersion="${lib.concatStringsSep "." (lib.take 2 (builtins.splitVersion version))}"
-    libName="libsdrplay_api"
-    cp "${arch}/$libName.so.$majorMinorVersion" $out/lib/
-    ln -s "$out/lib/$libName.so.$majorMinorVersion" "$out/lib/$libName.so.$majorVersion"
-    ln -s "$out/lib/$libName.so.$majorVersion" "$out/lib/$libName.so"
-    cp "${arch}/sdrplay_apiService" $out/bin/
-    cp -r inc/* $out/include/
-    cp 66-mirics.rules $out/lib/udev/rules.d/
-  '';
+    in
+    fetchurl source;
 
   meta = with lib; {
+    inherit platforms;
+
     description = "SDRplay API";
     longDescription = ''
       Proprietary library and api service for working with SDRplay devices. For documentation and licensing details see
       https://www.sdrplay.com/docs/SDRplay_API_Specification_v${lib.concatStringsSep "." (lib.take 2 (builtins.splitVersion version))}.pdf
     '';
+
     homepage = "https://www.sdrplay.com/downloads/";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
@@ -81,7 +61,7 @@ stdenv.mkDerivation rec {
       pmenke
       zaninime
     ];
-    platforms = platforms.linux;
+
     mainProgram = "sdrplay_apiService";
   };
 }


### PR DESCRIPTION
- Support darwin
- Update version to 3.15.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
