### PR TITLE
various: lib usage improvements

### DIFF
--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -3,7 +3,7 @@
 let
   commonH = hashTypes: rec {
     hashNames = [ "hash" ] ++ hashTypes;
-    hashSet = lib.genAttrs hashNames (lib.const { });
+    hashSet = lib.genAttrs hashNames (_: { });
   };
 
   fakeH = {

--- a/lib/strings-with-deps.nix
+++ b/lib/strings-with-deps.nix
@@ -46,7 +46,6 @@ let
     concatStringsSep
     head
     isAttrs
-    listToAttrs
     tail
     ;
 in
@@ -152,15 +151,7 @@ rec {
           else if done ? ${entry} then
             f done (tail todo)
           else
-            f (
-              done
-              // listToAttrs [
-                {
-                  name = entry;
-                  value = 1;
-                }
-              ]
-            ) ([ predefined.${entry} ] ++ tail todo);
+            f (done // { ${entry} = 1; }) ([ predefined.${entry} ] ++ tail todo);
     in
     (f { } arg).result;
 

--- a/maintainers/scripts/find-tarballs.nix
+++ b/maintainers/scripts/find-tarballs.nix
@@ -10,6 +10,7 @@ let
     addErrorContext
     attrNames
     concatLists
+    concatMap
     const
     filter
     genericClosure
@@ -56,7 +57,7 @@ let
     else if isDerivation x then
       optional (canEval x.drvPath) x
     else if isList x then
-      concatLists (map derivationsIn' x)
+      concatMap derivationsIn' x
     else if isAttrs x then
       concatLists (
         mapAttrsToList (n: v: addErrorContext "while finding tarballs in '${n}':" (derivationsIn' v)) x
@@ -95,7 +96,7 @@ let
     else if isDerivation x then
       optional (canEval x.drvPath) x
     else if isList x then
-      concatLists (map derivationsIn x)
+      concatMap derivationsIn x
     else
       [ ];
 

--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -12,7 +12,7 @@ let
   ]
   ++ lib.pipe config.i18n.extraLocaleSettings [
     # See description of extraLocaleSettings for why is this ignored here.
-    (lib.filterAttrs (n: v: n != "LANGUAGE"))
+    (x: lib.removeAttrs x [ "LANGUAGE" ])
     (lib.mapAttrs (n: v: (sanitizeUTF8Capitalization v)))
     (lib.mapAttrsToList (LCRole: lang: lang + "/" + (config.i18n.localeCharsets.${LCRole} or "UTF-8")))
   ]

--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -30,12 +30,12 @@ in
       glibcLocales = lib.mkOption {
         type = lib.types.path;
         default = pkgs.glibcLocales.override {
-          allLocales = lib.any (x: x == "all") config.i18n.supportedLocales;
+          allLocales = lib.elem "all" config.i18n.supportedLocales;
           locales = config.i18n.supportedLocales;
         };
         defaultText = lib.literalExpression ''
           pkgs.glibcLocales.override {
-            allLocales = lib.any (x: x == "all") config.i18n.supportedLocales;
+            allLocales = lib.elem "all" config.i18n.supportedLocales;
             locales = config.i18n.supportedLocales;
           }
         '';

--- a/nixos/modules/config/nix-flakes.nix
+++ b/nixos/modules/config/nix-flakes.nix
@@ -8,12 +8,12 @@
 { config, lib, ... }:
 let
   inherit (lib)
-    filterAttrs
     literalExpression
     mapAttrsToList
     mkDefault
     mkIf
     mkOption
+    removeAttrs
     types
     ;
 
@@ -98,7 +98,11 @@ in
                       type = "path";
                       path = config.flake.outPath;
                     }
-                    // filterAttrs (n: _: n == "lastModified" || n == "rev" || n == "narHash") config.flake
+                    // removeAttrs config.flake [
+                      "lastModified"
+                      "rev"
+                      "narHash"
+                    ]
                   )
                 );
               };

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -25,7 +25,6 @@ let
     hasAttr
     id
     length
-    listToAttrs
     literalExpression
     mapAttrs'
     mapAttrsToList
@@ -584,14 +583,9 @@ let
         let
           id = toString (getAttr idAttr (getAttr name set));
           exists = hasAttr id acc;
-          newAcc =
-            acc
-            // (listToAttrs [
-              {
-                name = id;
-                value = true;
-              }
-            ]);
+          newAcc = acc // {
+            ${id} = true;
+          };
         in
         if dup then
           args

--- a/nixos/modules/i18n/input-method/ibus.nix
+++ b/nixos/modules/i18n/input-method/ibus.nix
@@ -45,7 +45,7 @@ in
         example = lib.literalExpression "with pkgs.ibus-engines; [ mozc hangul ]";
         description =
           let
-            enginesDrv = lib.filterAttrs (lib.const lib.isDerivation) pkgs.ibus-engines;
+            enginesDrv = lib.filterAttrs (_: lib.isDerivation) pkgs.ibus-engines;
             engines = lib.concatStringsSep ", " (map (name: "`${name}`") (lib.attrNames enginesDrv));
           in
           "Enabled IBus engines. Available engines are: ${engines}.";

--- a/nixos/modules/programs/neovim.nix
+++ b/nixos/modules/programs/neovim.nix
@@ -167,19 +167,15 @@ in
     # from other packages will be used by neovim.
     environment.pathsToLink = [ "/share/nvim" ];
 
