### PR TITLE
nixos/murmur: Use lib.types.path where possible

### DIFF
--- a/nixos/modules/services/networking/murmur.nix
+++ b/nixos/modules/services/networking/murmur.nix
@@ -41,9 +41,9 @@ let
     ${lib.optionalString (cfg.registerHostname != "") "registerHostname=${cfg.registerHostname}"}
 
     certrequired=${lib.boolToString cfg.clientCertRequired}
-    ${lib.optionalString (cfg.sslCert != "") "sslCert=${cfg.sslCert}"}
-    ${lib.optionalString (cfg.sslKey != "") "sslKey=${cfg.sslKey}"}
-    ${lib.optionalString (cfg.sslCa != "") "sslCA=${cfg.sslCa}"}
+    ${lib.optionalString (cfg.sslCert != null) "sslCert=${cfg.sslCert}"}
+    ${lib.optionalString (cfg.sslKey != null) "sslKey=${cfg.sslKey}"}
+    ${lib.optionalString (cfg.sslCa != null) "sslCA=${cfg.sslCa}"}
 
     ${lib.optionalString (cfg.dbus != null) "dbus=${cfg.dbus}"}
 
@@ -238,20 +238,20 @@ in
       clientCertRequired = lib.mkEnableOption "requiring clients to authenticate via certificates";
 
       sslCert = lib.mkOption {
-        type = lib.types.str;
-        default = "";
+        type = lib.types.nullOr lib.types.path;
+        default = null;
         description = "Path to your SSL certificate.";
       };
 
       sslKey = lib.mkOption {
-        type = lib.types.str;
-        default = "";
+        type = lib.types.nullOr lib.types.path;
+        default = null;
         description = "Path to your SSL key.";
       };
 
       sslCa = lib.mkOption {
-        type = lib.types.str;
-        default = "";
+        type = lib.types.nullOr lib.types.path;
+        default = null;
         description = "Path to your SSL CA certificate.";
       };
 
@@ -418,13 +418,13 @@ in
     + lib.optionalString cfg.logToFile ''
       rw /var/log/murmur/murmurd.log,
     ''
-    + lib.optionalString (cfg.sslCert != "") ''
+    + lib.optionalString (cfg.sslCert != null) ''
       r ${cfg.sslCert},
     ''
-    + lib.optionalString (cfg.sslKey != "") ''
+    + lib.optionalString (cfg.sslKey != null) ''
       r ${cfg.sslKey},
     ''
-    + lib.optionalString (cfg.sslCa != "") ''
+    + lib.optionalString (cfg.sslCa != null) ''
       r ${cfg.sslCa},
     ''
     + lib.optionalString (cfg.dbus != null) ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
