### PR TITLE
cminpack: 1.3.8 -> 1.3.11

### DIFF
--- a/pkgs/by-name/cm/cminpack/package.nix
+++ b/pkgs/by-name/cm/cminpack/package.nix
@@ -3,20 +3,26 @@
   stdenv,
   cmake,
   fetchFromGitHub,
-  withBlas ? true,
+  withBlas ? false,
   blas,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
   pname = "cminpack";
-  version = "1.3.8";
+  version = "1.3.11";
 
   src = fetchFromGitHub {
     owner = "devernay";
     repo = "cminpack";
     rev = "v${version}";
-    hash = "sha256-eFJ43cHbSbWld+gPpMaNiBy1X5TIcN9aVxjh8PxvVDU=";
+    hash = "sha256-GF9HiITX/XV8hXrp5lJw2XM0Zyb/CBkMZkRFBbQj03A=";
   };
+
+  postPatch = ''
+    substituteInPlace cmake/cminpack.pc.in \
+      --replace-fail ''\'''${prefix}/' ""
+  '';
 
   strictDeps = true;
 
@@ -32,6 +38,10 @@ stdenv.mkDerivation rec {
     "-DUSE_BLAS=${if withBlas then "ON" else "OFF"}"
     "-DBUILD_SHARED_LIBS=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
   ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Software for solving nonlinear equations and nonlinear least squares problems";


### PR DESCRIPTION
Update cminpack to 1.3.11.
* BLAS is disabled by default as upstream also disabled BLAS by default in 1.3.10

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin