### PR TITLE
libcec: enable build on darwin platform

### DIFF
--- a/pkgs/development/libraries/libcec/default.nix
+++ b/pkgs/development/libraries/libcec/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   # Fix dlopen path
   postPatch = ''
-    substituteInPlace include/cecloader.h --replace "libcec.so" "$out/lib/libcec.so"
+    substituteInPlace include/cecloader.h --replace "\"libcec." "\"$out/lib/libcec."
   '';
 
   nativeBuildInputs = [
@@ -31,9 +31,9 @@ stdenv.mkDerivation rec {
     cmake
   ];
   buildInputs = [
-    udev
     libcec_platform
   ]
+  ++ lib.optional stdenv.hostPlatform.isLinux udev
   ++ lib.optional withLibraspberrypi libraspberrypi;
 
   cmakeFlags = [
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     description = "Allows you (with the right hardware) to control your device with your TV remote control using existing HDMI cabling";
     homepage = "http://libcec.pulse-eight.com";
     license = lib.licenses.gpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     teams = [ teams.kodi ];
   };
 }

--- a/pkgs/development/libraries/libcec/platform.nix
+++ b/pkgs/development/libraries/libcec/platform.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  cmakeFlags = lib.optional stdenv.hostPlatform.isDarwin "-DCMAKE_CXX_FLAGS='-std=c++11'";
+
   meta = with lib; {
     description = "Platform library for libcec and Kodi addons";
     homepage = "https://github.com/Pulse-Eight/platform";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Enable libcec builds on Darwin. I've only been able to test on aarch64-darwin so far.

Changes made to enable this:
 - Only add udev dependency when building for Linux
 - Pass `-DCMAKE_CXX_FLAGS='-std=c++11'` to CMake to fix compilation error when building p8-platform:
```
       > /tmp/nix-build-p8-platform-2.1.0.1.drv-0/source/src/util/StringUtils.cpp:456:69: error: no member named 'ptr_fun' in the global namespace
       >   456 |   str.erase(str.begin(), ::find_if(str.begin(), str.end(), ::not1(::ptr_fun(isspace_c))));
       >       |                                                                   ~~^
       > /tmp/nix-build-p8-platform-2.1.0.1.drv-0/source/src/util/StringUtils.cpp:469:58: error: no member named 'ptr_fun' in the global namespace
       >   469 |   str.erase(::find_if(str.rbegin(), str.rend(), ::not1(::ptr_fun(isspace_c))).base(), str.end());
       >       |                                                        ~~^
       > 2 errors generated.
```
 - Adjust the `postPatch` to also find the `.dylib` libraries.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
