### PR TITLE
vagrant: 2.4.8 -> 2.4.9

### DIFF
--- a/pkgs/by-name/cn/cnpypp/package.nix
+++ b/pkgs/by-name/cn/cnpypp/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  boost,
+  libzip,
+  range-v3,
+}:
+
+stdenv.mkDerivation {
+  pname = "cnpypp";
+  version = "0-unstable-2025-06-22";
+
+  src = fetchFromGitHub {
+    owner = "mreininghaus";
+    repo = "cnpypp";
+    rev = "c6cd4e2078e4f39e862720b66fb211c45577c510";
+    hash = "sha256-aV57931nis0W2cwCNeMjQDip9Au7K76VpC/BqACnT5M=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [
+    boost
+    libzip
+    range-v3
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CNPYPP_SPAN_IMPL" "BOOST")
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  checkPhase = ''
+    runHook preCheck
+
+    ./example1
+    ./example2
+    ./example_c
+    ./range_example
+    ./range_zip_example
+    ./npz_speedtest
+
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "C++17 library that allows to read and write NumPy data files";
+    homepage = "https://github.com/mreininghaus/cnpypp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jherland ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/va/vagrant/gemset.nix
+++ b/pkgs/by-name/va/vagrant/gemset.nix
@@ -24,10 +24,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1p2szbr4jdvmwaaj2kxlbv1rp0m6ycbgfyp0kjkkkswmniv5y21r";
+      sha256 = "06sfv80bmxfczkqi3pb3yc9zicqhf94adh5f8hpkn3bsqqd1vlgz";
       type = "gem";
     };
-    version = "3.2.2";
+    version = "3.2.3";
   };
   builder = {
     groups = [ "default" ];
@@ -119,10 +119,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1l1mn4g669lgmjzy0mz1vp38jqw7z6b5alvl7wmqv6wiyfh5f3qm";
+      sha256 = "1gj6h2r9ylkmz9wjlf6p04d3hw99qfnf0wb081lzjx3alk13ngfq";
       type = "gem";
     };
-    version = "1.2.8";
+    version = "1.3.0";
   };
   fake_ftp = {
     groups = [ "development" ];
@@ -175,10 +175,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0fgfzwhaiijccfks356i9rkix12w1hhsjdiri4vjgh5zr3dccl3h";
+      sha256 = "0c994vqf1vnjvvb4np9bckj5ycxi3svf7kh6z0011vr4a7pvarym";
       type = "gem";
     };
-    version = "1.74.0";
+    version = "1.75.0";
   };
   gssapi = {
     dependencies = [ "ffi" ];
@@ -262,10 +262,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0s5vklcy2fgdxa9c6da34jbfrqq7xs6mryjglqqb5iilshcg3q82";
+      sha256 = "0hj6yxpi710g1pfyg0aysahqv6dzz8y3l949q1y6kw79a7br92dh";
       type = "gem";
     };
-    version = "2.13.2";
+    version = "2.14.1";
   };
   jwt = {
     dependencies = [ "base64" ];
@@ -355,10 +355,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1baskvp6dkijrykbnnnwhvnkjg7jphslxzsl2flvnvkmmfqilzld";
+      sha256 = "0706xids054kgngsgnywajcwydxkhnlydvy3yb202j5c8hv7h3hb";
       type = "gem";
     };
-    version = "3.2025.0729";
+    version = "3.2025.0916";
   };
   multi_json = {
     groups = [ "default" ];
@@ -484,10 +484,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0gxbcjfgck9jd14mvmb4znc64xd67y680z880x6p44krkiabivgp";
+      sha256 = "0dcqwwlm8afr97mg1i633yia3hzd61f0j5csrspzsvf0mfp85qf4";
       type = "gem";
     };
-    version = "2.0.12";
+    version = "2.0.17";
   };
   ostruct = {
     groups = [ "default" ];
@@ -504,10 +504,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0da64fq3w671qhp7ji1zs84m5lyhalq4khqhbfw5dz0y6mn61dgg";
+      sha256 = "0cwy1br09dh5fklwf5xna7vabns8c1229kr2v0a0s6y2brz3zbrh";
       type = "gem";
     };
-    version = "3.1.16";
+    version = "3.2.1";
   };
   rake = {
     groups = [ "development" ];
@@ -567,10 +567,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1jmbf6lf7pcyacpb939xjjpn1f84c3nw83dy3p1lwjx0l2ljfif7";
+      sha256 = "0hninnbvqd2pn40h863lbrn9p11gvdxp928izkag5ysx8b1s5q0r";
       type = "gem";
     };
-    version = "3.4.1";
+    version = "3.4.4";
   };
   rspec = {
     dependencies = [
@@ -657,10 +657,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1xx3f4mgr84jz07fifd3r68hm6giqy91hqyzawmi0s59yqa1hjqq";
+      sha256 = "1cmgz34hwj5s3jwxhyl8mszs24nci12ffbrmr5jb1si74iqf739f";
       type = "gem";
     };
-    version = "3.13.4";
+    version = "3.13.6";
   };
   rubyntlm = {
     dependencies = [ "base64" ];
@@ -777,10 +777,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0270m29n7mq9yq4xnjzryzr6jxf292ahjn9fzywm2rg3rdz7cr59";
+      sha256 = "195r5qylwxwqbllnpli9c2pzin0lky6h3fw912h88g2lmri0j6hc";
       type = "gem";
     };
