### PR TITLE
maintainers: drop PeteE

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19993,12 +19993,6 @@
     githubId = 63069986;
     name = "Per Stark";
   };
-  petee = {
-    name = "Pete Erickson";
-    email = "pete.perickson@gmail.com";
-    github = "petee";
-    githubId = 89916;
-  };
   Peter3579 = {
     github = "Peter3579";
     githubId = 170885528;

--- a/pkgs/tools/misc/steampipe-packages/steampipe-plugin-azure/default.nix
+++ b/pkgs/tools/misc/steampipe-packages/steampipe-plugin-azure/default.nix
@@ -45,7 +45,7 @@ buildGoModule rec {
     homepage = "https://github.com/turbot/steampipe-plugin-azure";
     license = lib.licenses.apsl20;
     longDescription = "Use SQL to instantly query Azure resources across regions and subscriptions.";
-    maintainers = with lib.maintainers; [ petee ];
+    maintainers = with lib.maintainers; [ ];
     platforms = steampipe.meta.platforms;
   };
 }


### PR DESCRIPTION
Inactive on nixpkgs since Oct 2024, and was requested on 6 PRs.

Not an org member.

Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/tree/99b4fe0118ad739cbd4f9d60d76c020317908135/maintainers#losing-maintainer-status)

@PeteE: if you'd like to stay involved, please respond within a week and join the NixOS org (following the instructions in the "Tools for maintainers" section of maintainers/README.md).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
