### PR TITLE
python3Packages.arelle.tests.cli: Unhardcode version

### DIFF
--- a/pkgs/development/python-modules/arelle/test-cli.nix
+++ b/pkgs/development/python-modules/arelle/test-cli.nix
@@ -18,7 +18,7 @@ runCommand "arelle-test-cli${lib.optionalString (!arelle.hasGUI) "-headless"}"
     export HOME=$(mktemp -d)
 
     # Test basic CLI commands work with proper assertions
-    arelleCmdLine --version --disablePersistentConfig 2>&1 | grep "Arelle(r) 2.37.59" > /dev/null
+    arelleCmdLine --version --disablePersistentConfig 2>&1 | grep "Arelle(r) ${arelle.version}" > /dev/null
     arelleCmdLine --help --disablePersistentConfig 2>&1 | grep "Usage: arelleCmdLine \[options\]" > /dev/null
     arelleCmdLine --about --disablePersistentConfig 2>&1 | grep "An open source XBRL platform" > /dev/null
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Just fixing a small mistake in a test that slipped through

- Addresses https://github.com/NixOS/nixpkgs/pull/444607#discussion_r2366358499

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
