### PR TITLE
vscode-extensions.reditorsupport.r-syntax: init at 0.1.3

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3971,6 +3971,8 @@ let
 
       reditorsupport.r = callPackage ./reditorsupport.r { };
 
+      reditorsupport.r-syntax = callPackage ./reditorsupport.r-syntax { };
+
       release-candidate.vscode-scheme-repl = callPackage ./release-candidate.vscode-scheme-repl { };
 
       reloadedextensions.reloaded-cpp = buildVscodeMarketplaceExtension {

--- a/pkgs/applications/editors/vscode/extensions/reditorsupport.r-syntax/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/reditorsupport.r-syntax/default.nix
@@ -1,0 +1,21 @@
+{ lib, vscode-utils }:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "r-syntax";
+    publisher = "REditorSupport";
+    version = "0.1.3";
+    hash = "sha256-grkfkmyERVUkB8kSH+NPd2Mv4WF/h/obw8ebmxPx5zU=";
+  };
+  meta = {
+    changelog = "https://marketplace.visualstudio.com/items/REditorSupport.r-syntax/changelog";
+    description = "R Synxtax Highlight for Visual Studio Code";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=REditorSupport.r-syntax";
+    homepage = "https://github.com/REditorSupport/vscode-R-syntax";
+    license = lib.licenses.mit;
+    maintainers = [
+      lib.maintainers.ivyfanchiang
+      lib.maintainers.pandapip1
+    ];
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/reditorsupport.r/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/reditorsupport.r/default.nix
@@ -35,6 +35,9 @@ vscode-utils.buildVscodeMarketplaceExtension {
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=REditorSupport.r";
     homepage = "https://github.com/REditorSupport/vscode-R";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.pandapip1 ];
+    maintainers = [
+      lib.maintainers.pandapip1
+      lib.maintainers.ivyfanchiang
+    ];
   };
 }


### PR DESCRIPTION
New VSCode extension for [R Syntax](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r-syntax), required to use the [R Extension](https://search.nixos.org/packages?channel=unstable&show=vscode-extensions.reditorsupport.r&query=reditor) maintained by @Pandapip1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
