### PR TITLE
osgqt: fix for CMake v4

### DIFF
--- a/pkgs/by-name/os/osgqt/package.nix
+++ b/pkgs/by-name/os/osgqt/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "osgQt";
-  version = "3.5.7";
+  version = "3.5.7-unstable-2025-10-08";
 
   src = fetchFromGitHub {
     owner = "openscenegraph";
     repo = "osgQt";
-    rev = finalAttrs.version;
-    hash = "sha256-iUeIqRDlcAHdKXWAi4WhEaOCxa7ZivQw0K5E7ccEKnM=";
+    rev = "effd111b747d786d4937de93973188a48eee3412";
+    hash = "sha256-+rjy2a266p755Mbfk6jRApiERpOL8axHklK0cYokX40=";
   };
 
   buildInputs = [ libsForQt5.qtbase ];
@@ -31,13 +31,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-DDESIRED_QT_VERSION=5"
     "-DOpenGL_GL_PREFERENCE=GLVND"
   ];
-
-  postPatch = ''
-    substituteInPlace CMakeLists.txt --replace-fail \
-      "FIND_PACKAGE(Qt5Widgets REQUIRED)" \
-      "FIND_PACKAGE(Qt5Widgets REQUIRED)
-       FIND_PACKAGE(Qt5OpenGL REQUIRED)"
-  '';
 
   meta = {
     description = "Qt bindings for OpenSceneGraph";


### PR DESCRIPTION
ref. https://github.com/openscenegraph/osgQt/pull/65, ~~but upstream does not seem reactive~~.

part of https://github.com/NixOS/nixpkgs/issues/445447


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
