### PR TITLE
karabiner-elements: fix notarization for drivers, karabiner-dk: init at 6.2.0, kanata: Fix darwin drivers based on karabiner-elements, haskellPackages.kmonad: add output for darwinDriver

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2487,6 +2487,12 @@
     githubId = 574938;
     name = "Jonathan Glines";
   };
+  auscyber = {
+    email = "ivyp@outlook.com.au";
+    github = "auscyber";
+    name = "Ivy Pierlot";
+    githubId = 12080502;
+  };
   austin-artificial = {
     email = "austin.platt@artificial.io";
     github = "austin-artificial";

--- a/pkgs/by-name/ka/kanata/package.nix
+++ b/pkgs/by-name/ka/kanata/package.nix
@@ -4,20 +4,22 @@
   apple-sdk_13,
   darwinMinVersionHook,
   rustPlatform,
+  karabiner-dk,
   fetchFromGitHub,
   versionCheckHook,
   nix-update-script,
   writeShellScriptBin,
   withCmd ? false,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "kanata";
   version = "1.9.0";
+  darwinDriverVersion = "5.0.0"; # needs to be updated if karabiner-driverkit changes
 
   src = fetchFromGitHub {
     owner = "jtroo";
     repo = "kanata";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-xxAIwiwCQugDXpWga9bQ9ZGfem46rwDlmf64dX/tw7g=";
   };
 
@@ -47,14 +49,22 @@ rustPlatform.buildRustPackage rec {
 
   passthru = {
     updateScript = nix-update-script { };
+    darwinDriver = lib.optional stdenv.hostPlatform.isDarwin (
+      karabiner-dk.override {
+        driver-version = finalAttrs.darwinDriverVersion;
+      }
+    );
   };
 
   meta = with lib; {
     description = "Tool to improve keyboard comfort and usability with advanced customization";
     homepage = "https://github.com/jtroo/kanata";
     license = licenses.lgpl3Only;
-    maintainers = with maintainers; [ linj ];
+    maintainers = with maintainers; [
+      linj
+      auscyber
+    ];
     platforms = platforms.unix;
     mainProgram = "kanata";
   };
-}
+})

--- a/pkgs/by-name/ka/kanata/update.sh
+++ b/pkgs/by-name/ka/kanata/update.sh
@@ -1,0 +1,8 @@
+NEW_VERSION="$(curl --silent https://api.github.com/repos/jtroo/kanata/releases/latest  ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""}  | jq '.tag_name | ltrimstr("v")' --raw-output)"
+update-source-version "kanata" "$NEW_VERSION" --ignore-same-version
+karabinerDriverCrateVersion="$(curl -L "https://raw.githubusercontent.com/jtroo/kanata/refs/tags/v$NEW_VERSION/Cargo.lock" | tomlq | jq --raw-output '.package[] | select(.name |  test("karabiner-driverkit")) |.version')"
+newKarabinerDkVersion="$(curl -L "https://crates.io/api/v1/crates/karabiner-driverkit/$karabinerDriverCrateVersion/download" | tar xzvf - --strip-components=1 -O "karabiner-driverkit-$karabinerDriverCrateVersion/c_src/Karabiner-DriverKit-VirtualHIDDevice/version.json" | jq --raw-output0 .package_version)"
+importTree="(let tree = import ./.; in if builtins.isFunction tree then tree {} else tree)"
+oldDarwinVersion=$(nix-instantiate --eval -E "with $importTree; kanata.passthru.darwinDriverVersion" | tr -d '"')
+nixFile=$(nix-instantiate --eval --strict -A "kanata.meta.position" | sed -re 's/^"(.*):[0-9]+"$/\1/')
+sed -i "$nixFile" -re "s|\"$oldDarwinVersion\"|\"$newKarabinerDkVersion\"|"

