### PR TITLE
python3Packages.ldapdomaindump: add pycryptodome runtime dep (fix NTLM on py3.13)

### DIFF
--- a/pkgs/development/python-modules/ldapdomaindump/default.nix
+++ b/pkgs/development/python-modules/ldapdomaindump/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   dnspython,
   ldap3,
+  pycryptodome,
   setuptools,
 }:
 
@@ -24,6 +25,7 @@ buildPythonPackage rec {
   dependencies = [
     dnspython
     ldap3
+    pycryptodome
   ];
 
   # Tests require LDAP server


### PR DESCRIPTION
Fix missing Crypto Module


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

#### Motivation
`ldapdomaindump` fails on Python 3.13 with:

 ```ValueError: unsupported hash type MD4```

because `ldap3` relies on MD4. Since Python 3.13, MD4 is no longer in `hashlib`.  
Instead, `ldap3` expects `Crypto.Hash.MD4`, which is provided by `pycryptodome`.

#### Changes

- Added `pycryptodome` as a runtime dependency.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
