### PR TITLE
various: use more accurate int types

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -31,7 +31,7 @@ in
       description = ''
         The user IDs used in NixOS.
       '';
-      type = types.attrsOf types.int;
+      type = types.attrsOf types.ints.u32;
     };
 
     ids.gids = lib.mkOption {
@@ -39,7 +39,7 @@ in
       description = ''
         The group IDs used in NixOS.
       '';
-      type = types.attrsOf types.int;
+      type = types.attrsOf types.ints.u32;
     };
 
   };

--- a/nixos/modules/programs/shadow.nix
+++ b/nixos/modules/programs/shadow.nix
@@ -77,49 +77,49 @@ in
             SYS_UID_MIN = lib.mkOption {
               description = "Range of user IDs used for the creation of system users by useradd or newusers.";
               default = 400;
-              type = lib.types.int;
+              type = lib.types.ints.u32;
             };
 
             SYS_UID_MAX = lib.mkOption {
               description = "Range of user IDs used for the creation of system users by useradd or newusers.";
               default = 999;
-              type = lib.types.int;
+              type = lib.types.ints.u32;
             };
 
             UID_MIN = lib.mkOption {
               description = "Range of user IDs used for the creation of regular users by useradd or newusers.";
               default = 1000;
-              type = lib.types.int;
+              type = lib.types.ints.u32;
             };
 
             UID_MAX = lib.mkOption {
               description = "Range of user IDs used for the creation of regular users by useradd or newusers.";
               default = 29999;
-              type = lib.types.int;
+              type = lib.types.ints.u32;
             };
 
             SYS_GID_MIN = lib.mkOption {
               description = "Range of group IDs used for the creation of system groups by useradd, groupadd, or newusers";
               default = 400;
-              type = lib.types.int;
+              type = lib.types.ints.u32;
             };
 
             SYS_GID_MAX = lib.mkOption {
               description = "Range of group IDs used for the creation of system groups by useradd, groupadd, or newusers";
               default = 999;
-              type = lib.types.int;
+              type = lib.types.ints.u32;
             };
 
             GID_MIN = lib.mkOption {
               description = "Range of group IDs used for the creation of regular groups by useradd, groupadd, or newusers.";
               default = 1000;
-              type = lib.types.int;
+              type = lib.types.ints.u32;
             };
 
             GID_MAX = lib.mkOption {
               description = "Range of group IDs used for the creation of regular groups by useradd, groupadd, or newusers.";
               default = 29999;
-              type = lib.types.int;
+              type = lib.types.ints.u32;
             };
 
             TTYGROUP = lib.mkOption {

--- a/nixos/modules/services/development/distccd.nix
+++ b/nixos/modules/services/development/distccd.nix
@@ -65,7 +65,7 @@ in
       };
 
       nice = lib.mkOption {
-        type = lib.types.nullOr lib.types.int;
+        type = lib.types.nullOr (lib.types.ints.between (-20) 19);
         default = null;
         description = ''
           Niceness of the compilation tasks.

--- a/nixos/modules/services/logging/journalwatch.nix
+++ b/nixos/modules/services/logging/journalwatch.nix
@@ -72,7 +72,7 @@ in
       package = lib.mkPackageOption pkgs "journalwatch" { };
 
       priority = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.ints.between 0 7;
         default = 6;
         description = ''
           Lowest priority of message to be considered.

--- a/nixos/modules/services/misc/cpuminer-cryptonight.nix
+++ b/nixos/modules/services/misc/cpuminer-cryptonight.nix
@@ -43,7 +43,7 @@ in
         description = "Password for mining server";
       };
       threads = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.ints.unsigned;
         default = 0;
         description = "Number of miner threads, defaults to available processors";
       };

--- a/nixos/modules/services/misc/gotenberg.nix
+++ b/nixos/modules/services/misc/gotenberg.nix
@@ -107,7 +107,7 @@ in
         package = mkPackageOption pkgs "chromium" { };
 
         maxQueueSize = mkOption {
-          type = types.int;
+          type = types.ints.unsigned;
           default = 0;
           description = "Maximum queue size for chromium-based conversions. Setting to 0 disables the limit.";
         };