--- a/pkgs/by-name/ka/karabiner-dk/package.nix
+++ b/pkgs/by-name/ka/karabiner-dk/package.nix
@@ -1,0 +1,59 @@
+{
+  libarchive,
+  xar,
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  common-updater-scripts,
+  writeShellScript,
+  curl,
+  jq,
+  driver-version ? null,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "karabiner-dk";
+  sourceVersion = "6.3.0";
+  version = lib.defaultTo finalAttrs.sourceVersion driver-version;
+
+  src = fetchFromGitHub {
+    owner = "pqrs-org";
+    repo = "Karabiner-DriverKit-VirtualHIDDevice";
+    tag = "v${finalAttrs.sourceVersion}";
+    hash = "sha256-nLu//qG3RzrEDWvNmSJH7YmgVgiTiYTg5FaliiEtdpo=";
+  };
+
+  nativeBuildInputs = [
+    libarchive
+    xar
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    xar -xf $src/dist/Karabiner-DriverKit-VirtualHIDDevice-${finalAttrs.version}.pkg
+    zcat Payload | bsdcpio -i
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -R ./Applications ./Library $out
+    runHook postInstall
+  '';
+  dontFixup = true;
+
+  passthru.updateScript = writeShellScript "karabiner-dk" ''
+    NEW_VERSION=$(${lib.getExe curl} --silent https://api.github.com/repos/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice/releases/latest $${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} | ${lib.getExe jq} '.tag_name | ltrimstr("v")' --raw-output)
+    ${lib.getExe' common-updater-scripts "update-source-version"} "karabiner-dk" "$NEW_VERSION" --ignore-same-version --version-key="sourceVersion";
+  '';
+
+  meta = {
+    changelog = "https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice/releases/tag/${finalAttrs.src.tag}";
+    description = "Virtual keyboard and virtual mouse using DriverKit on macOS";
+    homepage = "https://karabiner-elements.pqrs.org/";
+    maintainers = with lib.maintainers; [ auscyber ];
+    license = lib.licenses.unlicense;
+    platforms = lib.platforms.darwin;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/ka/karabiner-elements/package.nix
+++ b/pkgs/by-name/ka/karabiner-elements/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  cpio,
+  libarchive,
   xar,
   undmg,
   nix-update-script,
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [
-    cpio
+    libarchive
     xar
     undmg
   ];
@@ -32,9 +32,9 @@ stdenv.mkDerivation (finalAttrs: {
     undmg $src
     xar -xf Karabiner-Elements.pkg
     cd Installer.pkg
-    zcat Payload | cpio -i
+    zcat Payload | bsdcpio -i
     cd ../Karabiner-DriverKit-VirtualHIDDevice.pkg
-    zcat Payload | cpio -i
+    zcat Payload | bsdcpio -i
     cd ..
   '';
 
@@ -49,12 +49,16 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out $driver
     cp -R Installer.pkg/Applications Installer.pkg/Library $out
     cp -R Karabiner-DriverKit-VirtualHIDDevice.pkg/Applications Karabiner-DriverKit-VirtualHIDDevice.pkg/Library $driver
 
     cp "$out/Library/Application Support/org.pqrs/Karabiner-Elements/package-version" "$out/Library/Application Support/org.pqrs/Karabiner-Elements/version"
+    runHook postInstall
   '';
+
+  dontFixup = true; # notarization breaks if fixup is enabled
 
   passthru.updateScript = nix-update-script { };
 
@@ -63,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Powerful utility for keyboard customization on macOS Ventura (13) or later";
     homepage = "https://karabiner-elements.pqrs.org/";
     license = lib.licenses.unlicense;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ auscyber ];
     platforms = lib.platforms.darwin;
   };
 })

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -196,6 +196,8 @@ package-maintainers:
     - hevm
   athas:
     - futhark
+  auscyber:
+    - kmonad
   bdesham:
     - pinboard-notes-backup
   berberman:

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1865,7 +1865,12 @@ builtins.intersectAttrs super {
   kmonad = lib.pipe super.kmonad [
     enableSeparateBinOutput
     (overrideCabal (drv: {
-      passthru = lib.recursiveUpdate drv.passthru or { } { tests.nixos = pkgs.nixosTests.kmonad; };
+      passthru = lib.recursiveUpdate drv.passthru or { } {
+        darwinDriver = pkgs.karabiner-dk.override {
+          driver-version = "5.0.0";
+        };
+        tests.nixos = pkgs.nixosTests.kmonad;
+      };
     }))
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^


-->

## Things done

karabiner-dk is the driverkit for karabiner-elements and has a weird notarization method which is reflected also in the karabiner-elements patches.
kanata now uses this and passes in a calculated driver version from the calculated cargoDeps.
I've fixed karabiner-elements to work properly on macos again.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