-    version = "1.1.8";
+    version = "1.1.9";
   };
   wdm = {
     groups = [ "default" ];

--- a/pkgs/by-name/va/vagrant/package.nix
+++ b/pkgs/by-name/va/vagrant/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchurl,
+  fetchFromGitHub,
   buildRubyGem,
   bundlerEnv,
   ruby_3_4,
@@ -16,9 +16,14 @@
 let
   # NOTE: bumping the version and updating the hash is insufficient;
   # you must use bundix to generate a new gemset.nix in the Vagrant source.
-  version = "2.4.8";
-  url = "https://github.com/hashicorp/vagrant/archive/v${version}.tar.gz";
-  hash = "sha256-AVagvZKbVT4RWrCJdskhABTunRM9tBb5+jovYM/VF+0=";
+  version = "2.4.9";
+
+  src = fetchFromGitHub {
+    owner = "hashicorp";
+    repo = "vagrant";
+    rev = "v${version}";
+    hash = "sha256-xlL0YLY5yG9Q2L93Ag1pO/F8LOp+JdcgrvWyw+bZP/I=";
+  };
 
   ruby = ruby_3_4;
 
@@ -34,8 +39,8 @@ let
       {
         vagrant = {
           source = {
-            type = "url";
-            inherit url hash;
+            type = "path";
+            path = src;
           };
           inherit version;
           dontCheckForBrokenSymlinks = true;
@@ -62,11 +67,10 @@ in
 buildRubyGem rec {
   name = "${gemName}-${version}";
   gemName = "vagrant";
-  inherit ruby version;
+  inherit ruby version src;
 
   doInstallCheck = true;
   dontBuild = false;
-  src = fetchurl { inherit url hash; };
 
   # Some reports indicate that some connection types, particularly
   # WinRM, suffer from "Digest initialization failed" errors. Adding

--- a/pkgs/development/python-modules/linearmodels/default.nix
+++ b/pkgs/development/python-modules/linearmodels/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  cython,
+  formulaic,
+  mypy-extensions,
+  numpy,
+  pandas,
+  pyhdfe,
+  pytestCheckHook,
+  scipy,
+  setuptools,
+  setuptools-scm,
+  statsmodels,
+}:
+
+buildPythonPackage rec {
+  pname = "linearmodels";
+  version = "6.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bashtage";
+    repo = "linearmodels";
+    tag = "v${version}";
+    hash = "sha256-oWVBsFSKnv/8AHYP5sxO6+u5+hsOw/uQlOetse5ue88=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+    cython
+  ];
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  dependencies = [
+    formulaic
+    mypy-extensions
+    numpy
+    pandas
+    pyhdfe
+    scipy
+    statsmodels
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "linearmodels" ];
+
+  meta = {
+    description = "Models for panel data, system regression, instrumental variables and asset pricing";
+    homepage = "https://bashtage.github.io/linearmodels/";
+    changelog = "https://github.com/bashtage/linearmodels/releases/tag/v${version}";
+    license = lib.licenses.ncsa;
+    maintainers = with lib.maintainers; [ jherland ];
+  };
+}

--- a/pkgs/development/python-modules/pyhdfe/default.nix
+++ b/pkgs/development/python-modules/pyhdfe/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  numpy,
+  pytestCheckHook,
+  scipy,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "pyhdfe";
+  version = "0.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jeffgortmaker";
+    repo = "pyhdfe";
+    tag = "v${version}";
+    hash = "sha256-UXVQHf4Nmq/zQZtPaLba4TShhpgPUBwPM+zCEa8qaKs=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    numpy
+    scipy
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pyhdfe" ];
+
+  meta = {
+    description = "Python 3 implementation of algorithms for absorbing high dimensional fixed effects";
+    homepage = "https://github.com/jeffgortmaker/pyhdfe";
+    changelog = "https://github.com/jeffgortmaker/pyhdfe/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jherland ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8440,6 +8440,8 @@ self: super: with self; {
 
   linear-operator = callPackage ../development/python-modules/linear-operator { };
 
+  linearmodels = callPackage ../development/python-modules/linearmodels { };
+
   lineax = callPackage ../development/python-modules/lineax { };
 
   linecache2 = callPackage ../development/python-modules/linecache2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13140,6 +13140,8 @@ self: super: with self; {
 
   pyhcl = callPackage ../development/python-modules/pyhcl { };
 
+  pyhdfe = callPackage ../development/python-modules/pyhdfe { };
+
   pyheck = callPackage ../development/python-modules/pyheck { };
 
   pyheos = callPackage ../development/python-modules/pyheos { };


### PR DESCRIPTION
Minimal changes to upgrade to vagrant 2.4.9 as 2.4.8 has compatibility issues with VirtualBox 7.2.x

Resolves https://github.com/NixOS/nixpkgs/issues/443778

## Things done

Updated gemset.nix with the new dependencies 
Updated the package.nix version and package hash


### Tests
- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
