### PR TITLE
maintainers: drop GuillaumeDesforges

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9782,12 +9782,6 @@
     githubId = 95086304;
     name = "Guilherme Lima";
   };
-  GuillaumeDesforges = {
-    email = "aceus02@gmail.com";
-    github = "GuillaumeDesforges";
-    githubId = 1882000;
-    name = "Guillaume Desforges";
-  };
   guillaumekoenig = {
     email = "guillaume.edward.koenig@gmail.com";
     github = "guillaumekoenig";

--- a/pkgs/by-name/db/dbx/package.nix
+++ b/pkgs/by-name/db/dbx/package.nix
@@ -157,6 +157,6 @@ python.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/databrickslabs/dbx";
     changelog = "https://github.com/databrickslabs/dbx/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.databricks-dbx;
-    maintainers = with lib.maintainers; [ GuillaumeDesforges ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/du/dummyhttp/package.nix
+++ b/pkgs/by-name/du/dummyhttp/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     description = "Super simple HTTP server that replies a fixed body with a fixed response code";
     homepage = "https://github.com/svenstaro/dummyhttp";
     license = with licenses; [ mit ];
-    maintainers = with maintainers; [ GuillaumeDesforges ];
+    maintainers = with maintainers; [ ];
     mainProgram = "dummyhttp";
   };
 }

--- a/pkgs/by-name/ma/marp-cli/package.nix
+++ b/pkgs/by-name/ma/marp-cli/package.nix
@@ -26,7 +26,7 @@ buildNpmPackage rec {
     description = "About A CLI interface for Marp and Marpit based converters";
     homepage = "https://github.com/marp-team/marp-cli";
     license = licenses.mit;
-    maintainers = with maintainers; [ GuillaumeDesforges ];
+    maintainers = with maintainers; [ ];
     platforms = nodejs.meta.platforms;
     mainProgram = "marp";
   };

--- a/pkgs/development/python-modules/geopy/default.nix
+++ b/pkgs/development/python-modules/geopy/default.nix
@@ -49,6 +49,6 @@ buildPythonPackage rec {
     description = "Python Geocoding Toolbox";
     changelog = "https://github.com/geopy/geopy/releases/tag/${version}";
     license = with licenses; [ mit ];
-    maintainers = with maintainers; [ GuillaumeDesforges ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pooch/default.nix
+++ b/pkgs/development/python-modules/pooch/default.nix
@@ -75,6 +75,6 @@ buildPythonPackage rec {
     description = "Friend to fetch your data files";
     homepage = "https://github.com/fatiando/pooch";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ GuillaumeDesforges ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/scikit-survival/default.nix
+++ b/pkgs/development/python-modules/scikit-survival/default.nix
@@ -93,6 +93,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/sebp/scikit-survival";
     changelog = "https://github.com/sebp/scikit-survival/releases/tag/v${version}";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ GuillaumeDesforges ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/standard-sunau/default.nix
+++ b/pkgs/development/python-modules/standard-sunau/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     description = "Standard library sunau redistribution";
     homepage = "https://github.com/youknowone/python-deadlib/tree/main/sunau";
     license = lib.licenses.psfl;
-    maintainers = with lib.maintainers; [ GuillaumeDesforges ];
+    maintainers = with lib.maintainers; [ ];
   };
 }


### PR DESCRIPTION
Inactive on nixpkgs since Dec 2024, and was requested on 10+ PRs.

Not an org member.

Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/tree/99b4fe0118ad739cbd4f9d60d76c020317908135/maintainers#losing-maintainer-status)

@GuillaumeDesforges: if you'd like to stay involved, please respond within a week and join the NixOS org (following the instructions in the "Tools for maintainers" section of maintainers/README.md).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
