### PR TITLE
scalapack: modernize; fix build with cmake4

### DIFF
--- a/pkgs/by-name/sc/scalapack/package.nix
+++ b/pkgs/by-name/sc/scalapack/package.nix
@@ -67,7 +67,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlagsArray = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
-    (lib.cmakeBool "BUILD_STATIC_LIBS" stdenv.hostPlatform.isStatic)
     (lib.cmakeFeature "LAPACK_LIBRARIES" "-llapack")
     (lib.cmakeFeature "BLAS_LIBRARIES" "-lblas")
     (lib.cmakeFeature "CMAKE_Fortran_COMPILER" "${lib.getDev mpi}/bin/mpif90")

--- a/pkgs/by-name/sc/scalapack/package.nix
+++ b/pkgs/by-name/sc/scalapack/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   fetchpatch,
   cmake,
+  gfortran,
   mpiCheckPhaseHook,
   mpi,
   blas,
@@ -56,7 +57,10 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    gfortran
+  ];
 
   nativeCheckInputs = [ mpiCheckPhaseHook ];
 
@@ -74,7 +78,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
     (lib.cmakeFeature "LAPACK_LIBRARIES" "-llapack")
     (lib.cmakeFeature "BLAS_LIBRARIES" "-lblas")
-    (lib.cmakeFeature "CMAKE_Fortran_COMPILER" "${lib.getDev mpi}/bin/mpif90")
     (lib.cmakeFeature "CMAKE_C_FLAGS" "${lib.concatStringsSep " " [
       "-Wno-implicit-function-declaration"
       (lib.optionalString finalAttrs.passthru.isILP64 "-DInt=long")

--- a/pkgs/by-name/sc/scalapack/package.nix
+++ b/pkgs/by-name/sc/scalapack/package.nix
@@ -57,12 +57,14 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [ cmake ];
+
   nativeCheckInputs = [ mpiCheckPhaseHook ];
-  buildInputs = [
+
+  propagatedBuildInputs = [
     blas
     lapack
+    mpi
   ];
-  propagatedBuildInputs = [ mpi ];
 
   # xslu and xsllt tests seem to time out on x86_64-darwin.
   # this line is left so those who force installation on x86_64-darwin can still build

--- a/pkgs/by-name/sc/scalapack/package.nix
+++ b/pkgs/by-name/sc/scalapack/package.nix
@@ -57,9 +57,6 @@ stdenv.mkDerivation (finalAttrs: {
     lapack
   ];
   propagatedBuildInputs = [ mpi ];
-  hardeningDisable = lib.optionals (stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isDarwin) [
-    "stackprotector"
-  ];
 
   # xslu and xsllt tests seem to time out on x86_64-darwin.
   # this line is left so those who force installation on x86_64-darwin can still build

--- a/pkgs/by-name/sc/scalapack/package.nix
+++ b/pkgs/by-name/sc/scalapack/package.nix
@@ -8,6 +8,7 @@
   mpi,
   blas,
   lapack,
+  testers,
 }:
 
 assert blas.isILP64 == lapack.isILP64;
@@ -23,7 +24,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-KDMW/D7ubGaD2L7eTwULJ04fAYDPAKl8xKPZGZMkeik=";
   };
 
-  passthru = { inherit (blas) isILP64; };
+  passthru = {
+    inherit (blas) isILP64;
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+    };
+  };
 
   __structuredAttrs = true;
 
@@ -93,6 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Library of high-performance linear algebra routines for parallel distributed memory machines";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
+    pkgConfigModules = [ "scalapack" ];
     maintainers = with lib.maintainers; [
       costrouc
       markuskowa


### PR DESCRIPTION
The last commit fix build with cmake4, one can test it on staging branch.

without the last commit, an error 
```
can not find CMAKE_Fortran_COMPILER
Configure in the BLACS INSTALL directory FAILED
```
will raise if build scalapack with cmake4.

Related source where the error raise: https://github.com/Reference-ScaLAPACK/scalapack/blob/25935e1a7e022ede9fd71bd86dcbaa7a3f1846b7/CMAKE/FortranMangling.cmake#L21-L33
Possible cause: cmake4 no longer respect global CMAKE_Fortran_COMPILER in subcommand. 
Solution: provide gfortran directly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
