### PR TITLE
maintainers: drop neonfuz

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18116,12 +18116,6 @@
     githubId = 50854675;
     name = "Nelson Jeppesen";
   };
-  neonfuz = {
-    email = "neonfuz@gmail.com";
-    github = "neonfuz";
-    githubId = 2590830;
-    name = "Sage Raflik";
-  };
   neosimsim = {
     email = "me@abn.sh";
     github = "neosimsim";

--- a/pkgs/by-name/ak/akira-unstable/package.nix
+++ b/pkgs/by-name/ak/akira-unstable/package.nix
@@ -70,7 +70,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [
       Br1ght0ne
-      neonfuz
     ];
     teams = [ teams.pantheon ];
     platforms = platforms.linux;

--- a/pkgs/by-name/cr/crispy-doom/package.nix
+++ b/pkgs/by-name/cr/crispy-doom/package.nix
@@ -65,7 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       Gliczy
       keenanweaver
-      neonfuz
     ];
   };
 })

--- a/pkgs/by-name/dw/dwm/package.nix
+++ b/pkgs/by-name/dw/dwm/package.nix
@@ -72,7 +72,6 @@ stdenv.mkDerivation (finalAttrs: {
       tags.
     '';
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ neonfuz ];
     platforms = lib.platforms.all;
     mainProgram = "dwm";
   };

--- a/pkgs/by-name/eu/eureka-editor/package.nix
+++ b/pkgs/by-name/eu/eureka-editor/package.nix
@@ -49,6 +49,5 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.all;
     badPlatforms = platforms.darwin;
-    maintainers = with maintainers; [ neonfuz ];
   };
 }

--- a/pkgs/by-name/ko/koreader/package.nix
+++ b/pkgs/by-name/ko/koreader/package.nix
@@ -138,7 +138,6 @@ stdenv.mkDerivation {
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [
       contrun
-      neonfuz
       liberodark
     ];
   };

--- a/pkgs/by-name/pi/pinyin-tool/package.nix
+++ b/pkgs/by-name/pi/pinyin-tool/package.nix
@@ -22,6 +22,5 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "pinyin-tool";
     homepage = "https://github.com/briankung/pinyin-tool";
     license = licenses.mit;
-    maintainers = with maintainers; [ neonfuz ];
   };
 }

--- a/pkgs/by-name/rp/rpcs3/package.nix
+++ b/pkgs/by-name/rp/rpcs3/package.nix
@@ -154,7 +154,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "PS3 emulator/debugger";
     homepage = "https://rpcs3.net/";
     maintainers = with maintainers; [
-      neonfuz
       ilian
     ];
     license = licenses.gpl2Only;

--- a/pkgs/by-name/xm/xmenu/package.nix
+++ b/pkgs/by-name/xm/xmenu/package.nix
@@ -36,7 +36,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Menu utility for X";
     homepage = "https://github.com/phillbush/xmenu";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ neonfuz ];
     platforms = lib.platforms.all;
     mainProgram = "xmenu";
   };

--- a/pkgs/by-name/ya/yaxg/package.nix
+++ b/pkgs/by-name/ya/yaxg/package.nix
@@ -59,7 +59,6 @@ stdenv.mkDerivation rec {
     '';
     platforms = platforms.all;
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ neonfuz ];
     mainProgram = "yaxg";
   };
 }

--- a/pkgs/games/papermc/derivation.nix
+++ b/pkgs/games/papermc/derivation.nix
@@ -56,7 +56,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
       aaronjanse
-      neonfuz
       MayNiklas
     ];
     mainProgram = "minecraft-server";


### PR DESCRIPTION
Inactive since 2023, not in the GitHub org.

Dropping according to guidelines: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md#losing-maintainer-status

@neonfuz, if you'd like to stay a maintainer, please respond within a week.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
