### PR TITLE
thrift: 0.18.1 -> 0.22.0 + clean

### DIFF
--- a/pkgs/by-name/th/thrift/package.nix
+++ b/pkgs/by-name/th/thrift/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  fetchpatch,
   fetchFromGitHub,
   boost,
   zlib,
@@ -15,15 +14,15 @@
   static ? stdenv.hostPlatform.isStatic,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "thrift";
-  version = "0.21.0";
+  version = "0.22.0";
 
   src = fetchFromGitHub {
     owner = "apache";
     repo = "thrift";
-    tag = "v0.21.0";
-    hash = "sha256-OF/pFG8OXROsyYGf6jgfVTYTrTc8UB5QJh4gbostFfU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-gGAO+D0A/hEoHMm6OvRBc1Mks9y52kfd0q/Sg96pdW4=";
   };
 
   # Workaround to make the Python wrapper not drop this package:
@@ -97,4 +96,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ bjornfor ];
   };
-}
+})

--- a/pkgs/by-name/th/thrift/package.nix
+++ b/pkgs/by-name/th/thrift/package.nix
@@ -1,8 +1,8 @@
 {
   lib,
   stdenv,
-  fetchurl,
   fetchpatch,
+  fetchFromGitHub,
   boost,
   zlib,
   libevent,
@@ -17,11 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "thrift";
-  version = "0.18.1";
+  version = "0.21.0";
 
-  src = fetchurl {
-    url = "https://archive.apache.org/dist/thrift/${version}/${pname}-${version}.tar.gz";
-    hash = "sha256-BMbxDl14jKeOE+4u8NIVLHsHDAr1VIPWuULinP8pZyY=";
+  src = fetchFromGitHub {
+    owner = "apache";
+    repo = "thrift";
+    tag = "v0.21.0";
+    hash = "sha256-OF/pFG8OXROsyYGf6jgfVTYTrTc8UB5QJh4gbostFfU=";
   };
 
   # Workaround to make the Python wrapper not drop this package:
@@ -58,45 +60,9 @@ stdenv.mkDerivation rec {
     zlib
   ];
 
-  postPatch = ''
-    # Python 3.10 related failures:
-    # SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats
-    # AttributeError: module 'collections' has no attribute 'Hashable'
-    substituteInPlace test/py/RunClientServer.py \
-      --replace "'FastbinaryTest.py'," "" \
-      --replace "'TestEof.py'," "" \
-      --replace "'TestFrozen.py'," ""
-
-    # these functions are removed in Python3.12
-    substituteInPlace test/py/SerializationTest.py \
-      --replace-fail "assertEquals" "assertEqual" \
-      --replace-fail "assertNotEquals" "assertNotEqual"
-  '';
-
   preConfigure = ''
     export PY_PREFIX=$out
   '';
-
-  patches = [
-    # ToStringTest.cpp is failing from some reason due to locale issue, this
-    # doesn't disable all UnitTests as in Darwin.
-    ./disable-failing-test.patch
-    (fetchpatch {
-      name = "setuptools-gte-62.1.0.patch"; # https://github.com/apache/thrift/pull/2635
-      url = "https://github.com/apache/thrift/commit/c41ad9d5119e9bdae1746167e77e224f390f2c42.diff";
-      hash = "sha256-FkErrg/6vXTomS4AsCsld7t+Iccc55ZiDaNjJ3W1km0=";
-    })
-    (fetchpatch {
-      name = "thrift-install-FindLibevent.patch"; # https://github.com/apache/thrift/pull/2726
-      url = "https://github.com/apache/thrift/commit/2ab850824f75d448f2ba14a468fb77d2594998df.diff";
-      hash = "sha256-ejMKFG/cJgoPlAFzVDPI4vIIL7URqaG06/IWdQ2NkhY=";
-    })
-    (fetchpatch {
-      name = "thrift-fix-tests-OpenSSL3.patch"; # https://github.com/apache/thrift/pull/2760
-      url = "https://github.com/apache/thrift/commit/eae3ac418f36c73833746bcd53e69ed8a12f0e1a.diff";
-      hash = "sha256-0jlN4fo94cfGFUKcLFQgVMI/x7uxn5OiLiFk6txVPzs=";
-    })
-  ];
 
   cmakeFlags = [
     "-DBUILD_JAVASCRIPT:BOOL=OFF"
@@ -109,31 +75,6 @@ stdenv.mkDerivation rec {
   ++ lib.optionals static [
     "-DWITH_STATIC_LIB:BOOL=ON"
     "-DOPENSSL_USE_STATIC_LIBS=ON"
-  ];
-
-  disabledTests = [
-    "PythonTestSSLSocket"
-    "PythonThriftTNonblockingServer"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # Tests that hang up in the Darwin sandbox
-    "SecurityTest"
-    "SecurityFromBufferTest"
-    "python_test"
-
-    # fails on hydra, passes locally
-    "concurrency_test"
-
-    # Tests that fail in the Darwin sandbox when trying to use network
-    "UnitTests"
-    "TInterruptTest"
-    "TServerIntegrationTest"
-    "processor"
-    "TNonblockingServerTest"
-    "TNonblockingSSLServerTest"
-    "StressTest"
-    "StressTestConcurrent"
-    "StressTestNonBlocking"
   ];
 
   doCheck = !static;

--- a/pkgs/by-name/th/thrift/package.nix
+++ b/pkgs/by-name/th/thrift/package.nix
@@ -11,6 +11,7 @@
   pkg-config,
   bison,
   flex,
+  ctestCheckHook,
   static ? stdenv.hostPlatform.isStatic,
 }:
 
@@ -59,6 +60,8 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
   ];
 
+  nativeCheckInputs = [ ctestCheckHook ];
+
   preConfigure = ''
     export PY_PREFIX=$out
   '';
@@ -74,15 +77,11 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_TESTING" (!static))
   ];
 
+  disabledTests = [
+    "UnitTests" # getaddrinfo() -> -3; Temporary failure in name resolution
+    "python_test" # many failures about python 2 or network things
+  ];
   doCheck = !static;
-
-  checkPhase = ''
-    runHook preCheck
-
-    ${lib.optionalString stdenv.hostPlatform.isDarwin "DY"}LD_LIBRARY_PATH=$PWD/lib ctest -E "($(echo "$disabledTests" | tr " " "|"))"
-
-    runHook postCheck
-  '';
 
   enableParallelChecking = false;
 

--- a/pkgs/by-name/th/thrift/package.nix
+++ b/pkgs/by-name/th/thrift/package.nix
@@ -80,7 +80,28 @@ stdenv.mkDerivation (finalAttrs: {
   disabledTests = [
     "UnitTests" # getaddrinfo() -> -3; Temporary failure in name resolution
     "python_test" # many failures about python 2 or network things
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Tests that hang up in the Darwin sandbox
+    "SecurityTest"
+    "SecurityFromBufferTest"
+    "python_test"
+
+    # fails on hydra, passes locally
+    "concurrency_test"
+
+    # Tests that fail in the Darwin sandbox when trying to use network
+    "UnitTests"
+    "TInterruptTest"
+    "TServerIntegrationTest"
+    "processor"
+    "TNonblockingServerTest"
+    "TNonblockingSSLServerTest"
+    "StressTest"
+    "StressTestConcurrent"
+    "StressTestNonBlocking"
   ];
+
   doCheck = !static;
 
   enableParallelChecking = false;

--- a/pkgs/by-name/th/thrift/package.nix
+++ b/pkgs/by-name/th/thrift/package.nix
@@ -64,16 +64,14 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   cmakeFlags = [
-    "-DBUILD_JAVASCRIPT:BOOL=OFF"
-    "-DBUILD_NODEJS:BOOL=OFF"
+    (lib.cmakeBool "BUILD_JAVASCRIPT" false)
+    (lib.cmakeBool "BUILD_NODEJS" false)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!static))
+    (lib.cmakeBool "OPENSSL_USE_STATIC_LIBS" static)
 
     # FIXME: Fails to link in static mode with undefined reference to
     # `boost::unit_test::unit_test_main(bool (*)(), int, char**)'
-    "-DBUILD_TESTING:BOOL=${if static then "OFF" else "ON"}"
-  ]
-  ++ lib.optionals static [
-    "-DWITH_STATIC_LIB:BOOL=ON"
-    "-DOPENSSL_USE_STATIC_LIBS=ON"
+    (lib.cmakeBool "BUILD_TESTING" (!static))
   ];
 
   doCheck = !static;


### PR DESCRIPTION
Follows #374710 but without removing disabledTests, because as seen in #444660, they were just not running.

cc @DaGenix @emilazy

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
