### PR TITLE
taktuk: 3.7.7 -> 3.7.8

### DIFF
--- a/pkgs/by-name/ta/taktuk/package.nix
+++ b/pkgs/by-name/ta/taktuk/package.nix
@@ -7,8 +7,8 @@
   buildPackages,
 }:
 
-stdenv.mkDerivation {
-  version = "3.7.7";
+stdenv.mkDerivation (finalAttrs: {
+  version = "3.7.8";
   pname = "taktuk";
 
   nativeBuildInputs = [
@@ -22,8 +22,8 @@ stdenv.mkDerivation {
     domain = "gitlab.inria.fr";
     owner = "taktuk";
     repo = "taktuk";
-    rev = "dcd763e389a414f540b43674cbc63752176f1ce3"; # does not tag releases
-    hash = "sha256-CerOBn1VDiKFLaW2WXv6wLxfcqy1H3dlF70lrequbog=";
+    tag = "version-${finalAttrs.version}";
+    hash = "sha256-/Xr2Jl3WbL68ZunBpko7jLbgAbDkERnrtuJnS0m59qY=";
   };
 
   preBuild = ''
@@ -53,4 +53,4 @@ stdenv.mkDerivation {
     maintainers = [ lib.maintainers.bzizou ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
This update removes an annoying warning from an old feature of SVN: Removed the release information, irrelevant without SVN

https://gitlab.inria.fr/taktuk/taktuk/-/blob/master/ChangeLog?ref_type=heads

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
