### PR TITLE
witsy: init at 2.14.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26855,6 +26855,12 @@
     githubId = 33242106;
     name = "Uri Baghin";
   };
+  uri-zafrir = {
+    email = "urizaf@gmail.com";
+    github = "uri-zafrir";
+    githubId = 35652384;
+    name = "Uri Zafrir";
+  };
   urlordjames = {
     email = "urlordjames@gmail.com";
     github = "urlordjames";

--- a/pkgs/by-name/wi/witsy/package.nix
+++ b/pkgs/by-name/wi/witsy/package.nix
@@ -1,0 +1,117 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  electron,
+  copyDesktopItems,
+  makeDesktopItem,
+  makeWrapper,
+  moreutils,
+  nodejs,
+  nodePackages,
+  jq,
+}:
+
+buildNpmPackage rec {
+  pname = "witsy";
+  version = "2.14.0";
+
+  src = fetchFromGitHub {
+    owner = "nbonamy";
+    repo = "witsy";
+    tag = "v${version}";
+    hash = "sha256-YW07wBx5Ybf+87gTY6QhxuK772kNo64qqED9RCPa/uw=";
+  };
+
+  npmDepsHash = "sha256-9r66P6T1heLV+eJN2TvXQYwcUeKkLkipqf45LiBOdKQ=";
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    nodejs
+  ];
+
+  forceGitDeps = true;
+
+  makeCacheWritable = true;
+
+  npmFlags = [ "--ignore-scripts" ];
+
+  postPatch = ''
+    # Remove the problematic Git dependency @vue/test-utils which has install scripts requiring rollup
+    # This is a dev dependency used for testing and not needed for the build
+    ${lib.getExe jq} 'del(.devDependencies."@vue/test-utils")' package.json | ${lib.getExe' moreutils "sponge"} package.json
+    ${lib.getExe jq} '
+      del(.devDependencies."@vue/test-utils") |
+      walk(
+        if type == "object" and has("packages") then
+          .packages |= with_entries(select(.key | contains("@vue/test-utils") | not))
+        else .
+        end
+      )
+    ' package-lock.json | ${lib.getExe' moreutils "sponge"} package-lock.json
+
+    # Remove @electron-forge/publisher-github to avoid network requests during build
+    ${lib.getExe jq} 'del(.devDependencies."@electron-forge/publisher-github")' package.json | ${lib.getExe' moreutils "sponge"} package.json
+    ${lib.getExe jq} '
+      walk(
+        if type == "object" and has("packages") then
+          .packages |= with_entries(select(.key | contains("@electron-forge/publisher-github") | not))
+        else .
+        end
+      )
+    ' package-lock.json | ${lib.getExe' moreutils "sponge"} package-lock.json
+
+    # no need to patch this, will be removed, but error still persists
+    # substituteInPlace package.json \
+    #   --replace-fail '    "@electron-forge/publisher-github": "^7.4.0",' ""
+  '';
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+  env.electronDist = electron.dist;
+
+  preConfigure = ''
+    export npm_config_offline="false"
+    export npm_config_ignore_scripts="true"
+  '';
+
+  npmBuildScript = "package";
+
+  npmConfigCache = "/tmp/npm-cache";
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "witsy";
+      exec = "witsy %U";
+      icon = "witsy";
+      desktopName = "Witsy";
+      genericName = "LLM Chat App";
+      comment = "Interact with LLMs";
+      categories = [ "Utility" ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/witsy $out/share/applications
+
+    # Copy the built app
+    cp -r out/Witsy-linux-x64/resources/app $out/share/witsy/
+
+    # Wrap electron
+    makeWrapper ${electron}/bin/electron $out/bin/witsy \
+      --add-flags $out/share/witsy \
+      --set ELECTRON_IS_PACKAGED 1
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "An app to interact with LLMs";
+    homepage = "https://github.com/nbonamy/witsy";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ uri-zafrir ];
+    platforms = electron.meta.platforms;
+    mainProgram = "witsy";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I tried to add the Witsy package.
https://github.com/nbonamy/witsy

this is my first PR to this repo.
It's not that beautiful code,
and I got stuck, but it might be better than nothing.
If someone could review it and help that would be awesome as I'd love to run it.

this is the error i got:

```

An unhandled rejection has occurred inside Forge:
RequestError: getaddrinfo EAI_AGAIN github.com
at ClientRequest.<anonymous> (/build/source/node_modules/got/dist/source/core/index.js:970:111)
    at Object.onceWrapper (node:events:634:26)
    at ClientRequest.emit (node:events:531:35)
    at ClientRequest.emit (node:domain:489:12)
    at ClientRequest.origin.emit (/build/source/node_modules/@szmarczak/http-timer/dist/source/index.js:43:20)
    at emitErrorEvent (node:_http_client:105:11)
    at TLSSocket.socketErrorListener (node:_http_client:518:5)
    at TLSSocket.emit (node:events:519:28)
    at TLSSocket.emit (node:domain:489:12)
    at emitErrorNT (node:internal/streams/destroy:170:8)
    at emitErrorCloseNT (node:internal/streams/destroy:129:3)
    at processTicksAndRejections (node:internal/process/task_queues:90:21)
    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:122:26)

ERROR: `npm build` failed

Here are a few things you can try, depending on the error:
1. Make sure your build script (package) exists
  If there is none, set `dontNpmBuild = true`.
2. If the error being thrown is something similar to "error:0308010C:digital envelope routines::unsupported", add `NODE_OPTIONS = "--openssl-legacy-provider"` to your derivation
  See https://github.com/webpack/webpack/issues/14532 for more information.

error: builder for '/nix/store/gx7i30vy7kv2m2ym33ll1n71jp9c3j19-witsy-2.14.0.drv' failed with exit code 1;
       last 25 log lines:
       > 
       > An unhandled rejection has occurred inside Forge:
       > RequestError: getaddrinfo EAI_AGAIN github.com
       > at ClientRequest.<anonymous> (/build/source/node_modules/got/dist/source/core/index.js:970:111)
       >     at Object.onceWrapper (node:events:634:26)
       >     at ClientRequest.emit (node:events:531:35)
       >     at ClientRequest.emit (node:domain:489:12)
       >     at ClientRequest.origin.emit (/build/source/node_modules/@szmarczak/http-timer/dist/source/index.js:43:20)
       >     at emitErrorEvent (node:_http_client:105:11)
       >     at TLSSocket.socketErrorListener (node:_http_client:518:5)
       >     at TLSSocket.emit (node:events:519:28)
       >     at TLSSocket.emit (node:domain:489:12)
       >     at emitErrorNT (node:internal/streams/destroy:170:8)
       >     at emitErrorCloseNT (node:internal/streams/destroy:129:3)
       >     at processTicksAndRejections (node:internal/process/task_queues:90:21)
       >     at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:122:26)
       > 
       > ERROR: `npm build` failed
       >
       > Here are a few things you can try, depending on the error:
       > 1. Make sure your build script (package) exists
       >   If there is none, set `dontNpmBuild = true`.
       > 2. If the error being thrown is something similar to "error:0308010C:digital envelope routines::unsupported", add `NODE_OPTIONS = "--openssl-legacy-provider"` to your derivation
       >   See https://github.com/webpack/webpack/issues/14532 for more information.
       >
       For full logs, run:
         nix log /nix/store/gx7i30vy7kv2m2ym33ll1n71jp9c3j19-witsy-2.14.0.drv

```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
 none
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
