### PR TITLE
warcit: init at unstable-2024-11-28

### DIFF
--- a/pkgs/by-name/wa/warcit/package.nix
+++ b/pkgs/by-name/wa/warcit/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication {
+  pname = "warcit";
+  version = "0.4.0-unstable-2024-11-28";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "webrecorder";
+    repo = "warcit";
+    rev = "3cba1ad2c3e9bddd33c3babf45c2a03b5d8935ef";
+    hash = "sha256-hqQPQWmhR6/NP3XsQkjlOIVbbDfoOf9uhhvlJvIPNZE=";
+  };
+
+  build-system = with python3.pkgs; [
+    setuptools
+  ];
+
+  dependencies = with python3.pkgs; [
+    warcio
+    faust-cchardet
+    pyyaml
+  ];
+
+  pythonImportsCheck = [
+    "warcit"
+  ];
+
+  meta = {
+    description = "Convert Directories, Files and ZIP Files to Web Archives (WARC)";
+    homepage = "https://github.com/webrecorder/warcit";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ zhaofengli ];
+    mainProgram = "warcit";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[`warcit`](https://github.com/webrecorder/warcit) takes directories and creates standard Web Archives (WARC). If you wish, you can then convert the WARCs into indexed WACZs (#420437).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
