### PR TITLE
pwmenu: init at 0.3.0

### DIFF
--- a/pkgs/by-name/pw/pwmenu/package.nix
+++ b/pkgs/by-name/pw/pwmenu/package.nix
@@ -1,0 +1,44 @@
+{
+  fetchFromGitHub,
+  lib,
+  pipewire,
+  pkg-config,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pwmenu";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "e-tho";
+    repo = "pwmenu";
+    tag = "v${version}";
+    hash = "sha256-Q02kOMC6oQ3fNyDWW9ztLgMs3wR4cA53/wmkbecTr/o=";
+  };
+
+  cargoHash = "sha256-jX4D4Xv2WYTcWnYO2cNsu7L9ppIw//Tkxl+Y7tflk+A=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    pipewire
+  ];
+
+  meta = {
+    homepage = "https://github.com/e-tho/pwmenu";
+    description = "Launcher-driven audio manager for Linux";
+    longDescription = ''
+      Use `pwmenu --launcher <launcher command>`
+      Supported launchers are: `dmenu`, `fuzzel`, `rofi`, `walker` and `custom` with `stdin`
+      for details refer to https://github.com/e-tho/pwmenu/blob/main/README.md#usage
+    '';
+    mainProgram = "pwmenu";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ vuimuich ];
+  };
+}


### PR DESCRIPTION
Similar to `iwmenu` and `bzmenu` this is a pipewire audio manager for launchers like dmenu, rofi or fuzzle.
For details see: https://github.com/e-tho/pwmenu/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
