### PR TITLE
wanderer: init at 0.19.2, nixos/wanderer: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -100,6 +100,8 @@
 
 - [bentopdf](https://github.com/alam00000/bentopdf), a privacy-first PDF toolkit running completely in-browser. Available as [services.bentopdf](#opt-services.bentopdf.enable).
 
+- [wanderer](https://wanderer.to), a self-hosted trail database. Save your adventures! Available as [services.wanderer](#opt-services.wanderer.enable).
+
 - [hyprwhspr-rs](https://github.com/better-slop/hyprwhspr-rs), a keybind activated speech-to-text voice dictation utility built for use with Hyprland. Available as `services.hyprwhspr-rs`
 
 - [DankMaterialShell](https://danklinux.com), a complete desktop shell for Wayland compositors built with Quickshell. Available as [programs.dms-shell](#opt-programs.dms-shell.enable).

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -16,6 +16,8 @@
 
 - [FlapAlerted](https://github.com/Kioubit/FlapAlerted), detects BGP flapping events and provides statistics based on BGP update messages. Available as [services.flap-alerted](#opt-services.flap-alerted.enable).
 
+- [wanderer](https://wanderer.to), a self-hosted trail database. Save your adventures! Available as [services.wanderer](#opt-services.wanderer.enable).
+
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1795,6 +1795,7 @@
   ./services/web-apps/umami.nix
   ./services/web-apps/vikunja.nix
   ./services/web-apps/wakapi.nix
+  ./services/web-apps/wanderer.nix
   ./services/web-apps/weblate.nix
   ./services/web-apps/websurfx.nix
   ./services/web-apps/whitebophir.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1805,6 +1805,7 @@
   ./services/web-apps/umami.nix
   ./services/web-apps/vikunja.nix
   ./services/web-apps/wakapi.nix
+  ./services/web-apps/wanderer.nix
   ./services/web-apps/weblate.nix
   ./services/web-apps/websurfx.nix
   ./services/web-apps/whitebophir.nix

--- a/nixos/modules/services/web-apps/wanderer.nix
+++ b/nixos/modules/services/web-apps/wanderer.nix
@@ -1,0 +1,270 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.wanderer;
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    types
+    mkIf
+    getExe
+    mapAttrs
+    boolToString
+    ;
+
+  stateDir = "/var/lib/wanderer";
+  user = "wanderer";
+  group = "wanderer";
+in
+{
+  options = {
+    services.wanderer = {
+      enable = mkEnableOption "wanderer";
+
+      origin = mkOption {
+        type = types.str;
+        default = "http://localhost";
+        description = ''
+          Scheme + address via which the wanderer frontend will be reachable.
+          This must match what users input into their browser's address bar *exactly*, otherwise wanderer shows a nasty warning on every page.
+          Set to `http://localhost` if you wish to use wanderer only from the same host it is running on, otherwise to a FQDN incl. scheme,
+          for example: `https://wanderer.example.com`.
+
+          Even if wanderer is running behind a reverse proxy like NGINX, you will get the warning about mismatched hosts unless you follow the advice above.
+          Note that setting this to an IP, incl. `http://127.0.0.1` and `http://0.0.0.0`, will cause wanderer to panic.
+        '';
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 3000;
+        description = "Port on which the wanderer web interface is served";
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Open ports in the firewall for the wanderer web interface";
+      };
+
+      services = {
+        valhalla.url = mkOption {
+          type = types.str;
+          default = "https://valhalla1.openstreetmap.de";
+          description = "Public IP or address (including the port) of a valhalla instance";
+        };
+
+        nominatim.url = mkOption {
+          type = types.str;
+          default = "https://nominatim.openstreetmap.org";
+          description = "Public IP or address (including the port) of a nominatim instance";
+        };
+
+        pocketbase.url = mkOption {
+          type = types.str;
+          default = "http://127.0.0.1:8090";
+          description = "Public IP or address of the wanderer pocketbase instance, incl. port and schema";
+        };
+
+        meilisearch = {
+          enable = mkOption {
+            type = types.bool;
+            default = true;
+            description = "wanderer requires a meilisearch instance. By default, one is started. If set to `false`, you need to manually configure an instance.";
+          };
+
+          url = mkOption {
+            type = types.str;
+            default = "http://127.0.0.1:7700";
+            description = "IP or address on which meilisearch is available, incl. schema and port";
+          };
+        };
+      };
+
+      settings = {
+        syncSchedule = mkOption {
+          type = types.str;
+          default = "0 2 * * *";
+          description = "Valid cron expression. Sets how often trails are synced from 3rd party integrations";
+        };
+
+        bodySizeLimit = mkOption {
+          type = types.str;
+          default = "Infinity";
+          description = "Maximum allowed upload size";
+        };
+
+        disableSignup = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Disables signup option for new users";
+        };
+
+        privateInstance = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Setting this to true will block visitors from viewing content without an account";
+        };
+
+        uploadDir = mkOption {
+          type = types.path;
+          default = "${stateDir}/upload";
+          description = "Folder from which wanderer auto-uploads trails";
+        };
+      };
+
+      extraConfig = mkOption {
+        type =
+          with types;
+          attrsOf (
+            nullOr (oneOf [
+              bool
+              int
+              str
+            ])
+          );
+        default = { };
+        example = {
+          POCKETBASE_SMTP_SENDER_NAME = "MyWandererInstance";
+        };
+        description = ''
+          The configuration of wanderer is handled through environment variables.
+          The available configuration options can be found in [the wanderer docs](https://wanderer.to/run/environment-configuration/).
+        '';
+      };
+
+      secretsFile = mkOption {
+        type = types.path;
+        example = "/run/secrets/wanderer";
+        description = ''
+          Secrets like {env}`MEILI_MASTER_KEY` and {env}`POCKETBASE_ENCRYPTION_KEY`
+          must be passed to the service without adding them to the world-readable Nix store.
+
+          This file needs to be available on the host on which `wanderer` is running.
+          {env}`POCKETBASE_ENCRYPTION_KEY` must be exactly 32 characters long.
+          One way to generate such a secret is to use `openssl rand -hex 16`.
+
+          At a **minimum**, the contents of the file must look like this:
+          ```
+          MEILI_MASTER_KEY=...master key used by the wanderer backend and frontend, and by meilisearch...
+          POCKETBASE_ENCRYPTION_KEY=...encryption key used by the wanderer backend, exactly 32 chars long...
+          ```
+        '';
+      };
+
+      package = mkPackageOption pkgs "wanderer" { };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.wanderer = {
+      description = "wanderer pocketbase db";
+      after = [
+        "network.target"
+        "meilisearch.service"
+      ];
+      wantedBy = [ "wanderer-web.service" ];
+
+      environment = {
+        ORIGIN = cfg.origin;
+        MEILI_URL = cfg.services.meilisearch.url;
+        POCKETBASE_CRON_SYNC_SCHEDULE = cfg.settings.syncSchedule;
+      }
+      // (mapAttrs (_: toString) cfg.extraConfig);
+
+      serviceConfig = {
+        Type = "simple";
+        DynamicUser = true;
+        User = user;
+        Group = group;
+
+        StateDirectory = baseNameOf stateDir;
+        BindPaths = [
+          "${cfg.package}/share/initial_data:${stateDir}/migrations/initial_data"
+        ];
+        WorkingDirectory = stateDir;
+
+        EnvironmentFile = cfg.secretsFile;
+
+        ExecStart =
+          let
+            url = cfg.services.pocketbase.url;
+            scheme =
+              if lib.hasPrefix "https://" url then
+                "https"
+              else if lib.hasPrefix "http://" url then
+                "http"
+              else
+                throw "pocketbase url must start with http:// or https://";
+            host = lib.removePrefix "${scheme}://" url;
+          in
+          "${getExe cfg.package} serve --dir=\"${stateDir}\" --${scheme}=\"${host}\"";
+        Restart = "on-failure";
+      };
+    };
+
+    systemd.services.wanderer-web = {
+      description = "wanderer web app";
+      bindsTo = [ "wanderer.service" ];
+      after = [
+        "wanderer.service"
+        "meilisearch.service"
+      ];
+      wantedBy = [ "multi-user.target" ];
+
+      environment = {
+        ORIGIN = cfg.origin;
+        PORT = toString cfg.port;
+        MEILI_URL = cfg.services.meilisearch.url;
+        BODY_SIZE_LIMIT = cfg.settings.bodySizeLimit;
+        UPLOAD_FOLDER = cfg.settings.uploadDir;
+        PUBLIC_DISABLE_SIGNUP = boolToString cfg.settings.disableSignup;
+        PUBLIC_PRIVATE_INSTANCE = boolToString cfg.settings.privateInstance;
+        PUBLIC_POCKETBASE_URL = cfg.services.pocketbase.url;
+        PUBLIC_VALHALLA_URL = cfg.services.valhalla.url;
+        PUBLIC_NOMINATIM_URL = cfg.services.nominatim.url;
+      }
+      // (mapAttrs (_: toString) cfg.extraConfig);
+
+      serviceConfig = {
+        Type = "simple";
+        DynamicUser = true;
+        User = user;
+        Group = group;
+
+        StateDirectory = baseNameOf stateDir;
+        BindReadOnlyPaths = [
+          "${cfg.package}/share/web:${stateDir}/web"
+        ];
+        WorkingDirectory = stateDir;
+
+        EnvironmentFile = cfg.secretsFile;
+
+        ExecStart = "${pkgs.nodejs}/bin/node ${stateDir}/web/build/index.js";
+        Restart = "on-failure";
+      };
+    };
+
+    services.meilisearch = mkIf cfg.services.meilisearch.enable {
+      enable = lib.mkDefault true;
+    };
+    systemd.services.meilisearch = mkIf cfg.services.meilisearch.enable {
+      wantedBy = [
+        "wanderer.service"
+        "wanderer-web.service"
+      ];
+      serviceConfig = {
+        Environment = [ "MEILI_URL=${cfg.services.meilisearch.url}" ];
+        EnvironmentFile = cfg.secretsFile;
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.optional cfg.openFirewall cfg.port;
+  };
+}

--- a/pkgs/by-name/wa/wanderer/package.nix
+++ b/pkgs/by-name/wa/wanderer/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenvNoCC,
+  buildGoModule,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+let
+  version = "0.18.5";
+  src = fetchFromGitHub {
+    owner = "Flomp";
+    repo = "wanderer";
+    rev = "v${version}";
+    hash = "sha256-f92FRP/eaoDqRcXrijs86yF28DLYY7NINB5j+URww/Q=";
+  };
+
+  wanderer = buildGoModule {
+    inherit src version;
+
+    pname = "wanderer";
+    sourceRoot = "${src.name}/db";
+    vendorHash = "sha256-t3PclWD+N8+nykR6T3GkCDtVtaIUQD7EVx45kzMy/L0=";
+  };
+
+  wanderer-web = buildNpmPackage {
+    inherit version;
+    pname = "wanderer-web";
+
+    src = "${src}/web";
+    npmDepsHash = "sha256-urJFziHSgDPFYg/V29HE5LTRocmYMQVZTA1UG/WQJBQ=";
+
+    makeCacheWritable = true;
+    npmFlags = [ "--legacy-peer-deps" ];
+
+    installPhase = ''
+      runHook preinstall
+
+      mkdir -p $out/share
+      cp -r build $out/share/build
+      cp package*.json $out/share
+      cp -r node_modules $out/share
+
+      runHook postinstall
+    '';
+  };
+in
+stdenvNoCC.mkDerivation {
+  inherit version;
+  pname = "wanderer";
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preinstall
+
+    mkdir -p $out/bin
+    ln -s ${wanderer}/bin/pocketbase $out/bin/wanderer
+
+    mkdir -p $out/share
+    ln -s ${wanderer-web}/share $out/share/web
+    cp -r ${src}/db/migrations/initial_data $out/share/initial_data
+
+    runHook postInstall
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Self-hosted trail database for storing and managing GPS tracking data";
+    mainProgram = "wanderer";
+    homepage = "https://wanderer.to";
+    changelog = "https://wanderer.to/changelog/";
+    downloadPage = "https://github.com/Flomp/wanderer";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ charludo ];
+    inherit (wanderer.meta) platforms;
+  };
+}

--- a/pkgs/by-name/wa/wanderer/package.nix
+++ b/pkgs/by-name/wa/wanderer/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenvNoCC,
+  buildGoModule,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+let
+  version = "0.19.2";
+  src = fetchFromGitHub {
+    owner = "Flomp";
+    repo = "wanderer";
+    rev = "v${version}";
+    hash = "sha256-w4DcM+0Rya5Q12VPWjyWXISXb3e0If7CmU5OJhQ0hvg=";
+  };
+
+  wanderer = buildGoModule {
+    inherit src version;
+
+    pname = "wanderer";
+    sourceRoot = "${src.name}/db";
+    vendorHash = "sha256-F7ax+Sk4+oaX2tA3/jUuvZPLOjLrpfiL/ZHEf3Cg8Kk=";
+  };
+
+  wanderer-web = buildNpmPackage {
+    inherit version;
+    pname = "wanderer-web";
+
+    src = "${src}/web";
+    npmDepsHash = "sha256-nJD5cf+PG8etjl/z3FUtGyygiBgGuhjtFe54buDSqm8=";
+
+    makeCacheWritable = true;
+    npmFlags = [ "--legacy-peer-deps" ];
+
+    installPhase = ''
+      runHook preinstall
+
+      mkdir -p $out/share
+      cp -r build $out/share/build
+      cp package*.json $out/share
+      cp -r node_modules $out/share
+
+      runHook postinstall
+    '';
+  };
+in
+stdenvNoCC.mkDerivation {
+  inherit version;
+  pname = "wanderer";
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preinstall
+
+    mkdir -p $out/bin
+    ln -s ${wanderer}/bin/pocketbase $out/bin/wanderer
+
+    mkdir -p $out/share
+    ln -s ${wanderer-web}/share $out/share/web
+    cp -r ${src}/db/migrations/initial_data $out/share/initial_data
+
+    runHook postInstall
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Self-hosted trail database for storing and managing GPS tracking data";
+    mainProgram = "wanderer";
+    homepage = "https://wanderer.to";
+    changelog = "https://wanderer.to/changelog/";
+    downloadPage = "https://github.com/Flomp/wanderer";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ charludo ];
+    inherit (wanderer.meta) platforms;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[wanderer](https://wanderer.to) is a self-hosted, federated trails database. You can upload your recorded GPS tracks or create new ones and add various metadata to build an easily searchable catalogue.

## Things done

- added the `wanderer` package
- added the `services.wanderer` NixOS module

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