@@ -143,7 +143,7 @@ in
           description = "Deny accepting URLs from these domains in the `downloadFrom` API field. Accepts a regular expression.";
         };
         maxRetries = mkOption {
-          type = types.int;
+          type = types.ints.unsigned;
           default = 4;
           description = "The maximum amount of times to retry downloading a file specified with `downloadFrom`.";
         };
@@ -158,13 +158,13 @@ in
         package = mkPackageOption pkgs "libreoffice" { };
 
         restartAfter = mkOption {
-          type = types.int;
+          type = types.ints.unsigned;
           default = 10;
           description = "Restart LibreOffice after this many conversions. Setting to 0 disables this feature.";
         };
 
         maxQueueSize = mkOption {
-          type = types.int;
+          type = types.ints.unsigned;
           default = 0;
           description = "Maximum queue size for LibreOffice-based conversions. Setting to 0 disables the limit.";
         };

--- a/nixos/modules/services/misc/rshim.nix
+++ b/nixos/modules/services/misc/rshim.nix
@@ -61,7 +61,7 @@ in
     };
 
     log-level = lib.mkOption {
-      type = lib.types.int;
+      type = lib.types.ints.between 0 4;
       description = ''
         Specify the log level (0:none, 1:error, 2:warning, 3:notice, 4:debug).
       '';

--- a/nixos/modules/services/monitoring/nezha-agent.nix
+++ b/nixos/modules/services/monitoring/nezha-agent.nix
@@ -98,12 +98,7 @@ in
               '';
             };
             report_delay = lib.mkOption {
-              type = lib.types.enum [
-                1
-                2
-                3
-                4
-              ];
+              type = lib.types.ints.between 1 4;
               default = 3;
               description = ''
                 The interval between system status reportings.

--- a/nixos/modules/services/networking/freenet.nix
+++ b/nixos/modules/services/networking/freenet.nix
@@ -15,7 +15,7 @@ in
       enable = lib.mkEnableOption "Freenet daemon";
 
       nice = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.ints.between (-20) 19;
         default = 10;
         description = "Set the nice level for the Freenet daemon";
       };

