### PR TITLE
nixos/config/lix: init

### DIFF
--- a/nixos/modules/config/lix.nix
+++ b/nixos/modules/config/lix.nix
@@ -1,0 +1,74 @@
+/*
+  This is the Lix variant of the `nix.` option tree.
+
+  This module is in charge of rewiring various programs to
+  reuse Lix directly.
+*/
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) mkEnableOption mkOption mkIf types literalExpression;
+  cfg = config.lix;
+in
+{
+  options.lix = {
+    enable = mkEnableOption "a Lix-based NixOS system";
+
+    packages = mkOption {
+      type = types.raw;
+      default = pkgs.lixPackageSets.stable;
+      defaultText = literalExpression "pkgs.lixPackageSets.stable";
+      example = literalExpression "pkgs.lixPackageSets.latest";
+      description = ''
+        This option specifies the set of Lix packages instance to use throughout the system.
+
+        It must contain the `lix` attribute at least.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    nix.package = cfg.packages.lix;
+
+    nixpkgs.overlays = [
+      (self: scope: {
+        nixpkgs-review = scope.nixpkgs-review.override {
+          nix = cfg.packages.lix;
+        };
+
+        nix-direnv = scope.nix-direnv.override {
+          nix = cfg.packages.lix;
+        };
+
+        nix-fast-build = scope.nix-fast-build.override {
+          inherit (self) nix-eval-jobs;
+        };
+
+        inherit (cfg.packages) nix-eval-jobs;
+
+        nix-serve-ng = lib.pipe (scope.nix-serve-ng.override { nix = cfg.packages.lix; }) [
+          (scope.haskell.lib.compose.enableCabalFlag "lix")
+          (scope.haskell.lib.compose.overrideCabal (drv: {
+            # https://github.com/aristanetworks/nix-serve-ng/issues/46
+            # Resetting (previous) broken flag since it may be related to C++ Nix
+            broken = lib.versionAtLeast self.lix.version "2.93";
+          }))
+        ];
+
+        colmena = scope.colmena.override {
+          nix = cfg.packages.lix;
+          inherit (self) nix-eval-jobs;
+        };
+
+        nix-update = scope.nix-update.override {
+          nix = cfg.packages.lix;
+          inherit (self) nixpkgs-review;
+        };
+      })
+    ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -14,6 +14,7 @@
   ./config/iproute2.nix
   ./config/ldap.nix
   ./config/ldso.nix
+  ./config/lix.nix
   ./config/locale.nix
   ./config/malloc.nix
   ./config/mysql.nix

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -562,5 +562,21 @@ rec {
         services.postgresql.package = pkgs.postgresql;
       }
     );
+
+    lix = makeClosure (
+      { pkgs, ... }:
+      {
+        lix.enable = true;
+        environment.systemPackages = [
+          pkgs.nixpkgs-review
+          pkgs.nix-direnv
+          pkgs.nix-eval-jobs
+          pkgs.nix-fast-build
+          pkgs.colmena
+          pkgs.nix-update
+          pkgs.nix-serve-ng
+        ];
+      }
+    );
   };
 }


### PR DESCRIPTION
In a quest to simplify even further and reduce the amount of confusion that end users may have when using Lix, we instantiate a new Lix module.

This Lix module is in charge of overlaying various programs commonly used by Lix users who depend (unfortunately) on a fixed Nix program reference.

I tried multiple approaches to reuse the "overlay" function in the package set, as I expected, I cannot see a way to make this work out:

- as soon as `pkgs` is involved to construct any overlay function or any overlaid package, `pkgs` will shift.

Therefore, `pkgs` cannot be used _inside_ `nixpkgs.overlays` values.

But, how can we pass then `cfg.packages` ? A possibly valid path is to reify `cfg.packages` into a thunk, but I do not want to expose this to the userspace, it's needlessly confusing and complicated.

Instead, let's just have a common file that defines the overlay and call it from the package set *AND* the module.

Change-Id: Iac8e082f76b45149fd466bb93d4ab0a2c2986961
Signed-off-by: Raito Bezarius <masterancpp@gmail.com>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
