### PR TITLE
beetsPackages.alternatives: 0.13.3 -> 0.13.4

### DIFF
--- a/pkgs/tools/audio/beets/common.nix
+++ b/pkgs/tools/audio/beets/common.nix
@@ -152,6 +152,7 @@ python3Packages.buildPythonApplication {
       rarfile
       responses
       requests-mock
+      pillow
     ]
     ++ [
       writableTmpDirAsHomeHook

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -42,23 +42,14 @@ lib.makeExtensible (
 
     beets-minimal = self.beets.override { disableAllPlugins = true; };
 
-    beets-unstable = callPackage ./common.nix {
-      inherit python3Packages;
-      version = "2.3.1";
-      src = fetchFromGitHub {
-        owner = "beetbox";
-        repo = "beets";
-        rev = "d487d675b9115672c484eab8a6729b1f0fd24b68";
-        hash = "sha256-INxL2XDn8kwRYYcZATv/NdLmAtfQvxVDWKB1OYo8dxY=";
-      };
-    };
-
     alternatives = callPackage ./plugins/alternatives.nix { beets = self.beets-minimal; };
     audible = callPackage ./plugins/audible.nix { beets = self.beets-minimal; };
     copyartifacts = callPackage ./plugins/copyartifacts.nix { beets = self.beets-minimal; };
     filetote = callPackage ./plugins/filetote.nix { beets = self.beets-minimal; };
   }
   // lib.optionalAttrs config.allowAliases {
+    beets-unstable = lib.warn "beets-unstable was aliased to beets, since upstream releases are frequent nowadays" self.beets;
+
     extrafiles = throw "extrafiles is unmaintained since 2020 and broken since beets 2.0.0";
   }
 )

--- a/pkgs/tools/audio/beets/plugins/alternatives.nix
+++ b/pkgs/tools/audio/beets/plugins/alternatives.nix
@@ -8,14 +8,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "beets-alternatives";
-  version = "0.13.3";
+  version = "0.13.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     repo = "beets-alternatives";
     owner = "geigerzaehler";
     tag = "v${version}";
-    hash = "sha256-j56AzbpZFACXy5KqafE8PCC+zM6pXrxr/rWy9UjZPQg=";
+    hash = "sha256-jGHRoBBXqJq0r/Gbp7gkuaEFPVMGE6cqQRi84AHTXxQ=";
   };
 
   nativeBuildInputs = [
@@ -33,6 +33,7 @@ python3Packages.buildPythonApplication rec {
       pytest-cov-stub
       mock
       pillow
+      tomli
       typeguard
     ]
     ++ [

--- a/pkgs/tools/audio/beets/plugins/copyartifacts.nix
+++ b/pkgs/tools/audio/beets/plugins/copyartifacts.nix
@@ -56,5 +56,7 @@ python3Packages.buildPythonApplication rec {
     changelog = "https://github.com/adammillerio/beets-copyartifacts/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     inherit (beets.meta) platforms;
+    # Isn't compatible with beets >= 2.3
+    broken = true;
   };
 }

--- a/pkgs/tools/audio/beets/plugins/filetote.nix
+++ b/pkgs/tools/audio/beets/plugins/filetote.nix
@@ -9,14 +9,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "beets-filetote";
-  version = "1.0.2";
+  version = "1.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "gtronset";
     repo = "beets-filetote";
     tag = "v${version}";
-    hash = "sha256-4goblrcSbjl8+xf1wwyoC2462kSy6biLUhTAVIJ8Pjc=";
+    hash = "sha256-5o0Hif0dNavYRH1pa1ZPTnOvk9VPXCU/Lqpg2rKzU/I=";
   };
 
   postPatch = ''

--- a/pkgs/tools/audio/beets/plugins/filetote.nix
+++ b/pkgs/tools/audio/beets/plugins/filetote.nix
@@ -84,5 +84,7 @@ python3Packages.buildPythonApplication rec {
     maintainers = with maintainers; [ dansbandit ];
     license = licenses.mit;
     inherit (beets.meta) platforms;
+    # https://github.com/gtronset/beets-filetote/issues/211
+    broken = true;
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -512,6 +512,7 @@ mapAliases {
   BeatSaberModManager = beatsabermodmanager; # Added 2024-06-12
   beam_nox = throw "beam_nox has been removed in favor of beam_minimal or beamMinimalPackages"; # Added 2025-04-01
   beatsabermodmanager = throw "'beatsabermodmanager' has been removed due to lack of upstream maintainenance. Consider using 'bs-manager' instead"; # Added 2025-03-18
+  inherit (beetsPackages) beets-unstable;
   betterbird = throw "betterbird has been removed as there were insufficient maintainer resources to keep up with security updates"; # Added 2024-10-25
   betterbird-unwrapped = throw "betterbird has been removed as there were insufficient maintainer resources to keep up with security updates"; # Added 2024-10-25
   bfc = throw "bfc has been removed, as it does not build with supported LLVM versions"; # Added 2025-08-10

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2392,7 +2392,7 @@ with pkgs;
   };
 
   beetsPackages = lib.recurseIntoAttrs (callPackage ../tools/audio/beets { });
-  inherit (beetsPackages) beets beets-unstable;
+  inherit (beetsPackages) beets;
 
   binlore = callPackage ../development/tools/analysis/binlore { };
 


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