--- a/nixos/modules/services/networking/hostapd.nix
+++ b/nixos/modules/services/networking/hostapd.nix
@@ -274,7 +274,7 @@ in
               channel = mkOption {
                 default = 0;
                 example = 11;
-                type = types.int;
+                type = types.ints.positive;
                 description = ''
                   The channel to operate on. Use 0 to enable ACS (Automatic Channel Selection).
                   Beware that not every device supports ACS in which case {command}`hostapd`
@@ -571,7 +571,7 @@ in
                     options = {
                       logLevel = mkOption {
                         default = 2;
-                        type = types.int;
+                        type = types.ints.between 0 4;
                         description = ''
                           Levels (minimum value for logged events):
                           0 = verbose debugging
@@ -957,7 +957,7 @@ in
                                 vlanid = mkOption {
                                   default = null;
                                   example = 1;
-                                  type = types.nullOr types.int;
+                                  type = types.nullOr types.ints.unsigned;
                                   description = "If this attribute is given, all clients using this entry will get tagged with the given VLAN ID.";
                                 };
 

--- a/nixos/modules/services/networking/icecream/daemon.nix
+++ b/nixos/modules/services/networking/icecream/daemon.nix
@@ -79,7 +79,7 @@ in
       };
 
       nice = mkOption {
-        type = types.int;
+        type = types.ints.between (-20) 19;
         default = 5;
         description = ''
           The level of niceness to use.

--- a/nixos/modules/services/networking/radvd.nix
+++ b/nixos/modules/services/networking/radvd.nix
@@ -39,7 +39,7 @@ in
     package = mkPackageOption pkgs "radvd" { };
 
     debugLevel = mkOption {
-      type = types.int;
+      type = types.ints.between 0 5;
       default = 0;
       example = 5;
       description = ''

--- a/nixos/modules/services/networking/resilio.nix
+++ b/nixos/modules/services/networking/resilio.nix
@@ -113,7 +113,7 @@ in
       };
 
       listeningPort = mkOption {
-        type = types.int;
+        type = types.port;
         default = 0;
         example = 44444;
         description = ''
@@ -139,7 +139,7 @@ in
       };
 
       downloadLimit = mkOption {
-        type = types.int;
+        type = types.ints.unsigned;
         default = 0;
         example = 1024;
         description = ''
@@ -148,7 +148,7 @@ in
       };
 
       uploadLimit = mkOption {
-        type = types.int;
+        type = types.ints.unsigned;
         default = 0;
         example = 1024;
         description = ''
@@ -166,7 +166,7 @@ in
       };
 
       httpListenPort = mkOption {
-        type = types.int;
+        type = types.port;
         default = 9000;
         description = ''
           HTTP port to bind on.

--- a/nixos/modules/services/security/cfssl.nix
+++ b/nixos/modules/services/security/cfssl.nix
@@ -154,14 +154,7 @@ in
 
     logLevel = lib.mkOption {
       default = 1;
-      type = lib.types.enum [
-        0
-        1
-        2
-        3
-        4
-        5
-      ];
+      type = lib.types.ints.between 0 5;
       description = "Log level (0 = DEBUG, 5 = FATAL).";
     };
 

--- a/nixos/modules/services/security/opensnitch.nix
+++ b/nixos/modules/services/security/opensnitch.nix
@@ -108,13 +108,7 @@ in
             };
 
             LogLevel = lib.mkOption {
-              type = lib.types.enum [
-                0
-                1
-                2
-                3
-                4
-              ];
+              type = lib.types.ints.between 0 4;
               description = ''
                 Default log level from 0 to 4 (debug, info, important, warning,
                 error).

--- a/nixos/modules/services/system/cachix-watch-store.nix
+++ b/nixos/modules/services/system/cachix-watch-store.nix
@@ -36,13 +36,13 @@ in
     };
 
     compressionLevel = lib.mkOption {
-      type = lib.types.nullOr lib.types.int;
+      type = lib.types.nullOr (lib.types.ints.between 0 16);
       description = "The compression level for ZSTD compression (between 0 and 16)";
       default = null;
     };
 
     jobs = lib.mkOption {
-      type = lib.types.nullOr lib.types.int;
+      type = lib.types.nullOr lib.types.ints.positive;
       description = "Number of threads used for pushing store paths";
       default = null;
     };

--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -704,14 +704,14 @@ in
       };
 
       maxClients = mkOption {
-        type = types.int;
+        type = types.ints.positive;
         default = 150;
         example = 8;
         description = "Maximum number of httpd processes (prefork)";
       };
 
       maxRequestsPerChild = mkOption {
-        type = types.int;
+        type = types.ints.unsigned;
         default = 0;
         example = 500;
         description = ''

--- a/nixos/modules/services/web-servers/stargazer.nix
+++ b/nixos/modules/services/web-servers/stargazer.nix
@@ -74,7 +74,7 @@ in
     };
 
     requestTimeout = lib.mkOption {
-      type = lib.types.int;
+      type = lib.types.ints.unsigned;
       default = 5;
       description = ''
         Number of seconds to wait for the client to send a complete
@@ -83,7 +83,7 @@ in
     };
 
     responseTimeout = lib.mkOption {
-      type = lib.types.int;
+      type = lib.types.ints.unsigned;
       default = 0;
       description = ''
         Number of seconds to wait for the client to send a complete

--- a/nixos/modules/services/x11/redshift.nix
+++ b/nixos/modules/services/x11/redshift.nix
@@ -51,7 +51,7 @@ in
 
     temperature = {
       day = mkOption {
-        type = types.int;
+        type = types.ints.between 1000 25000;
         default = 5500;
         description = ''
           Colour temperature to use during the day, between
@@ -59,7 +59,7 @@ in
         '';
       };
       night = mkOption {
-        type = types.int;
+        type = types.ints.between 1000 25000;
         default = 3700;
         description = ''
           Colour temperature to use at night, between


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Use some more restrictive types for a few different int settings.

For some options: UIDs/GIDs are u32, nice values range from -20 to 19

Note that I have not gone upstream and verified the description's claims about valid values for debug levels and similar.

Verified eval with `nix build .#htmlDocs.nixosManual.x86_64-linux`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
