### PR TITLE
various: use `types.port` instead of `types.int`

### DIFF
--- a/nixos/modules/profiles/nix-builder-vm.nix
+++ b/nixos/modules/profiles/nix-builder-vm.nix
@@ -85,7 +85,7 @@ in
     };
     hostPort = mkOption {
       default = 31022;
-      type = types.int;
+      type = types.port;
       example = 22;
       description = ''
         The localhost host port to forward TCP to the guest port.

--- a/nixos/modules/services/continuous-integration/buildbot/master.nix
+++ b/nixos/modules/services/continuous-integration/buildbot/master.nix
@@ -182,7 +182,7 @@ in
 
       pbPort = lib.mkOption {
         default = 9989;
-        type = lib.types.either lib.types.str lib.types.int;
+        type = lib.types.either lib.types.str lib.types.port;
         example = "'tcp:9990:interface=127.0.0.1'";
         description = ''
           The buildmaster will listen on a TCP port of your choosing

--- a/nixos/modules/services/continuous-integration/gocd-server/default.nix
+++ b/nixos/modules/services/continuous-integration/gocd-server/default.nix
@@ -64,7 +64,7 @@ in
 
       sslPort = mkOption {
         default = 8154;
-        type = types.int;
+        type = types.port;
         description = ''
           Specifies port number on which the Go.CD server HTTPS interface listens.
         '';

--- a/nixos/modules/services/databases/cassandra.nix
+++ b/nixos/modules/services/databases/cassandra.nix
@@ -415,7 +415,7 @@ in
     };
 
     jmxPort = mkOption {
-      type = types.int;
+      type = types.port;
       default = 7199;
       description = ''
         Specifies the default port over which Cassandra will be available for

--- a/nixos/modules/services/databases/foundationdb.nix
+++ b/nixos/modules/services/databases/foundationdb.nix
@@ -94,7 +94,7 @@ in
     };
 
     listenPortStart = lib.mkOption {
-      type = lib.types.int;
+      type = lib.types.port;
       default = 4500;
       description = ''
         Starting port number for database listening sockets. Every FDB process binds to a

--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -638,7 +638,7 @@ in
           description = "External address used to access registry from the internet";
         };
         externalPort = mkOption {
-          type = types.int;
+          type = types.port;
           description = "External port used to access registry from the internet";
         };
       };

--- a/nixos/modules/services/misc/homepage-dashboard.nix
+++ b/nixos/modules/services/misc/homepage-dashboard.nix
@@ -23,7 +23,7 @@ in
       };
 
       listenPort = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.port;
         default = 8082;
         description = "Port for Homepage to bind to.";
       };

--- a/nixos/modules/services/misc/taskserver/default.nix
+++ b/nixos/modules/services/misc/taskserver/default.nix
@@ -329,7 +329,7 @@ in
       };
 
       listenPort = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.port;
         default = 53589;
         description = ''
           Port number of the Taskserver.

