### PR TITLE
vscode/extensions/update_installed_exts.sh: log on download failure instead of early exit

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/update_installed_exts.sh
+++ b/pkgs/applications/editors/vscode/extensions/update_installed_exts.sh
@@ -40,7 +40,15 @@ function get_vsixpkg() {
     URL="https://$1.gallery.vsassets.io/_apis/public/gallery/publisher/$1/extension/$2/latest/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
 
     # Quietly but delicately curl down the file, blowing up at the first sign of trouble.
-    curl --silent --show-error --retry 3 --fail -X GET -o "$EXTTMP/$N.zip" "$URL"
+    curl --silent --show-error --retry 3 --fail -X GET -o "$EXTTMP/$N.zip" "$URL" || {
+        if (($? > 128))
+        then exit $?
+        fi
+        cat >&2 <<EOF
+unable to download $N
+EOF
+        return
+    }
     # Unpack the file we need to stdout then pull out the version
     VER=$(jq -r '.version' <(unzip -qc "$EXTTMP/$N.zip" "extension/package.json"))
     # Calculate the hash
@@ -73,7 +81,7 @@ if [ -z "$CODE" ]; then
 fi
 
 # Try to be a good citizen and clean up after ourselves if we're killed.
-trap clean_up SIGINT
+trap clean_up EXIT
 
 # Begin the printing of the nix expression that will house the list of extensions.
 printf '{ extensions = [\n'

--- a/pkgs/applications/editors/vscode/extensions/update_installed_exts.sh
+++ b/pkgs/applications/editors/vscode/extensions/update_installed_exts.sh
@@ -43,7 +43,6 @@ function get_vsixpkg() {
     # --fail is needed to treat 404 as an actual error instead of downloading the 404 error itself
     curl \
         --silent --show-error \
-        --retry 3 \
         --fail \
         -X GET \
         -o "$EXTTMP/$N.zip" "$URL" \

--- a/pkgs/applications/editors/vscode/extensions/update_installed_exts.sh
+++ b/pkgs/applications/editors/vscode/extensions/update_installed_exts.sh
@@ -69,13 +69,13 @@ EOF
 }
 
 # See if we can find our `code` binary somewhere.
-if [ $# -ne 0 ]; then
+if [[ $# -ne 0 ]]; then
     CODE=$1
 else
     CODE=$(command -v code || command -v codium)
 fi
 
-if [ -z "$CODE" ]; then
+if [[ -z "$CODE" ]]; then
     # Not much point continuing.
     fail "VSCode executable not found"
 fi

--- a/pkgs/applications/editors/vscode/extensions/update_installed_exts.sh
+++ b/pkgs/applications/editors/vscode/extensions/update_installed_exts.sh
@@ -39,8 +39,15 @@ function get_vsixpkg() {
 
     URL="https://$1.gallery.vsassets.io/_apis/public/gallery/publisher/$1/extension/$2/latest/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
 
-    # Quietly but delicately curl down the file, blowing up at the first sign of trouble.
-    curl --silent --show-error --retry 3 --fail -X GET -o "$EXTTMP/$N.zip" "$URL" || {
+    # Download the file. If curl exits from a signal, bail. If curl exits with its own status code, report the error and move on.
+    # --fail is needed to treat 404 as an actual error instead of downloading the 404 error itself
+    curl \
+        --silent --show-error \
+        --retry 3 \
+        --fail \
+        -X GET \
+        -o "$EXTTMP/$N.zip" "$URL" \
+    || {
         if (($? > 128))
         then exit $?
         fi

--- a/pkgs/applications/editors/vscode/extensions/update_installed_exts.sh
+++ b/pkgs/applications/editors/vscode/extensions/update_installed_exts.sh
@@ -44,7 +44,6 @@ function get_vsixpkg() {
     curl \
         --silent --show-error \
         --fail \
-        -X GET \
         -o "$EXTTMP/$N.zip" "$URL" \
     || {
         if (($? > 128))


### PR DESCRIPTION
This makes the script not fail if you have local extensions that aren’t on the marketplace.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
