### PR TITLE
maintainers: drop x3ro

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28051,12 +28051,6 @@
     github = "x123";
     githubId = 5481629;
   };
-  x3ro = {
-    name = "^x3ro";
-    email = "nix@x3ro.dev";
-    github = "x3rAx";
-    githubId = 2268851;
-  };
   x807x = {
     name = "x807x";
     email = "s10855168@gmail.com";

--- a/pkgs/by-name/ks/ksnip/package.nix
+++ b/pkgs/by-name/ks/ksnip/package.nix
@@ -77,7 +77,6 @@ stdenv.mkDerivation (finalAttrs: {
       - Many configuration options.
     '';
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ x3ro ];
     platforms = lib.platforms.linux;
     mainProgram = "ksnip";
   };

--- a/pkgs/by-name/li/linux-router/package.nix
+++ b/pkgs/by-name/li/linux-router/package.nix
@@ -108,7 +108,6 @@ stdenv.mkDerivation rec {
     '';
     changelog = "https://github.com/garywill/linux-router/releases/tag/${version}";
     license = lib.licenses.lgpl21Only;
-    maintainers = with lib.maintainers; [ x3ro ];
     platforms = lib.platforms.linux;
     mainProgram = "lnxrouter";
   };


### PR DESCRIPTION
Inactive since 2022, not part of the GitHub org.

Dropping according to guidelines: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md#losing-maintainer-status

@x3rAx if you'd like to stay a maintainer, please respond within a week. In that case, you should consider requesting an invite to the org again, so that you can be pinged for review properly: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md#tools-for-maintainers


## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
