### PR TITLE
nixos/scx-loader: init scx-loader at 1.0.16

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -130,6 +130,8 @@
 
 - [Sshwifty](https://github.com/nirui/sshwifty), a Telnet and SSH client for your browser. Available as [services.sshwifty](#opt-services.sshwifty.enable).
 
+- [services.scx_loader](https://github.com/sched-ext/scx/tree/main/tools/scx_loader), an alternative service for loading and configuring scx schedulers on boot.
+
 ## Backward Incompatibilities {#sec-release-25.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1428,6 +1428,7 @@
   ./services/scheduling/cron.nix
   ./services/scheduling/fcron.nix
   ./services/scheduling/prefect.nix
+  ./services/scheduling/scx-loader.nix
   ./services/scheduling/scx.nix
   ./services/search/elasticsearch-curator.nix
   ./services/search/elasticsearch.nix

--- a/nixos/modules/services/scheduling/scx-loader.nix
+++ b/nixos/modules/services/scheduling/scx-loader.nix
@@ -1,0 +1,180 @@
+{
+  lib,
+  pkgs,
+  config,
+  utils,
+  ...
+}:
+let
+  cfg = config.services.scx_loader;
+in
+{
+  options.services.scx_loader = {
+    enable = lib.mkEnableOption "Enable scx_loader";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.scx.full;
+      defaultText = lib.literalExpression "pkgs.scx.full";
+      example = lib.literalExpression "pkgs.scx.rustscheds";
+      description = ''
+        `scx` package to use. `scx.full`, which includes all schedulers, is the default.
+        You may choose a minimal package, such as `pkgs.scx.rustscheds`.
+
+        ::: {.note}
+        Overriding this does not change the default scheduler; you should set `services.scx_loader.default_sched` for it.
+        :::
+      '';
+    };
+
+    default_sched = lib.mkOption {
+      type = lib.types.enum [
+        "scx_bpfland"
+        "scx_cosmos"
+        "scx_flash"
+        "scx_lavd"
+        "scx_p2dq"
+        "scx_tickless"
+        "scx_rustland"
+        "scx_rusty"
+      ];
+      default = "scx_flash";
+      example = "scx_lavd";
+      description = ''
+        Which scheduler to use. See [SCX documentation](https://github.com/sched-ext/scx/tree/main/scheds)
+        for details on each scheduler and guidance on selecting the most suitable one.
+      '';
+    };
+
+    default_mode = lib.mkOption {
+      type = lib.types.enum [
+        "Auto"
+        "Gaming"
+        "LowLatency"
+        "PowerSave"
+        "Server"
+      ];
+      default = "Auto";
+      example = "Gaming";
+      description = ''
+        Which mode to use. See [scx_loader documentation](https://github.com/sched-ext/scx/blob/main/tools/scx_loader/configuration.md)
+        for details on how to the different modes.
+      '';
+    };
+
+    scheduler_config = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      example = ''
+        [scheds.scx_rustland]
+        auto_mode = []
+        gaming_mode = []
+        lowlatency_mode = []
+        powersave_mode = []
+        server_mode = []
+
+        [scheds.scx_lavd]
+        auto_mode = []
+        gaming_mode = ["--performance"]
+        lowlatency_mode = ["--performance"]
+        powersave_mode = ["--powersave"]
+        server_mode = []
+
+        [scheds.scx_flash]
+        auto_mode = []
+        gaming_mode = ["-m", "all"]
+        lowlatency_mode = ["-m", "performance", "-w", "-C", "0"]
+        powersave_mode = ["-m", "powersave", "-I", "10000", "-t", "10000", "-s", "10000", "-S", "1000"]
+        server_mode = ["-m", "all", "-s", "20000", "-S", "1000", "-I", "-1", "-D", "-L"]
+      '';
+      description = ''
+        Scheduler configuration in TOML format. This will be added to the generated config file
+        after the default_sched and default_mode settings.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.etc."scx_loader/config.toml".text = ''
+      default_sched = "${cfg.default_sched}"
+      default_mode = "${cfg.default_mode}"
+
+      ${cfg.scheduler_config}
+    '';
+
+    systemd.services.scx_loader = {
+      description = "DBUS on-demand loader of sched_ext schedulers";
+
+      # SCX service should be started only if the kernel supports sched-ext
+      unitConfig.ConditionPathIsDirectory = "/sys/kernel/sched_ext";
+
+      serviceConfig = {
+        Type = "dbus";
+        BusName = "org.scx.Loader";
+        Environment = "RUST_LOG=trace";
+        ExecStart = utils.escapeSystemdExecArgs [
+          (lib.getExe' cfg.package "scx_loader")
+        ];
+        KillSignal = "SIGINT";
+      };
+
+      wantedBy = [ "graphical.target" ];
+    };
+
+    # D-Bus service configuration
+    services.dbus = {
+      enable = true;
+      packages = [
+        (pkgs.writeTextFile {
+          name = "scx-loader-dbus-service";
+          destination = "/share/dbus-1/system-services/org.scx.Loader.service";
+          text = ''
+            [D-BUS Service]
+            Name=org.scx.Loader
+            Exec=${
+              utils.escapeSystemdExecArgs [
+                (lib.getExe' cfg.package "scx_loader")
+              ]
+            }
+            User=root
+            SystemdService=scx_loader.service
+          '';
+        })
+        (pkgs.writeTextFile {
+          name = "scx-loader-dbus-conf";
+          destination = "/share/dbus-1/system.d/org.scx.Loader.conf";
+          text = ''
+            <!DOCTYPE busconfig PUBLIC
+             "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+             "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+            <busconfig>
+                <policy user="root">
+                    <allow own="org.scx.Loader"/>
+                    <allow send_destination="org.scx.Loader"/>
+                    <allow receive_sender="org.scx.Loader"/>
+                </policy>
+                <policy context="default">
+                    <allow send_destination="org.scx.Loader"/>
+                    <allow receive_sender="org.scx.Loader"/>
+                </policy>
+            </busconfig>
+          '';
+        })
+      ];
+    };
+    assertions = [
+      {
+        assertion = lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.12";
+        message = "SCX is only supported on kernel version >= 6.12.";
+      }
+      {
+        assertion = !(cfg.enable && config.services.scx.enable);
+        message = "services.scx_loader and services.scx cannot be enabled simultaneously. Please enable only one.";
+      }
+    ];
+  };
+
+  meta = {
+    inherit (pkgs.scx.full.meta) maintainers;
+  };
+}

--- a/nixos/modules/services/scheduling/scx.nix
+++ b/nixos/modules/services/scheduling/scx.nix
@@ -118,6 +118,10 @@ in
         assertion = lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.12";
         message = "SCX is only supported on kernel version >= 6.12.";
       }
+      {
+        assertion = !(cfg.enable && config.services.scx_loader.enable);
+        message = "services.scx and services.scx_loader cannot be enabled simultaneously. Please enable only one.";
+      }
     ];
   };
 


### PR DESCRIPTION
[scx_loader](https://github.com/sched-ext/scx/tree/main/tools/scx_loader) is a utility that provides a convenient DBUS interface for starting, stopping, and managing sched_ext schedulers, and is meant to replace the original scx systemd service for loading these scx schedulers on startup.

It does **almost** everything the service in scx.nix does, plus gives users additional configuration options and modes for different schedulers, and the ability to interact with the schedulers dynamically using `scxctl`. The only thing that the scx service in scx.nix can do that `scx_loader` does not support is loading of scx.cscheds, so I don't think it should replace the current scx service, but be provided as an alternative service for now.

I'm not particularly sure how maintainership for this would work, so I've tagged it under the scx.full maintainers for now, but I'd be willing to volunteer as a maintainer for this module if needed to. @JohnRTitor @Gliczy 

I'm also not sure if scheduling is the right place to put this module, so any inputs would be appreciated.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Tested with own configuration
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
