### PR TITLE
[staging-next] electron: fix LLVM 21+ build by backporting patch

### DIFF
--- a/pkgs/development/tools/electron/common.nix
+++ b/pkgs/development/tools/electron/common.nix
@@ -140,6 +140,15 @@ in
         url = "https://github.com/chromium/chromium/commit/6aae0e2353c857d98980ff677bf304288d7c58de.patch";
         hash = "sha256-Dd38c/0hiH+PbGPJhhEFuW6kUR45A36XZqOVExoxlhM=";
       })
+    ]
+    ++ lib.optionals (lib.versionOlder info.version "38") [
+      # Fix build with LLVM 21+
+      # https://chromium-review.googlesource.com/c/chromium/src/+/6633292
+      (fetchpatch {
+        name = "Dont-return-an-enum-from-EnumSizeTraits-Count.patch";
+        url = "https://github.com/chromium/chromium/commit/b0ff8c3b258a8816c05bdebf472dbba719d3c491.patch";
+        hash = "sha256-YIWcsCj5w0jUd7D67hsuk0ljTA/IbHwA6db3eK4ggUY=";
+      })
     ];
 
   npmRoot = "third_party/node";


### PR DESCRIPTION
chromium <139's histogram_macros_internal contains a UB static cast that causes a compile error for LLVM 21+

`return static_cast<Enum>(base::to_underlying(Enum::kMaxValue) + 1);`
→
`integer value 4 is outside the valid range of values [0, 3] for the enumeration type 'LandlockState'`
→
`error: static assertion expression is not an integral constant expression
   UMA_HISTOGRAM_ENUMERATION("Security.Sandbox.LandlockState", landlock_state);`

vendoring upstream fix from https://chromium-review.googlesource.com/c/chromium/src/+/6633292

A static cast to an enum type that is outside the range of enum values was defined to be undefined behavior in February 2014 in https://cplusplus.github.io/CWG/issues/1766.html


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
