### PR TITLE
scaleway-cli: 2.42.0 -> 2.43.0

### DIFF
--- a/pkgs/by-name/sc/scaleway-cli/package.nix
+++ b/pkgs/by-name/sc/scaleway-cli/package.nix
@@ -2,25 +2,25 @@
   lib,
   fetchFromGitHub,
   buildGoModule,
+  writableTmpDirAsHomeHook,
 }:
 
 buildGoModule rec {
   pname = "scaleway-cli";
-  version = "2.42.0";
+  version = "2.43.0";
 
   src = fetchFromGitHub {
     owner = "scaleway";
     repo = "scaleway-cli";
     rev = "v${version}";
-    sha256 = "sha256-bLttAE8IXTeIZ70wxBGxwozI2DVrdFnHdrCS3PL9UHA=";
+    sha256 = "sha256-pUHsaHPNYT+pKn/Qh+AUyYBFkTmWELMoa69jHR52cYw=";
   };
 
-  vendorHash = "sha256-ivjTL/eiQmj8228VYlgoRzjw9pt6QiwnsXKyjIXfc3M=";
+  vendorHash = "sha256-6pxpUO3ead5gzmv7YiBP2+bcxF88QxPTzCLGsHDM4fA=";
 
   ldflags = [
     "-w"
-    "-extldflags"
-    "-static"
+    "-s"
     "-X main.Version=${version}"
     "-X main.GitCommit=ref/tags/${version}"
     "-X main.GitBranch=HEAD"
@@ -45,6 +45,8 @@ buildGoModule rec {
     substituteInPlace internal/e2e/sdk_errors_test.go \
       --replace-warn "TestSdkStandardErrors" "SkipSdkStandardErrors"
   '';
+
+  nativeBuildInputs = [ writableTmpDirAsHomeHook ];
 
   doInstallCheck = true;
 


### PR DESCRIPTION
https://github.com/scaleway/scaleway-cli/releases/tag/v2.43.0

ldflag changes are to match upstream

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
