### PR TITLE
nixos/veilid: rename 'node_id' and remove old defaults

### DIFF
--- a/nixos/modules/services/networking/veilid.nix
+++ b/nixos/modules/services/networking/veilid.nix
@@ -193,7 +193,7 @@ in
                   default = [ "bootstrap.veilid.net" ];
                   description = "Host name of existing well-known Veilid bootstrap servers for the network to connect to.";
                 };
-                node_id = lib.mkOption {
+                public_keys = lib.mkOption {
                   type = lib.types.nullOr lib.types.str;
                   default = null;
                   description = "Base64-encoded public key for the node, used as the node's ID.";

--- a/nixos/modules/services/networking/veilid.nix
+++ b/nixos/modules/services/networking/veilid.nix
@@ -10,7 +10,12 @@ let
   dataDir = "/var/db/veilid-server";
 
   settingsFormat = pkgs.formats.yaml { };
-  configFile = settingsFormat.generate "veilid-server.conf" cfg.settings;
+
+  configFile = settingsFormat.generate "veilid-server.conf" (
+    lib.converge (lib.filterAttrsRecursive (
+      _: v: v != null && v != { } && v != "" && v != [ ]
+    )) cfg.settings
+  );
 in
 {
   config = mkIf cfg.enable {
@@ -157,13 +162,13 @@ in
             };
             protected_store = {
               allow_insecure_fallback = mkOption {
-                type = types.bool;
-                default = true;
+                type = lib.types.nullOr types.bool;
+                default = null;
                 description = "If we can't use system-provided secure storage, should we proceed anyway?";
               };
               always_use_insecure_storage = mkOption {
-                type = types.bool;
-                default = true;
+                type = lib.types.nullOr types.bool;
+                default = null;
                 description = "Should we bypass any attempt to use system-provided secure storage?";
               };
               directory = mkOption {
@@ -189,8 +194,8 @@ in
             network = {
               routing_table = {
                 bootstrap = mkOption {
-                  type = types.listOf types.str;
-                  default = [ "bootstrap.veilid.net" ];
+                  type = lib.types.nullOr (types.listOf types.str);
+                  default = null;
                   description = "Host name of existing well-known Veilid bootstrap servers for the network to connect to.";
                 };
                 public_keys = lib.mkOption {
@@ -201,8 +206,8 @@ in
               };
               dht = {
                 min_peer_count = mkOption {
-                  type = types.number;
-                  default = 20;
+                  type = lib.types.nullOr types.number;
+                  default = null;
                   description = "Minimum number of nodes to keep in the peer table.";
                 };
               };


### PR DESCRIPTION
Someone in the Veilid discord had an issue with "zero activity on a headless server".

The Veilid creator advised to "remove this part of the config [...] those are old config keys and the defaults are what you want".

Before this change, I had the following error. Perhaps I didn't have any problem if my node was already bootstraped.
```
Network may be down. No bootstrap resolution for 'bootstrap.veilid.net': system resolver txt_lookup error: no record found for Query { name: Name("bootstrap.veilid.net."), query_type: TXT, query_class: IN }
```

We could add the new config keys if there is demand for them.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
