### PR TITLE
Revert "ngtcp2: 1.14.0 -> 1.15.1"

### DIFF
--- a/pkgs/development/libraries/ngtcp2/default.nix
+++ b/pkgs/development/libraries/ngtcp2/default.nix
@@ -14,14 +14,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ngtcp2";
-  version = "1.15.1";
+  version = "1.14.0";
 
   src = fetchFromGitHub {
     owner = "ngtcp2";
     repo = "ngtcp2";
     # must match version usage in meta.changelog
     tag = "v${finalAttrs.version}";
-    hash = "sha256-336khLt6LGxdctX7u3u8TVqN1EQjl+Gyz/44+bpatms=";
+    hash = "sha256-5Pmk752i/lgO/os2SegevGN+MKaVuQii2HrVWaR15Gg=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#436110

Seems to be a mass-rebuild on staging-next now.