### PR TITLE
tektoncd-cli: general maintenance

### DIFF
--- a/pkgs/by-name/te/tektoncd-cli/package.nix
+++ b/pkgs/by-name/te/tektoncd-cli/package.nix
@@ -4,6 +4,8 @@
   fetchFromGitHub,
   installShellFiles,
 
+  writableTmpDirAsHomeHook,
+
   stdenv,
   buildPackages,
 }:
@@ -31,10 +33,11 @@ buildGoModule (finalAttrs: {
 
   subPackages = [ "cmd/tkn" ];
 
-  preCheck = ''
-    # some tests try to write to the home dir
-    export HOME="$TMPDIR"
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+  ];
 
+  preCheck = ''
     # run all tests
     unset subPackages
 

--- a/pkgs/by-name/te/tektoncd-cli/package.nix
+++ b/pkgs/by-name/te/tektoncd-cli/package.nix
@@ -5,14 +5,14 @@
   installShellFiles,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "tektoncd-cli";
   version = "0.42.0";
 
   src = fetchFromGitHub {
     owner = "tektoncd";
     repo = "cli";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-WB3XsXT8bXo2GpHC6hGKilRwloy31y18JD09cQklsV0=";
   };
 
@@ -21,7 +21,7 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=${version}"
+    "-X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=${finalAttrs.version}"
   ];
 
   nativeBuildInputs = [ installShellFiles ];
@@ -55,13 +55,13 @@ buildGoModule rec {
   installCheckPhase = ''
     runHook preInstallCheck
     $out/bin/tkn --help
-    $out/bin/tkn version | grep "Client version: ${version}"
+    $out/bin/tkn version | grep "Client version: ${finalAttrs.version}"
     runHook postInstallCheck
   '';
 
   meta = {
     homepage = "https://tekton.dev";
-    changelog = "https://github.com/tektoncd/cli/releases/tag/v${version}";
+    changelog = "https://github.com/tektoncd/cli/releases/tag/v${finalAttrs.version}";
     description = "Provides a CLI for interacting with Tekton - tkn";
     longDescription = ''
       The Tekton Pipelines cli project provides a CLI for interacting with
@@ -77,4 +77,4 @@ buildGoModule rec {
     ];
     mainProgram = "tkn";
   };
-}
+})

--- a/pkgs/by-name/te/tektoncd-cli/package.nix
+++ b/pkgs/by-name/te/tektoncd-cli/package.nix
@@ -31,6 +31,9 @@ buildGoModule (finalAttrs: {
     "-X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=${finalAttrs.version}"
   ];
 
+  # tests bind to ::1
+  __darwinAllowLocalNetworking = true;
+
   nativeBuildInputs = [ installShellFiles ];
 
   subPackages = [ "cmd/tkn" ];
@@ -45,9 +48,6 @@ buildGoModule (finalAttrs: {
 
     # the tests expect the clientVersion ldflag not to be set
     unset ldflags
-
-    # remove tests with networking
-    rm pkg/cmd/version/version_test.go
   '';
 
   postInstall = ''

--- a/pkgs/by-name/te/tektoncd-cli/package.nix
+++ b/pkgs/by-name/te/tektoncd-cli/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "tektoncd";
     repo = "cli";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-WB3XsXT8bXo2GpHC6hGKilRwloy31y18JD09cQklsV0=";
   };
 
@@ -61,7 +61,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     homepage = "https://tekton.dev";
-    changelog = "https://github.com/tektoncd/cli/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/tektoncd/cli/releases/tag/${finalAttrs.src.tag}";
     description = "Provides a CLI for interacting with Tekton - tkn";
     longDescription = ''
       The Tekton Pipelines cli project provides a CLI for interacting with

--- a/pkgs/by-name/te/tektoncd-cli/package.nix
+++ b/pkgs/by-name/te/tektoncd-cli/package.nix
@@ -36,7 +36,13 @@ buildGoModule (finalAttrs: {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  subPackages = [ "cmd/tkn" ];
+  subPackages = [
+    "cmd/tkn"
+  ];
+
+  excludedPackages = [
+    "test/e2e"
+  ];
 
   nativeCheckInputs = [
     writableTmpDirAsHomeHook

--- a/pkgs/by-name/te/tektoncd-cli/package.nix
+++ b/pkgs/by-name/te/tektoncd-cli/package.nix
@@ -8,6 +8,8 @@
 
   stdenv,
   buildPackages,
+
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -67,13 +69,11 @@ buildGoModule (finalAttrs: {
     ''
   );
 
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
   doInstallCheck = true;
-  installCheckPhase = ''
-    runHook preInstallCheck
-    $out/bin/tkn --help
-    $out/bin/tkn version | grep "Client version: ${finalAttrs.version}"
-    runHook postInstallCheck
-  '';
+  versionCheckProgramArg = "version";
 
   meta = {
     homepage = "https://tekton.dev";


### PR DESCRIPTION
- tektoncd-cli: move to finalAttrs pattern
- tektoncd-cli: get release by tag
- tektoncd-cli: fix completion generation for cross-compiling
- tektoncd-cli: use writableTmpDirAsHomeHook
- tektoncd-cli: use versionCheckHook
- tektoncd-cli: add back working tests
- tektoncd-cli: remove e2e tests

Probably need local networking on darwin. Need to confirm.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
