### PR TITLE
harmonoid: init at 0.3.10

### DIFF
--- a/pkgs/by-name/ha/harmonoid/package.nix
+++ b/pkgs/by-name/ha/harmonoid/package.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  undmg,
+  autoPatchelfHook,
+  makeWrapper,
+  cairo,
+  gdk-pixbuf,
+  gtk3,
+  libz,
+  pango,
+  harfbuzz,
+  atkmm,
+  libcxx,
+  mpv-unwrapped,
+}:
+let
+  version = "0.3.10";
+  url_base = "https://github.com/alexmercerind2/harmonoid-releases/releases/download/v${version}";
+  url =
+    rec {
+      x86_64-linux = "${url_base}/harmonoid-linux-x86_64.tar.gz";
+      x86_64-darwin = "${url_base}/harmonoid-macos-universal.dmg";
+      aarch64-darwin = x86_64-darwin;
+    }
+    .${stdenv.hostPlatform.system}
+      or (throw "${stdenv.hostPlatform.system} is an unsupported platform");
+  hash =
+    rec {
+      x86_64-linux = "sha256-GTF9KrcTolCc1w/WT0flwlBCBitskFPaJuNUdxCW9gs=";
+      x86_64-darwin = "sha256-7qcUnYBasUqisEW56fq4JGgojBmfqycrDIMpCCWLxlc=";
+      aarch64-darwin = x86_64-darwin;
+    }
+    .${stdenv.hostPlatform.system};
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "harmonoid";
+  inherit version;
+
+  src = fetchurl {
+    inherit url hash;
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    undmg
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    cairo
+    gdk-pixbuf
+    gtk3
+    libz
+    pango
+    harfbuzz
+    atkmm
+    libcxx
+  ];
+
+  installPhase = ''
+    runHook preInstall
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    mkdir -p $out
+    cp -r bin $out
+    mkdir -p $out
+    cp -r share $out
+    wrapProgram $out/bin/harmonoid --prefix LD_LIBRARY_PATH : $out/share/harmonoid/lib:${
+      lib.makeLibraryPath [ mpv-unwrapped ]
+    }
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/Applications
+    cp -r . $out/Applications/Harmonoid.app
+  ''
+  + ''
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Plays & manages your music library";
+    homepage = "https://harmonoid.com/";
+    changelog = "https://github.com/harmonoid/harmonoid/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ ivyfanchiang ];
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    license = {
+      fullName = "PolyForm Strict License 1.0.0";
+      url = "https://polyformproject.org/licenses/strict/1.0.0/";
+      free = false;
+    };
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
[Harmonoid](https://harmonoid.com/) music player, is partially source available but not free

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
