### PR TITLE
_1password-gui: 8.11.8 -> 8.11.10

### DIFF
--- a/pkgs/by-name/_1/_1password-gui/sources.json
+++ b/pkgs/by-name/_1/_1password-gui/sources.json
@@ -1,28 +1,28 @@
 {
   "stable": {
     "linux": {
-      "version": "8.11.8",
+      "version": "8.11.10",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.11.8.x64.tar.gz",
-          "hash": "sha256-gidi2lnKFxcSxi6lekWODp9TJNGofWFp72Bp30KoRfY="
+          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.11.10.x64.tar.gz",
+          "hash": "sha256-AKqr1jMTFXPYYYJu8wD9P+xXwxobSbpjXwmBQhWYVhg="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.11.8.arm64.tar.gz",
-          "hash": "sha256-pZqhWd2K+5+B3eK52OZNSPh3Jx4MKBy+hAnC5tihzhM="
+          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.11.10.arm64.tar.gz",
+          "hash": "sha256-Xz66LYXgX64P9TTmI8D8Wtrz7qKTBrZx+rP26yJqcTw="
         }
       }
     },
     "darwin": {
-      "version": "8.11.8",
+      "version": "8.11.10",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.11.8-x86_64.zip",
-          "hash": "sha256-MYyWof17KLVRtnPqSICnny24f8YoXJWeGwErWFrb6C4="
+          "url": "https://downloads.1password.com/mac/1Password-8.11.10-x86_64.zip",
+          "hash": "sha256-sQK+qHdGvpIi+h2az8PYq6kROmiaGKBbNGFGXJSe1eg="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.11.8-aarch64.zip",
-          "hash": "sha256-wii983COooBCXyiV2a2MC7SKnFJLp1JashsOzT3+ZRA="
+          "url": "https://downloads.1password.com/mac/1Password-8.11.10-aarch64.zip",
+          "hash": "sha256-Hb+DEGM7ymDuf71uKTy8L/9bUWZ2+QD+w7h2tNvp0Pk="
         }
       }
     }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
