### PR TITLE
rustnet: init at 1.2.0

### DIFF
--- a/pkgs/by-name/ru/rustnet/package.nix
+++ b/pkgs/by-name/ru/rustnet/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  pkg-config,
+  versionCheckHook,
+  elfutils,
+  zlib,
+  libbpf,
+  libpcap,
+  clangStdenv,
+}:
+let
+  pname = "rustnet";
+  version = "1.2.0";
+in
+rustPlatform.buildRustPackage.override { stdenv = clangStdenv; } {
+  inherit pname version;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "domcyrus";
+    repo = "rustnet";
+    tag = "v${version}";
+    hash = "sha256-ZTCcPTKlKnUNlD4Ayf5dV7Yi2BuKwJ/0IwO3YqlB6u8=";
+  };
+
+  cargoHash = "sha256-5Zgo6Ypyrhy5IHC1IiWxgP4aOOdyBNEBBHWi0rsDji0=";
+
+  nativeBuildInputs = [
+    pkg-config
+    versionCheckHook
+  ];
+
+  buildInputs = [
+    elfutils
+    libbpf
+    libpcap
+    zlib
+  ];
+
+  # Required for libbpf-sys to build correctly
+  hardeningDisable = [
+    "zerocallusedregs"
+  ];
+
+  # Set environment variables for libbpf-sys
+  env = {
+    LIBBPF_SYS_LIBRARY_PATH = "${libbpf}/lib";
+    LIBBPF_SYS_INCLUDE_PATH = "${libbpf}/include";
+  };
+
+  checkFlags = [
+    "--skip=network::platform::linux::interface_stats::tests::test_get_all_stats"
+    "--skip=network::platform::linux::interface_stats::tests::test_list_interfaces"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "High-performance, cross-platform network monitoring terminal UI tool built with Rust";
+    homepage = "https://github.com/domcyrus/rustnet";
+    changelog = "https://github.com/domcyrus/rustnet/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ dvaerum ];
+    mainProgram = "rustnet";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I want to add this new package name: rustnet

~~The version is currently v0.8.0, I know that v0.9.0 is already out but includes the use of rust `libbpf-sys` and I have not been about to figure out what is required/what should be done to make the packaging work (with version v0.9.0).~~

I found out how to package v0.14.0 with Nix 😁

I can also see that someone else tried to add the package but closed the request again: https://github.com/NixOS/nixpkgs/pull/443178

**Update:**

- bumped to v0.15.0
- bumped to v0.17.0
- bumped to v0.18.0
- bumped to v1.2.0


**Description:**

RustNet provides real-time visibility into network connections with detailed state information, connection lifecycle management, deep packet inspection, and a terminal user interface.

https://github.com/domcyrus/rustnet


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
