### PR TITLE
[25.05] immich: 1.140.1 -> 1.142.0

### DIFF
--- a/pkgs/by-name/im/immich-cli/package.nix
+++ b/pkgs/by-name/im/immich-cli/package.nix
@@ -12,7 +12,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "immich-cli";
-  version = "2.2.86";
+  version = "2.2.89";
   inherit (immich) src pnpmDeps;
 
   postPatch = ''

--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -29,12 +29,12 @@
   pango,
   perl,
   pixman,
-  vips,
+  vips_8_17,
   buildPackages,
 }:
 let
   pnpm = pnpm_10;
-  version = "1.140.1";
+  version = "1.142.0";
 
   esbuild' = buildPackages.esbuild.override {
     buildGoModule =
@@ -108,14 +108,14 @@ let
     owner = "immich-app";
     repo = "immich";
     tag = "v${version}";
-    hash = "sha256-Bo9wFP0u39aoaNjc8K4Im3HRGZR/TLrDB7+UDAhV1xA=";
+    hash = "sha256-0nStZuSnb8tJ0+Y247MHitmMURl8vTuPLAhUm+OHctE=";
   };
 
   pnpmDeps = pnpm.fetchDeps {
     pname = "immich";
     inherit version src;
     fetcherVersion = 2;
-    hash = "sha256-DIcUKuU+ToRh/kSLcs4ZEHy7zhFir2nlbRx+/kMagrA=";
+    hash = "sha256-aYG5SpFZxhbz32YAdP39RYwn2GV+mFWhddd4IFuPuz8=";
   };
 
   web = stdenv.mkDerivation {
@@ -146,10 +146,6 @@ let
       runHook postInstall
     '';
   };
-
-  vips' = vips.overrideAttrs (prev: {
-    mesonFlags = prev.mesonFlags ++ [ "-Dtiff=disabled" ];
-  });
 in
 stdenv.mkDerivation {
   pname = "immich";
@@ -186,7 +182,7 @@ stdenv.mkDerivation {
     pango
     pixman
     # Required for sharp
-    vips'
+    vips_8_17
   ];
 
   env.SHARP_FORCE_GLOBAL_LIBVIPS = 1;

--- a/pkgs/by-name/vi/vips/8_17.nix
+++ b/pkgs/by-name/vi/vips/8_17.nix
@@ -1,0 +1,177 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  # Native build inputs
+  docbook-xsl-nons,
+  gi-docgen,
+  gobject-introspection,
+  meson,
+  ninja,
+  pkg-config,
+  buildPackages,
+
+  # Build inputs
+  expat,
+  glib,
+  libxml2,
+  python3,
+
+  # Optional dependencies
+  cfitsio,
+  cgif,
+  fftw,
+  imagemagick,
+  lcms2,
+  libarchive,
+  libexif,
+  libheif,
+  libhwy,
+  libimagequant,
+  libjpeg,
+  libjxl,
+  librsvg,
+  libpng,
+  libtiff,
+  libwebp,
+  matio,
+  openexr,
+  openjpeg,
+  openslide,
+  pango,
+  poppler,
+  withIntrospection ?
+    lib.meta.availableOn stdenv.hostPlatform gobject-introspection
+    && stdenv.hostPlatform.emulatorAvailable buildPackages,
+
+  # passthru
+  testers,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vips";
+  version = "8.17.1";
+
+  outputs = [
+    "bin"
+    "out"
+    "man"
+    "dev"
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isFreeBSD) [ "devdoc" ];
+
+  src = fetchFromGitHub {
+    owner = "libvips";
+    repo = "libvips";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Sc2BWdQIgL/dI0zfbEQVCs3+1QBrLE7BsE3uFHe9C/c=";
+    # Remove unicode file names which leads to different checksums on HFS+
+    # vs. other filesystems because of unicode normalisation.
+    postFetch = ''
+      rm -r $out/test/test-suite/images/
+    '';
+  };
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  nativeBuildInputs = [
+    docbook-xsl-nons
+    gobject-introspection
+    meson
+    ninja
+    pkg-config
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isFreeBSD) [
+    gi-docgen
+  ];
+
+  buildInputs = [
+    glib
+    libxml2
+    expat
+    (python3.withPackages (p: [ p.pycairo ]))
+
+    # Optional dependencies
+    cfitsio
+    cgif
+    fftw
+    imagemagick
+    lcms2
+    libarchive
+    libexif
+    libheif
+    libhwy
+    libimagequant
+    libjpeg
+    libjxl
+    librsvg
+    libpng
+    libtiff
+    libwebp
+    matio
+    openexr
+    openjpeg
+    openslide
+    pango
+    poppler
+  ];
+
+  # Required by .pc file
+  propagatedBuildInputs = [
+    glib
+  ];
+
+  mesonFlags = [
+    (lib.mesonEnable "pdfium" false)
+    (lib.mesonEnable "nifti" false)
+    (lib.mesonEnable "spng" false) # we want to use libpng
+    (lib.mesonEnable "introspection" withIntrospection)
+  ]
+  ++ lib.optional (!stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isFreeBSD) (
+    lib.mesonBool "docs" true
+  )
+  ++ lib.optional (imagemagick == null) (lib.mesonEnable "magick" false);
+
+  postFixup = ''
+    moveToOutput "share/doc" "$devdoc"
+  '';
+
+  passthru = {
+    tests = {
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+      };
+      version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+        command = "vips --version";
+      };
+    };
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "^v([0-9.]+)$"
+      ];
+    };
+  };
+
+  meta = {
+    changelog = "https://github.com/libvips/libvips/blob/${finalAttrs.src.rev}/ChangeLog";
+    homepage = "https://www.libvips.org/";
+    description = "Image processing system for large images";
+    license = lib.licenses.lgpl2Plus;
+    maintainers = with lib.maintainers; [
+      kovirobi
+      anthonyroussel
+    ];
+    pkgConfigModules = [
+      "vips"
+      "vips-cpp"
+    ];
+    platforms = lib.platforms.unix;
+    mainProgram = "vips";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16988,4 +16988,6 @@ with pkgs;
   rustdesk-flutter = callPackage ../by-name/ru/rustdesk-flutter/package.nix {
     flutter = flutter324;
   };
+
+  vips_8_17 = callPackage ../by-name/vi/vips/8_17.nix { };
 }


### PR DESCRIPTION
Backport of:
- https://github.com/NixOS/nixpkgs/pull/441343

Introduces a new `vips_8_17` package due to the upgrade breaking `haskellPackages.gi-vips`. See https://github.com/NixOS/nixpkgs/pull/442486 for relevant discussion.

Closes https://github.com/NixOS/nixpkgs/pull/442486

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
See e424a29