### PR TITLE
pip-audit: override cyclonedx-python-lib

### DIFF
--- a/pkgs/by-name/pi/pip-audit/package.nix
+++ b/pkgs/by-name/pi/pip-audit/package.nix
@@ -4,7 +4,25 @@
   python3,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+let
+  py = python3.override {
+    packageOverrides = self: super: {
+
+      # Requires cyclonedx-python-lib <10.0.0
+      cyclonedx-python-lib = super.cyclonedx-python-lib.overridePythonAttrs (oldAttrs: rec {
+        version = "9.1.0";
+        src = fetchFromGitHub {
+          owner = "CycloneDX";
+          repo = "cyclonedx-python-lib";
+          tag = "v${version}";
+          hash = "sha256-XnRyE+C29W+rKrJop15jMNAXfAOdty877fKluhmEqIc=";
+        };
+      });
+    };
+  };
+in
+
+py.pkgs.buildPythonApplication rec {
   pname = "pip-audit";
   version = "2.9.0";
   pyproject = true;
@@ -16,12 +34,10 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-j8ZKqE7PEwaCTUNnJunqM0A2eyuWfx8zG5i3nmZERow=";
   };
 
-  pythonRelaxDeps = [ "cyclonedx-python-lib" ];
-
-  build-system = with python3.pkgs; [ flit-core ];
+  build-system = with py.pkgs; [ flit-core ];
 
   dependencies =
-    with python3.pkgs;
+    with py.pkgs;
     [
       cachecontrol
       cyclonedx-python-lib
@@ -35,7 +51,7 @@ python3.pkgs.buildPythonApplication rec {
     ]
     ++ cachecontrol.optional-dependencies.filecache;
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with py.pkgs; [
     pretend
     pytestCheckHook
   ];


### PR DESCRIPTION
https://hydra.nixos.org/build/305636613

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
