### PR TITLE
expliot: 0.9.8 -> 0.11.1 + clean

### DIFF
--- a/pkgs/by-name/ex/expliot/package.nix
+++ b/pkgs/by-name/ex/expliot/package.nix
@@ -1,79 +1,52 @@
 {
   lib,
-  fetchFromGitHub,
   fetchFromGitLab,
   python3,
 }:
-let
-  py = python3.override {
-    self = py;
-    packageOverrides = self: super: {
-
-      cmd2 = super.cmd2.overridePythonAttrs (oldAttrs: rec {
-        version = "1.5.0";
-        src = oldAttrs.src.override {
-          inherit version;
-          hash = "sha256-cBqMmXXEq8ReXROQarFJ+Vn4EoaRBjRzI6P4msDoKmI=";
-        };
-        dependencies = oldAttrs.dependencies ++ [
-          python3.pkgs.attrs
-          python3.pkgs.colorama
-        ];
-        doCheck = false;
-      });
-
-      paho-mqtt = super.paho-mqtt.overridePythonAttrs (oldAttrs: rec {
-        version = "1.6.1";
-        src = fetchFromGitHub {
-          inherit (oldAttrs.src) owner repo;
-          tag = "v${version}";
-          hash = "sha256-9nH6xROVpmI+iTKXfwv2Ar1PAmWbEunI3HO0pZyK6Rg=";
-        };
-        build-system = with self; [ setuptools ];
-        doCheck = false;
-      });
-    };
-  };
-in
-with py.pkgs;
-
+with python3.pkgs;
 buildPythonApplication rec {
   pname = "expliot";
-  version = "0.9.8";
+  version = "0.11.1";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "expliot_framework";
     repo = "expliot";
     tag = version;
-    hash = "sha256-7Cuj3YKKwDxP2KKueJR9ZO5Bduv+lw0Y87Rw4b0jbGY=";
+    hash = "sha256-aFJVT5vE9YKirZEINKFzYWDffoVgluoUyvMmOifLq1M=";
   };
 
-  pythonRelaxDeps = [
-    "pymodbus"
-    "pynetdicom"
-    "cryptography"
-    "python-can"
-    "pyparsing"
-    "zeroconf"
+  build-system = [
+    poetry-core
   ];
 
-  build-system = [ setuptools ];
+  pythonRelaxDeps = [
+    "cryptography"
+    "paho-mqtt"
+    "pynetdicom"
+    "setuptools"
+    "xmltodict"
+    "zeroconf"
+  ];
 
   dependencies = [
     aiocoap
     awsiotpythonsdk
     bluepy
-    python-can
     cmd2
     cryptography
+    distro
+    jsonschema
     paho-mqtt
     pyi2cflash
     pymodbus
     pynetdicom
     pyparsing
-    pyserial
     pyspiflash
+    python-can
+    python-magic
+    pyudev
+    setuptools
     upnpy
     xmltodict
     zeroconf
@@ -84,7 +57,7 @@ buildPythonApplication rec {
 
   pythonImportsCheck = [ "expliot" ];
 
-  meta = with lib; {
+  meta = {
     description = "IoT security testing and exploitation framework";
     longDescription = ''
       EXPLIoT is a Framework for security testing and exploiting IoT
@@ -95,8 +68,8 @@ buildPythonApplication rec {
       purpose of the framework i.e. IoT exploitation.
     '';
     homepage = "https://expliot.readthedocs.io/";
-    license = licenses.agpl3Plus;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "expliot";
   };
 }


### PR DESCRIPTION
I saw this was broken in #445150, so here is a simple update

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
