### PR TITLE
bcache-tools: fix cross compilation

### DIFF
--- a/pkgs/by-name/bc/bcache-tools/package.nix
+++ b/pkgs/by-name/bc/bcache-tools/package.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
         -e "/INSTALL.*initcpio\/install/d" \
         -e "/INSTALL.*dracut\/module-setup.sh/d" \
         -e "/INSTALL.*probe-bcache/d" \
+        -e "s/pkg-config/$PKG_CONFIG/" \
         -i Makefile
     # * Remove probe-bcache which is handled by util-linux
     sed -e "/probe-bcache/d" \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes the following error:
```
Using udevCheckHook
Running phase: unpackPhase
unpacking source archive /nix/store/92cshp04yrhij8ydqvh29h17i122x9ih-bcache-tools
source root is bcache-tools
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
build flags: SHELL=/nix/store/q7sqwn7i6w2b67adw0bmix29pxg85x3w-bash-5.3p3/bin/bash PREFIX= DESTDIR=\$\(out\)
riscv64-unknown-linux-gnu-gcc -O2 -Wall -g `pkg-config --cflags uuid blkid smartcols`   -c -o make.o make.c
/nix/store/q7sqwn7i6w2b67adw0bmix29pxg85x3w-bash-5.3p3/bin/bash: line 1: pkg-config: command not found
riscv64-unknown-linux-gnu-gcc -O2 -Wall -g `pkg-config --cflags uuid blkid smartcols`   -c -o crc64.o crc64.c
/nix/store/q7sqwn7i6w2b67adw0bmix29pxg85x3w-bash-5.3p3/bin/bash: line 1: pkg-config: command not found
riscv64-unknown-linux-gnu-gcc -O2 -Wall -g `pkg-config --cflags uuid blkid smartcols`   -c -o lib.o lib.c
/nix/store/q7sqwn7i6w2b67adw0bmix29pxg85x3w-bash-5.3p3/bin/bash: line 1: pkg-config: command not found
lib.c:5:10: fatal error: blkid.h: No such file or directory
    5 | #include <blkid.h>
      |          ^~~~~~~~~
compilation terminated.
make: *** [<builtin>: lib.o] Error 1
```
Broken in https://github.com/NixOS/nixpkgs/pull/441847

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux (pkgs.bcache-tools)
  - [X] x86_64-linux (pkgsCross.riscv64.bcache-tools)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
