### PR TITLE
deno: remove esbuild use in tests, keep denort in a separate output

### DIFF
--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -21,7 +21,6 @@
   nodejs,
   git,
   python3,
-  esbuild,
 }:
 
 let
@@ -99,9 +98,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
     || (stdenv.hostPlatform.isLinux && (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isx86_64));
 
   preCheck =
-    # Provide esbuild binary at `./third_party/prebuilt/` just like upstream:
-    # https://github.com/denoland/deno_third_party/tree/master/prebuilt
-    # https://github.com/denoland/deno/blob/main/tests/util/server/src/servers/npm_registry.rs#L402
+    # Provide placeholder file for esbuild.
+    # The version of esbuild needs to exactly match the version deno requires
+    # for currently one integration test.
+    # https://github.com/evanw/esbuild/blob/195e05c16f03a341390feef38b8ebf17d3075e14/cmd/esbuild/main.go#L206-L214
+    # Updating esbuild in lockstep with deno releases isn't ideal and neither is
+    # modifying the deno source and diverging from upstream.
+    # A placeholder must be provided or the code which mocks an npm registry
+    # will fail for over 260 tests which use it.
     let
       platform =
         if stdenv.hostPlatform.isLinux then
@@ -120,7 +124,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     in
     ''
       mkdir -p ./third_party/prebuilt/${platform}
-      cp ${lib.getExe esbuild} ./third_party/prebuilt/${platform}/esbuild-${arch}
+      touch ./third_party/prebuilt/${platform}/esbuild-${arch}
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       # Unset the env var defined by bintools-wrapper because it triggers Deno's sandbox protection in some tests.
@@ -169,6 +173,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # Use of VSOCK, might not be available on all platforms
     "--skip=js_unit_tests::serve_test"
     "--skip=js_unit_tests::fetch_test"
+
+    # Requires a specific release of esbuild.
+    "--skip=watcher::bundle_watch"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Expects specific shared libraries from macOS to be linked

--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -97,13 +97,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # To avoid this we pre-download the file and export it via RUSTY_V8_ARCHIVE
   env.RUSTY_V8_ARCHIVE = librusty_v8;
 
-  # Many tests depend on prebuilt binaries being present at `./third_party/prebuilt`.
-  # We provide nixpkgs binaries for these for all platforms, but the test runner itself only handles
-  # these four arch+platform combinations.
-  doCheck =
-    stdenv.hostPlatform.isDarwin
-    || (stdenv.hostPlatform.isLinux && (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isx86_64));
-
   preCheck =
     # Provide placeholder file for esbuild.
     # The version of esbuild needs to exactly match the version deno requires

--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -30,6 +30,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "deno";
   version = "2.5.1";
 
+  outputs = [
+    "out"
+    # holds denort, used for standalone binaries produced with deno
+    # https://github.com/denoland/deno/blob/45d333a1c331926d7df80f63c533293be03b0070/cli/standalone/binary.rs#L1206
+    "rt"
+  ];
+
   src = fetchFromGitHub {
     owner = "denoland";
     repo = "deno";
@@ -211,7 +218,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   postInstall = ''
-    # Remove non-essential binaries like denort and test_server
+    mkdir -p "$rt/bin"
+    mv "$out/bin/denort" "$rt/bin/"
+    # Remove non-essential binaries like test_server
     find $out/bin/* -not -name "deno" -delete
   ''
   + lib.optionalString canExecute ''

--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -234,7 +234,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru.updateScript = ./update/update.ts;
   passthru.tests = callPackage ./tests { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://deno.land/";
     changelog = "https://github.com/denoland/deno/releases/tag/v${finalAttrs.version}";
     description = "Secure runtime for JavaScript and TypeScript";
@@ -247,9 +247,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
       Among other things, Deno is a great replacement for utility scripts that may have been historically written with
       bash or python.
     '';
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "deno";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       jk
       ofalvai
     ];


### PR DESCRIPTION
- deno: remove esbuild use in tests
- deno: keep denort in a separate output
- deno: leave doCheck defaults
- deno: reduce usage of `with lib;`

Unblocks #423375 
Sorry for the delay.

context:

https://github.com/nixos/nixpkgs/pull/423375#issuecomment-3209987484

<img width="936" height="937" alt="image" src="https://github.com/user-attachments/assets/c2eece66-a80f-4945-a349-4c87ba392a52" />


---

Keeping denort relates to the deno builder work in a separate PR

---

cc: @ofalvai 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
