### PR TITLE
fetchurl: fix downloadToTemp & hashedMirrors

### DIFF
--- a/pkgs/build-support/fetchurl/tests.nix
+++ b/pkgs/build-support/fetchurl/tests.nix
@@ -22,4 +22,24 @@
         ${jq}/bin/jq -r '.headers.Hello' $out | ${moreutils}/bin/sponge $out
       '';
     };
+  # Tests that downloadToTemp works with hashedMirrors
+  no-skipPostFetch = testers.invalidateFetcherByDrvHash fetchurl {
+    # Make sure that we can only download from hashed mirrors
+    url = "http://broken";
+    # A file with this hash is definitely on tarballs.nixos.org
+    sha256 = "1j1y3cq6ys30m734axc0brdm2q9n2as4h32jws15r7w5fwr991km";
+
+    # No chance
+    curlOptsList = [
+      "--retry"
+      "0"
+    ];
+
+    downloadToTemp = true;
+    # Usually postFetch is needed with downloadToTemp to populate $out from
+    # $downloadedFile, but here we know that because the URL is broken, it will
+    # have to fallback to fetching the previously-built derivation from
+    # tarballs.nixos.org, which provides pre-built derivation outputs.
+
+  };
 }


### PR DESCRIPTION
We must copy the file from `$downloadedFile` to `$out` when we're
skipping `postFetch`; otherwise `hashedMirrors` won't work with
`downloadToTemp`.

The provided test demonstrates a case which fails before this commit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