--- a/nixos/modules/services/monitoring/prometheus/exporters/fritzbox.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/fritzbox.nix
@@ -22,7 +22,7 @@ in
     };
 
     gatewayPort = mkOption {
-      type = types.int;
+      type = types.port;
       default = 49000;
       description = ''
         The port of the FRITZ!Box UPnP service.

--- a/nixos/modules/services/monitoring/statsd.nix
+++ b/nixos/modules/services/monitoring/statsd.nix
@@ -110,7 +110,7 @@ in
     graphitePort = lib.mkOption {
       description = "Port of Graphite server (i.e. carbon-cache).";
       default = null;
-      type = lib.types.nullOr lib.types.int;
+      type = lib.types.nullOr lib.types.port;
     };
 
     extraConfig = lib.mkOption {

--- a/nixos/modules/services/network-filesystems/nfsd.nix
+++ b/nixos/modules/services/network-filesystems/nfsd.nix
@@ -81,7 +81,7 @@ in
         };
 
         mountdPort = lib.mkOption {
-          type = lib.types.nullOr lib.types.int;
+          type = lib.types.nullOr lib.types.port;
           default = null;
           example = 4002;
           description = ''
@@ -90,7 +90,7 @@ in
         };
 
         lockdPort = lib.mkOption {
-          type = lib.types.nullOr lib.types.int;
+          type = lib.types.nullOr lib.types.port;
           default = null;
           example = 4001;
           description = ''
@@ -101,7 +101,7 @@ in
         };
 
         statdPort = lib.mkOption {
-          type = lib.types.nullOr lib.types.int;
+          type = lib.types.nullOr lib.types.port;
           default = null;
           example = 4000;
           description = ''

--- a/nixos/modules/services/network-filesystems/tahoe.nix
+++ b/nixos/modules/services/network-filesystems/tahoe.nix
@@ -140,7 +140,7 @@ in
             sftpd.enable = lib.mkEnableOption "SFTP service";
             sftpd.port = lib.mkOption {
               default = null;
-              type = lib.types.nullOr lib.types.int;
+              type = lib.types.nullOr lib.types.port;
               description = ''
                 The port on which the SFTP server will listen.
 

--- a/nixos/modules/services/networking/3proxy.nix
+++ b/nixos/modules/services/networking/3proxy.nix
@@ -83,7 +83,7 @@ in
               '';
             };
             bindPort = lib.mkOption {
-              type = lib.types.nullOr lib.types.int;
+              type = lib.types.nullOr lib.types.port;
               default = null;
               example = 3128;
               description = ''
@@ -192,7 +192,7 @@ in
                       '';
                     };
                     targetPorts = lib.mkOption {
-                      type = lib.types.listOf lib.types.int;
+                      type = lib.types.listOf lib.types.port;
                       default = [ ];
                       example = [
                         80

--- a/nixos/modules/services/networking/autossh.nix
+++ b/nixos/modules/services/networking/autossh.nix
@@ -33,7 +33,7 @@ in
                 description = "Name of the user the AutoSSH session should run as";
               };
               monitoringPort = lib.mkOption {
-                type = lib.types.int;
+                type = lib.types.port;
                 default = 0;
                 example = 20000;
                 description = ''

--- a/nixos/modules/services/networking/coturn.nix
+++ b/nixos/modules/services/networking/coturn.nix
@@ -50,7 +50,7 @@ in
     services.coturn = {
       enable = lib.mkEnableOption "coturn TURN server";
       listening-port = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.port;
         default = 3478;
         description = ''
           TURN listener port for UDP and TCP.
@@ -59,7 +59,7 @@ in
         '';
       };
       tls-listening-port = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.port;
         default = 5349;
         description = ''
           TURN listener port for TLS.
@@ -74,7 +74,7 @@ in
         '';
       };
       alt-listening-port = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.port;
         default = cfg.listening-port + 1;
         defaultText = lib.literalExpression "listening-port + 1";
         description = ''
@@ -89,7 +89,7 @@ in
         '';
       };
       alt-tls-listening-port = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.port;
         default = cfg.tls-listening-port + 1;
         defaultText = lib.literalExpression "tls-listening-port + 1";
         description = ''
@@ -130,14 +130,14 @@ in
         '';
       };
       min-port = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.port;
         default = 49152;
         description = ''
           Lower bound of UDP relay endpoints
         '';
       };
       max-port = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.port;
         default = 65535;
         description = ''
           Upper bound of UDP relay endpoints
@@ -263,7 +263,7 @@ in
         '';
       };
       cli-port = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.port;
         default = 5766;
         description = ''
           CLI server port.

--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -667,7 +667,7 @@ in
           description = "Upstream outproxy bind address.";
         };
         outproxyPort = mkOption {
-          type = types.int;
+          type = types.port;
           default = 4444;
           description = "Upstream outproxy bind port.";
         };
