### PR TITLE
go-arch-lint: init at 1.13.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8274,6 +8274,12 @@
     githubId = 541748;
     name = "Felipe Espinoza";
   };
+  fe3dback = {
+    email = "fe3dback@protonmail.com";
+    github = "fe3dback";
+    githubId = 2073883;
+    name = "fe3dback";
+  };
   feathecutie = {
     name = "feathecutie";
     github = "feathecutie";

--- a/pkgs/by-name/go/go-arch-lint/package.nix
+++ b/pkgs/by-name/go/go-arch-lint/package.nix
@@ -1,0 +1,63 @@
+{
+  # go-arch-lint has historically required code changes to support new versions of
+  # go so always use the latest specific go version that go-arch-lint supports
+  # rather than buildGoLatestModule.
+  # This can be bumped when the release notes of go-arch-lint detail support for
+  # new version of go.
+  buildGo125Module,
+  buildPackages,
+  fetchFromGitHub,
+  installShellFiles,
+  lib,
+  stdenv,
+}:
+
+buildGo125Module (finalAttrs: {
+  pname = "go-arch-lint";
+  version = "1.13.0";
+
+  src = fetchFromGitHub {
+    owner = "fe3dback";
+    repo = "go-arch-lint";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TtYeowoL8NEOw1coiLHJ/epcFMaxT4zsBSsnLgmhKDc=";
+  };
+
+  vendorHash = "sha256-2n7OjF4gl+qq9M5EtU0nmgWwRPZ3YvmLQDAgJ8w9S1M=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/fe3dback/go-arch-lint/internal/app.Version=${finalAttrs.version}"
+    "-X github.com/fe3dback/go-arch-lint/internal/app.CommitHash=v${finalAttrs.version}"
+    "-X github.com/fe3dback/go-arch-lint/internal/app.BuildTime=19700101-00:00:00"
+  ];
+
+  postInstall =
+    let
+      goarchlintBin =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out"
+        else
+          lib.getBin buildPackages.go-arch-lint;
+    in
+    ''
+      installShellCompletion --cmd go-arch-lint \
+        --bash <(${goarchlintBin}/bin/go-arch-lint completion bash) \
+        --fish <(${goarchlintBin}/bin/go-arch-lint completion fish) \
+        --zsh <(${goarchlintBin}/bin/go-arch-lint completion zsh)
+    '';
+
+  meta = {
+    description = "GoLang architecture linter (checker) tool. Will check all project import path and compare with arch rules defined in yml file";
+    homepage = "https://github.com/fe3dback/go-arch-lint";
+    changelog = "https://github.com/fe3dback/go-arch-lint/releases/tag/v${finalAttrs.version}";
+    mainProgram = "go-arch-lint";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      fe3dback
+    ];
+  };
+})


### PR DESCRIPTION
Adding [go-arch-lint](https://github.com/fe3dback/go-arch-lint): GoLang architecture linter (checker) tool. Will check all project import path and compare with arch rules defined in yml file.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