-    environment.etc = builtins.listToAttrs (
-      builtins.attrValues (
-        builtins.mapAttrs (name: value: {
-          name = "xdg/nvim/${name}";
-          value = builtins.removeAttrs (
-            value
-            // {
-              target = "xdg/nvim/${value.target}";
-            }
-          ) (lib.optionals (builtins.isNull value.source) [ "source" ]);
-        }) cfg.runtime
-      )
-    );
+    environment.etc = lib.mapAttrs' (name: value: {
+      name = "xdg/nvim/${name}";
+      value = lib.removeAttrs (
+        value
+        // {
+          target = "xdg/nvim/${value.target}";
+        }
+      ) (lib.optionals (builtins.isNull value.source) [ "source" ]);
+    }) cfg.runtime;
 
     programs.neovim.finalPackage = pkgs.wrapNeovim cfg.package {
       inherit (cfg)

--- a/nixos/modules/services/audio/mpdscribble.nix
+++ b/nixos/modules/services/audio/mpdscribble.nix
@@ -130,7 +130,7 @@ in
     passwordFile = lib.mkOption {
       default =
         if localMpd then
-          (lib.findFirst (c: lib.any (x: x == "read") c.permissions) {
+          (lib.findFirst (c: lib.elem "read" c.permissions) {
             passwordFile = null;
           } mpdCfg.credentials).passwordFile
         else

--- a/nixos/modules/services/backup/sanoid.nix
+++ b/nixos/modules/services/backup/sanoid.nix
@@ -250,7 +250,7 @@ in
   config = lib.mkIf cfg.enable {
     services.sanoid.settings = lib.mkMerge [
       (lib.mapAttrs' (d: v: lib.nameValuePair ("template_" + d) v) cfg.templates)
-      (lib.mapAttrs (d: v: v) cfg.datasets)
+      cfg.datasets
     ];
 
     systemd.services.sanoid = {

--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -108,9 +108,7 @@ let
       };
     };
 
-  taints = concatMapStringsSep "," (v: "${v.key}=${v.value}:${v.effect}") (
-    mapAttrsToList (n: v: v) cfg.taints
-  );
+  taints = concatMapStringsSep "," (v: "${v.key}=${v.value}:${v.effect}") (attrValues cfg.taints);
 in
 {
   imports = [

--- a/nixos/modules/services/databases/cassandra.nix
+++ b/nixos/modules/services/databases/cassandra.nix
@@ -7,6 +7,7 @@
 
 let
   inherit (lib)
+    concatMapStringsSep
     concatStringsSep
     flip
     literalMD
@@ -95,9 +96,9 @@ let
     '';
   };
 
-  defaultJmxRolesFile = builtins.foldl' (left: right: left + right) "" (
-    map (role: "${role.username} ${role.password}") cfg.jmxRoles
-  );
+  defaultJmxRolesFile = concatMapStringsSep "" (
+    role: "${role.username} ${role.password}"
+  ) cfg.jmxRoles;
 
   fullJvmOptions =
     cfg.jvmOpts

--- a/nixos/modules/services/hardware/thinkfan.nix
+++ b/nixos/modules/services/hardware/thinkfan.nix
@@ -101,14 +101,12 @@ let
   # removes NixOS special and unused attributes
   sensorToConf =
     { type, query, ... }@args:
-    (lib.filterAttrs (
-      k: v:
-      v != null
-      && !(lib.elem k [
+    (lib.filterAttrs (k: v: v != null) (
+      lib.removeAttrs args [
         "type"
         "query"
-      ])
-    ) args)
+      ]
+    ))
     // {
       "${type}" = query;
     };

--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -69,7 +69,7 @@ let
 
   # Filter null values from the configuration, so that we can still advertise
   # optional options in the config attribute.
-  filteredConfig = converge (filterAttrsRecursive (_: v: !elem v [ null ])) (
+  filteredConfig = converge (filterAttrsRecursive (_: v: v != null)) (
     recursiveUpdate customLovelaceModulesResources (cfg.config or { })
   );
   configFile = renderYAMLFile "configuration.yaml" filteredConfig;

--- a/nixos/modules/services/logging/logrotate.nix
+++ b/nixos/modules/services/logging/logrotate.nix
@@ -120,7 +120,7 @@ let
     '';
   };
 
-  mailOption = lib.optionalString (lib.foldr (n: a: a || (n.mail or false) != false) false (
+  mailOption = lib.optionalString (lib.any (n: n.mail or true) (
     lib.attrValues cfg.settings
   )) "--mail=${pkgs.mailutils}/bin/mail";
 in
@@ -146,7 +146,7 @@ in
   options = {
     services.logrotate = {
       enable = lib.mkEnableOption "the logrotate systemd service" // {
-        default = lib.foldr (n: a: a || n.enable) false (lib.attrValues cfg.settings);
+        default = lib.any (n: n.enable) (lib.attrValues cfg.settings);
         defaultText = lib.literalExpression "cfg.settings != {}";
       };
 

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -235,7 +235,7 @@ let
         ""
       ];
 
-      masterCf = lib.mapAttrsToList (lib.const (lib.getAttr "rawEntry")) cfg.settings.master;
+      masterCf = lib.mapAttrsToList (_: (lib.getAttr "rawEntry")) cfg.settings.master;
 
       # A list of the maximum width of the columns across all lines and labels
       maxWidths =
@@ -254,14 +254,14 @@ let
           ]
           ++ (map (l: lib.init l ++ [ "" ]) masterCf);
         in
-        lib.foldr foldLine (lib.genList (lib.const 0) (lib.length labels)) lines;
+        lib.foldr foldLine (lib.genList (_: 0) (lib.length labels)) lines;
 
       # Pad a string with spaces from the right (opposite of fixedWidthString).
       pad =
         width: str:
         let
           padWidth = width - lib.stringLength str;
-          padding = lib.concatStrings (lib.genList (lib.const " ") padWidth);
+          padding = lib.concatStrings (lib.genList (_: " ") padWidth);
         in
         str + lib.optionalString (padWidth > 0) padding;
 
@@ -272,7 +272,7 @@ let
 
       formattedLabels =
         let
-          sep = "# " + lib.concatStrings (lib.genList (lib.const "=") (fullWidth + 5));
+          sep = "# " + lib.concatStrings (lib.genList (_: "=") (fullWidth + 5));
           lines = [
             sep
             (formatLine labels)

--- a/nixos/modules/services/mail/public-inbox.nix
+++ b/nixos/modules/services/mail/public-inbox.nix
@@ -403,7 +403,7 @@ in
       }
     ];
     services.public-inbox.settings = filterAttrsRecursive (n: v: v != null) {
-      publicinbox = mapAttrs (n: filterAttrs (n: v: n != "description")) cfg.inboxes;
+      publicinbox = mapAttrs (n: v: removeAttrs v [ "description" ]) cfg.inboxes;
     };
     users = {
       users.public-inbox = {

--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -181,8 +181,7 @@ let
   isUnixSocket = socket: hasPrefix "/" (if (isString socket) then socket else socket.socket);
 
   mkBindSockets =
-    enabled: socks:
-    concatStringsSep "\n  " (flatten (map (each: "bind_socket = \"${each.rawEntry}\";") socks));
+    enabled: socks: concatMapStringsSep "\n  " (each: "bind_socket = \"${each.rawEntry}\";") socks;
 
   rspamdConfFile = pkgs.writeText "rspamd.conf" ''
     .include "$CONFDIR/common.conf"

--- a/nixos/modules/services/mail/stalwart-mail.nix
+++ b/nixos/modules/services/mail/stalwart-mail.nix
@@ -15,7 +15,7 @@ let
     let
       parseAddresses = listeners: lib.flatten (lib.mapAttrsToList (name: value: value.bind) listeners);
       splitAddress = addr: lib.splitString ":" addr;
-      extractPort = addr: lib.toInt (builtins.foldl' (a: b: b) "" (splitAddress addr));
+      extractPort = addr: lib.toInt (lib.last (splitAddress addr));
     in
     builtins.map (address: extractPort address) (parseAddresses listeners);
 

--- a/nixos/modules/services/matrix/synapse.nix
+++ b/nixos/modules/services/matrix/synapse.nix
@@ -1348,8 +1348,7 @@ in
               )
               && listenerSupportsResource "replication" listener
               && (
-                lib.hasAttr "host" main
-                && lib.any (bind: bind == main.host || bind == "0.0.0.0" || bind == "::") listener.bind_addresses
+                lib.hasAttr "host" main && lib.elem [ main.host "0.0.0.0" "::" ] listener.bind_addresses
                 || lib.hasAttr "path" main
               )
             ) null cfg.settings.listeners;

--- a/nixos/modules/services/misc/klipper.nix
+++ b/nixos/modules/services/misc/klipper.nix
@@ -161,7 +161,7 @@ in
       {
         assertion =
           cfg.settings != null
-          -> lib.foldl (a: b: a && b) true (
+          -> builtins.all (b: b) (
             lib.mapAttrsToList (
               mcu: _: mcu != null -> (lib.hasAttrByPath [ "${mcu}" "serial" ] cfg.settings)
             ) cfg.firmwares

--- a/nixos/modules/services/monitoring/grafana-image-renderer.nix
+++ b/nixos/modules/services/monitoring/grafana-image-renderer.nix
@@ -127,7 +127,7 @@ in
     services.grafana-image-renderer.chromium = lib.mkDefault pkgs.chromium;
 
     services.grafana-image-renderer.settings = {
-      rendering = lib.mapAttrs (lib.const lib.mkDefault) {
+      rendering = lib.mapAttrs (_: lib.mkDefault) {
         chromeBin = "${cfg.chromium}/bin/chromium";
         verboseLogging = cfg.verbose;
         timezone = config.time.timeZone;

--- a/nixos/modules/services/monitoring/grafana.nix
+++ b/nixos/modules/services/monitoring/grafana.nix
@@ -126,7 +126,7 @@ let
       '';
 
   # Get a submodule without any embedded metadata:
-  _filter = x: filterAttrs (k: v: k != "_module") x;
+  _filter = x: removeAttrs x [ "_module" ];
 
   # https://grafana.com/docs/grafana/latest/administration/provisioning/#datasources
   grafanaTypes.datasourceConfig = types.submodule {

--- a/nixos/modules/services/monitoring/prometheus/exporters/mail.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/mail.nix
@@ -15,6 +15,7 @@ let
     nameValuePair
     toLower
     filterAttrs
+    removeAttrs
     escapeShellArg
     literalExpression
     mkIf
@@ -41,7 +42,7 @@ let
           )
         else
           nameValuePair (toLower name) value
-      ) (filterAttrs (n: _: !(n == "_module")) cfg.configuration)
+      ) (removeAttrs cfg.configuration [ "_module" ])
     )
   );
 

--- a/nixos/modules/services/network-filesystems/orangefs/server.nix
+++ b/nixos/modules/services/network-filesystems/orangefs/server.nix
@@ -7,7 +7,7 @@
 let
   cfg = config.services.orangefs.server;
 
-  aliases = lib.mapAttrsToList (alias: url: alias) cfg.servers;
+  aliases = lib.attrNames cfg.servers;
 
   # Maximum handle number is 2^63
   maxHandle = 9223372036854775806;

--- a/nixos/modules/services/networking/anubis.nix
+++ b/nixos/modules/services/networking/anubis.nix
@@ -264,7 +264,7 @@ in
         after = [ "network-online.target" ];
         wants = [ "network-online.target" ];
 
-        environment = lib.mapAttrs (lib.const (lib.generators.mkValueStringDefault { })) (
+        environment = lib.mapAttrs (_: (lib.generators.mkValueStringDefault { })) (
           lib.filterAttrs (_: v: v != null) (
             instance.settings
             // {

--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -30,7 +30,7 @@ let
     map (i: i.name) (
       lib.filter (i: if i.useDHCP != null then !i.useDHCP else i.ipv4.addresses != [ ]) interfaces
     )
-    ++ lib.mapAttrsToList (i: _: i) config.networking.sits
+    ++ lib.attrNames config.networking.sits
     ++ lib.concatLists (lib.attrValues (lib.mapAttrs (n: v: v.interfaces) config.networking.bridges))
     ++ lib.flatten (
       lib.concatMap (

--- a/nixos/modules/services/networking/hylafax/systemd.nix
+++ b/nixos/modules/services/networking/hylafax/systemd.nix
@@ -270,6 +270,6 @@ in
 {
   config.systemd = mkIf cfg.enable {
     inherit sockets timers paths;
-    services = lib.mapAttrs (lib.const hardenService) (services // modemServices);
+    services = lib.mapAttrs (_: hardenService) (services // modemServices);
   };
 }

--- a/nixos/modules/services/networking/wgautomesh.nix
+++ b/nixos/modules/services/networking/wgautomesh.nix
@@ -13,7 +13,10 @@ let
     # if value is null
     settingsFormat.generate "wgautomesh-config.toml" (
       filterAttrs (k: v: v != null) (
-        mapAttrs (k: v: if k == "peers" then map (e: filterAttrs (k: v: v != null) e) v else v) cfg.settings
+        cfg.settings
+        // {
+          peers = map (filterAttrs (k: v: v != null)) cfg.settings.peers;
+        }
       )
     );
   runtimeConfigFile =

--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -137,7 +137,7 @@ let
     addresses:
     let
       splitAddress = addr: strings.splitString ":" addr;
-      extractPort = addr: builtins.foldl' (a: b: b) "" (splitAddress addr);
+      extractPort = addr: last (splitAddress addr);
     in
     builtins.map (address: strings.toInt (extractPort address)) addresses;
 

--- a/nixos/modules/services/security/authelia.nix
+++ b/nixos/modules/services/security/authelia.nix
@@ -270,7 +270,7 @@ let
     lib.updateManyAttrsByPath [
       {
         path = lib.init pathList;
-        update = old: lib.filterAttrs (n: v: n != (lib.last pathList)) old;
+        update = old: lib.removeAttrs old [ (lib.last pathList) ];
       }
     ] set;
 in

--- a/nixos/modules/services/video/frigate.nix
+++ b/nixos/modules/services/video/frigate.nix
@@ -29,7 +29,7 @@ let
 
   format = pkgs.formats.yaml { };
 
-  filteredConfig = converge (filterAttrsRecursive (_: v: !elem v [ null ])) cfg.settings;
+  filteredConfig = converge (filterAttrsRecursive (_: v: v != null)) cfg.settings;
 
   configFileUnchecked = format.generate "frigate.yaml" filteredConfig;
   configFileChecked =

--- a/nixos/modules/services/web-apps/glance.nix
+++ b/nixos/modules/services/web-apps/glance.nix
@@ -9,6 +9,7 @@ let
 
   inherit (lib)
     catAttrs
+    concatMap
     concatMapStrings
     getExe
     mkEnableOption
@@ -19,7 +20,6 @@ let
     ;
 
   inherit (builtins)
-    concatLists
     isAttrs
     isList
     attrNames
@@ -184,9 +184,9 @@ in
                 if data ? _secret then
                   [ data ]
                 else
-                  concatLists (map (attr: findSecrets (getAttr attr data)) (attrNames data))
+                  concatMap (attr: findSecrets (getAttr attr data)) (attrNames data)
               else if isList data then
-                concatLists (map findSecrets data)
+                concatMap findSecrets data
               else
                 [ ];
             secretPaths = catAttrs "_secret" (findSecrets cfg.settings);

--- a/nixos/modules/services/web-apps/kanboard.nix
+++ b/nixos/modules/services/web-apps/kanboard.nix
@@ -8,7 +8,7 @@
 let
   cfg = config.services.kanboard;
 
-  toStringAttrs = lib.mapAttrs (lib.const toString);
+  toStringAttrs = lib.mapAttrs (_: toString);
 in
 {
   meta.maintainers = with lib.maintainers; [ yzx9 ];

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -1082,7 +1082,7 @@ in
         );
 
         services.nextcloud.phpOptions = lib.mkMerge [
-          (lib.mapAttrs (lib.const lib.mkOptionDefault) defaultPHPSettings)
+          (lib.mapAttrs (_: lib.mkOptionDefault) defaultPHPSettings)
           {
             upload_max_filesize = cfg.maxUploadSize;
             post_max_size = cfg.maxUploadSize;

--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -912,7 +912,7 @@ in
     systemd.services.httpd = {
       description = "Apache HTTPD";
       wantedBy = [ "multi-user.target" ];
-      wants = concatLists (map (certName: [ "acme-${certName}.service" ]) vhostCertNames);
+      wants = map (certName: "acme-${certName}.service") vhostCertNames;
       after = [
         "network.target"
       ]

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -10,7 +10,7 @@ with lib;
 let
   cfg = config.services.nginx;
   inherit (config.security.acme) certs;
-  vhostsConfigs = mapAttrsToList (vhostName: vhostConfig: vhostConfig) virtualHosts;
+  vhostsConfigs = attrValues virtualHosts;
   acmeEnabledVhosts = filter (
     vhostConfig: vhostConfig.enableACME || vhostConfig.useACMEHost != null
   ) vhostsConfigs;

--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -1246,7 +1246,7 @@ in
 
     boot.initrd.systemd.services =
       let
-        devicesWithClevis = filterAttrs (device: _: (hasAttr device clevis.devices)) luks.devices;
+        devicesWithClevis = removeAttrs luks.devices (attrNames clevis.devices);
       in
       mkIf (clevis.enable && systemd.enable) (
         (mapAttrs' (

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -592,7 +592,7 @@ in
             '';
 
         enabledUpstreamSystemUnits = filter (n: !elem n cfg.suppressedSystemUnits) upstreamSystemUnits;
-        enabledUnits = filterAttrs (n: v: !elem n cfg.suppressedSystemUnits) cfg.units;
+        enabledUnits = removeAttrs cfg.units cfg.suppressedSystemUnits;
 
       in
       ({

--- a/nixos/modules/tasks/encrypted-devices.nix
+++ b/nixos/modules/tasks/encrypted-devices.nix
@@ -23,7 +23,7 @@ let
     else
       filter (dev: dev.encrypted.keyFile == null) encDevs;
 
-  anyEncrypted = foldr (j: v: v || j.encrypted.enable) false encDevs;
+  anyEncrypted = any (j: j.encrypted.enable) encDevs;
 
   encryptedFSOptions = {
 

--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -347,7 +347,7 @@ in
                         driverOpt:
                         assertTrace (elem driverOpt (knownOptions ++ unknownOptions))
                           "The bond.driverOption `${driverOpt}` cannot be mapped to the list of known networkd bond options. Please add it to the mapping above the assert or to `unknownOptions` should it not exist in networkd."
-                      ) (mapAttrsToList (k: _: k) do);
+                      ) (attrNames do);
                       "";
                     # get those driverOptions that have been set
                     filterSystemdOptions = filterAttrs (sysDOpt: kOpts: any (kOpt: do ? ${kOpt}) kOpts.optNames);

--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -21,8 +21,8 @@ let
   dhcpStr = useDHCP: if useDHCP == true || useDHCP == null then "yes" else "no";
 
   slaves =
-    concatLists (map (bond: bond.interfaces) (attrValues cfg.bonds))
-    ++ concatLists (map (bridge: bridge.interfaces) (attrValues cfg.bridges))
+    concatMap (bond: bond.interfaces) (attrValues cfg.bonds)
+    ++ concatMap (bridge: bridge.interfaces) (attrValues cfg.bridges)
     ++ map (sit: sit.dev) (attrValues cfg.sits)
     ++ map (ipip: ipip.dev) (attrValues cfg.ipips)
     ++ map (gre: gre.dev) (attrValues cfg.greTunnels)

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1866,8 +1866,12 @@ in
               wlanListDeviceFirst =
                 device: interfaces:
                 if hasAttr device interfaces then
-                  mapAttrsToList (n: v: v // { _iName = n; }) (filterAttrs (n: _: n == device) interfaces)
-                  ++ mapAttrsToList (n: v: v // { _iName = n; }) (filterAttrs (n: _: n != device) interfaces)
+                  pipe interfaces [
+                    (mapAttrs (n: v: v // { _iName = n; }))
+                    attrsToList
+                    (partition ({ name, ... }: name == device))
+                    ({ right, wrong }: right ++ wrong)
+                  ]
                 else
                   mapAttrsToList (n: v: v // { _iName = n; }) interfaces;
 

--- a/nixos/tests/networking/networkd-and-scripted.nix
+++ b/nixos/tests/networking/networkd-and-scripted.nix
@@ -1449,8 +1449,8 @@ let
   };
 
 in
-lib.mapAttrs (lib.const (
-  attrs:
+lib.mapAttrs (
+  _: attrs:
   makeTest (
     attrs
     // {
@@ -1458,4 +1458,4 @@ lib.mapAttrs (lib.const (
       meta.maintainers = with lib.maintainers; [ rnhmjoj ];
     }
   )
-)) testCases
+) testCases

--- a/nixos/tests/networking/networkmanager.nix
+++ b/nixos/tests/networking/networkmanager.nix
@@ -182,8 +182,8 @@ let
     };
   };
 in
-lib.mapAttrs (lib.const (
-  attrs:
+lib.mapAttrs (
+  _: attrs:
   makeTest (
     attrs
     // {
@@ -194,4 +194,4 @@ lib.mapAttrs (lib.const (
 
     }
   )
-)) testCases
+) testCases

--- a/nixos/tests/sftpgo.nix
+++ b/nixos/tests/sftpgo.nix
@@ -25,7 +25,7 @@ let
     groupName:
     # users.users attrset
     user:
-    lib.any (x: x == user.name) config.users.groups.${groupName}.members;
+    lib.any lib.elem user.name config.users.groups.${groupName}.members;
 
   # Generates a valid SFTPGo user configuration for a given user
   # Will be converted to JSON and loaded on application startup.

--- a/pkgs/applications/audio/zynaddsubfx/default.nix
+++ b/pkgs/applications/audio/zynaddsubfx/default.nix
@@ -48,7 +48,7 @@
   ctestCheckHook,
 }:
 
-assert builtins.any (g: guiModule == g) [
+assert builtins.elem guiModule [
   "fltk"
   "ntk"
   "zest"

--- a/pkgs/applications/editors/jupyter/kernel.nix
+++ b/pkgs/applications/editors/jupyter/kernel.nix
@@ -62,7 +62,7 @@ in
                 "logo64"
                 "extraPaths"
               ];
-              kernel = lib.filterAttrs (n: v: (lib.any (x: x == n) allowedKernelKeys)) unfilteredKernel;
+              kernel = lib.filterAttrs (n: v: (lib.elem n allowedKernelKeys)) unfilteredKernel;
               config = builtins.toJSON (
                 kernel
                 // {

--- a/pkgs/applications/editors/vim/plugins/utils/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/utils/vim-utils.nix
@@ -202,7 +202,7 @@ let
           startWithDeps = findDependenciesRecursively start;
           allPlugins = lib.unique (startWithDeps ++ depsOfOptionalPlugins);
           allPython3Dependencies =
-            ps: lib.flatten (builtins.map (plugin: (plugin.python3Dependencies or (_: [ ])) ps) allPlugins);
+            ps: lib.concatMap (plugin: (plugin.python3Dependencies or (_: [ ])) ps) allPlugins;
           python3Env = python3.withPackages allPython3Dependencies;
 
           packdirStart = vimFarm "pack/${packageName}/start" "packdir-start" allPlugins;

--- a/pkgs/applications/editors/vim/plugins/utils/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/utils/vim-utils.nix
@@ -158,8 +158,7 @@ let
   # transitive closure of plugin dependencies (plugin needs to be a derivation)
   transitiveClosure =
     plugin:
-    [ plugin ]
-    ++ (lib.unique (builtins.concatLists (map transitiveClosure plugin.dependencies or [ ])));
+    [ plugin ] ++ (lib.unique (builtins.concatMap transitiveClosure (plugin.dependencies or [ ])));
 
   findDependenciesRecursively = plugins: lib.concatMap transitiveClosure plugins;
 

--- a/pkgs/applications/emulators/wine/util.nix
+++ b/pkgs/applications/emulators/wine/util.nix
@@ -1,6 +1,6 @@
 { lib }:
 rec {
   toPackages = pkgNames: pkgs: map (pn: lib.getAttr pn pkgs) pkgNames;
-  toBuildInputs = pkgArches: archPkgs: lib.concatLists (map archPkgs pkgArches);
+  toBuildInputs = pkgArches: archPkgs: lib.concatMap archPkgs pkgArches;
   mkBuildInputs = pkgArches: pkgNames: toBuildInputs pkgArches (toPackages pkgNames);
 }

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -170,7 +170,7 @@ let
           ) { } extensions;
 
           Extensions = {
-            Install = lib.foldr (e: ret: ret ++ [ "${e.outPath}/${e.extid}.xpi" ]) [ ] extensions;
+            Install = map (e: "${e.outPath}/${e.extid}.xpi") extensions;
           };
         }
         // lib.optionalAttrs smartcardSupport {

--- a/pkgs/applications/networking/irc/weechat/wrapper.nix
+++ b/pkgs/applications/networking/irc/weechat/wrapper.nix
@@ -86,9 +86,7 @@ let
 
           mkScript = drv: lib.forEach drv.scripts (script: "/script load ${drv}/share/${script}");
 
-          scripts = builtins.concatStringsSep ";" (
-            lib.foldl (scripts: drv: scripts ++ mkScript drv) [ ] (config.scripts or [ ])
-          );
+          scripts = lib.concatMapStringsSep ";" mkScript (config.scripts or [ ]);
         in
         "${scripts};${init}";
 

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -165,8 +165,8 @@ assert builtins.elem variant [
 
 let
   inherit (lib)
-    flatten
     flip
+    concatMap
     concatMapStrings
     concatStringsSep
     getDev
@@ -248,8 +248,8 @@ let
   # See `postPatch` for details
   kdeDeps = symlinkJoin {
     name = "libreoffice-kde-dependencies-${version}";
-    paths = flatten (
-      map
+    paths =
+      concatMap
         (e: [
           (getDev e)
           (getLib e)
@@ -262,8 +262,7 @@ let
           kdePackages.ki18n
           kdePackages.kio
           kdePackages.kwindowsystem
-        ]
-    );
+        ];
   };
   tarballPath = "external/tarballs";
 

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -39,9 +39,13 @@ let
   version_ = lib.splitString "-" crateVersion;
   versionPre = lib.optionalString (lib.tail version_ != [ ]) (lib.elemAt version_ 1);
   version = lib.splitVersion (lib.head version_);
-  rustcOpts = lib.foldl' (opts: opt: opts + " " + opt) (
-    if release then "-C opt-level=3" else "-C debuginfo=2"
-  ) ([ "-C codegen-units=${toString codegenUnits}" ] ++ extraRustcOptsForBuildRs);
+  rustcOpts = lib.concatStringsSep " " (
+    [
+      (if release then "-C opt-level=3" else "-C debuginfo=2")
+      "-C codegen-units=${toString codegenUnits}"
+    ]
+    ++ extraRustcOptsForBuildRs
+  );
   buildDeps = mkRustcDepArgs buildDependencies crateRenames;
   authors = lib.concatStringsSep ":" crateAuthors;
   optLevel = if release then 3 else 0;

--- a/pkgs/by-name/in/inspircd/package.nix
+++ b/pkgs/by-name/in/inspircd/package.nix
@@ -24,7 +24,7 @@ let
   # libcs in nixpkgs (musl and glibc).
   compatible =
     lib: drv:
-    lib.any (lic: lic == (drv.meta.license or { })) [
+    lib.elem (drv.meta.license or { }) [
       lib.licenses.mit # musl
       lib.licenses.lgpl2Plus # glibc
     ];

--- a/pkgs/by-name/ot/otb/package.nix
+++ b/pkgs/by-name/ot/otb/package.nix
@@ -59,7 +59,7 @@ let
     # https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/-/issues/2454#note_112821
     "fftw"
   ];
-  itkIsInDepsToRemove = dep: builtins.any (d: d == dep.name) itkDepsToRemove;
+  itkIsInDepsToRemove = dep: builtins.elem dep.name itkDepsToRemove;
 
   # remove after https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/-/issues/2451
   otbSwig = swig.overrideAttrs (oldArgs: {

--- a/pkgs/by-name/qu/quartus-prime-lite/quartus.nix
+++ b/pkgs/by-name/qu/quartus-prime-lite/quartus.nix
@@ -35,9 +35,7 @@ let
       }) supportedDevices
     );
 
-  unsupportedDeviceIds = lib.filterAttrs (
-    name: value: !(lib.hasAttr name supportedDeviceIds)
-  ) deviceIds;
+  unsupportedDeviceIds = lib.removeAttrs deviceIds (lib.attrNames supportedDeviceIds);
 
   componentHashes = {
     "arria_lite" = "sha256-PNoc15Y5h+2bxhYFIxkg1qVAsXIX3IMfEQSdPLVNUp4=";

--- a/pkgs/by-name/re/retroarch-bare/wrapper.nix
+++ b/pkgs/by-name/re/retroarch-bare/wrapper.nix
@@ -24,12 +24,10 @@ let
   # but let's be safe here
   coresPath = lib.lists.unique (map (c: c.libretroCore) cores);
   wrapperArgs = lib.strings.escapeShellArgs (
-    (lib.lists.flatten (
-      map (p: [
-        "--add-flags"
-        "-L ${placeholder "out" + p}"
-      ]) coresPath
-    ))
+    (lib.concatMap (p: [
+      "--add-flags"
+      "-L ${placeholder "out" + p}"
+    ]) coresPath)
     ++ [
       "--add-flags"
       "--appendconfig=${settingsPath}"

--- a/pkgs/by-name/sa/sage/sage-with-env.nix
+++ b/pkgs/by-name/sa/sage/sage-with-env.nix
@@ -70,13 +70,13 @@ let
       [ dep ]
       ++ (
         if builtins.hasAttr "propagatedBuildInputs" dep then
-          lib.unique (builtins.concatLists (map transitiveClosure dep.propagatedBuildInputs))
+          lib.unique (builtins.concatMap transitiveClosure dep.propagatedBuildInputs)
         else
           [ ]
       );
 
   allInputs = lib.remove null (nativeBuildInputs ++ buildInputs ++ pythonEnv.extraLibs);
-  transitiveDeps = lib.unique (builtins.concatLists (map transitiveClosure allInputs));
+  transitiveDeps = lib.unique (builtins.concatMap transitiveClosure allInputs);
   # fix differences between spkg and sage names
   # (could patch sage instead, but this is more lightweight and also works for packages depending on sage)
   patch_names =

--- a/pkgs/by-name/sl/sleek-grub-theme/package.nix
+++ b/pkgs/by-name/sl/sleek-grub-theme/package.nix
@@ -6,7 +6,7 @@
   withStyle ? "light", # use override to specify one of "dark" / "orange" / "bigSur"
 }:
 
-assert builtins.any (s: withStyle == s) [
+assert builtins.elem withStyle [
   "light"
   "dark"
   "orange"

--- a/pkgs/development/idris-modules/default.nix
+++ b/pkgs/development/idris-modules/default.nix
@@ -65,7 +65,7 @@ let
 
       # The set of libraries that comes with idris
 
-      builtins = pkgs.lib.mapAttrsToList (name: value: value) builtins_;
+      builtins = pkgs.lib.attrValues builtins_;
 
       # Libraries
 

--- a/pkgs/development/interpreters/python/pypy/default.nix
+++ b/pkgs/development/interpreters/python/pypy/default.nix
@@ -111,7 +111,7 @@ stdenv.mkDerivation rec {
   ]
   ++
     lib.optionals
-      (lib.any (l: l == optimizationLevel) [
+      (lib.elem optimizationLevel [
         "0"
         "1"
         "2"

--- a/pkgs/development/interpreters/python/pypy/prebuilt.nix
+++ b/pkgs/development/interpreters/python/pypy/prebuilt.nix
@@ -176,7 +176,7 @@ stdenv.mkDerivation {
     description = "Fast, compliant alternative implementation of the Python language (${pythonVersion})";
     mainProgram = "pypy";
     license = licenses.mit;
-    platforms = lib.mapAttrsToList (arch: _: arch) downloadUrls;
+    platforms = lib.attrNames downloadUrls;
   };
 
 }

--- a/pkgs/development/interpreters/python/pypy/prebuilt_2_7.nix
+++ b/pkgs/development/interpreters/python/pypy/prebuilt_2_7.nix
@@ -170,7 +170,7 @@ stdenv.mkDerivation {
     homepage = "http://pypy.org/";
     description = "Fast, compliant alternative implementation of the Python language (${pythonVersion})";
     license = licenses.mit;
-    platforms = lib.mapAttrsToList (arch: _: arch) downloadUrls;
+    platforms = lib.attrNames downloadUrls;
   };
 
 }

--- a/pkgs/development/libraries/libint/default.nix
+++ b/pkgs/development/libraries/libint/default.nix
@@ -73,31 +73,19 @@ assert (eri2Deriv >= 0 && eri2Deriv <= 4);
 assert (eri3Deriv >= 0 && eri3Deriv <= 4);
 
 # Ensure valid arguments for generated angular momenta in ERI derivatives are used.
-assert (
-  builtins.length eriAm == eriDeriv + 1
-  && builtins.foldl' (a: b: a && b) true (builtins.map (a: a <= maxAm && a >= 0) eriAm)
-);
-assert (
-  builtins.length eri3Am == eriDeriv + 1
-  && builtins.foldl' (a: b: a && b) true (builtins.map (a: a <= maxAm && a >= 0) eri3Am)
-);
-assert (
-  builtins.length eri2Am == eriDeriv + 1
-  && builtins.foldl' (a: b: a && b) true (builtins.map (a: a <= maxAm && a >= 0) eri2Am)
-);
+assert (builtins.length eriAm == eriDeriv + 1 && builtins.all (a: a <= maxAm && a >= 0) eriAm);
+assert (builtins.length eri3Am == eriDeriv + 1 && builtins.all (a: a <= maxAm && a >= 0) eri3Am);
+assert (builtins.length eri2Am == eriDeriv + 1 && builtins.all (a: a <= maxAm && a >= 0) eri2Am);
 
 # Ensure valid arguments for generated angular momenta in optimised ERI derivatives are used.
 assert (
-  builtins.length eriOptAm == eriDeriv + 1
-  && builtins.foldl' (a: b: a && b) true (builtins.map (a: a <= maxAm && a >= 0) eriOptAm)
+  builtins.length eriOptAm == eriDeriv + 1 && builtins.all (a: a <= maxAm && a >= 0) eriOptAm
 );
 assert (
-  builtins.length eri3OptAm == eriDeriv + 1
-  && builtins.foldl' (a: b: a && b) true (builtins.map (a: a <= maxAm && a >= 0) eri3OptAm)
+  builtins.length eri3OptAm == eriDeriv + 1 && builtins.all (a: a <= maxAm && a >= 0) eri3OptAm
 );
 assert (
-  builtins.length eri2OptAm == eriDeriv + 1
-  && builtins.foldl' (a: b: a && b) true (builtins.map (a: a <= maxAm && a >= 0) eri2OptAm)
+  builtins.length eri2OptAm == eriDeriv + 1 && builtins.all (a: a <= maxAm && a >= 0) eri2OptAm
 );
 
 # Ensure a valid derivative order for one-electron integrals

--- a/pkgs/development/mobile/androidenv/test-suite.nix
+++ b/pkgs/development/mobile/androidenv/test-suite.nix
@@ -19,7 +19,7 @@ in
 stdenv.mkDerivation {
   name = "androidenv-test-suite";
   version = lib.substring 0 8 (builtins.hashFile "sha256" ./repo.json);
-  buildInputs = lib.mapAttrsToList (name: value: value) all-tests;
+  buildInputs = lib.attrValues all-tests;
 
   buildCommand = ''
     touch $out

--- a/pkgs/development/python-modules/markdown2/default.nix
+++ b/pkgs/development/python-modules/markdown2/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     code_syntax_highlighting = [ pygments ];
     wavedrom = [ wavedrom ];
     latex = [ latex2mathml ];
-    all = lib.flatten (lib.attrValues (lib.filterAttrs (n: v: n != "all") optional-dependencies));
+    all = lib.concatLists (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
   };
 
   meta = {

--- a/pkgs/development/python-modules/odc-loader/default.nix
+++ b/pkgs/development/python-modules/odc-loader/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
   optional-dependencies = {
     botocore = [ botocore ];
     zarr = [ zarr ];
-    all = lib.flatten (lib.attrValues (lib.filterAttrs (n: v: n != "all") optional-dependencies));
+    all = lib.concatLists (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
   };
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pettingzoo/default.nix
+++ b/pkgs/development/python-modules/pettingzoo/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = {
-    all = lib.flatten (lib.attrValues (lib.filterAttrs (n: v: n != "all") optional-dependencies));
+    all = lib.concatLists (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
     atari = [
       # multi-agent-ale-py
       pygame

--- a/pkgs/development/python-modules/planetary-computer/default.nix
+++ b/pkgs/development/python-modules/planetary-computer/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
   optional-dependencies = {
     adlfs = [ adlfs ];
     azure = [ azure-storage-blob ];
-    all = lib.flatten (lib.attrValues (lib.filterAttrs (n: v: n != "all") optional-dependencies));
+    all = lib.concatLists (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
   };
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/pulsar-client/default.nix
+++ b/pkgs/development/python-modules/pulsar-client/default.nix
@@ -67,7 +67,7 @@ buildPythonPackage rec {
       ratelimit
     ];
     avro = [ fastavro ];
-    all = lib.flatten (lib.attrValues (lib.filterAttrs (n: v: n != "all") optional-dependencies));
+    all = lib.flatten (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
   };
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pyproject-parser/default.nix
+++ b/pkgs/development/python-modules/pyproject-parser/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = {
-    all = lib.flatten (lib.attrValues (lib.filterAttrs (n: v: n != "all") optional-dependencies));
+    all = lib.concatLists (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
     cli = [
       click
       consolekit

--- a/pkgs/development/python-modules/tianshou/default.nix
+++ b/pkgs/development/python-modules/tianshou/default.nix
@@ -92,7 +92,7 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = {
-    all = lib.flatten (lib.attrValues (lib.filterAttrs (n: v: n != "all") optional-dependencies));
+    all = lib.concatLists (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
 
     argparse = [
       docstring-parser

--- a/pkgs/development/python-modules/whey/default.nix
+++ b/pkgs/development/python-modules/whey/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "whey" ];
 
   optional-dependencies = {
-    all = lib.flatten (lib.attrValues (lib.filterAttrs (n: v: n != "all") optional-dependencies));
+    all = lib.concatLists (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
     editable = [
       editables
     ];

--- a/pkgs/development/ruby-modules/testing/assertions.nix
+++ b/pkgs/development/ruby-modules/testing/assertions.nix
@@ -20,7 +20,7 @@
 
   haveKeys =
     expected: actual:
-    if builtins.all (ex: builtins.any (ac: ex == ac) (builtins.attrNames actual)) expected then
+    if builtins.all (ex: actual ? ${ex}) expected then
       (test.passed "has expected keys")
     else
       (test.failed "keys differ: expected: [${lib.concatStringsSep ";" expected}] actual: [${lib.concatStringsSep ";" (builtins.attrNames actual)}]");

--- a/pkgs/development/ruby-modules/testing/driver.nix
+++ b/pkgs/development/ruby-modules/testing/driver.nix
@@ -21,6 +21,6 @@ let
 
   tap = import ./tap-support.nix;
 
-  results = builtins.concatLists (map (file: callPackage file testTools) testFiles);
+  results = builtins.concatMap (file: callPackage file testTools) testFiles;
 in
 writeText "test-results.tap" (tap.output results)

--- a/pkgs/development/ruby-modules/testing/stubs.nix
+++ b/pkgs/development/ruby-modules/testing/stubs.nix
@@ -14,7 +14,7 @@ let
         builtins.toJSON (
           lib.filterAttrs (
             n: v:
-            builtins.any (x: x == n) [
+            builtins.elem n [
               "name"
               "system"
             ]

--- a/pkgs/development/ruby-modules/testing/tap-support.nix
+++ b/pkgs/development/ruby-modules/testing/tap-support.nix
@@ -21,7 +21,7 @@ in
     ''
       TAP version 13
       1..${toString (length reports)}''
-    + (foldl' (l: r: l + "\n" + r) "" (map testLine (withIndexes reports)))
+    + (concatStringsSep "\n" (map testLine (withIndexes reports)))
     + ''
 
       # Finished at ${toString currentTime}

--- a/pkgs/development/ruby-modules/testing/testing.nix
+++ b/pkgs/development/ruby-modules/testing/testing.nix
@@ -42,16 +42,14 @@ let
   run =
     name: under: tests:
     if isList tests then
-      (concatLists (map (run name under) tests))
+      (concatMap (run name under) tests)
     else if isAttrs tests then
-      (concatLists (
-        map (
-          subName:
-          run (name + "." + subName) (if hasAttr subName under then getAttr subName under else "<MISSING!>") (
-            getAttr subName tests
-          )
-        ) (attrNames tests)
-      ))
+      (concatMap (
+        subName:
+        run (name + "." + subName) (if hasAttr subName under then getAttr subName under else "<MISSING!>") (
+          getAttr subName tests
+        )
+      ) (attrNames tests))
     else if isFunction tests then
       let
         res = tests under;

--- a/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix
@@ -99,7 +99,7 @@ let
     let
       # only formatters that were not requested
       unwanted = lib.pipe knownFormatters [
-        (lib.filterAttrs (fmt: _: !(lib.elem fmt supportedFormatters)))
+        (fmts: lib.removeAttrs fmts supportedFormatters)
         lib.attrsToList
       ];
       # all flags to disable

--- a/pkgs/development/tools/yarn2nix-moretea/default.nix
+++ b/pkgs/development/tools/yarn2nix-moretea/default.nix
@@ -333,8 +333,7 @@ rec {
       baseName = unlessNull name "${safeName}-${version}";
 
       workspaceDependenciesTransitive = lib.unique (
-        (lib.flatten (builtins.map (dep: dep.workspaceDependencies) workspaceDependencies))
-        ++ workspaceDependencies
+        (lib.concatMap (dep: dep.workspaceDependencies) workspaceDependencies) ++ workspaceDependencies
       );
 
       deps = mkYarnModules {

--- a/pkgs/os-specific/bsd/freebsd/lib/default.nix
+++ b/pkgs/os-specific/bsd/freebsd/lib/default.nix
@@ -81,7 +81,7 @@
         else if (builtins.isPath patches) then
           (if (isDir patches) then (lib.filesystem.listFilesRecursive patches) else [ patches ])
         else if (builtins.isList patches) then
-          (lib.flatten (builtins.map consolidatePatches patches))
+          (lib.concatMap consolidatePatches patches)
         else
           throw "Bad patches - must be path or derivation or list thereof";
       consolidated = consolidatePatches patches;

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -57,7 +57,7 @@
         in
         {
           name = lib.removeSuffix ".patch" src.name;
-          patch = fetchurl (lib.filterAttrs (k: v: k != "extra") src);
+          patch = fetchurl (lib.removeAttrs src [ "extra" ]);
           extra = src.extra;
           inherit version sha256;
         };

--- a/pkgs/servers/nextcloud/notify_push.nix
+++ b/pkgs/servers/nextcloud/notify_push.nix
@@ -48,9 +48,7 @@ rustPlatform.buildRustPackage rec {
       };
     };
     tests =
-      lib.filterAttrs (
-        key: lib.const (lib.hasPrefix "with-postgresql-and-redis" key)
-      ) nixosTests.nextcloud
+      lib.filterAttrs (key: _: lib.hasPrefix "with-postgresql-and-redis" key) nixosTests.nextcloud
       // {
         inherit test_client;
       };

--- a/pkgs/servers/web-apps/wordpress/packages/default.nix
+++ b/pkgs/servers/web-apps/wordpress/packages/default.nix
@@ -43,7 +43,7 @@ let
           license,
           ...
         }@args:
-        assert lib.any (x: x == type) [
+        assert lib.elem type [
           "plugin"
           "theme"
           "language"

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -728,7 +728,10 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           (disallowedPackages prevStage)
           # Only cctools and ld64 are rebuilt from `bintoolsPackages` to avoid rebuilding their dependencies
           # again in this stage after building them in stage 1.
-          (lib.filterAttrs (name: _: name != "ld64" && name != "cctools") (bintoolsPackages prevStage))
+          (lib.removeAttrs (bintoolsPackages prevStage) [
+            "ld64"
+            "cctools"
+          ])
           (llvmToolsDeps prevStage)
           (sdkPackages prevStage)
           (sdkPackagesNoCC prevStage)

--- a/pkgs/tools/misc/grub/default.nix
+++ b/pkgs/tools/misc/grub/default.nix
@@ -71,7 +71,7 @@ let
     x86_64-linux.target = "i386"; # Xen PVH is only i386 on x86.
   };
 
-  inPCSystems = lib.any (system: stdenv.hostPlatform.system == system) (lib.attrNames pcSystems);
+  inPCSystems = lib.hasAttr stdenv.hostPlatform.system pcSystems;
 
   gnulib = fetchgit {
     url = "https://https.git.savannah.gnu.org/git/gnulib.git";

--- a/pkgs/tools/networking/maubot/plugins/generated.nix
+++ b/pkgs/tools/networking/maubot/plugins/generated.nix
@@ -69,7 +69,7 @@ lib.flip builtins.mapAttrs json (
             );
           in
           spdxLicenses.${spdx};
-        broken = builtins.any (x: x == null) reqDeps;
+        broken = builtins.elem null reqDeps;
       };
     }
     // lib.optionalAttrs (entry.isPoetry or false) {

--- a/pkgs/tools/networking/maubot/wrapper.nix
+++ b/pkgs/tools/networking/maubot/wrapper.nix
@@ -16,7 +16,7 @@ let
     }:
     let
       plugins' = plugins unwrapped.plugins;
-      extraPythonPackages = builtins.concatLists (map (p: p.propagatedBuildInputs or [ ]) plugins');
+      extraPythonPackages = builtins.concatMap (p: p.propagatedBuildInputs or [ ]) plugins';
     in
     symlinkJoin {
       name = "${unwrapped.pname}-with-plugins-${unwrapped.version}";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR goes over a few files and cleans up some lib usage patterns:

#### Prefer `removeAttrs` over `filterAttrs` when removing keys by name

Reason: Shorter, communicates intent better, `removeAttrs` is a builtin


#### Prefer `concatMap` over `flatten + map` and `concatLists + map`

Reason: Shorter, `concatMap` is a builtin


#### Prefer `elem` over `any` when testing for inclusion in list

Reason: Shorter, communicates intent better


#### Prefer explicit `(_: ...)` constructors over `lib.const`

Reason: `lib.const` adds an extra indirection, and can often be more confusing to read than a function that ignores its parameter.


#### Prefer `attrNames` and `attrValues` over `mapAttrsToList`

Reason: Shorter, communicates intent better, both replacements are builtins


#### Prefer more specialized functions over `foldl` and `foldr` where available

Reason: Usually shorter, communicates intent better.


#### Prefer `concatLists` over `flatten` where no recursive flattening is needed

Reason: `concatLists` is a builtin

Note that there are a bunch of python packages with this pattern that I have avoided due to there being so many. Might open a separate PR for those.

#### Other

There are some other one or two-off refactors in there that doesn't match the patterns described above. That includes some noop removals, refactors of more complex expressions and uncommon patterns that doesn't show intent well or has an easier equivalent.

----

Unfortunately, I haven't been able to find a good way to eval all of these since most are behind `mkIf cfg.enable` expressions. I have tried to be careful to ensure that all fixes are valid, but there might be a miss or two somewhere.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
