### PR TITLE
nixos/lldap: use systemd's LoadCredential for secrets

### DIFF
--- a/nixos/tests/lldap.nix
+++ b/nixos/tests/lldap.nix
@@ -1,6 +1,7 @@
 { ... }:
 let
   adminPassword = "mySecretPassword";
+  credentialPassword = "myCredentialPassword";
 in
 {
   name = "lldap";
@@ -40,6 +41,37 @@ in
               force_ldap_user_pass_reset = false;
             };
           };
+
+        credentialBasedPassword.configuration =
+          { ... }:
+          {
+            services.lldap = {
+              credentials.LLDAP_LDAP_USER_PASS_FILE = toString (
+                pkgs.writeText "credentialPasswordFile" credentialPassword
+              );
+              settings = {
+                ldap_user_pass = lib.mkForce null;
+                force_ldap_user_pass_reset = "always";
+              };
+            };
+          };
+
+        credentialWithJwtSecret.configuration =
+          { ... }:
+          {
+            services.lldap = {
+              credentials = {
+                LLDAP_LDAP_USER_PASS_FILE = toString (pkgs.writeText "credentialPasswordFile" credentialPassword);
+                LLDAP_JWT_SECRET_FILE = toString (
+                  pkgs.writeText "jwtSecretFile" "my-super-secret-jwt-key-for-testing"
+                );
+              };
+              settings = {
+                ldap_user_pass = lib.mkForce null;
+                force_ldap_user_pass_reset = "always";
+              };
+            };
+          };
       };
     };
 
@@ -56,6 +88,7 @@ in
       machine.succeed("curl --location --fail http://localhost:17170/")
 
       adminPassword="${adminPassword}"
+      credentialPassword="${credentialPassword}"
 
       def try_login(user, password, expect_success=True):
           cmd = f'ldapsearch -H ldap://localhost:3890 -D uid={user},ou=people,dc=example,dc=com -b "ou=people,dc=example,dc=com" -w {password}'
@@ -74,14 +107,26 @@ in
           try_login("admin", "password",    expect_success=True)
           try_login("admin", adminPassword, expect_success=False)
 
-      with subtest("different admin password"):
+      with subtest("different admin password with file setting"):
           machine.succeed('${specializations}/differentAdminPassword/bin/switch-to-configuration test')
           try_login("admin", "password",    expect_success=False)
           try_login("admin", adminPassword, expect_success=True)
 
       with subtest("change admin password has no effect"):
-          machine.succeed('${specializations}/differentAdminPassword/bin/switch-to-configuration test')
+          machine.succeed('${specializations}/changeAdminPassword/bin/switch-to-configuration test')
           try_login("admin", "password",    expect_success=False)
           try_login("admin", adminPassword, expect_success=True)
+
+      with subtest("credential based password"):
+          machine.succeed('${specializations}/credentialBasedPassword/bin/switch-to-configuration test')
+          try_login("admin", "password",         expect_success=False)
+          try_login("admin", adminPassword,      expect_success=False)
+          try_login("admin", credentialPassword, expect_success=True)
+
+      with subtest("credential with jwt secret"):
+          machine.succeed('${specializations}/credentialWithJwtSecret/bin/switch-to-configuration test')
+          try_login("admin", "password",         expect_success=False)
+          try_login("admin", adminPassword,      expect_success=False)
+          try_login("admin", credentialPassword, expect_success=True)
     '';
 }


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/pull/442324
Closes https://github.com/NixOS/nixpkgs/pull/287873
Fixes https://github.com/NixOS/nixpkgs/issues/438857

I decided to deprecate the config options as I don't think it's such a good idea to have that many ways to do the same thing.

I need to test things myself a bit more, but let me know what you think.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
