### PR TITLE
python3Packages.bluetooth-adapters: 2.1.0 -> 2.1.1

### DIFF
--- a/pkgs/development/python-modules/aranet4/default.nix
+++ b/pkgs/development/python-modules/aranet4/default.nix
@@ -3,6 +3,7 @@
   bleak,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   pytestCheckHook,
   pythonOlder,
   requests,
@@ -22,6 +23,15 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-/FBrP4aceIX9dcZmm+k13PSAPuK4SQenjWqOAFPSvL8=";
   };
+
+  patches = [
+    # https://github.com/Anrijs/Aranet4-Python/pull/62
+    (fetchpatch {
+      name = "fix-for-failing-test-with-bleak-1.1.0.patch";
+      url = "https://github.com/Anrijs/Aranet4-Python/pull/62/commits/0117633682050c77cd00ead1bce93375367d7a3c.patch";
+      hash = "sha256-S4Di6bKbapCpDdOIy4sSiG9dO7OZq5ixjjK+ux4EEp0=";
+    })
+  ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/bleak/default.nix
+++ b/pkgs/development/python-modules/bleak/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "bleak";
-  version = "1.0.1";
+  version = "1.1.1";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "hbldh";
     repo = "bleak";
     tag = "v${version}";
-    hash = "sha256-JHTyTHMMZDD75baQK3nf4R+8eW0Tt62CMTXb8eRKp94=";
+    hash = "sha256-z0Mxr1pUQWNEK01PKMV/CzpW+GeCRcv/+9BADts1FuU=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/bluetooth-adapters/default.nix
+++ b/pkgs/development/python-modules/bluetooth-adapters/default.nix
@@ -22,7 +22,7 @@
 
 buildPythonPackage rec {
   pname = "bluetooth-adapters";
-  version = "2.1.0";
+  version = "2.1.1";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     owner = "Bluetooth-Devices";
     repo = "bluetooth-adapters";
     tag = "v${version}";
-    hash = "sha256-euAyVSBmlMsPMUnxn8L7p0n939TQe4id+JTtUk4pHIY=";
+    hash = "sha256-M9Me+fTaw//wGVd9Ss9iYB7RMgfkxJZz2lT60lHe3Vg=";
   };
 
   outputs = [
@@ -71,7 +71,7 @@ buildPythonPackage rec {
   meta = {
     description = "Tools to enumerate and find Bluetooth Adapters";
     homepage = "https://github.com/Bluetooth-Devices/bluetooth-adapters";
-    changelog = "https://github.com/bluetooth-devices/bluetooth-adapters/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/Bluetooth-Devices/bluetooth-adapters/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     teams = [ lib.teams.home-assistant ];
   };


### PR DESCRIPTION
Diff: https://github.com/Bluetooth-Devices/bluetooth-adapters/compare/v2.1.0...v2.1.1

Changelog: https://github.com/Bluetooth-Devices/bluetooth-adapters/releases/tag/v2.1.1
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