@@ -686,7 +686,7 @@ in
             {
               options = {
                 destinationPort = mkOption {
-                  type = with types; nullOr int;
+                  type = with types; nullOr port;
                   default = null;
                   description = "Connect to particular port at destination.";
                 };
@@ -711,7 +711,7 @@ in
             {
               options = {
                 inPort = mkOption {
-                  type = types.int;
+                  type = types.port;
                   default = 0;
                   description = "Service port. Default to the tunnel's listen port.";
                 };

--- a/nixos/modules/services/networking/livekit-ingress.nix
+++ b/nixos/modules/services/networking/livekit-ingress.nix
@@ -71,13 +71,13 @@ in
 
           rtc_config = {
             port_range_start = lib.mkOption {
-              type = lib.types.int;
+              type = lib.types.port;
               default = 50000;
               description = "Start of UDP port range for WebRTC";
             };
 
             port_range_end = lib.mkOption {
-              type = lib.types.int;
+              type = lib.types.port;
               default = 51000;
               description = "End of UDP port range for WebRTC";
             };

--- a/nixos/modules/services/networking/livekit.nix
+++ b/nixos/modules/services/networking/livekit.nix
@@ -85,13 +85,13 @@ in
 
           rtc = {
             port_range_start = lib.mkOption {
-              type = lib.types.int;
+              type = lib.types.port;
               default = 50000;
               description = "Start of UDP port range for WebRTC";
             };
 
             port_range_end = lib.mkOption {
-              type = lib.types.int;
+              type = lib.types.port;
               default = 51000;
               description = "End of UDP port range for WebRTC";
             };

--- a/nixos/modules/services/networking/ntopng.nix
+++ b/nixos/modules/services/networking/ntopng.nix
@@ -80,7 +80,7 @@ in
 
       httpPort = mkOption {
         default = 3000;
-        type = types.int;
+        type = types.port;
         description = ''
           Sets the HTTP port of the embedded web server.
         '';

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -708,7 +708,7 @@ in
 
       # HTTP server-related options
       httpPorts = mkOption {
-        type = types.listOf types.int;
+        type = types.listOf types.port;
         description = "Listening HTTP ports list for this service.";
         default = [ 5280 ];
       };
@@ -723,7 +723,7 @@ in
       };
 
       httpsPorts = mkOption {
-        type = types.listOf types.int;
+        type = types.listOf types.port;
         description = "Listening HTTPS ports list for this service.";
         default = [ 5281 ];
       };

--- a/nixos/modules/services/networking/resilio.nix
+++ b/nixos/modules/services/networking/resilio.nix
@@ -113,7 +113,7 @@ in
       };
 
       listeningPort = mkOption {
-        type = types.int;
+        type = types.port;
         default = 0;
         example = 44444;
         description = ''
@@ -166,7 +166,7 @@ in
       };
 
       httpListenPort = mkOption {
-        type = types.int;
+        type = types.port;
         default = 9000;
         description = ''
           HTTP port to bind on.

--- a/nixos/modules/services/networking/squid.nix
+++ b/nixos/modules/services/networking/squid.nix
@@ -145,7 +145,7 @@ in
       };
 
       proxyPort = mkOption {
-        type = types.int;
+        type = types.port;
         default = 3128;
         description = "TCP port on which squid will listen.";
       };

--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -336,7 +336,7 @@ in
                     };
 
                     localAnnouncePort = mkOption {
-                      type = types.nullOr types.int;
+                      type = types.nullOr types.port;
                       default = null;
                       description = ''
                         The port on which to listen and send IPv4 broadcast announcements to.

--- a/nixos/modules/services/networking/websockify.nix
+++ b/nixos/modules/services/networking/websockify.nix
@@ -36,7 +36,7 @@ in
       portMap = mkOption {
         description = "Ports to map by default.";
         default = { };
-        type = types.attrsOf types.int;
+        type = types.attrsOf types.port;
       };
     };
   };

--- a/nixos/modules/services/networking/zerobin.nix
+++ b/nixos/modules/services/networking/zerobin.nix
@@ -44,7 +44,7 @@ in
       };
 
       listenPort = mkOption {
-        type = types.int;
+        type = types.port;
         default = 8000;
         example = 1357;
         description = ''

--- a/nixos/modules/services/search/elasticsearch.nix
+++ b/nixos/modules/services/search/elasticsearch.nix
@@ -72,7 +72,7 @@ in
     tcp_port = mkOption {
       description = "Elasticsearch port for the node to node communication.";
       default = 9300;
-      type = types.int;
+      type = types.port;
     };
 
     cluster_name = mkOption {

--- a/nixos/modules/services/security/shibboleth-sp.nix
+++ b/nixos/modules/services/security/shibboleth-sp.nix
@@ -30,13 +30,13 @@ in
       };
 
       fastcgi.shibAuthorizerPort = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.port;
         default = 9100;
         description = "Port for shibauthorizer FastCGI process to bind to";
       };
 
       fastcgi.shibResponderPort = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.port;
         default = 9101;
         description = "Port for shibauthorizer FastCGI process to bind to";
       };

--- a/nixos/modules/services/web-apps/anuko-time-tracker.nix
+++ b/nixos/modules/services/web-apps/anuko-time-tracker.nix
@@ -225,7 +225,7 @@ in
         };
 
         smtpPort = lib.mkOption {
-          type = lib.types.int;
+          type = lib.types.port;
           description = "MTA port.";
           default = 25;
         };

