### PR TITLE
civetweb: allow the OS to set the stack size

### DIFF
--- a/pkgs/by-name/ci/civetweb/package.nix
+++ b/pkgs/by-name/ci/civetweb/package.nix
@@ -40,6 +40,13 @@ stdenv.mkDerivation rec {
 
     # The civetweb unit tests rely on downloading their fork of libcheck.
     "-DCIVETWEB_BUILD_TESTING=OFF"
+
+    # The default stack size in civetweb is 102400 (see the CMakeLists [1]).
+    # This can lead to stack overflows even in basic usage;
+    # Setting this value to 0 lets the OS choose the stack size instead, which results in a more suitable value.
+    #
+    # [1] https://github.com/civetweb/civetweb/blob/cafd5f8fae3b859b7f8c29feb03ea075c7221497/CMakeLists.txt#L56
+    "-DCIVETWEB_THREAD_STACK_SIZE=0"
   ];
 
   meta = {


### PR DESCRIPTION
The default stack size in civetweb is 102400 (see the Makefile[1]).

This can lead to stack overflows even in basic usage; Setting this value
to 0 lets the OS choose the stack size instead, which results in a more
suitable value.

[1] https://github.com/civetweb/civetweb/blob/ce8f6d38a60eb16c996afee1e5340f76ef4d0923/Makefile#L42


## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
