### PR TITLE
qmake2cmake: 1.0.6 -> 1.0.7

### DIFF
--- a/pkgs/tools/misc/qmake2cmake/default.nix
+++ b/pkgs/tools/misc/qmake2cmake/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "qmake2cmake";
-  version = "1.0.6";
+  version = "1.0.7";
   format = "setuptools";
 
   src = fetchgit {
     url = "https://codereview.qt-project.org/qt/qmake2cmake";
-    rev = "v${version}";
-    hash = "sha256-M5XVQ8MXo2Yxg5eZCho2YAGFtB0h++mEAg8NcQVuP/w=";
+    tag = "v${version}";
+    hash = "sha256-Y1HU4bNZY0b1C8HIX43AR24zoIyTEgkVXpnweEBlOYk=";
   };
 
   patches = [

--- a/pkgs/tools/misc/qmake2cmake/default.nix
+++ b/pkgs/tools/misc/qmake2cmake/default.nix
@@ -6,14 +6,16 @@
   platformdirs,
   portalocker,
   pyparsing,
+  setuptools,
   sympy,
   pytestCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
   pname = "qmake2cmake";
   version = "1.0.7";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchgit {
     url = "https://codereview.qt-project.org/qt/qmake2cmake";
@@ -25,7 +27,9 @@ buildPythonPackage rec {
     ./fix-locations.patch
   ];
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     packaging
     platformdirs
     portalocker
@@ -35,16 +39,13 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+    writableTmpDirAsHomeHook
   ];
 
-  preCheck = ''
-    export HOME=$(mktemp -d)
-  '';
-
-  meta = with lib; {
+  meta = {
     description = "Tool to convert qmake .pro files to CMakeLists.txt";
     homepage = "https://wiki.qt.io/Qmake2cmake";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ wegank ];
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ wegank ];
   };
 }


### PR DESCRIPTION
https://codereview.qt-project.org/q/project:qt/qmake2cmake

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