--- a/nixos/modules/services/web-apps/cryptpad.nix
+++ b/nixos/modules/services/web-apps/cryptpad.nix
@@ -75,12 +75,12 @@ in
             description = "Address on which the Node.js server should listen";
           };
           httpPort = mkOption {
-            type = types.int;
+            type = types.port;
             default = 3000;
             description = "Port on which the Node.js server should listen";
           };
           websocketPort = mkOption {
-            type = types.int;
+            type = types.port;
             default = 3003;
             description = "Port for the websocket that needs to be separate";
           };

--- a/nixos/modules/services/web-apps/kasmweb/default.nix
+++ b/nixos/modules/services/web-apps/kasmweb/default.nix
@@ -102,7 +102,7 @@ in
     };
 
     listenPort = lib.mkOption {
-      type = lib.types.int;
+      type = lib.types.port;
       default = 443;
       description = ''
         The port on which kasmweb should listen.

--- a/nixos/modules/services/web-apps/nexus.nix
+++ b/nixos/modules/services/web-apps/nexus.nix
@@ -46,7 +46,7 @@ in
       };
 
       listenPort = mkOption {
-        type = types.int;
+        type = types.port;
         default = 8081;
         description = "Port to listen on.";
       };

--- a/nixos/modules/services/web-apps/nifi.nix
+++ b/nixos/modules/services/web-apps/nifi.nix
@@ -69,7 +69,7 @@ in
       };
 
       listenPort = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.port;
         default = if cfg.enableHTTPS then 8443 else 8080;
         defaultText = lib.literalExpression ''
           if config.${opt.enableHTTPS}
@@ -91,7 +91,7 @@ in
       };
 
       proxyPort = lib.mkOption {
-        type = lib.types.nullOr lib.types.int;
+        type = lib.types.nullOr lib.types.port;
         default = if cfg.enableHTTPS then 8443 else null;
         defaultText = lib.literalExpression ''
           if config.${opt.enableHTTPS}

--- a/nixos/modules/services/web-apps/pgpkeyserver-lite.nix
+++ b/nixos/modules/services/web-apps/pgpkeyserver-lite.nix
@@ -47,7 +47,7 @@ in
       hkpPort = mkOption {
         default = sksCfg.hkpPort;
         defaultText = literalExpression "config.${sksOpt.hkpPort}";
-        type = types.int;
+        type = types.port;
         description = ''
           Which port the sks-keyserver is listening on.
         '';

--- a/nixos/modules/services/web-apps/plantuml-server.nix
+++ b/nixos/modules/services/web-apps/plantuml-server.nix
@@ -75,7 +75,7 @@ in
       };
 
       listenPort = mkOption {
-        type = types.int;
+        type = types.port;
         default = 8080;
         description = "Port to listen on.";
       };

--- a/nixos/modules/services/web-apps/silverbullet.nix
+++ b/nixos/modules/services/web-apps/silverbullet.nix
@@ -24,7 +24,7 @@ in
       };
 
       listenPort = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.port;
         default = 3000;
         description = "Port to listen on.";
       };

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -416,11 +416,11 @@ let
               description = "The protocol specifier for port forwarding between host and container";
             };
             hostPort = mkOption {
-              type = types.int;
+              type = types.port;
               description = "Source port of the external interface on host";
             };
             containerPort = mkOption {
-              type = types.nullOr types.int;
+              type = types.nullOr types.port;
               default = null;
               description = "Target port of container";
             };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Swap out `types.int` for `types.port` in various nixos modules.

Verified eval with `nix build .#htmlDocs.nixosManual.x86_64-linux` (for all modules except `profiles/nix-builder-vm`)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
