### PR TITLE
panotools: add cmake4 patch from upstream

### DIFF
--- a/pkgs/by-name/pa/panotools/cmake4.patch
+++ b/pkgs/by-name/pa/panotools/cmake4.patch
@@ -1,0 +1,32 @@
+Subject: Vendor upstream patches (mercurial/sourceforge)
+Author: Andreas Metzler
+
+From:
+- https://sourceforge.net/p/panotools/libpano13/ci/698e20b4d296c1dbde9d010c3fb8d54050e56ddb/
+- https://sourceforge.net/p/panotools/libpano13/ci/6b0f2a5ef7a0490866fb224158d1dfbb8bf5896f/
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -28,8 +28,7 @@
+ ## may need to edit the wxWidgets version number below.
+ ##
+ 
+-# require at least cmake 3.0
+-cmake_minimum_required(VERSION 3.0)
++cmake_minimum_required(VERSION 3.12...4.0)
+ if(POLICY CMP0074)
+   cmake_policy(SET CMP0074 NEW)
+ endif()
+@@ -382,12 +382,12 @@
+ endif()
+ 
+ # create TAGS file
+-ADD_CUSTOM_COMMAND( OUTPUT ctags POST_BUILD
+-                   COMMAND ctags-exuberant -e *.c *.h tools/*.c
++ADD_CUSTOM_COMMAND( OUTPUT ${PROJECT_SOURCE_DIR}/TAGS
++                   COMMAND ctags -e *.c *.h tools/*.c
+                    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/
+                    COMMENT "Build TAGS file"
+                  )
+-ADD_CUSTOM_TARGET( TAGS DEPENDS ctags)
++ADD_CUSTOM_TARGET( TAGS DEPENDS ${PROJECT_SOURCE_DIR}/TAGS)

--- a/pkgs/by-name/pa/panotools/package.nix
+++ b/pkgs/by-name/pa/panotools/package.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-r/xoMM2+ccKNJzHcv43qKs2m2f/UYJxtvzugxoRAqOM=";
   };
 
+  patches = [ ./cmake4.patch ];
+
   strictDeps = true;
 
   nativeBuildInputs = [


### PR DESCRIPTION
From:
- https://sourceforge.net/p/panotools/libpano13/ci/698e20b4d296c1dbde9d010c3fb8d54050e56ddb/
- https://sourceforge.net/p/panotools/libpano13/ci/6b0f2a5ef7a0490866fb224158d1dfbb8bf5896f/


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
