### PR TITLE
remarshal_0_17: respect existing packageOverrides

### DIFF
--- a/pkgs/by-name/re/remarshal_0_17/package.nix
+++ b/pkgs/by-name/re/remarshal_0_17/package.nix
@@ -7,26 +7,27 @@
 }:
 
 let
-  python = python3Packages.python.override {
-    self = python3Packages.python;
-    packageOverrides = self: super: {
-      tomlkit = super.tomlkit.overridePythonAttrs (oldAttrs: rec {
-        version = "0.12.5";
-        src = fetchPypi {
-          pname = "tomlkit";
-          inherit version;
-          hash = "sha256-7vNPujmDTU1rc8m6fz5NHEF6Tlb4mn6W4JDdDSS4+zw=";
-        };
-        patches = [
-          (fetchpatch {
-            url = "https://github.com/python-poetry/tomlkit/commit/05d9be1c2b2a95a4eb3a53d999f1483dd7abae5a.patch";
-            hash = "sha256-9pLGxcGHs+XoKrqlh7Q0dyc07XrK7J6u2T7Kvfd0ICc=";
-            excludes = [ ".github/workflows/tests.yml" ];
-          })
-        ];
-      });
-    };
+  packageOverrides = self: super: {
+    tomlkit = super.tomlkit.overridePythonAttrs (oldAttrs: rec {
+      version = "0.12.5";
+      src = fetchPypi {
+        pname = "tomlkit";
+        inherit version;
+        hash = "sha256-7vNPujmDTU1rc8m6fz5NHEF6Tlb4mn6W4JDdDSS4+zw=";
+      };
+      patches = [
+        (fetchpatch {
+          url = "https://github.com/python-poetry/tomlkit/commit/05d9be1c2b2a95a4eb3a53d999f1483dd7abae5a.patch";
+          hash = "sha256-9pLGxcGHs+XoKrqlh7Q0dyc07XrK7J6u2T7Kvfd0ICc=";
+          excludes = [ ".github/workflows/tests.yml" ];
+        })
+      ];
+    });
   };
+  python = python3Packages.python.override (oa: {
+    self = python3Packages.python;
+    packageOverrides = lib.composeExtensions (oa.packageOverrides or (_: _: { })) packageOverrides;
+  });
   pythonPackages = python.pkgs;
 in
 pythonPackages.buildPythonApplication rec {


### PR DESCRIPTION
Setting packageOverrides when overriding python will unset any previous
overrides. We have to manually compose the packageOverrides.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
